### PR TITLE
✨ feat(doctor): skip branches merged into dev/main from orphan check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. The bash/zsh and PowerShell variants `unalias gcd` first so the function takes effect even if the shell already had a `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`). Closes #19.
 - `gwm doctor` — diagnose the gwm setup. Aggregates 7 cheap checks (`.gwm.toml` parses, guard references resolve, `when` predicates supported, external binaries on PATH, no prunable worktrees, no orphan gwm branches, base directory writable) and reports each with `✓ / ! / ✗`. Exit code `0` (all green), `1` (any warning), `2` (any failure) — wirable into CI / pre-commit. New `src/doctor.rs` module exposing `DoctorReport` / `Check` / `Severity` / `DoctorCtx` for library users. Closes #20.
 
+### Changed
+
+- `gwm doctor` no longer flags gwm-style branches as orphan when they're already fully merged into one of the trunk branches (`dev`, `main`). CONTRIBUTING.md mandates preserving the source branch post-merge, so the previous behaviour produced N false-positives on every successful release. The Ok detail now reads e.g. `7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans`. Genuine WIP branches (no worktree, no merge into a trunk) still surface as Warning. Closes #47.
+
 ### Docs
 
 - `CLAUDE.md` (new, repo root) — house rules for AI-assisted contributions. Promotes **TDD as the primordial contribution rule** (red → green → refactor, mandatory failing test before production code).

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -397,9 +397,25 @@ fn check_orphan_branches(ctx: &DoctorCtx<'_>) -> Check {
     let Some(branch_oid) = branch.get().target() else {
       continue;
     };
-    if is_merged_into_any(ctx.repo, branch_oid, &trunk_oids) {
-      merged_count += 1;
-      continue; // preserved on purpose per CONTRIBUTING — not flagged
+    match is_merged_into_any(ctx.repo, branch_oid, &trunk_oids) {
+      Ok(true) => {
+        merged_count += 1;
+        continue; // preserved on purpose per CONTRIBUTING — not flagged
+      }
+      Ok(false) => {
+        // Real orphan — fall through.
+      }
+      Err(e) => {
+        // libgit2 couldn't walk the graph (missing objects, shallow
+        // clone, repo corruption). Surface this loudly: silently
+        // assuming "not merged" and recommending `git branch -d` would
+        // be actively dangerous.
+        return Check::failed(
+          name,
+          format!("could not determine merge status for {}: {}", branch_name, e),
+        )
+        .with_hint("check the repository integrity (`git fsck`) or re-fetch missing objects");
+      }
     }
     orphans.push(branch_name.to_string());
   }
@@ -424,14 +440,28 @@ fn check_orphan_branches(ctx: &DoctorCtx<'_>) -> Check {
   .with_hint(suggestions.join(" && "))
 }
 
-/// Returns `true` iff `branch_oid` is fully reachable from at least one
-/// of `trunks` — i.e. the branch is merged into one of the trunks (or
-/// is equal to it). Implemented via libgit2's descendant check: trunk is
-/// a descendant of the branch iff the branch is reachable from trunk.
-fn is_merged_into_any(repo: &git2::Repository, branch_oid: git2::Oid, trunks: &[git2::Oid]) -> bool {
-  trunks
-    .iter()
-    .any(|trunk_oid| *trunk_oid == branch_oid || repo.graph_descendant_of(*trunk_oid, branch_oid).unwrap_or(false))
+/// Returns `Ok(true)` iff `branch_oid` is fully reachable from at least
+/// one of `trunks` — i.e. the branch is merged into one of the trunks
+/// (or is equal to it). Implemented via libgit2's descendant check:
+/// trunk is a descendant of the branch iff the branch is reachable
+/// from trunk. Propagates `git2::Error` so callers can distinguish
+/// "definitively unmerged" from "could not tell" — silently swallowing
+/// the error would let a misclassification lead to a destructive
+/// `git branch -d` suggestion.
+fn is_merged_into_any(
+  repo: &git2::Repository,
+  branch_oid: git2::Oid,
+  trunks: &[git2::Oid],
+) -> std::result::Result<bool, git2::Error> {
+  for trunk_oid in trunks {
+    if *trunk_oid == branch_oid {
+      return Ok(true);
+    }
+    if repo.graph_descendant_of(*trunk_oid, branch_oid)? {
+      return Ok(true);
+    }
+  }
+  Ok(false)
 }
 
 /// Probe a directory for write access by creating and deleting a sentinel

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -341,10 +341,21 @@ fn check_prunable_worktrees(ctx: &DoctorCtx<'_>) -> Check {
   .with_hint("run `gwm prune` to clear them")
 }
 
+/// Trunk branches the doctor considers "merged into" — branches fully
+/// reachable from one of these are deliberately preserved per
+/// CONTRIBUTING.md (`Never delete the source branch after merge`), so we
+/// don't flag them as orphan even when their worktree is gone.
+const TRUNK_BRANCHES: &[&str] = &["dev", "main"];
+
 /// Check #6: every local branch matching the `<type>/#<issue>-<desc>`
 /// shape has a worktree pointing at it. A branch without a worktree was
 /// likely created by `gwm create` and lost its worktree without a
 /// `--delete-branch` — purely cosmetic dead weight, hence Warning not Failed.
+///
+/// Branches already fully merged into one of the trunk branches
+/// (`dev`, `main`) are filtered out: keeping them is the project
+/// convention, and surfacing them would make the check produce N false
+/// positives on every successful release.
 fn check_orphan_branches(ctx: &DoctorCtx<'_>) -> Check {
   let name = "no orphan gwm branches";
 
@@ -354,33 +365,73 @@ fn check_orphan_branches(ctx: &DoctorCtx<'_>) -> Check {
   };
   let claimed: BTreeSet<String> = trees.iter().filter_map(|w| w.branch.clone()).collect();
 
+  // Resolve the trunk OIDs once. Missing trunks (e.g. a repo without `dev`)
+  // are silently skipped — we only check against what exists.
+  let trunk_oids: Vec<git2::Oid> = TRUNK_BRANCHES
+    .iter()
+    .filter_map(|t| {
+      ctx
+        .repo
+        .find_branch(t, BranchType::Local)
+        .ok()
+        .and_then(|b| b.get().target())
+    })
+    .collect();
+
   let branches = match ctx.repo.branches(Some(BranchType::Local)) {
     Ok(b) => b,
     Err(e) => return Check::failed(name, format!("could not list local branches: {}", e)),
   };
 
   let mut orphans: Vec<String> = Vec::new();
+  let mut merged_count: usize = 0;
   for entry in branches.flatten() {
     let (branch, _) = entry;
     let Ok(Some(branch_name)) = branch.name() else { continue };
     if parse_branch(branch_name).is_none() {
       continue; // user-managed branch, leave it alone
     }
-    if !claimed.contains(branch_name) {
-      orphans.push(branch_name.to_string());
+    if claimed.contains(branch_name) {
+      continue; // has a worktree — not orphan in any sense
     }
+    let Some(branch_oid) = branch.get().target() else {
+      continue;
+    };
+    if is_merged_into_any(ctx.repo, branch_oid, &trunk_oids) {
+      merged_count += 1;
+      continue; // preserved on purpose per CONTRIBUTING — not flagged
+    }
+    orphans.push(branch_name.to_string());
   }
 
   if orphans.is_empty() {
-    return Check::ok(name, "every gwm-style branch has a matching worktree");
+    let detail = if merged_count == 0 {
+      "every gwm-style branch has a matching worktree".to_string()
+    } else {
+      format!(
+        "{} merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans",
+        merged_count
+      )
+    };
+    return Check::ok(name, detail);
   }
 
   let suggestions: Vec<String> = orphans.iter().map(|b| format!("git branch -d {}", b)).collect();
   Check::warning(
     name,
-    format!("{} orphan branch(es): {}", orphans.len(), orphans.join(", ")),
+    format!("{} unmerged orphan branch(es): {}", orphans.len(), orphans.join(", ")),
   )
   .with_hint(suggestions.join(" && "))
+}
+
+/// Returns `true` iff `branch_oid` is fully reachable from at least one
+/// of `trunks` — i.e. the branch is merged into one of the trunks (or
+/// is equal to it). Implemented via libgit2's descendant check: trunk is
+/// a descendant of the branch iff the branch is reachable from trunk.
+fn is_merged_into_any(repo: &git2::Repository, branch_oid: git2::Oid, trunks: &[git2::Oid]) -> bool {
+  trunks
+    .iter()
+    .any(|trunk_oid| *trunk_oid == branch_oid || repo.graph_descendant_of(*trunk_oid, branch_oid).unwrap_or(false))
 }
 
 /// Probe a directory for write access by creating and deleting a sentinel

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -408,9 +408,14 @@ fn merged_gwm_branch_is_not_flagged_as_orphan() {
   // So a branch fully merged into a trunk (`dev` or `main`) is preserved
   // on purpose — flagging it would be noise on every doctor run. The
   // doctor must filter it out.
+  //
+  // This test exercises the *equality* short-circuit: the branch tip is
+  // the same commit as main's tip. See
+  // `merged_via_merge_commit_gwm_branch_is_not_flagged_as_orphan` for the
+  // descendant-of case, which is what every real "merge commit" flow
+  // produces.
   let (dir, repo) = init_repo();
   let head = repo.head().unwrap().peel_to_commit().unwrap();
-  // Branch points at the same commit as main — fully merged by definition.
   repo.branch("feat/#99-already-merged", &head, false).unwrap();
 
   let config = Config::default();
@@ -420,6 +425,53 @@ fn merged_gwm_branch_is_not_flagged_as_orphan() {
   assert!(
     !c.detail.contains("feat/#99-already-merged"),
     "merged branch must not appear in the orphan list, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn merged_via_merge_commit_gwm_branch_is_not_flagged_as_orphan() {
+  // The realistic case: a feature branch had its own commit, then a
+  // merge commit on `main` joined it back. After that, `main`'s tip is
+  // a descendant of the feature tip, but they're NOT equal. The
+  // equality short-circuit alone would miss this; the descendant check
+  // (`graph_descendant_of`) is what catches it.
+  let (dir, repo) = init_repo();
+  let main_initial = repo.head().unwrap().peel_to_commit().unwrap();
+  let sig = git2::Signature::now("test", "test@test").unwrap();
+  let tree = main_initial.tree().unwrap();
+
+  // Feature branch with its own commit, not on main yet.
+  let feature_oid = repo
+    .commit(None, &sig, &sig, "feature work", &tree, &[&main_initial])
+    .unwrap();
+  let feature_commit = repo.find_commit(feature_oid).unwrap();
+  repo
+    .branch("feat/#88-merged-via-merge", &feature_commit, false)
+    .unwrap();
+
+  // Merge commit on main combining the initial commit and the feature.
+  // Main now points at a commit that has the feature tip as one of its
+  // parents — `graph_descendant_of(main_tip, feature_tip) == true`,
+  // but `main_tip != feature_tip`.
+  repo
+    .commit(
+      Some("refs/heads/main"),
+      &sig,
+      &sig,
+      "merge feat/#88",
+      &tree,
+      &[&main_initial, &feature_commit],
+    )
+    .unwrap();
+
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("orphan")).unwrap();
+  assert_eq!(c.status, CheckStatus::Ok);
+  assert!(
+    !c.detail.contains("feat/#88-merged-via-merge"),
+    "branch merged via a merge commit must not appear in the orphan list, got: {}",
     c.detail
   );
 }

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -373,11 +373,19 @@ fn fresh_repo_has_no_prunable_worktrees() {
 // --------------------------------------------------------------------------
 
 #[test]
-fn orphan_gwm_branch_is_warning() {
+fn orphan_unmerged_gwm_branch_is_warning() {
   let (dir, repo) = init_repo();
-  // Manufacture a gwm-style branch with no worktree pointing at it.
+  // Build a commit that is NOT reachable from main, then branch off it.
+  // This is what an in-flight WIP branch looks like: still divergent from
+  // the trunk, so leaving it around is genuine dead weight.
   let head = repo.head().unwrap().peel_to_commit().unwrap();
-  repo.branch("feat/#99-stale-thing", &head, false).unwrap();
+  let sig = git2::Signature::now("test", "test@test").unwrap();
+  let tree = head.tree().unwrap();
+  let oid = repo
+    .commit(None, &sig, &sig, "off-main commit", &tree, &[&head])
+    .unwrap();
+  let commit = repo.find_commit(oid).unwrap();
+  repo.branch("feat/#99-stale-thing", &commit, false).unwrap();
 
   let config = Config::default();
   let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
@@ -390,6 +398,28 @@ fn orphan_gwm_branch_is_warning() {
   assert!(
     c.detail.contains("feat/#99-stale-thing"),
     "orphan branch should be quoted in the detail, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn merged_gwm_branch_is_not_flagged_as_orphan() {
+  // CONTRIBUTING.md mandates "never delete the source branch after merge".
+  // So a branch fully merged into a trunk (`dev` or `main`) is preserved
+  // on purpose — flagging it would be noise on every doctor run. The
+  // doctor must filter it out.
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  // Branch points at the same commit as main — fully merged by definition.
+  repo.branch("feat/#99-already-merged", &head, false).unwrap();
+
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("orphan")).unwrap();
+  assert_eq!(c.status, CheckStatus::Ok);
+  assert!(
+    !c.detail.contains("feat/#99-already-merged"),
+    "merged branch must not appear in the orphan list, got: {}",
     c.detail
   );
 }


### PR DESCRIPTION
## Description

\`gwm doctor\` flagged every gwm-style branch without a worktree as orphan, even when the branch was preserved post-merge per CONTRIBUTING. On this repo today, that meant **7 false positives** on every run, exit code 1, and a `git branch -d ...` hint that would delete deliberately-preserved history.

This PR filters out branches fully merged into one of the trunk branches (\`dev\`, \`main\`). Genuine WIP orphans (unmerged, no worktree) still surface as Warning.

Smoke test live on this repo, pre- vs post-fix:

\`\`\`
- ! no orphan gwm branches
-     7 orphan branch(es): feat/#18-shell-completions, feat/#19-cd-shell-init, …
-     → git branch -d feat/#18-shell-completions && …
+ ✓ no orphan gwm branches
+     7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
\`\`\`

Closes #47

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests (1 new + 1 rewritten)
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- \`src/doctor.rs\` — \`check_orphan_branches\`:
  - New \`TRUNK_BRANCHES = ["dev", "main"]\` constant.
  - Resolve trunk OIDs once via \`repo.find_branch + .target()\`. Missing trunks are silently skipped (a repo without \`dev\` falls back to checking against \`main\` only).
  - For each gwm-style branch without a worktree, call \`is_merged_into_any\` (new helper) which returns true iff \`trunk_oid == branch_oid\` or \`repo.graph_descendant_of(trunk_oid, branch_oid)\`.
  - Merged branches are counted but not added to \`orphans\`. Ok detail mentions the count + the policy justification.
  - Warning wording sharpened to \`"N unmerged orphan branch(es): …"\` to distinguish the surviving real-orphan case.
- \`tests/doctor_tests.rs\` —
  - \`orphan_gwm_branch_is_warning\` → renamed \`orphan_unmerged_gwm_branch_is_warning\`. Now builds a commit off-main and branches from it, guaranteeing the branch is not merged into any trunk.
  - New \`merged_gwm_branch_is_not_flagged_as_orphan\`: branch pointing at the HEAD of main → must come back Ok with the merged branch not appearing in the detail.
- \`CHANGELOG.md\` — entry under \`[Unreleased] > Changed\`. Will need a trivial rebase if PR #46 (CHANGELOG split) lands first; the entry moves to \`changelogs/0.3.0.md > Changed\` instead.

## Tests

- [x] \`cargo test\` passes locally (22 doctor + 25 CLI binary + 44 worktree + 16 TUI + 13 naming + 10 bootstrap + 8 config + 0 ui)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [x] New tests added under \`tests/\` (TDD: red → green cycle)

## Screenshots / TUI captures

N/A — diagnostic output only, see the smoke-test diff in the description.

## Checklist

- [x] Branch follows \`<type>/#<issue>-<description>\` (\`feat/#47-doctor-skip-merged\`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under \`## [Unreleased]\`
- [ ] README updated if CLI surface changed (N/A — same subcommand, same exit-code contract, just less noise)
- [ ] \`examples/gwm.toml.example\` updated if config schema changed (N/A — no config change; trunk list is hardcoded for now, exposing it as config can come later)
- [x] No \`unwrap()\` on user-facing paths
- [x] No \`println!\` in TUI render code

## Linked issues / docs

- Issue: #47
- Related PR: #46 (CHANGELOG split) — if #46 lands first, the \`[Unreleased] > Changed\` entry here moves into \`changelogs/0.3.0.md > Changed\` on rebase.

## Notes for reviewers

- The trunk list is hardcoded (\`["dev", "main"]\`) on purpose: those are the two trunks for this repo per CONTRIBUTING. Configurability via \`.gwm.toml\` is a follow-up if the need arises — flagged in the issue body.
- \`is_merged_into_any\` uses \`repo.graph_descendant_of(trunk_oid, branch_oid)\` which is the libgit2 primitive for "is X reachable from Y". An equal-OID short-circuit handles the edge case where the branch points exactly at the trunk's tip (which \`graph_descendant_of\` would otherwise return false for).
- Pre-validation: ran \`cargo test\` with \`PATH=$(dirname $(which cargo)):/usr/bin:/bin\` to neutralise local-only ambient dependencies — all green.