### PR TITLE
✅ test(structure): audit sentinel / regression-only tests for cost vs. value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- Sentinel / regression-only audit ([#57](https://github.com/kbrdn1/gwm-cli/issues/57)) — classified all 193 tests at v0.4.0 into three buckets (drives production logic, regression sentinel, dead weight), deleted 3 bucket-#3 tests (`bootstrap_when_tests::evaluator_is_pure_for_a_given_cwd`, `doctor_tests::prunable_check_detail_uses_singular_plural_correctly`, `cli_binary::shell_init_posix_does_not_use_paren_function_syntax`) that asserted constants against themselves or duplicated positive coverage, and annotated the 11 retained sentinels with a `// regression: <one-line>` tag so the incident target is discoverable without `git blame`. Total: **193 → 190**. Full audit table in [`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md).
+
 ### Docs
 
 - `CLAUDE.md` + `CONTRIBUTING.md` §Releases — new "Step 0: reconcile open PRs" rule. Before any RC or stable cut, run `gh pr list --state open` and reconcile every open PR (in the changeset, intentionally deferred, or closed as stale). Codifies the lesson from the v0.3.0 cut, which shipped without three queued feature PRs (#51, #52, #53) and required an immediate v0.4.0 promotion 38 minutes later. Step 0 sits explicitly at the top of both the pre-release and stable-release procedures.
+- README — bumped the suite-size advert to 190 tests, added the missing `bootstrap_when_tests.rs`, `doctor_tests.rs`, and `flake_tests.rs` entries to the file tree, and pointed at the audit doc for sentinel hygiene.
 
 ## Past releases
 

--- a/README.md
+++ b/README.md
@@ -350,13 +350,13 @@ Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde
 | multi-repo portability              | per-project script   | one binary, per-repo config      |
 | TUI                                 | linear bash menu     | full ratatui screen              |
 | anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 140 tests (config / naming / bootstrap / worktree / TUI / CLI) |
+| tests                               | none                 | 190 tests (config / naming / bootstrap / doctor / flake / worktree / TUI / CLI) |
 
 ## development
 
 ```bash
 cargo build              # debug build
-cargo test               # 140 tests
+cargo test               # 190 tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally
@@ -376,10 +376,18 @@ tests/
 ├── config_tests.rs               # .gwm.toml parsing + write_default
 ├── naming_tests.rs               # kebab, branch validation, parse roundtrip
 ├── bootstrap_tests.rs            # copies / guards / no-symlink / commands
+├── bootstrap_when_tests.rs       # `when:` predicate grammar (file/cmd/env/glob + boolean ops)
+├── doctor_tests.rs               # `gwm doctor` checks + severity arithmetic
+├── flake_tests.rs                # Nix flake structure (build, devShell, app)
 ├── worktree_integration.rs       # git2 add/list/remove/prune
 ├── tui_app_tests.rs              # state transitions (ratatui-free)
 └── cli_binary.rs                 # assert_cmd end-to-end
 ```
+
+Sentinel tests (pinned to catch a specific regression) are prefixed with a
+`// regression: <one-line>` tag inside the test body so the target incident
+is discoverable without `git blame`. Suite hygiene was last audited in
+[`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md).
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branch / commit / PR conventions.
 

--- a/claudedocs/test-audit-0.4.0.md
+++ b/claudedocs/test-audit-0.4.0.md
@@ -1,0 +1,297 @@
+# Test-suite audit — v0.4.0
+
+Closes part of [#57](https://github.com/kbrdn1/gwm-cli/issues/57).
+
+Walk of every test under `tests/` (193 total at v0.4.0), classified into
+the three buckets defined by the issue:
+
+1. **drives** — exercises a real production code path. Failure reveals
+   a regression in the system under test.
+2. **sentinel** — pinned exclusively to catch a previously-introduced
+   bug from reappearing. Annotated inline with `// regression: <one-line>`
+   so a future reader can identify the target without git-archaeology.
+3. **dead** — drifts from intent: asserts a constant against itself,
+   restates coverage another test already provides, or pins a behaviour
+   we have since changed. Deleted in this PR.
+
+## Summary
+
+| Bucket               | Count | Δ vs v0.4.0 |
+|:---------------------|------:|------------:|
+| #1 drives            |   179 |           — |
+| #2 sentinel (kept)   |    11 |    annotated|
+| #3 dead (deleted)    |     3 |          −3 |
+| **Total after audit**| **190** | **−3**    |
+
+Target band per the issue: `[180, 195]`. We land on `190`, holding most
+of the growth (193 → 190) while clearing the three tests that were
+asserting against themselves or duplicating positive coverage.
+
+## Deletions
+
+All three are bucket #3 — deleted in this PR. Each deletion commit cites
+the consolidating positive test that already subsumes the path.
+
+| File                       | Test                                                  | Why dead | Subsumed by |
+|:---------------------------|:------------------------------------------------------|:---------|:------------|
+| `bootstrap_when_tests.rs`  | `evaluator_is_pure_for_a_given_cwd`                    | A "sanity probe" calling `evaluate_when(expr, cwd)` twice with the same args and asserting equality. The function is a pure read-over-FS-and-env predicate; the test pins purity that already follows from the signature. If `evaluate_when` ever mutated process state between calls, no realistic regression path lands in this test before crashing the surrounding suite. | The 27 positive evaluator tests next to it — each calls `evaluate_when` once on a controlled tempdir and asserts the boolean result. Any non-deterministic behaviour would show up there, not in a self-equality check. |
+| `doctor_tests.rs`          | `prunable_check_detail_uses_singular_plural_correctly` | Constructs a `gwm::doctor::Check::warning(...)` *by hand* with the literal string `"1 prunable entry: feat-12-old"`, then asserts the string does not contain `entrie(`. The doctor's pluralisation logic is never invoked — the test is asserting its own input against itself. | The pluralisation contract is enforced where it lives, in `src/doctor.rs::pluralise_prunable_count` (and the existing `fresh_repo_has_no_prunable_worktrees` end-to-end path). If `pluralise_prunable_count` regressed, it would surface in any real `gwm doctor` run with one prunable worktree. |
+| `cli_binary.rs`            | `shell_init_posix_does_not_use_paren_function_syntax`  | Asserts `gcd()` is **not** in the `shell-init` output. But `shell_init_bash_emits_gcd_function` and `shell_init_zsh_emits_gcd_function` already assert `function gcd` **is** present — for a realistic regression the implementation would switch from one form to the other, not emit both. The negative assertion duplicates the contract pinned by the positives. | `shell_init_bash_emits_gcd_function` + `shell_init_zsh_emits_gcd_function` (positive `function gcd` assertion). Together they pin the keyword form unambiguously; the explosive `gcd()` form cannot satisfy them. |
+
+## Per-file classification
+
+### `tests/bootstrap_tests.rs` — 13 tests, **all drives**
+
+| Test                                            | Bucket  |
+|:------------------------------------------------|:--------|
+| `copy_step_happy_path`                          | drives  |
+| `copy_step_skipped_when_dest_exists`            | drives  |
+| `copy_step_required_source_missing_fails`       | drives  |
+| `copy_step_optional_source_missing_skipped`     | drives  |
+| `copy_step_inline_fallback_writes_content`      | drives  |
+| `guard_abort_blocks_copy`                       | drives  |
+| `guard_seed_from_example_substitutes`           | drives  |
+| `guard_does_not_trip_on_safe_content`           | drives  |
+| `no_symlink_removes_existing_symlink`           | drives  |
+| `command_when_file_exists_skips_if_missing`     | drives  |
+| `command_runs_when_condition_satisfied`         | drives  |
+| `command_failure_recorded`                      | drives  |
+| `command_env_is_propagated`                     | drives  |
+
+### `tests/bootstrap_when_tests.rs` — 28 tests → 27 after audit
+
+| Test                                                       | Bucket   | Notes |
+|:-----------------------------------------------------------|:---------|:------|
+| `file_exists_true_when_target_present`                     | drives   ||
+| `file_exists_false_when_target_missing`                    | drives   ||
+| `cmd_exists_true_for_sh`                                   | drives   ||
+| `cmd_exists_false_for_made_up_binary`                      | drives   ||
+| `env_set_true_for_path`                                    | drives   ||
+| `env_set_false_for_unset_var`                              | drives   ||
+| `env_eq_true_when_value_matches`                           | drives   ||
+| `env_eq_false_when_value_mismatch`                         | drives   ||
+| `env_eq_false_when_var_missing`                            | drives   ||
+| `glob_exists_true_when_pattern_matches_in_root`            | drives   ||
+| `glob_exists_true_for_recursive_pattern`                   | drives   ||
+| `glob_exists_false_when_no_match`                          | drives   ||
+| `not_inverts_file_exists_true`                             | drives   ||
+| `not_inverts_file_exists_false`                            | drives   ||
+| `and_true_when_both_sides_true`                            | drives   ||
+| `and_false_when_left_false`                                | drives   ||
+| `and_false_when_right_false`                               | drives   ||
+| `or_true_when_left_true`                                   | drives   ||
+| `or_true_when_right_true`                                  | drives   ||
+| `or_false_when_both_sides_false`                           | drives   ||
+| `precedence_not_binds_tighter_than_and`                    | drives   ||
+| `precedence_and_binds_tighter_than_or`                     | drives   ||
+| `precedence_and_binds_tighter_than_or_negative`            | drives   ||
+| `extra_whitespace_around_operators_is_tolerated`           | drives   ||
+| `unicode_whitespace_inside_atom_is_trimmed`                | sentinel | regression: NBSP-prefixed atoms forwarded to `Path::join` pre `.trim()` fix |
+| `unicode_path_does_not_panic`                              | sentinel | regression: `tokenize_when` byte-slicing on multibyte UTF-8 paths |
+| `unknown_keyword_still_defaults_to_true`                   | drives   | (forward-compat contract) |
+| ~~`evaluator_is_pure_for_a_given_cwd`~~                    | **dead** | deleted — see *Deletions* |
+
+### `tests/cli_binary.rs` — 31 tests → 30 after audit
+
+| Test                                                       | Bucket   | Notes |
+|:-----------------------------------------------------------|:---------|:------|
+| `help_prints_subcommands`                                  | drives   | canary per CONTRIBUTING.md |
+| `switch_alias_s_resolves_to_switch`                        | drives   ||
+| `top_level_help_advertises_switch_alias`                   | drives   ||
+| `switch_outside_git_repo_fails`                            | drives   ||
+| `doctor_on_fresh_repo_prints_checks`                       | drives   ||
+| `doctor_outside_git_repo_fails`                            | drives   ||
+| `doctor_exits_two_on_invalid_config`                       | drives   ||
+| `version_flag`                                             | drives   ||
+| `types_lists_branch_types`                                 | drives   ||
+| `create_outside_git_repo_fails`                            | drives   | exercises `list` outside a repo (mis-named) |
+| `completions_zsh_emits_compdef_header`                     | drives   ||
+| `completions_bash_emits_complete_directive`                | drives   ||
+| `completions_fish_emits_complete_directive`                | drives   ||
+| `completions_powershell_emits_register_block`              | drives   ||
+| `completions_rejects_unknown_shell`                        | drives   ||
+| `list_format_names_emits_one_name_per_line`                | drives   ||
+| `cd_unknown_pattern_fails_with_not_found`                  | drives   ||
+| `cd_outside_git_repo_fails`                                | drives   ||
+| `shell_init_bash_emits_gcd_function`                       | drives   ||
+| `shell_init_zsh_emits_gcd_function`                        | drives   ||
+| ~~`shell_init_posix_does_not_use_paren_function_syntax`~~  | **dead** | deleted — see *Deletions* |
+| `shell_init_posix_unaliases_gcd_first`                     | sentinel | regression: oh-my-zsh's `gcd='git checkout'` shadowed our function definition |
+| `shell_init_powershell_unaliases_gcd_first`                | drives   ||
+| `shell_init_fish_emits_function_block`                     | drives   ||
+| `shell_init_fish_quotes_target_with_double_dash`           | sentinel | regression: fish wildcard expansion mangled `[`, `]`, `*` paths without `cd -- "$target"` |
+| `shell_init_powershell_emits_function_block`               | drives   ||
+| `shell_init_posix_no_arg_invokes_switch`                   | drives   ||
+| `shell_init_fish_no_arg_invokes_switch`                    | drives   ||
+| `shell_init_powershell_no_arg_invokes_switch`              | drives   ||
+| `shell_init_rejects_unknown_shell`                         | drives   ||
+| `list_format_table_is_default`                             | drives   ||
+
+### `tests/config_tests.rs` — 8 tests, **all drives**
+
+| Test                                            | Bucket  |
+|:------------------------------------------------|:--------|
+| `defaults_are_sane`                             | drives  |
+| `placeholders_expand`                           | drives  |
+| `placeholders_no_optional_args_leave_repo_only` | drives  |
+| `load_returns_defaults_when_no_file`            | drives  |
+| `load_parses_repo_config`                       | drives  |
+| `write_default_creates_file`                    | drives  |
+| `write_default_refuses_overwrite`               | drives  |
+| `malformed_config_returns_error`                | drives  |
+
+### `tests/doctor_tests.rs` — 26 tests → 25 after audit
+
+| Test                                                                | Bucket   | Notes |
+|:--------------------------------------------------------------------|:---------|:------|
+| `fresh_repo_without_config_reports_defaults_assumed`                | drives   ||
+| `invalid_toml_marks_config_check_failed_with_severity_failed`       | drives   ||
+| `valid_toml_marks_config_check_ok`                                  | drives   ||
+| `severity_ok_when_all_checks_ok`                                    | drives   | hand-built report (env-independent) |
+| `severity_warning_when_any_check_warns`                             | drives   | hand-built report |
+| `severity_failed_dominates_warning`                                 | drives   | hand-built report |
+| `dangling_guard_reference_is_failed`                                | drives   ||
+| `matching_guard_reference_is_ok`                                    | drives   ||
+| `unsupported_when_predicate_is_failed`                              | drives   ||
+| `negated_supported_keyword_is_ok`                                   | drives   ||
+| `unsupported_keyword_on_rhs_of_and_is_failed`                       | drives   ||
+| `file_exists_when_predicate_is_ok`                                  | drives   ||
+| `no_when_predicates_is_ok`                                          | drives   ||
+| `when_predicates_detail_counts_checked_predicates_not_keywords`     | sentinel | regression: detail used `SUPPORTED_WHEN_PREFIXES.len()` and reported "1 predicate" regardless |
+| `when_predicates_detail_says_none_when_no_predicates_configured`    | sentinel | regression: same miscount when no predicates configured |
+| `missing_command_binary_is_warning`                                 | drives   ||
+| `resolvable_command_binary_is_ok`                                   | drives   ||
+| `extract_binary_handles_shell_quoted_run_strings`                   | sentinel | regression: `split_whitespace` returned `"my` for `"my tool" --flag`; shell-words migration |
+| `base_dir_existing_and_writable_is_ok`                              | drives   ||
+| `base_dir_missing_but_parent_writable_is_ok`                        | drives   ||
+| ~~`prunable_check_detail_uses_singular_plural_correctly`~~          | **dead** | deleted — see *Deletions* |
+| `fresh_repo_has_no_prunable_worktrees`                              | drives   ||
+| `orphan_unmerged_gwm_branch_is_warning`                             | drives   ||
+| `merged_gwm_branch_is_not_flagged_as_orphan`                        | drives   ||
+| `merged_via_merge_commit_gwm_branch_is_not_flagged_as_orphan`       | drives   ||
+| `non_gwm_branch_is_not_flagged_as_orphan`                           | drives   ||
+
+### `tests/flake_tests.rs` — 5 tests, **all drives**
+
+| Test                                                  | Bucket  |
+|:------------------------------------------------------|:--------|
+| `flake_exists_at_repo_root`                           | drives  |
+| `flake_declares_top_level_description_inputs_outputs` | drives  |
+| `flake_exposes_gwm_package_via_build_rust_package`    | drives  |
+| `flake_exposes_runnable_app`                          | drives  |
+| `flake_exposes_dev_shell_with_rust_toolchain`         | drives  |
+
+### `tests/naming_tests.rs` — 10 tests, **all drives**
+
+| Test                                          | Bucket  |
+|:----------------------------------------------|:--------|
+| `kebab_normalizes`                            | drives  |
+| `kebab_treats_punctuation_as_separator`       | drives  |
+| `branch_validation`                           | drives  |
+| `all_branch_types_accepted`                   | drives  |
+| `invalid_issue_must_be_digits`                | drives  |
+| `description_normalized_before_validation`    | drives  |
+| `parse_roundtrip`                             | drives  |
+| `parse_rejects_garbage`                       | drives  |
+| `renders_paths`                               | drives  |
+| `renders_with_custom_patterns`                | drives  |
+
+### `tests/tui_app_tests.rs` — 56 tests, none deleted
+
+| Test                                                              | Bucket   | Notes |
+|:------------------------------------------------------------------|:---------|:------|
+| `new_loads_main_worktree`                                          | drives   ||
+| `enter_create_initializes_form`                                    | drives   ||
+| `create_field_navigation_loops`                                    | drives   ||
+| `create_type_navigation_loops`                                     | drives   ||
+| `create_push_only_digits_on_issue`                                 | drives   ||
+| `create_push_accepts_desc_chars`                                   | drives   ||
+| `enter_confirm_delete_refuses_main`                                | drives   ||
+| `toggle_delete_branch_flips`                                       | drives   ||
+| `next_prev_with_single_entry_stays_put`                            | drives   ||
+| `refresh_keeps_selection_in_bounds`                                | drives   ||
+| `sidebar_open_by_default`                                          | drives   ||
+| `toggle_sidebar_flips_open_flag`                                   | drives   ||
+| `toggle_sidebar_when_closed_resets_focus_to_list`                  | drives   ||
+| `toggle_focus_only_works_when_sidebar_open`                        | drives   ||
+| `first_selects_first_worktree`                                     | drives   ||
+| `last_selects_last_worktree`                                       | drives   ||
+| `handle_g_motion_tracks_pending_then_jumps_to_first`               | drives   ||
+| `pending_g_resets_on_other_key`                                    | drives   ||
+| `sidebar_scroll_clamps_to_zero`                                    | drives   ||
+| `sidebar_scroll_clamps_at_max`                                     | drives   ||
+| `focus_routes_navigation_to_sidebar`                               | drives   ||
+| `next_prev_invalidate_sidebar_cache`                               | drives   ||
+| `refresh_invalidates_sidebar_cache`                                | drives   ||
+| `filter_state_defaults_to_inactive_and_empty`                      | drives   ||
+| `enter_filter_activates_capture_and_disarms_gg`                    | drives   ||
+| `enter_filter_drops_sidebar_focus`                                 | sentinel | regression: PR #44 Copilot review — sidebar focus survived `/` and broke j/k after Enter |
+| `enter_filter_preserves_existing_query`                            | drives   ||
+| `filter_push_char_appends_to_query`                                | drives   ||
+| `filter_pop_char_removes_last_char`                                | drives   ||
+| `filter_pop_char_on_empty_is_noop`                                 | drives   ||
+| `exit_filter_keep_disables_capture_keeps_query`                    | drives   ||
+| `exit_filter_cancel_clears_query`                                  | drives   ||
+| `filtered_indices_returns_all_when_query_empty`                    | drives   ||
+| `filtered_indices_keeps_only_matching_worktrees`                   | drives   ||
+| `filtered_indices_supports_subsequence_match`                      | drives   | issue #21 contract |
+| `filtered_indices_ranks_substring_above_subsequence`               | drives   | issue #21 ranking |
+| `filtered_indices_skips_when_no_match`                             | drives   ||
+| `selected_returns_filtered_worktree`                               | drives   ||
+| `selected_returns_none_when_filter_matches_nothing`                | drives   ||
+| `next_navigates_within_filtered_subset_and_wraps`                  | drives   ||
+| `prev_navigates_within_filtered_subset_and_wraps`                  | drives   ||
+| `first_and_last_jump_inside_filtered_subset`                       | drives   ||
+| `filter_push_clamps_selection_when_subset_shrinks`                 | drives   ||
+| `exit_filter_cancel_restores_full_list_selection`                  | drives   ||
+| `picker_mode_defaults_to_false`                                    | drives   ||
+| `new_picker_at_enables_picker_mode`                                | drives   ||
+| `new_picker_at_opens_filter_bar`                                   | drives   | issue #22 contract |
+| `picker_confirm_records_selected_path`                             | drives   ||
+| `picker_confirm_with_no_selection_keeps_result_none`               | drives   ||
+| `picker_confirm_outside_picker_mode_is_inert`                      | drives   ||
+| `picker_should_exit_defaults_false`                                | drives   ||
+| `picker_confirm_with_selection_signals_exit`                       | drives   ||
+| `picker_confirm_without_selection_does_not_signal_exit`            | sentinel | regression: PR #53 Copilot review — empty filter result triggered exit-1 |
+| `picker_confirm_without_selection_reports_status`                  | sentinel | regression: PR #53 — empty picker result was silently swallowed without status hint |
+| `picker_cancel_signals_exit_without_path`                          | sentinel | regression: PR #53 — picker footer reads `esc:cancel` but Esc-in-filter only cleared the query |
+| `picker_cancel_outside_picker_mode_is_inert`                       | drives   ||
+
+### `tests/worktree_integration.rs` — 16 tests, **all drives**
+
+| Test                                                       | Bucket  |
+|:-----------------------------------------------------------|:--------|
+| `discover_finds_repo`                                      | drives  |
+| `list_includes_main_worktree`                              | drives  |
+| `add_creates_branch_and_worktree`                          | drives  |
+| `add_refuses_to_clobber_existing_dir`                      | drives  |
+| `remove_deletes_dir_and_prunes`                            | drives  |
+| `remove_with_delete_branch_drops_branch`                   | drives  |
+| `find_fuzzy_matches_substring`                             | drives  |
+| `find_fuzzy_errors_on_ambiguous`                           | drives  |
+| `prune_returns_zero_when_clean`                            | drives  |
+| `repo_name_derives_from_workdir`                           | drives  |
+| `discover_from_inside_linked_worktree_walks_back_to_main`  | drives  |
+| `git_log_oneline_returns_seed_commit`                      | drives  |
+| `git_log_oneline_respects_limit`                           | drives  |
+| `git_status_short_empty_on_clean_repo`                     | drives  |
+| `git_status_short_lists_untracked_file`                    | drives  |
+| `git_log_oneline_errors_outside_repo`                      | drives  |
+
+## Reading guide for future PRs
+
+When adding a test, ask yourself which bucket it falls into **before**
+committing it:
+
+- If it exercises a production code path: bucket #1. No prefix needed.
+- If it guards a specific incident (regression, review comment, escape
+  hatch): bucket #2. Prefix the test body with `// regression: <one-line>`.
+  The `<one-line>` should name the incident (PR number, issue, or a
+  short symptom) — enough that a future reader can find the context
+  without `git blame`.
+- If you cannot say which production path it pins, or if another test
+  already covers that path: it is bucket #3. Don't write it.
+
+Goal: signal-to-noise per test stays high even as the suite grows.
+A 250-test suite where 50 are noise serves the project worse than
+the 190-test suite this audit leaves behind.

--- a/tests/bootstrap_when_tests.rs
+++ b/tests/bootstrap_when_tests.rs
@@ -261,6 +261,8 @@ fn extra_whitespace_around_operators_is_tolerated() {
 
 #[test]
 fn unicode_whitespace_inside_atom_is_trimmed() {
+  // regression: NBSP-prefixed atoms were forwarded to Path::join before the
+  // `.trim()` on the keyword remainder was restored.
   // The tokenizer only splits on ASCII whitespace, so a non-ASCII Unicode
   // whitespace character (here NBSP `\u{00A0}`) stays glued to the atom.
   // Pre-fix `evaluate_when` would forward the whitespace-prefixed string
@@ -278,6 +280,8 @@ fn unicode_whitespace_inside_atom_is_trimmed() {
 
 #[test]
 fn unicode_path_does_not_panic() {
+  // regression: tokenize_when byte-slicing must not break inside a
+  // multibyte UTF-8 codepoint when the path contains non-ASCII chars.
   // Regression guard for tokenize_when: it slices `expr` by byte index.
   // The delimiters (`!`, `&`, `|`, ASCII whitespace) are all single-byte
   // ASCII codepoints, so the loop can never break mid-character of a

--- a/tests/bootstrap_when_tests.rs
+++ b/tests/bootstrap_when_tests.rs
@@ -12,7 +12,6 @@
 //! end-to-end wiring covered.
 
 use gwm::bootstrap::evaluate_when;
-use std::path::Path;
 use tempfile::TempDir;
 
 // Sentinel name used wherever a test needs an env var that is guaranteed
@@ -302,18 +301,4 @@ fn unknown_keyword_still_defaults_to_true() {
   // predicates keep running while the doctor surfaces the unknown keyword.
   let dir = TempDir::new().unwrap();
   assert!(evaluate_when("totally_made_up:whatever", dir.path()));
-}
-
-// --------------------------------------------------------------------------
-// Sanity probe — evaluator is a pure function of (expr, cwd)
-// --------------------------------------------------------------------------
-
-#[test]
-fn evaluator_is_pure_for_a_given_cwd() {
-  let dir = TempDir::new().unwrap();
-  std::fs::write(dir.path().join("a"), "").unwrap();
-  let cwd: &Path = dir.path();
-  let first = evaluate_when("file_exists:a && cmd_exists:sh", cwd);
-  let second = evaluate_when("file_exists:a && cmd_exists:sh", cwd);
-  assert_eq!(first, second);
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -291,6 +291,8 @@ fn shell_init_posix_does_not_use_paren_function_syntax() {
 // regardless of the user's prior aliases.
 #[test]
 fn shell_init_posix_unaliases_gcd_first() {
+  // regression: oh-my-zsh's git plugin defines `gcd='git checkout'` which
+  // shadowed our gcd function ("defining function based on alias").
   for shell in ["bash", "zsh"] {
     let mut cmd = Command::cargo_bin("gwm").unwrap();
     cmd.args(["shell-init", shell]);
@@ -327,6 +329,8 @@ fn shell_init_fish_emits_function_block() {
 // parsing and glob expansion.
 #[test]
 fn shell_init_fish_quotes_target_with_double_dash() {
+  // regression: fish wildcard expansion mangled paths containing `[`, `]`,
+  // or `*` when the helper used `cd $target` without `cd -- "$target"`.
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["shell-init", "fish"]);
   cmd

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -274,16 +274,6 @@ fn shell_init_zsh_emits_gcd_function() {
     .stdout(predicate::str::contains("gwm cd \"$@\""));
 }
 
-#[test]
-fn shell_init_posix_does_not_use_paren_function_syntax() {
-  for shell in ["bash", "zsh"] {
-    let mut cmd = Command::cargo_bin("gwm").unwrap();
-    cmd.args(["shell-init", shell]);
-    // `gcd()` is the form that explodes under an existing alias.
-    cmd.assert().success().stdout(predicate::str::contains("gcd()").not());
-  }
-}
-
 // Regression: in zsh, an existing alias (e.g. `gcd='git checkout'` from
 // oh-my-zsh's git plugin) wins over a same-named function and refuses to
 // be shadowed at definition time ("defining function based on alias").

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -436,19 +436,6 @@ fn base_dir_missing_but_parent_writable_is_ok() {
 // --------------------------------------------------------------------------
 
 #[test]
-fn prunable_check_detail_uses_singular_plural_correctly() {
-  // The `entrie(s)` text from the first cut was a typo. The doctor output is
-  // user-facing, so the singular and plural forms should each be spelled
-  // out — `entry` for 1, `entries` for >1, never `entrie`.
-  let mut report = gwm::doctor::DoctorReport::new();
-  report.checks.push(gwm::doctor::Check::warning(
-    "no prunable worktrees",
-    "1 prunable entry: feat-12-old",
-  ));
-  assert!(!report.checks[0].detail.contains("entrie("));
-}
-
-#[test]
 fn fresh_repo_has_no_prunable_worktrees() {
   let (dir, repo) = init_repo();
   let config = Config::default();

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -260,6 +260,8 @@ fn no_when_predicates_is_ok() {
 
 #[test]
 fn when_predicates_detail_counts_checked_predicates_not_keywords() {
+  // regression: doctor detail used SUPPORTED_WHEN_PREFIXES.len() and reported
+  // "1 predicate" regardless of the number of `when:` clauses actually checked.
   let (dir, repo) = init_repo();
   let mut config = Config::default();
   // Three commands carrying a `when:` predicate. The detail message must
@@ -288,6 +290,8 @@ fn when_predicates_detail_counts_checked_predicates_not_keywords() {
 
 #[test]
 fn when_predicates_detail_says_none_when_no_predicates_configured() {
+  // regression: same SUPPORTED_WHEN_PREFIXES.len() miscount as above, surfaced
+  // even when zero `when:` predicates were configured.
   let (dir, repo) = init_repo();
   let config = Config::default();
   let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
@@ -360,6 +364,9 @@ fn resolvable_command_binary_is_ok() {
 
 #[test]
 fn extract_binary_handles_shell_quoted_run_strings() {
+  // regression: `extract_binary` used `split_whitespace` and returned the
+  // leading-quoted token `"my` for `"my tool" --flag` before the shell-words
+  // migration.
   // Pre-fix, `extract_binary` used `split_whitespace` and returned `"my`
   // as the binary name for a quoted run-string like `"my tool" --flag`,
   // producing a "binary not on PATH" warning that doesn't match anything

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -315,6 +315,8 @@ fn enter_filter_activates_capture_and_disarms_gg() {
 
 #[test]
 fn enter_filter_drops_sidebar_focus() {
+  // regression: PR #44 Copilot review — sidebar focus survived `/` and broke
+  // j/k navigation after Enter committed the filter.
   // Regression for the Copilot review on PR #44: if the sidebar held focus
   // when the user hit `/`, after `exit_filter_keep` (Enter) the focus would
   // still be on the sidebar, so `j` / `k` would scroll it instead of walking
@@ -724,6 +726,8 @@ fn picker_confirm_with_selection_signals_exit() {
 
 #[test]
 fn picker_confirm_without_selection_does_not_signal_exit() {
+  // regression: PR #53 Copilot review — picker_confirm with an empty filter
+  // result unconditionally broke the event loop and exited 1.
   // When the fuzzy filter narrows the list down to zero matches, Enter
   // must keep the TUI open so the user can back-space and try again,
   // not exit with code 1.
@@ -742,6 +746,8 @@ fn picker_confirm_without_selection_does_not_signal_exit() {
 
 #[test]
 fn picker_confirm_without_selection_reports_status() {
+  // regression: PR #53 — Enter on an empty filter result was silently
+  // swallowed; no status-bar hint surfaced the no-match state.
   // The user needs feedback explaining why Enter was inert. Surface a
   // status-bar hint so the no-match case isn't silently swallowed.
   let (_dir, mut app) = make_app();
@@ -765,6 +771,8 @@ fn picker_confirm_without_selection_reports_status() {
 
 #[test]
 fn picker_cancel_signals_exit_without_path() {
+  // regression: PR #53 — picker footer reads `esc:cancel` but Esc-in-filter
+  // only cleared the query; the picker contract wasn't honored.
   let (_dir, mut app) = make_app();
   app.picker_mode = true;
   app.list_state.select(Some(0));


### PR DESCRIPTION
## Description

Closes #57.

Walked all 193 tests at v0.4.0 and classified each into one of the three buckets the issue defined (drives logic / regression sentinel / dead weight). The full table — per file, per test — lives in [`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md) so reviewers can follow the call on each test without re-doing the audit.

**Outcome:**

- **179** drives — exercise a real production code path (unchanged)
- **11** sentinels — kept and now machine-findable via `grep -rn "// regression:" tests/`
- **3** dead — deleted, each with a positive test cited as the consolidator

Suite size: **193 → 190**, well within the `[180, 195]` band targeted by the issue.

## Type of change

- [x] ✅ Tests
- [x] 📝 Docs
- [x] 🔧 Chore (3 test deletions)

## Changes

- Added `claudedocs/test-audit-0.4.0.md` — per-file classification table, deletion rationale with subsuming tests cited, and a forward-looking reading guide for new tests.
- Annotated 11 sentinels with a `// regression: <one-line>` tag at the top of each test body. Existing multi-line context comments are preserved.
- Deleted 3 bucket-#3 tests:
  - `bootstrap_when_tests::evaluator_is_pure_for_a_given_cwd` (and the now-unused `use std::path::Path;`) — asserted `evaluate_when(...) == evaluate_when(...)`, pinned nothing real.
  - `doctor_tests::prunable_check_detail_uses_singular_plural_correctly` — built a `Check::warning` by hand and asserted its own input back against itself.
  - `cli_binary::shell_init_posix_does_not_use_paren_function_syntax` — negative `gcd().not()` was already redundant with the positive `function gcd` assertions in `shell_init_{bash,zsh}_emits_gcd_function`.
- README — bumped the suite-size advert from 140 → 190, added the missing `bootstrap_when_tests.rs`, `doctor_tests.rs`, `flake_tests.rs` entries to the file tree, and pointed at the audit doc.
- CHANGELOG `[Unreleased]` — added `Tests` and `Docs` entries citing the audit and the README sweep.

## Tests

- [x] `cargo test` passes locally (190 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] No new tests added under `tests/` — this PR is an audit-and-prune of the existing suite (allowed exception under CONTRIBUTING.md §Testing: "comment-only changes" doesn't strictly apply, but every deletion is justified inline in [`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md) by naming a positive test that already covers the same path; sentinel annotations are pure metadata)

## Screenshots / TUI captures

n/a — no user-visible behaviour change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`test/#57-audit-sentinel-tests`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — no CLI change, but README test-count adverts and file tree refreshed alongside
- [ ] `examples/gwm.toml.example` updated if config schema changed — no schema change
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead) — only tests touched
- [x] No `println!` in TUI render code (status bar only) — only tests touched

## Linked issues / docs

- Issue: #57
- Audit doc: [`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md)

## Notes for reviewers

- The audit doc has a per-file table — feel free to spot-check the bucket I assigned to a test you care about. If you disagree on a sentinel I kept (or one I deleted), say so on the diff and we'll reclassify.
- Commits are split four ways by concern so the deletion commit (`🔥 chore(tests): drop 3 bucket-#3 tests...`) is reviewable in isolation. Each deletion in that commit message cites the positive test that already covers the path.
- The forward-looking reading guide at the bottom of the audit doc is the part most likely to keep paying off in v0.5+: it codifies the bucket decision *before* a new test gets written.