### PR TITLE
✨ feat(config): make doctor trunk branches configurable via `[doctor]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `[doctor].trunks` in `.gwm.toml` ([#59](https://github.com/kbrdn1/gwm-cli/issues/59)) — `gwm doctor`'s orphan-branch check now reads its trunk list from a new `[doctor]` table, default `["dev", "main"]`. Repos with non-standard trunk conventions (`master`, release trains like `release-3.x` / `release-4.x`) can opt in via config instead of seeing every merged gwm-style branch flagged as "unmerged orphan" — the silent no-op that previously affected every repo not following gwm-cli's own convention. An explicit empty list (`trunks = []`) disables the merge filter entirely. Zero-diff for repos without a `[doctor]` section, since `#[serde(default)]` on `Config::doctor` resolves to the same `["dev", "main"]` that lived in the removed `TRUNK_BRANCHES` const.
+
 ### Docs
 
 - `CLAUDE.md` + `CONTRIBUTING.md` §Releases — new "Step 0: reconcile open PRs" rule. Before any RC or stable cut, run `gh pr list --state open` and reconcile every open PR (in the changeset, intentionally deferred, or closed as stale). Codifies the lesson from the v0.3.0 cut, which shipped without three queued feature PRs (#51, #52, #53) and required an immediate v0.4.0 promotion 38 minutes later. Step 0 sits explicitly at the top of both the pre-release and stable-release procedures.
+- `examples/gwm.toml.example` — documents the new `[doctor].trunks` knob with a commented-out block matching the bootstrap-step style already in the file.
 
 ## Past releases
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -94,3 +94,15 @@ when = "file_exists:package.json && !cmd_exists:bun"
 name = "full local build"
 run = "./scripts/full-build.sh"
 when = "glob_exists:src/**/*.rs && !env_set:CI"
+
+# --- doctor knobs -----------------------------------------------------------
+# Trunk branches `gwm doctor`'s orphan-branch check treats as merge
+# destinations. A gwm-style branch fully reachable from one of these is
+# preserved per CONTRIBUTING ("never delete the source branch after
+# merge") and is NOT flagged as orphan. Default: ["dev", "main"]. Repos
+# with non-standard trunk conventions (e.g. release trains) opt in here.
+# An empty list (`trunks = []`) disables the filter — every unclaimed
+# gwm-style branch becomes an orphan warning.
+#
+# [doctor]
+# trunks = ["master", "release-3.x", "release-4.x"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
   pub worktree: WorktreeConfig,
   #[serde(default)]
   pub bootstrap: BootstrapConfig,
+  #[serde(default)]
+  pub doctor: DoctorConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -95,6 +97,34 @@ pub struct CommandStep {
 pub struct FallbackContent {
   pub target: String,
   pub content: String,
+}
+
+/// `[doctor]` table — knobs for `gwm doctor`. Currently exposes the trunk
+/// list used by the orphan-branch check; previously this was hardcoded to
+/// `["dev", "main"]` in `doctor.rs`, which silently no-op'd the filter on
+/// any repo using a different trunk convention (`master`, `trunk`,
+/// `release-1.x`, …). Default preserves the previous behaviour.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoctorConfig {
+  /// Trunk branches the orphan-branch check treats as "merge destinations".
+  /// A gwm-style branch fully reachable from one of these is preserved per
+  /// CONTRIBUTING.md ("never delete the source branch after merge") and is
+  /// therefore not flagged as orphan. An empty list disables the filter
+  /// entirely (every unclaimed gwm-style branch becomes orphan).
+  #[serde(default = "default_trunks")]
+  pub trunks: Vec<String>,
+}
+
+impl Default for DoctorConfig {
+  fn default() -> Self {
+    Self {
+      trunks: default_trunks(),
+    }
+  }
+}
+
+fn default_trunks() -> Vec<String> {
+  vec!["dev".into(), "main".into()]
 }
 
 impl Config {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -372,29 +372,30 @@ fn check_prunable_worktrees(trees: &[worktree::WorktreeInfo]) -> Check {
   .with_hint("run `gwm prune` to clear them")
 }
 
-/// Trunk branches the doctor considers "merged into" — branches fully
-/// reachable from one of these are deliberately preserved per
-/// CONTRIBUTING.md (`Never delete the source branch after merge`), so we
-/// don't flag them as orphan even when their worktree is gone.
-const TRUNK_BRANCHES: &[&str] = &["dev", "main"];
-
 /// Check #6: every local branch matching the `<type>/#<issue>-<desc>`
 /// shape has a worktree pointing at it. A branch without a worktree was
 /// likely created by `gwm create` and lost its worktree without a
 /// `--delete-branch` — purely cosmetic dead weight, hence Warning not Failed.
 ///
 /// Branches already fully merged into one of the trunk branches
-/// (`dev`, `main`) are filtered out: keeping them is the project
-/// convention, and surfacing them would make the check produce N false
-/// positives on every successful release.
+/// (configured via `[doctor].trunks`, default `["dev", "main"]`) are
+/// filtered out: keeping them is the project convention, and surfacing
+/// them would make the check produce N false positives on every
+/// successful release. Repos with non-standard trunk names (`master`,
+/// release-trains like `release-3.x`, …) opt in by overriding the list
+/// in `.gwm.toml`. An empty list disables the filter entirely.
 fn check_orphan_branches(ctx: &DoctorCtx<'_>, trees: &[worktree::WorktreeInfo]) -> Check {
   let name = "no orphan gwm branches";
 
   let claimed: BTreeSet<String> = trees.iter().filter_map(|w| w.branch.clone()).collect();
 
-  // Resolve the trunk OIDs once. Missing trunks (e.g. a repo without `dev`)
-  // are silently skipped — we only check against what exists.
-  let trunk_oids: Vec<git2::Oid> = TRUNK_BRANCHES
+  // Resolve the trunk OIDs once. Missing trunks (e.g. a repo without `dev`,
+  // or a `[doctor].trunks` entry that doesn't exist locally) are silently
+  // skipped — we only check against what exists.
+  let trunk_oids: Vec<git2::Oid> = ctx
+    .config
+    .doctor
+    .trunks
     .iter()
     .filter_map(|t| {
       ctx

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -12,6 +12,78 @@ fn defaults_are_sane() {
 }
 
 #[test]
+fn doctor_section_defaults_to_dev_and_main() {
+  // The hardcoded list previously living in `src/doctor.rs` is now a
+  // configurable default — but the default value must stay
+  // `["dev", "main"]` so existing repos see zero behaviour change.
+  let cfg = Config::default();
+  assert_eq!(cfg.doctor.trunks, vec!["dev".to_string(), "main".to_string()]);
+}
+
+#[test]
+fn doctor_section_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[doctor]
+trunks = ["master", "release-3.x", "release-4.x"]
+"#,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(
+    cfg.doctor.trunks,
+    vec![
+      "master".to_string(),
+      "release-3.x".to_string(),
+      "release-4.x".to_string()
+    ]
+  );
+}
+
+#[test]
+fn doctor_section_absent_keeps_defaults() {
+  // A config that defines only `[worktree]` (no `[doctor]` section) must
+  // still resolve `cfg.doctor.trunks` to the documented default — that's
+  // the backwards-compatibility contract for repos predating the section.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[worktree]
+base = "/tmp/wt/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.doctor.trunks, vec!["dev".to_string(), "main".to_string()]);
+}
+
+#[test]
+fn doctor_section_empty_trunks_means_no_filter() {
+  // An explicit empty list is a valid config choice — it tells doctor
+  // "no merge filter, flag every gwm-style branch without a worktree".
+  // Distinct from "section absent" (which falls back to defaults).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[doctor]
+trunks = []
+"#,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert!(cfg.doctor.trunks.is_empty());
+}
+
+#[test]
 fn placeholders_expand() {
   let out = expand_placeholders(
     "{home}/cc-worktree/{repo}/{type}-{issue}-{desc}",

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -576,3 +576,92 @@ fn non_gwm_branch_is_not_flagged_as_orphan() {
   let c = report.checks.iter().find(|c| c.name.contains("orphan")).unwrap();
   assert_eq!(c.status, CheckStatus::Ok);
 }
+
+#[test]
+fn orphan_check_honours_configured_trunks() {
+  // Repos with non-standard trunk conventions (`master`, `release-3.x`,
+  // …) must be able to opt in via `[doctor].trunks`. Pre-#59 the trunk
+  // list was hardcoded to `["dev", "main"]` and `[doctor].trunks` was
+  // silently ignored, so any repo with a different trunk saw every
+  // merged gwm-style branch flagged as "unmerged orphan".
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  let sig = git2::Signature::now("test", "test@test").unwrap();
+  let tree = head.tree().unwrap();
+
+  // Divergent commit off main's HEAD. This is what an in-flight feature
+  // branch looks like before merge.
+  let feature_oid = repo.commit(None, &sig, &sig, "feature work", &tree, &[&head]).unwrap();
+  let feature_commit = repo.find_commit(feature_oid).unwrap();
+  repo.branch("feat/#77-on-custom-trunk", &feature_commit, false).unwrap();
+
+  // `custom-trunk` carries the feature work — i.e. the gwm branch is
+  // fully merged into the configured trunk but NOT into `main`.
+  repo.branch("custom-trunk", &feature_commit, false).unwrap();
+
+  let mut config = Config::default();
+  config.doctor.trunks = vec!["custom-trunk".into()];
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("orphan"))
+    .expect("expected an orphan-branches check");
+  assert_eq!(c.status, CheckStatus::Ok);
+  assert!(
+    !c.detail.contains("feat/#77-on-custom-trunk"),
+    "merged branch must not appear in the orphan list when its trunk is configured, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn orphan_check_with_empty_trunks_disables_merge_filter() {
+  // `trunks = []` is the documented escape hatch: report every unclaimed
+  // gwm-style branch, regardless of whether it's merged. Pre-#59 the
+  // empty config silently fell back to the hardcoded `["dev", "main"]`
+  // because the value lived in a `const`. Confirms the config value is
+  // actually wired through.
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+
+  // A gwm-style branch pointing at main's tip. With the default config
+  // this would be filtered out (equality short-circuit, merged into main).
+  repo.branch("feat/#88-merged-into-main", &head, false).unwrap();
+
+  let mut config = Config::default();
+  config.doctor.trunks = vec![];
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("orphan"))
+    .expect("expected an orphan-branches check");
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.contains("feat/#88-merged-into-main"),
+    "with no configured trunks every gwm branch must surface as orphan, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn orphan_check_ignores_configured_trunks_that_do_not_exist() {
+  // A trunk listed in config but absent from the repo must not crash
+  // the check — doctor should silently skip the missing trunk and use
+  // the rest of the list. Matches the existing tolerance for "no `dev`
+  // branch" in a fresh `gwm init` repo.
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#99-merged-into-main", &head, false).unwrap();
+
+  let mut config = Config::default();
+  // `phantom-trunk` doesn't exist; `main` does and reaches the gwm branch.
+  config.doctor.trunks = vec!["phantom-trunk".into(), "main".into()];
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("orphan")).unwrap();
+  assert_eq!(c.status, CheckStatus::Ok);
+}


### PR DESCRIPTION
## Description

`gwm doctor`'s orphan-branch filter (#47, shipped in v0.4.0) hardcoded the trunk list as `["dev", "main"]` in a `const` inside `src/doctor.rs`. Repos with different trunk conventions (`master`, `trunk`, release trains like `release-3.x`) saw the filter silently no-op, flagging every gwm-style branch fully merged into their real trunk as "unmerged orphan" — complete with a dangerous `git branch -d` hint — on every `gwm doctor` run.

This PR moves the trunk list into a new `[doctor]` table in `.gwm.toml`. Default behaviour is unchanged for repos without the section.

Closes #59

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- New `DoctorConfig { trunks: Vec<String> }` in `src/config.rs`, with `Default` returning `vec!["dev", "main"]` and `#[serde(default)]` on the parent `Config::doctor` field so existing `.gwm.toml` files keep the previous behaviour without edits.
- `check_orphan_branches` in `src/doctor.rs` reads `ctx.config.doctor.trunks` instead of the hardcoded `const TRUNK_BRANCHES`; the const is removed. Missing trunks (configured but absent locally) are tolerated, matching the existing leniency for repos without a `dev` branch.
- `examples/gwm.toml.example` documents the new `[doctor].trunks` knob as a commented-out block mirroring the bootstrap-step style already in the file.
- `CHANGELOG.md` `[Unreleased] > Added` and `> Docs` capture the new contract and the example-file delta.

## Tests

- [x] `cargo test` passes locally — 200/200 across all integration crates
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (`--all-targets`)
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Test diff highlights:

- `tests/config_tests.rs` gains four cases covering the four section states (absent, default, custom, empty).
- `tests/doctor_tests.rs` gains three cases for the wiring: configured-trunks-honoured, empty-trunks-disables-filter, missing-trunk-is-tolerated. Each one targets a previously-broken behaviour, asserting that the doctor's classification flips with the config — failing on `main` for the right reason (assertion mismatch, not compile error) before the wiring commit landed.
- Ran end-to-end `gwm doctor` against the worktree's own `gwm-cli` checkout: all checks green, including the orphan check counting 15 merged gwm-style branches preserved per CONTRIBUTING.

## Screenshots / TUI captures

N/A — CLI / config schema change only, no TUI surface.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#59-doctor-trunks-config`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — N/A, no CLI surface change
- [x] `examples/gwm.toml.example` updated (config schema changed)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead) — config parsing already routes through `toml::from_str` → `GwmError::from`
- [x] No `println!` in TUI render code (status bar only) — N/A

## Linked issues / docs

- Issue: #59
- Builds on the doctor orphan-branch check from #47 (v0.4.0)
- Related tracker entry: post-cleanup tracker #54 (listed as LOW), promoted by the v0.4.0 decision log open question

## Notes for reviewers

Three atomic commits, each scoped to one concern:

1. `✨ feat(config)` — widens the schema only (no behaviour change yet, but the config is plumbed through and tested).
2. `♻️ refactor(doctor)` — swaps the const for the config field. This is where the user-visible behaviour change lands.
3. `📝 docs` — example + CHANGELOG.

Split this way to let reviewers verify the schema and the wiring independently. The middle commit's tests are the canary: they fail without commit 1 in place and succeed after the const is removed in commit 2.

CI-like minimal PATH was pre-validated locally per CLAUDE.md:

```bash
PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test --test doctor_tests orphan_check
# 3 passed, 0 failed
```