### PR TITLE
✨ feat(tui): redesign Details sidebar with bordered subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Changed
+
+- **TUI Details sidebar redesign** (#69) — the right pane is now made of four
+  independent rounded-border subsections (`Worktree` / `Issue / PR` /
+  `Working Tree` / `Recent Commits`) instead of one big `Details` block with
+  flat `Label:` headers. The outer `Details` frame is dropped to reclaim
+  vertical space. Section titles live on the block borders, so the inline
+  `Basic Settings:` / `Recent commits:` / `Working tree:` content lines are
+  gone. The redundant `─── Issue / PR ───` content header is removed in
+  favour of the block title.
+
+### Removed
+
+- **`Commands:` cheat-sheet from the Details sidebar** — the 15-line
+  keybindings list duplicated the `?` help overlay and pushed the
+  `Issue / PR` block off-screen on common terminal sizes. Press `?` for the
+  full key map. (#69)
+
+### Docs
+
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to
+  match the current `0.6.0-rc.1` surface: new subcommands (`doctor`,
+  `switch`, `tmux`, `zellij`, `link` / `unlink` / `open` / `status`,
+  `completions`, `shell-init`), composable `when` predicates, `[doctor]` /
+  `[tui]` config sections, opt-in pre-commit hook at `.githooks/pre-commit`,
+  updated triggers / TUI key map / troubleshooting.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`). gwm renders the node column only
-  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
-  sidebar and need cross-row topology tracking.
+  lazygit's initial `git log -300`). Includes the full graph topology
+  renderer — vertical pipes `│`, corners `╮ ╭ ╯ ╰`, junctions `┴ ┬`,
+  horizontal strokes `─` — driven by a Rust port of lazygit's
+  `pkg/gui/presentation/graph/` package (`graph.go` / `cell.go`).
+  Linear history collapses to a single `○`-stack column; merges spawn
+  fresh columns to the right, and the algorithm is width-deterministic
+  on the commit list (independent of terminal width).
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now occupies exactly **one visual line** (was wrapping onto two on long
   subjects), and the block **fills the available height** instead of
   showing a hardcoded 10 entries. Per-row format mirrors lazygit:
-  `<8-char hash>  <author initials>  <subject>` (initials follow the
-  same `KB`-from-`Kylian Bardini` rule as
-  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  `<8-char hash>  <author initials>  <node>  <subject>`, where `<node>`
+  is `○` for a normal commit and `◎` for a merge commit (matches
+  `lazygit/pkg/gui/presentation/graph/cell.go` constants
+  `CommitSymbol` / `MergeSymbol`). Initials follow the same
+  `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`. Subjects are
   **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
   disabled across every sidebar block now, so the `Constraint::Length`
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`).
+  lazygit's initial `git log -300`). gwm renders the node column only
+  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
+  sidebar and need cross-row topology tracking.
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TUI Recent Commits panel — lazygit-style layout** (#71) — each commit
+  now occupies exactly **one visual line** (was wrapping onto two on long
+  subjects), and the block **fills the available height** instead of
+  showing a hardcoded 10 entries. Per-row format mirrors lazygit:
+  `<8-char hash>  <author initials>  <subject>` (initials follow the
+  same `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
+  disabled across every sidebar block now, so the `Constraint::Length`
+  budget always matches the rendered height. A right-aligned footer
+  `<viewport-bottom> of <total>` lives at the bottom of the block, à la
+  lazygit's panel footer. Default buffer is **300 commits** (same as
+  lazygit's initial `git log -300`).
+
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /
   `Working Tree` / `Recent Commits`) instead of one big `Details` block with

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: gwm
-description: Manage git worktrees across any repository with the `gwm` Rust binary (CLI + ratatui TUI). Use when the user asks to create / list / remove / bootstrap worktrees, mentions `gwm`, `gwq`, `git worktree`, or asks about per-repo `.gwm.toml` config (branch conventions, file copies, regex guards on `.env`, shell hooks like composer/npm install, no-symlink invariants). Replaces project-specific `tools/worktree-manager.sh` bash wrappers. Triggers on "worktree", "gwm", "gwm create", "gwm list", "gwm bootstrap", ".gwm.toml", "bootstrap worktree", "feat/#", "fix/#".
+description: Manage git worktrees across any repository with the `gwm` Rust binary (CLI + ratatui TUI). Use when the user asks to create / list / remove / bootstrap / switch / link worktrees, diagnose with `gwm doctor`, drive tmux/zellij from a worktree, or wire `gcd` via `gwm shell-init`. Triggers on `gwm`, `gwq`, `git worktree`, `.gwm.toml`, `gwm create`, `gwm list`, `gwm bootstrap`, `gwm doctor`, `gwm switch`, `gwm tmux`, `gwm zellij`, `gwm link`, `gwm status`, `gwm shell-init`, `gcd`, `feat/#`, `fix/#`, GitHub issue/PR linking on a worktree.
 allowed-tools: Bash, Read, Edit, Write
 ---
 
 # gwm — git worktree manager (Rust CLI + TUI)
 
-Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, and a declarative per-repo bootstrap (`.gwm.toml`). Replaces project-specific bash wrappers (`tools/worktree-manager.sh`-style) with one portable binary that works in any git repo.
+Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli
+Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0-rc.1`.
 
 ## When to use this skill
 
-- User runs or asks about `gwm <subcommand>` (init / list / create / remove / path / bootstrap / prune / types).
-- User opens the TUI by running `gwm` alone in a repo.
-- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`.
+- User runs or asks about any `gwm <subcommand>`: `init`, `list`, `create`, `remove`, `path` / `cd`, `bootstrap`, `prune`, `doctor`, `types`, `completions`, `shell-init`, `switch` (alias `s`), `tmux`, `zellij`, `link`, `unlink`, `open`, `status`.
+- User opens the TUI by running `gwm` alone in a repo, or the picker via `gwm switch` / `gwm s`.
+- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[doctor]`, `[tui]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[bootstrap.fallback.*]`.
+- User asks about composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`) and the `!` / `&&` / `||` operators.
 - User wants to migrate a `tools/worktree-manager.sh` or `gwq`-based workflow to `gwm`.
 - User asks how to set up the AWS RDS guard, the safe `.env.testing` fallback, or the no-symlink invariant for `vendor/` / `node_modules/`.
 - User asks about the branch convention `<type>/#<issue>-<desc>` or its overrides.
+- User wants to link a worktree to a GitHub issue / PR, refresh GitHub status from inside the TUI, or run `gwm doctor` to validate setup before pushing.
+- User mentions `gcd <pattern>` (shell wrapper from `gwm shell-init <shell>`).
+- User wants tmux / zellij hand-off (`gwm tmux <pat>`, `gwm zellij <pat>` with optional `--split`).
 
 ## Prerequisites
 
@@ -25,6 +29,10 @@ Source: https://github.com/kbrdn1/gwm-cli
 command -v gwm           # required — installed by `cargo install --path .` from the gwm-cli repo
 command -v cargo         # required at install time (1.80+ recommended)
 command -v git           # required at runtime
+command -v gh            # OPTIONAL — needed for live `gwm status` GitHub data
+command -v tmux          # OPTIONAL — needed by `gwm tmux`
+command -v zellij        # OPTIONAL — needed by `gwm zellij` (≥ 0.40 for `--cwd` on new-tab)
+command -v lazygit       # OPTIONAL — needed by the TUI `l` hand-off
 ```
 
 `gwm` vendors `libgit2`, so no system git2 lib is needed. The binary is self-contained once compiled.
@@ -38,7 +46,7 @@ cargo install --path .         # → ~/.cargo/bin/gwm
 gwm --version
 ```
 
-Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): https://github.com/kbrdn1/gwm-cli/releases.
+Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): https://github.com/kbrdn1/gwm-cli/releases. A Homebrew formula ships under `packaging/homebrew/` and a Nix `flake.nix` is at the repo root.
 
 ## Default conventions
 
@@ -48,6 +56,8 @@ Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): ht
 | Worktree dir name   | `<type>-<issue>-<desc>`              | `.gwm.toml` `path_pattern`     |
 | Worktree base       | `~/cc-worktree/<repo>/`              | `.gwm.toml` `base`             |
 | Bootstrap           | none (just `git worktree add`)       | `.gwm.toml` `[bootstrap.*]`    |
+| Doctor trunks       | `["dev", "main"]`                    | `.gwm.toml` `[doctor] trunks`  |
+| TUI confirm timer   | `3` (clamped 0..=5)                  | `.gwm.toml` `[tui] confirm_countdown_secs` |
 
 Branch types: `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
 
@@ -66,12 +76,73 @@ gwm create feat 123 foo --no-bootstrap    # skip the .gwm.toml stages
 
 gwm list                                  # list worktrees of the current repo
 gwm path <pattern>                        # print path (fuzzy match) → use $(gwm path auth)
+gwm cd   <pattern>                        # alias of `gwm path`
 gwm bootstrap                             # re-run bootstrap on cwd worktree
 gwm bootstrap <pattern>                   # ...or on a named worktree
 gwm remove <pattern>                      # remove (fuzzy). Keeps the branch.
 gwm remove <pattern> --delete-branch      # also drop the local branch
 gwm prune                                 # clean stale .git/worktrees entries
+
+gwm doctor                                # diagnose setup. Exit: 0=green, 1=warn, 2=fail
+gwm completions <bash|elvish|fish|powershell|zsh>   # emit a shell-completion script on stdout
+gwm shell-init  <bash|fish|powershell|zsh>          # emit a `gcd <pattern>` wrapper to eval/source
+
+gwm switch                                # interactive picker → prints chosen path to stdout
+gwm s                                     # alias of `gwm switch`
+
+gwm tmux   <pattern> [-p|--split]         # open matched worktree in new tmux window (or split)
+gwm zellij <pattern> [-p|--split]         # open matched worktree in new zellij tab (or pane)
+
+gwm link   issue|pr <N> [--worktree PAT]  # bind a worktree to a GitHub issue or PR
+gwm unlink issue|pr      [--worktree PAT] # remove the explicit link
+gwm open   [issue|pr]    [--worktree PAT] # open the linked URL in $BROWSER
+gwm status [--worktree PAT] [--json]      # show link + live GitHub state (needs `gh`)
 ```
+
+### `gwm doctor`
+
+Runs a structured set of checks across config, environment, and worktree state. Designed for CI / pre-commit hooks:
+
+| Exit | Meaning                                                                  |
+|:-----|:-------------------------------------------------------------------------|
+| `0`  | All checks green                                                         |
+| `1`  | At least one **warning** (advisory, e.g. orphan gwm-style branch)        |
+| `2`  | At least one **failure** (broken config, prunable worktree, etc.)        |
+
+Trunk branches the orphan-branch check treats as merge destinations come from `[doctor] trunks = [...]` (default `["dev", "main"]`). Setting `trunks = []` disables the filter (every unclaimed gwm-style branch is flagged).
+
+### `gwm shell-init` → `gcd <pattern>`
+
+The emitted wrapper defines a `gcd` function that resolves a worktree by fuzzy pattern and `cd`s into it in one keystroke. Install per shell:
+
+```bash
+# zsh
+echo 'eval "$(gwm shell-init zsh)"'  >> ~/.zshrc
+# bash
+echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
+# fish
+gwm shell-init fish | source        # also add the eval to ~/.config/fish/config.fish
+# powershell
+Invoke-Expression (& gwm shell-init powershell | Out-String)
+```
+
+`gcd` (no arg) launches `gwm switch` (the picker) and `cd`s into the chosen entry.
+
+### GitHub linking (`link` / `unlink` / `open` / `status`)
+
+Links live in **per-branch git config**:
+
+- `branch.<name>.gwm-issue` ← `gwm link issue <N>`
+- `branch.<name>.gwm-pr`    ← `gwm link pr <N>`
+
+Local, per-branch, survives worktree moves. Issue numbers are auto-detected from the `<type>/#<N>-<slug>` convention when no explicit override is set; PR numbers are **not** auto-detected and must be linked explicitly.
+
+`gwm status` shells out to `gh issue view` / `gh pr view` to fetch state, title, labels, and the CI rollup. Without `gh` (or outside a GitHub repo), it prints only the local link. `--json` emits a stable schema for scripting.
+
+### Multiplexer hand-off (`tmux` / `zellij`)
+
+- `gwm tmux <pat>` requires `$TMUX` to be set (i.e. you are already inside a tmux session) — otherwise it exits non-zero with a clear error rather than spawning a stray server. `--split` opens a horizontal split of the current pane instead of a new window.
+- `gwm zellij <pat>` requires `$ZELLIJ`. `--cwd` on `zellij action new-tab` needs zellij ≥ 0.40. `--split` opens a new pane in the current tab instead of a new tab.
 
 ## Status column
 
@@ -98,25 +169,34 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 | `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
 | `gg`        | jump to the first worktree                                                      |
 | `G`         | jump to the last worktree                                                       |
+| `/`         | enter fuzzy filter mode (live narrowing as you type; `Esc` to clear)            |
 | `n`         | new worktree form (type ↑/↓, Tab between fields, Enter on desc submits)         |
-| `d`         | delete (confirm `y`)                                                            |
+| `d`         | delete (confirm `y`; under the safety countdown, `y` again cancels)             |
+| `p`         | toggle "delete branch on remove" (arms the safety countdown when ON)            |
 | `b`         | re-run bootstrap on selected                                                    |
 | `o`         | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`)         |
+| `O`         | open menu — pick issue or PR URL to open in `$BROWSER`                          |
+| `L`         | link prompt — bind selected worktree to a GitHub issue or PR number             |
+| `R`         | refresh GitHub status for the selection (re-fetches issue + PR data)            |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; gwm resumes on lazygit exit |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)    |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `r`         | refresh                                                                         |
-| `p`         | toggle "delete branch on remove"                                                |
-| `Enter`     | show path in status bar                                                         |
+| `r`         | refresh worktree list                                                           |
+| `Enter`     | show path in status bar (in picker mode: print path to stdout + exit)           |
 | `?`         | help overlay                                                                    |
-| `q` / `Esc` | quit                                                                            |
+| `q` / `Esc` | quit (Esc also exits filter / overlays without quitting)                        |
 | `Ctrl-C`    | force quit                                                                      |
+
+## Picker mode (`gwm switch` / `gcd`)
+
+`gwm switch` opens the same TUI minus the create / delete / bootstrap actions. The fuzzy filter bar opens immediately so typing narrows the list right away. `Enter` commits the highlighted pick (path → stdout). `Esc` / `Ctrl-C` / `q` exit non-zero without printing.
 
 ## Details sidebar
 
-When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the selected worktree:
+When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a details panel for the selected worktree:
 
 - **Basic Settings**: branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **GitHub**: linked issue / PR with live state (open / closed / merged), title, labels, CI rollup — populated by `gh`. State machine per worktree: `Idle → Loading → Loaded(T) | Error(String)`. Refresh manually with `R`.
 - **Recent commits**: `git log --oneline -n 10` (shells out to `git`).
 - **Working tree**: `git status --short` (`✓ clean` when empty).
 - **Commands**: keybindings cheat-sheet inside the panel.
@@ -137,7 +217,7 @@ base           = "{home}/cc-worktree/{repo}"
 path_pattern   = "{type}-{issue}-{desc}"
 branch_pattern = "{type}/#{issue}-{desc}"
 
-# File copies main → worktree (run in order).
+# --- file copies main → worktree (run in order) -----------------------------
 [[bootstrap.copy]]
 from = ".env.testing"
 to   = ".env.testing"
@@ -150,15 +230,15 @@ to   = ".env"
 required = false
 guards = ["no-aws-rds"]       # references guard names
 
-# Regex guards on copied files.
+# --- regex guards on copied files -------------------------------------------
 [[bootstrap.guard]]
 name           = "no-aws-rds"
 deny_patterns  = ["amazonaws\\.com", "\\.rds\\."]
 on_match       = "seed-from-example"   # or "abort"
 example_file   = ".env.example"
 
-# Inline fallback when a required source is missing.
-# Key is the destination filename normalized: ".env.testing" → "env_testing".
+# --- inline fallback when a required source is missing ----------------------
+# Key is the destination filename normalised: ".env.testing" → "env_testing".
 [bootstrap.fallback.env_testing]
 target  = ".env.testing"
 content = """
@@ -167,24 +247,53 @@ DB_CONNECTION=sqlite
 DB_DATABASE=:memory:
 """
 
-# Symlinks to refuse (inherited from main).
+# --- symlinks to refuse (inherited from main) ------------------------------
 [[bootstrap.no_symlink]]
 path = "vendor"
 
 [[bootstrap.no_symlink]]
 path = "node_modules"
 
-# Shell commands after copies.
+# --- shell commands after copies -------------------------------------------
 [[bootstrap.command]]
 name = "composer install"
 run  = "composer install --no-interaction --prefer-dist"
-when = "file_exists:composer.json"     # only predicate supported today
+when = "file_exists:composer.json"
 env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 
+# --- composable when predicates --------------------------------------------
+# Atoms : file_exists:<path> | cmd_exists:<bin> | env_set:<VAR>
+#         env_eq:<VAR>=<value> | glob_exists:<pattern>
+# Ops   : ! (NOT) | && (AND) | || (OR)
+# Precedence: ! > && > ||
+
 [[bootstrap.command]]
-name = "direnv allow"
-run  = "direnv allow ."
-when = "file_exists:.envrc"
+name = "install (bun if available)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run  = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "full local build"
+run  = "./scripts/full-build.sh"
+when = "glob_exists:src/**/*.rs && !env_set:CI"
+
+# --- doctor knobs -----------------------------------------------------------
+# Trunks the orphan-branch check treats as merge destinations.
+# Default: ["dev", "main"]. `trunks = []` disables the filter entirely.
+[doctor]
+trunks = ["master", "release-3.x", "release-4.x"]
+
+# --- TUI knobs --------------------------------------------------------------
+# Safety countdown (seconds) applied to the delete-confirm overlay when
+# `delete branch on remove` (`p` in the TUI) is armed. Range 0..=5;
+# above 5 is clamped on read; 0 disables the countdown. Default: 3.
+[tui]
+confirm_countdown_secs = 3
 ```
 
 ## Bootstrap report
@@ -209,6 +318,8 @@ A run with any ✗ should be inspected before testing inside the worktree.
 3. Replace `./tools/worktree-manager.sh create feat 123 foo` with `gwm create feat 123 foo`.
 4. Replace `gwq list` / `gwq remove` / `gwq prune` with `gwm list` / `gwm remove` / `gwm prune`.
 5. Drop `gwq` from the repo's prerequisites (gwm is self-contained).
+6. Wire `gcd` into your shell: `echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc`.
+7. Add `gwm doctor` to CI / pre-commit to catch broken setups before push.
 
 ### Setting up the AWS RDS guard (Laravel / production-safe)
 
@@ -257,7 +368,7 @@ when = "file_exists:composer.json"
 env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 ```
 
-### Node project (npm / pnpm / bun)
+### Node project (bun preferred, npm fallback)
 
 ```toml
 [[bootstrap.copy]]
@@ -269,9 +380,14 @@ required = false
 path = "node_modules"
 
 [[bootstrap.command]]
-name = "install deps"
+name = "install (bun)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
 run  = "npm ci"
-when = "file_exists:package-lock.json"
+when = "file_exists:package.json && !cmd_exists:bun"
 ```
 
 ### Quick create + cd
@@ -279,13 +395,63 @@ when = "file_exists:package-lock.json"
 ```bash
 gwm create feat 42 cool-thing
 cd "$(gwm path cool-thing)"
+# …or with the shell wrapper installed:
+gcd cool-thing
 ```
 
-Wrap as a shell function:
+### Picker → cd in one keystroke
 
 ```bash
-gwmcd() { cd "$(gwm path "$1")"; }
-gwmcd cool-thing
+# After `eval "$(gwm shell-init zsh)"`
+gcd            # opens the picker; cd into the chosen worktree on Enter
+```
+
+### Hand-off into tmux / zellij
+
+```bash
+# Inside tmux:
+gwm tmux api-rewrite              # new window in current session
+gwm tmux api-rewrite --split      # …or split the current pane
+
+# Inside zellij (>= 0.40):
+gwm zellij api-rewrite            # new tab
+gwm zellij api-rewrite --split    # …or new pane in current tab
+```
+
+### Link a worktree to a GitHub issue / PR
+
+```bash
+# Auto-detected from feat/#123-foo branches → no link needed.
+gwm status                                  # shows the local link + (with gh) live state
+
+# Explicit linking:
+gwm link issue 456                          # current worktree → issue #456
+gwm link pr   789  --worktree api-rewrite   # named worktree → PR #789
+gwm open      pr                            # open the PR URL in $BROWSER
+gwm unlink    issue                         # drop the explicit issue link
+
+# Scripting:
+gwm status --json
+```
+
+### Pre-push sanity check
+
+```bash
+gwm doctor && git push           # blocks the push on any warning/failure
+```
+
+### Opt-in pre-commit hook (contributors)
+
+The repo ships an opt-in hook at `.githooks/pre-commit` that combines two gates:
+
+1. **Env-dependent test pre-validation** — if any staged `tests/*.rs` file references ambient state (`assert_cmd`, `std::env::var`, `which::which`, `dirs::`, `Command::cargo_bin`), the suite is re-run under a stripped `PATH="$(dirname cargo):/usr/bin:/bin"` to catch tests that pass in a rich dev shell but fail on minimal CI.
+2. **Local `gwm doctor`** — if staged files touch `.gwm.toml`, the bootstrap / doctor modules, the example config, or their tests, `gwm doctor` runs. Exit `0` is silent, `1` is advisory (commit proceeds), `2` blocks the commit. Unknown exits fail open.
+
+Enable per-clone:
+
+```bash
+git config core.hooksPath .githooks
+git commit --no-verify        # bypass for one commit, sparingly
 ```
 
 ## Architecture (for skill agents asked to extend gwm)
@@ -295,30 +461,37 @@ src/
 ├── lib.rs               # public re-exports — tests import these
 ├── main.rs              # bin entry, dispatches to cli::run
 ├── error.rs             # GwmError (thiserror) + Result alias
-├── config.rs            # serde TOML → Config (worktree, bootstrap)
+├── config.rs            # serde TOML → Config (worktree, bootstrap, doctor, tui)
 ├── naming.rs            # BranchSpec, kebab(), parse_branch()
-├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy (all via git2)
-├── bootstrap.rs         # run(BootstrapCtx) → BootstrapReport
+├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy (libgit2)
+├── bootstrap.rs         # run(BootstrapCtx) → BootstrapReport (copies / guards / commands / when DSL)
+├── doctor.rs            # `gwm doctor` checks (config, env, orphan branches, prunable wts)
+├── github.rs            # issue / PR link storage in git config + `gh` shell-out
+├── multiplexer.rs       # tmux / zellij hand-off (window/tab/split)
 ├── cli.rs               # clap subcommands + handlers
 └── tui/
-    ├── mod.rs           # crossterm event loop
-    ├── app.rs           # App state, transitions
-    └── ui.rs            # ratatui drawing
+    ├── mod.rs           # crossterm event loop (filter, link prompt, open menu, refresh)
+    ├── app.rs           # App state, transitions, GitHubFetchState<T>, ConfirmKeyAction
+    └── ui.rs            # ratatui drawing (sidebar incl. GitHub panel)
 ```
 
-Tests under `tests/` mirror this layout. TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one.
+Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.rs`, `bootstrap_when_tests.rs`, `cli_binary.rs`, `config_tests.rs`, `doctor_tests.rs`, `error_tests.rs`, `flake_tests.rs`, `github_tests.rs`, `homebrew_formula_tests.rs`, `multiplexer_tests.rs`, `naming_tests.rs`, `precommit_hook_tests.rs`, `tui_app_tests.rs`, `worktree_integration.rs` (+ `tests/common/` helpers). **TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one** (project rule, enforced in `CLAUDE.md`).
 
 ## Differences vs. the bash + gwq stack
 
-| Capability                  | bash + gwq            | gwm                            |
-|:----------------------------|:----------------------|:-------------------------------|
-| worktree engine             | `gwq` CLI external    | `libgit2` vendored             |
-| bootstrap                   | hardcoded shell       | declarative TOML + hooks       |
-| portability across repos    | per-project script    | one binary + per-repo config   |
-| TUI                         | linear bash menu      | full ratatui screen            |
-| anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list   |
-| tests                       | 0                     | 71 (config / naming / bootstrap / worktree / TUI / CLI) |
-| install                     | `chmod +x` per repo   | `cargo install --path .`       |
+| Capability                  | bash + gwq            | gwm                                                      |
+|:----------------------------|:----------------------|:---------------------------------------------------------|
+| worktree engine             | `gwq` CLI external    | `libgit2` vendored                                       |
+| bootstrap                   | hardcoded shell       | declarative TOML + composable `when` predicates          |
+| portability across repos    | per-project script    | one binary + per-repo config                             |
+| TUI                         | linear bash menu      | full ratatui screen + filter + GitHub panel              |
+| picker                      | none                  | `gwm switch` / `gcd` shell wrapper                       |
+| multiplexer hand-off        | none                  | `gwm tmux` / `gwm zellij` (window/tab/split)             |
+| GitHub linking              | none                  | issue / PR per-branch git config + `gh` live status      |
+| diagnostics                 | none                  | `gwm doctor` (exit 0/1/2, CI-ready)                      |
+| anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list                             |
+| tests                       | 0                     | 316 across 14 test files (config / bootstrap / when DSL / doctor / github / multiplexer / TUI / CLI / homebrew / flake / pre-commit hook) |
+| install                     | `chmod +x` per repo   | `cargo install --path .` (or Homebrew / Nix / prebuilts) |
 
 ## Troubleshooting
 
@@ -332,22 +505,42 @@ Tests under `tests/` mirror this layout. TDD bar: any new behaviour ships with a
 
 **TUI shows `(prunable)` next to a worktree** — its working dir was deleted out-of-band. Run `gwm prune` (or hit `r` in the TUI after manual cleanup).
 
+**`gwm doctor` exits `2` complaining about an orphan branch** — the branch matches `<type>/#<N>-<slug>` but isn't reachable from any trunk in `[doctor] trunks`. Either delete the branch, merge it, or add its merge target to `trunks`.
+
+**`gwm tmux` says `not inside a tmux session`** — `$TMUX` is unset. Start tmux first; gwm refuses to spawn a stray server.
+
+**`gwm zellij` errors on `--cwd`** — your zellij is older than 0.40. Upgrade, or fall back to opening the path manually.
+
+**`gwm status` shows only the local link, no live data** — `gh` isn't on `$PATH` (or you're outside a GitHub repo). Install GitHub CLI and `gh auth login`.
+
 **`cargo install --path .` fails to build libgit2** — install a C toolchain (`xcode-select --install` on macOS, `build-essential` on Debian/Ubuntu). The `git2` crate uses `vendored-libgit2` so it builds from source.
 
 **`.env` was copied even though it points to prod** — the guard's regex didn't match. Test it with `echo $YOUR_HOST | grep -E '<pattern>'`. Regex syntax is Rust `regex` crate (PCRE-like, no lookaround).
 
+**`gcd` says command not found** — the shell-init wrapper isn't sourced. Re-run `eval "$(gwm shell-init <shell>)"` in your current shell and add it to your shell's rc file.
+
 ## Quick reference card
 
 ```
-gwm                        # TUI
-gwm init                   # scaffold .gwm.toml
-gwm create <t> <#> <desc>  # create + bootstrap
-gwm list                   # list worktrees
-gwm path <pat>             # print path
-gwm bootstrap [pat]        # re-run bootstrap
-gwm remove <pat> [-b]      # remove (-b drops branch)
-gwm prune                  # clean stale refs
-gwm types                  # show branch types
+gwm                          # TUI
+gwm init                     # scaffold .gwm.toml
+gwm create <t> <#> <desc>    # create + bootstrap
+gwm list                     # list worktrees
+gwm path|cd <pat>            # print path
+gwm switch | gwm s | gcd     # interactive picker (cd via shell wrapper)
+gwm bootstrap [pat]          # re-run bootstrap
+gwm remove <pat> [-b]        # remove (-b drops branch)
+gwm prune                    # clean stale refs
+gwm types                    # show branch types
+gwm doctor                   # diagnose setup (exit 0/1/2)
+gwm completions <shell>      # emit shell completion script (bash/elvish/fish/powershell/zsh)
+gwm shell-init  <shell>      # emit gcd wrapper to eval (bash/fish/powershell/zsh)
+gwm tmux   <pat> [-p]        # tmux window / split hand-off
+gwm zellij <pat> [-p]        # zellij tab / pane hand-off
+gwm link   issue|pr <N>      # bind to GitHub issue / PR
+gwm unlink issue|pr          # drop the link
+gwm open   [issue|pr]        # open URL in $BROWSER
+gwm status [--json]          # local link + live gh state
 ```
 
 ## Related
@@ -355,3 +548,4 @@ gwm types                  # show branch types
 - Repo: https://github.com/kbrdn1/gwm-cli
 - Bash predecessor: `tools/worktree-manager.sh` (skill: `worktree-wrapper`) — `gwm` is the multi-repo replacement.
 - Naming convention: `CONTRIBUTING.md` (per repo) — matches `gwm` defaults.
+- Project rules for contributors / AI agents: `CLAUDE.md` (TDD mandatory, `gwm doctor` before PRs touching `.gwm.toml` / bootstrap schema / doctor).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,7 +9,7 @@ use nucleo_matcher::{
   pattern::{CaseMatching, Normalization, Pattern},
   Config as NucleoConfig, Matcher, Utf32Str,
 };
-use ratatui::{text::Line, widgets::TableState};
+use ratatui::widgets::TableState;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -108,10 +108,11 @@ pub struct App {
   pub sidebar_open: bool,
   pub sidebar_focused: bool,
   pub sidebar_scroll: u16,
-  /// Cache of rendered sidebar lines, keyed by the selected worktree path.
-  /// Prevents re-shelling `git log` / `git status` on every TUI redraw — they
-  /// only run when the selection actually changes (or on explicit refresh).
-  pub sidebar_cache: Option<(PathBuf, Vec<Line<'static>>)>,
+  /// Cache of the rendered sidebar sections, keyed by the selected worktree
+  /// path. Prevents re-shelling `git log` / `git status` on every TUI redraw
+  /// — they only run when the selection actually changes (or on explicit
+  /// refresh).
+  pub sidebar_cache: Option<(PathBuf, super::ui::SidebarSections)>,
   /// Upper bound for `sidebar_scroll`, recomputed by the renderer each frame.
   /// Keeps scrolling clamped to the rendered content height so the user can't
   /// scroll the panel entirely off-screen.

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -13,10 +13,12 @@
 //!
 //! Differences from lazygit, all intentional:
 //!
-//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
-//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//! - **Single green palette** — `Color::Green` for connectors and
+//!   `Color::Green` + bold for `○` / `◎` nodes. Lazygit uses per-author
 //!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
-//!   is authored by the same person, so the rainbow is wasted ink.
+//!   is authored by the same person, so the rainbow is wasted ink. The
+//!   green matches the `Worktree` block's "synced" status badge for
+//!   visual consistency across the sidebar.
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
@@ -350,8 +352,8 @@ pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
     c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
   }
 
-  let connector_style = Style::default().fg(Color::DarkGray);
-  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+  let connector_style = Style::default().fg(Color::Green);
+  let node_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
 
   let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
   for cell in &cells {

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -6,10 +6,15 @@
 //! consecutive rows, and renders each row as a fixed sequence of 2-char
 //! cells (`<glyph><filler>`).
 //!
-//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
-//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
-//! independent of terminal width — the graph is width-deterministic on
-//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//! The output is a `Vec<Span<'static>>` per row (from
+//! [`render_pipe_set`]) or a `Vec<Vec<Span<'static>>>` for the full
+//! commit list (from [`render_commits`]). Callers assemble those spans
+//! into a `ratatui::text::Line` together with the rest of the row
+//! (hash, author initials, subject) — see
+//! `src/tui/ui.rs::commit_row_line`. Each row's spans cover exactly
+//! `2 * (max_pos + 1)` cells, independent of terminal width — the
+//! graph is width-deterministic on the input commit list (lazygit
+//! caches on `(head_hash, count)` only).
 //!
 //! Differences from lazygit, all intentional:
 //!
@@ -22,9 +27,14 @@
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
-//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
-//!   target for the first commit so its `○` doesn't appear orphaned;
-//!   here we simply skip the seeded `Starts` pipe in that case.
+//! - **No empty-tree sentinel** — lazygit targets a synthetic
+//!   `EmptyTreeCommitHash` from the first commit's `Starts` pipe so
+//!   `○` doesn't look orphaned. gwm uses an empty string for the
+//!   first parent of a root commit; the rendered cell is still a
+//!   plain `○` because the seeded sentinel pipe from row 0 terminates
+//!   on it. The trivial commit-on-commit `Terminates` (where
+//!   `from_pos == to_pos == commit_pos`) is skipped in
+//!   [`render_pipe_set`] so it doesn't overwrite the node glyph.
 
 use crate::worktree::CommitRow;
 use ratatui::{

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -1,0 +1,433 @@
+//! Per-row commit graph renderer for the Recent Commits sidebar block.
+//!
+//! Direct Rust port of lazygit's `pkg/gui/presentation/graph/` package
+//! (`graph.go` + `cell.go`). The algorithm walks the commit list once,
+//! maintains a set of active "pipes" (vertical line segments) between
+//! consecutive rows, and renders each row as a fixed sequence of 2-char
+//! cells (`<glyph><filler>`).
+//!
+//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
+//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
+//! independent of terminal width — the graph is width-deterministic on
+//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//!
+//! Differences from lazygit, all intentional:
+//!
+//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
+//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
+//!   is authored by the same person, so the rainbow is wasted ink.
+//! - **No selected-commit override** — lazygit highlights the pipes
+//!   originating from the cursor; our sidebar's selection lives on the
+//!   *worktree* list, not on a specific commit.
+//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
+//!   target for the first commit so its `○` doesn't appear orphaned;
+//!   here we simply skip the seeded `Starts` pipe in that case.
+
+use crate::worktree::CommitRow;
+use ratatui::{
+  style::{Color, Modifier, Style},
+  text::Span,
+};
+use std::collections::HashSet;
+
+/// Lifecycle of a pipe across the row it sits in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PipeKind {
+  /// A pipe arriving from above that ends on the current row's commit.
+  Terminates,
+  /// A pipe starting from the current row's commit, heading downward
+  /// toward one of its parents.
+  Starts,
+  /// A pipe that arrived from above and continues below — passing
+  /// through the current row, possibly shifting columns left/right.
+  Continues,
+}
+
+#[derive(Debug, Clone)]
+pub struct Pipe {
+  pub from_pos: i16,
+  pub to_pos: i16,
+  pub from_hash: String,
+  pub to_hash: String,
+  pub kind: PipeKind,
+}
+
+impl Pipe {
+  #[inline]
+  fn left(&self) -> i16 {
+    self.from_pos.min(self.to_pos)
+  }
+  #[inline]
+  fn right(&self) -> i16 {
+    self.from_pos.max(self.to_pos)
+  }
+}
+
+/// What a cell represents at render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellType {
+  Connection,
+  Commit,
+  Merge,
+}
+
+#[derive(Debug, Clone)]
+struct Cell {
+  up: bool,
+  down: bool,
+  left: bool,
+  right: bool,
+  cell_type: CellType,
+}
+
+impl Cell {
+  fn new_connection() -> Self {
+    Self {
+      up: false,
+      down: false,
+      left: false,
+      right: false,
+      cell_type: CellType::Connection,
+    }
+  }
+  fn set_up(&mut self) {
+    self.up = true;
+  }
+  fn set_down(&mut self) {
+    self.down = true;
+  }
+  fn set_left(&mut self) {
+    self.left = true;
+  }
+  fn set_right(&mut self) {
+    self.right = true;
+  }
+  fn set_type(&mut self, t: CellType) {
+    self.cell_type = t;
+  }
+}
+
+/// Port of lazygit's 16-case `getBoxDrawingChars` truth table
+/// (`cell.go:147-183`). Returns `(glyph, right_filler)` — each cell emits
+/// two characters so a continuous horizontal stroke can be drawn by
+/// chaining `─` fillers across columns.
+///
+/// Glyphs are all in the U+2500 light-box-drawing block.
+pub fn box_drawing_chars(up: bool, down: bool, left: bool, right: bool) -> (char, char) {
+  match (up, down, left, right) {
+    (true, true, true, true) => ('│', '─'),
+    (true, true, true, false) => ('│', ' '),
+    (true, true, false, true) => ('│', '─'),
+    (true, true, false, false) => ('│', ' '),
+    (true, false, true, true) => ('┴', '─'),
+    (true, false, true, false) => ('╯', ' '),
+    (true, false, false, true) => ('╰', '─'),
+    (true, false, false, false) => ('╵', ' '),
+    (false, true, true, true) => ('┬', '─'),
+    (false, true, true, false) => ('╮', ' '),
+    (false, true, false, true) => ('╭', '─'),
+    (false, true, false, false) => ('╷', ' '),
+    (false, false, true, true) => ('─', '─'),
+    (false, false, true, false) => ('─', ' '),
+    (false, false, false, true) => ('╶', '─'),
+    (false, false, false, false) => (' ', ' '),
+  }
+}
+
+/// Seed sentinel hash used by lazygit for the pipe that ends on the
+/// very first commit (`graph.go:36`). The actual value is opaque — it
+/// just must never equal any real SHA-1.
+const START_HASH: &str = "__GWM_GRAPH_START__";
+
+/// Walk `commits` once, producing the per-row pipe sets. This is the
+/// Rust translation of lazygit's `GetPipeSets` (`graph.go:60-69`).
+pub fn build_pipe_sets(commits: &[CommitRow]) -> Vec<Vec<Pipe>> {
+  if commits.is_empty() {
+    return Vec::new();
+  }
+  let mut pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: START_HASH.to_string(),
+    to_hash: commits[0].hash.clone(),
+    kind: PipeKind::Starts,
+  }];
+  let mut out = Vec::with_capacity(commits.len());
+  for commit in commits {
+    pipes = get_next_pipes(&pipes, commit);
+    out.push(pipes.clone());
+  }
+  out
+}
+
+/// Per-row transition. Port of lazygit's `getNextPipes`
+/// (`graph.go:109-273`). Given the previous row's pipes and the current
+/// commit, produces the current row's pipe set.
+fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
+  let max_pos: i16 = prev_pipes.iter().map(|p| p.to_pos).max().unwrap_or(0);
+
+  // Pipes that terminated last row do not carry into this one.
+  let current_pipes: Vec<&Pipe> = prev_pipes.iter().filter(|p| p.kind != PipeKind::Terminates).collect();
+
+  // Default to a brand-new commit column. Falls back to the column of
+  // any descendant pipe pointing at us.
+  let mut pos: i16 = max_pos + 1;
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      pos = pipe.to_pos;
+      break;
+    }
+  }
+
+  let mut new_pipes: Vec<Pipe> = Vec::with_capacity(current_pipes.len() + commit.parents.len());
+
+  // Emit the STARTS pipe for the *first* parent (or empty-tree sentinel
+  // when this is the root commit).
+  let first_parent = commit.parents.first().cloned().unwrap_or_else(|| String::from(""));
+  new_pipes.push(Pipe {
+    from_pos: pos,
+    to_pos: pos,
+    from_hash: commit.hash.clone(),
+    to_hash: first_parent,
+    kind: PipeKind::Starts,
+  });
+
+  // Shared mutable state for the per-pipe loops below.
+  let mut taken_spots: HashSet<i16> = HashSet::new();
+  let mut traversed_spots: HashSet<i16> = HashSet::new();
+
+  // Pre-compute the spots that continuing pipes already occupy — a new
+  // merge-parent pipe must not land on top of them.
+  let mut traversed_spots_for_continuing: HashSet<i16> = HashSet::new();
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash {
+      traversed_spots_for_continuing.insert(pipe.to_pos);
+    }
+  }
+
+  // Helper closures need shared borrows of the spot sets, so inline
+  // them as plain `fn`-style helpers operating on locals here.
+  fn next_free(spots: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while spots.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn next_free_for_new(taken: &HashSet<i16>, traversed_for_continuing: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while taken.contains(&i) || traversed_for_continuing.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn traverse(taken: &mut HashSet<i16>, traversed: &mut HashSet<i16>, from: i16, to: i16) {
+    let (l, r) = if from <= to { (from, to) } else { (to, from) };
+    for i in l..=r {
+      traversed.insert(i);
+    }
+    taken.insert(to);
+  }
+
+  // Phase 1: terminating + leftward-continuing pipes from the previous row.
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      // pipe ends on this commit
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: pos,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Terminates,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, pos);
+    } else if pipe.to_pos < pos {
+      // pipe continues; pick the next free column to its right
+      let avail = next_free(&traversed_spots);
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: avail,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, avail);
+    }
+  }
+
+  // Phase 2: extra parents of a merge commit each open a new column.
+  if commit.parents.len() >= 2 {
+    for parent in commit.parents.iter().skip(1) {
+      let avail = next_free_for_new(&taken_spots, &traversed_spots_for_continuing);
+      new_pipes.push(Pipe {
+        from_pos: pos,
+        to_pos: avail,
+        from_hash: commit.hash.clone(),
+        to_hash: parent.clone(),
+        kind: PipeKind::Starts,
+      });
+      taken_spots.insert(avail);
+    }
+  }
+
+  // Phase 3: continuing pipes from the *right* of the commit. They may
+  // shift leftward to fill blank columns.
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash && pipe.to_pos > pos {
+      let mut last = pipe.to_pos;
+      let mut i = pipe.to_pos;
+      while i > pos {
+        i -= 1;
+        if taken_spots.contains(&i) || traversed_spots.contains(&i) {
+          break;
+        }
+        last = i;
+      }
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: last,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, last);
+    }
+  }
+
+  // Stable ordering by to_pos, then kind (matches lazygit's sort).
+  new_pipes.sort_by(|a, b| {
+    if a.to_pos == b.to_pos {
+      a.kind.cmp(&b.kind)
+    } else {
+      a.to_pos.cmp(&b.to_pos)
+    }
+  });
+
+  new_pipes
+}
+
+/// Render a single pipe set into ratatui spans, two spans per cell. Port
+/// of lazygit's `renderPipeSet` (`graph.go:275-385`).
+pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
+  let mut max_pos: i16 = 0;
+  let mut commit_pos: i16 = 0;
+  let mut start_count: usize = 0;
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      start_count += 1;
+      commit_pos = pipe.from_pos;
+    } else if pipe.kind == PipeKind::Terminates {
+      commit_pos = pipe.to_pos;
+    }
+    if pipe.right() > max_pos {
+      max_pos = pipe.right();
+    }
+  }
+  let is_merge = start_count > 1;
+
+  let mut cells: Vec<Cell> = (0..=max_pos).map(|_| Cell::new_connection()).collect();
+
+  // First pass: STARTS pipes paint their downward stroke + any leftward
+  // continuation. Done first so subsequent passes can layer on top.
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+  // Second pass: TERMINATES and CONTINUES (except the trivial commit-
+  // on-commit terminate that would erase the commit cell glyph).
+  for pipe in pipes {
+    if pipe.kind != PipeKind::Starts
+      && !(pipe.kind == PipeKind::Terminates && pipe.from_pos == commit_pos && pipe.to_pos == commit_pos)
+    {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+
+  // Mark the commit cell.
+  if let Some(c) = cells.get_mut(commit_pos as usize) {
+    c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
+  }
+
+  let connector_style = Style::default().fg(Color::DarkGray);
+  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+
+  let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
+  for cell in &cells {
+    let (glyph, filler) = box_drawing_chars(cell.up, cell.down, cell.left, cell.right);
+    let render_glyph: String = match cell.cell_type {
+      CellType::Connection => glyph.to_string(),
+      CellType::Commit => '○'.to_string(),
+      CellType::Merge => '◎'.to_string(),
+    };
+    let style = if matches!(cell.cell_type, CellType::Commit | CellType::Merge) {
+      node_style
+    } else {
+      connector_style
+    };
+    out.push(Span::styled(render_glyph, style));
+    // The right filler is always a connector (never a node), so it
+    // keeps the connector style.
+    out.push(Span::styled(filler.to_string(), connector_style));
+  }
+  out
+}
+
+fn apply_pipe(cells: &mut [Cell], pipe: &Pipe) {
+  let left = pipe.left();
+  let right = pipe.right();
+
+  if left != right {
+    for i in (left + 1)..right {
+      if let Some(c) = cells.get_mut(i as usize) {
+        c.set_left();
+        c.set_right();
+      }
+    }
+    if let Some(c) = cells.get_mut(left as usize) {
+      c.set_right();
+    }
+    if let Some(c) = cells.get_mut(right as usize) {
+      c.set_left();
+    }
+  }
+
+  match pipe.kind {
+    PipeKind::Starts | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.to_pos as usize) {
+        c.set_down();
+      }
+    }
+    PipeKind::Terminates => {}
+  }
+  match pipe.kind {
+    PipeKind::Terminates | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.from_pos as usize) {
+        c.set_up();
+      }
+    }
+    PipeKind::Starts => {}
+  }
+}
+
+/// One-shot helper: compute pipe sets for the commit list and render
+/// each row's spans. Output length matches `commits.len()`.
+pub fn render_commits(commits: &[CommitRow]) -> Vec<Vec<Span<'static>>> {
+  build_pipe_sets(commits)
+    .into_iter()
+    .map(|pipes| render_pipe_set(&pipes))
+    .collect()
+}
+
+/// Convenience constructor for tests — builds a `CommitRow` with the
+/// minimum data the graph algorithm needs.
+#[doc(hidden)]
+pub fn test_row(hash: &str, parents: &[&str]) -> CommitRow {
+  CommitRow {
+    hash: hash.into(),
+    author: String::new(),
+    parents: parents.iter().map(|s| s.to_string()).collect(),
+    subject: String::new(),
+  }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{build_sidebar_sections, filled_cells_for_progress, SidebarSections};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,10 @@
 mod app;
+/// Commit-graph topology renderer, ported from lazygit. **Not part of the
+/// public SemVer surface** — exposed only so the integration tests under
+/// `tests/` can pin the algorithm. Use `gwm::tui::recent_commits_lines`
+/// (re-exported below) for the stable entry point that callers should
+/// actually depend on.
+#[doc(hidden)]
 pub mod commit_graph;
 mod ui;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod commit_graph;
 mod ui;
 
 use crate::error::Result;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,8 +16,8 @@ pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
 pub use ui::{
-  build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line, tilde_compress_with_home,
-  SidebarSections,
+  author_initials, build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line,
+  recent_commits_lines, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run() -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::{build_sidebar_sections, filled_cells_for_progress, SidebarSections};
+pub use ui::{build_sidebar_sections, filled_cells_for_progress, tilde_compress_with_home, SidebarSections};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,10 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::{build_sidebar_sections, filled_cells_for_progress, tilde_compress_with_home, SidebarSections};
+pub use ui::{
+  build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line, tilde_compress_with_home,
+  SidebarSections,
+};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,10 +7,29 @@ use ratatui::{
   layout::{Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
+  widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
   Frame,
 };
 use std::time::Instant;
+
+/// Per-section content of the worktree details sidebar. Rendered by
+/// [`draw_sidebar`] into separate rounded-border blocks (no outer
+/// `Details` frame, so each section reads as an independent card).
+///
+/// The Issue / PR section is intentionally absent here: it depends on
+/// live `App` fetch state and is built per-frame via
+/// [`github_status_lines`], not cached on the worktree.
+#[derive(Debug, Clone, Default)]
+pub struct SidebarSections {
+  /// Compact identity block: name (bold), `branch · head`, badges
+  /// (`✓ synced` / `● dirty` / `↑N` / `↓M` plus optional `★ main`,
+  /// `🔒 locked`, `⚠ prunable`), tilde-compressed path.
+  pub worktree: Vec<Line<'static>>,
+  /// `git status --short` lines, or `✓ clean`, or a load error.
+  pub working_tree: Vec<Line<'static>>,
+  /// Up to 10 oneline commits, or an empty / error notice.
+  pub recent_commits: Vec<Line<'static>>,
+}
 
 /// Minimum total terminal width required to render the sidebar alongside the
 /// worktree table without compressing the table beyond readability.
@@ -192,155 +211,218 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     Color::DarkGray
   };
 
-  // Resolve (or populate) the cached content for the currently selected worktree.
-  // The cached block is the git preview; the Issue/PR block is rebuilt every
-  // frame (it's small, and its state changes with fetch progress).
-  let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
+  // Resolve (or populate) the cached worktree sections for the current
+  // selection. Issue / PR block is rebuilt every frame (its fetch state
+  // moves independently of the worktree info).
+  let sections = match app.selected().cloned() {
     Some(w) => {
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
         None => true,
       };
       if needs_refresh {
-        app.sidebar_cache = Some((w.path.clone(), sidebar_lines(&w)));
+        app.sidebar_cache = Some((w.path.clone(), build_sidebar_sections(&w)));
       }
-      app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default()
+      app.sidebar_cache.as_ref().map(|(_, s)| s.clone()).unwrap_or_default()
     }
-    None => vec![Line::from("(nothing selected)")],
+    None => SidebarSections {
+      worktree: vec![Line::from("(nothing selected)")],
+      working_tree: vec![],
+      recent_commits: vec![],
+    },
   };
-  // Append the live Issue / PR block.
-  lines.push(Line::from(""));
-  lines.extend(github_status_lines(app));
+  let issue_pr_lines = github_status_lines(app);
 
-  // Track the maximum scrollable offset so `sidebar_scroll_down` can clamp.
-  // `area.height - 2` accounts for the top + bottom border lines.
-  let content_len = lines.len() as u16;
-  let visible = area.height.saturating_sub(2);
-  app.sidebar_max_scroll = content_len.saturating_sub(visible);
+  // Per-section block height = content rows + 2 border lines. Fixed for
+  // the small sections (worktree / issue-PR / working-tree); Recent
+  // Commits flexes to fill the rest of the sidebar height.
+  let h = |lines: usize| (lines as u16).saturating_add(2);
+  let constraints = [
+    Constraint::Length(h(sections.worktree.len())),
+    Constraint::Length(h(issue_pr_lines.len())),
+    Constraint::Length(h(sections.working_tree.len())),
+    Constraint::Min(3),
+  ];
+  let chunks = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints(constraints)
+    .split(area);
+
+  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0);
+  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0);
+  render_section(f, chunks[2], " Working Tree ", sections.working_tree, border_color, 0);
+
+  // Recent Commits is the only scrollable section. Clamp the scroll
+  // offset to its visible area so `j` / `k` can't scroll past the end.
+  let commits_area = chunks[3];
+  let commits_visible = commits_area.height.saturating_sub(2);
+  app.sidebar_max_scroll = (sections.recent_commits.len() as u16).saturating_sub(commits_visible);
   if app.sidebar_scroll > app.sidebar_max_scroll {
     app.sidebar_scroll = app.sidebar_max_scroll;
   }
+  render_section(
+    f,
+    commits_area,
+    " Recent Commits ",
+    sections.recent_commits,
+    border_color,
+    app.sidebar_scroll,
+  );
+}
 
+fn render_section(
+  f: &mut Frame,
+  area: Rect,
+  title: &'static str,
+  lines: Vec<Line<'static>>,
+  border_color: Color,
+  scroll: u16,
+) {
   let block = Block::default()
     .borders(Borders::ALL)
-    .title(" Details ")
+    .border_type(BorderType::Rounded)
+    .title(title)
     .border_style(Style::default().fg(border_color));
-
-  let paragraph = Paragraph::new(lines)
+  // Pad content with one leading space per line for breathing room against
+  // the left border. Cheap and avoids per-call `format!` churn.
+  let padded: Vec<Line<'static>> = lines
+    .into_iter()
+    .map(|l| {
+      let mut spans = Vec::with_capacity(l.spans.len() + 1);
+      spans.push(Span::raw(" "));
+      spans.extend(l.spans);
+      Line::from(spans)
+    })
+    .collect();
+  let paragraph = Paragraph::new(padded)
     .block(block)
     .wrap(Wrap { trim: false })
-    .scroll((app.sidebar_scroll, 0));
-
+    .scroll((scroll, 0));
   f.render_widget(paragraph, area);
 }
 
-fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
-  let mut out: Vec<Line> = vec![
-    // Header — worktree name in bold.
-    Line::from(Span::styled(
-      w.name.clone(),
-      Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-    )),
-    Line::from(""),
-    // Basic Settings block.
-    section_header("Basic Settings:"),
-    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), Color::Green),
-    kv("Path", w.path.display().to_string(), Color::Gray),
-    kv(
-      "Head",
-      w.head.as_deref().map(short_oid).unwrap_or_else(|| "-".into()),
-      Color::Yellow,
-    ),
-    kv("Main", yes_no(w.is_main), Color::Yellow),
-    kv("Locked", yes_no(w.is_locked), Color::Magenta),
-    kv("Prunable", yes_no(w.is_prunable), Color::Red),
-    kv("Status", branch_status_label(&w.status), branch_status_color(&w.status)),
-    Line::from(""),
-  ];
-
-  // Recent commits block.
-  out.push(section_header("Recent commits:"));
-  match worktree::git_log_oneline(&w.path, 10) {
-    Ok(s) if !s.trim().is_empty() => {
-      for line in s.lines() {
-        out.push(Line::from(format!("  {}", line)));
-      }
-    }
-    Ok(_) => out.push(Line::from(Span::styled(
-      "  (no commits)",
-      Style::default().fg(Color::DarkGray),
-    ))),
-    Err(e) => out.push(Line::from(Span::styled(
-      format!("  ! {}", e),
-      Style::default().fg(Color::Red),
-    ))),
+/// Build the per-section content of the details sidebar for one worktree.
+///
+/// The Commands cheat-sheet block is intentionally not produced here — it
+/// duplicated the `?` help overlay and consumed ~15 vertical lines for no
+/// new information. Press `?` for the full key map.
+pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
+  SidebarSections {
+    worktree: worktree_identity_lines(w),
+    working_tree: working_tree_lines(w),
+    recent_commits: recent_commits_lines(w),
   }
-  out.push(Line::from(""));
+}
 
-  // Working tree block.
-  out.push(section_header("Working tree:"));
-  match worktree::git_status_short(&w.path) {
-    Ok(s) if s.trim().is_empty() => out.push(Line::from(Span::styled("  ✓ clean", Style::default().fg(Color::Green)))),
-    Ok(s) => {
-      for line in s.lines() {
-        out.push(Line::from(format!("  {}", line)));
-      }
-    }
-    Err(e) => out.push(Line::from(Span::styled(
-      format!("  ! {}", e),
-      Style::default().fg(Color::Red),
-    ))),
-  }
-  out.push(Line::from(""));
+/// 3–4 line identity card: name, `branch · head`, status + flag badges,
+/// tilde-compressed path. Skips badges whose flags are false to avoid
+/// visual noise (`false`/`true` columns scaled poorly with the old layout).
+fn worktree_identity_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  let mut out: Vec<Line<'static>> = Vec::with_capacity(4);
 
-  // Commands cheat-sheet (lazyssh style).
-  out.push(section_header("Commands:"));
-  for (key, label) in [
-    ("Enter", "Copy path to status"),
-    ("    l", "Launch lazygit fullscreen"),
-    ("    o", "Open dir in OS file manager"),
-    ("    b", "Bootstrap worktree"),
-    ("    n", "New worktree"),
-    ("    d", "Delete worktree"),
-    ("    p", "Toggle delete-branch-on-remove"),
-    ("    r", "Refresh"),
-    ("    v", "Toggle this sidebar"),
-    ("  Tab", "Swap focus list ↔ sidebar"),
-    ("    /", "Fuzzy filter worktrees"),
-    ("   gg", "Jump to first worktree"),
-    ("    G", "Jump to last worktree"),
-    ("  j/k", "Next / Prev (or scroll sidebar)"),
-    ("    ?", "Help"),
-    ("    q", "Quit"),
-  ] {
-    out.push(Line::from(vec![
-      Span::styled(format!("  {}: ", key), Style::default().fg(Color::Cyan)),
-      Span::raw(label),
-    ]));
+  // Line 1 — worktree name in bold white.
+  out.push(Line::from(Span::styled(
+    w.name.clone(),
+    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+  )));
+
+  // Line 2 — "<branch> · <short head>". Skip head sub-span when absent.
+  let branch = w.branch.clone().unwrap_or_else(|| "-".into());
+  let mut spans = vec![Span::styled(branch, Style::default().fg(Color::Green))];
+  if let Some(head) = w.head.as_deref() {
+    spans.push(Span::styled("  ·  ".to_string(), Style::default().fg(Color::DarkGray)));
+    spans.push(Span::styled(short_oid(head), Style::default().fg(Color::Yellow)));
   }
+  out.push(Line::from(spans));
+
+  // Line 3 — status badge + optional flag badges. Only renders the badges
+  // that are *true* / *interesting*; the false cases stay invisible.
+  out.push(badges_line(w));
+
+  // Line 4 — path, tilde-compressed for compactness.
+  out.push(Line::from(Span::styled(
+    tilde_compress(&w.path.display().to_string()),
+    Style::default().fg(Color::DarkGray),
+  )));
+
   out
 }
 
-fn section_header(text: &str) -> Line<'static> {
-  Line::from(Span::styled(
-    text.to_string(),
-    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-  ))
-}
-
-fn kv(key: &str, value: String, value_color: Color) -> Line<'static> {
-  Line::from(vec![
-    Span::styled(format!("  {}: ", key), Style::default().fg(Color::DarkGray)),
-    Span::styled(value, Style::default().fg(value_color)),
-  ])
-}
-
-fn yes_no(b: bool) -> String {
-  if b {
-    "true".into()
+fn badges_line(w: &WorktreeInfo) -> Line<'static> {
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  // Status sigil: ✓ synced / clean | ● dirty | ↑N ↓M | unknown.
+  let status_label = branch_status_label(&w.status);
+  let status_color = branch_status_color(&w.status);
+  let sigil = if w.status.unknown {
+    "?"
+  } else if w.status.is_dirty {
+    "●"
   } else {
-    "false".into()
+    "✓"
+  };
+  spans.push(Span::styled(
+    format!("{} {}", sigil, status_label),
+    Style::default().fg(status_color),
+  ));
+
+  let sep = || Span::styled("  ".to_string(), Style::default().fg(Color::DarkGray));
+  if w.is_main {
+    spans.push(sep());
+    spans.push(Span::styled("★ main".to_string(), Style::default().fg(Color::Yellow)));
   }
+  if w.is_locked {
+    spans.push(sep());
+    spans.push(Span::styled(
+      "🔒 locked".to_string(),
+      Style::default().fg(Color::Magenta),
+    ));
+  }
+  if w.is_prunable {
+    spans.push(sep());
+    spans.push(Span::styled("⚠ prunable".to_string(), Style::default().fg(Color::Red)));
+  }
+  Line::from(spans)
+}
+
+fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  match worktree::git_status_short(&w.path) {
+    Ok(s) if s.trim().is_empty() => vec![Line::from(Span::styled(
+      "✓ clean".to_string(),
+      Style::default().fg(Color::Green),
+    ))],
+    Ok(s) => s.lines().map(|l| Line::from(l.to_string())).collect(),
+    Err(e) => vec![Line::from(Span::styled(
+      format!("! {}", e),
+      Style::default().fg(Color::Red),
+    ))],
+  }
+}
+
+fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  match worktree::git_log_oneline(&w.path, 10) {
+    Ok(s) if !s.trim().is_empty() => s.lines().map(|l| Line::from(l.to_string())).collect(),
+    Ok(_) => vec![Line::from(Span::styled(
+      "(no commits)".to_string(),
+      Style::default().fg(Color::DarkGray),
+    ))],
+    Err(e) => vec![Line::from(Span::styled(
+      format!("! {}", e),
+      Style::default().fg(Color::Red),
+    ))],
+  }
+}
+
+/// Replace the user's home prefix with `~` so paths render compactly in
+/// the narrow sidebar. Falls back to the raw path if `$HOME` is unset or
+/// the path doesn't live under it.
+fn tilde_compress(path: &str) -> String {
+  if let Some(home) = dirs::home_dir() {
+    let home_s = home.display().to_string();
+    if let Some(rest) = path.strip_prefix(&home_s) {
+      return format!("~{}", rest);
+    }
+  }
+  path.to_string()
 }
 
 fn short_oid(oid: &str) -> String {
@@ -874,21 +956,16 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// Append the issue/PR status block to the bottom of the sidebar. Called
-/// from `draw_sidebar` after the git preview, so it shows below the recent
-/// commits / status block.
+/// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)
+/// is supplied by [`draw_sidebar`] via the surrounding `Block`, so this
+/// function only returns the content rows.
 pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
   let link = app.current_link();
   let mut lines: Vec<Line<'static>> = Vec::new();
 
-  lines.push(Line::from(Span::styled(
-    "─── Issue / PR ───",
-    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-  )));
-
   if link.issue.is_none() && link.pr.is_none() {
     lines.push(Line::from(Span::styled(
-      "  no link · press L to link",
+      "no link · press L to link".to_string(),
       Style::default().fg(Color::DarkGray),
     )));
     return lines;
@@ -903,7 +980,7 @@ pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
   if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
   {
     lines.push(Line::from(Span::styled(
-      "  press R to fetch status",
+      "press R to fetch status".to_string(),
       Style::default().fg(Color::DarkGray),
     )));
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,12 +448,15 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <subject>
+/// <8-char hash>  <author initials>  <node>  <subject>
 /// ```
 ///
-/// The subject is **not** truncated here — the renderer relies on ratatui's
-/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
-/// commit per visual line, overflow cut at the right edge without `…`.
+/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
+/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
+/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
+/// truncated here — the renderer relies on ratatui's view-level
+/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
+/// per visual line, overflow cut at the right edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
     Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,18 +448,30 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <node>  <subject>
+/// <8-char hash>  <author initials>  <graph>  <subject>
 /// ```
 ///
-/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
-/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
-/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
-/// truncated here — the renderer relies on ratatui's view-level
-/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
-/// per visual line, overflow cut at the right edge without `…`.
+/// where `<graph>` is the per-row output of the topology renderer in
+/// [`super::commit_graph`] — a sequence of `2 * (max_pos + 1)` cells
+/// drawing `○` / `◎` nodes plus the `│ ─ ╮ ╭ ╯ ╰ …` connectors that
+/// link consecutive commits across branch / merge boundaries. The
+/// graph width is deterministic on the commit list — independent of
+/// terminal width — so the cache stays valid across resizes.
+///
+/// The subject is **not** truncated here — the renderer relies on
+/// ratatui's view-level hard-clip (no `Wrap`) to match lazygit's gocui
+/// behaviour: one commit per visual line, overflow cut at the right
+/// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
-    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
+    Ok(rows) if !rows.is_empty() => {
+      let graphs = super::commit_graph::render_commits(&rows);
+      rows
+        .into_iter()
+        .zip(graphs)
+        .map(|(row, graph_spans)| commit_row_line(row, graph_spans))
+        .collect()
+    }
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -471,42 +483,21 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
   }
 }
 
-fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+fn commit_row_line(row: worktree::CommitRow, graph: Vec<Span<'static>>) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
-  let marker = commit_node_marker(&row);
-  Line::from(vec![
-    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
-    Span::raw("  "),
-    Span::styled(
-      format!("{:<2}", initials),
-      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-    ),
-    Span::raw("  "),
-    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
-    Span::raw("  "),
-    Span::raw(row.subject),
-  ])
-}
-
-/// Glyph that marks a commit node in the Recent Commits graph column.
-/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
-/// (`pkg/gui/presentation/graph/cell.go:11-14`):
-///
-/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
-///   no parents).
-/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
-///
-/// gwm renders a single graph column without inter-row connectors
-/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
-/// rows and would clutter a narrow sidebar. The node-only column is
-/// the most readable subset for a previewer.
-fn commit_node_marker(row: &worktree::CommitRow) -> char {
-  if row.parents.len() >= 2 {
-    '◎'
-  } else {
-    '○'
-  }
+  let mut spans: Vec<Span<'static>> = Vec::with_capacity(5 + graph.len());
+  spans.push(Span::styled(short_hash, Style::default().fg(Color::Yellow)));
+  spans.push(Span::raw("  "));
+  spans.push(Span::styled(
+    format!("{:<2}", initials),
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  ));
+  spans.push(Span::raw("  "));
+  spans.extend(graph);
+  spans.push(Span::raw(" "));
+  spans.push(Span::raw(row.subject));
+  Line::from(spans)
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -471,6 +471,7 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
 fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
+  let marker = commit_node_marker(&row);
   Line::from(vec![
     Span::styled(short_hash, Style::default().fg(Color::Yellow)),
     Span::raw("  "),
@@ -479,8 +480,30 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
       Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
     ),
     Span::raw("  "),
+    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
+    Span::raw("  "),
     Span::raw(row.subject),
   ])
+}
+
+/// Glyph that marks a commit node in the Recent Commits graph column.
+/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
+/// (`pkg/gui/presentation/graph/cell.go:11-14`):
+///
+/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
+///   no parents).
+/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
+///
+/// gwm renders a single graph column without inter-row connectors
+/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
+/// rows and would clutter a narrow sidebar. The node-only column is
+/// the most readable subset for a previewer.
+fn commit_node_marker(row: &worktree::CommitRow) -> char {
+  if row.parents.len() >= 2 {
+    '◎'
+  } else {
+    '○'
+  }
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -483,17 +483,27 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   ])
 }
 
-/// Derive lazygit-style author initials from a full name. Mirrors
-/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+/// Derive lazygit-style author initials from a full name. Closely
+/// mirrors `getInitials` in lazygit's
+/// `pkg/gui/presentation/authors/authors.go`:
 ///
-/// - Empty → empty.
-/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
-/// - Single word → first 2 chars of that word.
-/// - ≥ 2 words → first char of split[0] + first char of split[1].
+/// - Empty / whitespace-only → empty.
+/// - Single word → first 2 Unicode scalar values of that word.
+/// - ≥ 2 words → first scalar of split[0] + first scalar of split[1].
 ///
-/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
-/// grapheme then char[0] of split[1]). Capped at 2 visible chars
-/// (`CommitAuthorShortLength` in lazygit).
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C`.
+/// Capped at 2 visible characters (`CommitAuthorShortLength` in
+/// lazygit).
+///
+/// **Divergence from lazygit** (PR #72 review, Copilot): lazygit uses
+/// `uniseg.FirstGraphemeClusterInString` and keeps multi-scalar
+/// grapheme clusters intact (e.g. regional-indicator flags like
+/// "🇫🇷"). gwm slices on Unicode scalar values via `str::chars()`,
+/// so the French flag is split into its two regional indicators and
+/// only the first survives. We accept this divergence intentionally
+/// — pulling in `unicode-segmentation` for a near-zero-impact author
+/// renderer would inflate the dependency tree without user-visible
+/// benefit on the typical "FirstName LastName" pattern.
 pub fn author_initials(author: &str) -> String {
   let trimmed = author.trim();
   if trimmed.is_empty() {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -350,20 +350,26 @@ fn worktree_identity_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
 
 fn badges_line(w: &WorktreeInfo) -> Line<'static> {
   let mut spans: Vec<Span<'static>> = Vec::new();
-  // Status sigil: ✓ synced / clean | ● dirty | ↑N ↓M | unknown.
+  // Status sigil:
+  //   `?`     — unknown
+  //   `●`     — dirty (working tree or index)
+  //   `✓`     — synced / clean (no divergence)
+  //   (none)  — ahead / behind / both — the label already carries `↑N` /
+  //             `↓M` / `↑N ↓M`. Prefixing `✓` here would lie about
+  //             divergence (raised by PR #70 Copilot review).
   let status_label = branch_status_label(&w.status);
   let status_color = branch_status_color(&w.status);
-  let sigil = if w.status.unknown {
-    "?"
+  let is_diverged = w.status.has_upstream && (w.status.ahead > 0 || w.status.behind > 0);
+  let badge_text = if w.status.unknown {
+    format!("? {}", status_label)
   } else if w.status.is_dirty {
-    "●"
+    format!("● {}", status_label)
+  } else if is_diverged {
+    status_label
   } else {
-    "✓"
+    format!("✓ {}", status_label)
   };
-  spans.push(Span::styled(
-    format!("{} {}", sigil, status_label),
-    Style::default().fg(status_color),
-  ));
+  spans.push(Span::styled(badge_text, Style::default().fg(status_color)));
 
   let sep = || Span::styled("  ".to_string(), Style::default().fg(Color::DarkGray));
   if w.is_main {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -231,7 +231,14 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       recent_commits: vec![],
     },
   };
-  let issue_pr_lines = github_status_lines(app);
+  // Inner width = block area − 2 border columns − 1 leading-padding column
+  // (applied by `render_section`). Summary lines trim their variable parts
+  // (title / error blob) so the total visible width fits — without this,
+  // long PR titles would either overflow the block right border or be
+  // wrapped onto a second visual row that the `Constraint::Length` below
+  // never budgeted for, breaking the layout.
+  let issue_pr_inner_width = area.width.saturating_sub(3) as usize;
+  let issue_pr_lines = github_status_lines(app, issue_pr_inner_width);
 
   // Per-section block height = content rows + 2 border lines. Fixed for
   // the small sections (worktree / issue-PR / working-tree); Recent
@@ -981,29 +988,37 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
 
 /// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)
 /// is supplied by [`draw_sidebar`] via the surrounding `Block`, so this
-/// function only returns the content rows.
-pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
+/// function only returns the content rows. `max_width` is the inner
+/// width of the Issue / PR block (chunk width minus 2 borders and the
+/// 1-char left padding applied by [`render_section`]); summary lines
+/// trim their variable parts so total visible width ≤ `max_width`.
+pub(super) fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   let link = app.current_link();
   let mut lines: Vec<Line<'static>> = Vec::new();
 
   if link.issue.is_none() && link.pr.is_none() {
     lines.push(Line::from(Span::styled(
-      "no link · press L to link".to_string(),
+      trunc("no link · press L to link", max_width),
       Style::default().fg(Color::DarkGray),
     )));
     return lines;
   }
 
   if let Some(n) = link.issue {
-    lines.push(issue_summary_line(n, link.issue_source, app.issue_fetch_state()));
+    lines.push(issue_summary_line(
+      n,
+      link.issue_source,
+      app.issue_fetch_state(),
+      max_width,
+    ));
   }
   if let Some(n) = link.pr {
-    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state()));
+    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state(), max_width));
   }
   if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
   {
     lines.push(Line::from(Span::styled(
-      "press R to fetch status".to_string(),
+      trunc("press R to fetch status", max_width),
       Style::default().fg(Color::DarkGray),
     )));
   }
@@ -1018,11 +1033,21 @@ fn source_marker(s: LinkSource) -> &'static str {
   }
 }
 
-fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::IssueStatus>) -> Line<'static> {
+/// Render the Loaded / Idle / Loading / Error variants for an issue link
+/// row in the sidebar. `max_width` is the number of columns the line is
+/// allowed to occupy (sidebar inner width minus padding); the variable
+/// part (title or error blob) is trimmed so the total visible width
+/// stays ≤ `max_width`. Fixed elements (head, badge) are preserved.
+pub fn issue_summary_line(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::IssueStatus>,
+  max_width: usize,
+) -> Line<'static> {
   let head = format!("Issue #{}{}", n, source_marker(src));
   match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
-    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
     GitHubFetchState::Loaded(s) => {
       let badge_color = match s.state {
         IssueState::Open => Color::Green,
@@ -1032,6 +1057,18 @@ fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::g
         IssueState::Open => "open",
         IssueState::Closed => "closed",
       };
+      // Fixed prefix = "<head> [<badge>] " — try to preserve in full and
+      // trim the title to whatever budget remains. If the prefix alone
+      // already exceeds the width budget (very narrow sidebar), fall
+      // back to flattening the line into a single styled string and
+      // truncating it — preserves no badge color but stays inside the
+      // block.
+      let fixed = head.chars().count() + 4 + badge.chars().count(); // " [" + badge + "] "
+      if fixed >= max_width {
+        let raw = format!("{} [{}] {}", head, badge, s.title);
+        return Line::from(trunc(&raw, max_width));
+      }
+      let budget = max_width - fixed;
       Line::from(vec![
         Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         Span::raw(" ["),
@@ -1040,22 +1077,35 @@ fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::g
           Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
         ),
         Span::raw("] "),
-        Span::raw(trunc(&s.title, 40)),
+        Span::raw(trunc(&s.title, budget)),
       ])
     }
-    GitHubFetchState::Error(e) => Line::from(vec![
-      Span::styled(head, Style::default().fg(Color::White)),
-      Span::raw(" "),
-      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
-    ]),
+    GitHubFetchState::Error(e) => {
+      let fixed = head.chars().count() + 2; // " " + "!"
+      let budget = max_width.saturating_sub(fixed);
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White)),
+        Span::raw(" "),
+        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(Color::Red)),
+      ])
+    }
   }
 }
 
-fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::PrStatus>) -> Line<'static> {
+/// Render the Loaded / Idle / Loading / Error variants for a PR link
+/// row in the sidebar. See [`issue_summary_line`] for the `max_width`
+/// contract — same idea, with a `checks N/M` segment squeezed in between
+/// badge and title when the rollup is non-zero.
+pub fn pr_summary_line(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::PrStatus>,
+  max_width: usize,
+) -> Line<'static> {
   let head = format!("PR    #{}{}", n, source_marker(src));
   match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
-    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
     GitHubFetchState::Loaded(s) => {
       let (badge, badge_color) = match s.state {
         PrState::Open => ("open", Color::Green),
@@ -1068,6 +1118,14 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
       } else {
         String::new()
       };
+      let fixed = head.chars().count() + 3 + badge.chars().count() + checks.chars().count() + 1; // " [" + badge + "]" + checks + " "
+      if fixed >= max_width {
+        // Very narrow sidebar — fall back to a single truncated string.
+        // Drops the badge color but keeps the line inside the block.
+        let raw = format!("{} [{}]{} {}", head, badge, checks, s.title);
+        return Line::from(trunc(&raw, max_width));
+      }
+      let budget = max_width - fixed;
       Line::from(vec![
         Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         Span::raw(" ["),
@@ -1078,13 +1136,17 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
         Span::raw("]"),
         Span::raw(checks),
         Span::raw(" "),
-        Span::raw(trunc(&s.title, 36)),
+        Span::raw(trunc(&s.title, budget)),
       ])
     }
-    GitHubFetchState::Error(e) => Line::from(vec![
-      Span::styled(head, Style::default().fg(Color::White)),
-      Span::raw(" "),
-      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
-    ]),
+    GitHubFetchState::Error(e) => {
+      let fixed = head.chars().count() + 2; // " " + "!"
+      let budget = max_width.saturating_sub(fixed);
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White)),
+        Span::raw(" "),
+        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(Color::Red)),
+      ])
+    }
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -423,8 +423,25 @@ fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
 /// the path doesn't live under it.
 fn tilde_compress(path: &str) -> String {
   if let Some(home) = dirs::home_dir() {
-    let home_s = home.display().to_string();
-    if let Some(rest) = path.strip_prefix(&home_s) {
+    tilde_compress_with_home(path, &home)
+  } else {
+    path.to_string()
+  }
+}
+
+/// Pure variant of [`tilde_compress`] that takes the home directory
+/// explicitly. Exposed for tests — the production `tilde_compress`
+/// wrapper just looks up `dirs::home_dir()` and delegates.
+///
+/// Enforces a path-separator boundary at the end of the home prefix so
+/// `/home/al` does not slice into `/home/alice/repo` and produce
+/// `~ice/repo` (raised by PR #70 Copilot review).
+pub fn tilde_compress_with_home(path: &str, home: &std::path::Path) -> String {
+  let home_s = home.display().to_string();
+  if let Some(rest) = path.strip_prefix(&home_s) {
+    // Accept exact-home (`rest.is_empty()`) and home-followed-by-separator
+    // matches. Reject prefix matches that bleed into a longer dir name.
+    if rest.is_empty() || rest.starts_with('/') || rest.starts_with(std::path::MAIN_SEPARATOR) {
       return format!("~{}", rest);
     }
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -255,18 +255,36 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     .constraints(constraints)
     .split(area);
 
-  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0);
-  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0);
-  render_section(f, chunks[2], " Working Tree ", sections.working_tree, border_color, 0);
+  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0, None);
+  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
+  render_section(
+    f,
+    chunks[2],
+    " Working Tree ",
+    sections.working_tree,
+    border_color,
+    0,
+    None,
+  );
 
   // Recent Commits is the only scrollable section. Clamp the scroll
   // offset to its visible area so `j` / `k` can't scroll past the end.
+  // The block's bottom-right title mirrors lazygit's footer
+  // ("<i+1> of <N>") so the user can tell at a glance how much history
+  // is queued and where the viewport sits.
   let commits_area = chunks[3];
   let commits_visible = commits_area.height.saturating_sub(2);
-  app.sidebar_max_scroll = (sections.recent_commits.len() as u16).saturating_sub(commits_visible);
+  let commits_len = sections.recent_commits.len() as u16;
+  app.sidebar_max_scroll = commits_len.saturating_sub(commits_visible);
   if app.sidebar_scroll > app.sidebar_max_scroll {
     app.sidebar_scroll = app.sidebar_max_scroll;
   }
+  let footer = if commits_len == 0 {
+    None
+  } else {
+    let bottom = app.sidebar_scroll.saturating_add(commits_visible).min(commits_len);
+    Some(format!(" {} of {} ", bottom, commits_len))
+  };
   render_section(
     f,
     commits_area,
@@ -274,6 +292,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     sections.recent_commits,
     border_color,
     app.sidebar_scroll,
+    footer,
   );
 }
 
@@ -284,12 +303,16 @@ fn render_section(
   lines: Vec<Line<'static>>,
   border_color: Color,
   scroll: u16,
+  footer: Option<String>,
 ) {
-  let block = Block::default()
+  let mut block = Block::default()
     .borders(Borders::ALL)
     .border_type(BorderType::Rounded)
     .title(title)
     .border_style(Style::default().fg(border_color));
+  if let Some(f) = footer {
+    block = block.title_bottom(ratatui::text::Line::from(f).right_aligned());
+  }
   // Pad content with one leading space per line for breathing room against
   // the left border. Cheap and avoids per-call `format!` churn.
   let padded: Vec<Line<'static>> = lines
@@ -301,10 +324,10 @@ fn render_section(
       Line::from(spans)
     })
     .collect();
-  let paragraph = Paragraph::new(padded)
-    .block(block)
-    .wrap(Wrap { trim: false })
-    .scroll((scroll, 0));
+  // No `Wrap`: every section now relies on ratatui's view-level hard-clip,
+  // matching lazygit's commits panel and ensuring 1 logical row = 1 visual
+  // row (so the layout's `Constraint::Length` always matches what we draw).
+  let paragraph = Paragraph::new(padded).block(block).scroll((scroll, 0));
   f.render_widget(paragraph, area);
 }
 
@@ -317,7 +340,7 @@ pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
   SidebarSections {
     worktree: worktree_identity_lines(w),
     working_tree: working_tree_lines(w),
-    recent_commits: recent_commits_lines(w),
+    recent_commits: recent_commits_lines(w, RECENT_COMMITS_LIMIT),
   }
 }
 
@@ -411,9 +434,29 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   }
 }
 
-fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
-  match worktree::git_log_oneline(&w.path, 10) {
-    Ok(s) if !s.trim().is_empty() => s.lines().map(|l| Line::from(l.to_string())).collect(),
+/// Default number of commits pulled into the Recent Commits block — chosen
+/// to match lazygit's initial `git log -300` window so the panel stays
+/// dense on tall terminals without paginating.
+pub const RECENT_COMMITS_LIMIT: usize = 300;
+
+/// Number of hex chars rendered for each commit's SHA in the sidebar.
+/// Matches lazygit's `Gui.CommitHashLength` default of 8.
+pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
+
+/// Produce the styled rows of the Recent Commits sidebar block for a
+/// worktree, limited to `limit` entries. Each `Line` mirrors lazygit's
+/// per-row format:
+///
+/// ```text
+/// <8-char hash>  <author initials>  <subject>
+/// ```
+///
+/// The subject is **not** truncated here — the renderer relies on ratatui's
+/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
+/// commit per visual line, overflow cut at the right edge without `…`.
+pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
+  match worktree::git_log_with_author(&w.path, limit) {
+    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -422,6 +465,49 @@ fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
       format!("! {}", e),
       Style::default().fg(Color::Red),
     ))],
+  }
+}
+
+fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+  let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
+  let initials = author_initials(&row.author);
+  Line::from(vec![
+    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
+    Span::raw("  "),
+    Span::styled(
+      format!("{:<2}", initials),
+      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    ),
+    Span::raw("  "),
+    Span::raw(row.subject),
+  ])
+}
+
+/// Derive lazygit-style author initials from a full name. Mirrors
+/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+///
+/// - Empty → empty.
+/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
+/// - Single word → first 2 chars of that word.
+/// - ≥ 2 words → first char of split[0] + first char of split[1].
+///
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
+/// grapheme then char[0] of split[1]). Capped at 2 visible chars
+/// (`CommitAuthorShortLength` in lazygit).
+pub fn author_initials(author: &str) -> String {
+  let trimmed = author.trim();
+  if trimmed.is_empty() {
+    return String::new();
+  }
+  let mut parts = trimmed.split_whitespace();
+  let first = parts.next().unwrap_or("");
+  match parts.next() {
+    Some(second) => {
+      let a: String = first.chars().take(1).collect();
+      let b: String = second.chars().take(1).collect();
+      format!("{}{}", a, b)
+    }
+    None => first.chars().take(2).collect(),
   }
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -256,9 +256,12 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// A commit row pulled from `git log` for the Recent Commits sidebar block.
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
-/// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
-/// a merge commit, which the renderer marks with `◎` instead of `○`.
+/// 40-char SHAs; the renderer trims them on display to a fixed length
+/// (the `COMMIT_HASH_DISPLAY_LEN` constant in `src/tui/ui.rs`, currently
+/// 8 chars, matching lazygit's `Gui.CommitHashLength` default). Not
+/// user-configurable today — change the constant to retune.
+/// `parents.len() >= 2` flags a merge commit, which the renderer marks
+/// with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -257,24 +257,28 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
 /// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit).
+/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
+/// a merge commit, which the renderer marks with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,
   pub author: String,
+  pub parents: Vec<String>,
   pub subject: String,
 }
 
-/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
-/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
-/// this for the Recent Commits block — the NUL separator avoids ambiguity
-/// when a subject contains the usual ` `, `|`, or tab characters lazygit
-/// also relies on.
+/// Shell out to `git log --format='%H%x00%aN%x00%P%x00%s' -n <n>` inside
+/// `path` and parse the NUL-separated output into [`CommitRow`]s. The TUI
+/// sidebar uses this for the Recent Commits block — the NUL separator
+/// avoids ambiguity when a subject contains the usual ` `, `|`, or tab
+/// characters lazygit also relies on. The `%P` field carries the
+/// space-separated list of parent SHAs (empty for the seed commit, one for
+/// a normal commit, two-plus for a merge).
 pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let output = Command::new("git")
     .arg("-C")
     .arg(path)
-    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .args(["log", "--format=%H%x00%aN%x00%P%x00%s", "-n"])
     .arg(n.to_string())
     .output()
     .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
@@ -288,14 +292,21 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let raw = String::from_utf8_lossy(&output.stdout).into_owned();
   let mut rows = Vec::new();
   for line in raw.lines() {
-    let mut parts = line.splitn(3, '\u{0}');
+    let mut parts = line.splitn(4, '\u{0}');
     let hash = parts.next().unwrap_or("").to_string();
     let author = parts.next().unwrap_or("").to_string();
+    let parents_field = parts.next().unwrap_or("");
     let subject = parts.next().unwrap_or("").to_string();
     if hash.is_empty() {
       continue;
     }
-    rows.push(CommitRow { hash, author, subject });
+    let parents: Vec<String> = parents_field.split_whitespace().map(|s| s.to_string()).collect();
+    rows.push(CommitRow {
+      hash,
+      author,
+      parents,
+      subject,
+    });
   }
   Ok(rows)
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -253,6 +253,53 @@ pub fn prune(repo: &Repository) -> Result<usize> {
   Ok(pruned)
 }
 
+/// A commit row pulled from `git log` for the Recent Commits sidebar block.
+/// Mirrors lazygit's columnar layout (hash + author + subject) so the
+/// renderer can lay out one commit per visual line. Hashes are full
+/// 40-char SHAs; the renderer trims them to the configured display
+/// length (default 8 chars, à la lazygit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRow {
+  pub hash: String,
+  pub author: String,
+  pub subject: String,
+}
+
+/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
+/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
+/// this for the Recent Commits block — the NUL separator avoids ambiguity
+/// when a subject contains the usual ` `, `|`, or tab characters lazygit
+/// also relies on.
+pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .arg(n.to_string())
+    .output()
+    .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::Other(format!(
+      "git log exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+  let mut rows = Vec::new();
+  for line in raw.lines() {
+    let mut parts = line.splitn(3, '\u{0}');
+    let hash = parts.next().unwrap_or("").to_string();
+    let author = parts.next().unwrap_or("").to_string();
+    let subject = parts.next().unwrap_or("").to_string();
+    if hash.is_empty() {
+      continue;
+    }
+    rows.push(CommitRow { hash, author, subject });
+  }
+  Ok(rows)
+}
+
 /// Shell out to `git log --oneline -n <n>` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview recent commits of the selected worktree.
 pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1882,6 +1882,171 @@ fn recent_commits_line_marks_merge_commit_with_bullseye() {
   );
 }
 
+// ---- Commit graph topology (lazygit port — pipes + connectors) ---------
+
+use gwm::tui::commit_graph::{box_drawing_chars, build_pipe_sets, render_commits, render_pipe_set, test_row, PipeKind};
+
+fn spans_to_text(spans: &[ratatui::text::Span<'static>]) -> String {
+  spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+#[allow(clippy::type_complexity)]
+fn graph_glyph_table_matches_lazygit_truth_table() {
+  // 16-case ground truth ported verbatim from
+  // `lazygit/pkg/gui/presentation/graph/cell.go::getBoxDrawingChars`.
+  // If any of these flip, the entire graph rendering will silently shift.
+  let cases: &[((bool, bool, bool, bool), (char, char))] = &[
+    ((true, true, true, true), ('│', '─')),
+    ((true, true, true, false), ('│', ' ')),
+    ((true, true, false, true), ('│', '─')),
+    ((true, true, false, false), ('│', ' ')),
+    ((true, false, true, true), ('┴', '─')),
+    ((true, false, true, false), ('╯', ' ')),
+    ((true, false, false, true), ('╰', '─')),
+    ((true, false, false, false), ('╵', ' ')),
+    ((false, true, true, true), ('┬', '─')),
+    ((false, true, true, false), ('╮', ' ')),
+    ((false, true, false, true), ('╭', '─')),
+    ((false, true, false, false), ('╷', ' ')),
+    ((false, false, true, true), ('─', '─')),
+    ((false, false, true, false), ('─', ' ')),
+    ((false, false, false, true), ('╶', '─')),
+    ((false, false, false, false), (' ', ' ')),
+  ];
+  for &((u, d, l, r), expected) in cases {
+    assert_eq!(
+      box_drawing_chars(u, d, l, r),
+      expected,
+      "case ({}, {}, {}, {}) — expected {:?}",
+      u,
+      d,
+      l,
+      r,
+      expected
+    );
+  }
+}
+
+#[test]
+fn graph_linear_history_emits_single_column_circles() {
+  // Three commits, each pointing at the next: c (parent b) → b (parent a) → a (no parent).
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  assert_eq!(graphs.len(), 3);
+  // Each row should be a 2-cell render (one column → 2 chars).
+  for (idx, g) in graphs.iter().enumerate() {
+    let text = spans_to_text(g);
+    assert!(
+      text.contains('○'),
+      "linear history row {} must carry a ○ node, got {:?}",
+      idx,
+      text
+    );
+    assert!(
+      !text.contains('◎'),
+      "linear history row {} must NOT carry a ◎ merge node, got {:?}",
+      idx,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_merge_commit_carries_bullseye_and_branch_corners() {
+  // Topology:
+  //   c (merge: parents = a, b)
+  //   b (parent a)         ← side branch
+  //   a (no parent)        ← trunk root
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  // Row 0 = merge commit, must carry ◎.
+  let merge_text = spans_to_text(&graphs[0]);
+  assert!(merge_text.contains('◎'), "merge row must carry ◎, got {:?}", merge_text);
+  // Row 1 (the side branch) must spawn somewhere outside column 0 —
+  // there should be a `╮` corner on row 0 to drop the second parent
+  // into a fresh column.
+  assert!(
+    merge_text.contains('╮') || merge_text.contains('─'),
+    "merge row must carry a corner / horizontal stroke into the new branch column, got {:?}",
+    merge_text
+  );
+}
+
+#[test]
+fn graph_pipe_set_first_commit_seeds_starts_pipe() {
+  // Internal invariant: the first row's pipe set must contain a STARTS
+  // pipe for the first commit, regardless of how many parents it has.
+  let rows = vec![test_row("a", &["b"])];
+  let pipes = build_pipe_sets(&rows);
+  assert_eq!(pipes.len(), 1);
+  assert!(
+    pipes[0]
+      .iter()
+      .any(|p| p.kind == PipeKind::Starts && p.from_hash == "a"),
+    "first row must contain a STARTS pipe whose from_hash is the commit itself, got {:?}",
+    pipes[0]
+  );
+}
+
+#[test]
+fn graph_pipe_set_merge_commit_emits_extra_starts_per_parent() {
+  // A merge with 2 parents should emit 2 STARTS pipes whose from_pos is
+  // the commit's column and to_pos points at distinct columns.
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let pipes = build_pipe_sets(&rows);
+  let row0 = &pipes[0];
+  let starts: Vec<_> = row0.iter().filter(|p| p.kind == PipeKind::Starts).collect();
+  assert_eq!(
+    starts.len(),
+    2,
+    "merge row must emit 2 STARTS pipes (one per parent), got {} ({:?})",
+    starts.len(),
+    starts
+  );
+}
+
+#[test]
+fn graph_render_pipe_set_empty_input_returns_empty() {
+  let graphs = render_commits(&[]);
+  assert!(graphs.is_empty());
+}
+
+#[test]
+fn graph_row_width_is_deterministic_on_commit_list() {
+  // The graph width is `2 * (max_pos + 1)` chars, derived from pipe
+  // topology — it must NOT depend on terminal width or external state.
+  // Snapshot the linear-history width so a regression caught quickly.
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  for g in &graphs {
+    let text = spans_to_text(g);
+    let chars = text.chars().count();
+    assert!(
+      (1..=8).contains(&chars),
+      "linear-history row must render in ≤ 8 chars, got {} ({:?})",
+      chars,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_render_pipe_set_handles_single_pipe_starts() {
+  use gwm::tui::commit_graph::Pipe;
+  let pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: "a".into(),
+    to_hash: "b".into(),
+    kind: PipeKind::Starts,
+  }];
+  let spans = render_pipe_set(&pipes);
+  let text = spans_to_text(&spans);
+  // Cell 0: ○ + filler (space, since right has no neighbor)
+  assert!(text.starts_with('○'), "expected ○ glyph at column 0, got {:?}", text);
+}
+
 #[test]
 fn recent_commits_line_marks_normal_commit_with_open_circle() {
   let (dir, _repo) = init_repo();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -274,11 +274,11 @@ fn next_prev_invalidate_sidebar_cache() {
   // Moving selection must drop any cached sidebar content so the new
   // worktree's preview is recomputed on the next frame.
   let (_dir, mut app) = make_app();
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.next();
   assert!(app.sidebar_cache.is_none(), "next() must invalidate the sidebar cache");
 
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.prev();
   assert!(app.sidebar_cache.is_none(), "prev() must invalidate the sidebar cache");
 }
@@ -286,7 +286,7 @@ fn next_prev_invalidate_sidebar_cache() {
 #[test]
 fn refresh_invalidates_sidebar_cache() {
   let (_dir, mut app) = make_app();
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.refresh().unwrap();
   assert!(app.sidebar_cache.is_none());
 }
@@ -1301,5 +1301,145 @@ fn refresh_github_status_message_celebrates_full_success() {
     app.status.to_lowercase().contains("refreshed") || app.status.to_lowercase().contains("ok"),
     "all-green refresh should signal success: {}",
     app.status
+  );
+}
+
+// ---- Sidebar sections (Option C — bordered subsections, no Commands block) ----
+
+use gwm::tui::build_sidebar_sections;
+
+fn detailed_worktree_fixture() -> WorktreeInfo {
+  WorktreeInfo {
+    name: "api-rest".into(),
+    path: PathBuf::from("/Users/test/cc-worktree/api-rest"),
+    branch: Some("feat/#42-api-rest".into()),
+    head: Some("08d1029f1234567890abcdef".into()),
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus {
+      is_dirty: false,
+      has_upstream: true,
+      ahead: 0,
+      behind: 0,
+      unknown: false,
+    },
+  }
+}
+
+fn section_text(lines: &[ratatui::text::Line<'static>]) -> String {
+  lines
+    .iter()
+    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+    .collect::<Vec<_>>()
+    .join("")
+}
+
+#[test]
+fn sidebar_sections_omit_commands_block() {
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let all = format!(
+    "{}\n{}\n{}",
+    section_text(&sections.worktree),
+    section_text(&sections.working_tree),
+    section_text(&sections.recent_commits),
+  );
+  assert!(
+    !all.contains("Commands"),
+    "the Commands cheat-sheet block must be removed (lives in ? help); got: {}",
+    all
+  );
+  assert!(
+    !all.contains("Bootstrap worktree"),
+    "help-overlay phrasing must not leak into the sidebar: {}",
+    all
+  );
+  assert!(
+    !all.contains("Toggle this sidebar"),
+    "help-overlay phrasing must not leak into the sidebar: {}",
+    all
+  );
+}
+
+#[test]
+fn sidebar_sections_omit_inline_section_headers() {
+  // The new layout puts section titles on the Block borders, so the inline
+  // `Basic Settings:` / `Recent commits:` / `Working tree:` headers must
+  // disappear from the content lines.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let all = format!(
+    "{}\n{}\n{}",
+    section_text(&sections.worktree),
+    section_text(&sections.working_tree),
+    section_text(&sections.recent_commits),
+  );
+  assert!(!all.contains("Basic Settings:"), "got: {}", all);
+  assert!(!all.contains("Recent commits:"), "got: {}", all);
+  assert!(!all.contains("Working tree:"), "got: {}", all);
+}
+
+#[test]
+fn sidebar_worktree_section_is_compact_identity() {
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let text = section_text(&sections.worktree);
+
+  assert!(text.contains("api-rest"), "name on top line: {}", text);
+  assert!(text.contains("feat/#42-api-rest"), "branch shown: {}", text);
+  assert!(text.contains("08d1029"), "short head shown: {}", text);
+  assert!(
+    text.contains("synced") || text.contains("✓"),
+    "synced state badge shown: {}",
+    text
+  );
+  assert!(
+    text.contains("main") || text.contains("★"),
+    "main badge shown: {}",
+    text
+  );
+}
+
+#[test]
+fn sidebar_worktree_section_short_enough_for_compact_layout() {
+  // Compact identity block: name, branch · head, badges, path → 4 lines target.
+  // Allow ≤5 to leave headroom for variable badges.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  assert!(
+    sections.worktree.len() <= 5,
+    "compact worktree block must stay ≤5 lines (target 4), got {}: {:?}",
+    sections.worktree.len(),
+    sections.worktree.iter().map(section_text_single).collect::<Vec<_>>()
+  );
+}
+
+fn section_text_single(l: &ratatui::text::Line<'static>) -> String {
+  l.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+fn sidebar_worktree_section_skips_irrelevant_badges() {
+  // A non-main, unlocked, non-prunable worktree should NOT advertise
+  // those flags — only the ones that are true add visual noise.
+  let mut w = detailed_worktree_fixture();
+  w.is_main = false;
+  let sections = build_sidebar_sections(&w);
+  let text = section_text(&sections.worktree);
+  assert!(
+    !text.contains("★ main"),
+    "non-main worktree must not show ★ main: {}",
+    text
+  );
+  assert!(
+    !text.contains("locked"),
+    "unlocked worktree must not show locked badge: {}",
+    text
+  );
+  assert!(
+    !text.contains("prunable"),
+    "non-prunable worktree must not show prunable badge: {}",
+    text
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1443,3 +1443,59 @@ fn sidebar_worktree_section_skips_irrelevant_badges() {
     text
   );
 }
+
+#[test]
+fn sidebar_worktree_badge_uses_divergence_sigil_when_ahead() {
+  // Regression: PR #70 review (Copilot) flagged that a non-dirty/non-unknown
+  // status always rendered `✓ <label>`, which produced misleading badges like
+  // `✓ ↑2` for branches that were *ahead* of upstream. The `✓` is reserved
+  // for synced / clean — divergence must use `↑` / `↓` / `⇅` (or no sigil).
+  let mut w = detailed_worktree_fixture();
+  w.status = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 2,
+    behind: 0,
+    unknown: false,
+  };
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(
+    !badge.contains("✓"),
+    "ahead-only branch must not display the synced/clean ✓ sigil: {}",
+    badge
+  );
+  assert!(badge.contains("↑2"), "ahead label must still be visible: {}", badge);
+}
+
+#[test]
+fn sidebar_worktree_badge_uses_divergence_sigil_when_behind() {
+  let mut w = detailed_worktree_fixture();
+  w.status = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 3,
+    unknown: false,
+  };
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(
+    !badge.contains("✓"),
+    "behind-only branch must not display the synced/clean ✓ sigil: {}",
+    badge
+  );
+  assert!(badge.contains("↓3"), "behind label must still be visible: {}", badge);
+}
+
+#[test]
+fn sidebar_worktree_badge_keeps_check_sigil_when_synced() {
+  // Sanity: the fixture has `has_upstream=true, ahead=0, behind=0` so the
+  // synced label *should* still display `✓`. Guards against an over-eager
+  // fix that would drop the sigil everywhere.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(badge.contains("✓"), "synced branch must keep the ✓ sigil: {}", badge);
+  assert!(badge.contains("synced"), "label must still say synced: {}", badge);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1772,6 +1772,23 @@ fn author_initials_empty_returns_empty() {
 }
 
 #[test]
+fn author_initials_takes_first_unicode_scalar_per_token() {
+  // Documented divergence from lazygit (PR #72 Copilot review): gwm's
+  // `author_initials` uses `str::chars()` and slices on Unicode scalar
+  // values, NOT grapheme clusters. Single-scalar emoji ("🦀") survive
+  // intact, but multi-scalar grapheme clusters like the French flag
+  // "🇫🇷" (two regional indicators) are split — only the first scalar
+  // makes it into the initials. Pinning this so a future contributor
+  // doesn't quietly break it by adopting a grapheme-aware crate.
+  assert_eq!(author_initials("🦀 Crab"), "🦀C");
+  assert_eq!(
+    author_initials("🇫🇷 Bardini"),
+    "🇫B",
+    "two-scalar grapheme cluster (flag) is intentionally split per scalar"
+  );
+}
+
+#[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly
   // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1858,7 +1858,10 @@ fn commit_row_carries_parent_hashes() {
 }
 
 #[test]
-fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+fn recent_commits_line_marks_merge_commit_with_bullseye() {
+  // U+25CE ◎ is named "BULLSEYE" in Unicode — it is what lazygit uses
+  // for `MergeSymbol`. The previous test name said "diamond" which
+  // was geometrically wrong; this name pins the actual glyph.
   let (dir, repo) = init_repo();
   add_merge_commit(&repo);
   let w = worktree_pointing_at_dir(dir.path());
@@ -1874,7 +1877,7 @@ fn recent_commits_line_marks_merge_commit_with_open_diamond() {
   let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
   assert!(
     joined.contains('◎'),
-    "merge row must carry the ◎ marker, got: {}",
+    "merge row must carry the ◎ bullseye marker, got: {}",
     joined
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1648,3 +1648,188 @@ fn issue_summary_line_truncates_error_state_to_budget() {
   let width = line_visible_width(&line);
   assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
 }
+
+// ---- Recent Commits panel: lazygit-style fill + clip (issue #71) ---------
+
+use gwm::tui::{recent_commits_lines, RECENT_COMMITS_LIMIT};
+
+fn add_commits(repo: &git2::Repository, count: usize) {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  for i in 0..count {
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(Some("HEAD"), &sig, &sig, &format!("commit-{}", i), &tree, &[&parent])
+      .unwrap();
+  }
+}
+
+fn worktree_pointing_at_dir(dir: &std::path::Path) -> WorktreeInfo {
+  WorktreeInfo {
+    name: "test".into(),
+    path: dir.to_path_buf(),
+    branch: Some("main".into()),
+    head: None,
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus::default(),
+  }
+}
+
+#[test]
+fn recent_commits_lines_respects_limit_when_repo_has_more() {
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 14); // 15 total commits (1 seed + 14)
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 5);
+  assert_eq!(
+    lines.len(),
+    5,
+    "limit=5 must produce exactly 5 lines, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+fn recent_commits_lines_returns_all_when_under_limit() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 100);
+  assert_eq!(
+    lines.len(),
+    1,
+    "init_repo has 1 commit, asking for 100 should still return 1, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+#[allow(clippy::assertions_on_constants)] // intentional const pin
+fn recent_commits_default_limit_fills_modern_terminal_heights() {
+  // Regression: the previous hardcoded limit of 10 left the bottom of tall
+  // sidebars empty. On a 50-line terminal, the Recent Commits block gets
+  // ~12–18 rows after the small fixed sections take their slice; on a
+  // 100-line terminal it gets ~70+. Keep the default generous so the
+  // block fills the panel without re-shelling git on scroll. A future
+  // contributor that lowers the constant will trip this test.
+  assert!(
+    RECENT_COMMITS_LIMIT >= 50,
+    "RECENT_COMMITS_LIMIT must be ≥ 50 to fill a typical sidebar, got {}",
+    RECENT_COMMITS_LIMIT
+  );
+}
+
+#[test]
+fn build_sidebar_sections_fetches_up_to_default_recent_commits_limit() {
+  // Wire-up smoke: build_sidebar_sections must use RECENT_COMMITS_LIMIT (or
+  // higher) so the cached section is dense enough to fill a tall panel.
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 30); // 31 total commits
+  let w = worktree_pointing_at_dir(dir.path());
+  let sections = build_sidebar_sections(&w);
+  assert_eq!(
+    sections.recent_commits.len(),
+    31,
+    "expected all 31 commits to be cached (default limit ≥ 50 ≥ 31), got {}",
+    sections.recent_commits.len()
+  );
+}
+
+// ---- lazygit-style row format (hash + initials + subject) ----------------
+
+use gwm::tui::{author_initials, COMMIT_HASH_DISPLAY_LEN};
+
+#[test]
+fn author_initials_two_word_name_picks_first_letters_of_each() {
+  assert_eq!(author_initials("Kylian Bardini"), "KB");
+  assert_eq!(author_initials("Jesse Duffield"), "JD");
+}
+
+#[test]
+fn author_initials_single_word_takes_first_two_chars() {
+  assert_eq!(author_initials("Linus"), "Li");
+  assert_eq!(author_initials("kb"), "kb");
+}
+
+#[test]
+fn author_initials_three_or_more_words_only_uses_first_two() {
+  // Lazygit caps the result at 2 chars regardless of token count.
+  assert_eq!(author_initials("Jean-Paul Marie Dupont"), "JM");
+}
+
+#[test]
+fn author_initials_strips_leading_whitespace() {
+  assert_eq!(author_initials("  Kylian Bardini"), "KB");
+}
+
+#[test]
+fn author_initials_empty_returns_empty() {
+  assert_eq!(author_initials(""), "");
+  assert_eq!(author_initials("   "), "");
+}
+
+#[test]
+fn recent_commits_line_starts_with_short_hash() {
+  // The first span of every row must be a hash of exactly
+  // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  assert_eq!(lines.len(), 1, "init_repo should produce 1 commit");
+  let head_span = lines[0]
+    .spans
+    .first()
+    .expect("commit row must carry at least the hash span");
+  assert_eq!(
+    head_span.content.chars().count(),
+    COMMIT_HASH_DISPLAY_LEN,
+    "expected hash span of {} chars, got {:?}",
+    COMMIT_HASH_DISPLAY_LEN,
+    head_span.content
+  );
+  // Must be all-hex.
+  assert!(
+    head_span.content.chars().all(|c| c.is_ascii_hexdigit()),
+    "expected hex hash, got {:?}",
+    head_span.content
+  );
+}
+
+#[test]
+fn recent_commits_line_includes_author_initials_after_hash() {
+  // init_repo signs commits as "gwm-test" — a single token → first 2 chars.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  // Initials live as a styled span after the hash + double space.
+  assert!(
+    joined.contains("gw"),
+    "expected 'gw' initials from 'gwm-test', got {:?}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_carries_subject_unclipped() {
+  // The renderer relies on ratatui's view-level clip — `recent_commits_lines`
+  // itself must NOT pre-truncate the subject (otherwise scrollback / wider
+  // sidebars would lose information). Verify the full subject is preserved.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains("init"),
+    "expected the seed 'init' subject, got {:?}",
+    joined
+  );
+  assert!(
+    !joined.contains('…'),
+    "must not pre-emptively truncate with ellipsis: {:?}",
+    joined
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1788,6 +1788,115 @@ fn author_initials_takes_first_unicode_scalar_per_token() {
   );
 }
 
+// ---- Graph node markers (○ commit, ◎ merge) -----------------------------
+
+fn add_merge_commit(repo: &git2::Repository) -> git2::Oid {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+
+  // Start from current HEAD. Create a sibling branch with one commit, then
+  // merge it back into HEAD with a true 2-parent merge commit.
+  let base = repo.head().unwrap().peel_to_commit().unwrap();
+  let branch_name = "tmp-side";
+  repo.branch(branch_name, &base, false).unwrap();
+  // Side commit.
+  let side_oid = {
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(
+        Some(&format!("refs/heads/{}", branch_name)),
+        &sig,
+        &sig,
+        "side",
+        &tree,
+        &[&base],
+      )
+      .unwrap()
+  };
+  let side = repo.find_commit(side_oid).unwrap();
+  // Merge commit on HEAD with two parents.
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo
+    .commit(
+      Some("HEAD"),
+      &sig,
+      &sig,
+      "merge: side into trunk",
+      &tree,
+      &[&base, &side],
+    )
+    .unwrap()
+}
+
+#[test]
+fn commit_row_carries_parent_hashes() {
+  // Regression: the renderer needs the parent count to pick ○ vs ◎.
+  // git_log_with_author must surface the parent list, not flatten it.
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo); // adds two extra commits (side + merge)
+  let rows = gwm::worktree::git_log_with_author(dir.path(), 10).unwrap();
+  // First row = merge commit (HEAD), should have 2 parents.
+  assert!(!rows.is_empty(), "expected at least 1 commit");
+  assert_eq!(
+    rows[0].parents.len(),
+    2,
+    "HEAD is a merge commit and must surface both parents, got {:?}",
+    rows[0].parents
+  );
+  // The seed `init` commit has no parent.
+  let seed = rows
+    .iter()
+    .find(|r| r.subject == "init")
+    .expect("seed commit must be in log");
+  assert!(
+    seed.parents.is_empty(),
+    "seed commit has no parents, got {:?}",
+    seed.parents
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo);
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 10);
+  // Find the merge commit row by subject; assert it carries ◎ somewhere.
+  let merge = lines
+    .iter()
+    .find(|l| {
+      let joined: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+      joined.contains("merge: side into trunk")
+    })
+    .expect("merge row must be present");
+  let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('◎'),
+    "merge row must carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_normal_commit_with_open_circle() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('○'),
+    "non-merge row must carry the ○ marker, got: {}",
+    joined
+  );
+  assert!(
+    !joined.contains('◎'),
+    "non-merge row must NOT carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
 #[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1499,3 +1499,38 @@ fn sidebar_worktree_badge_keeps_check_sigil_when_synced() {
   assert!(badge.contains("✓"), "synced branch must keep the ✓ sigil: {}", badge);
   assert!(badge.contains("synced"), "label must still say synced: {}", badge);
 }
+
+// ---- tilde_compress path-boundary safety (PR #70 review, Copilot) -------
+
+use gwm::tui::tilde_compress_with_home;
+
+#[test]
+fn tilde_compress_does_not_slice_across_path_boundaries() {
+  // Regression: PR #70 review (Copilot) flagged that string `strip_prefix`
+  // on the rendered home dir would slice into longer directory names that
+  // merely *start with* the same characters — e.g. home `/home/al` would
+  // turn `/home/alice/repo` into `~ice/repo`. The compression must only
+  // fire when the prefix ends at a path separator boundary.
+  let home = std::path::Path::new("/home/al");
+  assert_eq!(
+    tilde_compress_with_home("/home/alice/repo", home),
+    "/home/alice/repo",
+    "must not slice across the `alice` directory name"
+  );
+}
+
+#[test]
+fn tilde_compress_compresses_exact_home_match() {
+  let home = std::path::Path::new("/home/alice");
+  assert_eq!(tilde_compress_with_home("/home/alice", home), "~");
+  assert_eq!(tilde_compress_with_home("/home/alice/repo", home), "~/repo");
+  assert_eq!(tilde_compress_with_home("/home/alice/repo/sub", home), "~/repo/sub");
+}
+
+#[test]
+fn tilde_compress_falls_back_when_path_outside_home() {
+  let home = std::path::Path::new("/home/alice");
+  assert_eq!(tilde_compress_with_home("/var/log/x", home), "/var/log/x");
+  // Sibling directory starting with the same letters → no match.
+  assert_eq!(tilde_compress_with_home("/home/alicent/x", home), "/home/alicent/x");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1534,3 +1534,117 @@ fn tilde_compress_falls_back_when_path_outside_home() {
   // Sibling directory starting with the same letters → no match.
   assert_eq!(tilde_compress_with_home("/home/alicent/x", home), "/home/alicent/x");
 }
+
+// ---- Issue / PR summary line width budgeting ----------------------------
+
+use gwm::tui::{issue_summary_line, pr_summary_line};
+
+fn line_visible_width(line: &ratatui::text::Line<'static>) -> usize {
+  line.spans.iter().map(|s| s.content.chars().count()).sum()
+}
+
+#[test]
+fn issue_summary_line_truncates_loaded_state_to_budget() {
+  // Regression: with a 48-column sidebar, a fully-loaded issue line was
+  // `#67 (auto) [open] <40-char title>` ≈ 58 chars, overflowing the
+  // Issue/PR block and forcing ratatui's `Wrap` to push the title onto a
+  // second visual row that the layout's `Constraint::Length` didn't
+  // budget for. The Loaded variant must keep the head + badge prefix
+  // intact and trim the title so the total ≤ max_width.
+  let status = gwm::github::IssueStatus {
+    number: 828,
+    title:
+      "Stats: subscriptions distribution across schools and individual customers (very long title to force truncation)"
+        .into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  };
+  let line = issue_summary_line(
+    828,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    30,
+  );
+  let width = line_visible_width(&line);
+  assert!(
+    width <= 30,
+    "loaded issue line must fit in 30 cols, got {}: {:?}",
+    width,
+    line.spans.iter().map(|s| s.content.as_ref()).collect::<Vec<_>>()
+  );
+  // Ellipsis confirms the title was actually trimmed (not just clipped).
+  let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(joined.ends_with('…'), "expected trailing ellipsis: {}", joined);
+}
+
+#[test]
+fn pr_summary_line_truncates_loaded_state_to_budget() {
+  let status = gwm::github::PrStatus {
+    number: 70,
+    title: "feat(tui): redesign Details sidebar with bordered subsections and four cards".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 3,
+    checks_total: 3,
+    updated_at: String::new(),
+  };
+  let line = pr_summary_line(
+    70,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    35,
+  );
+  let width = line_visible_width(&line);
+  assert!(
+    width <= 35,
+    "loaded PR line must fit in 35 cols, got {}: {:?}",
+    width,
+    line.spans.iter().map(|s| s.content.as_ref()).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn issue_summary_line_keeps_short_title_intact() {
+  // Sanity: budget large enough → no truncation, no spurious ellipsis.
+  let status = gwm::github::IssueStatus {
+    number: 1,
+    title: "short".into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  };
+  let line = issue_summary_line(
+    1,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Loaded(status),
+    80,
+  );
+  let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains("short"),
+    "short title must not be truncated: {}",
+    joined
+  );
+  assert!(
+    !joined.contains('…'),
+    "no ellipsis when budget exceeds content: {}",
+    joined
+  );
+}
+
+#[test]
+fn issue_summary_line_truncates_error_state_to_budget() {
+  let line = issue_summary_line(
+    42,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Error(
+      "gh: API rate limit exceeded for user, retry after 60s with exponential backoff please".into(),
+    ),
+    30,
+  );
+  let width = line_visible_width(&line);
+  assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
+}


### PR DESCRIPTION
## Description

Re-architect the TUI Details sidebar into four independent rounded-border subsections — `Worktree` / `Issue / PR` / `Working Tree` / `Recent Commits` — dropping the outer `Details` frame to reclaim vertical space. Removes the 15-line `Commands:` cheat-sheet (it duplicated the `?` help overlay and pushed the `Issue / PR` block off-screen on common terminals).

Closes #69

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **TUI sidebar layout** — `src/tui/ui.rs::draw_sidebar` now splits its area into four `Layout` chunks, each rendered with its own `Block::default().borders(ALL).border_type(Rounded).title(...)`. Scroll is restricted to `Recent Commits`; the small fixed sections (Worktree / Issue PR / Working Tree) stay pinned.
- **Compact Worktree identity card** — name (bold), `<branch> · <short head>`, status badge + optional `★ main` / `🔒 locked` / `⚠ prunable` (skipped when false), tilde-compressed path. Drops the `Main: false` / `Locked: false` / `Prunable: false` lines.
- **`Commands:` block removed** — keybindings live in `?` (View::Help) only. Saves ~15 vertical lines.
- **New public `SidebarSections` struct + `build_sidebar_sections` helper** exported via `gwm::tui::{SidebarSections, build_sidebar_sections}` so integration tests can pin the new structure without going through `Frame` rendering.
- **`github_status_lines` cleanup** — drops the redundant `─── Issue / PR ───` content header (now carried by the block title) and the spurious double-indent.
- **5 new tests** in `tests/tui_app_tests.rs` pinning the contract: no `Commands` block, no inline `Basic Settings:` / `Recent commits:` / `Working tree:` content headers, compact identity (≤5 lines), badges only when relevant.
- **`skills/SKILL.md` refresh** for 0.6.0-rc.1 (new subcommands, composable `when` predicates, `[doctor]` / `[tui]` config, opt-in pre-commit hook, updated triggers).
- **`CHANGELOG.md > [Unreleased]`** updated under `Changed`, `Removed`, `Docs`.

## Tests

- [x] `cargo test` passes locally — **321 passed, 0 failed** (was 316 → +5 sidebar tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: tests written first, failed against missing `build_sidebar_sections`, then implementation made them green)

## Screenshots / TUI captures

**Before** (at 80 cols → sidebar auto-hidden; at 120+ cols, the wall of text):

```
┌ Details ────────────────────────────────────┐
│ fiches-pedagogiques-api-rest                │
│                                             │
│ Basic Settings:                             │
│   Branch: dev                               │
│   Path: /Users/kbrdn1/Projects/Flippad/…    │
│   Head: 08d1029                             │
│   Main: true                                │
│   Locked: false                             │
│   Prunable: false                           │
│   Status: synced                            │
│                                             │
│ Recent commits:                             │
│   08d1029 …                                 │
│   …                                         │
│                                             │
│ Working tree:                               │
│   ✓ clean                                   │
│                                             │
│ Commands:                                   │
│   Enter: Copy path to status                │
│   l: Launch lazygit fullscreen              │
│   o: Open dir in OS file manager            │
│   b: Bootstrap worktree                     │
│   n: New worktree                           │
│   d: Delete worktree                        │
│   p: Toggle delete-branch-on-remove         │
│   r: Refresh                                │
│   v: Toggle this sidebar                    │
│   Tab: Swap focus list ↔ sidebar            │
│   /: Fuzzy filter worktrees                 │
│   gg: Jump to first worktree                │
│   G: Jump to last worktree                  │
│   j/k: Next / Prev (or scroll sidebar)      │
│   ?: Help                                   │
│   q: Quit                                   │
│                                             │
│ ─── Issue / PR ───                          │
│   no link · press L to link                 │
└─────────────────────────────────────────────┘
```

**After**:

```
╭─ Worktree ──────────────────────────────────╮
│ fiches-pedagogiques-api-rest                │
│ dev  ·  08d1029                             │
│ ✓ synced  ★ main                            │
│ ~/Projects/Flippad/…/api-rest               │
╰─────────────────────────────────────────────╯
╭─ Issue / PR ────────────────────────────────╮
│ no link · press L to link                   │
╰─────────────────────────────────────────────╯
╭─ Working Tree ──────────────────────────────╮
│ ✓ clean                                     │
╰─────────────────────────────────────────────╯
╭─ Recent Commits ────────────────────────────╮
│ 08d1029 …                                   │
│ 4d874e7 …                                   │
│ …                                           │
╰─────────────────────────────────────────────╯
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` → `feat/#69-tui-details-redesign`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md) — 4 atomic commits split by concern (feat / test / docs-skill / docs-changelog)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — N/A (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed — N/A (no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #69
- Related PR: #67 (Issue / PR linking — this PR makes that work readable on common terminal sizes)