### PR TITLE
✨ feat(cli): shell completions (zsh / bash / fish / powershell / elvish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `gwm completions <shell>` — prints a static completion script on stdout, generated from the live clap argument tree via [`clap_complete`](https://docs.rs/clap_complete). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. Closes #18.
+- `gwm list --format=names` — prints one worktree name per line (no header, no marker, no STATUS column). Suitable for backing dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap` (see the README "shell completions" section for a zsh wiring example).
+
+### Dependencies
+
+- `clap_complete` `4.5` (new).
+
 ## [0.2.0] - 2026-05-18
 
 Validated via `v0.2.0-rc.1` (pre-release published on 2026-05-18).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +716,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "dirs 5.0.1",
  "git2",
@@ -1873,7 +1883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive", "color"] }
+clap_complete = "4.5"
 ratatui = "0.30"
 crossterm = "0.29"
 git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }

--- a/README.md
+++ b/README.md
@@ -89,12 +89,41 @@ gwm types                                   # list valid branch types
 gwm create feat 123 "user-authentication"   # → feat/#123-user-authentication
 gwm create feat 123 foo --no-bootstrap      # skip the .gwm.toml bootstrap stages
 gwm list                                    # list all worktrees of the current repo
+gwm list --format=names                     # one worktree name per line (for shell completion)
 gwm path auth                               # print the resolved path (use $(gwm path ...))
 gwm bootstrap                               # re-run bootstrap on the CWD worktree
 gwm bootstrap auth                          # ...or on a named one
 gwm remove auth                             # remove (fuzzy match) — keeps the branch
 gwm remove auth --delete-branch             # remove + drop the branch
 gwm prune                                   # clean stale .git/worktrees entries
+gwm completions zsh                         # print a zsh / bash / fish / powershell / elvish script
+```
+
+### shell completions
+
+`gwm completions <shell>` prints a static completion script (generated from the live clap argument tree, so it never drifts from the actual subcommands). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`.
+
+```bash
+# zsh — drop into the first writable fpath entry
+gwm completions zsh > "${fpath[1]}/_gwm"
+
+# bash — system-wide
+gwm completions bash | sudo tee /etc/bash_completion.d/gwm > /dev/null
+# bash — per-user
+gwm completions bash > ~/.local/share/bash-completion/completions/gwm
+
+# fish
+gwm completions fish > ~/.config/fish/completions/gwm.fish
+
+# PowerShell — append to your $PROFILE
+gwm completions powershell | Out-String | Invoke-Expression
+```
+
+For dynamic completion of worktree names (the `<pattern>` arg of `path` / `remove` / `bootstrap`), wire a custom completer to `gwm list --format=names` — e.g. in zsh:
+
+```zsh
+_gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
+compdef _gwm_worktrees gwm-path gwm-remove gwm-bootstrap
 ```
 
 ## configuration
@@ -172,13 +201,13 @@ Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde
 | multi-repo portability              | per-project script   | one binary, per-repo config      |
 | TUI                                 | linear bash menu     | full ratatui screen              |
 | anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 71 tests (config / naming / bootstrap / worktree / TUI / CLI) |
+| tests                               | none                 | 81 tests (config / naming / bootstrap / worktree / TUI / CLI) |
 
 ## development
 
 ```bash
 cargo build              # debug build
-cargo test               # 71 tests
+cargo test               # 81 tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ gwm completions bash > ~/.local/share/bash-completion/completions/gwm
 # fish
 gwm completions fish > ~/.config/fish/completions/gwm.fish
 
-# PowerShell — append to your $PROFILE
+# PowerShell — load into the current session (ephemeral)
 gwm completions powershell | Out-String | Invoke-Expression
+# PowerShell — persist by appending to $PROFILE
+gwm completions powershell | Out-File -Append -Encoding utf8 $PROFILE
 ```
 
 For dynamic completion of worktree names (the `<pattern>` arg of `path` / `remove` / `bootstrap`), wire a custom completer to `gwm list --format=names` — e.g. in zsh:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,7 +115,10 @@ fn cmd_list(format: ListFormat) -> Result<()> {
   let trees = worktree::list(&repo)?;
 
   if format == ListFormat::Names {
-    for w in &trees {
+    // Mirror `worktree::find_fuzzy`, which excludes the main workdir:
+    // emitting its name here would suggest a completion candidate that
+    // `path` / `remove` / `bootstrap` can never accept.
+    for w in trees.iter().filter(|w| !w.is_main) {
       println!("{}", w.name);
     }
     return Ok(());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,9 @@ use crate::config::Config;
 use crate::error::{GwmError, Result};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::{generate, Shell};
+use std::io;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -13,12 +15,24 @@ pub struct Cli {
   pub command: Option<Command>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ListFormat {
+  /// Human-readable table (default).
+  Table,
+  /// One worktree name per line — suitable for shell completion.
+  Names,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
   /// Write a default .gwm.toml to the current repo.
   Init,
   /// List worktrees in the current repo.
-  List,
+  List {
+    /// Output format. `names` prints one worktree name per line (for shell completion).
+    #[arg(long, value_enum, default_value_t = ListFormat::Table)]
+    format: ListFormat,
+  },
   /// Create a new worktree (and matching branch).
   Create {
     /// Branch type (feat, fix, hotfix, docs, test, refactor, chore, perf, ci, build).
@@ -52,6 +66,16 @@ pub enum Command {
   Prune,
   /// List the supported branch types.
   Types,
+  /// Generate a shell completion script on stdout.
+  ///
+  /// Install (zsh):  `gwm completions zsh > $fpath[1]/_gwm`
+  /// Install (bash): `gwm completions bash > /etc/bash_completion.d/gwm`
+  /// Install (fish): `gwm completions fish > ~/.config/fish/completions/gwm.fish`
+  Completions {
+    /// Target shell.
+    #[arg(value_enum)]
+    shell: Shell,
+  },
 }
 
 pub fn run(cli: Cli) -> Result<()> {
@@ -62,7 +86,7 @@ pub fn run(cli: Cli) -> Result<()> {
 
   match cmd {
     Command::Init => cmd_init(),
-    Command::List => cmd_list(),
+    Command::List { format } => cmd_list(format),
     Command::Create {
       branch_type,
       issue,
@@ -74,6 +98,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Bootstrap { target } => cmd_bootstrap(target),
     Command::Prune => cmd_prune(),
     Command::Types => cmd_types(),
+    Command::Completions { shell } => cmd_completions(shell),
   }
 }
 
@@ -85,9 +110,16 @@ fn cmd_init() -> Result<()> {
   Ok(())
 }
 
-fn cmd_list() -> Result<()> {
+fn cmd_list(format: ListFormat) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let trees = worktree::list(&repo)?;
+
+  if format == ListFormat::Names {
+    for w in &trees {
+      println!("{}", w.name);
+    }
+    return Ok(());
+  }
 
   // Dynamic widths based on observed content.
   let name_w = trees.iter().map(|w| w.name.len()).max().unwrap_or(4).clamp(4, 40);
@@ -250,6 +282,13 @@ fn cmd_types() -> Result<()> {
   for (t, d) in BRANCH_TYPES {
     println!("  {:<10} {}", t, d);
   }
+  Ok(())
+}
+
+fn cmd_completions(shell: Shell) -> Result<()> {
+  let mut cmd = Cli::command();
+  let name = cmd.get_name().to_string();
+  generate(shell, &mut cmd, name, &mut io::stdout());
   Ok(())
 }
 

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -114,7 +114,11 @@ fn list_format_names_emits_one_name_per_line() {
     .success()
     // No table header, no leading "*" marker, no STATUS column.
     .stdout(predicate::str::contains("NAME").not())
-    .stdout(predicate::str::contains("STATUS").not());
+    .stdout(predicate::str::contains("STATUS").not())
+    // Main worktree is excluded so the output mirrors what `find_fuzzy`
+    // accepts (path/remove/bootstrap skip the main workdir). A fresh repo
+    // therefore prints nothing.
+    .stdout(predicate::str::is_empty());
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1,7 +1,10 @@
 //! End-to-end tests that invoke the compiled `gwm` binary via assert_cmd.
 //! These exercise the user-visible CLI surface (subcommands, help, errors).
 
+mod common;
+
 use assert_cmd::Command;
+use common::init_repo;
 use predicates::prelude::*;
 
 #[test]
@@ -15,7 +18,8 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("list"))
     .stdout(predicate::str::contains("create"))
     .stdout(predicate::str::contains("bootstrap"))
-    .stdout(predicate::str::contains("prune"));
+    .stdout(predicate::str::contains("prune"))
+    .stdout(predicate::str::contains("completions"));
 }
 
 #[test]
@@ -47,4 +51,81 @@ fn create_outside_git_repo_fails() {
     .assert()
     .failure()
     .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn completions_zsh_emits_compdef_header() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["completions", "zsh"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("#compdef gwm"))
+    .stdout(predicate::str::contains("_gwm"));
+}
+
+#[test]
+fn completions_bash_emits_complete_directive() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["completions", "bash"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("_gwm"))
+    .stdout(predicate::str::contains("complete "));
+}
+
+#[test]
+fn completions_fish_emits_complete_directive() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["completions", "fish"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("complete -c gwm"));
+}
+
+#[test]
+fn completions_powershell_emits_register_block() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["completions", "powershell"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("Register-ArgumentCompleter"))
+    .stdout(predicate::str::contains("gwm"));
+}
+
+#[test]
+fn completions_rejects_unknown_shell() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["completions", "tcsh"]);
+  cmd.assert().failure();
+}
+
+#[test]
+fn list_format_names_emits_one_name_per_line() {
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["list", "--format=names"])
+    .assert()
+    .success()
+    // No table header, no leading "*" marker, no STATUS column.
+    .stdout(predicate::str::contains("NAME").not())
+    .stdout(predicate::str::contains("STATUS").not());
+}
+
+#[test]
+fn list_format_table_is_default() {
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .arg("list")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("NAME"))
+    .stdout(predicate::str::contains("STATUS"));
 }


### PR DESCRIPTION
## Description

Adds shell completion support to `gwm` per the proposal in #18 — both static script generation and a list mode that backs dynamic worktree-name completion.

Closes #18

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `gwm completions <shell>` — prints a static completion script on stdout via `clap_complete::generate` (one new runtime dep, `clap_complete = "4.5"`). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. The script is generated from the live clap argument tree, so it cannot drift from the actual subcommands as the CLI evolves.
- `gwm list --format=names` — one worktree name per line (no header, no marker, no STATUS column). Suitable for backing dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap` from a custom shell completer (README ships a zsh `compdef` snippet).
- README: new "shell completions" section under `usage / CLI` with per-shell install commands.
- CHANGELOG: `[Unreleased]` entries.

Commit breakdown (atomic, themed):

1. `✨ feat(cli)` — both features in `src/cli.rs` + Cargo dep
2. `✅ test(cli)` — end-to-end coverage in `tests/cli_binary.rs`
3. `📝 docs` — README + CHANGELOG

## Tests

- [x] `cargo test` passes locally (81 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` — 7 new (5 completions + 2 list format)

Coverage details:

- `completions_zsh_emits_compdef_header` — asserts `#compdef gwm` + `_gwm` function.
- `completions_bash_emits_complete_directive` — asserts `_gwm` + `complete `.
- `completions_fish_emits_complete_directive` — asserts `complete -c gwm`.
- `completions_powershell_emits_register_block` — asserts `Register-ArgumentCompleter` + `gwm`.
- `completions_rejects_unknown_shell` — clap rejects e.g. `tcsh`.
- `list_format_names_emits_one_name_per_line` — confirms the table header / `NAME` / `STATUS` columns are absent.
- `list_format_table_is_default` — confirms `gwm list` (no flag) still produces the table.

Also extended `help_prints_subcommands` to assert `completions` shows up in `--help`.

## Screenshots / TUI captures

CLI-only change, no TUI surface touched. Sample output:

```text
$ gwm completions zsh | head -4
#compdef gwm

autoload -U is-at-least
```

```text
$ gwm completions bash | head -2
_gwm() {
    local i cur prev opts cmd
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#18-shell-completions`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated — new "shell completions" section + CLI cheat-sheet entries
- [ ] `examples/gwm.toml.example` updated if config schema changed — N/A (no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only) — N/A, CLI-only

## Linked issues / docs

- Issue: #18
- Related PR: —

## Notes for reviewers

- The completion script is **static** (regenerated by re-running `gwm completions <shell>`). Dynamic completion of worktree names is opt-in — users wire `gwm list --format=names` into their shell's own completer (the README has a zsh `compdef` example). This was the simplest path that ships both halves of the issue's proposal without bundling a shell-runtime dependency.
- `clap_complete` is the standard companion crate for clap derive; one new crate, no codegen at startup, no runtime impact on the existing subcommands.
- `tests/cli_binary.rs` now pulls in `tests/common/` (previously only `worktree_integration.rs` used it). `paths_equal` is `#[allow(dead_code)]` so the second consumer doesn't warn.