### PR TITLE
✨ feat: link issues & PRs to worktrees with CLI + TUI controls and live status panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+
+- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67)) — link the current worktree to a GitHub issue and / or pull request, open them in the browser, and surface their status in the TUI details panel.
+  - New CLI subcommands: `gwm link {issue|pr} <N>`, `gwm unlink {issue|pr}`, `gwm open {issue|pr} [--print-url]`, `gwm status [--json]`.
+  - Storage: `git config branch.<name>.gwm-issue` and `branch.<name>.gwm-pr` (local, per-branch, survives worktree moves).
+  - Auto-detection: branches following `<type>/#<N>-<slug>` derive the issue automatically; explicit `gwm link issue <N>` overrides.
+  - TUI key bindings: `O` open menu (issue / pr), `L` link prompt, `R` refresh GitHub status.
+  - Right-panel status: live issue state (open / closed) and PR state (open / draft / closed / merged) with CI check rollup (`checks N/M`). Fetched via `gh issue view` / `gh pr view`.
+
+### Dependencies
+
+- Add `serde_json = "1"` for parsing the `gh` CLI JSON output.
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
  "ratatui",
  "regex",
  "serde",
+ "serde_json",
  "shell-words",
  "shellexpand",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ratatui = "0.30"
 crossterm = "0.29"
 git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "1.1"
 anyhow = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,29 @@ gwm tmux auth -p                            # ...or in a split of the current pa
 gwm zellij auth                             # same, but for zellij — new tab via `--cwd`
 gwm zellij auth -p                          # ...or in a new pane of the current tab
 gwm doctor                                  # diagnose config + env + worktree state (exit 0/1/2)
+gwm link issue 42                           # link an issue to the current worktree
+gwm link pr 61                              # link a PR
+gwm unlink issue                            # remove the issue link (auto-detect resurfaces)
+gwm open issue                              # open the linked issue in the browser
+gwm open pr --print-url                     # print the URL on stdout instead of spawning
+gwm status                                  # show link + live state via `gh`
+gwm status --json                           # machine-readable JSON of the status
 ```
+
+### Issue / PR linking ([#67](https://github.com/kbrdn1/gwm-cli/issues/67))
+
+Every worktree can be linked to a GitHub issue and / or pull request:
+
+- Branches following `<type>/#<N>-<slug>` are auto-linked to issue `#N` — zero setup.
+- Explicit overrides land in `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, no extra file).
+- `gwm status` shells out to `gh issue view` / `gh pr view` to fetch the live state, title, labels, and CI rollup. Without `gh` (or outside a GitHub remote), only the local link is shown.
+
+In the TUI:
+
+- `O` — open menu (`i` open issue, `p` open PR) in the browser.
+- `L` — link prompt (`i` issue, `p` pr, then type the number).
+- `R` — refresh the GitHub status (synchronous fetch).
+- The right details panel renders a live block: `Issue #42 [open] TUI: fuzzy search` / `PR #61 [draft] · checks 2/3`.
 
 ### multiplexer integration (`gwm tmux` / `gwm zellij`)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use crate::bootstrap::{self, BootstrapCtx, StepStatus};
 use crate::config::Config;
 use crate::doctor::{self, CheckStatus, DoctorCtx};
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
@@ -9,6 +10,7 @@ use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
+use git2::Repository;
 use std::io;
 use std::path::PathBuf;
 
@@ -33,6 +35,15 @@ pub enum InitShell {
   Zsh,
   Fish,
   Powershell,
+}
+
+/// Target of `gwm link / unlink / open` — issue or pull request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LinkTarget {
+  /// GitHub issue.
+  Issue,
+  /// GitHub pull request.
+  Pr,
 }
 
 #[derive(Debug, Subcommand)]
@@ -146,6 +157,66 @@ pub enum Command {
     #[arg(short = 'p', long = "split")]
     split: bool,
   },
+  /// Link the current (or named) worktree to a GitHub issue or pull request.
+  ///
+  /// The link is stored in `git config branch.<name>.gwm-issue` (or
+  /// `gwm-pr`) — local, per-branch, survives worktree moves. Issue
+  /// numbers are auto-detected from the `<type>/#<N>-<slug>` convention
+  /// when no explicit override is set; `gwm link issue <N>` overrides
+  /// that. PR numbers are not auto-detected; link them explicitly with
+  /// `gwm link pr <N>`.
+  Link {
+    /// What to link: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Number to link (digits only).
+    number: u64,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+  },
+  /// Remove the explicit issue / PR link on the current (or named) worktree.
+  ///
+  /// After `gwm unlink issue`, auto-detection from the branch name
+  /// resurfaces if the branch follows `<type>/#<N>-<slug>`. Idempotent —
+  /// safe to run when nothing is linked.
+  Unlink {
+    /// What to unlink: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+  },
+  /// Open the linked issue or PR in the browser.
+  ///
+  /// Uses the OS opener (`open` on macOS, `xdg-open` on Linux,
+  /// `explorer` on Windows). Pass `--print-url` to emit the URL on
+  /// stdout instead — useful for piping, testing, and headless shells.
+  Open {
+    /// What to open: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+    /// Print the URL on stdout instead of spawning the browser.
+    #[arg(long)]
+    print_url: bool,
+  },
+  /// Show the issue / PR link and (when `gh` is available) live GitHub status.
+  ///
+  /// Shells out to `gh issue view` and `gh pr view` to fetch state, title,
+  /// labels, and CI rollup. Without `gh` (or outside a GitHub repo), prints
+  /// only the local link. `--json` emits a stable schema for scripting.
+  Status {
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+    /// Emit JSON instead of the human-readable summary.
+    #[arg(long)]
+    json: bool,
+  },
 }
 
 pub fn run(cli: Cli) -> Result<()> {
@@ -174,6 +245,18 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Switch => cmd_switch(),
     Command::Tmux { pattern, split } => cmd_multiplexer(Multiplexer::Tmux, pattern, split),
     Command::Zellij { pattern, split } => cmd_multiplexer(Multiplexer::Zellij, pattern, split),
+    Command::Link {
+      target,
+      number,
+      worktree,
+    } => cmd_link(target, number, worktree),
+    Command::Unlink { target, worktree } => cmd_unlink(target, worktree),
+    Command::Open {
+      target,
+      worktree,
+      print_url,
+    } => cmd_open(target, worktree, print_url),
+    Command::Status { worktree, json } => cmd_status(worktree, json),
   }
 }
 
@@ -505,6 +588,276 @@ fn spawn_multiplexer(mux: Multiplexer, argv: &[String]) -> Result<()> {
     )));
   }
   Ok(())
+}
+
+// ---- Issue / PR link commands (issue #67) -------------------------------
+
+/// Resolve the repo + branch + repo-relative path to operate on.
+///
+/// `--worktree <pattern>` overrides; otherwise we use the current directory.
+/// The returned Repository is opened *at the target worktree*, so reading
+/// HEAD gives the branch the user expects, but git config writes still land
+/// on the main repo's config (git2 propagates branch.* config up).
+fn resolve_target_repo(worktree: Option<String>) -> Result<(Repository, String, PathBuf)> {
+  let path: PathBuf = match worktree {
+    Some(pat) => {
+      // Allow either a fuzzy worktree pattern or a direct path.
+      let p = PathBuf::from(&pat);
+      if p.is_dir() {
+        p
+      } else {
+        let main = worktree::discover_repo(None)?;
+        worktree::find_fuzzy(&main, &pat)?.path
+      }
+    }
+    None => std::env::current_dir()?,
+  };
+  let repo = Repository::discover(&path).map_err(|_| GwmError::NotInGitRepo)?;
+  let branch = current_branch(&repo)?;
+  Ok((repo, branch, path))
+}
+
+fn current_branch(repo: &Repository) -> Result<String> {
+  let head = repo
+    .head()
+    .map_err(|_| GwmError::Other("HEAD is unborn or detached".into()))?;
+  head
+    .shorthand()
+    .map(|s| s.to_string())
+    .ok_or_else(|| GwmError::Other("HEAD has no shorthand (detached?)".into()))
+}
+
+fn cmd_link(target: LinkTarget, number: u64, worktree: Option<String>) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  match target {
+    LinkTarget::Issue => {
+      github::link_issue(&repo, &branch, number)?;
+      println!("✓ linked issue #{} to branch {}", number, branch);
+    }
+    LinkTarget::Pr => {
+      github::link_pr(&repo, &branch, number)?;
+      println!("✓ linked PR #{} to branch {}", number, branch);
+    }
+  }
+  Ok(())
+}
+
+fn cmd_unlink(target: LinkTarget, worktree: Option<String>) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  match target {
+    LinkTarget::Issue => {
+      github::unlink_issue(&repo, &branch)?;
+      println!("✓ unlinked issue on branch {}", branch);
+    }
+    LinkTarget::Pr => {
+      github::unlink_pr(&repo, &branch)?;
+      println!("✓ unlinked PR on branch {}", branch);
+    }
+  }
+  Ok(())
+}
+
+fn cmd_open(target: LinkTarget, worktree: Option<String>, print_url: bool) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  let link = github::read_link(&repo, &branch)?;
+  let slug = github::repo_slug(&repo)?;
+
+  let url = match target {
+    LinkTarget::Issue => {
+      let n = link
+        .issue
+        .ok_or_else(|| GwmError::Other(format!("no issue linked to branch '{}'", branch)))?;
+      github::issue_url(&slug, n)
+    }
+    LinkTarget::Pr => {
+      let n = link
+        .pr
+        .ok_or_else(|| GwmError::Other(format!("no PR linked to branch '{}'", branch)))?;
+      github::pr_url(&slug, n)
+    }
+  };
+
+  if print_url {
+    println!("{}", url);
+    return Ok(());
+  }
+  spawn_opener(&url)
+}
+
+fn spawn_opener(url: &str) -> Result<()> {
+  let opener = if cfg!(target_os = "macos") {
+    "open"
+  } else if cfg!(target_os = "windows") {
+    "explorer"
+  } else {
+    "xdg-open"
+  };
+  let status = std::process::Command::new(opener)
+    .arg(url)
+    .status()
+    .map_err(|e| GwmError::CommandFailed(format!("could not spawn {}: {}", opener, e)))?;
+  if !status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "{} exited with status {:?}",
+      opener,
+      status.code()
+    )));
+  }
+  Ok(())
+}
+
+fn cmd_status(worktree: Option<String>, json: bool) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  let link = github::read_link(&repo, &branch)?;
+
+  // Slug + fetched status are best-effort: if there's no GitHub remote
+  // or `gh` isn't installed, we still print the local link.
+  let slug = github::repo_slug(&repo).ok();
+  let (issue_status, pr_status) = fetch_link_status(&link, slug.as_deref());
+
+  if json {
+    print_status_json(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
+  } else {
+    print_status_human(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
+  }
+  Ok(())
+}
+
+fn fetch_link_status(link: &BranchLink, slug: Option<&str>) -> (Option<IssueStatus>, Option<PrStatus>) {
+  let Some(slug) = slug else {
+    return (None, None);
+  };
+  // `gh` is optional — if either call fails we degrade gracefully.
+  let issue = link.issue.and_then(|n| github::fetch_issue(slug, n).ok());
+  let pr = link.pr.and_then(|n| github::fetch_pr(slug, n).ok());
+  (issue, pr)
+}
+
+fn issue_state_str(s: IssueState) -> &'static str {
+  match s {
+    IssueState::Open => "open",
+    IssueState::Closed => "closed",
+  }
+}
+
+fn pr_state_str(s: PrState) -> &'static str {
+  match s {
+    PrState::Open => "open",
+    PrState::Draft => "draft",
+    PrState::Closed => "closed",
+    PrState::Merged => "merged",
+  }
+}
+
+fn link_source_str(s: LinkSource) -> &'static str {
+  match s {
+    LinkSource::None => "none",
+    LinkSource::BranchName => "branch-name",
+    LinkSource::Explicit => "explicit",
+  }
+}
+
+fn print_status_human(
+  branch: &str,
+  slug: Option<&str>,
+  link: &BranchLink,
+  issue: &Option<IssueStatus>,
+  pr: &Option<PrStatus>,
+) {
+  println!("branch: {}", branch);
+  if let Some(s) = slug {
+    println!("repo:   {}", s);
+  }
+  println!("link:   {}", link.summary());
+
+  if let Some(n) = link.issue {
+    print!("issue:  #{}", n);
+    match issue {
+      Some(s) => println!(" [{}] {}", issue_state_str(s.state), s.title),
+      None => println!(" (status unavailable)"),
+    }
+  }
+  if let Some(n) = link.pr {
+    print!("pr:     #{}", n);
+    match pr {
+      Some(s) => {
+        let checks = if s.checks_total > 0 {
+          format!(" · checks {}/{}", s.checks_passed, s.checks_total)
+        } else {
+          String::new()
+        };
+        println!(" [{}]{} {}", pr_state_str(s.state), checks, s.title);
+      }
+      None => println!(" (status unavailable)"),
+    }
+  }
+}
+
+fn print_status_json(
+  branch: &str,
+  slug: Option<&str>,
+  link: &BranchLink,
+  issue: &Option<IssueStatus>,
+  pr: &Option<PrStatus>,
+) {
+  let mut obj = serde_json::Map::new();
+  obj.insert("branch".into(), serde_json::Value::String(branch.into()));
+  if let Some(s) = slug {
+    obj.insert("repo".into(), serde_json::Value::String(s.into()));
+  }
+  obj.insert(
+    "issue".into(),
+    match link.issue {
+      Some(n) => {
+        let mut o = serde_json::Map::new();
+        o.insert("number".into(), serde_json::Value::Number(n.into()));
+        o.insert(
+          "source".into(),
+          serde_json::Value::String(link_source_str(link.issue_source).into()),
+        );
+        if let Some(s) = issue {
+          o.insert(
+            "state".into(),
+            serde_json::Value::String(issue_state_str(s.state).into()),
+          );
+          o.insert("title".into(), serde_json::Value::String(s.title.clone()));
+          o.insert(
+            "labels".into(),
+            serde_json::Value::Array(s.labels.iter().map(|l| serde_json::Value::String(l.clone())).collect()),
+          );
+          o.insert("url".into(), serde_json::Value::String(s.url.clone()));
+        }
+        serde_json::Value::Object(o)
+      }
+      None => serde_json::Value::Null,
+    },
+  );
+  obj.insert(
+    "pr".into(),
+    match link.pr {
+      Some(n) => {
+        let mut o = serde_json::Map::new();
+        o.insert("number".into(), serde_json::Value::Number(n.into()));
+        o.insert(
+          "source".into(),
+          serde_json::Value::String(link_source_str(link.pr_source).into()),
+        );
+        if let Some(s) = pr {
+          o.insert("state".into(), serde_json::Value::String(pr_state_str(s.state).into()));
+          o.insert("title".into(), serde_json::Value::String(s.title.clone()));
+          o.insert(
+            "checks_passed".into(),
+            serde_json::Value::Number(s.checks_passed.into()),
+          );
+          o.insert("checks_total".into(), serde_json::Value::Number(s.checks_total.into()));
+          o.insert("url".into(), serde_json::Value::String(s.url.clone()));
+        }
+        serde_json::Value::Object(o)
+      }
+      None => serde_json::Value::Null,
+    },
+  );
+  println!("{}", serde_json::Value::Object(obj));
 }
 
 pub fn shell_init_script(shell: InitShell) -> &'static str {

--- a/src/github.rs
+++ b/src/github.rs
@@ -169,7 +169,12 @@ fn parse_github_slug(url: &str) -> Result<String> {
 }
 
 fn trim_git_suffix(s: &str) -> &str {
-  s.strip_suffix(".git").unwrap_or(s).trim_end_matches('/')
+  // Normalise trailing slashes first so `owner/repo.git/` becomes
+  // `owner/repo.git` before the `.git` strip kicks in. Pre-fix this
+  // returned `owner/repo.git` because `.git` was sought with a trailing
+  // `/` still attached (Copilot PR #68 review).
+  let trimmed = s.trim_end_matches('/');
+  trimmed.strip_suffix(".git").unwrap_or(trimmed)
 }
 
 // ---- Issue / PR status ---------------------------------------------------

--- a/src/github.rs
+++ b/src/github.rs
@@ -336,8 +336,11 @@ pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
   parse_pr_json(&stdout)
 }
 
-/// Find the PR opened from `branch` (head ref) on the given repo. Returns
-/// `Ok(Some(N))` if exactly one open PR is found, `Ok(None)` if none.
+/// Find the most recent PR opened from `branch` (head ref) on the given
+/// repo, regardless of state. Returns `Ok(Some(N))` if at least one PR
+/// exists (open, draft, closed, or merged — `gh pr list --state all`),
+/// `Ok(None)` otherwise. Callers that need state-aware filtering should
+/// pair this with `fetch_pr` to inspect `PrState` afterwards.
 pub fn find_pr_for_branch(slug: &str, branch: &str) -> Result<Option<u64>> {
   let stdout = run_gh(&[
     "pr", "list", "--repo", slug, "--head", branch, "--state", "all", "--json", "number", "--limit", "1",

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,372 @@
+//! Issue ↔ PR ↔ branch link storage + GitHub API fetch (via `gh` CLI).
+//!
+//! Storage lives in git branch config: `branch.<name>.gwm-issue` and
+//! `branch.<name>.gwm-pr`. Issue numbers are auto-detected from the
+//! `<type>/#<N>-<slug>` branch convention when no explicit override is set.
+//!
+//! Fetch shells out to `gh` and parses its JSON output. The parsing functions
+//! (`parse_issue_json`, `parse_pr_json`) are exposed publicly so tests can
+//! cover the JSON contract without depending on a real `gh` binary.
+
+use crate::error::{GwmError, Result};
+use crate::naming::parse_branch;
+use git2::Repository;
+use serde::Deserialize;
+use std::process::Command;
+
+const ISSUE_CONFIG_KEY: &str = "gwm-issue";
+const PR_CONFIG_KEY: &str = "gwm-pr";
+
+/// Where the issue or PR number came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkSource {
+  /// No link known (no branch-name match and no explicit override).
+  None,
+  /// Inferred from a branch following `<type>/#<N>-<slug>`.
+  BranchName,
+  /// Explicit override set via `gwm link …` (lives in git branch config).
+  Explicit,
+}
+
+/// Resolved link for one branch: which issue (if any), which PR (if any),
+/// and where each number came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchLink {
+  pub issue: Option<u64>,
+  pub pr: Option<u64>,
+  pub issue_source: LinkSource,
+  pub pr_source: LinkSource,
+}
+
+impl BranchLink {
+  pub fn empty() -> Self {
+    Self {
+      issue: None,
+      pr: None,
+      issue_source: LinkSource::None,
+      pr_source: LinkSource::None,
+    }
+  }
+
+  /// One-line human-readable rendering for the CLI / TUI status bar.
+  pub fn summary(&self) -> String {
+    match (self.issue, self.pr) {
+      (None, None) => "no link".into(),
+      (Some(i), None) => format!("issue #{i}"),
+      (None, Some(p)) => format!("PR #{p}"),
+      (Some(i), Some(p)) => format!("issue #{i} · PR #{p}"),
+    }
+  }
+}
+
+/// Read the link for `branch`. Explicit overrides win over branch-name auto-detect.
+pub fn read_link(repo: &Repository, branch: &str) -> Result<BranchLink> {
+  let explicit_issue = read_branch_u64(repo, branch, ISSUE_CONFIG_KEY)?;
+  let explicit_pr = read_branch_u64(repo, branch, PR_CONFIG_KEY)?;
+
+  let (issue, issue_source) = match explicit_issue {
+    Some(n) => (Some(n), LinkSource::Explicit),
+    None => match parse_branch(branch).and_then(|s| s.issue.parse::<u64>().ok()) {
+      Some(n) => (Some(n), LinkSource::BranchName),
+      None => (None, LinkSource::None),
+    },
+  };
+
+  let (pr, pr_source) = match explicit_pr {
+    Some(n) => (Some(n), LinkSource::Explicit),
+    None => (None, LinkSource::None),
+  };
+
+  Ok(BranchLink {
+    issue,
+    pr,
+    issue_source,
+    pr_source,
+  })
+}
+
+pub fn link_issue(repo: &Repository, branch: &str, number: u64) -> Result<()> {
+  write_branch_u64(repo, branch, ISSUE_CONFIG_KEY, number)
+}
+
+pub fn link_pr(repo: &Repository, branch: &str, number: u64) -> Result<()> {
+  write_branch_u64(repo, branch, PR_CONFIG_KEY, number)
+}
+
+pub fn unlink_issue(repo: &Repository, branch: &str) -> Result<()> {
+  remove_branch_key(repo, branch, ISSUE_CONFIG_KEY)
+}
+
+pub fn unlink_pr(repo: &Repository, branch: &str) -> Result<()> {
+  remove_branch_key(repo, branch, PR_CONFIG_KEY)
+}
+
+fn config_key(branch: &str, leaf: &str) -> String {
+  format!("branch.{}.{}", branch, leaf)
+}
+
+fn read_branch_u64(repo: &Repository, branch: &str, leaf: &str) -> Result<Option<u64>> {
+  let cfg = repo.config()?;
+  let key = config_key(branch, leaf);
+  match cfg.get_string(&key) {
+    Ok(s) => s
+      .trim()
+      .parse::<u64>()
+      .map(Some)
+      .map_err(|_| GwmError::Other(format!("config '{}' is not a valid number: {}", key, s))),
+    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+    Err(e) => Err(GwmError::Git(e)),
+  }
+}
+
+fn write_branch_u64(repo: &Repository, branch: &str, leaf: &str, value: u64) -> Result<()> {
+  let mut cfg = repo.config()?;
+  cfg.set_str(&config_key(branch, leaf), &value.to_string())?;
+  Ok(())
+}
+
+fn remove_branch_key(repo: &Repository, branch: &str, leaf: &str) -> Result<()> {
+  let mut cfg = repo.config()?;
+  let key = config_key(branch, leaf);
+  match cfg.remove(&key) {
+    Ok(_) => Ok(()),
+    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+    Err(e) => Err(GwmError::Git(e)),
+  }
+}
+
+// ---- Repo slug from origin remote --------------------------------------
+
+/// Extract the `owner/repo` slug from the `origin` remote URL.
+/// Supports the two GitHub URL flavours: `git@github.com:owner/repo(.git)?`
+/// and `https://github.com/owner/repo(.git)?`.
+pub fn repo_slug(repo: &Repository) -> Result<String> {
+  let remote = repo
+    .find_remote("origin")
+    .map_err(|_| GwmError::Other("no 'origin' remote configured".into()))?;
+  let url = remote
+    .url()
+    .ok_or_else(|| GwmError::Other("origin remote has no URL (non-utf8?)".into()))?
+    .to_string();
+  parse_github_slug(&url)
+}
+
+fn parse_github_slug(url: &str) -> Result<String> {
+  // SSH: git@github.com:owner/repo(.git)?
+  if let Some(rest) = url.strip_prefix("git@github.com:") {
+    return Ok(trim_git_suffix(rest).to_string());
+  }
+  // HTTPS: https://github.com/owner/repo(.git)?
+  for prefix in ["https://github.com/", "http://github.com/"] {
+    if let Some(rest) = url.strip_prefix(prefix) {
+      return Ok(trim_git_suffix(rest).to_string());
+    }
+  }
+  Err(GwmError::Other(format!(
+    "origin '{}' is not a github URL (expected git@github.com:… or https://github.com/…)",
+    url
+  )))
+}
+
+fn trim_git_suffix(s: &str) -> &str {
+  s.strip_suffix(".git").unwrap_or(s).trim_end_matches('/')
+}
+
+// ---- Issue / PR status ---------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueState {
+  Open,
+  Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueStatus {
+  pub number: u64,
+  pub title: String,
+  pub state: IssueState,
+  pub url: String,
+  pub labels: Vec<String>,
+  pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrState {
+  Open,
+  Draft,
+  Closed,
+  Merged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrStatus {
+  pub number: u64,
+  pub title: String,
+  pub state: PrState,
+  pub url: String,
+  pub updated_at: String,
+  pub checks_passed: u32,
+  pub checks_total: u32,
+}
+
+#[derive(Deserialize)]
+struct RawIssue {
+  number: u64,
+  title: String,
+  state: String,
+  url: String,
+  #[serde(default)]
+  labels: Vec<RawLabel>,
+  #[serde(rename = "updatedAt", default)]
+  updated_at: String,
+}
+
+#[derive(Deserialize)]
+struct RawLabel {
+  name: String,
+}
+
+#[derive(Deserialize)]
+struct RawPr {
+  number: u64,
+  title: String,
+  state: String,
+  #[serde(rename = "isDraft", default)]
+  is_draft: bool,
+  url: String,
+  #[serde(rename = "updatedAt", default)]
+  updated_at: String,
+  #[serde(rename = "statusCheckRollup", default)]
+  status_check_rollup: Vec<RawCheck>,
+}
+
+#[derive(Deserialize)]
+struct RawCheck {
+  #[serde(default)]
+  status: String,
+  #[serde(default)]
+  conclusion: Option<String>,
+}
+
+pub fn parse_issue_json(s: &str) -> Result<IssueStatus> {
+  let raw: RawIssue =
+    serde_json::from_str(s).map_err(|e| GwmError::Other(format!("failed to parse issue json: {}", e)))?;
+  let state = match raw.state.as_str() {
+    "OPEN" | "open" => IssueState::Open,
+    "CLOSED" | "closed" => IssueState::Closed,
+    other => return Err(GwmError::Other(format!("unknown issue state '{}'", other))),
+  };
+  Ok(IssueStatus {
+    number: raw.number,
+    title: raw.title,
+    state,
+    url: raw.url,
+    labels: raw.labels.into_iter().map(|l| l.name).collect(),
+    updated_at: raw.updated_at,
+  })
+}
+
+pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
+  let raw: RawPr = serde_json::from_str(s).map_err(|e| GwmError::Other(format!("failed to parse PR json: {}", e)))?;
+  let state = match (raw.state.as_str(), raw.is_draft) {
+    ("MERGED" | "merged", _) => PrState::Merged,
+    ("CLOSED" | "closed", _) => PrState::Closed,
+    ("OPEN" | "open", true) => PrState::Draft,
+    ("OPEN" | "open", false) => PrState::Open,
+    (other, _) => return Err(GwmError::Other(format!("unknown PR state '{}'", other))),
+  };
+  let checks_total = raw.status_check_rollup.len() as u32;
+  let checks_passed = raw
+    .status_check_rollup
+    .iter()
+    .filter(|c| {
+      c.status.eq_ignore_ascii_case("COMPLETED")
+        && c
+          .conclusion
+          .as_deref()
+          .is_some_and(|s| s.eq_ignore_ascii_case("SUCCESS"))
+    })
+    .count() as u32;
+  Ok(PrStatus {
+    number: raw.number,
+    title: raw.title,
+    state,
+    url: raw.url,
+    updated_at: raw.updated_at,
+    checks_passed,
+    checks_total,
+  })
+}
+
+// ---- gh CLI invocation ---------------------------------------------------
+
+const ISSUE_JSON_FIELDS: &str = "number,title,state,url,labels,updatedAt";
+const PR_JSON_FIELDS: &str = "number,title,state,isDraft,url,updatedAt,statusCheckRollup";
+
+/// Run `gh issue view <n> --repo <slug> --json …` and parse the result.
+pub fn fetch_issue(slug: &str, number: u64) -> Result<IssueStatus> {
+  let stdout = run_gh(&[
+    "issue",
+    "view",
+    &number.to_string(),
+    "--repo",
+    slug,
+    "--json",
+    ISSUE_JSON_FIELDS,
+  ])?;
+  parse_issue_json(&stdout)
+}
+
+/// Run `gh pr view <n> --repo <slug> --json …` and parse the result.
+pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
+  let stdout = run_gh(&[
+    "pr",
+    "view",
+    &number.to_string(),
+    "--repo",
+    slug,
+    "--json",
+    PR_JSON_FIELDS,
+  ])?;
+  parse_pr_json(&stdout)
+}
+
+/// Find the PR opened from `branch` (head ref) on the given repo. Returns
+/// `Ok(Some(N))` if exactly one open PR is found, `Ok(None)` if none.
+pub fn find_pr_for_branch(slug: &str, branch: &str) -> Result<Option<u64>> {
+  let stdout = run_gh(&[
+    "pr", "list", "--repo", slug, "--head", branch, "--state", "all", "--json", "number", "--limit", "1",
+  ])?;
+  #[derive(Deserialize)]
+  struct PrRef {
+    number: u64,
+  }
+  let arr: Vec<PrRef> =
+    serde_json::from_str(&stdout).map_err(|e| GwmError::Other(format!("failed to parse pr list json: {}", e)))?;
+  Ok(arr.into_iter().next().map(|p| p.number))
+}
+
+fn run_gh(args: &[&str]) -> Result<String> {
+  let output = Command::new("gh")
+    .args(args)
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("gh: failed to spawn ({}). Is `gh` installed and on PATH?", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "gh exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Build the canonical GitHub URL for an issue, given the repo slug.
+pub fn issue_url(slug: &str, number: u64) -> String {
+  format!("https://github.com/{}/issues/{}", slug, number)
+}
+
+/// Build the canonical GitHub URL for a PR, given the repo slug.
+pub fn pr_url(slug: &str, number: u64) -> String {
+  format!("https://github.com/{}/pull/{}", slug, number)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cli;
 pub mod config;
 pub mod doctor;
 pub mod error;
+pub mod github;
 pub mod multiplexer;
 pub mod naming;
 pub mod tui;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -234,6 +234,7 @@ impl App {
 
   pub fn refresh(&mut self) -> Result<()> {
     self.worktrees = worktree::list(&self.repo)?;
+    // `clamp_selection_to_filter` re-resolves the link cache for us.
     self.clamp_selection_to_filter();
     self.invalidate_sidebar_cache();
     self.status = format!("refreshed — {} worktree(s)", self.worktrees.len());
@@ -263,6 +264,7 @@ impl App {
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
     self.invalidate_sidebar_cache();
+    self.refresh_link();
   }
 
   pub fn prev(&mut self) {
@@ -281,6 +283,7 @@ impl App {
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
     self.invalidate_sidebar_cache();
+    self.refresh_link();
   }
 
   // ---- Vim-style motions / list jumps -------------------------------------
@@ -291,6 +294,7 @@ impl App {
       self.list_state.select(Some(0));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
+      self.refresh_link();
     }
   }
 
@@ -300,6 +304,7 @@ impl App {
       self.list_state.select(Some(len - 1));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
+      self.refresh_link();
     }
   }
 
@@ -708,11 +713,15 @@ impl App {
 
   /// Reposition the selection so it stays inside the current filtered subset.
   /// Called whenever the filter mutates (`/`-mode typing, `Esc`-clear) or the
-  /// worktree list itself changes (`refresh`).
+  /// worktree list itself changes (`refresh`). Also re-resolves the issue/PR
+  /// link cache so the right-panel block tracks the new selection — PR #68
+  /// Copilot review caught that selection changes were leaving the cache
+  /// pointing at the previously selected worktree.
   fn clamp_selection_to_filter(&mut self) {
     let len = self.filtered_indices().len();
     if len == 0 {
       self.list_state.select(None);
+      self.refresh_link();
       return;
     }
     match self.list_state.selected() {
@@ -720,6 +729,7 @@ impl App {
       Some(_) => {}
       None => self.list_state.select(Some(0)),
     }
+    self.refresh_link();
   }
 
   // ---- Bootstrap flow ------------------------------------------------------

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::Config;
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
@@ -47,6 +48,33 @@ pub enum View {
   Confirm,
   Report,
   Help,
+  /// Compact menu to pick which GitHub URL to open (issue / pr).
+  OpenMenu,
+  /// Two-stage prompt: pick the link kind, then enter the number.
+  LinkPrompt,
+}
+
+/// Target of an open / link action.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LinkTarget {
+  Issue,
+  Pr,
+}
+
+/// Stage of the two-step link prompt.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LinkPromptStage {
+  ChooseTarget,
+  InputNumber,
+}
+
+/// State of a background GitHub fetch (issue or PR).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitHubFetchState<T> {
+  Idle,
+  Loading,
+  Loaded(T),
+  Error(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -121,6 +149,20 @@ pub struct App {
   /// `confirm_countdown_secs = 0`), or armed-but-just-disarmed by a
   /// second `y` press.
   pub confirm_countdown_started_at: Option<Instant>,
+
+  // ---- Issue/PR linking (issue #67) -------------------------------------
+  /// Cached link for the currently selected worktree's branch.
+  link: BranchLink,
+  /// Repo slug parsed from `origin` (None when no GitHub remote).
+  link_slug: Option<String>,
+  issue_state: GitHubFetchState<IssueStatus>,
+  pr_state: GitHubFetchState<PrStatus>,
+  /// In `View::LinkPrompt`, which stage are we in.
+  link_prompt_stage: LinkPromptStage,
+  /// In `View::LinkPrompt::InputNumber`, the digits typed so far.
+  link_prompt_number: String,
+  /// In `View::LinkPrompt::InputNumber`, the chosen target.
+  link_prompt_target: Option<LinkTarget>,
 }
 
 impl App {
@@ -138,7 +180,7 @@ impl App {
     if !worktrees.is_empty() {
       state.select(Some(0));
     }
-    Ok(Self {
+    let mut out = Self {
       repo,
       repo_name,
       workdir,
@@ -165,7 +207,16 @@ impl App {
       picker_result: None,
       picker_should_exit: false,
       confirm_countdown_started_at: None,
-    })
+      link: BranchLink::empty(),
+      link_slug: None,
+      issue_state: GitHubFetchState::Idle,
+      pr_state: GitHubFetchState::Idle,
+      link_prompt_stage: LinkPromptStage::ChooseTarget,
+      link_prompt_number: String::new(),
+      link_prompt_target: None,
+    };
+    out.refresh_link();
+    Ok(out)
   }
 
   /// Constructor for `gwm switch`: same App, but picker mode is on and the
@@ -738,5 +789,202 @@ impl App {
       }
       Err(e) => self.status = format!("bootstrap error: {}", e),
     }
+  }
+
+  // ---- Issue/PR linking (issue #67) -------------------------------------
+
+  /// Re-read the link for the currently selected worktree's branch. Also
+  /// re-resolves the repo slug from the origin remote, and resets any
+  /// previously cached GitHub fetch state since it would refer to a
+  /// different (issue, pr) tuple now.
+  pub fn refresh_link(&mut self) {
+    self.link = self.read_selected_link().unwrap_or_else(BranchLink::empty);
+    self.link_slug = github::repo_slug(&self.repo).ok();
+    self.issue_state = GitHubFetchState::Idle;
+    self.pr_state = GitHubFetchState::Idle;
+  }
+
+  fn read_selected_link(&self) -> Option<BranchLink> {
+    let branch = self
+      .selected()
+      .and_then(|w| w.branch.clone())
+      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))?;
+    github::read_link(&self.repo, &branch).ok()
+  }
+
+  pub fn current_link(&self) -> &BranchLink {
+    &self.link
+  }
+
+  pub fn current_slug(&self) -> Option<&str> {
+    self.link_slug.as_deref()
+  }
+
+  pub fn issue_fetch_state(&self) -> &GitHubFetchState<IssueStatus> {
+    &self.issue_state
+  }
+
+  pub fn pr_fetch_state(&self) -> &GitHubFetchState<PrStatus> {
+    &self.pr_state
+  }
+
+  /// Drive the issue/PR fetch synchronously. Called from the event loop
+  /// when the user presses `R`. Sets states to `Loading` first so the UI
+  /// can flag the in-flight state, then runs the fetches.
+  pub fn refresh_github_status(&mut self) {
+    if self.link.issue.is_none() && self.link.pr.is_none() {
+      self.status = "nothing linked — press L to link an issue or PR".into();
+      return;
+    }
+    let Some(slug) = self.link_slug.clone() else {
+      self.status = "no GitHub remote — cannot fetch status".into();
+      return;
+    };
+    if let Some(n) = self.link.issue {
+      self.issue_state = GitHubFetchState::Loading;
+      let r = github::fetch_issue(&slug, n).map_err(|e| e.to_string());
+      self.apply_issue_fetch_result(r);
+    }
+    if let Some(n) = self.link.pr {
+      self.pr_state = GitHubFetchState::Loading;
+      let r = github::fetch_pr(&slug, n).map_err(|e| e.to_string());
+      self.apply_pr_fetch_result(r);
+    }
+    self.status = "github status refreshed".into();
+  }
+
+  pub fn apply_issue_fetch_result(&mut self, r: std::result::Result<IssueStatus, String>) {
+    self.issue_state = match r {
+      Ok(s) => GitHubFetchState::Loaded(s),
+      Err(e) => GitHubFetchState::Error(e),
+    };
+  }
+
+  pub fn apply_pr_fetch_result(&mut self, r: std::result::Result<PrStatus, String>) {
+    self.pr_state = match r {
+      Ok(s) => GitHubFetchState::Loaded(s),
+      Err(e) => GitHubFetchState::Error(e),
+    };
+  }
+
+  // ---- Open menu ----------------------------------------------------------
+
+  pub fn enter_open_menu(&mut self) {
+    // Re-resolve link + slug in case the user just linked something
+    // (`gwm link …` from a parallel terminal) or moved the origin remote.
+    self.refresh_link();
+    self.view = View::OpenMenu;
+  }
+
+  pub fn exit_open_menu(&mut self) {
+    self.view = View::List;
+  }
+
+  /// Pick a target from the open menu. Returns the URL to open, or `None`
+  /// when the link is missing (the status bar carries the explanation).
+  pub fn open_menu_pick(&mut self, target: LinkTarget) -> Option<String> {
+    self.view = View::List;
+    let Some(slug) = self.link_slug.clone() else {
+      self.status = "no GitHub remote — cannot build URL".into();
+      return None;
+    };
+    let url = match target {
+      LinkTarget::Issue => match self.link.issue {
+        Some(n) => github::issue_url(&slug, n),
+        None => {
+          self.status = "no issue linked — press L to link one".into();
+          return None;
+        }
+      },
+      LinkTarget::Pr => match self.link.pr {
+        Some(n) => github::pr_url(&slug, n),
+        None => {
+          self.status = "no PR linked — press L to link one".into();
+          return None;
+        }
+      },
+    };
+    Some(url)
+  }
+
+  // ---- Link prompt --------------------------------------------------------
+
+  pub fn enter_link_prompt(&mut self) {
+    self.view = View::LinkPrompt;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+    self.status = "link: [i]ssue / [p]r · esc cancels".into();
+  }
+
+  pub fn link_prompt_cancel(&mut self) {
+    self.view = View::List;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+  }
+
+  pub fn link_prompt_stage(&self) -> LinkPromptStage {
+    self.link_prompt_stage
+  }
+
+  pub fn link_prompt_number_input(&self) -> &str {
+    &self.link_prompt_number
+  }
+
+  pub fn link_prompt_target(&self) -> Option<LinkTarget> {
+    self.link_prompt_target
+  }
+
+  pub fn link_prompt_choose(&mut self, target: LinkTarget) {
+    self.link_prompt_target = Some(target);
+    self.link_prompt_stage = LinkPromptStage::InputNumber;
+    self.link_prompt_number.clear();
+    self.status = match target {
+      LinkTarget::Issue => "issue # — digits, enter to link, esc to cancel".into(),
+      LinkTarget::Pr => "pr # — digits, enter to link, esc to cancel".into(),
+    };
+  }
+
+  pub fn link_prompt_push_char(&mut self, c: char) {
+    if self.link_prompt_stage == LinkPromptStage::InputNumber && c.is_ascii_digit() {
+      self.link_prompt_number.push(c);
+    }
+  }
+
+  pub fn link_prompt_pop_char(&mut self) {
+    if self.link_prompt_stage == LinkPromptStage::InputNumber {
+      self.link_prompt_number.pop();
+    }
+  }
+
+  pub fn link_prompt_submit(&mut self) -> Result<()> {
+    let Some(target) = self.link_prompt_target else {
+      self.status = "no target chosen".into();
+      return Ok(());
+    };
+    let n: u64 = self
+      .link_prompt_number
+      .parse()
+      .map_err(|_| GwmError::Other("number is empty or invalid".into()))?;
+    let branch = self
+      .selected()
+      .and_then(|w| w.branch.clone())
+      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))
+      .ok_or_else(|| GwmError::Other("no branch resolved for selected worktree".into()))?;
+    match target {
+      LinkTarget::Issue => github::link_issue(&self.repo, &branch, n)?,
+      LinkTarget::Pr => github::link_pr(&self.repo, &branch, n)?,
+    }
+    self.status = match target {
+      LinkTarget::Issue => format!("linked issue #{} to {}", n, branch),
+      LinkTarget::Pr => format!("linked PR #{} to {}", n, branch),
+    };
+    self.view = View::List;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+    self.refresh_link();
+    Ok(())
   }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -860,7 +860,43 @@ impl App {
       let r = github::fetch_pr(&slug, n).map_err(|e| e.to_string());
       self.apply_pr_fetch_result(r);
     }
-    self.status = "github status refreshed".into();
+    self.report_github_refresh_status();
+  }
+
+  /// Compute the post-refresh status line message based on the actual
+  /// outcome of the issue / PR fetches. PR #68 Copilot review caught
+  /// that always printing "refreshed" misled users when one of the
+  /// fetches had failed.
+  pub fn report_github_refresh_status(&mut self) {
+    let issue_err = matches!(self.issue_state, GitHubFetchState::Error(_));
+    let pr_err = matches!(self.pr_state, GitHubFetchState::Error(_));
+    self.status = match (issue_err, pr_err) {
+      (false, false) => "github status refreshed".into(),
+      (true, false) => format!(
+        "issue fetch failed: {}",
+        self.issue_error_message().unwrap_or("?".into())
+      ),
+      (false, true) => format!("pr fetch failed: {}", self.pr_error_message().unwrap_or("?".into())),
+      (true, true) => format!(
+        "issue + pr fetch failed — issue: {} · pr: {}",
+        self.issue_error_message().unwrap_or("?".into()),
+        self.pr_error_message().unwrap_or("?".into())
+      ),
+    };
+  }
+
+  fn issue_error_message(&self) -> Option<String> {
+    match &self.issue_state {
+      GitHubFetchState::Error(e) => Some(e.clone()),
+      _ => None,
+    }
+  }
+
+  fn pr_error_message(&self) -> Option<String> {
+    match &self.pr_state {
+      GitHubFetchState::Error(e) => Some(e.clone()),
+      _ => None,
+    }
   }
 
   pub fn apply_issue_fetch_result(&mut self, r: std::result::Result<IssueStatus, String>) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,7 +12,9 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+pub use app::{
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+};
 pub use ui::filled_cells_for_progress;
 
 pub fn run() -> Result<()> {
@@ -165,6 +167,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Char('b') if !app.picker_mode => app.bootstrap_selected(),
           KeyCode::Char('p') if !app.picker_mode => app.toggle_delete_branch(),
           KeyCode::Char('o') => app.open_selected_in_finder(),
+          // Issue/PR linking (issue #67).
+          KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
+          KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
+          KeyCode::Char('R') if !app.picker_mode => app.refresh_github_status(),
           KeyCode::Enter => {
             if app.picker_mode {
               app.picker_confirm();
@@ -219,6 +225,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         }
         _ => {}
       },
+      View::OpenMenu => match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => app.exit_open_menu(),
+        KeyCode::Char('i') => {
+          if let Some(url) = app.open_menu_pick(LinkTarget::Issue) {
+            open_url(&url, &mut app);
+          }
+        }
+        KeyCode::Char('p') => {
+          if let Some(url) = app.open_menu_pick(LinkTarget::Pr) {
+            open_url(&url, &mut app);
+          }
+        }
+        _ => {}
+      },
+      View::LinkPrompt => match (app.link_prompt_stage(), key.code) {
+        (_, KeyCode::Esc) => app.link_prompt_cancel(),
+        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('i')) => app.link_prompt_choose(LinkTarget::Issue),
+        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('p')) => app.link_prompt_choose(LinkTarget::Pr),
+        (app::LinkPromptStage::InputNumber, KeyCode::Enter) => {
+          if let Err(e) = app.link_prompt_submit() {
+            app.status = format!("link failed: {}", e);
+          }
+        }
+        (app::LinkPromptStage::InputNumber, KeyCode::Char(c)) => app.link_prompt_push_char(c),
+        (app::LinkPromptStage::InputNumber, KeyCode::Backspace) => app.link_prompt_pop_char(),
+        _ => {}
+      },
     }
 
     // Picker contract (Copilot PR #53): only break when the App has
@@ -258,4 +291,20 @@ fn run_lazygit(
     Err(e) => app.status = format!("failed to launch lazygit: {}", e),
   }
   Ok(())
+}
+
+/// Spawn the OS opener for `url` (used by the OpenMenu key handler).
+/// Failures land in the status bar — we never propagate up.
+fn open_url(url: &str, app: &mut App) {
+  let opener = if cfg!(target_os = "macos") {
+    "open"
+  } else if cfg!(target_os = "windows") {
+    "explorer"
+  } else {
+    "xdg-open"
+  };
+  match std::process::Command::new(opener).arg(url).spawn() {
+    Ok(_) => app.status = format!("opened {}", url),
+    Err(e) => app.status = format!("failed to open {}: {}", url, e),
+  }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,5 +1,6 @@
-use super::app::{App, Field, View};
+use super::app::{App, Field, GitHubFetchState, LinkPromptStage, View};
 use crate::bootstrap::StepStatus;
+use crate::github::{IssueState, LinkSource, PrState};
 use crate::naming::BRANCH_TYPES;
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
@@ -51,6 +52,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::Create => draw_create(f, app),
     View::Confirm => draw_confirm(f, app),
     View::Report => draw_report(f, app),
+    View::OpenMenu => draw_open_menu(f, app),
+    View::LinkPrompt => draw_link_prompt(f, app),
     View::List => {}
   }
 }
@@ -190,7 +193,9 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   };
 
   // Resolve (or populate) the cached content for the currently selected worktree.
-  let lines: Vec<Line<'static>> = match app.selected().cloned() {
+  // The cached block is the git preview; the Issue/PR block is rebuilt every
+  // frame (it's small, and its state changes with fetch progress).
+  let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
     Some(w) => {
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
@@ -203,6 +208,9 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     }
     None => vec![Line::from("(nothing selected)")],
   };
+  // Append the live Issue / PR block.
+  lines.push(Line::from(""));
+  lines.extend(github_status_lines(app));
 
   // Track the maximum scrollable offset so `sidebar_scroll_down` can clamp.
   // `area.height - 2` accounts for the top + bottom border lines.
@@ -518,6 +526,11 @@ fn draw_help(f: &mut Frame, app: &App) {
   if !app.picker_mode {
     lines.push(Line::from("  p             toggle 'delete branch on remove'"));
     lines.push(Line::from("  enter         show path in status bar"));
+    lines.push(Line::from(""));
+    lines.push(Line::from("issue / PR (#67)"));
+    lines.push(Line::from("  O             open menu — i=issue · p=pull request"));
+    lines.push(Line::from("  L             link prompt — i / p then digits"));
+    lines.push(Line::from("  R             refresh GitHub status via `gh`"));
   }
   lines.push(Line::from("  ?             this help"));
   if !app.picker_mode {
@@ -791,5 +804,187 @@ fn trunc(s: &str, max: usize) -> String {
     let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
     out.push('…');
     out
+  }
+}
+
+// ---- Issue/PR linking (issue #67) ---------------------------------------
+
+fn draw_open_menu(f: &mut Frame, _app: &App) {
+  let area = centered(40, 22, f.area());
+  f.render_widget(Clear, area);
+  let block = Block::default()
+    .borders(Borders::ALL)
+    .title(" open ")
+    .border_style(Style::default().fg(Color::Magenta));
+  let lines = vec![
+    Line::from(Span::styled(
+      "open in browser",
+      Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+    )),
+    Line::from(""),
+    Line::from("  i   linked issue"),
+    Line::from("  p   linked pull request"),
+    Line::from(""),
+    Line::from(Span::styled("  esc to cancel", Style::default().fg(Color::DarkGray))),
+  ];
+  f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_link_prompt(f: &mut Frame, app: &App) {
+  let area = centered(50, 30, f.area());
+  f.render_widget(Clear, area);
+  let block = Block::default()
+    .borders(Borders::ALL)
+    .title(" link ")
+    .border_style(Style::default().fg(Color::Yellow));
+
+  let lines = match app.link_prompt_stage() {
+    LinkPromptStage::ChooseTarget => vec![
+      Line::from(Span::styled(
+        "link this worktree to:",
+        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+      )),
+      Line::from(""),
+      Line::from("  i   a GitHub issue"),
+      Line::from("  p   a pull request"),
+      Line::from(""),
+      Line::from(Span::styled("  esc to cancel", Style::default().fg(Color::DarkGray))),
+    ],
+    LinkPromptStage::InputNumber => {
+      let label = match app.link_prompt_target() {
+        Some(super::app::LinkTarget::Issue) => "issue #",
+        Some(super::app::LinkTarget::Pr) => "PR #",
+        None => "#",
+      };
+      vec![
+        Line::from(Span::styled(
+          format!("type the {} number", label.trim_end_matches('#').trim()),
+          Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(format!("  {}{}_", label, app.link_prompt_number_input())),
+        Line::from(""),
+        Line::from(Span::styled(
+          "  enter confirms · esc cancels · backspace deletes",
+          Style::default().fg(Color::DarkGray),
+        )),
+      ]
+    }
+  };
+  f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// Append the issue/PR status block to the bottom of the sidebar. Called
+/// from `draw_sidebar` after the git preview, so it shows below the recent
+/// commits / status block.
+pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
+  let link = app.current_link();
+  let mut lines: Vec<Line<'static>> = Vec::new();
+
+  lines.push(Line::from(Span::styled(
+    "─── Issue / PR ───",
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  )));
+
+  if link.issue.is_none() && link.pr.is_none() {
+    lines.push(Line::from(Span::styled(
+      "  no link · press L to link",
+      Style::default().fg(Color::DarkGray),
+    )));
+    return lines;
+  }
+
+  if let Some(n) = link.issue {
+    lines.push(issue_summary_line(n, link.issue_source, app.issue_fetch_state()));
+  }
+  if let Some(n) = link.pr {
+    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state()));
+  }
+  if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
+  {
+    lines.push(Line::from(Span::styled(
+      "  press R to fetch status",
+      Style::default().fg(Color::DarkGray),
+    )));
+  }
+  lines
+}
+
+fn source_marker(s: LinkSource) -> &'static str {
+  match s {
+    LinkSource::None => "",
+    LinkSource::BranchName => " (auto)",
+    LinkSource::Explicit => "",
+  }
+}
+
+fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::IssueStatus>) -> Line<'static> {
+  let head = format!("Issue #{}{}", n, source_marker(src));
+  match state {
+    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Loaded(s) => {
+      let badge_color = match s.state {
+        IssueState::Open => Color::Green,
+        IssueState::Closed => Color::Red,
+      };
+      let badge = match s.state {
+        IssueState::Open => "open",
+        IssueState::Closed => "closed",
+      };
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::raw(" ["),
+        Span::styled(
+          badge.to_string(),
+          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("] "),
+        Span::raw(trunc(&s.title, 40)),
+      ])
+    }
+    GitHubFetchState::Error(e) => Line::from(vec![
+      Span::styled(head, Style::default().fg(Color::White)),
+      Span::raw(" "),
+      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
+    ]),
+  }
+}
+
+fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::PrStatus>) -> Line<'static> {
+  let head = format!("PR    #{}{}", n, source_marker(src));
+  match state {
+    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Loaded(s) => {
+      let (badge, badge_color) = match s.state {
+        PrState::Open => ("open", Color::Green),
+        PrState::Draft => ("draft", Color::DarkGray),
+        PrState::Closed => ("closed", Color::Red),
+        PrState::Merged => ("merged", Color::Magenta),
+      };
+      let checks = if s.checks_total > 0 {
+        format!(" · checks {}/{}", s.checks_passed, s.checks_total)
+      } else {
+        String::new()
+      };
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::raw(" ["),
+        Span::styled(
+          badge.to_string(),
+          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("]"),
+        Span::raw(checks),
+        Span::raw(" "),
+        Span::raw(trunc(&s.title, 36)),
+      ])
+    }
+    GitHubFetchState::Error(e) => Line::from(vec![
+      Span::styled(head, Style::default().fg(Color::White)),
+      Span::raw(" "),
+      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
+    ]),
   }
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -33,7 +33,11 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  switch "))
     .stdout(predicate::str::contains("  tmux "))
     .stdout(predicate::str::contains("  zellij "))
-    .stdout(predicate::str::contains("  doctor "));
+    .stdout(predicate::str::contains("  doctor "))
+    .stdout(predicate::str::contains("  link "))
+    .stdout(predicate::str::contains("  unlink "))
+    .stdout(predicate::str::contains("  open "))
+    .stdout(predicate::str::contains("  status "));
 }
 
 #[test]
@@ -573,4 +577,174 @@ fn zellij_help_mentions_split_flag() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["zellij", "--help"]);
   cmd.assert().success().stdout(predicate::str::contains("--split"));
+}
+
+// --- Issue/PR linking (issue #67) ----------------------------------------
+
+#[test]
+fn link_help_documents_issue_and_pr_targets() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["link", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"));
+}
+
+#[test]
+fn unlink_help_documents_issue_and_pr_targets() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["unlink", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"));
+}
+
+#[test]
+fn open_help_documents_issue_and_pr_and_print_url() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["open", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"))
+    .stdout(predicate::str::contains("--print-url"));
+}
+
+#[test]
+fn status_help_documents_json_flag() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["status", "--help"]);
+  cmd.assert().success().stdout(predicate::str::contains("--json"));
+}
+
+#[test]
+fn link_outside_git_repo_fails() {
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["link", "issue", "42"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn link_issue_persists_and_status_reflects_it() {
+  // E2E: link an issue then `gwm status --json` reads it back.
+  // The repo has no remote configured so `status` runs in "local link only" mode
+  // (no GitHub fetch). The JSON output should still carry the linked number.
+  let (dir, repo) = init_repo();
+  // Need a branch that's checked out for the CWD-resolved status to find it.
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  // link
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["link", "issue", "99"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue #99"));
+
+  // status --json
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"issue\""))
+    .stdout(predicate::str::contains("99"));
+}
+
+#[test]
+fn unlink_issue_falls_back_to_branch_name_auto_detect() {
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  // Override then unlink.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["link", "issue", "99"])
+    .assert()
+    .success();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["unlink", "issue"])
+    .assert()
+    .success();
+
+  // After unlink the branch-name auto-detect should resurface (issue #42).
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("42"));
+}
+
+#[test]
+fn open_print_url_emits_url_without_spawning_browser() {
+  // `--print-url` is the test-friendly mode: we want to assert the URL
+  // construction without actually shelling out to `open`/`xdg-open`.
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["open", "issue", "--print-url"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("https://github.com/kbrdn1/gwm-cli/issues/42"));
+}
+
+#[test]
+fn open_pr_without_link_fails_clearly() {
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  // Branch without an issue number (no auto-detect) and no explicit PR link.
+  repo.branch("random-branch", &head, false).unwrap();
+  repo.set_head("refs/heads/random-branch").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["open", "pr", "--print-url"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("no PR linked"));
+}
+
+#[test]
+fn status_on_branch_with_no_link_reports_no_link() {
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("random-branch", &head, false).unwrap();
+  repo.set_head("refs/heads/random-branch").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no link"));
 }

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -1,0 +1,276 @@
+//! Unit tests for the `github` module: link storage (git branch config),
+//! repo-slug extraction from the `origin` remote, and JSON parsing of
+//! `gh issue view` / `gh pr view --json` payloads.
+
+mod common;
+
+use common::init_repo;
+use gwm::github::{self, parse_issue_json, parse_pr_json, BranchLink, IssueState, LinkSource, PrState};
+
+fn make_branch(repo: &git2::Repository, name: &str) {
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch(name, &head, false).unwrap();
+}
+
+#[test]
+fn read_link_returns_none_when_branch_name_has_no_issue() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "random-branch");
+
+  let link = github::read_link(&repo, "random-branch").unwrap();
+
+  assert_eq!(link.issue, None);
+  assert_eq!(link.pr, None);
+  assert_eq!(link.issue_source, LinkSource::None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
+fn read_link_auto_detects_issue_from_branch_name() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+  assert_eq!(link.pr, None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
+fn link_issue_writes_branch_config_overriding_auto_detect() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.issue, Some(99));
+  assert_eq!(link.issue_source, LinkSource::Explicit);
+}
+
+#[test]
+fn unlink_issue_removes_explicit_override_and_falls_back_to_branch_name() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  github::unlink_issue(&repo, "feat/#42-tui-search").unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  // Auto-detection from branch name kicks back in.
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+}
+
+#[test]
+fn unlink_issue_on_unlinked_branch_is_idempotent() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "random-branch");
+
+  // Should not error even if nothing to unlink.
+  github::unlink_issue(&repo, "random-branch").unwrap();
+  github::unlink_issue(&repo, "random-branch").unwrap();
+}
+
+#[test]
+fn link_pr_writes_branch_config() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.pr, Some(61));
+  assert_eq!(link.pr_source, LinkSource::Explicit);
+}
+
+#[test]
+fn unlink_pr_clears_the_pr_link_only() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  github::unlink_pr(&repo, "feat/#42-tui-search").unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.issue, Some(99));
+  assert_eq!(link.pr, None);
+}
+
+// --- Repo-slug extraction ------------------------------------------------
+
+fn set_origin(repo: &git2::Repository, url: &str) {
+  // remote_set_url is a no-op when the remote doesn't exist, so create it first.
+  let _ = repo.remote("origin", url);
+}
+
+#[test]
+fn repo_slug_from_ssh_origin() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "git@github.com:kbrdn1/gwm-cli.git");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_from_https_origin() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli.git");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_strips_trailing_dot_git_when_absent() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_errors_when_no_origin_remote() {
+  let (_dir, repo) = init_repo();
+
+  let err = github::repo_slug(&repo).unwrap_err();
+  let msg = err.to_string();
+  assert!(msg.contains("origin"), "error should mention origin remote: {}", msg);
+}
+
+#[test]
+fn repo_slug_errors_when_origin_is_not_github() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://gitlab.com/kbrdn1/something.git");
+
+  let err = github::repo_slug(&repo).unwrap_err();
+  let msg = err.to_string();
+  assert!(msg.contains("github"), "error should mention github: {}", msg);
+}
+
+// --- JSON parsing --------------------------------------------------------
+
+#[test]
+fn parse_issue_json_extracts_open_state_and_labels() {
+  let json = r#"{
+    "number": 42,
+    "title": "TUI: fuzzy search",
+    "state": "OPEN",
+    "url": "https://github.com/kbrdn1/gwm-cli/issues/42",
+    "labels": [
+      {"name": "feature", "color": "0e8a16"},
+      {"name": "tui", "color": "5319e7"}
+    ],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let issue = parse_issue_json(json).unwrap();
+
+  assert_eq!(issue.number, 42);
+  assert_eq!(issue.title, "TUI: fuzzy search");
+  assert_eq!(issue.state, IssueState::Open);
+  assert_eq!(issue.url, "https://github.com/kbrdn1/gwm-cli/issues/42");
+  assert_eq!(issue.labels, vec!["feature", "tui"]);
+}
+
+#[test]
+fn parse_issue_json_handles_closed_state() {
+  let json = r#"{
+    "number": 7,
+    "title": "old bug",
+    "state": "CLOSED",
+    "url": "https://github.com/x/y/issues/7",
+    "labels": [],
+    "updatedAt": "2025-01-01T00:00:00Z"
+  }"#;
+
+  let issue = parse_issue_json(json).unwrap();
+
+  assert_eq!(issue.state, IssueState::Closed);
+  assert!(issue.labels.is_empty());
+}
+
+#[test]
+fn parse_pr_json_extracts_state_draft_and_checks() {
+  // Mirror of `gh pr view <N> --json state,title,isDraft,url,statusCheckRollup,updatedAt`.
+  let json = r#"{
+    "number": 61,
+    "title": "feat(tui): fuzzy search",
+    "state": "OPEN",
+    "isDraft": true,
+    "url": "https://github.com/kbrdn1/gwm-cli/pull/61",
+    "statusCheckRollup": [
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "fmt", "status": "IN_PROGRESS", "conclusion": null}
+    ],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.number, 61);
+  assert_eq!(pr.title, "feat(tui): fuzzy search");
+  assert_eq!(pr.state, PrState::Draft);
+  assert_eq!(pr.url, "https://github.com/kbrdn1/gwm-cli/pull/61");
+  // 2 out of 3 checks completed (the IN_PROGRESS one is still running).
+  assert_eq!(pr.checks_passed, 2);
+  assert_eq!(pr.checks_total, 3);
+}
+
+#[test]
+fn parse_pr_json_merged_state_overrides_open() {
+  let json = r#"{
+    "number": 61,
+    "title": "feat(tui): fuzzy search",
+    "state": "MERGED",
+    "isDraft": false,
+    "url": "https://github.com/kbrdn1/gwm-cli/pull/61",
+    "statusCheckRollup": [],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.state, PrState::Merged);
+  assert_eq!(pr.checks_total, 0);
+}
+
+#[test]
+fn parse_pr_json_handles_missing_status_check_rollup() {
+  let json = r#"{
+    "number": 5,
+    "title": "x",
+    "state": "OPEN",
+    "isDraft": false,
+    "url": "https://github.com/x/y/pull/5",
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.checks_total, 0);
+  assert_eq!(pr.checks_passed, 0);
+  assert_eq!(pr.state, PrState::Open);
+}
+
+#[test]
+fn branch_link_summary_renders_human_readable() {
+  let link = BranchLink {
+    issue: Some(42),
+    pr: Some(61),
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::Explicit,
+  };
+  let s = link.summary();
+  assert!(s.contains("#42"), "summary should mention issue #42: {}", s);
+  assert!(s.contains("#61"), "summary should mention PR #61: {}", s);
+}

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -138,6 +138,29 @@ fn repo_slug_strips_trailing_dot_git_when_absent() {
 }
 
 #[test]
+fn repo_slug_handles_trailing_slash_after_dot_git() {
+  // Copilot PR #68 review: `https://…/repo.git/` previously left ".git"
+  // in the slug because we stripped `.git` before trimming `/`. The fix
+  // is to normalise trailing slashes first, then strip `.git`.
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli.git/");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_handles_trailing_slash_without_dot_git() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli/");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
 fn repo_slug_errors_when_no_origin_remote() {
   let (_dir, repo) = init_repo();
 

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1249,3 +1249,57 @@ fn refresh_worktrees_resets_fetch_state() {
   app.refresh().unwrap();
   assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
 }
+
+#[test]
+fn refresh_github_status_message_reflects_partial_failure() {
+  // PR #68 Copilot review: when one of the fetches fails the status line
+  // must not claim "refreshed" — the user should see something hinting
+  // the refresh was incomplete.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // Simulate the result of a refresh where the issue fetch failed but
+  // (for the sake of this test) the PR fetch went through. Apply the
+  // failure directly — we can't shell out to `gh` in unit tests.
+  app.apply_issue_fetch_result(Err("gh: connection refused".into()));
+  let pr = gwm::github::PrStatus {
+    number: 1,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: "https://example.test/pr".into(),
+    updated_at: "".into(),
+    checks_passed: 0,
+    checks_total: 0,
+  };
+  app.apply_pr_fetch_result(Ok(pr));
+  // Now call the same status-rendering logic the refresh would have run.
+  app.report_github_refresh_status();
+  assert!(
+    !app.status.contains("refreshed"),
+    "status must not claim 'refreshed' on partial failure: {}",
+    app.status
+  );
+  assert!(
+    app.status.to_lowercase().contains("error") || app.status.to_lowercase().contains("fail"),
+    "status should mention failure: {}",
+    app.status
+  );
+}
+
+#[test]
+fn refresh_github_status_message_celebrates_full_success() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let issue = gwm::github::IssueStatus {
+    number: 42,
+    title: "x".into(),
+    state: gwm::github::IssueState::Open,
+    url: "https://example.test".into(),
+    labels: vec![],
+    updated_at: "".into(),
+  };
+  app.apply_issue_fetch_result(Ok(issue));
+  app.report_github_refresh_status();
+  assert!(
+    app.status.to_lowercase().contains("refreshed") || app.status.to_lowercase().contains("ok"),
+    "all-green refresh should signal success: {}",
+    app.status
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1010,3 +1010,173 @@ fn filled_cells_floors_partial_progress() {
   // 0.5 exact → 5 cells.
   assert_eq!(filled_cells_for_progress(0.5, 10), 5);
 }
+
+// ---- Issue / PR linking (issue #67) -------------------------------------
+
+use gwm::github::{IssueState, IssueStatus, LinkSource, PrState, PrStatus};
+use gwm::tui::{GitHubFetchState, LinkPromptStage, LinkTarget};
+
+fn make_app_on_branch(name: &str) -> (tempfile::TempDir, git2::Repository, App) {
+  let (dir, repo) = init_repo();
+  {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch(name, &head, false).unwrap();
+  }
+  repo.set_head(&format!("refs/heads/{}", name)).unwrap();
+  let app = App::new_at(Some(dir.path())).unwrap();
+  (dir, repo, app)
+}
+
+#[test]
+fn current_link_reflects_branch_name_auto_detect() {
+  let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
+  let link = app.current_link();
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+  assert_eq!(link.pr, None);
+}
+
+#[test]
+fn enter_open_menu_transitions_view() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.enter_open_menu();
+  assert_eq!(app.view, View::OpenMenu);
+}
+
+#[test]
+fn open_menu_choose_issue_returns_url_when_linked_and_slug_available() {
+  let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  app.enter_open_menu();
+  let url = app.open_menu_pick(LinkTarget::Issue).unwrap();
+  assert_eq!(url, "https://github.com/kbrdn1/gwm-cli/issues/42");
+  // After picking, the view is back to the list.
+  assert_eq!(app.view, View::List);
+}
+
+#[test]
+fn open_menu_pick_returns_none_when_no_link() {
+  let (_dir, repo, mut app) = make_app_on_branch("random-branch");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  app.enter_open_menu();
+  let url = app.open_menu_pick(LinkTarget::Pr);
+  assert!(url.is_none());
+  // Status bar should hint why.
+  assert!(
+    app.status.to_lowercase().contains("no pr"),
+    "status should mention missing PR link: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_link_prompt_starts_at_choose_target() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert_eq!(app.view, View::LinkPrompt);
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::ChooseTarget);
+  assert!(app.link_prompt_number_input().is_empty());
+}
+
+#[test]
+fn link_prompt_choose_issue_advances_to_input() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::InputNumber);
+}
+
+#[test]
+fn link_prompt_only_accepts_digits() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  for c in "12a3".chars() {
+    app.link_prompt_push_char(c);
+  }
+  assert_eq!(app.link_prompt_number_input(), "123");
+}
+
+#[test]
+fn link_prompt_submit_writes_branch_config() {
+  let (_dir, repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  for c in "42".chars() {
+    app.link_prompt_push_char(c);
+  }
+  app.link_prompt_submit().unwrap();
+  // After submit, view returns to list and the link is persisted.
+  assert_eq!(app.view, View::List);
+  let cfg = repo.config().unwrap();
+  let v = cfg.get_string("branch.random-branch.gwm-issue").unwrap();
+  assert_eq!(v, "42");
+}
+
+#[test]
+fn link_prompt_cancel_returns_to_list() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_cancel();
+  assert_eq!(app.view, View::List);
+}
+
+#[test]
+fn github_fetch_state_default_is_idle() {
+  let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn apply_fetch_results_loads_issue_and_pr_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let issue = IssueStatus {
+    number: 42,
+    title: "TUI search".into(),
+    state: IssueState::Open,
+    url: "https://example.test".into(),
+    labels: vec!["feature".into()],
+    updated_at: "2026-05-19T00:00:00Z".into(),
+  };
+  let pr = PrStatus {
+    number: 61,
+    title: "feat(tui): search".into(),
+    state: PrState::Draft,
+    url: "https://example.test/pr".into(),
+    updated_at: "2026-05-19T00:00:00Z".into(),
+    checks_passed: 2,
+    checks_total: 3,
+  };
+  app.apply_issue_fetch_result(Ok(issue.clone()));
+  app.apply_pr_fetch_result(Ok(pr.clone()));
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(_) => {}
+    other => panic!("expected Loaded, got {:?}", other),
+  }
+  match app.pr_fetch_state() {
+    GitHubFetchState::Loaded(_) => {}
+    other => panic!("expected Loaded, got {:?}", other),
+  }
+}
+
+#[test]
+fn apply_fetch_error_stores_error_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_issue_fetch_result(Err("gh not found".into()));
+  match app.issue_fetch_state() {
+    GitHubFetchState::Error(msg) => assert!(msg.contains("gh"), "msg = {}", msg),
+    other => panic!("expected Error, got {:?}", other),
+  }
+}
+
+#[test]
+fn refresh_link_invalidates_fetch_state() {
+  // After the user changes selection or the branch link changes, any
+  // previously fetched status no longer applies. The state must reset.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_issue_fetch_result(Err("e".into()));
+  app.refresh_link();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1180,3 +1180,72 @@ fn refresh_link_invalidates_fetch_state() {
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
   assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
 }
+
+#[test]
+fn next_resets_fetch_state_on_selection_change() {
+  // PR #68 Copilot review: selection change must invalidate the cached
+  // GitHub fetch state, otherwise the right-panel Issue/PR block shows
+  // stale data from the previously selected worktree.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.next();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn prev_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_pr_fetch_result(Err("stale".into()));
+  app.prev();
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn first_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(1));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.first();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn last_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.last();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn filter_clamping_resets_fetch_state_when_selection_moves() {
+  // When typing into the filter narrows the visible set so much that the
+  // current selection no longer points at the same worktree, the link
+  // cache must invalidate too. Otherwise the right-panel block lies.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("zzz-unique"));
+  app.list_state.select(Some(1));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.enter_filter();
+  app.filter_push_char('z'); // only the second fixture matches
+                             // The selection survives but the link cache should still reset because
+                             // the filter operation can drop selection back to index 0 on the
+                             // filtered subset. The contract: any selection-state mutation refreshes.
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn refresh_worktrees_resets_fetch_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_pr_fetch_result(Err("stale".into()));
+  app.refresh().unwrap();
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}


### PR DESCRIPTION
## Description

Adds a first-class **issue ↔ PR ↔ worktree link** to `gwm`, surfaced both via four new CLI subcommands and three new TUI key bindings. Status of the linked issue / PR is fetched via the `gh` CLI and rendered live in the TUI right-panel — the equivalent of my nvim plugin's side panel.

Closes #67

## Type of change
- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **`src/github.rs`** (new) — link storage in `git config branch.<name>.gwm-issue` / `gwm-pr`, auto-detection from `<type>/#<N>-<slug>`, `repo_slug` parsing (SSH + HTTPS GitHub URLs), and `IssueStatus` / `PrStatus` with `parse_issue_json` / `parse_pr_json` exposed publicly so JSON contract tests don't depend on a real `gh` binary.
- **`src/cli.rs`** — four new subcommands:
  - `gwm link {issue|pr} <N> [--worktree <pattern>]`
  - `gwm unlink {issue|pr} [--worktree <pattern>]`
  - `gwm open {issue|pr} [--worktree <pattern>] [--print-url]`
  - `gwm status [--worktree <pattern>] [--json]`
- **`src/tui/`** — three new key bindings on the worktree list:
  - `O` → open menu (`i` issue / `p` PR) → spawns OS opener
  - `L` → two-stage link prompt (target → digits) → persists via git config
  - `R` → synchronous GitHub status refresh via `gh`
  - Live status block in the right details panel: state badge (open / closed / draft / merged), labels, CI rollup (`checks N/M`).
- **`README.md` + `CHANGELOG.md`** — document the new CLI surface, TUI key bindings, and storage convention. CHANGELOG `[Unreleased]` lists the feature and the `serde_json` dependency bump.

## Tests

- [x] \`cargo test\` passes locally — 296 tests across 14 binaries (18 new in \`github_tests\`, 10 new in \`cli_binary\`, 13 new in \`tui_app_tests\`)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [x] New tests added under \`tests/\` (TDD: a PR adding behaviour without tests is sent back)
- [x] Pre-validated against a stripped CI-like PATH: \`PATH="\$(dirname "\$(command -v cargo)"):/usr/bin:/bin" cargo test\` is green

## Screenshots / TUI captures

The right-panel status block renders like this (text mock, exact rendering uses ratatui colour spans):

\`\`\`
─── Issue / PR ───
Issue #42 (auto) [open] TUI: fuzzy search on worktree list
PR    #61        [draft] · checks 2/3 ✨ feat(tui): fuzzy search
\`\`\`

When nothing is linked: \`no link · press L to link\`. When linked but not yet fetched: \`press R to fetch status\`.

## Checklist

- [x] Branch follows \`<type>/#<issue>-<description>\` — \`feat/#67-issue-pr-linking\`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md) — 5 atomic commits by concern (deps → github module → CLI → TUI → docs)
- [x] CHANGELOG.md updated under \`## [Unreleased]\` (root file = current release only)
- [x] README updated — new CLI snippet entries and dedicated "Issue / PR linking" section
- [x] \`examples/gwm.toml.example\` updated if config schema changed — N/A (no config schema change)
- [x] No \`unwrap()\` on user-facing paths (return \`GwmError\` instead)
- [x] No \`println!\` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #67
- Related PR: —

## Notes for reviewers

- **Storage choice.** \`git config branch.<name>.gwm-*\` was picked over a \`.gwm/\` file because it's the idiomatic git location for per-branch metadata, survives worktree moves without extra bookkeeping, and doesn't need a gitignore / commit decision.
- **\`gh\` is optional.** \`gwm status\` shells out best-effort: missing \`gh\`, no origin remote, non-GitHub origin, or fetch errors all degrade gracefully to "local link only" output. The TUI status block likewise renders an inline error on fetch failure instead of crashing.
- **TUI refresh is synchronous.** \`R\` blocks the UI for the duration of the \`gh\` call (~500ms-1s typically). A follow-up could move it to a worker thread; intentionally deferred for this PR to keep the diff focused.
- **Key binding choices.** \`O\` / \`L\` / \`R\` were picked uppercase to avoid colliding with existing bindings (\`o\` opens the directory in the OS file manager; \`l\` launches lazygit; \`r\` refreshes the worktree list). Help screen updated accordingly.