### PR TITLE
🔧 chore: CI advisory `gwm doctor` + CLAUDE.md pre-validation rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
     name: gwm doctor (advisory)
     runs-on: ubuntu-latest
     needs: test
+    # Restrict to the `dev` integration branch only — `main` is meant to be
+    # stable, the doctor exists to catch in-development regressions before
+    # they reach a release. Without this guard the job would also run on
+    # every push/PR targeting `main` (the workflow header lists both).
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'dev')
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,26 @@ jobs:
       - name: cargo audit
         run: cargo audit
         continue-on-error: true
+
+  doctor:
+    name: gwm doctor (advisory)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: configure git identity
+        run: |
+          git config --global user.email "ci@gwm.test"
+          git config --global user.name "ci"
+      # Build the binary once with the same release profile gh actions
+      # cache benefits from, then ask it to diagnose this very repo.
+      # Advisory: a non-zero exit means we want eyes on the report, but
+      # not a blocked merge. `lazygit` is intentionally absent on the
+      # runner so a Warning here is the floor, not a regression.
+      - name: cargo build
+        run: cargo build --release --quiet
+      - name: gwm doctor
+        run: ./target/release/gwm doctor
+        continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. The bash/zsh and PowerShell variants `unalias gcd` first so the function takes effect even if the shell already had a `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`). Closes #19.
 - `gwm doctor` — diagnose the gwm setup. Aggregates 7 cheap checks (`.gwm.toml` parses, guard references resolve, `when` predicates supported, external binaries on PATH, no prunable worktrees, no orphan gwm branches, base directory writable) and reports each with `✓ / ! / ✗`. Exit code `0` (all green), `1` (any warning), `2` (any failure) — wirable into CI / pre-commit. New `src/doctor.rs` module exposing `DoctorReport` / `Check` / `Severity` / `DoctorCtx` for library users. Closes #20.
 
+### CI
+
+- New advisory job `gwm doctor` in `.github/workflows/ci.yml` — runs `cargo build --release` then `./target/release/gwm doctor` against the repo on every push to `dev` and on every PR targeting `dev`. `continue-on-error: true` so it never blocks a merge, but a non-zero exit surfaces config / env / worktree-state regressions for human review. Closes #49.
+
 ### Docs
 
 - `CLAUDE.md` (new, repo root) — house rules for AI-assisted contributions. Promotes **TDD as the primordial contribution rule** (red → green → refactor, mandatory failing test before production code).
 - `CONTRIBUTING.md` — `TDD expectations` section rewritten as `🔴 TDD is mandatory — non-negotiable`: explicit loop, narrow exceptions, reviewer enforcement via `git log --stat tests/`.
 - `CODE_OF_CONDUCT.md` — new `Engineering conduct` section anchoring the TDD rule as a contribution-conduct expectation (applies equally to human and AI-assisted PRs).
+- `CLAUDE.md` — two new house rules: pre-validate environment-dependent tests with a stripped `PATH` before push (one-liner included), and run `gwm doctor` locally on PRs that touch `.gwm.toml` / bootstrap / doctor. Codifies the recipe that would have spared the 3 CI round-trips on PR #43.
 
 ### Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ exception; codify the manual test as an integration test.
   reproduces a CI-like minimal PATH:
 
   ```bash
-  PATH="$(dirname $(which cargo)):/usr/bin:/bin" cargo test
+  PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test
   ```
 
   Run it before push. The cost is one minute; the cost of skipping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,27 @@ exception; codify the manual test as an integration test.
 
 ## Other house rules
 
+- **Pre-validate environment-dependent tests.** Any test that reads
+  `$PATH`, the user's home directory, or other ambient state must be
+  pre-validated locally against a stripped environment before the test
+  gets pushed — CI runners don't have `lazygit`, a pre-created
+  `~/cc-worktree/`, or your installed dev tooling. The one-liner that
+  reproduces a CI-like minimal PATH:
+
+  ```bash
+  PATH="$(dirname $(which cargo)):/usr/bin:/bin" cargo test
+  ```
+
+  Run it before push. The cost is one minute; the cost of skipping
+  it is at least two CI round-trips (witnessed on PR #43 — three
+  fix commits before the suite went green). If a test can't be made
+  env-independent, assert intent (sigils, names) instead of exit
+  codes; cover the deterministic 0/1/2 contract in a separate hand-
+  built unit test.
+- **Run `gwm doctor` locally** before opening a PR that touches
+  `.gwm.toml`, the bootstrap schema, or the doctor module itself. The
+  same check runs in CI as an advisory job — green there means you'll
+  not surprise a reviewer.
 - **Indentation**: 2 spaces. `cargo fmt` is run on every commit; CI
   enforces `cargo fmt --check`.
 - **Linter**: `cargo clippy --all-targets -- -D warnings` must pass.


### PR DESCRIPTION
## Description

Two post-v0.3.0-rc.2 housekeeping items in a single PR, one commit per concern:

1. **CI advisory `gwm doctor` job** — runs `gwm doctor` against the repo on every push/PR targeting `dev`. `continue-on-error: true` so a Warning never blocks a merge, but the report shows up on the PR for the reviewer to consider. Locks the 0/1/2 exit-code contract to actual practice instead of theory.

2. **CLAUDE.md pre-validation rules** — codifies the recipe that would have spared the 3 CI round-trips on PR #43: any test reading `$PATH` / `$HOME` / ambient state must be pre-validated with a stripped PATH before push. Plus a separate rule asking contributors to run `gwm doctor` locally on PRs that touch `.gwm.toml`, the bootstrap schema, or the doctor module itself.

Best paired with #47 (doctor skip-merged-branches) — once #47 lands, the doctor exit code on this repo goes from 1 to 0 and the new CI job has a real signal to track.

Closes #49

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs (CLAUDE.md + CHANGELOG)
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

- \`.github/workflows/ci.yml\` — new \`doctor\` job, \`needs: test\`, \`continue-on-error: true\`.
- \`CLAUDE.md\` — two new bullets under "Other house rules" (env-dep test pre-validation + local doctor).
- \`CHANGELOG.md\` — new \`### CI\` section + a \`### Docs\` line under \`[Unreleased]\`.

## Tests

- [x] \`cargo test\` passes locally (no code changes — verified nothing else broke)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [x] New tests added under \`tests/\` — **N/A** (CI workflow + docs only; narrow exception per CONTRIBUTING §TDD: "Comment-only changes" extended to CI YAML + Markdown house rules)

## Screenshots / TUI captures

N/A.

## Checklist

- [x] Branch follows \`<type>/#<issue>-<description>\` (\`chore/#49-ci-doctor-and-claude-note\`)
- [x] Commits follow Gitmoji + Conventional Commits (3 atomic commits, one per concern)
- [x] CHANGELOG.md updated under \`## [Unreleased]\` (will conflict trivially with PR #46 if #46 lands first — the entries move to \`changelogs/0.3.0.md\` on rebase)
- [ ] README updated (N/A — no CLI change)
- [ ] \`examples/gwm.toml.example\` updated (N/A — no config change)

## Linked issues / docs

- Issue: #49
- Related PRs: #46 (CHANGELOG split — same dev cycle), #48 (doctor skip-merged — informs whether the CI job will ever be green on this repo)

## Notes for reviewers

- The CI job is advisory (\`continue-on-error: true\`) by design, **not** because it's expected to flake. The intent is to keep a signal that's noisy enough to spot real regressions without ever blocking a merge on environment specifics of the runner (e.g. \`lazygit\` not being installed on \`ubuntu-latest\`).
- \`needs: test\` gates the doctor on the test matrix passing first — no point diagnosing a broken build.
- Pre-validated locally: \`PATH="\$(dirname \$(which cargo)):/usr/bin:/bin" cargo test\` → green.