### PR TITLE
✨ feat(tui): responsive details sidebar + lazygit fullscreen + vim motions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `STATUS` column in both the TUI table and `gwm list` CLI output, with colour-coding (`green` clean / synced, `yellow` dirty or behind, `cyan` ahead, `red` prunable, `magenta` locked, `dark_gray` unknown).
 - CI on the `dev` integration branch: `fmt`, `clippy`, multi-OS test, and `cargo audit` now run on every push to `dev` and on every PR targeting `dev` (same matrix as `main`).
 - `.github/workflows/pre-release.yml`: builds the 5 release targets (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64) and publishes a GitHub Release with `prerelease: true` whenever a SemVer-rc / -alpha / -beta tag is pushed (e.g. `v0.2.0-rc.1`). Also supports `workflow_dispatch` for manual reruns.
+- **TUI details sidebar** (auto-shown when terminal width ≥ 120 cols, toggle with `v`): lazyssh-style panel listing the selected worktree's branch, path, head, locked / prunable / main flags, status, plus `git log --oneline -n 10`, `git status --short`, and a commands cheat-sheet.
+- **TUI keybinding `l`**: suspend the TUI and launch `lazygit -p <selected-worktree-path>` fullscreen; resume the TUI when lazygit exits. Surfaces a clear error in the status bar if `lazygit` is not on `$PATH`.
+- **TUI focus toggle (`Tab`)**: swap focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel; the focused panel's border turns cyan.
+- **TUI vim motions**: `gg` jumps to the first worktree, `G` to the last.
+- `worktree::git_log_oneline(path, n)` and `worktree::git_status_short(path)` — thin `Command::new("git")` wrappers used by the sidebar (and exposed for tests).
+- `.gwm.toml` config for this repo (Rust-flavoured): `target/` no_symlink + `cargo fetch` bootstrap step + `direnv allow` when an `.envrc` exists.
 
 ### Changed
 
 - TUI worktree view: ratatui `List` → `Table` with dynamic column widths derived from data (name/branch capped to [18, 38], status fixed 16, path takes the rest). No more `…`-truncated names for typical branch lengths.
 - `gwm list` CLI output uses the same dynamic column widths.
+- TUI list `j` / `k`: now reset the sidebar scroll offset when navigating worktrees, and scroll the sidebar instead of moving selection when the sidebar has focus.
 
 ## [0.1.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -47,19 +47,39 @@ gwm                # opens the TUI on the current repo
 
 Key bindings:
 
-| Key       | Action                                          |
-|:----------|:------------------------------------------------|
-| `↑` / `k` | previous worktree                                |
-| `↓` / `j` | next worktree                                    |
-| `n`       | new worktree (form: type → issue → description)  |
-| `d`       | delete selected (confirm `y`)                    |
-| `b`       | re-run bootstrap on the selected worktree        |
-| `o`       | open the worktree dir in the OS file manager (`open` / `xdg-open` / `explorer`) |
-| `r`       | refresh                                          |
-| `p`       | toggle "delete branch on remove"                 |
-| `Enter`   | show selected path in status bar                 |
-| `?`       | help overlay                                     |
-| `q` / `Esc` | quit                                           |
+| Key         | Action                                                                          |
+|:------------|:--------------------------------------------------------------------------------|
+| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                       |
+| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
+| `gg`        | jump to the first worktree                                                      |
+| `G`         | jump to the last worktree                                                       |
+| `n`         | new worktree (form: type → issue → description)                                 |
+| `d`         | delete selected (confirm `y`)                                                   |
+| `b`         | re-run bootstrap on the selected worktree                                       |
+| `o`         | open the worktree dir in the OS file manager (`open` / `xdg-open` / `explorer`) |
+| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
+| `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
+| `Tab`       | swap focus between the worktree list and the sidebar                            |
+| `r`         | refresh                                                                         |
+| `p`         | toggle "delete branch on remove"                                                |
+| `Enter`     | show selected path in status bar                                                |
+| `?`         | help overlay                                                                    |
+| `q` / `Esc` | quit                                                                            |
+
+### details sidebar
+
+When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the currently selected worktree:
+
+- **Basic Settings** — branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **Recent commits** — `git log --oneline -n 10`.
+- **Working tree** — `git status --short` (`✓ clean` when empty).
+- **Commands** — keybindings cheat-sheet.
+
+Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+### lazygit integration
+
+Press `l` on any worktree to suspend the TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on that worktree (`lazygit -p <path>`). When you quit lazygit, the gwm TUI is restored exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it without crashing.
 
 ### CLI
 
@@ -152,13 +172,13 @@ Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde
 | multi-repo portability              | per-project script   | one binary, per-repo config      |
 | TUI                                 | linear bash menu     | full ratatui screen              |
 | anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 56 tests (config / naming / bootstrap / worktree / TUI / CLI) |
+| tests                               | none                 | 71 tests (config / naming / bootstrap / worktree / TUI / CLI) |
 
 ## development
 
 ```bash
 cargo build              # debug build
-cargo test               # 56 tests
+cargo test               # 71 tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -92,20 +92,40 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 
 ## TUI key map
 
-| Key       | Action                                          |
-|:----------|:------------------------------------------------|
-| `↑` / `k` | previous worktree                                |
-| `↓` / `j` | next worktree                                    |
-| `n`       | new worktree form (type ↑/↓, Tab between fields, Enter on desc submits) |
-| `d`       | delete (confirm `y`)                             |
-| `b`       | re-run bootstrap on selected                     |
-| `o`       | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`) |
-| `r`       | refresh                                          |
-| `p`       | toggle "delete branch on remove"                 |
-| `Enter`   | show path in status bar                          |
-| `?`       | help overlay                                     |
-| `q` / `Esc` | quit                                           |
-| `Ctrl-C`  | force quit                                       |
+| Key         | Action                                                                          |
+|:------------|:--------------------------------------------------------------------------------|
+| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                       |
+| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
+| `gg`        | jump to the first worktree                                                      |
+| `G`         | jump to the last worktree                                                       |
+| `n`         | new worktree form (type ↑/↓, Tab between fields, Enter on desc submits)         |
+| `d`         | delete (confirm `y`)                                                            |
+| `b`         | re-run bootstrap on selected                                                    |
+| `o`         | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`)         |
+| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; gwm resumes on lazygit exit |
+| `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)    |
+| `Tab`       | swap focus between the worktree list and the sidebar                            |
+| `r`         | refresh                                                                         |
+| `p`         | toggle "delete branch on remove"                                                |
+| `Enter`     | show path in status bar                                                         |
+| `?`         | help overlay                                                                    |
+| `q` / `Esc` | quit                                                                            |
+| `Ctrl-C`    | force quit                                                                      |
+
+## Details sidebar
+
+When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the selected worktree:
+
+- **Basic Settings**: branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **Recent commits**: `git log --oneline -n 10` (shells out to `git`).
+- **Working tree**: `git status --short` (`✓ clean` when empty).
+- **Commands**: keybindings cheat-sheet inside the panel.
+
+`Tab` swaps focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel. The focused panel's border turns cyan.
+
+## Lazygit integration
+
+Press `l` to suspend the gwm TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on the selected worktree (`lazygit -p <path>`). Quitting lazygit restores the gwm TUI exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it and the TUI keeps running.
 
 ## `.gwm.toml` schema
 
@@ -297,7 +317,7 @@ Tests under `tests/` mirror this layout. TDD bar: any new behaviour ships with a
 | portability across repos    | per-project script    | one binary + per-repo config   |
 | TUI                         | linear bash menu      | full ratatui screen            |
 | anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list   |
-| tests                       | 0                     | 56 (config / naming / bootstrap / worktree / TUI / CLI) |
+| tests                       | 0                     | 71 (config / naming / bootstrap / worktree / TUI / CLI) |
 | install                     | `chmod +x` per repo   | `cargo install --path .`       |
 
 ## Troubleshooting

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -42,6 +42,14 @@ pub struct App {
 
   // Bootstrap report
   pub report: Option<BootstrapReport>,
+
+  // Sidebar (git preview) state
+  pub sidebar_open: bool,
+  pub sidebar_focused: bool,
+  pub sidebar_scroll: u16,
+
+  // Vim motion buffer: armed by first `g`, completed by the second.
+  pub pending_g: bool,
 }
 
 impl App {
@@ -74,6 +82,10 @@ impl App {
       create_issue: String::new(),
       create_desc: String::new(),
       report: None,
+      sidebar_open: true,
+      sidebar_focused: false,
+      sidebar_scroll: 0,
+      pending_g: false,
     })
   }
 
@@ -93,6 +105,11 @@ impl App {
   }
 
   pub fn next(&mut self) {
+    // Route navigation to the sidebar when it's focused; otherwise move the list.
+    if self.sidebar_open && self.sidebar_focused {
+      self.sidebar_scroll_down();
+      return;
+    }
     if self.worktrees.is_empty() {
       return;
     }
@@ -101,9 +118,14 @@ impl App {
       None => 0,
     };
     self.list_state.select(Some(i));
+    self.sidebar_scroll = 0;
   }
 
   pub fn prev(&mut self) {
+    if self.sidebar_open && self.sidebar_focused {
+      self.sidebar_scroll_up();
+      return;
+    }
     if self.worktrees.is_empty() {
       return;
     }
@@ -112,6 +134,78 @@ impl App {
       Some(i) => i - 1,
     };
     self.list_state.select(Some(i));
+    self.sidebar_scroll = 0;
+  }
+
+  // ---- Vim-style motions / list jumps -------------------------------------
+
+  pub fn first(&mut self) {
+    if !self.worktrees.is_empty() {
+      self.list_state.select(Some(0));
+      self.sidebar_scroll = 0;
+    }
+  }
+
+  pub fn last(&mut self) {
+    if !self.worktrees.is_empty() {
+      self.list_state.select(Some(self.worktrees.len() - 1));
+      self.sidebar_scroll = 0;
+    }
+  }
+
+  /// Drive the two-keystroke `gg` motion. First press arms it, second jumps to top.
+  pub fn handle_g(&mut self) {
+    if self.pending_g {
+      self.pending_g = false;
+      self.first();
+    } else {
+      self.pending_g = true;
+    }
+  }
+
+  pub fn cancel_pending_motion(&mut self) {
+    self.pending_g = false;
+  }
+
+  // ---- Sidebar ------------------------------------------------------------
+
+  pub fn toggle_sidebar(&mut self) {
+    self.sidebar_open = !self.sidebar_open;
+    if !self.sidebar_open {
+      // Hidden sidebar can't be focused.
+      self.sidebar_focused = false;
+    }
+    self.status = if self.sidebar_open {
+      "sidebar shown".into()
+    } else {
+      "sidebar hidden".into()
+    };
+  }
+
+  pub fn toggle_focus(&mut self) {
+    if !self.sidebar_open {
+      return;
+    }
+    self.sidebar_focused = !self.sidebar_focused;
+  }
+
+  pub fn sidebar_scroll_down(&mut self) {
+    self.sidebar_scroll = self.sidebar_scroll.saturating_add(1);
+  }
+
+  pub fn sidebar_scroll_up(&mut self) {
+    self.sidebar_scroll = self.sidebar_scroll.saturating_sub(1);
+  }
+
+  /// Path to launch lazygit on, or `None` if nothing selected or lazygit is missing.
+  /// The caller drives the actual TUI suspension/restoration around the spawn.
+  pub fn launch_lazygit(&mut self) -> Option<PathBuf> {
+    let path = self.selected()?.path.clone();
+    if which::which("lazygit").is_err() {
+      self.status = "lazygit not found in PATH".into();
+      return None;
+    }
+    Some(path)
   }
 
   pub fn selected(&self) -> Option<&WorktreeInfo> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,7 +4,7 @@ use crate::error::{GwmError, Result};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
-use ratatui::widgets::TableState;
+use ratatui::{text::Line, widgets::TableState};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -47,6 +47,14 @@ pub struct App {
   pub sidebar_open: bool,
   pub sidebar_focused: bool,
   pub sidebar_scroll: u16,
+  /// Cache of rendered sidebar lines, keyed by the selected worktree path.
+  /// Prevents re-shelling `git log` / `git status` on every TUI redraw — they
+  /// only run when the selection actually changes (or on explicit refresh).
+  pub sidebar_cache: Option<(PathBuf, Vec<Line<'static>>)>,
+  /// Upper bound for `sidebar_scroll`, recomputed by the renderer each frame.
+  /// Keeps scrolling clamped to the rendered content height so the user can't
+  /// scroll the panel entirely off-screen.
+  pub sidebar_max_scroll: u16,
 
   // Vim motion buffer: armed by first `g`, completed by the second.
   pub pending_g: bool,
@@ -85,6 +93,8 @@ impl App {
       sidebar_open: true,
       sidebar_focused: false,
       sidebar_scroll: 0,
+      sidebar_cache: None,
+      sidebar_max_scroll: 0,
       pending_g: false,
     })
   }
@@ -100,8 +110,15 @@ impl App {
         self.list_state.select(Some(self.worktrees.len() - 1));
       }
     }
+    self.invalidate_sidebar_cache();
     self.status = format!("refreshed — {} worktree(s)", self.worktrees.len());
     Ok(())
+  }
+
+  /// Drop the cached sidebar content. Call on any change that may have altered
+  /// what the sidebar shows: worktree list refresh, selection change, etc.
+  pub fn invalidate_sidebar_cache(&mut self) {
+    self.sidebar_cache = None;
   }
 
   pub fn next(&mut self) {
@@ -119,6 +136,7 @@ impl App {
     };
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
+    self.invalidate_sidebar_cache();
   }
 
   pub fn prev(&mut self) {
@@ -135,6 +153,7 @@ impl App {
     };
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
+    self.invalidate_sidebar_cache();
   }
 
   // ---- Vim-style motions / list jumps -------------------------------------
@@ -143,6 +162,7 @@ impl App {
     if !self.worktrees.is_empty() {
       self.list_state.select(Some(0));
       self.sidebar_scroll = 0;
+      self.invalidate_sidebar_cache();
     }
   }
 
@@ -150,6 +170,7 @@ impl App {
     if !self.worktrees.is_empty() {
       self.list_state.select(Some(self.worktrees.len() - 1));
       self.sidebar_scroll = 0;
+      self.invalidate_sidebar_cache();
     }
   }
 
@@ -190,7 +211,10 @@ impl App {
   }
 
   pub fn sidebar_scroll_down(&mut self) {
-    self.sidebar_scroll = self.sidebar_scroll.saturating_add(1);
+    // Clamp to the last-known content max so scrolling stops at the bottom
+    // instead of running off-screen. The renderer keeps `sidebar_max_scroll`
+    // up to date with the visible content height.
+    self.sidebar_scroll = self.sidebar_scroll.saturating_add(1).min(self.sidebar_max_scroll);
   }
 
   pub fn sidebar_scroll_up(&mut self) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -48,20 +48,35 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> 
     }
 
     match app.view {
-      View::List => match key.code {
-        KeyCode::Char('q') | KeyCode::Esc => break,
-        KeyCode::Char('?') => app.view = View::Help,
-        KeyCode::Char('j') | KeyCode::Down => app.next(),
-        KeyCode::Char('k') | KeyCode::Up => app.prev(),
-        KeyCode::Char('r') => app.refresh()?,
-        KeyCode::Char('n') => app.enter_create(),
-        KeyCode::Char('d') => app.enter_confirm_delete(),
-        KeyCode::Char('b') => app.bootstrap_selected(),
-        KeyCode::Char('p') => app.toggle_delete_branch(),
-        KeyCode::Char('o') => app.open_selected_in_finder(),
-        KeyCode::Enter => app.copy_path_to_status(),
-        _ => {}
-      },
+      View::List => {
+        // Two-keystroke vim motion `gg`: any non-'g' keypress disarms it.
+        if !matches!(key.code, KeyCode::Char('g')) {
+          app.cancel_pending_motion();
+        }
+        match key.code {
+          KeyCode::Char('q') | KeyCode::Esc => break,
+          KeyCode::Char('?') => app.view = View::Help,
+          KeyCode::Char('j') | KeyCode::Down => app.next(),
+          KeyCode::Char('k') | KeyCode::Up => app.prev(),
+          KeyCode::Char('g') => app.handle_g(),
+          KeyCode::Char('G') => app.last(),
+          KeyCode::Char('v') => app.toggle_sidebar(),
+          KeyCode::Tab => app.toggle_focus(),
+          KeyCode::Char('l') => {
+            if let Some(path) = app.launch_lazygit() {
+              run_lazygit(terminal, &path, &mut app)?;
+            }
+          }
+          KeyCode::Char('r') => app.refresh()?,
+          KeyCode::Char('n') => app.enter_create(),
+          KeyCode::Char('d') => app.enter_confirm_delete(),
+          KeyCode::Char('b') => app.bootstrap_selected(),
+          KeyCode::Char('p') => app.toggle_delete_branch(),
+          KeyCode::Char('o') => app.open_selected_in_finder(),
+          KeyCode::Enter => app.copy_path_to_status(),
+          _ => {}
+        }
+      }
       View::Help => match key.code {
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => app.view = View::List,
         _ => {}
@@ -101,6 +116,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> 
         _ => {}
       },
     }
+  }
+  Ok(())
+}
+
+/// Suspend the TUI, run `lazygit -p <path>` inheriting the terminal, then restore.
+/// Errors from lazygit itself are surfaced via the status bar, never propagated up.
+fn run_lazygit(
+  terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+  path: &std::path::Path,
+  app: &mut App,
+) -> Result<()> {
+  // Release the terminal so lazygit can take over.
+  disable_raw_mode()?;
+  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+  terminal.show_cursor()?;
+
+  let spawn = std::process::Command::new("lazygit").arg("-p").arg(path).status();
+
+  // Always restore the TUI, even if lazygit failed.
+  enable_raw_mode()?;
+  execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
+  terminal.clear()?;
+
+  match spawn {
+    Ok(s) if s.success() => app.status = format!("lazygit exited ok ({})", path.display()),
+    Ok(s) => app.status = format!("lazygit exited with code {:?}", s.code()),
+    Err(e) => app.status = format!("failed to launch lazygit: {}", e),
   }
   Ok(())
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -46,6 +46,8 @@ fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
     draw_list(f, split[0], app);
     draw_sidebar(f, split[1], app);
   } else {
+    // Sidebar not rendered → no scrollable surface → no max scroll to track.
+    app.sidebar_max_scroll = 0;
     draw_list(f, area, app);
   }
 }
@@ -114,20 +116,44 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
 
 /// Details panel for the selected worktree — structured info, recent commits,
 /// working-tree status, and a commands cheat-sheet (lazyssh-style layout).
-fn draw_sidebar(f: &mut Frame, area: Rect, app: &App) {
+///
+/// Content is cached on `App` keyed by the selected worktree's path so the
+/// underlying `git log` / `git status` only run when the selection changes
+/// or `refresh()` invalidates the cache.
+fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   let border_color = if app.sidebar_focused {
     Color::Cyan
   } else {
     Color::DarkGray
   };
-  let (title, lines) = match app.selected() {
-    Some(w) => (" Details ".to_string(), sidebar_lines(w)),
-    None => (" Details ".into(), vec![Line::from("(nothing selected)")]),
+
+  // Resolve (or populate) the cached content for the currently selected worktree.
+  let lines: Vec<Line<'static>> = match app.selected().cloned() {
+    Some(w) => {
+      let needs_refresh = match &app.sidebar_cache {
+        Some((p, _)) => *p != w.path,
+        None => true,
+      };
+      if needs_refresh {
+        app.sidebar_cache = Some((w.path.clone(), sidebar_lines(&w)));
+      }
+      app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default()
+    }
+    None => vec![Line::from("(nothing selected)")],
   };
+
+  // Track the maximum scrollable offset so `sidebar_scroll_down` can clamp.
+  // `area.height - 2` accounts for the top + bottom border lines.
+  let content_len = lines.len() as u16;
+  let visible = area.height.saturating_sub(2);
+  app.sidebar_max_scroll = content_len.saturating_sub(visible);
+  if app.sidebar_scroll > app.sidebar_max_scroll {
+    app.sidebar_scroll = app.sidebar_max_scroll;
+  }
 
   let block = Block::default()
     .borders(Borders::ALL)
-    .title(title)
+    .title(" Details ")
     .border_style(Style::default().fg(border_color));
 
   let paragraph = Paragraph::new(lines)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,7 +1,7 @@
 use super::app::{App, Field, View};
 use crate::bootstrap::StepStatus;
 use crate::naming::BRANCH_TYPES;
-use crate::worktree::{BranchStatus, WorktreeInfo};
+use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
   layout::{Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
@@ -10,6 +10,10 @@ use ratatui::{
   Frame,
 };
 
+/// Minimum total terminal width required to render the sidebar alongside the
+/// worktree table without compressing the table beyond readability.
+pub const SIDEBAR_MIN_WIDTH: u16 = 120;
+
 pub fn draw(f: &mut Frame, app: &mut App) {
   let chunks = Layout::default()
     .direction(Direction::Vertical)
@@ -17,7 +21,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     .split(f.area());
 
   draw_header(f, chunks[0], app);
-  draw_list(f, chunks[1], app);
+  draw_body(f, chunks[1], app);
   draw_footer(f, chunks[2], app);
 
   match app.view {
@@ -26,6 +30,23 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::Confirm => draw_confirm(f, app),
     View::Report => draw_report(f, app),
     View::List => {}
+  }
+}
+
+/// Decide whether to split horizontally for a sidebar, based on terminal width
+/// and user preference. Sidebar is hidden on narrow terminals to keep the
+/// worktree table readable.
+fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
+  let show_sidebar = app.sidebar_open && area.width >= SIDEBAR_MIN_WIDTH;
+  if show_sidebar {
+    let split = Layout::default()
+      .direction(Direction::Horizontal)
+      .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+      .split(area);
+    draw_list(f, split[0], app);
+    draw_sidebar(f, split[1], app);
+  } else {
+    draw_list(f, area, app);
   }
 }
 
@@ -73,6 +94,9 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     Constraint::Min(20),
   ];
 
+  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
+  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
+
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
@@ -80,12 +104,190 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
       Block::default()
         .borders(Borders::ALL)
         .title(format!(" worktrees ({}) ", app.worktrees.len()))
-        .border_style(Style::default().fg(Color::DarkGray)),
+        .border_style(Style::default().fg(border_color)),
     )
     .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
     .highlight_symbol("▶ ");
 
   f.render_stateful_widget(table, area, &mut app.list_state);
+}
+
+/// Details panel for the selected worktree — structured info, recent commits,
+/// working-tree status, and a commands cheat-sheet (lazyssh-style layout).
+fn draw_sidebar(f: &mut Frame, area: Rect, app: &App) {
+  let border_color = if app.sidebar_focused {
+    Color::Cyan
+  } else {
+    Color::DarkGray
+  };
+  let (title, lines) = match app.selected() {
+    Some(w) => (" Details ".to_string(), sidebar_lines(w)),
+    None => (" Details ".into(), vec![Line::from("(nothing selected)")]),
+  };
+
+  let block = Block::default()
+    .borders(Borders::ALL)
+    .title(title)
+    .border_style(Style::default().fg(border_color));
+
+  let paragraph = Paragraph::new(lines)
+    .block(block)
+    .wrap(Wrap { trim: false })
+    .scroll((app.sidebar_scroll, 0));
+
+  f.render_widget(paragraph, area);
+}
+
+fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  let mut out: Vec<Line> = vec![
+    // Header — worktree name in bold.
+    Line::from(Span::styled(
+      w.name.clone(),
+      Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+    )),
+    Line::from(""),
+    // Basic Settings block.
+    section_header("Basic Settings:"),
+    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), Color::Green),
+    kv("Path", w.path.display().to_string(), Color::Gray),
+    kv(
+      "Head",
+      w.head.as_deref().map(short_oid).unwrap_or_else(|| "-".into()),
+      Color::Yellow,
+    ),
+    kv("Main", yes_no(w.is_main), Color::Yellow),
+    kv("Locked", yes_no(w.is_locked), Color::Magenta),
+    kv("Prunable", yes_no(w.is_prunable), Color::Red),
+    kv("Status", branch_status_label(&w.status), branch_status_color(&w.status)),
+    Line::from(""),
+  ];
+
+  // Recent commits block.
+  out.push(section_header("Recent commits:"));
+  match worktree::git_log_oneline(&w.path, 10) {
+    Ok(s) if !s.trim().is_empty() => {
+      for line in s.lines() {
+        out.push(Line::from(format!("  {}", line)));
+      }
+    }
+    Ok(_) => out.push(Line::from(Span::styled(
+      "  (no commits)",
+      Style::default().fg(Color::DarkGray),
+    ))),
+    Err(e) => out.push(Line::from(Span::styled(
+      format!("  ! {}", e),
+      Style::default().fg(Color::Red),
+    ))),
+  }
+  out.push(Line::from(""));
+
+  // Working tree block.
+  out.push(section_header("Working tree:"));
+  match worktree::git_status_short(&w.path) {
+    Ok(s) if s.trim().is_empty() => out.push(Line::from(Span::styled("  ✓ clean", Style::default().fg(Color::Green)))),
+    Ok(s) => {
+      for line in s.lines() {
+        out.push(Line::from(format!("  {}", line)));
+      }
+    }
+    Err(e) => out.push(Line::from(Span::styled(
+      format!("  ! {}", e),
+      Style::default().fg(Color::Red),
+    ))),
+  }
+  out.push(Line::from(""));
+
+  // Commands cheat-sheet (lazyssh style).
+  out.push(section_header("Commands:"));
+  for (key, label) in [
+    ("Enter", "Copy path to status"),
+    ("    l", "Launch lazygit fullscreen"),
+    ("    o", "Open dir in OS file manager"),
+    ("    b", "Bootstrap worktree"),
+    ("    n", "New worktree"),
+    ("    d", "Delete worktree"),
+    ("    p", "Toggle delete-branch-on-remove"),
+    ("    r", "Refresh"),
+    ("    v", "Toggle this sidebar"),
+    ("  Tab", "Swap focus list ↔ sidebar"),
+    ("   gg", "Jump to first worktree"),
+    ("    G", "Jump to last worktree"),
+    ("  j/k", "Next / Prev (or scroll sidebar)"),
+    ("    ?", "Help"),
+    ("    q", "Quit"),
+  ] {
+    out.push(Line::from(vec![
+      Span::styled(format!("  {}: ", key), Style::default().fg(Color::Cyan)),
+      Span::raw(label),
+    ]));
+  }
+  out
+}
+
+fn section_header(text: &str) -> Line<'static> {
+  Line::from(Span::styled(
+    text.to_string(),
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  ))
+}
+
+fn kv(key: &str, value: String, value_color: Color) -> Line<'static> {
+  Line::from(vec![
+    Span::styled(format!("  {}: ", key), Style::default().fg(Color::DarkGray)),
+    Span::styled(value, Style::default().fg(value_color)),
+  ])
+}
+
+fn yes_no(b: bool) -> String {
+  if b {
+    "true".into()
+  } else {
+    "false".into()
+  }
+}
+
+fn short_oid(oid: &str) -> String {
+  oid.chars().take(7).collect()
+}
+
+fn branch_status_label(s: &BranchStatus) -> String {
+  if s.unknown {
+    return "unknown".into();
+  }
+  let mut parts: Vec<String> = Vec::new();
+  if s.is_dirty {
+    parts.push("dirty".into());
+  }
+  if s.has_upstream {
+    if s.ahead > 0 {
+      parts.push(format!("↑{}", s.ahead));
+    }
+    if s.behind > 0 {
+      parts.push(format!("↓{}", s.behind));
+    }
+    if !s.is_dirty && s.synced() {
+      parts.push("synced".into());
+    }
+  } else if !s.is_dirty {
+    parts.push("clean".into());
+  }
+  if parts.is_empty() {
+    "clean".into()
+  } else {
+    parts.join(" ")
+  }
+}
+
+fn branch_status_color(s: &BranchStatus) -> Color {
+  if s.unknown {
+    Color::DarkGray
+  } else if s.is_dirty || s.behind > 0 {
+    Color::Yellow
+  } else if s.ahead > 0 {
+    Color::Cyan
+  } else {
+    Color::Green
+  }
 }
 
 /// Constraint-friendly column width based on observed content, clamped to [min, max].
@@ -169,7 +371,7 @@ fn format_status(s: &BranchStatus, width: usize) -> (String, Color) {
 }
 
 fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
-  let help = "n:new  d:del  b:bootstrap  o:open  r:refresh  p:tog-branch  enter:path  ?:help  q:quit";
+  let help = "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus gg/G:top/bot j/k:nav r:refresh ?:help q:quit";
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
     Span::raw("  "),
@@ -191,12 +393,17 @@ fn draw_help(f: &mut Frame) {
     Line::from("  Ctrl-C        force quit"),
     Line::from(""),
     Line::from("list view"),
-    Line::from("  j / ↓         next"),
-    Line::from("  k / ↑         prev"),
+    Line::from("  j / ↓         next (scrolls sidebar when focused)"),
+    Line::from("  k / ↑         prev (scrolls sidebar when focused)"),
+    Line::from("  gg            jump to first worktree"),
+    Line::from("  G             jump to last worktree"),
     Line::from("  n             new worktree"),
     Line::from("  d             delete selected"),
     Line::from("  b             bootstrap selected"),
     Line::from("  o             open dir in OS file manager (open / xdg-open / explorer)"),
+    Line::from("  l             launch lazygit fullscreen on selected worktree"),
+    Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
+    Line::from("  Tab           swap focus between worktree list and sidebar"),
     Line::from("  r             refresh"),
     Line::from("  p             toggle 'delete branch on remove'"),
     Line::from("  enter         show path in status bar"),

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,6 +1,7 @@
 use crate::error::{GwmError, Result};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -250,6 +251,45 @@ pub fn prune(repo: &Repository) -> Result<usize> {
     }
   }
   Ok(pruned)
+}
+
+/// Shell out to `git log --oneline -n <n>` inside `path` and return raw stdout.
+/// Used by the TUI sidebar to preview recent commits of the selected worktree.
+pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["log", "--oneline", "-n"])
+    .arg(n.to_string())
+    .output()
+    .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::Other(format!(
+      "git log exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Shell out to `git status --short` inside `path` and return raw stdout.
+/// Used by the TUI sidebar to preview the working-tree state.
+pub fn git_status_short(path: &Path) -> Result<String> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["status", "--short"])
+    .output()
+    .map_err(|e| GwmError::Other(format!("git status failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::Other(format!(
+      "git status exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Resolve a worktree by exact name first, then by substring (case-insensitive) within the dir name.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -107,3 +107,127 @@ fn refresh_keeps_selection_in_bounds() {
   app.refresh().unwrap();
   assert_eq!(app.list_state.selected(), Some(0));
 }
+
+// ---- sidebar / focus / vim motions ---------------------------------------
+
+#[test]
+fn sidebar_open_by_default() {
+  let (_dir, app) = make_app();
+  assert!(
+    app.sidebar_open,
+    "sidebar should default to open (will be hidden when narrow)"
+  );
+  assert!(!app.sidebar_focused, "focus defaults to the worktree list");
+}
+
+#[test]
+fn toggle_sidebar_flips_open_flag() {
+  let (_dir, mut app) = make_app();
+  let before = app.sidebar_open;
+  app.toggle_sidebar();
+  assert_eq!(app.sidebar_open, !before);
+  app.toggle_sidebar();
+  assert_eq!(app.sidebar_open, before);
+}
+
+#[test]
+fn toggle_sidebar_when_closed_resets_focus_to_list() {
+  let (_dir, mut app) = make_app();
+  app.sidebar_focused = true;
+  app.sidebar_open = true;
+  app.toggle_sidebar(); // close
+  assert!(!app.sidebar_open);
+  assert!(
+    !app.sidebar_focused,
+    "closing the sidebar must drop focus back to the list"
+  );
+}
+
+#[test]
+fn toggle_focus_only_works_when_sidebar_open() {
+  let (_dir, mut app) = make_app();
+  app.sidebar_open = false;
+  app.toggle_focus();
+  assert!(!app.sidebar_focused, "focus cannot move to a hidden sidebar");
+
+  app.sidebar_open = true;
+  app.toggle_focus();
+  assert!(app.sidebar_focused);
+  app.toggle_focus();
+  assert!(!app.sidebar_focused);
+}
+
+#[test]
+fn first_selects_first_worktree() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.first();
+  assert_eq!(app.list_state.selected(), Some(0));
+}
+
+#[test]
+fn last_selects_last_worktree() {
+  let (_dir, mut app) = make_app();
+  app.last();
+  let expected = app.worktrees.len().saturating_sub(1);
+  assert_eq!(app.list_state.selected(), Some(expected));
+}
+
+#[test]
+fn handle_g_motion_tracks_pending_then_jumps_to_first() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  // First `g` arms the motion but does not move.
+  assert!(!app.pending_g);
+  app.handle_g();
+  assert!(app.pending_g, "first 'g' must arm the gg sequence");
+  // Second `g` jumps to first and disarms.
+  app.handle_g();
+  assert!(!app.pending_g, "second 'g' completes gg and disarms");
+  assert_eq!(app.list_state.selected(), Some(0));
+}
+
+#[test]
+fn pending_g_resets_on_other_key() {
+  let (_dir, mut app) = make_app();
+  app.handle_g();
+  assert!(app.pending_g);
+  app.cancel_pending_motion();
+  assert!(!app.pending_g, "any non-g keypress must drop the pending motion");
+}
+
+#[test]
+fn sidebar_scroll_clamps_to_zero() {
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.sidebar_scroll, 0);
+  app.sidebar_scroll_up();
+  assert_eq!(app.sidebar_scroll, 0, "scrolling up from 0 stays at 0");
+  app.sidebar_scroll_down();
+  assert_eq!(app.sidebar_scroll, 1);
+  app.sidebar_scroll_up();
+  assert_eq!(app.sidebar_scroll, 0);
+}
+
+#[test]
+fn focus_routes_navigation_to_sidebar() {
+  // When sidebar is focused, next()/prev() should NOT move the list selection.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.sidebar_open = true;
+  app.sidebar_focused = true;
+
+  app.next();
+  assert_eq!(
+    app.list_state.selected(),
+    Some(0),
+    "list must stay put when sidebar has focus"
+  );
+  assert!(
+    app.sidebar_scroll >= 1,
+    "next() must scroll the sidebar when it has focus"
+  );
+
+  app.prev();
+  assert_eq!(app.list_state.selected(), Some(0));
+  assert_eq!(app.sidebar_scroll, 0, "prev() scrolled back up");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -202,10 +202,27 @@ fn sidebar_scroll_clamps_to_zero() {
   assert_eq!(app.sidebar_scroll, 0);
   app.sidebar_scroll_up();
   assert_eq!(app.sidebar_scroll, 0, "scrolling up from 0 stays at 0");
+
+  // The renderer normally publishes a max bound; simulate enough room for scroll.
+  app.sidebar_max_scroll = 5;
   app.sidebar_scroll_down();
   assert_eq!(app.sidebar_scroll, 1);
   app.sidebar_scroll_up();
   assert_eq!(app.sidebar_scroll, 0);
+}
+
+#[test]
+fn sidebar_scroll_clamps_at_max() {
+  // The renderer sets `sidebar_max_scroll`. Scrolling past it must stop there
+  // so the user can't push the panel content entirely off-screen.
+  let (_dir, mut app) = make_app();
+  app.sidebar_max_scroll = 3;
+  app.sidebar_scroll_down();
+  app.sidebar_scroll_down();
+  app.sidebar_scroll_down();
+  assert_eq!(app.sidebar_scroll, 3);
+  app.sidebar_scroll_down();
+  assert_eq!(app.sidebar_scroll, 3, "scrolling beyond max must clamp");
 }
 
 #[test]
@@ -215,6 +232,7 @@ fn focus_routes_navigation_to_sidebar() {
   app.list_state.select(Some(0));
   app.sidebar_open = true;
   app.sidebar_focused = true;
+  app.sidebar_max_scroll = 5; // pretend the renderer has populated this
 
   app.next();
   assert_eq!(
@@ -230,4 +248,26 @@ fn focus_routes_navigation_to_sidebar() {
   app.prev();
   assert_eq!(app.list_state.selected(), Some(0));
   assert_eq!(app.sidebar_scroll, 0, "prev() scrolled back up");
+}
+
+#[test]
+fn next_prev_invalidate_sidebar_cache() {
+  // Moving selection must drop any cached sidebar content so the new
+  // worktree's preview is recomputed on the next frame.
+  let (_dir, mut app) = make_app();
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.next();
+  assert!(app.sidebar_cache.is_none(), "next() must invalidate the sidebar cache");
+
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.prev();
+  assert!(app.sidebar_cache.is_none(), "prev() must invalidate the sidebar cache");
+}
+
+#[test]
+fn refresh_invalidates_sidebar_cache() {
+  let (_dir, mut app) = make_app();
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.refresh().unwrap();
+  assert!(app.sidebar_cache.is_none());
 }

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -134,3 +134,65 @@ fn discover_from_inside_linked_worktree_walks_back_to_main() {
   let main_again = worktree::discover_repo(Some(&target)).unwrap();
   assert!(paths_equal(main_again.workdir().unwrap(), dir.path()));
 }
+
+// ---- git_log_oneline / git_status_short -------------------------------------
+
+#[test]
+fn git_log_oneline_returns_seed_commit() {
+  let (dir, _) = init_repo();
+  let out = worktree::git_log_oneline(dir.path(), 10).unwrap();
+  let lines: Vec<&str> = out.lines().collect();
+  assert_eq!(lines.len(), 1, "init_repo seeds one commit, got: {:?}", lines);
+  assert!(
+    lines[0].contains("init"),
+    "expected seed commit message 'init', got: {}",
+    lines[0]
+  );
+}
+
+#[test]
+fn git_log_oneline_respects_limit() {
+  use git2::Signature;
+  let (dir, repo) = init_repo();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  // Add two extra commits on top of the seed → 3 total.
+  for i in 0..2 {
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let tree = repo.find_tree(repo.index().unwrap().write_tree().unwrap()).unwrap();
+    repo
+      .commit(Some("HEAD"), &sig, &sig, &format!("c{}", i), &tree, &[&parent])
+      .unwrap();
+  }
+  let out = worktree::git_log_oneline(dir.path(), 2).unwrap();
+  assert_eq!(out.lines().count(), 2);
+}
+
+#[test]
+fn git_status_short_empty_on_clean_repo() {
+  let (dir, _) = init_repo();
+  let out = worktree::git_status_short(dir.path()).unwrap();
+  assert!(
+    out.trim().is_empty(),
+    "clean repo should produce empty status, got: {:?}",
+    out
+  );
+}
+
+#[test]
+fn git_status_short_lists_untracked_file() {
+  let (dir, _) = init_repo();
+  std::fs::write(dir.path().join("new.txt"), "hello").unwrap();
+  let out = worktree::git_status_short(dir.path()).unwrap();
+  assert!(
+    out.contains("new.txt"),
+    "expected untracked new.txt in status, got: {:?}",
+    out
+  );
+}
+
+#[test]
+fn git_log_oneline_errors_outside_repo() {
+  let empty = TempDir::new().unwrap();
+  let err = worktree::git_log_oneline(empty.path(), 5);
+  assert!(err.is_err(), "expected error outside a git repo, got: {:?}", err);
+}


### PR DESCRIPTION
## Description

Adds a lazyssh-style **details sidebar** to the gwm TUI listing view, plus a one-key launch of **lazygit fullscreen** on the selected worktree, and **vim motions** (`gg`/`G`) for first/last navigation.

Closes #10

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **New `worktree::git_log_oneline(path, n)` + `worktree::git_status_short(path)`**: thin `std::process::Command` wrappers around `git log --oneline -n N` and `git status --short`. Errors surface as `GwmError::Other` so the TUI can render them in-pane.
- **Responsive details sidebar** (right pane, auto-shown when terminal ≥ **120 cols**, toggle with `v`). Lazyssh-inspired layout:
  - **Basic Settings** — branch, path, head (short OID), `main` / `locked` / `prunable` flags, branch status.
  - **Recent commits** — `git log --oneline -n 10`.
  - **Working tree** — `git status --short` (`✓ clean` when empty).
  - **Commands** — keybindings cheat-sheet rendered inside the panel.
- **Focus toggle (`Tab`)**: cyan border marks the focused panel. `j`/`k` (and arrows) scroll the sidebar when it has focus instead of moving the worktree selection.
- **Lazygit fullscreen (`l`)**: suspends the TUI (`LeaveAlternateScreen` + raw mode off), runs `lazygit -p <selected-path>` inheriting the terminal, restores the TUI on exit. Missing binary → clean status-bar message, no crash.
- **Vim motions**: `gg` jumps to first worktree, `G` to last. Two-keystroke `gg` driven by a `pending_g` flag, cancelled by any non-`g` key.
- Docs in sync: `CHANGELOG.md` (Unreleased), `README.md` key map / sidebar / lazygit sections, `skills/SKILL.md` for the Claude Code skill.

## Tests

- [x] \`cargo test\` passes locally — **71 tests, all green** (was 56).
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [x] New tests under \`tests/\` (TDD: written before implementation):
  - \`tests/worktree_integration.rs\` — 5 new tests for \`git_log_oneline\` / \`git_status_short\` (seed commit, limit, clean status, untracked file, error path).
  - \`tests/tui_app_tests.rs\` — 10 new tests: sidebar default open, toggle, focus-on-close reset, focus only when open, first/last, \`gg\` motion, pending-motion reset, scroll clamp, focus routes nav to sidebar.

## Screenshots / TUI captures

Visual reference (lazyssh, provided by the user) was used as the layout inspiration for the right pane: header → \`Basic Settings:\` block → \`Commands:\` block. Local manual run: \`cargo run\` in this repo with the terminal at ≥ 120 cols renders the sidebar; toggling \`v\` hides it; \`Tab\` swaps focus; \`l\` opens lazygit on the selected worktree.

## Checklist

- [x] Branch follows \`<type>/#<issue>-<description>\` → \`feat/#10-tui-lazygit-sidebar\`
- [x] Commits follow Gitmoji + Conventional Commits (3 atomic commits: helpers, TUI feature, docs)
- [x] CHANGELOG.md updated under \`## [Unreleased]\`
- [x] README updated (key map, sidebar section, lazygit section)
- [ ] \`examples/gwm.toml.example\` updated if config schema changed — N/A (no schema change)
- [x] No \`unwrap()\` on user-facing paths (returns \`GwmError\` instead)
- [x] No \`println!\` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #10
- Related PR: —

## Notes for reviewers

- **Why static preview + fullscreen launch instead of a true embedded PTY?** A real embedded lazygit panel would need \`portable-pty\` + \`tui-term\` (~300-500 LoC of plumbing, complex focus/resize routing, 2 heavy deps). The chosen design covers ~95% of the use case at a fraction of the cost: see the selected worktree's state at a glance, drop into lazygit on demand.
- **Why \`std::process::Command\` for \`git log\`/\`git status\` instead of git2?** One-liner formatting via git2 would need ~30 lines and re-implement \`--oneline\`/\`--short\` semantics. The shell-out is bounded (10 commits, \`status --short\`), runs once per draw on a cached selection, and errors are surfaced safely.
- **Base branch is \`dev\`** (not \`main\`) — per the new \`dev\` → \`main\` workflow set up earlier this session.