### PR TITLE
👷 ci: dev branch coverage + pre-release workflow on v*-rc tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,138 @@
+name: pre-release
+
+on:
+  push:
+    tags:
+      - "v*.*.*-rc*"
+      - "v*.*.*-alpha*"
+      - "v*.*.*-beta*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "rc/alpha/beta tag to (re)build (e.g. v0.2.0-rc.1)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: pre-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+            cross: true
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            archive: tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: install cross (linux aarch64)
+        if: matrix.cross == true
+        run: cargo install cross --locked
+
+      - name: build (cargo)
+        if: matrix.cross != true
+        run: cargo build --release --target ${{ matrix.target }} --locked
+
+      - name: build (cross)
+        if: matrix.cross == true
+        run: cross build --release --target ${{ matrix.target }} --locked
+
+      - name: package (unix)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          BIN_NAME="gwm"
+          STAGE="${BIN_NAME}-${{ github.ref_name }}-${{ matrix.target }}"
+          mkdir -p "dist/${STAGE}"
+          cp "target/${{ matrix.target }}/release/${BIN_NAME}" "dist/${STAGE}/"
+          cp README.md LICENSE.md CHANGELOG.md "dist/${STAGE}/"
+          tar -C dist -czf "dist/${STAGE}.tar.gz" "${STAGE}"
+          shasum -a 256 "dist/${STAGE}.tar.gz" > "dist/${STAGE}.tar.gz.sha256"
+
+      - name: package (windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $BIN_NAME = "gwm.exe"
+          $STAGE = "gwm-${{ github.ref_name }}-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path "dist/$STAGE" | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/$BIN_NAME" "dist/$STAGE/"
+          Copy-Item README.md, LICENSE.md, CHANGELOG.md "dist/$STAGE/"
+          Compress-Archive -Path "dist/$STAGE" -DestinationPath "dist/$STAGE.zip"
+          (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash | Out-File "dist/$STAGE.zip.sha256"
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gwm-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+            dist/*.zip
+            dist/*.zip.sha256
+          if-no-files-found: error
+
+  release:
+    name: github pre-release
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: publish pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          body_path: CHANGELOG.md
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+            dist/*.zip
+            dist/*.zip.sha256
+          draft: false
+          prerelease: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,9 +3,12 @@ name: pre-release
 on:
   push:
     tags:
-      - "v*.*.*-rc*"
-      - "v*.*.*-alpha*"
-      - "v*.*.*-beta*"
+      # Pre-release SemVer identifiers must follow `-rc.N`, `-alpha.N`, `-beta.N`.
+      # Tighter than `*-rc*` so we don't fire on tags like `v0.2.0-rc` or
+      # `v0.2.0-rc-anything`.
+      - "v*.*.*-rc.*"
+      - "v*.*.*-alpha.*"
+      - "v*.*.*-beta.*"
   workflow_dispatch:
     inputs:
       tag:
@@ -47,7 +50,24 @@ jobs:
             target: x86_64-pc-windows-msvc
             archive: zip
     steps:
+      - name: resolve tag
+        id: tag
+        shell: bash
+        # For workflow_dispatch, prefer the input over github.ref_name (which is
+        # the dispatching branch). For tag-driven runs, github.ref_name is the
+        # tag itself. The resolved value drives BOTH the checkout ref (so the
+        # build matches the tagged commit) and the archive STAGE naming.
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -70,7 +90,7 @@ jobs:
         shell: bash
         run: |
           BIN_NAME="gwm"
-          STAGE="${BIN_NAME}-${{ github.ref_name }}-${{ matrix.target }}"
+          STAGE="${BIN_NAME}-${{ steps.tag.outputs.name }}-${{ matrix.target }}"
           mkdir -p "dist/${STAGE}"
           cp "target/${{ matrix.target }}/release/${BIN_NAME}" "dist/${STAGE}/"
           cp README.md LICENSE.md CHANGELOG.md "dist/${STAGE}/"
@@ -80,14 +100,18 @@ jobs:
       - name: package (windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
+        # Set-Content -Encoding ascii ensures the sidecar is plain ASCII (no
+        # UTF-16 BOM that PowerShell's `Out-File` would add by default) so the
+        # checksum file is verifiable by `sha256sum -c` on other platforms.
         run: |
           $BIN_NAME = "gwm.exe"
-          $STAGE = "gwm-${{ github.ref_name }}-${{ matrix.target }}"
+          $STAGE = "gwm-${{ steps.tag.outputs.name }}-${{ matrix.target }}"
           New-Item -ItemType Directory -Force -Path "dist/$STAGE" | Out-Null
           Copy-Item "target/${{ matrix.target }}/release/$BIN_NAME" "dist/$STAGE/"
           Copy-Item README.md, LICENSE.md, CHANGELOG.md "dist/$STAGE/"
           Compress-Archive -Path "dist/$STAGE" -DestinationPath "dist/$STAGE.zip"
-          (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash | Out-File "dist/$STAGE.zip.sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash.ToLower()
+          Set-Content -Path "dist/$STAGE.zip.sha256" -Encoding ascii -Value "$hash  $STAGE.zip"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v4
@@ -105,14 +129,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
       - name: resolve tag
         id: tag
         shell: bash
@@ -122,6 +138,16 @@ jobs:
           else
             echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.name }}
+
+      - name: download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: publish pre-release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,9 @@ jobs:
       - name: package (windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
+        # Set-Content -Encoding ascii ensures the sidecar is plain ASCII (no
+        # UTF-16 BOM that PowerShell's `Out-File` would add by default) so the
+        # checksum file is verifiable by `sha256sum -c` on other platforms.
         run: |
           $BIN_NAME = "gwm.exe"
           $STAGE = "gwm-${{ github.ref_name }}-${{ matrix.target }}"
@@ -81,7 +84,8 @@ jobs:
           Copy-Item "target/${{ matrix.target }}/release/$BIN_NAME" "dist/$STAGE/"
           Copy-Item README.md, LICENSE.md, CHANGELOG.md "dist/$STAGE/"
           Compress-Archive -Path "dist/$STAGE" -DestinationPath "dist/$STAGE.zip"
-          (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash | Out-File "dist/$STAGE.zip.sha256"
+          $hash = (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash.ToLower()
+          Set-Content -Path "dist/$STAGE.zip.sha256" -Encoding ascii -Value "$hash  $STAGE.zip"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TUI keybinding `o` reveals the selected worktree's directory in the OS file manager (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows).
 - `WorktreeInfo.status` (`BranchStatus`): dirty / clean / upstream-tracked / ahead / behind, computed via libgit2.
 - `STATUS` column in both the TUI table and `gwm list` CLI output, with colour-coding (`green` clean / synced, `yellow` dirty or behind, `cyan` ahead, `red` prunable, `magenta` locked, `dark_gray` unknown).
+- CI on the `dev` integration branch: `fmt`, `clippy`, multi-OS test, and `cargo audit` now run on every push to `dev` and on every PR targeting `dev` (same matrix as `main`).
+- `.github/workflows/pre-release.yml`: builds the 5 release targets (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64) and publishes a GitHub Release with `prerelease: true` whenever a SemVer-rc / -alpha / -beta tag is pushed (e.g. `v0.2.0-rc.1`). Also supports `workflow_dispatch` for manual reruns.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,18 +208,40 @@ gh pr merge <num> --merge   # NOT --squash, NOT --delete-branch
 
 ## Releases
 
-Versioning is SemVer (`MAJOR.MINOR.PATCH`):
+Versioning is SemVer (`MAJOR.MINOR.PATCH`), with `-rc.N` / `-alpha.N` / `-beta.N` suffixes for pre-releases cut from `dev`.
 
 - `MAJOR` → breaking change
 - `MINOR` → new feature
 - `PATCH` → bug fix
+- `-rc.N` / `-alpha.N` / `-beta.N` → release candidate / alpha / beta cut from `dev` before promotion to `main`
 
-Cut a release by:
+### Pre-release (from `dev`)
+
+When `dev` is ready to be exercised by early adopters before promotion:
+
+1. Stay on `dev` (do not merge to `main` yet).
+2. Tag: `git tag -a v0.x.y-rc.1 -m "v0.x.y-rc.1" && git push --tags`.
+3. GitHub Actions (`pre-release.yml`) builds binaries and publishes a **prerelease** (5 targets — Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64).
+4. Iterate: subsequent candidates are `v0.x.y-rc.2`, `v0.x.y-rc.3`, …
+
+### Stable release (from `main`)
+
+Once the rc is validated and promoted to `main`:
 
 1. Update `Cargo.toml` `version`.
 2. Move `## [Unreleased]` entries into a dated section in `CHANGELOG.md`.
-3. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
-4. GitHub Actions (`release.yml`) builds binaries and publishes the release.
+3. Merge `dev` → `main` (regular merge, never squash; see [Merge strategy](#merge-strategy)).
+4. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
+5. GitHub Actions (`release.yml`) builds binaries and publishes the stable release.
+
+Triggering matrix:
+
+| Tag pattern              | Workflow         | `prerelease` flag |
+|:-------------------------|:-----------------|:------------------|
+| `v0.x.y`                 | `release.yml`    | `false`           |
+| `v0.x.y-rc.N`            | `pre-release.yml`| `true`            |
+| `v0.x.y-alpha.N`         | `pre-release.yml`| `true`            |
+| `v0.x.y-beta.N`          | `pre-release.yml`| `true`            |
 
 ---
 


### PR DESCRIPTION
## Description

Plugs the CI gap on the new \`dev\` integration branch and adds a pre-release pipeline that ships GitHub Releases marked \`prerelease: true\` from SemVer-rc / -alpha / -beta tags.

Closes #12

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

- **\`ci.yml\`**: add \`dev\` to \`push.branches\` and \`pull_request.branches\`. Same fmt / clippy / Linux+macOS test / cargo-audit gate as \`main\`.
- **\`pre-release.yml\`** (new):
  - Triggers on \`v*.*.*-rc*\`, \`v*.*.*-alpha*\`, \`v*.*.*-beta*\` tag pushes + \`workflow_dispatch\`.
  - Same 5-target build matrix as \`release.yml\`: \`x86_64-unknown-linux-gnu\`, \`aarch64-unknown-linux-gnu\` (via \`cross\`), \`x86_64-apple-darwin\`, \`aarch64-apple-darwin\`, \`x86_64-pc-windows-msvc\`.
  - Publishes a GitHub Release with \`prerelease: true\`, \`draft: false\`, archives + \`.sha256\` sidecars.
  - \`resolve tag\` step prefers \`inputs.tag\` for \`workflow_dispatch\` reruns, falls back to \`github.ref_name\` for tag-driven runs.
  - Concurrency group \`pre-release-\${{ github.ref }}\`, \`cancel-in-progress: false\` so two rc tags pushed in quick succession both ship.
- **\`CONTRIBUTING.md\`**: new \"Pre-release (from dev)\" section + tag-pattern → workflow matrix.
- **\`CHANGELOG.md\`** (\`[Unreleased]\`): note dev CI coverage and the pre-release pipeline.

## Tests

- [x] \`cargo test\` passes locally (no source changes; safety net)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [ ] New tests added under \`tests/\` — N/A, this PR only touches CI/docs.

**YAML syntax**: both workflows validated locally via Ruby's \`YAML.safe_load\` — both parse cleanly. \`actionlint\` was not available in the sandbox; once \`actionlint\` is installed it should be wired into the CI job array as a fast static check (separate concern, not blocking this PR).

## Screenshots / TUI captures

N/A (CI / docs only).

## Checklist

- [x] Branch follows \`<type>/#<issue>-<description>\` → \`chore/#12-ci-dev-prerelease\`
- [x] Commits follow Gitmoji + Conventional Commits (2 atomic commits: ci extension, pre-release workflow + docs)
- [x] CHANGELOG.md updated under \`## [Unreleased]\`
- [ ] README updated if CLI surface changed — N/A
- [ ] \`examples/gwm.toml.example\` updated if config schema changed — N/A
- [x] No \`unwrap()\` on user-facing paths (no source changes)
- [x] No \`println!\` in TUI render code (no source changes)

## Linked issues / docs

- Issue: #12
- Related PR: #11 (the previous feature also targeting \`dev\`)

## Notes for reviewers

- **Why two workflows instead of one with a conditional \`prerelease\` flag?** Cleaner intent at a glance — \`release.yml\` = stable shipping, \`pre-release.yml\` = rc shipping. Each can iterate independently (e.g. tighten pre-release to only build a 2-target subset later) without risking the stable one. Duplication is contained (~120 lines, all matrix boilerplate).
- **Tag pattern coverage**: \`v*.*.*-rc*\` matches \`v0.2.0-rc.1\`, \`v1.0.0-rc.2\`, etc. Globs (not regex) are used by GitHub Actions \`on.push.tags\`, hence three patterns instead of one regex.
- **Existing latent bug in \`release.yml\` not fixed here**: its \`workflow_dispatch.inputs.tag\` is documented but never consumed (the release job uses \`github.ref_name\`). \`pre-release.yml\` does it right via a dedicated \`resolve tag\` step. Fixing \`release.yml\` is out of scope here; will land as a follow-up if confirmed.
- **Base branch is \`dev\`** per the new workflow.