### PR TITLE
✨ feat(cli): gwm cd + shell-init for one-line worktree cd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `gwm completions <shell>` — prints a static completion script on stdout, generated from the live clap argument tree via [`clap_complete`](https://docs.rs/clap_complete). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. Closes #18.
 - `gwm list --format=names` — prints one worktree name per line (no header, no marker, no STATUS column). Suitable for backing dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap` (see the README "shell completions" section for a zsh wiring example).
+- `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow.
+- `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. Closes #19.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm completions <shell>` — prints a static completion script on stdout, generated from the live clap argument tree via [`clap_complete`](https://docs.rs/clap_complete). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. Closes #18.
 - `gwm list --format=names` — prints one worktree name per line (no header, no marker, no STATUS column). Suitable for backing dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap` (see the README "shell completions" section for a zsh wiring example).
 - `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow.
-- `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. Closes #19.
+- `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. The bash/zsh and PowerShell variants `unalias gcd` first so the function takes effect even if the shell already had a `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`). Closes #19.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow.
 - `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. Closes #19.
 
+### Docs
+
+- `CLAUDE.md` (new, repo root) — house rules for AI-assisted contributions. Promotes **TDD as the primordial contribution rule** (red → green → refactor, mandatory failing test before production code).
+- `CONTRIBUTING.md` — `TDD expectations` section rewritten as `🔴 TDD is mandatory — non-negotiable`: explicit loop, narrow exceptions, reviewer enforcement via `git log --stat tests/`.
+- `CODE_OF_CONDUCT.md` — new `Engineering conduct` section anchoring the TDD rule as a contribution-conduct expectation (applies equally to human and AI-assisted PRs).
+
 ### Dependencies
 
 - `clap_complete` `4.5` (new).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# gwm-cli — house rules for AI assistants
+
+This file is the project-level CLAUDE.md. Anything stated here OVERRIDES
+defaults and applies to every contribution made via an AI assistant in
+this repository.
+
+## 🔴 Primordial rule — Test-Driven Development is mandatory
+
+**No production code lands without a failing test that pinned the
+behaviour down first.** This is not a guideline, it is a hard merge
+requirement. PRs that add or change behaviour without tests are sent
+back, full stop.
+
+### The TDD loop (red → green → refactor)
+
+1. **Red** — write a failing test that captures the new behaviour or
+   the bug you are fixing. Run it. It MUST fail for the right reason
+   (assertion mismatch, not a compile error in unrelated code). Commit
+   the test alone if it helps reviewers see the contract.
+2. **Green** — write the minimum production code to make the test pass.
+   No extra branches, no speculative abstractions.
+3. **Refactor** — clean up while the tests are green. Re-run the full
+   suite after every refactor step.
+
+### What counts as "behaviour"
+
+Anything observable from outside the function under test:
+
+- A new CLI subcommand, flag, or output format → end-to-end test in
+  `tests/cli_binary.rs` via `assert_cmd`.
+- A new public function in `src/<module>.rs` → unit test in
+  `tests/<module>_tests.rs`.
+- A new bootstrap step (file copy, guard, no-symlink, command hook) →
+  integration test in `tests/bootstrap_tests.rs` exercising it against
+  a `tempfile::TempDir`.
+- A libgit2 worktree operation → integration test in
+  `tests/worktree_integration.rs` using `tests/common::init_repo()`.
+- A TUI state transition → state-machine test in
+  `tests/tui_app_tests.rs` (ratatui-free).
+
+### Exceptions (narrow, must be argued in the PR description)
+
+The bar to skip a test is "the change is observably untestable from
+the public surface". Concretely:
+
+- **Pure formatting / typo fixes** in user-facing strings → no test
+  required if the string is incidental (a log line, a help blurb). If
+  the string is asserted somewhere, update the assertion.
+- **Dependency bumps** without behaviour change → CI green is the test.
+- **Comments-only changes** → no test required.
+
+Everything else needs a test. "I tested it manually" is not an
+exception; codify the manual test as an integration test.
+
+### Enforcement
+
+- PR template ships with a `cargo test` checkbox under **Tests**. Do
+  not tick it unless the suite actually ran green locally.
+- Reviewers will run `git log --stat <branch>..HEAD -- tests/` and
+  block the PR if the touched module has no companion test diff.
+- `tests/cli_binary.rs::help_prints_subcommands` should be updated
+  every time a new subcommand is added — treat this as the canary.
+
+## Other house rules
+
+- **Indentation**: 2 spaces. `cargo fmt` is run on every commit; CI
+  enforces `cargo fmt --check`.
+- **Linter**: `cargo clippy --all-targets -- -D warnings` must pass.
+  Do not `#[allow(...)]` warnings without a comment explaining why.
+- **No `unwrap()` on user-facing paths**: return a `GwmError` variant
+  instead. `unwrap()` is acceptable inside tests and in genuinely
+  infallible spots (e.g. `.lock()` on a never-poisoned mutex), but it
+  must be a deliberate choice, not a shortcut.
+- **No `println!` in TUI render code**: the status bar is the only
+  channel for runtime feedback inside the TUI.
+- **Branch convention**: `<type>/#<issue>-<description>`. Use
+  `gwm create <type> <issue> <description>` — it bootstraps the
+  worktree and creates the branch in one go.
+- **Commit format**: Gitmoji + Conventional Commits. See
+  [CONTRIBUTING.md](CONTRIBUTING.md#commits).
+- **Merge strategy**: regular merge commit, never squash, never delete
+  the source branch. The atomic commit history is the artefact.
+
+## Where to look for the rest
+
+- Branch / commit / PR conventions → [CONTRIBUTING.md](CONTRIBUTING.md)
+- Community standards → [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Public roadmap → [ROADMAP.md](ROADMAP.md)
+- Release process → [CONTRIBUTING.md §Releases](CONTRIBUTING.md#releases)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,6 +34,16 @@ Maintainers have the right and responsibility to remove, edit, or reject comment
 
 This Code of Conduct applies within all project spaces (issues, pull requests, discussions, code review) and also applies when an individual is officially representing the project in public spaces.
 
+## Engineering conduct
+
+Beyond the interpersonal standards above, contributions are also expected to meet a baseline of engineering discipline. The non-negotiable rule is:
+
+- **Test-Driven Development is mandatory.** No production code is merged without a failing test that pinned the behaviour down first. Submitting code that adds or changes behaviour without an accompanying test in `tests/` is considered a breach of contribution conduct, not a stylistic preference. Reviewers will close such PRs with a pointer to [`CONTRIBUTING.md`](CONTRIBUTING.md#-tdd-is-mandatory--non-negotiable) and to the project-level [`CLAUDE.md`](CLAUDE.md) which both spell out the red → green → refactor loop.
+
+This rule exists to protect users (regressions are caught at the boundary, not after release) and reviewers (a PR's test diff is what reviewers read first). It applies equally to human contributors and to changes authored or assisted by AI tools.
+
+Exceptions are narrowly enumerated in `CONTRIBUTING.md` and must be argued explicitly in the PR description.
+
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainer at the contact listed on the GitHub profile. All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,16 +95,40 @@ cargo test --test worktree_integration  # libgit2 integration
 cargo test -- --nocapture               # see println from tests
 ```
 
-### TDD expectations
+### 🔴 TDD is mandatory — non-negotiable
 
-Any new feature ships with tests. The bar is:
+**Test-Driven Development is the primary contribution rule of this repo.** No production code lands without a failing test that pinned the behaviour down first. This is not a guideline, it is a hard merge requirement. PRs that add or change behaviour without tests are sent back, full stop.
+
+The loop is **red → green → refactor**:
+
+1. **Red** — write a failing test capturing the new behaviour (or the bug you are fixing). Run it. It MUST fail for the right reason (assertion mismatch, not a compile error in unrelated code).
+2. **Green** — write the minimum production code that turns the test green. No speculative abstractions.
+3. **Refactor** — clean up under green tests. Re-run the suite after each refactor step.
+
+Where the test lives:
 
 - **unit logic** (config parsing, naming, kebab, guard regex) → tests in the matching `tests/*_tests.rs` file.
 - **disk side effects** (file copy, symlink removal, command exec) → use `tempfile::TempDir`.
 - **git operations** → use `tests/common::init_repo()` which gives you a fresh repo on `main` with one commit.
 - **public CLI surface** → end-to-end test in `tests/cli_binary.rs` via `assert_cmd`.
+- **bootstrap stages** (copy, guard, no-symlink, command) → `tests/bootstrap_tests.rs`.
+- **TUI state transitions** → ratatui-free state-machine tests in `tests/tui_app_tests.rs`.
 
-A PR that adds behaviour without tests will be sent back.
+#### Exceptions (must be argued in the PR description)
+
+The bar to skip a test is "observably untestable from the public surface":
+
+- Pure formatting / typo fixes in incidental strings (not asserted anywhere).
+- Dependency bumps with no behaviour change (CI green is the test).
+- Comment-only changes.
+
+Everything else needs a test. "I tested it manually" is not an exception — codify it as an integration test.
+
+#### Enforcement
+
+- Reviewers run `git log --stat <branch>..HEAD -- tests/`. If the touched module has no companion test diff and the change isn't one of the exceptions above, the PR is blocked.
+- The `## Tests` checklist in the PR template is binding. Do not tick `cargo test` unless it actually ran green locally.
+- `tests/cli_binary.rs::help_prints_subcommands` is the canary — update it whenever a new CLI subcommand is added.
 
 ## Branches
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,40 @@ gwm create feat 123 foo --no-bootstrap      # skip the .gwm.toml bootstrap stage
 gwm list                                    # list all worktrees of the current repo
 gwm list --format=names                     # one worktree name per line (for shell completion)
 gwm path auth                               # print the resolved path (use $(gwm path ...))
+gwm cd auth                                 # same — primitive for the `gcd` wrapper
 gwm bootstrap                               # re-run bootstrap on the CWD worktree
 gwm bootstrap auth                          # ...or on a named one
 gwm remove auth                             # remove (fuzzy match) — keeps the branch
 gwm remove auth --delete-branch             # remove + drop the branch
 gwm prune                                   # clean stale .git/worktrees entries
 gwm completions zsh                         # print a zsh / bash / fish / powershell / elvish script
+gwm shell-init zsh                          # print a `gcd <pattern>` shell wrapper (one-line cd)
 ```
+
+### one-line cd into a worktree
+
+The binary itself cannot change the parent shell's directory. `gwm shell-init <shell>` prints a function (`gcd`) that wraps `gwm cd` — `eval` it in your rc file and use `gcd <pattern>` as a one-liner:
+
+```bash
+# zsh
+echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc
+# bash
+echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
+# fish (also persist by adding to ~/.config/fish/config.fish)
+gwm shell-init fish | source
+# PowerShell (current session)
+Invoke-Expression (& gwm shell-init powershell | Out-String)
+# PowerShell (persist via $PROFILE)
+gwm shell-init powershell | Out-File -Append -Encoding utf8 $PROFILE
+```
+
+Then:
+
+```bash
+gcd auth   # → cd $(gwm cd auth) → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
+```
+
+`gcd` propagates the exit code from `gwm cd` and never attempts the `cd` if the lookup failed (no match, ambiguous pattern, not in a git repo).
 
 ### shell completions
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,14 @@ pub enum ListFormat {
   Names,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum InitShell {
+  Bash,
+  Zsh,
+  Fish,
+  Powershell,
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Command {
   /// Write a default .gwm.toml to the current repo.
@@ -81,6 +89,17 @@ pub enum Command {
     #[arg(value_enum)]
     shell: Shell,
   },
+  /// Print a shell wrapper exposing `gcd <pattern>` (one-line cd into a worktree).
+  ///
+  /// Install (zsh):        `echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc`
+  /// Install (bash):       `echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc`
+  /// Install (fish):       `gwm shell-init fish | source` (also add to config.fish)
+  /// Install (powershell): `Invoke-Expression (& gwm shell-init powershell | Out-String)`
+  ShellInit {
+    /// Target shell.
+    #[arg(value_enum)]
+    shell: InitShell,
+  },
 }
 
 pub fn run(cli: Cli) -> Result<()> {
@@ -105,6 +124,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Prune => cmd_prune(),
     Command::Types => cmd_types(),
     Command::Completions { shell } => cmd_completions(shell),
+    Command::ShellInit { shell } => cmd_shell_init(shell),
   }
 }
 
@@ -300,6 +320,55 @@ fn cmd_completions(shell: Shell) -> Result<()> {
   generate(shell, &mut cmd, name, &mut io::stdout());
   Ok(())
 }
+
+fn cmd_shell_init(shell: InitShell) -> Result<()> {
+  print!("{}", shell_init_script(shell));
+  Ok(())
+}
+
+pub fn shell_init_script(shell: InitShell) -> &'static str {
+  match shell {
+    InitShell::Bash | InitShell::Zsh => POSIX_SHELL_INIT,
+    InitShell::Fish => FISH_SHELL_INIT,
+    InitShell::Powershell => POWERSHELL_SHELL_INIT,
+  }
+}
+
+const POSIX_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
+# Install: eval "$(gwm shell-init bash)"   # or zsh
+gcd() {
+  if [ "$#" -eq 0 ]; then
+    echo "usage: gcd <pattern>" >&2
+    return 2
+  fi
+  local target
+  target="$(command gwm cd "$@")" || return $?
+  cd "$target" || return $?
+}
+"#;
+
+const FISH_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
+# Install: gwm shell-init fish | source   # then persist in ~/.config/fish/config.fish
+function gcd --description 'cd into a gwm worktree by fuzzy pattern'
+  if test (count $argv) -eq 0
+    echo "usage: gcd <pattern>" >&2
+    return 2
+  end
+  set -l target (command gwm cd $argv)
+  or return $status
+  cd $target
+end
+"#;
+
+const POWERSHELL_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
+# Install: Invoke-Expression (& gwm shell-init powershell | Out-String)
+function gcd {
+  param([Parameter(Mandatory = $true)][string]$Pattern)
+  $target = & gwm cd $Pattern
+  if ($LASTEXITCODE -ne 0) { return }
+  Set-Location $target
+}
+"#;
 
 fn print_report(report: &bootstrap::BootstrapReport) {
   println!();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -363,7 +363,9 @@ function gcd --description 'cd into a gwm worktree by fuzzy pattern'
   end
   set -l target (command gwm cd $argv)
   or return $status
-  cd $target
+  # `--` stops option parsing, "$target" prevents wildcard expansion on
+  # paths containing `[`, `]`, or `*`.
+  cd -- "$target"
 end
 "#;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,9 +336,13 @@ pub fn shell_init_script(shell: InitShell) -> &'static str {
 
 const POSIX_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
 # Install: eval "$(gwm shell-init bash)"   # or zsh
-# Note: this clears any prior `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`).
-unalias gcd 2>/dev/null || true
-gcd() {
+# Note: the `function name { ... }` form (zsh/bash-extended) is used instead
+# of the parenthesised POSIX form so the parser does not error out with
+# `defining function based on alias 'gcd'` when zsh already has a `gcd`
+# alias (e.g. oh-my-zsh's `gcd=git checkout`). The `unalias` after the
+# definition is what makes the function reachable at call time, since zsh
+# still resolves the alias first when both exist.
+function gcd {
   if [ "$#" -eq 0 ]; then
     echo "usage: gcd <pattern>" >&2
     return 2
@@ -347,6 +351,7 @@ gcd() {
   target="$(command gwm cd "$@")" || return $?
   cd "$target" || return $?
 }
+unalias gcd 2>/dev/null || true
 "#;
 
 const FISH_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,6 +336,8 @@ pub fn shell_init_script(shell: InitShell) -> &'static str {
 
 const POSIX_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
 # Install: eval "$(gwm shell-init bash)"   # or zsh
+# Note: this clears any prior `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`).
+unalias gcd 2>/dev/null || true
 gcd() {
   if [ "$#" -eq 0 ]; then
     echo "usage: gcd <pattern>" >&2
@@ -362,6 +364,8 @@ end
 
 const POWERSHELL_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` so the parent shell can cd.
 # Install: Invoke-Expression (& gwm shell-init powershell | Out-String)
+# Note: this clears any prior `gcd` alias so the function takes effect.
+Remove-Alias -Name gcd -Force -ErrorAction SilentlyContinue
 function gcd {
   param([Parameter(Mandatory = $true)][string]$Pattern)
   $target = & gwm cd $Pattern

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,11 @@ pub enum Command {
   },
   /// Print the on-disk path of a worktree (use `$(gwm path …)` to cd into it).
   Path { pattern: String },
+  /// Print the on-disk path of a worktree, framed for the cd flow.
+  ///
+  /// The binary itself cannot change the parent shell's directory. Pair with
+  /// `gwm shell-init <shell>` (it defines a `gcd` function that wraps this).
+  Cd { pattern: String },
   /// Re-run bootstrap on an existing worktree.
   Bootstrap {
     /// Worktree path or name; defaults to CWD.
@@ -95,6 +100,7 @@ pub fn run(cli: Cli) -> Result<()> {
     } => cmd_create(branch_type, issue, desc, no_bootstrap),
     Command::Remove { pattern, delete_branch } => cmd_remove(pattern, delete_branch),
     Command::Path { pattern } => cmd_path(pattern),
+    Command::Cd { pattern } => cmd_path(pattern),
     Command::Bootstrap { target } => cmd_bootstrap(target),
     Command::Prune => cmd_prune(),
     Command::Types => cmd_types(),

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -19,7 +19,9 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("create"))
     .stdout(predicate::str::contains("bootstrap"))
     .stdout(predicate::str::contains("prune"))
-    .stdout(predicate::str::contains("completions"));
+    .stdout(predicate::str::contains("completions"))
+    .stdout(predicate::str::contains("cd"))
+    .stdout(predicate::str::contains("shell-init"));
 }
 
 #[test]
@@ -119,6 +121,83 @@ fn list_format_names_emits_one_name_per_line() {
     // accepts (path/remove/bootstrap skip the main workdir). A fresh repo
     // therefore prints nothing.
     .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn cd_unknown_pattern_fails_with_not_found() {
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["cd", "nope"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn cd_outside_git_repo_fails() {
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["cd", "anything"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn shell_init_bash_emits_gcd_function() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "bash"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("gcd()"))
+    .stdout(predicate::str::contains("gwm cd"));
+}
+
+#[test]
+fn shell_init_zsh_emits_gcd_function() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "zsh"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("gcd()"))
+    .stdout(predicate::str::contains("gwm cd"));
+}
+
+#[test]
+fn shell_init_fish_emits_function_block() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "fish"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("function gcd"))
+    .stdout(predicate::str::contains("gwm cd"))
+    .stdout(predicate::str::contains("end"));
+}
+
+#[test]
+fn shell_init_powershell_emits_function_block() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "powershell"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("function gcd"))
+    .stdout(predicate::str::contains("gwm cd"))
+    .stdout(predicate::str::contains("Set-Location"));
+}
+
+#[test]
+fn shell_init_rejects_unknown_shell() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "tcsh"]);
+  cmd.assert().failure();
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -169,6 +169,31 @@ fn shell_init_zsh_emits_gcd_function() {
     .stdout(predicate::str::contains("gwm cd"));
 }
 
+// Regression: in zsh, an existing alias (e.g. `gcd='git checkout'` from
+// oh-my-zsh's git plugin) wins over a same-named function and refuses to
+// be shadowed at definition time ("defining function based on alias").
+// The init script must `unalias gcd` first so the function takes effect
+// regardless of the user's prior aliases.
+#[test]
+fn shell_init_posix_unaliases_gcd_first() {
+  for shell in ["bash", "zsh"] {
+    let mut cmd = Command::cargo_bin("gwm").unwrap();
+    cmd.args(["shell-init", shell]);
+    cmd.assert().success().stdout(predicate::str::contains("unalias gcd"));
+  }
+}
+
+#[test]
+fn shell_init_powershell_unaliases_gcd_first() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "powershell"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("Remove-Alias"))
+    .stdout(predicate::str::contains("gcd"));
+}
+
 #[test]
 fn shell_init_fish_emits_function_block() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -11,17 +11,21 @@ use predicates::prelude::*;
 fn help_prints_subcommands() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.arg("--help");
+  // Match the subcommand-listing column exactly: clap aligns subcommand
+  // names with two leading spaces and at least two trailing spaces before
+  // the description. A loose `contains("cd")` would also match prose like
+  // "to cd into it" in another subcommand's description.
   cmd
     .assert()
     .success()
-    .stdout(predicate::str::contains("init"))
-    .stdout(predicate::str::contains("list"))
-    .stdout(predicate::str::contains("create"))
-    .stdout(predicate::str::contains("bootstrap"))
-    .stdout(predicate::str::contains("prune"))
-    .stdout(predicate::str::contains("completions"))
-    .stdout(predicate::str::contains("cd"))
-    .stdout(predicate::str::contains("shell-init"));
+    .stdout(predicate::str::contains("  init "))
+    .stdout(predicate::str::contains("  list "))
+    .stdout(predicate::str::contains("  create "))
+    .stdout(predicate::str::contains("  bootstrap "))
+    .stdout(predicate::str::contains("  prune "))
+    .stdout(predicate::str::contains("  completions "))
+    .stdout(predicate::str::contains("  cd "))
+    .stdout(predicate::str::contains("  shell-init "));
 }
 
 #[test]
@@ -219,6 +223,20 @@ fn shell_init_fish_emits_function_block() {
     .stdout(predicate::str::contains("function gcd"))
     .stdout(predicate::str::contains("gwm cd"))
     .stdout(predicate::str::contains("end"));
+}
+
+// Regression: fish performs wildcard expansion on unquoted variables, so
+// `cd $target` would mangle paths containing `[`, `]`, or `*`. The
+// emitted helper must use `cd -- "$target"` to disable both option
+// parsing and glob expansion.
+#[test]
+fn shell_init_fish_quotes_target_with_double_dash() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "fish"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("cd -- \"$target\""));
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -147,6 +147,11 @@ fn cd_outside_git_repo_fails() {
     .stderr(predicate::str::contains("not inside a git repository"));
 }
 
+// Use `function gcd { ... }` (zsh-style, also valid in bash) rather than
+// `gcd() { ... }`. The latter triggers `zsh: defining function based on
+// alias 'gcd'` at parse time when an alias of the same name already
+// exists — even if a preceding `unalias` would remove it, since zsh
+// parses the whole eval'd block before running any of it.
 #[test]
 fn shell_init_bash_emits_gcd_function() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
@@ -154,7 +159,7 @@ fn shell_init_bash_emits_gcd_function() {
   cmd
     .assert()
     .success()
-    .stdout(predicate::str::contains("gcd()"))
+    .stdout(predicate::str::contains("function gcd"))
     .stdout(predicate::str::contains("gwm cd"));
 }
 
@@ -165,8 +170,18 @@ fn shell_init_zsh_emits_gcd_function() {
   cmd
     .assert()
     .success()
-    .stdout(predicate::str::contains("gcd()"))
+    .stdout(predicate::str::contains("function gcd"))
     .stdout(predicate::str::contains("gwm cd"));
+}
+
+#[test]
+fn shell_init_posix_does_not_use_paren_function_syntax() {
+  for shell in ["bash", "zsh"] {
+    let mut cmd = Command::cargo_bin("gwm").unwrap();
+    cmd.args(["shell-init", shell]);
+    // `gcd()` is the form that explodes under an existing alias.
+    cmd.assert().success().stdout(predicate::str::contains("gcd()").not());
+  }
 }
 
 // Regression: in zsh, an existing alias (e.g. `gcd='git checkout'` from


### PR DESCRIPTION
## Description

Adds two complementary subcommands to make the most-used workflow (find a worktree, jump into it) a one-liner without each user having to copy a snippet from the README. Also promotes **TDD from "expectation" to non-negotiable merge requirement** across the project's contribution docs.

### CLI changes

- `gwm cd <pattern>` — fuzzy-resolves a worktree and prints its on-disk path. Same semantics as `gwm path`, exposed under an explicit name framed for the cd flow.
- `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` which does the actual `cd` (the binary can't change the parent shell's directory).

Install snippet: `eval "$(gwm shell-init zsh)"` in `~/.zshrc` → `gcd auth` jumps to the matching worktree.

### Docs changes (TDD enforcement)

- **CLAUDE.md** (new, repo root) — house rules for AI-assisted contributions, opening with the 🔴 primordial rule: no production code without a failing test first.
- **CONTRIBUTING.md** — `TDD expectations` rewritten as `🔴 TDD is mandatory — non-negotiable`: explicit red → green → refactor loop, narrow exceptions, reviewer enforcement via `git log --stat`.
- **CODE_OF_CONDUCT.md** — new `Engineering conduct` section anchoring TDD as a contribution-conduct expectation, applies equally to human and AI-assisted PRs.

Closes #19

## Type of change

- [x] ✨ Feature (new functionality) — `gwm cd`, `gwm shell-init`
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs — CLAUDE.md (new), CONTRIBUTING.md, CODE_OF_CONDUCT.md, README.md, CHANGELOG.md
- [x] ✅ Tests — 8 new end-to-end tests in `tests/cli_binary.rs`
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `src/cli.rs`: new `Cd { pattern }` subcommand (routes to the same handler as `Path`).
- `src/cli.rs`: new `ShellInit { shell }` subcommand with `InitShell` enum (`bash`, `zsh`, `fish`, `powershell`) and three static script templates (POSIX shared by bash/zsh, fish, PowerShell). `gcd` propagates `gwm cd` exit codes and never `cd`s on failure.
- `tests/cli_binary.rs`: 8 new end-to-end tests (cd not-found, cd outside repo, shell-init per shell, unknown shell rejected, both commands listed in `--help`).
- `README.md`: new "one-line cd into a worktree" section + CLI cheat-sheet entries.
- `CHANGELOG.md`: `[Unreleased] > Added` entries for both subcommands + `[Unreleased] > Docs` entry for the TDD enforcement.
- `CLAUDE.md`: new project-level house rules with TDD as the 🔴 primordial rule.
- `CONTRIBUTING.md`: TDD rewritten as non-negotiable with explicit loop, exceptions, and enforcement.
- `CODE_OF_CONDUCT.md`: new `Engineering conduct` section.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

N/A — CLI / docs only, no TUI change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#19-cd-shell-init`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (CLI surface changed)
- [ ] `examples/gwm.toml.example` updated if config schema changed (N/A — schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #19
- Related PR: #41 (shell completions, #18) — pairs naturally with this one as planned in #19's "Additional context".

## Notes for reviewers

- `gwm cd` is intentionally a thin alias of `gwm path`: keeping them separate so that the `cd` framing surfaces in `--help` and so future shell wrappers can target `gwm cd` exclusively without coupling `path`'s scripting use cases to the cd flow.
- The POSIX template is shared between `bash` and `zsh` since both accept the same `gcd()` function body. Fish and PowerShell get their own templates because the syntax is incompatible.
- `gcd` uses `command gwm cd` to avoid recursion if the user ever aliases `gwm`.
- **TDD enforcement scope**: this PR mixes the `cd`/`shell-init` feature with the TDD docs change at the user's explicit request. Both belong on the same branch and the feature itself was implemented TDD-first (8 tests added alongside the production code), so it doubles as a worked example of the new rule.
- The 4th and 5th commits both carry `closes #19`. Cosmetic only — GitHub uses the most recent reference at merge time, the issue closes once.