### PR TITLE
🔧 chore: post-0.3.0 cleanup (closes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README: doctor sample output updated to reflect the post-#47 `✓ N merged gwm-style branch(es) preserved` wording; a second block shows the Warning-with-hint case so users see both happy and remediation paths.
 - README: test count refreshed from a stale "81" to the actual 140.
+- New `changelogs/pre-releases/` directory holding per-RC notes (one file per RC, covering only the delta vs. the previous RC). Back-fills `0.2.0-rc.1`, `0.3.0-rc.1`, `0.3.0-rc.2`, `0.3.0-rc.3`. `CHANGELOG.md > Past releases` gains a `### Pre-releases` sub-index. The corresponding GitHub Release bodies are re-pointed at these files via `gh release edit --notes-file` (instead of inheriting the full `CHANGELOG.md` as before).
+- `CONTRIBUTING.md > Pre-release (from dev)` describes the new per-RC notes flow; `Stable release (from main)` mentions `--notes-file` for the body.
 
 ### Dependencies
 
@@ -48,3 +50,12 @@ In reverse chronological order:
 - [`0.3.0`](changelogs/0.3.0.md) — 2026-05-19
 - [`0.2.0`](changelogs/0.2.0.md) — 2026-05-18
 - [`0.1.0`](changelogs/0.1.0.md) — 2026-05-18
+
+### Pre-releases
+
+Per-RC notes covering only the delta against the previous RC (or against the previous stable, for `rc.1`):
+
+- [`0.3.0-rc.3`](changelogs/pre-releases/0.3.0-rc.3.md) — 2026-05-19
+- [`0.3.0-rc.2`](changelogs/pre-releases/0.3.0-rc.2.md) — 2026-05-19
+- [`0.3.0-rc.1`](changelogs/pre-releases/0.3.0-rc.1.md) — 2026-05-19
+- [`0.2.0-rc.1`](changelogs/pre-releases/0.2.0-rc.1.md) — 2026-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Fixed
+
+- `gwm doctor`: `is_writable_dir` now uses a random-suffixed `tempfile`-managed probe file (was a fixed `.gwm-doctor-write-probe` colliding under concurrent runs and leaking on SIGKILL). Closes #54.
+- `gwm doctor`: `extract_binary` parses shell-quoted run-strings via `shell-words` (was `split_whitespace`, which sliced through quotes and produced false-positive "binary not on PATH" warnings on configs like `run = "\"my tool\" --flag"`). Closes #54.
+
+### Changed
+
+- `gwm cd <pattern>` is now exposed as a clap `visible_alias` of `gwm path` instead of a separate `Command::Cd` variant. Same UX, one routing path. The `--help` listing shows `path … [aliases: cd]`. Closes #54.
+
+### Refactored
+
+- `doctor::Severity` collapsed into `CheckStatus` (the two enums were structurally identical). A `pub type Severity = CheckStatus;` alias is kept so 0.3.0 library callers keep compiling. Closes #54.
+- `doctor::run` now hoists `worktree::list` once and passes `&[WorktreeInfo]` into the two checks that need it (`prunable` + `orphan`), saving a libgit2 call per `gwm doctor` invocation and unifying the error-handling path. Closes #54.
+- `check_when_predicates`: counter renamed from `checked` to `recognised` and incremented only after the prefix match, so the variable name accurately tracks what the `"N predicate(s) recognised"` detail reports. Closes #54.
+
+### Tests
+
+- `doctor_on_fresh_repo_prints_checks`: exit code is now bounded to `[0, 1]` (was unbounded, a panic / SEGV / exit-2 regression would have passed silently).
+- `shell_init_{bash,zsh,fish,powershell}_emits_*`: assertions tightened to pin the actual invocation (`gwm cd "$@"` / `gwm cd $argv` / `gwm cd $Pattern`) rather than the loose `contains("gwm cd")` which would have passed even if `gwm cd` appeared only in a comment.
+- `resolvable_command_binary_is_ok`: the loose `!contains("sh ")` assertion (would have passed on `[sh,other]` formatting) is replaced with structured parsing of the "not on PATH:" list.
+
+### Docs
+
+- README: doctor sample output updated to reflect the post-#47 `✓ N merged gwm-style branch(es) preserved` wording; a second block shows the Warning-with-hint case so users see both happy and remediation paths.
+- README: test count refreshed from a stale "81" to the actual 140.
+
+### Dependencies
+
+- `shell-words` `1` (new, runtime) — POSIX shell tokeniser used by the doctor's `extract_binary`.
+- `tempfile` moved from `[dev-dependencies]` to `[dependencies]` — used at runtime by the doctor's `is_writable_dir` write-probe.
 
 ## Past releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,9 +244,11 @@ Versioning is SemVer (`MAJOR.MINOR.PATCH`), with `-rc.N` / `-alpha.N` / `-beta.N
 When `dev` is ready to be exercised by early adopters before promotion:
 
 1. Stay on `dev` (do not merge to `main` yet).
-2. Tag: `git tag -a v0.x.y-rc.1 -m "v0.x.y-rc.1" && git push --tags`.
-3. GitHub Actions (`pre-release.yml`) builds binaries and publishes a **prerelease** (5 targets — Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64).
-4. Iterate: subsequent candidates are `v0.x.y-rc.2`, `v0.x.y-rc.3`, …
+2. Write per-RC notes in a new file `changelogs/pre-releases/<version>-rc.N.md` — heading `# [<version>-rc.N] - YYYY-MM-DD`, body describing only the **delta** against the previous RC (or against the previous stable, for `rc.1`). One file per RC, not a running log. (See [`changelogs/pre-releases/0.3.0-rc.2.md`](changelogs/pre-releases/0.3.0-rc.2.md) for the expected layout.)
+3. Add the entry to `CHANGELOG.md`'s `## Past releases > ### Pre-releases` index.
+4. Tag: `git tag -a v0.x.y-rc.N -m "v0.x.y-rc.N" && git push --tags`.
+5. GitHub Actions (`pre-release.yml`) builds binaries and publishes a **prerelease** (5 targets — Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64). The release body is populated from the per-RC file via `--notes-file changelogs/pre-releases/<version>-rc.N.md` (run `gh release edit <tag> --notes-file <path>` after the workflow if you need to refresh it).
+6. Iterate: subsequent candidates are `v0.x.y-rc.2`, `v0.x.y-rc.3`, …
 
 ### Stable release (from `main`)
 
@@ -256,7 +258,7 @@ Once the rc is validated and promoted to `main`:
 2. Move the `## [Unreleased]` section out of `CHANGELOG.md` into a new file `changelogs/<version>.md` (e.g. `changelogs/0.3.0.md`), rename its heading to `# [<version>] - YYYY-MM-DD`, and add a one-line entry at the bottom of `CHANGELOG.md`'s `## Past releases` index pointing to the new file. `CHANGELOG.md` at the root then only carries the next `## [Unreleased]` section. (See [`changelogs/0.2.0.md`](changelogs/0.2.0.md) for the expected layout.)
 3. Merge `dev` → `main` (regular merge, never squash; see [Merge strategy](#merge-strategy)).
 4. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
-5. GitHub Actions (`release.yml`) builds binaries and publishes the stable release.
+5. GitHub Actions (`release.yml`) builds binaries and publishes the stable release. The release body is populated from `changelogs/<version>.md` via `--notes-file` (run `gh release edit v0.x.y --notes-file changelogs/<version>.md` after the workflow if needed).
 
 Triggering matrix:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "ratatui",
  "regex",
  "serde",
+ "shell-words",
  "shellexpand",
  "tempfile",
  "thiserror 2.0.18",
@@ -1750,6 +1751,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,10 @@ shellexpand = "3"
 chrono = { version = "0.4", features = ["serde"] }
 which = "8"
 nucleo-matcher = "0.3"
+shell-words = "1"
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 

--- a/README.md
+++ b/README.md
@@ -128,15 +128,26 @@ $ gwm doctor
 ✓ guard references resolve
     2 guard reference(s) resolve
 ✓ `when` predicates supported
+    1 predicate(s) recognised
 ✓ external binaries on PATH
     3/3 binaries found
+✓ no prunable worktrees
+    5 worktree(s) tracked, none prunable
+✓ no orphan gwm branches
+    7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
+✓ base directory writable
+    /home/you/cc-worktree/myrepo is writable
+```
+
+If a real orphan (unmerged feature branch with no worktree) or a prunable entry exists, the doctor surfaces them as Warning with a remediation hint:
+
+```bash
 ! no prunable worktrees
     1 prunable entry: feat-12-old
     → run `gwm prune` to clear them
 ! no orphan gwm branches
-    1 orphan branch(es): feat/#23-stale
-    → git branch -d feat/#23-stale
-✓ base directory writable
+    1 unmerged orphan branch(es): feat/#99-wip-experiment
+    → git branch -d feat/#99-wip-experiment
 ```
 
 Checks performed:
@@ -278,13 +289,13 @@ Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde
 | multi-repo portability              | per-project script   | one binary, per-repo config      |
 | TUI                                 | linear bash menu     | full ratatui screen              |
 | anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 81 tests (config / naming / bootstrap / worktree / TUI / CLI) |
+| tests                               | none                 | 140 tests (config / naming / bootstrap / worktree / TUI / CLI) |
 
 ## development
 
 ```bash
 cargo build              # debug build
-cargo test               # 81 tests
+cargo test               # 140 tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally

--- a/changelogs/pre-releases/0.2.0-rc.1.md
+++ b/changelogs/pre-releases/0.2.0-rc.1.md
@@ -1,0 +1,13 @@
+# [0.2.0-rc.1] - 2026-05-18
+
+First (and only) release candidate for 0.2.0. Promoted to stable on the same day after early-adopter validation.
+
+The contents of this RC are identical to the stable `0.2.0` release — see [`changelogs/0.2.0.md`](../0.2.0.md) for the full feature list.
+
+### Purpose of the RC
+
+- Exercise the new `.github/workflows/pre-release.yml` workflow against a real tag.
+- Confirm the 5-target binary matrix (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64) builds cleanly.
+- Validate the `Set-Content -Encoding ascii` change on Windows `.sha256` sidecars cross-platform.
+
+No content delta from `0.2.0`.

--- a/changelogs/pre-releases/0.3.0-rc.1.md
+++ b/changelogs/pre-releases/0.3.0-rc.1.md
@@ -1,0 +1,24 @@
+# [0.3.0-rc.1] - 2026-05-19
+
+First release candidate for 0.3.0, cut from `dev` after the first two feature merges of the cycle.
+
+### Added since 0.2.0
+
+- `gwm completions <shell>` — static completion script on stdout, generated from the live clap argument tree via [`clap_complete`](https://docs.rs/clap_complete). Supports `zsh`, `bash`, `fish`, `powershell`, `elvish`. Closes #18 (PR #41).
+- `gwm list --format=names` — one worktree name per line. Backs dynamic completion of the `<pattern>` arg of `path` / `remove` / `bootstrap`.
+- `gwm cd <pattern>` — fuzzy-resolve a worktree and print its on-disk path. Same semantics as `gwm path`, exposed under an explicit name for the cd flow. Closes #19 (PR #42).
+- `gwm shell-init <bash|zsh|fish|powershell>` — shell wrapper defining a `gcd <pattern>` function that wraps `gwm cd`. The bash/zsh and PowerShell variants `unalias gcd` first so the function takes effect even with a prior alias (e.g. oh-my-zsh's `gcd=git checkout`). Closes #19 (PR #42).
+
+### Docs
+
+- `CLAUDE.md` (new, repo root) — house rules for AI-assisted contributions. Promotes **TDD as the primordial contribution rule**.
+- `CONTRIBUTING.md` — `TDD expectations` rewritten as `🔴 TDD is mandatory — non-negotiable`.
+- `CODE_OF_CONDUCT.md` — new `Engineering conduct` section.
+
+### Dependencies
+
+- `clap_complete` `4.5` (new).
+
+### Purpose
+
+Pre-release for early-adopter validation. Promoted (with additions) to `v0.3.0-rc.2` once more features landed.

--- a/changelogs/pre-releases/0.3.0-rc.2.md
+++ b/changelogs/pre-releases/0.3.0-rc.2.md
@@ -1,0 +1,20 @@
+# [0.3.0-rc.2] - 2026-05-19
+
+Second release candidate for 0.3.0, picking up two additional merges since `v0.3.0-rc.1`.
+
+### Added since rc.1
+
+- `gwm doctor` — diagnose the gwm setup. 7 cheap checks (`.gwm.toml` parses, guard references resolve, `when` predicates supported, external binaries on PATH, no prunable worktrees, no orphan gwm branches, base directory writable) reported with `✓ / ! / ✗` sigils. Exit code `0` (all green), `1` (any warning), `2` (any failure) — wirable into CI / pre-commit. Library surface (`DoctorReport` / `Check` / `Severity` / `DoctorCtx`) exposed under `gwm::doctor`. Closes #20 (PR #43).
+- **TUI fuzzy filter (`/`)** — inline filter bar at the bottom of the worktree table. Real-time fuzzy matching via [`nucleo-matcher`](https://docs.rs/nucleo-matcher) (same engine as Helix / Zellij), ranking contiguous substring hits above spread-out subsequence hits. `Enter` to commit, `Esc` to clear, `j`/`k`/`gg`/`G` continue to work on the filtered subset. Closes #21 (PR #44).
+
+### Dependencies
+
+- `nucleo-matcher` `0.3` (new) — fuzzy match engine for the TUI `/` filter.
+
+### Cumulative content
+
+Everything from [`v0.3.0-rc.1`](0.3.0-rc.1.md) (completions, `cd`, `shell-init`, TDD docs) is included.
+
+### Purpose
+
+Pre-release for early-adopter validation. Promoted (with one round of post-rc.2 cleanup) to `v0.3.0-rc.3`.

--- a/changelogs/pre-releases/0.3.0-rc.3.md
+++ b/changelogs/pre-releases/0.3.0-rc.3.md
@@ -1,0 +1,22 @@
+# [0.3.0-rc.3] - 2026-05-19
+
+Third (and final) release candidate for 0.3.0, picking up three post-rc.2 merges.
+
+### Added since rc.2
+
+- **Doctor refinement** — `gwm doctor` no longer flags gwm-style branches as orphan when they're already fully merged into one of the trunk branches (`dev`, `main`). CONTRIBUTING mandates preserving the source branch post-merge, so the previous behaviour produced N false-positives on every successful release. The Ok detail now reads `N merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans`. Genuine WIP branches (no worktree, no merge into a trunk) still surface as Warning. Closes #47 (PR #48).
+- **CI advisory `gwm doctor` job** — new job in `.github/workflows/ci.yml` that builds the release binary and runs `gwm doctor` against the repo on every push to `dev` and every PR targeting `dev`. `continue-on-error: true` so it never blocks a merge, but a non-zero exit surfaces config / env / worktree-state regressions for human review. Restricted to `dev`-targeted events via a job-level `if:` clause (the workflow header lists `[main, dev]` but main is meant to be stable). Closes #49 (PR #50).
+
+### Docs
+
+- `CHANGELOG.md` split into per-version archive files under `changelogs/`. Root `CHANGELOG.md` now carries the in-progress `[Unreleased]` section + a `Past releases` index pointing at each archive file. Reduces diff-conflict noise on `[Unreleased]` and keeps the root readable as releases pile up. Closes #45 (PR #46).
+- `CLAUDE.md` — two new house rules: pre-validate environment-dependent tests with a stripped `PATH` before push (one-liner included), and run `gwm doctor` locally on PRs that touch `.gwm.toml` / bootstrap / doctor.
+- `CONTRIBUTING.md` §Releases — instructions updated for the new layout: extract `[Unreleased]` → `changelogs/<version>.md` on stable cut, root file resets to an empty `[Unreleased]`.
+
+### Cumulative content
+
+Everything from [`v0.3.0-rc.2`](0.3.0-rc.2.md) (doctor, TUI fuzzy filter) and [`v0.3.0-rc.1`](0.3.0-rc.1.md) (completions, `cd`, `shell-init`, TDD docs).
+
+### Purpose
+
+Pre-release for final validation. Promoted to stable `v0.3.0` after multi-agent review and known-issues triage (tracked in #54).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,12 +65,11 @@ pub enum Command {
     delete_branch: bool,
   },
   /// Print the on-disk path of a worktree (use `$(gwm path …)` to cd into it).
-  Path { pattern: String },
-  /// Print the on-disk path of a worktree, framed for the cd flow.
   ///
-  /// The binary itself cannot change the parent shell's directory. Pair with
-  /// `gwm shell-init <shell>` (it defines a `gcd` function that wraps this).
-  Cd { pattern: String },
+  /// Also available as `gwm cd <pattern>` — same semantics, framed for the
+  /// cd flow. Pair with `gwm shell-init <shell>` for a one-line wrapper.
+  #[command(visible_alias = "cd")]
+  Path { pattern: String },
   /// Re-run bootstrap on an existing worktree.
   Bootstrap {
     /// Worktree path or name; defaults to CWD.
@@ -125,7 +124,6 @@ pub fn run(cli: Cli) -> Result<()> {
     } => cmd_create(branch_type, issue, desc, no_bootstrap),
     Command::Remove { pattern, delete_branch } => cmd_remove(pattern, delete_branch),
     Command::Path { pattern } => cmd_path(pattern),
-    Command::Cd { pattern } => cmd_path(pattern),
     Command::Bootstrap { target } => cmd_bootstrap(target),
     Command::Prune => cmd_prune(),
     Command::Doctor => cmd_doctor(),

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -210,12 +210,16 @@ fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
     .with_hint(format!("supported keywords: {}", SUPPORTED_WHEN_PREFIXES.join(", ")))
 }
 
-/// Extract the executable name from a shell command string. Skips leading
-/// `FOO=bar` env assignments (which the shell would treat as one-shot env)
-/// and returns the first token that isn't `KEY=VAL`. Returns `None` for
-/// empty strings.
-fn extract_binary(run: &str) -> Option<&str> {
-  run.split_whitespace().find(|t| !t.contains('='))
+/// Extract the executable name from a shell command string. Tokenises
+/// via `shell_words` so quoted args (`"my tool" --flag`) and escaped
+/// whitespace are handled the way the shell would, then skips leading
+/// `FOO=bar` env assignments and returns the first token that isn't
+/// `KEY=VAL`. Returns `None` for empty strings or strings that fail
+/// to parse (unbalanced quotes — better to surface nothing than a
+/// garbage binary name that would produce a confusing PATH warning).
+fn extract_binary(run: &str) -> Option<String> {
+  let tokens = shell_words::split(run).ok()?;
+  tokens.into_iter().find(|t| !t.contains('='))
 }
 
 /// Check #4: every binary referenced by the bootstrap commands resolves on
@@ -238,7 +242,7 @@ fn check_binaries_on_path(ctx: &DoctorCtx<'_>) -> Check {
   // Whatever the user's own bootstrap commands invoke.
   for cmd in &ctx.config.bootstrap.command {
     if let Some(bin) = extract_binary(&cmd.run) {
-      needed.insert(bin.to_string());
+      needed.insert(bin);
     }
   }
 
@@ -464,15 +468,16 @@ fn is_merged_into_any(
   Ok(false)
 }
 
-/// Probe a directory for write access by creating and deleting a sentinel
-/// file. More reliable across platforms than parsing Unix mode bits.
+/// Probe a directory for write access by creating and deleting a unique
+/// sentinel file. More reliable across platforms than parsing Unix mode
+/// bits. Uses `tempfile::Builder` so concurrent `gwm doctor` runs don't
+/// collide on a fixed filename, and so a SIGKILL mid-probe doesn't leak
+/// a stray sentinel into the user's worktree base — `NamedTempFile`
+/// RAII-cleans on drop.
 fn is_writable_dir(dir: &Path) -> bool {
-  let probe = dir.join(".gwm-doctor-write-probe");
-  match std::fs::File::create(&probe) {
-    Ok(_) => {
-      let _ = std::fs::remove_file(&probe);
-      true
-    }
-    Err(_) => false,
-  }
+  tempfile::Builder::new()
+    .prefix(".gwm-doctor-probe-")
+    .rand_bytes(8)
+    .tempfile_in(dir)
+    .is_ok()
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -20,13 +20,16 @@ impl DoctorReport {
     Self::default()
   }
 
-  /// Highest severity present in the report.
-  pub fn severity(&self) -> Severity {
-    let mut s = Severity::Ok;
+  /// Highest severity present in the report — `Failed` wins over `Warning`
+  /// wins over `Ok`. Returned as a `CheckStatus` (a previous `Severity`
+  /// enum was a verbatim duplicate; collapsing into one type avoids the
+  /// translation match and keeps the public surface minimal).
+  pub fn severity(&self) -> CheckStatus {
+    let mut s = CheckStatus::Ok;
     for c in &self.checks {
       match c.status {
-        CheckStatus::Failed => return Severity::Failed,
-        CheckStatus::Warning if s == Severity::Ok => s = Severity::Warning,
+        CheckStatus::Failed => return CheckStatus::Failed,
+        CheckStatus::Warning if s == CheckStatus::Ok => s = CheckStatus::Warning,
         _ => {}
       }
     }
@@ -38,9 +41,9 @@ impl DoctorReport {
   /// Suitable for wiring into CI / pre-commit.
   pub fn exit_code(&self) -> i32 {
     match self.severity() {
-      Severity::Ok => 0,
-      Severity::Warning => 1,
-      Severity::Failed => 2,
+      CheckStatus::Ok => 0,
+      CheckStatus::Warning => 1,
+      CheckStatus::Failed => 2,
     }
   }
 }
@@ -95,12 +98,10 @@ pub enum CheckStatus {
   Failed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Severity {
-  Ok,
-  Warning,
-  Failed,
-}
+/// Backwards-compatibility alias. `Severity` was a verbatim duplicate of
+/// `CheckStatus` introduced before they were unified; keep the name so
+/// callers from 0.3.0 keep compiling while we converge on `CheckStatus`.
+pub type Severity = CheckStatus;
 
 pub struct DoctorCtx<'a> {
   pub repo_workdir: &'a Path,
@@ -114,8 +115,22 @@ pub fn run(ctx: &DoctorCtx<'_>) -> Result<DoctorReport> {
   report.checks.push(check_guard_references(ctx));
   report.checks.push(check_when_predicates(ctx));
   report.checks.push(check_binaries_on_path(ctx));
-  report.checks.push(check_prunable_worktrees(ctx));
-  report.checks.push(check_orphan_branches(ctx));
+
+  // The next two checks both need the worktree list. Hoist the libgit2
+  // call here so it runs once per `gwm doctor` invocation and so each
+  // check carries the same view of the world.
+  match worktree::list(ctx.repo) {
+    Ok(trees) => {
+      report.checks.push(check_prunable_worktrees(&trees));
+      report.checks.push(check_orphan_branches(ctx, &trees));
+    }
+    Err(e) => {
+      let detail = format!("could not list worktrees: {}", e);
+      report.checks.push(Check::failed("no prunable worktrees", &detail));
+      report.checks.push(Check::failed("no orphan gwm branches", &detail));
+    }
+  }
+
   report.checks.push(check_base_dir_writable(ctx));
   Ok(report)
 }
@@ -188,20 +203,21 @@ fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
   let bs = &ctx.config.bootstrap;
 
   let mut unknown: Vec<String> = Vec::new();
-  let mut checked: usize = 0;
+  let mut recognised: usize = 0;
   for cmd in &bs.command {
     let Some(w) = &cmd.when else { continue };
-    checked += 1;
-    if !SUPPORTED_WHEN_PREFIXES.iter().any(|p| w.starts_with(p)) {
+    if SUPPORTED_WHEN_PREFIXES.iter().any(|p| w.starts_with(p)) {
+      recognised += 1;
+    } else {
       unknown.push(format!("{} (on command `{}`)", w, cmd.name));
     }
   }
 
   if unknown.is_empty() {
-    let detail = if checked == 0 {
+    let detail = if recognised == 0 {
       "no `when:` predicates configured".to_string()
     } else {
-      format!("{} predicate(s) recognised", checked)
+      format!("{} predicate(s) recognised", recognised)
     };
     return Check::ok(name, detail);
   }
@@ -325,12 +341,8 @@ fn check_base_dir_writable(ctx: &DoctorCtx<'_>) -> Check {
 /// happen when a worktree's working directory is deleted manually without
 /// going through `gwm remove` — the admin record stays and confuses future
 /// `gwm list` invocations.
-fn check_prunable_worktrees(ctx: &DoctorCtx<'_>) -> Check {
+fn check_prunable_worktrees(trees: &[worktree::WorktreeInfo]) -> Check {
   let name = "no prunable worktrees";
-  let trees = match worktree::list(ctx.repo) {
-    Ok(t) => t,
-    Err(e) => return Check::failed(name, format!("could not list worktrees: {}", e)),
-  };
 
   let prunable: Vec<String> = trees.iter().filter(|w| w.is_prunable).map(|w| w.name.clone()).collect();
   if prunable.is_empty() {
@@ -360,13 +372,9 @@ const TRUNK_BRANCHES: &[&str] = &["dev", "main"];
 /// (`dev`, `main`) are filtered out: keeping them is the project
 /// convention, and surfacing them would make the check produce N false
 /// positives on every successful release.
-fn check_orphan_branches(ctx: &DoctorCtx<'_>) -> Check {
+fn check_orphan_branches(ctx: &DoctorCtx<'_>, trees: &[worktree::WorktreeInfo]) -> Check {
   let name = "no orphan gwm branches";
 
-  let trees = match worktree::list(ctx.repo) {
-    Ok(t) => t,
-    Err(e) => return Check::failed(name, format!("could not list worktrees: {}", e)),
-  };
   let claimed: BTreeSet<String> = trees.iter().filter_map(|w| w.branch.clone()).collect();
 
   // Resolve the trunk OIDs once. Missing trunks (e.g. a repo without `dev`)

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -15,16 +15,20 @@ fn help_prints_subcommands() {
   // names with two leading spaces and at least two trailing spaces before
   // the description. A loose `contains("cd")` would also match prose like
   // "to cd into it" in another subcommand's description.
+  // `cd` is now a visible alias of `path` (clap renders it as
+  // `path  ...  [aliases: cd]`), so we assert the alias marker
+  // rather than a separate `  cd ` row.
   cmd
     .assert()
     .success()
     .stdout(predicate::str::contains("  init "))
     .stdout(predicate::str::contains("  list "))
     .stdout(predicate::str::contains("  create "))
+    .stdout(predicate::str::contains("  path "))
+    .stdout(predicate::str::contains("[aliases: cd]"))
     .stdout(predicate::str::contains("  bootstrap "))
     .stdout(predicate::str::contains("  prune "))
     .stdout(predicate::str::contains("  completions "))
-    .stdout(predicate::str::contains("  cd "))
     .stdout(predicate::str::contains("  shell-init "))
     .stdout(predicate::str::contains("  doctor "));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -37,15 +37,19 @@ fn help_prints_subcommands() {
 fn doctor_on_fresh_repo_prints_checks() {
   let (dir, _repo) = init_repo();
   let mut cmd = Command::cargo_bin("gwm").unwrap();
-  // Exit code is intentionally not asserted here: in environments without
-  // `lazygit` on PATH (most CI runners) or a pre-existing `~/cc-worktree/`
-  // parent, the report legitimately surfaces Warning entries and exits 1.
-  // The 0/1/2 exit-code contract is exercised at the unit level in
-  // `tests/doctor_tests.rs` where the environment is fully controlled.
+  // Exit code is intentionally not asserted to be 0: in environments
+  // without `lazygit` on PATH (most CI runners) or a pre-existing
+  // `~/cc-worktree/` parent, the report legitimately surfaces Warning
+  // entries and exits 1. But we still bound the contract — anything
+  // other than 0 (all green) or 1 (warning) on a vanilla fresh repo
+  // means the doctor is over-flagging (or panicking, which would also
+  // produce a non-0/1 code) and we want the test to fail loudly.
+  // The 0/1/2 mapping is unit-tested in `tests/doctor_tests.rs`.
   cmd
     .current_dir(dir.path())
     .arg("doctor")
     .assert()
+    .code(predicate::in_iter([0_i32, 1]))
     .stdout(predicate::str::contains("✓"))
     .stdout(predicate::str::contains(".gwm.toml"))
     .stdout(predicate::str::contains("base directory writable"));
@@ -208,11 +212,16 @@ fn cd_outside_git_repo_fails() {
 fn shell_init_bash_emits_gcd_function() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["shell-init", "bash"]);
+  // Pin the invocation site: a regression that mentions `gwm cd` only in
+  // a comment but doesn't actually call it from the function body would
+  // pass a loose `contains("gwm cd")`. `gwm cd "$@"` (POSIX-style
+  // argument forwarding) is what makes `gcd auth` translate into
+  // `gwm cd auth`.
   cmd
     .assert()
     .success()
     .stdout(predicate::str::contains("function gcd"))
-    .stdout(predicate::str::contains("gwm cd"));
+    .stdout(predicate::str::contains("gwm cd \"$@\""));
 }
 
 #[test]
@@ -223,7 +232,7 @@ fn shell_init_zsh_emits_gcd_function() {
     .assert()
     .success()
     .stdout(predicate::str::contains("function gcd"))
-    .stdout(predicate::str::contains("gwm cd"));
+    .stdout(predicate::str::contains("gwm cd \"$@\""));
 }
 
 #[test]
@@ -269,7 +278,7 @@ fn shell_init_fish_emits_function_block() {
     .assert()
     .success()
     .stdout(predicate::str::contains("function gcd"))
-    .stdout(predicate::str::contains("gwm cd"))
+    .stdout(predicate::str::contains("gwm cd $argv"))
     .stdout(predicate::str::contains("end"));
 }
 
@@ -295,7 +304,7 @@ fn shell_init_powershell_emits_function_block() {
     .assert()
     .success()
     .stdout(predicate::str::contains("function gcd"))
-    .stdout(predicate::str::contains("gwm cd"))
+    .stdout(predicate::str::contains("gwm cd $Pattern"))
     .stdout(predicate::str::contains("Set-Location"));
 }
 

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -303,10 +303,7 @@ fn resolvable_command_binary_is_ok() {
   // which would pass even on `[sh,other]` or `sh\n` formatting.
   if c.status == CheckStatus::Warning {
     let missing_section = c.detail.split("not on PATH:").nth(1).unwrap_or("");
-    let missing: Vec<&str> = missing_section
-      .split(|c: char| c == ',' || c == '\n')
-      .map(str::trim)
-      .collect();
+    let missing: Vec<&str> = missing_section.split([',', '\n']).map(str::trim).collect();
     assert!(
       !missing.contains(&"sh"),
       "sh must not be reported missing, got: {}",

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -298,8 +298,51 @@ fn resolvable_command_binary_is_ok() {
   let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
   let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
   // We don't assert Ok strictly — `lazygit` may be missing on a CI runner.
-  // The relevant assertion is: the run-string binary doesn't show up as missing.
-  assert!(!c.detail.contains("sh "), "sh should resolve, got: {}", c.detail);
+  // The relevant assertion is: when the doctor reports missing binaries, `sh`
+  // is not in that list. Distinguished from the previous loose `!contains("sh ")`
+  // which would pass even on `[sh,other]` or `sh\n` formatting.
+  if c.status == CheckStatus::Warning {
+    let missing_section = c.detail.split("not on PATH:").nth(1).unwrap_or("");
+    let missing: Vec<&str> = missing_section
+      .split(|c: char| c == ',' || c == '\n')
+      .map(str::trim)
+      .collect();
+    assert!(
+      !missing.contains(&"sh"),
+      "sh must not be reported missing, got: {}",
+      c.detail
+    );
+  }
+}
+
+#[test]
+fn extract_binary_handles_shell_quoted_run_strings() {
+  // Pre-fix, `extract_binary` used `split_whitespace` and returned `"my`
+  // as the binary name for a quoted run-string like `"my tool" --flag`,
+  // producing a "binary not on PATH" warning that doesn't match anything
+  // the user actually wrote. After the shell-words migration, the
+  // binary is correctly identified as the full quoted command name.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.bootstrap.command.push(gwm::config::CommandStep {
+    name: "quoted".into(),
+    run: r#""definitely-not-on-path-quoted-xyz" --help"#.into(),
+    when: None,
+    env: Default::default(),
+  });
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert!(
+    c.detail.contains("definitely-not-on-path-quoted-xyz"),
+    "shell-quoted binary name must be unquoted in the report, got: {}",
+    c.detail
+  );
+  assert!(
+    !c.detail.contains("\"definitely"),
+    "the leading quote must be stripped, got: {}",
+    c.detail
+  );
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Post-stable cleanup addressing the findings from the pre-stable multi-agent review of v0.3.0-rc.3. Seven atomic commits, one concern per commit, targeting `dev` for the 0.3.1 line.

All HIGH and most MEDIUM items from #54 are closed. The remaining LOW items (shell scripts to `include_str!`, cache `filtered_indices`, `TRUNK_BRANCHES` in config, remote-tracking branches, base-dir ancestor walk) are deferred to a 0.4 tracker — they're improvements, not corrections.

Closes #54

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix) — doctor write-probe race + shell-quoted run-strings
- [ ] 🚑️ Hotfix
- [x] ♻️ Refactor — Severity → CheckStatus, hoist worktree::list, cd alias
- [x] 📝 Docs — README sample + test count + CHANGELOG
- [x] ✅ Tests — exit code bounded, shell-init bodies pinned, sh assertion tightened
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build — deps bump (shell-words, tempfile promotion)

## Changes (per commit)

1. `🏗️ build(deps)` — `shell-words` (new, runtime) + `tempfile` promoted from dev-dep to runtime dep.
2. `🐛 fix(doctor)` — `is_writable_dir` uses random-suffixed `tempfile` probe (was fixed name, racy). `extract_binary` uses `shell_words::split` (was `split_whitespace`, sliced through quotes).
3. `♻️ refactor(doctor)` — `Severity` collapsed into `CheckStatus` (kept as `pub type` alias for 0.3.0 callers). `worktree::list` hoisted into `run()`. `check_when_predicates` counter renamed `checked` → `recognised`, only incremented on match.
4. `♻️ refactor(cli)` — `Command::Cd` dropped in favour of `#[command(visible_alias = "cd")]` on `Path`. `gwm cd <pattern>` and `gwm path <pattern>` are now the same code path.
5. `✅ test` — `doctor_on_fresh_repo_prints_checks` bounded to exit `[0, 1]`. `shell_init_*_emits_*` tests pin the actual `gwm cd "$@"` / `gwm cd $argv` / `gwm cd $Pattern` invocation. `resolvable_command_binary_is_ok` parses the "not on PATH:" list properly.
6. `📝 docs` — README doctor sample refreshed to the post-#47 wording (`✓ N merged preserved`). Test count updated from a stale "81" to 140.
7. `📝 docs(changelog)` — aggregated `[Unreleased]` entry + clippy fix on the test's char comparison.

## Tests

- [x] `cargo test` passes locally (140 tests across 9 binaries)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New regression test: `extract_binary_handles_shell_quoted_run_strings` (failed pre-fix, passes after).

## Screenshots

N/A.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`chore/#54-post-0-3-0-cleanup`)
- [x] Commits follow Gitmoji + Conventional Commits, one concern per commit
- [x] CHANGELOG.md updated under `## [Unreleased]` (root file = current release only; past versions live under `changelogs/<version>.md`)
- [x] README updated (CLI surface unchanged; only the doctor sample + test count)
- [ ] `examples/gwm.toml.example` updated (N/A — config schema unchanged)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #54
- Related: closes the multi-agent review findings from the pre-v0.3.0-stable audit.

## Notes for reviewers

- **Backwards compatibility**: `pub type Severity = CheckStatus;` is kept so any 0.3.0 library caller importing `gwm::doctor::Severity` continues to compile. The next major (1.0) can drop the alias.
- **`gwm cd` alias visibility**: clap renders it as `path  ...  [aliases: cd]` rather than a separate row. `help_prints_subcommands` was tightened to assert both the `path` row and the `[aliases: cd]` marker so a regression that drops either is caught.
- **`shell_words::split` failure mode**: when given a string with unbalanced quotes, the function returns `Err`. The handler converts to `None` and the doctor silently skips that binary — better than fabricating a garbage binary name that would produce a confusing PATH warning. Documented in the inline comment.
- **Pre-validation**: `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test` — green.