### PR TITLE
📝 docs: split CHANGELOG into per-version files under changelogs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented here.
+
+This file tracks the **in-progress** release only. Past releases live under
+[`changelogs/`](changelogs/) — one Markdown file per SemVer version.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -21,66 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CLAUDE.md` (new, repo root) — house rules for AI-assisted contributions. Promotes **TDD as the primordial contribution rule** (red → green → refactor, mandatory failing test before production code).
 - `CONTRIBUTING.md` — `TDD expectations` section rewritten as `🔴 TDD is mandatory — non-negotiable`: explicit loop, narrow exceptions, reviewer enforcement via `git log --stat tests/`.
 - `CODE_OF_CONDUCT.md` — new `Engineering conduct` section anchoring the TDD rule as a contribution-conduct expectation (applies equally to human and AI-assisted PRs).
+- `CHANGELOG.md` trimmed to the in-progress release only; past releases moved under `changelogs/`.
 
 ### Dependencies
 
 - `clap_complete` `4.5` (new).
 - `nucleo-matcher` `0.3` (new) — fuzzy match engine for the TUI `/` filter.
 
-## [0.2.0] - 2026-05-18
+## Past releases
 
-Validated via `v0.2.0-rc.1` (pre-release published on 2026-05-18).
+In reverse chronological order:
 
-### Added
-
-- TUI keybinding `o` reveals the selected worktree's directory in the OS file manager (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows).
-- `WorktreeInfo.status` (`BranchStatus`): dirty / clean / upstream-tracked / ahead / behind, computed via libgit2.
-- `STATUS` column in both the TUI table and `gwm list` CLI output, with colour-coding (`green` clean / synced, `yellow` dirty or behind, `cyan` ahead, `red` prunable, `magenta` locked, `dark_gray` unknown).
-- CI on the `dev` integration branch: `fmt`, `clippy`, multi-OS test, and `cargo audit` now run on every push to `dev` and on every PR targeting `dev` (same matrix as `main`).
-- `.github/workflows/pre-release.yml`: builds the 5 release targets (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64) and publishes a GitHub Release with `prerelease: true` whenever a SemVer-rc / -alpha / -beta tag is pushed (e.g. `v0.2.0-rc.1`). Also supports `workflow_dispatch` for manual reruns.
-- **TUI details sidebar** (auto-shown when terminal width ≥ 120 cols, toggle with `v`): lazyssh-style panel listing the selected worktree's branch, path, head, locked / prunable / main flags, status, plus `git log --oneline -n 10`, `git status --short`, and a commands cheat-sheet.
-- **TUI keybinding `l`**: suspend the TUI and launch `lazygit -p <selected-worktree-path>` fullscreen; resume the TUI when lazygit exits. Surfaces a clear error in the status bar if `lazygit` is not on `$PATH`.
-- **TUI focus toggle (`Tab`)**: swap focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel; the focused panel's border turns cyan.
-- **TUI vim motions**: `gg` jumps to the first worktree, `G` to the last.
-- `worktree::git_log_oneline(path, n)` and `worktree::git_status_short(path)` — thin `Command::new("git")` wrappers used by the sidebar (and exposed for tests).
-- `.gwm.toml` config for this repo (Rust-flavoured): `target/` no_symlink + `cargo fetch` bootstrap step + `direnv allow` when an `.envrc` exists.
-- `dependabot.yml`: `target-branch: dev` on both ecosystems so new automated PRs land on the integration branch instead of `main`.
-
-### Changed
-
-- TUI worktree view: ratatui `List` → `Table` with dynamic column widths derived from data (name/branch capped to [18, 38], status fixed 16, path takes the rest). No more `…`-truncated names for typical branch lengths.
-- `gwm list` CLI output uses the same dynamic column widths.
-- TUI list `j` / `k`: now reset the sidebar scroll offset when navigating worktrees, and scroll the sidebar instead of moving selection when the sidebar has focus.
-- Sidebar content is now cached on the `App` (keyed by selected worktree's path); `git log` / `git status` only run when the selection actually changes. Sidebar scrolling clamps to the rendered content height.
-- Windows `.sha256` sidecars (release + pre-release workflows) now use `Set-Content -Encoding ascii` and the conventional `<hash>  <file>` format so they verify cleanly with `sha256sum -c` across platforms.
-
-### Dependencies
-
-- `ratatui` `0.28` → `0.30` (and `crossterm` `0.28` → `0.29`). Renamed `Table::highlight_style` → `row_highlight_style` to track the deprecation.
-- `git2` `0.19` → `0.20`.
-- `toml` `0.8` → `1.1`.
-- `thiserror` `1` → `2`.
-- `which` `6` → `8`.
-- `actions/checkout` `4` → `6`, `actions/upload-artifact` `4` → `7`, `actions/download-artifact` `4` → `8`, `softprops/action-gh-release` `2` → `3`.
-
-## [0.1.0] - 2026-05-18
-
-### Added
-
-- Native git worktree management via libgit2 (vendored), no `gwq` / `git` CLI dependency.
-- CLI subcommands: `init`, `list`, `create`, `remove`, `path`, `bootstrap`, `prune`, `types`.
-- TUI (ratatui) with views: List, Create form, Confirm delete, Bootstrap report, Help.
-- Per-repo configuration via `.gwm.toml`:
-  - `[worktree]` — `base`, `path_pattern`, `branch_pattern` with `{home}/{repo}/{type}/{issue}/{desc}` placeholders.
-  - `[[bootstrap.copy]]` — file copies main → worktree, with optional inline fallbacks.
-  - `[[bootstrap.guard]]` — regex deny patterns with `abort` or `seed-from-example` actions.
-  - `[[bootstrap.no_symlink]]` — paths that must never be symlinks (e.g. `vendor`, `node_modules`).
-  - `[[bootstrap.command]]` — shell commands with `when = "file_exists:..."` predicates and env injection.
-- Branch convention `<type>/#<issue>-<desc>` (matches the original bash script) with override via `.gwm.toml`.
-- Fuzzy worktree lookup (`gwm remove <substring>`, `gwm path <substring>`).
-- 56 tests covering config, naming, bootstrap, worktree (libgit2 integration), TUI state machine, and CLI end-to-end (assert_cmd).
-- Examples: `examples/gwm.toml.example` with the AWS RDS guard pattern from the original script's incident.
-
-### Notes
-
-This is the initial release. Behaviour and config schema may still change before `1.0`.
+- [`0.2.0`](changelogs/0.2.0.md) — 2026-05-18
+- [`0.1.0`](changelogs/0.1.0.md) — 2026-05-18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,7 @@ When `dev` is ready to be exercised by early adopters before promotion:
 Once the rc is validated and promoted to `main`:
 
 1. Update `Cargo.toml` `version`.
-2. Move `## [Unreleased]` entries into a dated section in `CHANGELOG.md`.
+2. Move the `## [Unreleased]` section out of `CHANGELOG.md` into a new file `changelogs/<version>.md` (e.g. `changelogs/0.3.0.md`), rename its heading to `# [<version>] - YYYY-MM-DD`, and add a one-line entry at the bottom of `CHANGELOG.md`'s `## Past releases` index pointing to the new file. `CHANGELOG.md` at the root then only carries the next `## [Unreleased]` section. (See [`changelogs/0.2.0.md`](changelogs/0.2.0.md) for the expected layout.)
 3. Merge `dev` → `main` (regular merge, never squash; see [Merge strategy](#merge-strategy)).
 4. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
 5. GitHub Actions (`release.yml`) builds binaries and publishes the stable release.

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,21 @@
+# [0.1.0] - 2026-05-18
+
+### Added
+
+- Native git worktree management via libgit2 (vendored), no `gwq` / `git` CLI dependency.
+- CLI subcommands: `init`, `list`, `create`, `remove`, `path`, `bootstrap`, `prune`, `types`.
+- TUI (ratatui) with views: List, Create form, Confirm delete, Bootstrap report, Help.
+- Per-repo configuration via `.gwm.toml`:
+  - `[worktree]` — `base`, `path_pattern`, `branch_pattern` with `{home}/{repo}/{type}/{issue}/{desc}` placeholders.
+  - `[[bootstrap.copy]]` — file copies main → worktree, with optional inline fallbacks.
+  - `[[bootstrap.guard]]` — regex deny patterns with `abort` or `seed-from-example` actions.
+  - `[[bootstrap.no_symlink]]` — paths that must never be symlinks (e.g. `vendor`, `node_modules`).
+  - `[[bootstrap.command]]` — shell commands with `when = "file_exists:..."` predicates and env injection.
+- Branch convention `<type>/#<issue>-<desc>` (matches the original bash script) with override via `.gwm.toml`.
+- Fuzzy worktree lookup (`gwm remove <substring>`, `gwm path <substring>`).
+- 56 tests covering config, naming, bootstrap, worktree (libgit2 integration), TUI state machine, and CLI end-to-end (assert_cmd).
+- Examples: `examples/gwm.toml.example` with the AWS RDS guard pattern from the original script's incident.
+
+### Notes
+
+This is the initial release. Behaviour and config schema may still change before `1.0`.

--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,35 @@
+# [0.2.0] - 2026-05-18
+
+Validated via `v0.2.0-rc.1` (pre-release published on 2026-05-18).
+
+### Added
+
+- TUI keybinding `o` reveals the selected worktree's directory in the OS file manager (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows).
+- `WorktreeInfo.status` (`BranchStatus`): dirty / clean / upstream-tracked / ahead / behind, computed via libgit2.
+- `STATUS` column in both the TUI table and `gwm list` CLI output, with colour-coding (`green` clean / synced, `yellow` dirty or behind, `cyan` ahead, `red` prunable, `magenta` locked, `dark_gray` unknown).
+- CI on the `dev` integration branch: `fmt`, `clippy`, multi-OS test, and `cargo audit` now run on every push to `dev` and on every PR targeting `dev` (same matrix as `main`).
+- `.github/workflows/pre-release.yml`: builds the 5 release targets (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64) and publishes a GitHub Release with `prerelease: true` whenever a SemVer-rc / -alpha / -beta tag is pushed (e.g. `v0.2.0-rc.1`). Also supports `workflow_dispatch` for manual reruns.
+- **TUI details sidebar** (auto-shown when terminal width ≥ 120 cols, toggle with `v`): lazyssh-style panel listing the selected worktree's branch, path, head, locked / prunable / main flags, status, plus `git log --oneline -n 10`, `git status --short`, and a commands cheat-sheet.
+- **TUI keybinding `l`**: suspend the TUI and launch `lazygit -p <selected-worktree-path>` fullscreen; resume the TUI when lazygit exits. Surfaces a clear error in the status bar if `lazygit` is not on `$PATH`.
+- **TUI focus toggle (`Tab`)**: swap focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel; the focused panel's border turns cyan.
+- **TUI vim motions**: `gg` jumps to the first worktree, `G` to the last.
+- `worktree::git_log_oneline(path, n)` and `worktree::git_status_short(path)` — thin `Command::new("git")` wrappers used by the sidebar (and exposed for tests).
+- `.gwm.toml` config for this repo (Rust-flavoured): `target/` no_symlink + `cargo fetch` bootstrap step + `direnv allow` when an `.envrc` exists.
+- `dependabot.yml`: `target-branch: dev` on both ecosystems so new automated PRs land on the integration branch instead of `main`.
+
+### Changed
+
+- TUI worktree view: ratatui `List` → `Table` with dynamic column widths derived from data (name/branch capped to [18, 38], status fixed 16, path takes the rest). No more `…`-truncated names for typical branch lengths.
+- `gwm list` CLI output uses the same dynamic column widths.
+- TUI list `j` / `k`: now reset the sidebar scroll offset when navigating worktrees, and scroll the sidebar instead of moving selection when the sidebar has focus.
+- Sidebar content is now cached on the `App` (keyed by selected worktree's path); `git log` / `git status` only run when the selection actually changes. Sidebar scrolling clamps to the rendered content height.
+- Windows `.sha256` sidecars (release + pre-release workflows) now use `Set-Content -Encoding ascii` and the conventional `<hash>  <file>` format so they verify cleanly with `sha256sum -c` across platforms.
+
+### Dependencies
+
+- `ratatui` `0.28` → `0.30` (and `crossterm` `0.28` → `0.29`). Renamed `Table::highlight_style` → `row_highlight_style` to track the deprecation.
+- `git2` `0.19` → `0.20`.
+- `toml` `0.8` → `1.1`.
+- `thiserror` `1` → `2`.
+- `which` `6` → `8`.
+- `actions/checkout` `4` → `6`, `actions/upload-artifact` `4` → `7`, `actions/download-artifact` `4` → `8`, `softprops/action-gh-release` `2` → `3`.


### PR DESCRIPTION
## Description

`CHANGELOG.md` at the root now carries only the in-progress `## [Unreleased]` section plus a `## Past releases` index linking to per-version archive files in `changelogs/`. Past releases (`[0.1.0]`, `[0.2.0]`) move out of the root file into their own `changelogs/<version>.md` files verbatim.

Two reasons:

1. **Discoverability.** A user landing on the root file should see what's coming in the next release, not scroll past 60 lines of past entries first.
2. **Diff conflict noise.** With multiple PRs touching `[Unreleased]` simultaneously, every PR rebased on `dev` had to re-resolve the same `CHANGELOG.md` chunk. Splitting reduces the conflict surface to the affected version file.

Closes #45

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `CHANGELOG.md` — trimmed to `[Unreleased]` + `Past releases` index. Header rewritten to state the new contract ("This file tracks the **in-progress** release only").
- `changelogs/0.1.0.md` — new, verbatim extraction.
- `changelogs/0.2.0.md` — new, verbatim extraction.
- `CONTRIBUTING.md` §Releases step 2 — instructions updated for the new flow (extract `[Unreleased]` → `changelogs/<version>.md`, append a one-line entry to the root index).

## Tests

- [x] `cargo test` passes locally (no code touched — just verifying nothing else broke)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` — **N/A** (docs-only, narrow exception per CONTRIBUTING §TDD: "Comment-only changes" extended to documentation files; no behaviour change)

## Screenshots / TUI captures

N/A — docs only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`chore/#45-changelog-split`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]` (the `Docs` block now mentions the split itself)
- [ ] README updated if CLI surface changed (N/A — no CLI change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (N/A)
- [x] No `unwrap()` on user-facing paths (no code)
- [x] No `println!` in TUI render code (no code)

## Linked issues / docs

- Issue: #45

## Notes for reviewers

- The split happens **on `dev`, before the `v0.3.0` stable cut**, so the next release's promotion step (per the updated CONTRIBUTING §Releases) will create `changelogs/0.3.0.md` directly — no retroactive migration needed.
- Anchors like `#020---2026-05-18` on the root file are broken by this change. No external link to those anchors is known. New anchors live inside the per-version files.