### PR TITLE
👷 chore(structure): opt-in pre-commit hook + CI smoke (#56)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/sh
+# .githooks/pre-commit — opt-in commit gates for gwm-cli contributors.
+#
+# Two gates that prevent the two most common CI round-trips this repo
+# has burned in the past:
+#
+#   1. Env-dependent test pre-validation. If staged tests/*.rs files
+#      reference ambient state (assert_cmd, std::env::var, which::which,
+#      dirs::, Command::cargo_bin), the suite is re-run under a stripped
+#      PATH ("$(dirname cargo):/usr/bin:/bin") to catch tests that pass
+#      in a rich dev shell but fail on minimal CI runners.
+#
+#   2. Local `gwm doctor`. If staged files touch .gwm.toml, the bootstrap
+#      module, the doctor module, the example config, or the bootstrap/
+#      doctor test files, `gwm doctor` is invoked. Exit codes follow the
+#      doctor contract: 0 silent, 1 advisory (warnings, commit proceeds),
+#      2 blocks the commit. Unknown gwm exits never block — fail open.
+#
+# Install (opt-in, recommended):
+#   git config core.hooksPath .githooks
+#
+# Bypass for a single commit (use sparingly):
+#   git commit --no-verify
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
+[ -z "$STAGED" ] && exit 0
+
+# ─── Gate 1: env-dependent test pre-validation ───────────────────────────
+TEST_FILES=$(printf '%s\n' "$STAGED" | grep -E '^tests/.*\.rs$' || true)
+if [ -n "$TEST_FILES" ]; then
+  AMBIENT='Command::cargo_bin|which::which|dirs::|std::env::var|assert_cmd'
+  # IFS handles newline-separated TEST_FILES for git's pathspec expansion.
+  # shellcheck disable=SC2086
+  if git diff --cached -- $TEST_FILES | grep -qE "$AMBIENT"; then
+    printf 'pre-commit gate 1: staged tests touch ambient state — re-running under stripped PATH\n'
+    CARGO_PATH=$(command -v cargo 2>/dev/null)
+    if [ -z "$CARGO_PATH" ]; then
+      printf 'pre-commit gate 1: cargo not in PATH — skipping (install Rust toolchain)\n' >&2
+    else
+      CARGO_BIN_DIR=$(dirname "$CARGO_PATH")
+      if ! PATH="$CARGO_BIN_DIR:/usr/bin:/bin" cargo test --quiet; then
+        printf 'pre-commit gate 1: stripped-PATH cargo test FAILED — commit blocked.\n' >&2
+        printf '  Reproduce: PATH="%s:/usr/bin:/bin" cargo test\n' "$CARGO_BIN_DIR" >&2
+        printf '  Bypass (not recommended): git commit --no-verify\n' >&2
+        exit 1
+      fi
+    fi
+  fi
+fi
+
+# ─── Gate 2: local gwm doctor ────────────────────────────────────────────
+DOCTOR_TRIGGERS='^(\.gwm\.toml|src/bootstrap\.rs|src/doctor\.rs|examples/gwm\.toml\.example|tests/bootstrap.*|tests/doctor.*)$'
+if printf '%s\n' "$STAGED" | grep -qE "$DOCTOR_TRIGGERS"; then
+  if ! command -v gwm >/dev/null 2>&1; then
+    printf 'pre-commit gate 2: gwm not in PATH — skipping local doctor (install gwm to enable)\n' >&2
+  else
+    printf 'pre-commit gate 2: staged config/bootstrap/doctor files — running gwm doctor\n'
+    gwm doctor
+    DOCTOR_EXIT=$?
+    case $DOCTOR_EXIT in
+      0) ;;
+      1) printf 'pre-commit gate 2: gwm doctor reported warnings (advisory) — commit proceeds.\n' ;;
+      2) printf 'pre-commit gate 2: gwm doctor reported ERRORS — commit blocked.\n' >&2
+         printf '  Bypass (not recommended): git commit --no-verify\n' >&2
+         exit 1 ;;
+      *) printf 'pre-commit gate 2: gwm doctor unexpected exit %d — commit proceeds.\n' "$DOCTOR_EXIT" >&2 ;;
+    esac
+  fi
+fi
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,48 @@ jobs:
       - name: cargo test
         run: cargo test --verbose
 
+  hook-smoke:
+    name: pre-commit hook smoke
+    runs-on: ubuntu-latest
+    # Cheap regression net for .githooks/pre-commit. Runs in parallel with
+    # the heavy `test` job — no Rust toolchain needed, just shell + git.
+    steps:
+      - uses: actions/checkout@v6
+      - name: shellcheck pre-commit hook
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: ./.githooks
+          severity: error
+      - name: hook is executable
+        run: test -x .githooks/pre-commit
+      - name: hook short-circuits on empty index
+        run: |
+          scratch=$(mktemp -d)
+          (
+            cd "$scratch"
+            git init -q
+            git config user.email "ci@gwm.test"
+            git config user.name "ci"
+            cp "$GITHUB_WORKSPACE/.githooks/pre-commit" pre-commit
+            sh pre-commit
+          )
+      - name: gate 2 detects .gwm.toml and skips when gwm absent
+        run: |
+          scratch=$(mktemp -d)
+          (
+            cd "$scratch"
+            git init -q
+            git config user.email "ci@gwm.test"
+            git config user.name "ci"
+            cp "$GITHUB_WORKSPACE/.githooks/pre-commit" pre-commit
+            echo "[bootstrap]" > .gwm.toml
+            git add .gwm.toml
+            out=$(PATH="/usr/bin:/bin" sh pre-commit 2>&1)
+            echo "$out"
+            echo "$out" | grep -q "gwm not in PATH" \
+              || (echo "FAIL: gate 2 should print 'gwm not in PATH' skip message" && exit 1)
+          )
+
   audit:
     name: cargo audit
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.githooks/pre-commit` — opt-in POSIX shell hook that gates commits on two checks contributors used to enforce by hand (#56). Gate 1 re-runs the test suite under a stripped PATH when staged `tests/*.rs` hunks touch ambient state (`assert_cmd`, `std::env::var`, `which::which`, `dirs::`, `Command::cargo_bin`) — catches CI-only failures locally. Gate 2 runs `gwm doctor` when staged paths touch `.gwm.toml`, `src/{bootstrap,doctor}.rs`, `examples/gwm.toml.example`, or `tests/{bootstrap,doctor}*`, blocking on doctor exit 2 and advising on exit 1. Install with `git config core.hooksPath .githooks`; bypass with `git commit --no-verify`.
+
+### CI
+
+- New `hook-smoke` job in `.github/workflows/ci.yml` (#56). Cheap parallel job (~30s, no Rust toolchain) that `shellcheck`s the hook, asserts it is executable, verifies the empty-index short-circuit, and exercises gate 2's "gwm not in PATH" skip path. Guards against hook bit-rot without doubling CI time.
+
 ### Docs
 
+- `CONTRIBUTING.md` — new "Local hooks (recommended, opt-in)" subsection under Development describing the install one-liner, both gates, the doctor exit-code contract, the `--no-verify` bypass, and the CI smoke-test safety net (#56).
 - `CLAUDE.md` + `CONTRIBUTING.md` §Releases — new "Step 0: reconcile open PRs" rule. Before any RC or stable cut, run `gh pr list --state open` and reconcile every open PR (in the changeset, intentionally deferred, or closed as stale). Codifies the lesson from the v0.3.0 cut, which shipped without three queued feature PRs (#51, #52, #53) and required an immediate v0.4.0 promotion 38 minutes later. Step 0 sits explicitly at the top of both the pre-release and stable-release procedures.
 
 ## Past releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,44 @@ cargo install --path .   # install gwm into ~/.cargo/bin
 - **Linter**: `cargo clippy -- -D warnings`.
 - Run `cargo fmt && cargo clippy` before opening a PR.
 
+### Local hooks (recommended, opt-in)
+
+A POSIX `pre-commit` script lives under [`.githooks/`](.githooks/). It is **not installed automatically** — opt in with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Once enabled, two gates run on every `git commit`:
+
+1. **Env-dependent test pre-validation.** If staged `tests/*.rs` hunks reference ambient state (`assert_cmd`, `std::env::var`, `which::which`, `dirs::`, `Command::cargo_bin`), the hook re-runs the suite under a stripped PATH:
+
+   ```bash
+   PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test
+   ```
+
+   This catches tests that pass in your rich dev shell but fail on a minimal CI runner — the lesson from PR #43 (three CI round-trips before the suite went green).
+
+2. **Local `gwm doctor`.** If staged paths touch `.gwm.toml`, `src/bootstrap.rs`, `src/doctor.rs`, `examples/gwm.toml.example`, or `tests/{bootstrap,doctor}*`, the hook runs `gwm doctor`. Exit codes follow the doctor contract:
+
+   | Exit | Meaning  | Commit behaviour          |
+   |:-----|:---------|:--------------------------|
+   | `0`  | Clean    | proceeds silently         |
+   | `1`  | Warnings | proceeds with advisory    |
+   | `2`  | Errors   | **blocked** until resolved |
+
+   If `gwm` is not on `PATH`, the gate prints a skip notice and the commit proceeds — the CI `doctor` job is the safety net.
+
+Both gates short-circuit in O(1) when no staged paths match — contributors who never touch tests or config pay nothing per commit.
+
+**Bypass** for a single commit you know is safe:
+
+```bash
+git commit --no-verify
+```
+
+CI runs `shellcheck` against the hook and a smoke test on every PR — see the `hook-smoke` job in [`ci.yml`](.github/workflows/ci.yml) — so a broken hook is caught before it reaches you.
+
 ## Testing
 
 ```bash

--- a/tests/precommit_hook_tests.rs
+++ b/tests/precommit_hook_tests.rs
@@ -1,0 +1,288 @@
+//! Integration tests for `.githooks/pre-commit`.
+//!
+//! The hook is a POSIX shell script that gates commits on two checks:
+//!   1. Env-dependent test pre-validation (stripped-PATH `cargo test`).
+//!   2. Local `gwm doctor` with exit-code interpretation
+//!      (0 = clean, 1 = advisory warnings, 2 = errors → block).
+//!
+//! Tests stub `cargo` and `gwm` so gate behaviour can be exercised
+//! deterministically without touching the real toolchain.
+
+#![cfg(unix)]
+
+mod common;
+
+use common::init_repo;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn hook_path() -> PathBuf {
+  Path::new(env!("CARGO_MANIFEST_DIR")).join(".githooks/pre-commit")
+}
+
+fn install_stub(dir: &Path, name: &str, body: &str) {
+  let path = dir.join(name);
+  fs::write(&path, format!("#!/bin/sh\n{}\n", body)).unwrap();
+  fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn stage(repo: &Path, relative_path: &str, content: &str) {
+  let full = repo.join(relative_path);
+  if let Some(parent) = full.parent() {
+    fs::create_dir_all(parent).unwrap();
+  }
+  fs::write(&full, content).unwrap();
+  let status = Command::new("git")
+    .args(["add", "--", relative_path])
+    .current_dir(repo)
+    .status()
+    .expect("git add ran");
+  assert!(status.success(), "git add failed for {relative_path}");
+}
+
+fn run_hook(repo: &Path, stub_dir: Option<&Path>, extra_env: &[(&str, &str)]) -> Output {
+  let path = match stub_dir {
+    Some(p) => format!("{}:/usr/bin:/bin", p.display()),
+    None => "/usr/bin:/bin".into(),
+  };
+  let mut cmd = Command::new("sh");
+  cmd
+    .arg(hook_path())
+    .current_dir(repo)
+    .env_clear()
+    .env("PATH", path)
+    .env("HOME", repo);
+  for (k, v) in extra_env {
+    cmd.env(k, v);
+  }
+  cmd.output().expect("hook ran")
+}
+
+// ─── short-circuit ─────────────────────────────────────────────────────────
+
+#[test]
+fn passes_silently_when_nothing_staged() {
+  let (dir, _repo) = init_repo();
+  let out = run_hook(dir.path(), None, &[]);
+  assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn passes_when_only_unrelated_files_staged() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "README.md", "edit\n");
+  let out = run_hook(dir.path(), None, &[]);
+  assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    !stdout.contains("gate 1") && !stdout.contains("gate 2"),
+    "no gate should trigger: {stdout}"
+  );
+}
+
+// ─── gate 1: env-dependent test pre-validation ────────────────────────────
+
+#[test]
+fn gate1_skipped_when_test_file_has_no_ambient_state_refs() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "tests/sample.rs", "#[test] fn t() { assert_eq!(1, 1); }\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "cargo", "echo CARGO_INVOKED; exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    !stdout.contains("CARGO_INVOKED"),
+    "gate 1 should not invoke cargo without ambient-state refs: {stdout}"
+  );
+}
+
+#[test]
+fn gate1_triggers_on_assert_cmd_reference() {
+  let (dir, _repo) = init_repo();
+  stage(
+    dir.path(),
+    "tests/sample.rs",
+    "use assert_cmd::Command;\n#[test] fn t() {}\n",
+  );
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "cargo", "echo CARGO_INVOKED; exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(stdout.contains("gate 1"), "gate 1 message missing: {stdout}");
+  assert!(stdout.contains("CARGO_INVOKED"), "cargo not invoked: {stdout}");
+}
+
+#[test]
+fn gate1_triggers_on_std_env_var_reference() {
+  let (dir, _repo) = init_repo();
+  stage(
+    dir.path(),
+    "tests/sample.rs",
+    "fn t() { let _ = std::env::var(\"PATH\"); }\n",
+  );
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "cargo", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    stdout.contains("gate 1"),
+    "gate 1 should trigger on std::env::var ref: {stdout}"
+  );
+}
+
+#[test]
+fn gate1_blocks_commit_when_cargo_fails() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "tests/sample.rs", "use assert_cmd::Command;\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "cargo", "exit 1");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(!out.status.success(), "hook should block on cargo failure");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.contains("blocked") || stderr.contains("FAILED"),
+    "stderr should explain the block: {stderr}"
+  );
+}
+
+// ─── gate 2: local gwm doctor ─────────────────────────────────────────────
+
+#[test]
+fn gate2_triggers_on_gwm_toml_change() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), ".gwm.toml", "[bootstrap]\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "echo GWM_ARGS:$*; exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(stdout.contains("gate 2"), "gate 2 message missing: {stdout}");
+  assert!(
+    stdout.contains("GWM_ARGS:doctor"),
+    "doctor subcommand not invoked: {stdout}"
+  );
+}
+
+#[test]
+fn gate2_triggers_on_src_bootstrap_change() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "src/bootstrap.rs", "// edit\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  assert!(
+    String::from_utf8_lossy(&out.stdout).contains("gate 2"),
+    "gate 2 should trigger on src/bootstrap.rs"
+  );
+}
+
+#[test]
+fn gate2_triggers_on_src_doctor_change() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "src/doctor.rs", "// edit\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  assert!(
+    String::from_utf8_lossy(&out.stdout).contains("gate 2"),
+    "gate 2 should trigger on src/doctor.rs"
+  );
+}
+
+#[test]
+fn gate2_triggers_on_examples_gwm_toml_example() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "examples/gwm.toml.example", "[bootstrap]\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  assert!(
+    String::from_utf8_lossy(&out.stdout).contains("gate 2"),
+    "gate 2 should trigger on examples/gwm.toml.example"
+  );
+}
+
+#[test]
+fn gate2_triggers_on_tests_bootstrap_file() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "tests/bootstrap_when_tests.rs", "// edit\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 0");
+  install_stub(stub.path(), "cargo", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  assert!(
+    String::from_utf8_lossy(&out.stdout).contains("gate 2"),
+    "gate 2 should trigger on tests/bootstrap*.rs"
+  );
+}
+
+#[test]
+fn gate2_triggers_on_tests_doctor_file() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), "tests/doctor_tests.rs", "// edit\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 0");
+  install_stub(stub.path(), "cargo", "exit 0");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(out.status.success());
+  assert!(
+    String::from_utf8_lossy(&out.stdout).contains("gate 2"),
+    "gate 2 should trigger on tests/doctor*.rs"
+  );
+}
+
+#[test]
+fn gate2_skips_with_message_when_gwm_absent() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), ".gwm.toml", "[bootstrap]\n");
+  let out = run_hook(dir.path(), None, &[]);
+  assert!(out.status.success(), "hook should proceed when gwm absent");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.contains("gwm not in PATH"),
+    "stderr should mention gwm absence: {stderr}"
+  );
+}
+
+#[test]
+fn gate2_advisory_when_doctor_exits_1() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), ".gwm.toml", "[bootstrap]\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 1");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(
+    out.status.success(),
+    "warnings (exit 1) should not block commit; stderr: {}",
+    String::from_utf8_lossy(&out.stderr)
+  );
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    stdout.contains("advisory") || stdout.contains("warnings"),
+    "advisory message missing: {stdout}"
+  );
+}
+
+#[test]
+fn gate2_blocks_when_doctor_exits_2() {
+  let (dir, _repo) = init_repo();
+  stage(dir.path(), ".gwm.toml", "[bootstrap]\n");
+  let stub = tempfile::tempdir().unwrap();
+  install_stub(stub.path(), "gwm", "exit 2");
+  let out = run_hook(dir.path(), Some(stub.path()), &[]);
+  assert!(!out.status.success(), "exit 2 must block commit");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.contains("ERRORS") || stderr.contains("blocked"),
+    "stderr should explain the block: {stderr}"
+  );
+}


### PR DESCRIPTION
## Description

Adds an opt-in POSIX `pre-commit` hook under `.githooks/` that codifies the two house rules contributors used to enforce by hand:

- **Env-dependent test pre-validation** — re-runs `cargo test` under a stripped PATH when staged `tests/*.rs` hunks touch ambient state (`assert_cmd`, `std::env::var`, `which::which`, `dirs::`, `Command::cargo_bin`). Catches CI-only failures locally; the lesson from PR #43 (three CI round-trips before green).
- **Local `gwm doctor`** — runs the doctor when staged paths touch `.gwm.toml`, `src/{bootstrap,doctor}.rs`, `examples/gwm.toml.example`, or `tests/{bootstrap,doctor}*`. Honours the doctor exit-code contract (0 silent, 1 advisory, 2 blocking).

Both gates short-circuit in O(1) when no staged paths match, so contributors who never touch those areas pay nothing per commit. `git commit --no-verify` remains the standard bypass.

Closes #56

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `.githooks/pre-commit` — POSIX shell script with two gates and exit-code semantics matching the doctor contract.
- `.github/workflows/ci.yml` — new `hook-smoke` job (parallel, ~30s, no Rust toolchain) running `shellcheck` + empty-index short-circuit check + gate-2 detection with `gwm` absent.
- `tests/precommit_hook_tests.rs` — 15 integration tests stubbing `cargo` and `gwm` to drive gate behaviour deterministically (short-circuit, gate 1 ambient-state detection, gate 1 blocking, gate 2 trigger matrix across all 6 path patterns, gwm-absent skip, advisory on exit 1, blocking on exit 2).
- `CONTRIBUTING.md` — new "Local hooks (recommended, opt-in)" subsection under Development.
- `CHANGELOG.md` — `### Added` (the hook) and `### CI` (the smoke job) entries under `[Unreleased]`.

## Tests

- [x] `cargo test` passes locally (16 + 15 + … = full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] New tests added under `tests/precommit_hook_tests.rs` — 15 cases following the project's TDD discipline (red commit first, then green hook commit)
- [x] Pre-validated under stripped PATH: `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test --test precommit_hook_tests` → 15 passed
- [x] Hook dogfooded on this very PR's docs-only staging step → short-circuits cleanly

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`chore/#56-precommit-hook`)
- [x] Commits follow Gitmoji + Conventional Commits (4 atomic commits: ✅ test → ✨ feat → 👷 ci → 📝 docs)
- [x] CHANGELOG.md updated under `## [Unreleased]` (root file = current release only)
- [x] README untouched (no CLI surface change)
- [x] `examples/gwm.toml.example` untouched (no config schema change)
- [x] No `unwrap()` on user-facing paths (test helpers only)
- [x] No `println!` in TUI render code (none touched)

## Linked issues / docs

- Issue: #56
- Related lessons codified: PR #43 (stripped-PATH validation), v0.3.0 doctor PR (#54 follow-up)