### PR TITLE
✨ feat(tui): add fuzzy filter on the worktree list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TUI fuzzy filter (`/`)** — press `/` on the worktree list to open an inline filter bar at the bottom of the table. As you type, the table narrows in real time via [`nucleo-matcher`](https://docs.rs/nucleo-matcher) (same matcher as Helix / Zellij), ranking contiguous substring hits above spread-out subsequence hits. `Enter` confirms (filter sticks, navigation returns to the table); `Esc` clears the filter and restores the full list. `j` / `k` / `gg` / `G` continue to work on the filtered subset. Table title shows `worktrees (N/M)` while a filter is active. `Esc` on the plain list view clears any sticky filter before it considers quitting, so a stale filter can't accidentally exit the TUI. Closes #21.
 - `gwm completions <shell>` — prints a static completion script on stdout, generated from the live clap argument tree via [`clap_complete`](https://docs.rs/clap_complete). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. Closes #18.
 - `gwm list --format=names` — prints one worktree name per line (no header, no marker, no STATUS column). Suitable for backing dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap` (see the README "shell completions" section for a zsh wiring example).
 - `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow.
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 
 - `clap_complete` `4.5` (new).
+- `nucleo-matcher` `0.3` (new) — fuzzy match engine for the TUI `/` filter.
 
 ## [0.2.0] - 2026-05-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "crossterm",
  "dirs 5.0.1",
  "git2",
+ "nucleo-matcher",
  "predicates",
  "ratatui",
  "regex",
@@ -1181,6 +1182,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "num-conv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1"
 shellexpand = "3"
 chrono = { version = "0.4", features = ["serde"] }
 which = "8"
+nucleo-matcher = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ Key bindings:
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
+| `/`         | open the fuzzy filter bar (`Enter` confirms sticky filter · `Esc` clears)       |
 | `r`         | refresh                                                                         |
 | `p`         | toggle "delete branch on remove"                                                |
 | `Enter`     | show selected path in status bar                                                |
 | `?`         | help overlay                                                                    |
-| `q` / `Esc` | quit                                                                            |
+| `q`         | quit                                                                            |
+| `Esc`       | clear a sticky filter if any, otherwise quit                                    |
 
 ### details sidebar
 
@@ -76,6 +78,19 @@ When the terminal is at least **120 columns wide** and the sidebar is enabled (d
 - **Commands** — keybindings cheat-sheet.
 
 Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+### fuzzy filter
+
+Press `/` to open an inline filter bar at the bottom of the worktree table. As you type, the table narrows in real time using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) — the same fuzzy engine used by Helix and Zellij. Matches are ranked by how tight the hit is (contiguous substring beats spread-out subsequence), so the most likely candidate sits on top.
+
+```
+/                            → filter bar opens
+auth                         → table now shows feat-99-user-authentication only
+<Enter>                       → filter sticks, navigation back on the table
+<Esc>                         → clears filter, full list back
+```
+
+The filter is sticky between Enter and Esc: `j` / `k` / `gg` / `G` continue to work on the filtered subset, and the table title shows `worktrees (N/M)` (visible / total). Hit `/` again to re-open the bar and refine the query. `Esc` from the list view clears the sticky filter before it considers quitting, so you can't accidentally quit when you meant to drop the filter.
 
 ### lazygit integration
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -397,8 +397,14 @@ impl App {
   /// Open the inline filter bar. The existing query is preserved so the user
   /// can refine an already-sticky filter; `Esc` is the way to start fresh.
   /// Disarms any pending `gg` motion so `/g` doesn't half-trigger it.
+  ///
+  /// Forces focus back onto the list: opening `/` is an intent to narrow the
+  /// list, and the post-`Enter` contract is "navigation returns to the
+  /// table". Leaving the sidebar focused would make `j` / `k` scroll it
+  /// instead of walking the filtered worktrees after the filter sticks.
   pub fn enter_filter(&mut self) {
     self.filter_active = true;
+    self.sidebar_focused = false;
     self.cancel_pending_motion();
     self.status = "/ filter — type to narrow · enter confirms · esc clears".into();
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4,6 +4,10 @@ use crate::error::{GwmError, Result};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
+use nucleo_matcher::{
+  pattern::{CaseMatching, Normalization, Pattern},
+  Config as NucleoConfig, Matcher, Utf32Str,
+};
 use ratatui::{text::Line, widgets::TableState};
 use std::path::{Path, PathBuf};
 
@@ -58,6 +62,14 @@ pub struct App {
 
   // Vim motion buffer: armed by first `g`, completed by the second.
   pub pending_g: bool,
+
+  // Inline fuzzy filter on the worktree list (issue #21).
+  // `filter_active` is true while the user is typing in the filter bar (`/`).
+  // `filter_query` carries the current pattern; when non-empty, the list view
+  // shows only matching worktrees ranked by `nucleo_matcher`. Esc clears the
+  // query, Enter confirms (sticky filter, focus returns to the list).
+  pub filter_active: bool,
+  pub filter_query: String,
 }
 
 impl App {
@@ -96,20 +108,14 @@ impl App {
       sidebar_cache: None,
       sidebar_max_scroll: 0,
       pending_g: false,
+      filter_active: false,
+      filter_query: String::new(),
     })
   }
 
   pub fn refresh(&mut self) -> Result<()> {
     self.worktrees = worktree::list(&self.repo)?;
-    if self.worktrees.is_empty() {
-      self.list_state.select(None);
-    } else if self.list_state.selected().is_none() {
-      self.list_state.select(Some(0));
-    } else if let Some(i) = self.list_state.selected() {
-      if i >= self.worktrees.len() {
-        self.list_state.select(Some(self.worktrees.len() - 1));
-      }
-    }
+    self.clamp_selection_to_filter();
     self.invalidate_sidebar_cache();
     self.status = format!("refreshed — {} worktree(s)", self.worktrees.len());
     Ok(())
@@ -127,11 +133,12 @@ impl App {
       self.sidebar_scroll_down();
       return;
     }
-    if self.worktrees.is_empty() {
+    let len = self.filtered_indices().len();
+    if len == 0 {
       return;
     }
     let i = match self.list_state.selected() {
-      Some(i) => (i + 1) % self.worktrees.len(),
+      Some(i) => (i + 1) % len,
       None => 0,
     };
     self.list_state.select(Some(i));
@@ -144,11 +151,12 @@ impl App {
       self.sidebar_scroll_up();
       return;
     }
-    if self.worktrees.is_empty() {
+    let len = self.filtered_indices().len();
+    if len == 0 {
       return;
     }
     let i = match self.list_state.selected() {
-      Some(0) | None => self.worktrees.len() - 1,
+      Some(0) | None => len - 1,
       Some(i) => i - 1,
     };
     self.list_state.select(Some(i));
@@ -159,7 +167,8 @@ impl App {
   // ---- Vim-style motions / list jumps -------------------------------------
 
   pub fn first(&mut self) {
-    if !self.worktrees.is_empty() {
+    let len = self.filtered_indices().len();
+    if len > 0 {
       self.list_state.select(Some(0));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
@@ -167,8 +176,9 @@ impl App {
   }
 
   pub fn last(&mut self) {
-    if !self.worktrees.is_empty() {
-      self.list_state.select(Some(self.worktrees.len() - 1));
+    let len = self.filtered_indices().len();
+    if len > 0 {
+      self.list_state.select(Some(len - 1));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
     }
@@ -233,7 +243,13 @@ impl App {
   }
 
   pub fn selected(&self) -> Option<&WorktreeInfo> {
-    self.list_state.selected().and_then(|i| self.worktrees.get(i))
+    // The visible list is the filtered subset, so the table state's index is
+    // into `filtered_indices()`, not the raw `worktrees` vec. Resolving the
+    // selection means hopping through the filter map.
+    let i = self.list_state.selected()?;
+    let filtered = self.filtered_indices();
+    let original = *filtered.get(i)?;
+    self.worktrees.get(original)
   }
 
   pub fn copy_path_to_status(&mut self) {
@@ -374,6 +390,96 @@ impl App {
     self.status = format!("removed {} ({})", name, label);
     self.view = View::List;
     self.refresh()
+  }
+
+  // ---- Fuzzy filter (issue #21) -------------------------------------------
+
+  /// Open the inline filter bar. The existing query is preserved so the user
+  /// can refine an already-sticky filter; `Esc` is the way to start fresh.
+  /// Disarms any pending `gg` motion so `/g` doesn't half-trigger it.
+  pub fn enter_filter(&mut self) {
+    self.filter_active = true;
+    self.cancel_pending_motion();
+    self.status = "/ filter — type to narrow · enter confirms · esc clears".into();
+  }
+
+  /// Close the filter bar but keep the query: `Enter` confirms the current
+  /// match set and returns the cursor to list navigation.
+  pub fn exit_filter_keep(&mut self) {
+    self.filter_active = false;
+    self.status = if self.filter_query.is_empty() {
+      "press ? for help".into()
+    } else {
+      format!("filter sticky: {}", self.filter_query)
+    };
+  }
+
+  /// Close the filter bar and clear the query: `Esc` returns to the full list.
+  pub fn exit_filter_cancel(&mut self) {
+    let had_query = !self.filter_query.is_empty();
+    self.filter_active = false;
+    self.filter_query.clear();
+    self.clamp_selection_to_filter();
+    self.invalidate_sidebar_cache();
+    self.status = if had_query {
+      "filter cleared".into()
+    } else {
+      "press ? for help".into()
+    };
+  }
+
+  pub fn filter_push_char(&mut self, c: char) {
+    self.filter_query.push(c);
+    self.clamp_selection_to_filter();
+    self.invalidate_sidebar_cache();
+  }
+
+  pub fn filter_pop_char(&mut self) {
+    if self.filter_query.pop().is_some() {
+      self.clamp_selection_to_filter();
+      self.invalidate_sidebar_cache();
+    }
+  }
+
+  /// Indices into `self.worktrees`, in display order:
+  /// - empty query: identity (every worktree in source order).
+  /// - non-empty: only worktrees whose name matches the query via
+  ///   `nucleo_matcher`, ranked by descending score (nucleo intrinsically
+  ///   ranks exact/substring/prefix matches above subsequence matches).
+  ///
+  /// Score ties are broken by original index so output is stable.
+  pub fn filtered_indices(&self) -> Vec<usize> {
+    if self.filter_query.is_empty() {
+      return (0..self.worktrees.len()).collect();
+    }
+    let pattern = Pattern::parse(self.filter_query.as_str(), CaseMatching::Smart, Normalization::Smart);
+    let mut matcher = Matcher::new(NucleoConfig::DEFAULT);
+    let mut buf: Vec<char> = Vec::new();
+    let mut scored: Vec<(u32, usize)> = Vec::with_capacity(self.worktrees.len());
+    for (i, w) in self.worktrees.iter().enumerate() {
+      let hay = Utf32Str::new(&w.name, &mut buf);
+      if let Some(score) = pattern.score(hay, &mut matcher) {
+        scored.push((score, i));
+      }
+    }
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+    scored.into_iter().map(|(_, i)| i).collect()
+  }
+
+  /// Reposition the selection so it stays inside the current filtered subset.
+  /// Called whenever the filter mutates (`/`-mode typing, `Esc`-clear) or the
+  /// worktree list itself changes (`refresh`).
+  fn clamp_selection_to_filter(&mut self) {
+    let len = self.filtered_indices().len();
+    if len == 0 {
+      self.list_state.select(None);
+      return;
+    }
+    match self.list_state.selected() {
+      Some(i) if i >= len => self.list_state.select(Some(len - 1)),
+      Some(_) => {}
+      None => self.list_state.select(Some(0)),
+    }
   }
 
   // ---- Bootstrap flow ------------------------------------------------------

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -48,13 +48,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> 
     }
 
     match app.view {
+      // When the inline filter bar is open, capture every key as filter input
+      // so the user can type a query containing `q`, `?`, `/`, etc. The only
+      // ways out are Enter (sticky filter) or Esc (clear filter).
+      View::List if app.filter_active => match key.code {
+        KeyCode::Esc => app.exit_filter_cancel(),
+        KeyCode::Enter => app.exit_filter_keep(),
+        KeyCode::Backspace => app.filter_pop_char(),
+        KeyCode::Char(c) => app.filter_push_char(c),
+        _ => {}
+      },
       View::List => {
         // Two-keystroke vim motion `gg`: any non-'g' keypress disarms it.
         if !matches!(key.code, KeyCode::Char('g')) {
           app.cancel_pending_motion();
         }
         match key.code {
-          KeyCode::Char('q') | KeyCode::Esc => break,
+          KeyCode::Char('q') => break,
+          // Esc on the list clears a sticky filter first, then quits if the
+          // list is already in its plain state. Avoids the trap where a user
+          // hits Esc expecting to clear /-filter and accidentally exits.
+          KeyCode::Esc => {
+            if !app.filter_query.is_empty() {
+              app.exit_filter_cancel();
+            } else {
+              break;
+            }
+          }
           KeyCode::Char('?') => app.view = View::Help,
           KeyCode::Char('j') | KeyCode::Down => app.next(),
           KeyCode::Char('k') | KeyCode::Up => app.prev(),
@@ -62,6 +82,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> 
           KeyCode::Char('G') => app.last(),
           KeyCode::Char('v') => app.toggle_sidebar(),
           KeyCode::Tab => app.toggle_focus(),
+          KeyCode::Char('/') => app.enter_filter(),
           KeyCode::Char('l') => {
             if let Some(path) = app.launch_lazygit() {
               run_lazygit(terminal, &path, &mut app)?;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -15,14 +15,35 @@ use ratatui::{
 pub const SIDEBAR_MIN_WIDTH: u16 = 120;
 
 pub fn draw(f: &mut Frame, app: &mut App) {
-  let chunks = Layout::default()
-    .direction(Direction::Vertical)
-    .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(2)])
-    .split(f.area());
+  // Filter bar is shown while the user is typing, AND while a sticky filter
+  // remains in effect (so they can see what's filtering the list).
+  let filter_visible = app.filter_active || !app.filter_query.is_empty();
+
+  let chunks = if filter_visible {
+    Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([
+        Constraint::Length(3),
+        Constraint::Min(0),
+        Constraint::Length(1),
+        Constraint::Length(2),
+      ])
+      .split(f.area())
+  } else {
+    Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(2)])
+      .split(f.area())
+  };
 
   draw_header(f, chunks[0], app);
   draw_body(f, chunks[1], app);
-  draw_footer(f, chunks[2], app);
+  if filter_visible {
+    draw_filter_bar(f, chunks[2], app);
+    draw_footer(f, chunks[3], app);
+  } else {
+    draw_footer(f, chunks[2], app);
+  }
 
   match app.view {
     View::Help => draw_help(f),
@@ -31,6 +52,29 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::Report => draw_report(f, app),
     View::List => {}
   }
+}
+
+/// Single-line filter bar rendered between the table and the footer.
+/// Mirrors Vim's `/` prompt: leading slash, the live query, and a block cursor
+/// while the user is actively typing.
+fn draw_filter_bar(f: &mut Frame, area: Rect, app: &App) {
+  let mut spans = vec![
+    Span::styled("/", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+    Span::raw(app.filter_query.as_str().to_string()),
+  ];
+  if app.filter_active {
+    spans.push(Span::styled(
+      "█",
+      Style::default().fg(Color::Yellow).add_modifier(Modifier::SLOW_BLINK),
+    ));
+  } else {
+    // Sticky filter: hint how to clear / refine without re-entering the bar.
+    spans.push(Span::styled(
+      "   (sticky — / to refine, esc on list to clear)",
+      Style::default().fg(Color::DarkGray),
+    ));
+  }
+  f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
 /// Decide whether to split horizontally for a sidebar, based on terminal width
@@ -67,10 +111,16 @@ fn draw_header(f: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
-  // Dynamic column widths: derive from current data, capped to keep room for the path column.
-  // The path column is always last and takes whatever remains.
-  let name_w = column_width(app.worktrees.iter().map(|w| w.name.as_str()), 18, 38);
-  let branch_w = column_width(app.worktrees.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
+  // Filter-aware: the visible rows are the filtered subset (issue #21). When
+  // there is no active filter, this is the identity over `app.worktrees`.
+  let filtered = app.filtered_indices();
+  let visible: Vec<&WorktreeInfo> = filtered.iter().filter_map(|&i| app.worktrees.get(i)).collect();
+
+  // Dynamic column widths derived from the visible subset so columns fit the
+  // rows actually on screen. The path column is always last and absorbs the
+  // remaining width.
+  let name_w = column_width(visible.iter().map(|w| w.name.as_str()), 18, 38);
+  let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
   let header = Row::new(vec![
@@ -82,8 +132,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   ])
   .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
 
-  let rows: Vec<Row> = app
-    .worktrees
+  let rows: Vec<Row> = visible
     .iter()
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
@@ -99,13 +148,19 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
   let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
 
+  let title = if app.filter_query.is_empty() {
+    format!(" worktrees ({}) ", app.worktrees.len())
+  } else {
+    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
+  };
+
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
     .block(
       Block::default()
         .borders(Borders::ALL)
-        .title(format!(" worktrees ({}) ", app.worktrees.len()))
+        .title(title)
         .border_style(Style::default().fg(border_color)),
     )
     .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
@@ -236,6 +291,7 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
     ("    r", "Refresh"),
     ("    v", "Toggle this sidebar"),
     ("  Tab", "Swap focus list ↔ sidebar"),
+    ("    /", "Fuzzy filter worktrees"),
     ("   gg", "Jump to first worktree"),
     ("    G", "Jump to last worktree"),
     ("  j/k", "Next / Prev (or scroll sidebar)"),
@@ -397,7 +453,8 @@ fn format_status(s: &BranchStatus, width: usize) -> (String, Color) {
 }
 
 fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
-  let help = "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus gg/G:top/bot j/k:nav r:refresh ?:help q:quit";
+  let help =
+    "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit";
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
     Span::raw("  "),
@@ -430,6 +487,7 @@ fn draw_help(f: &mut Frame) {
     Line::from("  l             launch lazygit fullscreen on selected worktree"),
     Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
     Line::from("  Tab           swap focus between worktree list and sidebar"),
+    Line::from("  /             open fuzzy filter bar (enter: sticky, esc: clear)"),
     Line::from("  r             refresh"),
     Line::from("  p             toggle 'delete branch on remove'"),
     Line::from("  enter         show path in status bar"),

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3,6 +3,24 @@ mod common;
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
 use gwm::tui::{App, Field, View};
+use gwm::worktree::{BranchStatus, WorktreeInfo};
+use std::path::PathBuf;
+
+/// Build a synthetic worktree row for state-machine tests that need a known
+/// list shape (fuzzy filter ranking, multi-row navigation). Lets the test
+/// drive the filter without going through real `git2::worktree_add` calls.
+fn worktree_fixture(name: &str) -> WorktreeInfo {
+  WorktreeInfo {
+    name: name.into(),
+    path: PathBuf::from(format!("/tmp/gwm-test/{}", name)),
+    branch: Some(format!("feat/#0-{}", name)),
+    head: None,
+    is_main: false,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus::default(),
+  }
+}
 
 fn make_app() -> (tempfile::TempDir, App) {
   let (dir, _) = init_repo();
@@ -270,4 +288,294 @@ fn refresh_invalidates_sidebar_cache() {
   app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
   app.refresh().unwrap();
   assert!(app.sidebar_cache.is_none());
+}
+
+// ---- fuzzy filter (issue #21) -------------------------------------------
+
+#[test]
+fn filter_state_defaults_to_inactive_and_empty() {
+  let (_dir, app) = make_app();
+  assert!(!app.filter_active, "filter must default to inactive");
+  assert!(app.filter_query.is_empty(), "filter query must default to empty");
+}
+
+#[test]
+fn enter_filter_activates_capture_and_disarms_gg() {
+  let (_dir, mut app) = make_app();
+  app.handle_g(); // arm `gg`
+  assert!(app.pending_g);
+
+  app.enter_filter();
+  assert!(app.filter_active);
+  assert!(
+    !app.pending_g,
+    "opening the filter bar must drop any half-typed gg motion"
+  );
+}
+
+#[test]
+fn enter_filter_preserves_existing_query() {
+  // Hitting `/` on a sticky filter re-opens the bar so the user can refine
+  // it; only Esc clears.
+  let (_dir, mut app) = make_app();
+  app.filter_query = "auth".into();
+  app.enter_filter();
+  assert_eq!(app.filter_query, "auth");
+  assert!(app.filter_active);
+}
+
+#[test]
+fn filter_push_char_appends_to_query() {
+  let (_dir, mut app) = make_app();
+  app.enter_filter();
+  for c in "tui".chars() {
+    app.filter_push_char(c);
+  }
+  assert_eq!(app.filter_query, "tui");
+}
+
+#[test]
+fn filter_pop_char_removes_last_char() {
+  let (_dir, mut app) = make_app();
+  app.enter_filter();
+  app.filter_query = "tuix".into();
+  app.filter_pop_char();
+  assert_eq!(app.filter_query, "tui");
+}
+
+#[test]
+fn filter_pop_char_on_empty_is_noop() {
+  let (_dir, mut app) = make_app();
+  app.enter_filter();
+  app.filter_pop_char();
+  assert_eq!(app.filter_query, "");
+  assert!(app.filter_active, "popping an empty query must not exit filter mode");
+}
+
+#[test]
+fn exit_filter_keep_disables_capture_keeps_query() {
+  // Enter behaviour: filter sticks, navigation returns to the list.
+  let (_dir, mut app) = make_app();
+  app.enter_filter();
+  app.filter_query = "auth".into();
+  app.exit_filter_keep();
+  assert!(!app.filter_active);
+  assert_eq!(app.filter_query, "auth", "Enter must not wipe the query");
+}
+
+#[test]
+fn exit_filter_cancel_clears_query() {
+  // Esc behaviour: full list back, query gone.
+  let (_dir, mut app) = make_app();
+  app.enter_filter();
+  app.filter_query = "auth".into();
+  app.exit_filter_cancel();
+  assert!(!app.filter_active);
+  assert!(app.filter_query.is_empty(), "Esc must clear the query");
+}
+
+#[test]
+fn filtered_indices_returns_all_when_query_empty() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("beta"),
+    worktree_fixture("gamma"),
+  ];
+  let idx = app.filtered_indices();
+  assert_eq!(idx, vec![0, 1, 2], "empty query is the identity over worktrees");
+}
+
+#[test]
+fn filtered_indices_keeps_only_matching_worktrees() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("feat-1-tui-search"),
+    worktree_fixture("feat-2-cli-completions"),
+    worktree_fixture("fix-3-locked-worktree"),
+  ];
+  app.filter_query = "tui".into();
+
+  let idx = app.filtered_indices();
+  let names: Vec<&str> = idx.iter().map(|&i| app.worktrees[i].name.as_str()).collect();
+  assert_eq!(
+    names,
+    vec!["feat-1-tui-search"],
+    "only the worktree whose name contains 'tui' should match"
+  );
+}
+
+#[test]
+fn filtered_indices_supports_subsequence_match() {
+  // 'auth' is a sub-sequence of 'user-authentication' — nucleo's fuzzy
+  // matcher must surface it even without an exact substring.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("feat-99-user-authentication"),
+    worktree_fixture("chore-1-bump-deps"),
+  ];
+  app.filter_query = "auth".into();
+
+  let idx = app.filtered_indices();
+  assert_eq!(idx.len(), 1);
+  assert_eq!(app.worktrees[idx[0]].name, "feat-99-user-authentication");
+}
+
+#[test]
+fn filtered_indices_ranks_substring_above_subsequence() {
+  // Issue #21 contract: "exact substring match > prefix match > sub-sequence
+  // match". Verify by feeding a candidate that contains the literal needle
+  // and another that only matches via gaps; the contiguous one must rank
+  // first in the returned index list.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    // subsequence: a-u-t-h spread out across the name
+    worktree_fixture("a-zzz-u-yyy-t-xxx-h"),
+    // direct substring of "auth"
+    worktree_fixture("auth-service"),
+  ];
+  app.filter_query = "auth".into();
+
+  let idx = app.filtered_indices();
+  assert!(!idx.is_empty(), "at least the substring candidate must match");
+  assert_eq!(
+    app.worktrees[idx[0]].name, "auth-service",
+    "contiguous substring must outrank a spread subsequence"
+  );
+}
+
+#[test]
+fn filtered_indices_skips_when_no_match() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![worktree_fixture("alpha"), worktree_fixture("beta")];
+  app.filter_query = "zzzz".into();
+  assert!(app.filtered_indices().is_empty());
+}
+
+#[test]
+fn selected_returns_filtered_worktree() {
+  // `selected()` must resolve the table state's index through the filter map
+  // back to the underlying worktree, not blindly index into `worktrees`.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("authentication"),
+    worktree_fixture("beta"),
+  ];
+  app.filter_query = "auth".into();
+  app.list_state.select(Some(0));
+
+  let sel = app.selected().expect("filtered selection must resolve");
+  assert_eq!(sel.name, "authentication");
+}
+
+#[test]
+fn selected_returns_none_when_filter_matches_nothing() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![worktree_fixture("alpha"), worktree_fixture("beta")];
+  app.filter_query = "zzzz".into();
+  app.list_state.select(Some(0));
+  assert!(app.selected().is_none());
+}
+
+#[test]
+fn next_navigates_within_filtered_subset_and_wraps() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("foo-a"),
+    worktree_fixture("foo-b"),
+  ];
+  app.filter_query = "foo".into();
+  app.list_state.select(Some(0));
+
+  app.next();
+  assert_eq!(app.list_state.selected(), Some(1));
+  app.next();
+  assert_eq!(
+    app.list_state.selected(),
+    Some(0),
+    "wrap-around to start of filtered subset"
+  );
+}
+
+#[test]
+fn prev_navigates_within_filtered_subset_and_wraps() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("foo-a"),
+    worktree_fixture("foo-b"),
+  ];
+  app.filter_query = "foo".into();
+  app.list_state.select(Some(0));
+
+  app.prev();
+  assert_eq!(app.list_state.selected(), Some(1), "wrap-around backwards");
+}
+
+#[test]
+fn first_and_last_jump_inside_filtered_subset() {
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("foo-1"),
+    worktree_fixture("beta"),
+    worktree_fixture("foo-2"),
+    worktree_fixture("gamma"),
+  ];
+  app.filter_query = "foo".into();
+  app.list_state.select(Some(1));
+
+  app.first();
+  assert_eq!(app.list_state.selected(), Some(0));
+  app.last();
+  assert_eq!(
+    app.list_state.selected(),
+    Some(1),
+    "last must use the filtered length (2 matches → index 1)"
+  );
+}
+
+#[test]
+fn filter_push_clamps_selection_when_subset_shrinks() {
+  // User starts on the second match, then types more so only the first stays;
+  // selection must clamp instead of dangling past the new end.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![worktree_fixture("foo-bar"), worktree_fixture("foo-baz-xx")];
+  app.filter_query = "foo".into();
+  app.list_state.select(Some(1));
+
+  // Typing more reduces the match set to just "foo-bar".
+  for c in "-bar".chars() {
+    app.filter_push_char(c);
+  }
+  let filtered = app.filtered_indices();
+  assert_eq!(filtered.len(), 1, "only foo-bar should still match foo-bar");
+  assert_eq!(
+    app.list_state.selected(),
+    Some(0),
+    "selection must clamp to inside the new filtered subset"
+  );
+}
+
+#[test]
+fn exit_filter_cancel_restores_full_list_selection() {
+  // After clearing the filter, the original full list comes back and a
+  // selection past the filtered len must remain valid for the larger set.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![
+    worktree_fixture("alpha"),
+    worktree_fixture("foo"),
+    worktree_fixture("beta"),
+  ];
+  app.filter_query = "foo".into();
+  app.list_state.select(Some(0));
+
+  app.exit_filter_cancel();
+  assert!(app.filter_query.is_empty());
+  assert_eq!(app.filtered_indices(), vec![0, 1, 2]);
+  // Selection from the filtered view (index 0) remains a valid index in the
+  // full list (index 0). The clamp logic doesn't move it forward, only back.
+  assert_eq!(app.list_state.selected(), Some(0));
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -314,6 +314,25 @@ fn enter_filter_activates_capture_and_disarms_gg() {
 }
 
 #[test]
+fn enter_filter_drops_sidebar_focus() {
+  // Regression for the Copilot review on PR #44: if the sidebar held focus
+  // when the user hit `/`, after `exit_filter_keep` (Enter) the focus would
+  // still be on the sidebar, so `j` / `k` would scroll it instead of walking
+  // the filtered worktrees — contradicting the documented "navigation
+  // returns to the table" contract. Opening the filter bar must therefore
+  // pre-emptively pull focus back to the list.
+  let (_dir, mut app) = make_app();
+  app.sidebar_open = true;
+  app.sidebar_focused = true;
+
+  app.enter_filter();
+  assert!(
+    !app.sidebar_focused,
+    "opening the filter bar must hand focus back to the list"
+  );
+}
+
+#[test]
 fn enter_filter_preserves_existing_query() {
   // Hitting `/` on a sticky filter re-opens the bar so the user can refine
   // it; only Esc clears.
@@ -407,18 +426,29 @@ fn filtered_indices_keeps_only_matching_worktrees() {
 
 #[test]
 fn filtered_indices_supports_subsequence_match() {
-  // 'auth' is a sub-sequence of 'user-authentication' — nucleo's fuzzy
-  // matcher must surface it even without an exact substring.
+  // The candidate must NOT contain the query as a contiguous substring —
+  // otherwise a regression that downgrades the fuzzy matcher to plain
+  // substring matching would still pass. Spread the query characters across
+  // the haystack so only the subsequence path can score it.
   let (_dir, mut app) = make_app();
   app.worktrees = vec![
-    worktree_fixture("feat-99-user-authentication"),
+    // 'a'-'u'-'t'-'h' appear in order but separated by other characters;
+    // there is no literal `auth` substring anywhere in this name.
+    worktree_fixture("a-foo-u-bar-t-baz-h-qux"),
     worktree_fixture("chore-1-bump-deps"),
   ];
   app.filter_query = "auth".into();
+  // Sanity-guard the precondition: if a future refactor introduces an `auth`
+  // substring into the fixture, the test would silently degrade to a
+  // substring check again.
+  assert!(
+    !app.worktrees[0].name.contains("auth"),
+    "fixture must not contain 'auth' as a substring or the test stops covering subsequence"
+  );
 
   let idx = app.filtered_indices();
   assert_eq!(idx.len(), 1);
-  assert_eq!(app.worktrees[idx[0]].name, "feat-99-user-authentication");
+  assert_eq!(app.worktrees[idx[0]].name, "a-foo-u-bar-t-baz-h-qux");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Press `/` in the TUI list view to open an inline filter bar that narrows the worktree table in real time, using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) (the fuzzy engine behind Helix and Zellij). `Enter` confirms (the filter sticks, the cursor returns to the table); `Esc` clears the filter and restores the full list. `j` / `k` / `gg` / `G` continue to walk the filtered subset, and the table title shows `worktrees (N/M)` while a filter is active.

`Esc` on the plain list view clears any sticky filter before considering quit, so a stale filter can't accidentally exit the TUI.

Closes #21

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `src/tui/app.rs` — `filter_active` / `filter_query` state; methods `enter_filter`, `exit_filter_keep`, `exit_filter_cancel`, `filter_push_char`, `filter_pop_char`, `filtered_indices`, and a private `clamp_selection_to_filter` helper. Navigation (`next` / `prev` / `first` / `last`) and `selected()` route through `filtered_indices()` so list-state indices are always relative to the visible subset.
- `src/tui/mod.rs` — bind `/` to `enter_filter`; add a `View::List if app.filter_active` guarded match arm that routes printable chars / Backspace / Enter / Esc to the filter input; change `Esc` on the regular list view to clear a sticky filter before falling through to quit.
- `src/tui/ui.rs` — render a single-line filter bar between the body and the footer when the filter is active or sticky (Vim-style `/` prompt, cursor block while typing, sticky-hint when confirmed); render the filtered subset in `draw_list`; show `worktrees (N/M)` in the table title; mention `/` in the help overlay, the sidebar commands cheat-sheet, and the footer hint.
- `Cargo.toml` — add `nucleo-matcher = "0.3"`.
- `tests/tui_app_tests.rs` — 20 new state-machine tests covering defaults, mode toggling, query mutation, ranking semantics, selection mapping, navigation on the filtered subset, and clamp behaviour.
- `README.md` / `CHANGELOG.md` — keybinding table updated, new `fuzzy filter` section, `[Unreleased] / Added` entry.

## Tests

- [x] `cargo test` passes locally (43 tests in `tui_app_tests` including 20 new filter tests, plus the unchanged 13 / 22 / 8 / 10 / 16 across `bootstrap_tests` / `cli_binary` / `config_tests` / `naming_tests` / `worktree_integration`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/tui_app_tests.rs` (TDD: ranking and navigation behaviours are pinned down by tests before merge)

## Screenshots / TUI captures

Manual smoke test only — the filter bar renders inline above the footer, the worktree count in the table title flips to `(N/M)` while a filter is active, and the bar shows a Vim-style `/<query>█` while typing or `/<query>   (sticky — / to refine, esc on list to clear)` once Enter is pressed.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#21-tui-fuzzy-filter`)
- [x] Commits follow Gitmoji + Conventional Commits (`✨ feat(tui)`, `✅ test(tui)`, `📝 docs`)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (new TUI keybinding row + a `fuzzy filter` section)
- [ ] `examples/gwm.toml.example` updated — N/A, config schema unchanged
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code (only `Paragraph` / status bar feedback)

## Linked issues / docs

- Issue: #21

## Notes for reviewers

- The filter is implemented purely at the `App` state level; `mod.rs` only wires keys, and `ui.rs` only consumes `filtered_indices()`. Each layer is exercised by either the new tests (state) or visual inspection (wiring + rendering), mirroring how the existing TUI splits its tests.
- `nucleo-matcher` runs synchronously on the current thread. For ~10s–100s worktrees the cost is negligible (one alloc per haystack and a small DFA per query); the high-level `nucleo` crate would only matter if the list grew an order of magnitude.
- `Esc` semantics on the list view changed from "always quit" to "clear filter first, otherwise quit". This is intentional: the inline filter bar advertises `esc on list to clear` while sticky, and the new README quit row reflects the split.