### PR TITLE
📝 docs(cli): document gcd no-arg → gwm switch routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - `CLAUDE.md` + `CONTRIBUTING.md` §Releases — new "Step 0: reconcile open PRs" rule. Before any RC or stable cut, run `gh pr list --state open` and reconcile every open PR (in the changeset, intentionally deferred, or closed as stale). Codifies the lesson from the v0.3.0 cut, which shipped without three queued feature PRs (#51, #52, #53) and required an immediate v0.4.0 promotion 38 minutes later. Step 0 sits explicitly at the top of both the pre-release and stable-release procedures.
+- `README.md` + `gwm shell-init` output + `gwm switch --help` — document the `gcd` two-paths routing ([#58](https://github.com/kbrdn1/gwm-cli/issues/58)). The bare `gcd` (no argument) call routes to `gwm switch` (interactive picker), while `gcd <pattern>` routes to `gwm cd <pattern>` (fuzzy resolve); both branches wait on a successful exit code before performing the `cd`. The bridge was wired up in PR [#53](https://github.com/kbrdn1/gwm-cli/pull/53) but lived only in the code — fresh users reading the README, the eval'd wrapper, or `gwm switch --help` now see the no-arg route surfaced consistently across all three surfaces. New `tests/cli_binary.rs::shell_init_*_header_documents_no_arg_route` + `switch_help_mentions_gcd_wrapper` pin the docstring so future drift breaks the suite instead of going unnoticed.
 
 ## Past releases
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,14 @@ Checks performed:
 
 ### one-line cd into a worktree
 
-The binary itself cannot change the parent shell's directory. `gwm shell-init <shell>` prints a function (`gcd`) that wraps `gwm cd` — `eval` it in your rc file and use `gcd <pattern>` as a one-liner:
+The binary itself cannot change the parent shell's directory. `gwm shell-init <shell>` prints a function (`gcd`) that bridges two flows in one wrapper:
+
+- **`gcd <pattern>`** → `gwm cd <pattern>` (fuzzy resolve, exits `0` on a hit, `1` on miss / ambiguous / not in a repo).
+- **`gcd`** (no argument) → `gwm switch` (interactive picker — `Enter` to commit, `Esc` / `Ctrl-C` / `q` to cancel with exit code `1`).
+
+In both cases the wrapper only performs the `cd` after a successful exit code, so a cancelled picker or a missed pattern never strands you in `$HOME`.
+
+`eval` the wrapper in your rc file:
 
 ```bash
 # zsh
@@ -201,21 +208,19 @@ Then:
 
 ```bash
 gcd auth   # → cd $(gwm cd auth) → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
-gcd        # no arg → opens `gwm switch` and cd's into the picked worktree
+gcd        # → cd $(gwm switch)  → opens the picker, cd's into the chosen worktree
 ```
-
-`gcd` propagates the exit code from `gwm cd` (or `gwm switch`, when called without args) and never attempts the `cd` if the lookup / pick failed (no match, ambiguous pattern, cancelled picker, not in a git repo).
 
 ### interactive picker (`gwm switch`)
 
 When you can't remember the exact pattern, `gwm switch` opens the worktree TUI in picker mode — same table, fuzzy filter bar pre-open, create / delete / bootstrap disabled. `Enter` confirms the highlighted row and prints its path on stdout; `Esc` / `q` / `Ctrl-C` cancels with exit code `1`.
 
+The recommended invocation is via the `gcd` wrapper from [one-line cd into a worktree](#one-line-cd-into-a-worktree) — bare `gcd` (no argument) routes to `gwm switch` and cd's into the chosen worktree in one keystroke. If you haven't installed the wrapper, the raw form is:
+
 ```bash
 cd "$(gwm switch)"   # open picker, type to narrow, Enter to commit
 gwm s                # same, via the alias
 ```
-
-The shell wrapper installed by `gwm shell-init` makes this even quicker: bare `gcd` (no argument) invokes `gwm switch` and cd's into the chosen worktree in one keystroke.
 
 ### shell completions
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -112,7 +112,9 @@ pub enum Command {
   /// away. Press Enter to commit the highlighted pick; Esc / Ctrl-C / `q`
   /// quits without printing anything (exit code 1).
   ///
-  /// Daily usage:  cd "$(gwm switch)"   (or `gwm s`, the alias).
+  /// Typically invoked via `gcd` (no arg) from the bundled `gwm shell-init`
+  /// wrapper, which cd's into the picked worktree in one keystroke. The raw
+  /// form is `cd "$(gwm switch)"` (or `gwm s`, the alias).
   #[command(visible_alias = "s")]
   Switch,
 }
@@ -411,6 +413,11 @@ pub fn shell_init_script(shell: InitShell) -> &'static str {
 
 const POSIX_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: eval "$(gwm shell-init bash)"   # or zsh
+#
+# Two paths:
+#   gcd <pattern>        # fuzzy resolve via `gwm cd <pattern>`, then cd
+#   gcd                  # no arg → opens the interactive picker via `gwm switch`, then cd
+#
 # Note: the `function name { ... }` form (zsh/bash-extended) is used instead
 # of the parenthesised POSIX form so the parser does not error out with
 # `defining function based on alias 'gcd'` when zsh already has a `gcd`
@@ -433,6 +440,10 @@ unalias gcd 2>/dev/null || true
 
 const FISH_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: gwm shell-init fish | source   # then persist in ~/.config/fish/config.fish
+#
+# Two paths:
+#   gcd <pattern>        # fuzzy resolve via `gwm cd <pattern>`, then cd
+#   gcd                  # no arg → opens the interactive picker via `gwm switch`, then cd
 function gcd --description 'cd into a gwm worktree (no arg = interactive picker)'
   set -l target
   if test (count $argv) -eq 0
@@ -452,6 +463,11 @@ end
 
 const POWERSHELL_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: Invoke-Expression (& gwm shell-init powershell | Out-String)
+#
+# Two paths:
+#   gcd <pattern>        # fuzzy resolve via `gwm cd <pattern>`, then Set-Location
+#   gcd                  # no arg → opens the interactive picker via `gwm switch`, then Set-Location
+#
 # Note: this clears any prior `gcd` alias so the function takes effect.
 Remove-Alias -Name gcd -Force -ErrorAction SilentlyContinue
 function gcd {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -385,6 +385,57 @@ fn shell_init_powershell_no_arg_invokes_switch() {
     .stdout(predicate::str::contains("IsNullOrEmpty"));
 }
 
+// Issue #58: users who eval the wrapper without reading the README must
+// still discover the no-arg route. Pin a one-line cheat-sheet comment in
+// the script header that names the bridge to `gwm switch`. The exact
+// phrase `picker via `gwm switch`` is asserted because the README, the
+// CLI --help, and the wrapper now share that wording — drift in one
+// surface should break the test instead of going unnoticed.
+#[test]
+fn shell_init_posix_header_documents_no_arg_route() {
+  for shell in ["bash", "zsh"] {
+    let mut cmd = Command::cargo_bin("gwm").unwrap();
+    cmd.args(["shell-init", shell]);
+    cmd
+      .assert()
+      .success()
+      .stdout(predicate::str::contains("picker via `gwm switch`"));
+  }
+}
+
+#[test]
+fn shell_init_fish_header_documents_no_arg_route() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "fish"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("picker via `gwm switch`"));
+}
+
+#[test]
+fn shell_init_powershell_header_documents_no_arg_route() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["shell-init", "powershell"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("picker via `gwm switch`"));
+}
+
+// Issue #58: a user who lands on `gwm switch --help` first (e.g. via tab
+// completion) should learn that the recommended invocation is the `gcd`
+// wrapper from `gwm shell-init`, not the raw `cd "$(gwm switch)"` form.
+#[test]
+fn switch_help_mentions_gcd_wrapper() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["switch", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("gcd").and(predicate::str::contains("shell-init")));
+}
+
 #[test]
 fn shell_init_rejects_unknown_shell() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();


### PR DESCRIPTION
## Description

Close the discoverability hole flagged as v0.4.0 decision-log question #12: the bare `gcd` → `gwm switch` route exists in the code since PR #53 but a fresh user reading the README, the eval'd `gwm shell-init` wrapper, or `gwm switch --help` could not tell that the two subcommands were already bridged in the wrapper they installed.

This PR surfaces the routing in all three docs surfaces and pins it with tests so future drift breaks the suite.

Closes #58

## Type of change

- [x] 📝 Docs

## Changes

- `tests/cli_binary.rs` — four new pinning tests:
  - `shell_init_posix_header_documents_no_arg_route`
  - `shell_init_fish_header_documents_no_arg_route`
  - `shell_init_powershell_header_documents_no_arg_route`
  - `switch_help_mentions_gcd_wrapper`
- `src/cli.rs` — add a "Two paths" cheat-sheet block to the header of `POSIX_SHELL_INIT` / `FISH_SHELL_INIT` / `POWERSHELL_SHELL_INIT`; rewrite the `gwm switch` clap docstring to name `gcd` (no arg) from `gwm shell-init` as the recommended invocation.
- `README.md` — open `### one-line cd into a worktree` with a two-bullet routing block (`gcd <pattern>` vs bare `gcd`) and a single exit-code contract paragraph; rewrite `### interactive picker (gwm switch)` to point readers back to the wrapper section via an in-page anchor; keep the raw `cd \"$(gwm switch)\"` form as a fallback.
- `CHANGELOG.md` — entry under `[Unreleased] > Docs` referencing all three surfaces, the new test guards, and PR #53 for context.

## Tests

- [x] `cargo test` passes locally (56 + 16 integration tests + 0 doc-tests, all green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: the four new tests were committed red before the docs edits — see commit history)

## Screenshots / TUI captures

_TUI-untouched (docs-only PR)._

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`docs/#58-gcd-no-arg-switch`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased] > Docs`
- [x] README updated (CLI surface unchanged; docstring wording changed)
- [ ] `examples/gwm.toml.example` updated if config schema changed — n/a
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #58
- Related PR: #53 (wired the runtime bridge for the no-arg → switch route)
- v0.4.0 decision log: question ouverte #12

## Notes for reviewers

- The shared anchor phrase across the wrapper header, the README, and `gwm switch --help` is `picker via \`gwm switch\``. The three header tests assert that exact substring so any rewording in one surface that drops it will break the suite — adjust all three surfaces together (or update the assertion).
- The README anchor `[one-line cd into a worktree](#one-line-cd-into-a-worktree)` follows GitHub's default heading-to-anchor slugification (lowercase, spaces → hyphens, parens stripped). Tested by clicking the rendered link before push.
- `gwm doctor` was run locally and reported all green, even though no `.gwm.toml` / bootstrap / doctor code was touched.