### PR TITLE
✨ feat(bootstrap): extend when-predicate grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow.
 - `gwm shell-init <bash|zsh|fish|powershell>` — prints a shell wrapper defining `gcd <pattern>` (the function does the actual `cd`, since the binary can't change the parent shell's directory). One-liner install: `eval "$(gwm shell-init zsh)"` in your rc file → `gcd auth` jumps to the matching worktree. The bash/zsh and PowerShell variants `unalias gcd` first so the function takes effect even if the shell already had a `gcd` alias (e.g. oh-my-zsh's `gcd=git checkout`). Closes #19.
 - `gwm doctor` — diagnose the gwm setup. Aggregates 7 cheap checks (`.gwm.toml` parses, guard references resolve, `when` predicates supported, external binaries on PATH, no prunable worktrees, no orphan gwm branches, base directory writable) and reports each with `✓ / ! / ✗`. Exit code `0` (all green), `1` (any warning), `2` (any failure) — wirable into CI / pre-commit. New `src/doctor.rs` module exposing `DoctorReport` / `Check` / `Severity` / `DoctorCtx` for library users. Closes #20.
+- **Extended `[[bootstrap.command]].when` predicates** — the evaluator now recognises four additional keyword atoms alongside the legacy `file_exists:`: `cmd_exists:<binary>` (resolves via `which`), `env_set:<NAME>` (variable defined), `env_eq:<NAME>=<value>` (variable equals literal), `glob_exists:<pattern>` (recursive `**` glob match under the worktree). Atoms compose with `!`, `&&`, `||` at the conventional precedence (`!` > `&&` > `||`); no parentheses. Example: `when = "file_exists:package.json && cmd_exists:bun"` picks `bun install` only when bun is on PATH. `bootstrap::evaluate_when` is now part of the public lib surface. `gwm doctor` recognises the new keywords; unknown keywords still default to true. Closes #25.
 
 ### Changed
 
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `clap_complete` `4.5` (new).
 - `nucleo-matcher` `0.3` (new) — fuzzy match engine for the TUI `/` filter.
+- `glob` `0.3` (new) — backs the `glob_exists:` predicate in `bootstrap::evaluate_when`.
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gwm"
 version = "0.3.0-rc.3"
 dependencies = [
@@ -720,6 +726,7 @@ dependencies = [
  "crossterm",
  "dirs 5.0.1",
  "git2",
+ "glob",
  "nucleo-matcher",
  "predicates",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1"
 shellexpand = "3"
 chrono = { version = "0.4", features = ["serde"] }
 which = "8"
+glob = "0.3"
 nucleo-matcher = "0.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Born as a rewrite of a project-specific `tools/worktree-manager.sh` script — t
 - **Per-repo config** in `.gwm.toml`: branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
 - **Branch convention**: `<type>/#<issue>-<description>` by default (`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`). Overridable per repo.
 - **Safety guards**: deny-list regexes on copied files (e.g. refuse to inherit a `.env` pointing at AWS RDS). Pluggable actions: `abort` or `seed-from-example`.
-- **Bootstrap hooks**: shell commands gated by `file_exists:` predicates and arbitrary `env` injection.
+- **Bootstrap hooks**: shell commands gated by composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||`) and arbitrary `env` injection.
 - **Fuzzy lookup**: `gwm remove auth` matches `feat-123-user-authentication` if unambiguous.
 - **Branch status column**: dirty / clean / `↑N ↓M` vs upstream, color-coded in TUI and CLI output.
 
@@ -143,7 +143,7 @@ Checks performed:
 
 1. **`.gwm.toml` parses** — Ok if it parses (or absent, defaults assumed); Failed if the TOML is broken.
 2. **guard references resolve** — every `[[bootstrap.copy]].guards = [...]` points at an existing `[[bootstrap.guard]]`.
-3. **`when` predicates supported** — every `[[bootstrap.command]].when` uses a known keyword prefix (currently only `file_exists:`).
+3. **`when` predicates supported** — every `[[bootstrap.command]].when` uses one of the known keyword prefixes (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`). Boolean composition via `!`, `&&`, `||` (precedence `!` > `&&` > `||`) is allowed inside the expression.
 4. **external binaries on PATH** — `lazygit` (TUI `l` keybinding), `direnv` (only if `.envrc` exists), and the first executable token of every `[[bootstrap.command]].run`.
 5. **no prunable worktrees** — `.git/worktrees/` entries whose working dir was removed manually.
 6. **no orphan gwm branches** — local branches matching `<type>/#<issue>-<desc>` (created by `gwm create`) with no worktree. User-managed branches (`main`, `release-*`, `dependabot/...`) are ignored.
@@ -252,7 +252,36 @@ name = "composer install"
 run  = "composer install --no-interaction --prefer-dist"
 when = "file_exists:composer.json"
 env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
+
+# composable when predicates: pick `bun install` if bun is on PATH,
+# fall back to `npm ci` otherwise, and skip the noisy step in CI.
+[[bootstrap.command]]
+name = "install (bun)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run  = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "build docs"
+run  = "./scripts/full-build.sh"
+when = "glob_exists:docs/**/*.md && !env_set:CI"
 ```
+
+`when` predicates recognised by the evaluator:
+
+| Predicate                    | True when …                                                  |
+|:-----------------------------|:-------------------------------------------------------------|
+| `file_exists:<path>`         | `<worktree>/<path>` resolves on disk                          |
+| `cmd_exists:<binary>`        | `<binary>` resolves on `$PATH` (`which` lookup)              |
+| `env_set:<NAME>`             | `std::env::var(NAME)` returns `Ok`                            |
+| `env_eq:<NAME>=<value>`      | `NAME` is set and its value matches `<value>` exactly         |
+| `glob_exists:<pattern>`      | at least one path under the worktree matches `<pattern>` (supports `**`) |
+
+Combine atoms with `!` (NOT), `&&` (AND), `||` (OR), conventional precedence `!` > `&&` > `||`. Whitespace around operators is tolerated. Unknown keywords default to `true` so old configs keep running while `gwm doctor` surfaces them.
 
 Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/...`) is also expanded.
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -75,3 +75,22 @@ when = "file_exists:.envrc"
 name = "npm install"
 run = "npm install"
 when = "file_exists:package.json"
+
+# --- composable when predicates --------------------------------------------
+# Atoms: file_exists / cmd_exists / env_set / env_eq / glob_exists
+# Operators: ! (NOT), && (AND), || (OR) — precedence: ! > && > ||
+
+[[bootstrap.command]]
+name = "install (bun if available)"
+run = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "full local build"
+run = "./scripts/full-build.sh"
+when = "glob_exists:src/**/*.rs && !env_set:CI"

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -402,23 +402,26 @@ impl<'a> WhenParser<'a> {
 }
 
 fn eval_when_atom(atom: &str, cwd: &Path) -> bool {
+  // Each atom-argument is trimmed to absorb any Unicode whitespace that
+  // the ASCII-only tokenizer left glued to the value. Preserves the
+  // legacy `file_exists:` tolerance from the pre-tokenizer evaluator.
   if let Some(rest) = atom.strip_prefix("file_exists:") {
-    return cwd.join(rest).exists();
+    return cwd.join(rest.trim()).exists();
   }
   if let Some(rest) = atom.strip_prefix("cmd_exists:") {
-    return which::which(rest).is_ok();
+    return which::which(rest.trim()).is_ok();
   }
   if let Some(rest) = atom.strip_prefix("env_set:") {
-    return std::env::var(rest).is_ok();
+    return std::env::var(rest.trim()).is_ok();
   }
   if let Some(rest) = atom.strip_prefix("env_eq:") {
     let Some((name, value)) = rest.split_once('=') else {
       return false;
     };
-    return std::env::var(name).ok().as_deref() == Some(value);
+    return std::env::var(name.trim()).ok().as_deref() == Some(value);
   }
   if let Some(pattern) = atom.strip_prefix("glob_exists:") {
-    return glob_exists(pattern, cwd);
+    return glob_exists(pattern.trim(), cwd);
   }
   // Unknown keyword: default to true so we don't silently neutralise a
   // command the user clearly wanted to run.

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -281,13 +281,159 @@ fn run_commands(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut Boots
 }
 
 /// Evaluate a `[[bootstrap.command]].when` expression against the given
-/// worktree. Unknown predicates default to `true` so configs we don't
-/// understand still run (the doctor surfaces them as a warning).
+/// worktree. Supports the keyword predicates `file_exists:`, `cmd_exists:`,
+/// `env_set:`, `env_eq:`, `glob_exists:`, plus the boolean operators `!`,
+/// `&&`, `||` with conventional precedence (`!` > `&&` > `||`). Unknown
+/// keyword predicates default to `true` so older configs keep running while
+/// the doctor surfaces them as warnings.
 pub fn evaluate_when(expr: &str, cwd: &Path) -> bool {
-  if let Some(rest) = expr.strip_prefix("file_exists:") {
-    return cwd.join(rest.trim()).exists();
+  let tokens = tokenize_when(expr);
+  let mut parser = WhenParser {
+    tokens: &tokens,
+    pos: 0,
+    cwd,
+  };
+  parser.parse_or()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum WhenToken {
+  Atom(String),
+  Not,
+  And,
+  Or,
+}
+
+fn tokenize_when(expr: &str) -> Vec<WhenToken> {
+  let bytes = expr.as_bytes();
+  let mut tokens = Vec::new();
+  let mut i = 0;
+  while i < bytes.len() {
+    let c = bytes[i];
+    if c.is_ascii_whitespace() {
+      i += 1;
+      continue;
+    }
+    if c == b'!' {
+      tokens.push(WhenToken::Not);
+      i += 1;
+      continue;
+    }
+    if c == b'&' && bytes.get(i + 1) == Some(&b'&') {
+      tokens.push(WhenToken::And);
+      i += 2;
+      continue;
+    }
+    if c == b'|' && bytes.get(i + 1) == Some(&b'|') {
+      tokens.push(WhenToken::Or);
+      i += 2;
+      continue;
+    }
+    let start = i;
+    while i < bytes.len() {
+      let b = bytes[i];
+      if b.is_ascii_whitespace() {
+        break;
+      }
+      if b == b'&' && bytes.get(i + 1) == Some(&b'&') {
+        break;
+      }
+      if b == b'|' && bytes.get(i + 1) == Some(&b'|') {
+        break;
+      }
+      i += 1;
+    }
+    tokens.push(WhenToken::Atom(expr[start..i].to_string()));
   }
+  tokens
+}
+
+struct WhenParser<'a> {
+  tokens: &'a [WhenToken],
+  pos: usize,
+  cwd: &'a Path,
+}
+
+impl<'a> WhenParser<'a> {
+  fn peek(&self) -> Option<&WhenToken> {
+    self.tokens.get(self.pos)
+  }
+
+  fn parse_or(&mut self) -> bool {
+    let mut acc = self.parse_and();
+    while let Some(WhenToken::Or) = self.peek() {
+      self.pos += 1;
+      let rhs = self.parse_and();
+      acc = acc || rhs;
+    }
+    acc
+  }
+
+  fn parse_and(&mut self) -> bool {
+    let mut acc = self.parse_not();
+    while let Some(WhenToken::And) = self.peek() {
+      self.pos += 1;
+      let rhs = self.parse_not();
+      acc = acc && rhs;
+    }
+    acc
+  }
+
+  fn parse_not(&mut self) -> bool {
+    if let Some(WhenToken::Not) = self.peek() {
+      self.pos += 1;
+      return !self.parse_not();
+    }
+    self.parse_atom()
+  }
+
+  fn parse_atom(&mut self) -> bool {
+    match self.tokens.get(self.pos) {
+      Some(WhenToken::Atom(s)) => {
+        self.pos += 1;
+        eval_when_atom(s, self.cwd)
+      }
+      // Empty expression or a dangling operator: fall back to true to
+      // match the "unknown predicate" contract — a config we can't
+      // understand should not silently skip every command.
+      _ => true,
+    }
+  }
+}
+
+fn eval_when_atom(atom: &str, cwd: &Path) -> bool {
+  if let Some(rest) = atom.strip_prefix("file_exists:") {
+    return cwd.join(rest).exists();
+  }
+  if let Some(rest) = atom.strip_prefix("cmd_exists:") {
+    return which::which(rest).is_ok();
+  }
+  if let Some(rest) = atom.strip_prefix("env_set:") {
+    return std::env::var(rest).is_ok();
+  }
+  if let Some(rest) = atom.strip_prefix("env_eq:") {
+    let Some((name, value)) = rest.split_once('=') else {
+      return false;
+    };
+    return std::env::var(name).ok().as_deref() == Some(value);
+  }
+  if let Some(pattern) = atom.strip_prefix("glob_exists:") {
+    return glob_exists(pattern, cwd);
+  }
+  // Unknown keyword: default to true so we don't silently neutralise a
+  // command the user clearly wanted to run.
   true
+}
+
+fn glob_exists(pattern: &str, cwd: &Path) -> bool {
+  let full = cwd.join(pattern);
+  let Some(full_str) = full.to_str() else {
+    return false;
+  };
+  match glob::glob(full_str) {
+    Ok(mut iter) => iter.any(|r| r.is_ok()),
+    Err(_) => false,
+  }
 }
 
 fn exec_shell(step: &CommandStep, cwd: &Path) -> Result<String> {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -296,6 +296,21 @@ pub fn evaluate_when(expr: &str, cwd: &Path) -> bool {
   parser.parse_or()
 }
 
+/// Return every atom string contained in a `when` expression, dropping
+/// the boolean operators. Callers (e.g. `doctor::check_when_predicates`)
+/// can then validate each atom independently — `w.starts_with(prefix)`
+/// on the raw expression misses negated atoms (`!env_set:CI`) and
+/// unsupported keywords sitting on the RHS of `&&` / `||`.
+pub fn when_atoms(expr: &str) -> Vec<String> {
+  tokenize_when(expr)
+    .into_iter()
+    .filter_map(|t| match t {
+      WhenToken::Atom(s) => Some(s),
+      _ => None,
+    })
+    .collect()
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum WhenToken {
   Atom(String),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -256,7 +256,7 @@ fn run_commands(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut Boots
   for step in &bs.command {
     let label = format!("run {}", step.name);
     if let Some(ref guard) = step.when {
-      if !check_when(guard, ctx.worktree) {
+      if !evaluate_when(guard, ctx.worktree) {
         report.steps.push(StepResult {
           label,
           status: StepStatus::Skipped,
@@ -280,11 +280,13 @@ fn run_commands(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut Boots
   }
 }
 
-fn check_when(expr: &str, cwd: &Path) -> bool {
+/// Evaluate a `[[bootstrap.command]].when` expression against the given
+/// worktree. Unknown predicates default to `true` so configs we don't
+/// understand still run (the doctor surfaces them as a warning).
+pub fn evaluate_when(expr: &str, cwd: &Path) -> bool {
   if let Some(rest) = expr.strip_prefix("file_exists:") {
     return cwd.join(rest.trim()).exists();
   }
-  // Unknown predicates default to true (so configs that we don't understand still run).
   true
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -174,9 +174,9 @@ fn check_guard_references(ctx: &DoctorCtx<'_>) -> Check {
     .with_hint("declare the missing `[[bootstrap.guard]]` block(s) or drop the reference")
 }
 
-/// Recognised `when:` predicates. Update this list when a new keyword
-/// lands in `bootstrap.rs::evaluate_when`.
-const SUPPORTED_WHEN_PREFIXES: &[&str] = &["file_exists:"];
+/// Recognised `when:` predicate keywords. Update this list when a new
+/// keyword lands in `bootstrap.rs::evaluate_when`.
+const SUPPORTED_WHEN_PREFIXES: &[&str] = &["file_exists:", "cmd_exists:", "env_set:", "env_eq:", "glob_exists:"];
 
 /// Check #3: every `[[bootstrap.command]].when` predicate uses one of the
 /// supported keywords. Unknown predicates default to `true` in

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -180,9 +180,14 @@ const SUPPORTED_WHEN_PREFIXES: &[&str] = &["file_exists:", "cmd_exists:", "env_s
 
 /// Check #3: every `[[bootstrap.command]].when` predicate uses one of the
 /// supported keywords. Unknown predicates default to `true` in
-/// `bootstrap::check_when`, so the command runs anyway and the user's
+/// `bootstrap::evaluate_when`, so the command runs anyway and the user's
 /// intended gating condition is silently ignored — that's still a footgun
 /// worth flagging, just not "command never runs".
+///
+/// Walks every atom in the expression (via `bootstrap::when_atoms`) so
+/// negated atoms (`!env_set:CI`) and compound expressions
+/// (`file_exists:a && bogus:1`) are validated as a whole instead of
+/// being green-lit by their first keyword.
 fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
   let name = "`when` predicates supported";
   let bs = &ctx.config.bootstrap;
@@ -192,8 +197,10 @@ fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
   for cmd in &bs.command {
     let Some(w) = &cmd.when else { continue };
     checked += 1;
-    if !SUPPORTED_WHEN_PREFIXES.iter().any(|p| w.starts_with(p)) {
-      unknown.push(format!("{} (on command `{}`)", w, cmd.name));
+    for atom in crate::bootstrap::when_atoms(w) {
+      if !SUPPORTED_WHEN_PREFIXES.iter().any(|p| atom.starts_with(p)) {
+        unknown.push(format!("{} (on command `{}`)", atom, cmd.name));
+      }
     }
   }
 

--- a/tests/bootstrap_when_tests.rs
+++ b/tests/bootstrap_when_tests.rs
@@ -259,6 +259,35 @@ fn extra_whitespace_around_operators_is_tolerated() {
   assert!(evaluate_when("  file_exists:a   &&   file_exists:b  ", dir.path()));
 }
 
+#[test]
+fn unicode_whitespace_inside_atom_is_trimmed() {
+  // The tokenizer only splits on ASCII whitespace, so a non-ASCII Unicode
+  // whitespace character (here NBSP `\u{00A0}`) stays glued to the atom.
+  // Pre-fix `evaluate_when` would forward the whitespace-prefixed string
+  // straight to `Path::join`, producing a path that doesn't exist. The
+  // restored `.trim()` on the keyword remainder keeps the legacy
+  // `file_exists:` tolerance intact.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("payload"), "").unwrap();
+  let expr = "file_exists:\u{00A0}payload";
+  assert!(
+    evaluate_when(expr, dir.path()),
+    "expected `file_exists:` to strip leading Unicode whitespace"
+  );
+}
+
+#[test]
+fn unicode_path_does_not_panic() {
+  // Regression guard for tokenize_when: it slices `expr` by byte index.
+  // The delimiters (`!`, `&`, `|`, ASCII whitespace) are all single-byte
+  // ASCII codepoints, so the loop can never break mid-character of a
+  // multi-byte UTF-8 sequence. This test pins that invariant down.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("σ.rs"), "// greek lowercase sigma").unwrap();
+  assert!(evaluate_when("file_exists:σ.rs", dir.path()));
+  assert!(!evaluate_when("file_exists:λ.rs", dir.path()));
+}
+
 // --------------------------------------------------------------------------
 // Backward compatibility — unknown keyword still defaults to true
 // --------------------------------------------------------------------------

--- a/tests/bootstrap_when_tests.rs
+++ b/tests/bootstrap_when_tests.rs
@@ -83,10 +83,22 @@ fn env_set_false_for_unset_var() {
 
 #[test]
 fn env_eq_true_when_value_matches() {
+  // Picking a known env var whose value contains spaces or `&&` would
+  // make the tokenizer split the atom mid-value, so we cherry-pick any
+  // currently-set variable with a clean value at runtime. This keeps the
+  // test portable across CI environments without relying on a specific
+  // variable being defined.
   let dir = TempDir::new().unwrap();
-  let path = std::env::var("PATH").expect("PATH must be set");
-  let expr = format!("env_eq:PATH={}", path);
-  assert!(evaluate_when(&expr, dir.path()));
+  let (name, value) = std::env::vars()
+    .find(|(_, v)| !v.is_empty() && !v.contains(char::is_whitespace) && !v.contains("&&") && !v.contains("||"))
+    .expect("at least one env var should have a simple value at test time");
+  let expr = format!("env_eq:{}={}", name, value);
+  assert!(
+    evaluate_when(&expr, dir.path()),
+    "expected env_eq:{}={} to evaluate true",
+    name,
+    value
+  );
 }
 
 #[test]
@@ -244,10 +256,7 @@ fn extra_whitespace_around_operators_is_tolerated() {
   let dir = TempDir::new().unwrap();
   std::fs::write(dir.path().join("a"), "").unwrap();
   std::fs::write(dir.path().join("b"), "").unwrap();
-  assert!(evaluate_when(
-    "  file_exists:a   &&   file_exists:b  ",
-    dir.path()
-  ));
+  assert!(evaluate_when("  file_exists:a   &&   file_exists:b  ", dir.path()));
 }
 
 // --------------------------------------------------------------------------

--- a/tests/bootstrap_when_tests.rs
+++ b/tests/bootstrap_when_tests.rs
@@ -1,0 +1,277 @@
+//! Unit tests for `bootstrap::evaluate_when`, the `[[bootstrap.command]].when`
+//! predicate evaluator. The single legacy keyword `file_exists:` is covered
+//! alongside the four extended keywords introduced for issue #25
+//! (`cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`) plus the boolean
+//! composition operators `!`, `&&`, `||`.
+//!
+//! These tests deliberately exercise the evaluator directly (rather than
+//! going through `bootstrap::run`) so the predicate grammar can be pinned
+//! down without dragging in a shell, a temp `Config`, and the rest of the
+//! bootstrap pipeline. A handful of integration tests through
+//! `bootstrap::run` live next door in `bootstrap_tests.rs` to keep the
+//! end-to-end wiring covered.
+
+use gwm::bootstrap::evaluate_when;
+use std::path::Path;
+use tempfile::TempDir;
+
+// Sentinel name used wherever a test needs an env var that is guaranteed
+// not to be set. The suffix is random enough that no real environment
+// would ever define it.
+const UNSET_VAR: &str = "GWM_TEST_PREDICATE_DEFINITELY_UNSET_8c4f9a";
+
+// --------------------------------------------------------------------------
+// file_exists: — regression coverage for the legacy keyword
+// --------------------------------------------------------------------------
+
+#[test]
+fn file_exists_true_when_target_present() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("Cargo.toml"), "[package]").unwrap();
+  assert!(evaluate_when("file_exists:Cargo.toml", dir.path()));
+}
+
+#[test]
+fn file_exists_false_when_target_missing() {
+  let dir = TempDir::new().unwrap();
+  assert!(!evaluate_when("file_exists:Cargo.toml", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// cmd_exists: — binary resolves on $PATH
+// --------------------------------------------------------------------------
+
+#[test]
+fn cmd_exists_true_for_sh() {
+  // `sh` is guaranteed on every Unix host the project supports. On Windows
+  // CI we'd substitute `cmd.exe`, but the integration matrix is Unix-only
+  // today so this assertion is portable enough.
+  let dir = TempDir::new().unwrap();
+  assert!(evaluate_when("cmd_exists:sh", dir.path()));
+}
+
+#[test]
+fn cmd_exists_false_for_made_up_binary() {
+  let dir = TempDir::new().unwrap();
+  assert!(!evaluate_when(
+    "cmd_exists:gwm_test_definitely_no_such_binary_4f7a3b",
+    dir.path()
+  ));
+}
+
+// --------------------------------------------------------------------------
+// env_set: — variable is defined (any value)
+// --------------------------------------------------------------------------
+
+#[test]
+fn env_set_true_for_path() {
+  let dir = TempDir::new().unwrap();
+  // PATH is guaranteed set by every reasonable test runner.
+  assert!(evaluate_when("env_set:PATH", dir.path()));
+}
+
+#[test]
+fn env_set_false_for_unset_var() {
+  let dir = TempDir::new().unwrap();
+  let expr = format!("env_set:{}", UNSET_VAR);
+  assert!(!evaluate_when(&expr, dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// env_eq: — variable exactly matches the provided literal
+// --------------------------------------------------------------------------
+
+#[test]
+fn env_eq_true_when_value_matches() {
+  let dir = TempDir::new().unwrap();
+  let path = std::env::var("PATH").expect("PATH must be set");
+  let expr = format!("env_eq:PATH={}", path);
+  assert!(evaluate_when(&expr, dir.path()));
+}
+
+#[test]
+fn env_eq_false_when_value_mismatch() {
+  let dir = TempDir::new().unwrap();
+  assert!(!evaluate_when(
+    "env_eq:PATH=/definitely/not/the/real/path/xyz",
+    dir.path()
+  ));
+}
+
+#[test]
+fn env_eq_false_when_var_missing() {
+  let dir = TempDir::new().unwrap();
+  let expr = format!("env_eq:{}=whatever", UNSET_VAR);
+  assert!(!evaluate_when(&expr, dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// glob_exists: — at least one path under cwd matches the glob
+// --------------------------------------------------------------------------
+
+#[test]
+fn glob_exists_true_when_pattern_matches_in_root() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
+  assert!(evaluate_when("glob_exists:*.rs", dir.path()));
+}
+
+#[test]
+fn glob_exists_true_for_recursive_pattern() {
+  let dir = TempDir::new().unwrap();
+  std::fs::create_dir_all(dir.path().join("src/inner")).unwrap();
+  std::fs::write(dir.path().join("src/inner/lib.rs"), "// nested").unwrap();
+  assert!(evaluate_when("glob_exists:**/*.rs", dir.path()));
+}
+
+#[test]
+fn glob_exists_false_when_no_match() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("README.md"), "no rust").unwrap();
+  assert!(!evaluate_when("glob_exists:*.rs", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// Boolean composition: ! (NOT)
+// --------------------------------------------------------------------------
+
+#[test]
+fn not_inverts_file_exists_true() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  assert!(!evaluate_when("!file_exists:a", dir.path()));
+}
+
+#[test]
+fn not_inverts_file_exists_false() {
+  let dir = TempDir::new().unwrap();
+  assert!(evaluate_when("!file_exists:missing", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// Boolean composition: && (AND)
+// --------------------------------------------------------------------------
+
+#[test]
+fn and_true_when_both_sides_true() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(evaluate_when("file_exists:a && file_exists:b", dir.path()));
+}
+
+#[test]
+fn and_false_when_left_false() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(!evaluate_when("file_exists:a && file_exists:b", dir.path()));
+}
+
+#[test]
+fn and_false_when_right_false() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  assert!(!evaluate_when("file_exists:a && file_exists:b", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// Boolean composition: || (OR)
+// --------------------------------------------------------------------------
+
+#[test]
+fn or_true_when_left_true() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  assert!(evaluate_when("file_exists:a || file_exists:b", dir.path()));
+}
+
+#[test]
+fn or_true_when_right_true() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(evaluate_when("file_exists:a || file_exists:b", dir.path()));
+}
+
+#[test]
+fn or_false_when_both_sides_false() {
+  let dir = TempDir::new().unwrap();
+  assert!(!evaluate_when("file_exists:a || file_exists:b", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// Precedence: ! > && > ||
+// --------------------------------------------------------------------------
+
+#[test]
+fn precedence_not_binds_tighter_than_and() {
+  // Parsed as `(!file_exists:a) && file_exists:b`. With `a` missing and
+  // `b` present, the result is `true && true == true`.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(evaluate_when("!file_exists:a && file_exists:b", dir.path()));
+}
+
+#[test]
+fn precedence_and_binds_tighter_than_or() {
+  // Parsed as `file_exists:a || (file_exists:b && file_exists:c)`. With
+  // only `a` present, the disjunction short-circuits to true.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  assert!(evaluate_when(
+    "file_exists:a || file_exists:b && file_exists:c",
+    dir.path()
+  ));
+}
+
+#[test]
+fn precedence_and_binds_tighter_than_or_negative() {
+  // Same expression, but `a` is missing and `b` is present without `c`.
+  // The RHS group `b && c` is false, so the OR is false too.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(!evaluate_when(
+    "file_exists:a || file_exists:b && file_exists:c",
+    dir.path()
+  ));
+}
+
+// --------------------------------------------------------------------------
+// Whitespace tolerance — operators may be flanked by any amount of spaces
+// --------------------------------------------------------------------------
+
+#[test]
+fn extra_whitespace_around_operators_is_tolerated() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  std::fs::write(dir.path().join("b"), "").unwrap();
+  assert!(evaluate_when(
+    "  file_exists:a   &&   file_exists:b  ",
+    dir.path()
+  ));
+}
+
+// --------------------------------------------------------------------------
+// Backward compatibility — unknown keyword still defaults to true
+// --------------------------------------------------------------------------
+
+#[test]
+fn unknown_keyword_still_defaults_to_true() {
+  // Matches the long-standing contract that lets old configs with future
+  // predicates keep running while the doctor surfaces the unknown keyword.
+  let dir = TempDir::new().unwrap();
+  assert!(evaluate_when("totally_made_up:whatever", dir.path()));
+}
+
+// --------------------------------------------------------------------------
+// Sanity probe — evaluator is a pure function of (expr, cwd)
+// --------------------------------------------------------------------------
+
+#[test]
+fn evaluator_is_pure_for_a_given_cwd() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join("a"), "").unwrap();
+  let cwd: &Path = dir.path();
+  let first = evaluate_when("file_exists:a && cmd_exists:sh", cwd);
+  let second = evaluate_when("file_exists:a && cmd_exists:sh", cwd);
+  assert_eq!(first, second);
+}

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -173,7 +173,7 @@ fn unsupported_when_predicate_is_failed() {
   config.bootstrap.command.push(gwm::config::CommandStep {
     name: "noop".into(),
     run: "true".into(),
-    when: Some("env_set:FOO".into()),
+    when: Some("bogus_predicate:FOO".into()),
     env: Default::default(),
   });
 
@@ -184,7 +184,7 @@ fn unsupported_when_predicate_is_failed() {
     .find(|c| c.name.contains("when"))
     .expect("expected a `when` predicate check");
   assert_eq!(c.status, CheckStatus::Failed);
-  assert!(c.detail.contains("env_set"));
+  assert!(c.detail.contains("bogus_predicate"));
 }
 
 #[test]

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -188,6 +188,52 @@ fn unsupported_when_predicate_is_failed() {
 }
 
 #[test]
+fn negated_supported_keyword_is_ok() {
+  // `!env_set:CI` should be accepted: the doctor must reach past the
+  // leading `!` (and any other boolean operator) and validate each
+  // atom against the supported-keyword list.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.bootstrap.command.push(gwm::config::CommandStep {
+    name: "skip-in-ci".into(),
+    run: "./scripts/full-build.sh".into(),
+    when: Some("!env_set:CI".into()),
+    env: Default::default(),
+  });
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("when"))
+    .expect("expected a `when` predicate check");
+  assert_eq!(c.status, CheckStatus::Ok);
+}
+
+#[test]
+fn unsupported_keyword_on_rhs_of_and_is_failed() {
+  // Compound expressions need atom-level validation. A LHS that looks
+  // legitimate (`file_exists:a`) must not paper over a bogus RHS.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.bootstrap.command.push(gwm::config::CommandStep {
+    name: "compound".into(),
+    run: "true".into(),
+    when: Some("file_exists:a && bogus_predicate:1".into()),
+    env: Default::default(),
+  });
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("when"))
+    .expect("expected a `when` predicate check");
+  assert_eq!(c.status, CheckStatus::Failed);
+  assert!(c.detail.contains("bogus_predicate"));
+}
+
+#[test]
 fn file_exists_when_predicate_is_ok() {
   let (dir, repo) = init_repo();
   let mut config = Config::default();


### PR DESCRIPTION
## Description

Extends the `[[bootstrap.command]].when` evaluator with four new keyword
predicates and three boolean composition operators while preserving the
legacy `file_exists:` keyword and the "unknown predicate defaults to
true" backward-compat contract.

Closes #25

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **New keyword predicates** in `bootstrap::evaluate_when`:
  - `cmd_exists:<binary>` — true when the binary resolves on `$PATH`
    (via the existing `which` dep).
  - `env_set:<NAME>` — true when `std::env::var(NAME).is_ok()`.
  - `env_eq:<NAME>=<value>` — true when the variable is set and equal to
    the literal exactly. Malformed expressions (no `=`) → false.
  - `glob_exists:<pattern>` — true when at least one filesystem entry
    under the worktree matches the glob. Supports `**` recursion via
    the new `glob = "0.3"` dep.
- **Boolean composition** with conventional precedence `!` > `&&` > `||`
  (no parentheses): `!atom`, `atom && atom`, `atom || atom`. Whitespace
  around operators is tolerated.
- **Public API**: `bootstrap::evaluate_when` is now `pub` so callers can
  reuse the evaluator without going through the full bootstrap pipeline.
  The doctor's `SUPPORTED_WHEN_PREFIXES` is updated to recognise the
  five keywords; unknown keywords still default to true so older
  configs keep running.
- **Docs**: README gains a predicate reference table and a refreshed
  bootstrap example; `examples/gwm.toml.example` ships three composable
  `when` snippets (bun-or-npm fallback, glob-gated local script).
- **CHANGELOG**: new entries under `[Unreleased] > Added` and
  `[Unreleased] > Dependencies`.

## Tests

- [x] `cargo test` passes locally (`cargo test --quiet` → all suites
  green, including the new `tests/bootstrap_when_tests.rs` with 26
  unit tests across atoms, operators, precedence, whitespace and
  backward-compat fallback)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without
  tests is sent back) — `tests/bootstrap_when_tests.rs` covers the new
  grammar exhaustively; the existing doctor test for "unsupported
  predicate" was retargeted to a still-unknown sentinel keyword.

## Screenshots / TUI captures

n/a — bootstrap-only change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
  (`feat/#25-extended-bootstrap-predicates`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
  — four atomic commits: refactor → test (RED) → feat (GREEN) → docs
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (feature blurb + bootstrap example + doctor check
  description)
- [x] `examples/gwm.toml.example` updated
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #25

## Notes for reviewers

- Implemented from a fresh `gwm` worktree at
  `~/cc-worktree/gwm-cli/feat-25-extended-bootstrap-predicates/` —
  `gwm doctor` runs green there.
- Grammar is a small hand-written tokenizer + recursive-descent parser
  in `src/bootstrap.rs` (no parens, no escape syntax — matches the
  YAGNI scoping in the issue). Promoting to a real PEG (e.g. with
  `nom`) is open if we later want parens or quoted values.
- Short-circuit caveat: evaluation walks the full token stream rather
  than truly lazy-folding the AST. Atoms are cheap (`which` /
  `std::env::var` / `Path::exists`), so the simplicity wins.