### PR TITLE
🐛 fix(tui): lazygit-style Recent Commits — fill + clip + footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`). gwm renders the node column only
-  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
-  sidebar and need cross-row topology tracking.
+  lazygit's initial `git log -300`). Includes the full graph topology
+  renderer — vertical pipes `│`, corners `╮ ╭ ╯ ╰`, junctions `┴ ┬`,
+  horizontal strokes `─` — driven by a Rust port of lazygit's
+  `pkg/gui/presentation/graph/` package (`graph.go` / `cell.go`).
+  Linear history collapses to a single `○`-stack column; merges spawn
+  fresh columns to the right, and the algorithm is width-deterministic
+  on the commit list (independent of terminal width).
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now occupies exactly **one visual line** (was wrapping onto two on long
   subjects), and the block **fills the available height** instead of
   showing a hardcoded 10 entries. Per-row format mirrors lazygit:
-  `<8-char hash>  <author initials>  <subject>` (initials follow the
-  same `KB`-from-`Kylian Bardini` rule as
-  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  `<8-char hash>  <author initials>  <node>  <subject>`, where `<node>`
+  is `○` for a normal commit and `◎` for a merge commit (matches
+  `lazygit/pkg/gui/presentation/graph/cell.go` constants
+  `CommitSymbol` / `MergeSymbol`). Initials follow the same
+  `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`. Subjects are
   **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
   disabled across every sidebar block now, so the `Constraint::Length`
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`).
+  lazygit's initial `git log -300`). gwm renders the node column only
+  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
+  sidebar and need cross-row topology tracking.
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TUI Recent Commits panel — lazygit-style layout** (#71) — each commit
+  now occupies exactly **one visual line** (was wrapping onto two on long
+  subjects), and the block **fills the available height** instead of
+  showing a hardcoded 10 entries. Per-row format mirrors lazygit:
+  `<8-char hash>  <author initials>  <subject>` (initials follow the
+  same `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
+  disabled across every sidebar block now, so the `Constraint::Length`
+  budget always matches the rendered height. A right-aligned footer
+  `<viewport-bottom> of <total>` lives at the bottom of the block, à la
+  lazygit's panel footer. Default buffer is **300 commits** (same as
+  lazygit's initial `git log -300`).
+
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /
   `Working Tree` / `Recent Commits`) instead of one big `Details` block with

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -13,10 +13,12 @@
 //!
 //! Differences from lazygit, all intentional:
 //!
-//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
-//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//! - **Single green palette** — `Color::Green` for connectors and
+//!   `Color::Green` + bold for `○` / `◎` nodes. Lazygit uses per-author
 //!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
-//!   is authored by the same person, so the rainbow is wasted ink.
+//!   is authored by the same person, so the rainbow is wasted ink. The
+//!   green matches the `Worktree` block's "synced" status badge for
+//!   visual consistency across the sidebar.
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
@@ -350,8 +352,8 @@ pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
     c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
   }
 
-  let connector_style = Style::default().fg(Color::DarkGray);
-  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+  let connector_style = Style::default().fg(Color::Green);
+  let node_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
 
   let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
   for cell in &cells {

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -6,10 +6,15 @@
 //! consecutive rows, and renders each row as a fixed sequence of 2-char
 //! cells (`<glyph><filler>`).
 //!
-//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
-//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
-//! independent of terminal width — the graph is width-deterministic on
-//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//! The output is a `Vec<Span<'static>>` per row (from
+//! [`render_pipe_set`]) or a `Vec<Vec<Span<'static>>>` for the full
+//! commit list (from [`render_commits`]). Callers assemble those spans
+//! into a `ratatui::text::Line` together with the rest of the row
+//! (hash, author initials, subject) — see
+//! `src/tui/ui.rs::commit_row_line`. Each row's spans cover exactly
+//! `2 * (max_pos + 1)` cells, independent of terminal width — the
+//! graph is width-deterministic on the input commit list (lazygit
+//! caches on `(head_hash, count)` only).
 //!
 //! Differences from lazygit, all intentional:
 //!
@@ -22,9 +27,14 @@
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
-//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
-//!   target for the first commit so its `○` doesn't appear orphaned;
-//!   here we simply skip the seeded `Starts` pipe in that case.
+//! - **No empty-tree sentinel** — lazygit targets a synthetic
+//!   `EmptyTreeCommitHash` from the first commit's `Starts` pipe so
+//!   `○` doesn't look orphaned. gwm uses an empty string for the
+//!   first parent of a root commit; the rendered cell is still a
+//!   plain `○` because the seeded sentinel pipe from row 0 terminates
+//!   on it. The trivial commit-on-commit `Terminates` (where
+//!   `from_pos == to_pos == commit_pos`) is skipped in
+//!   [`render_pipe_set`] so it doesn't overwrite the node glyph.
 
 use crate::worktree::CommitRow;
 use ratatui::{

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -1,0 +1,433 @@
+//! Per-row commit graph renderer for the Recent Commits sidebar block.
+//!
+//! Direct Rust port of lazygit's `pkg/gui/presentation/graph/` package
+//! (`graph.go` + `cell.go`). The algorithm walks the commit list once,
+//! maintains a set of active "pipes" (vertical line segments) between
+//! consecutive rows, and renders each row as a fixed sequence of 2-char
+//! cells (`<glyph><filler>`).
+//!
+//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
+//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
+//! independent of terminal width — the graph is width-deterministic on
+//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//!
+//! Differences from lazygit, all intentional:
+//!
+//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
+//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
+//!   is authored by the same person, so the rainbow is wasted ink.
+//! - **No selected-commit override** — lazygit highlights the pipes
+//!   originating from the cursor; our sidebar's selection lives on the
+//!   *worktree* list, not on a specific commit.
+//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
+//!   target for the first commit so its `○` doesn't appear orphaned;
+//!   here we simply skip the seeded `Starts` pipe in that case.
+
+use crate::worktree::CommitRow;
+use ratatui::{
+  style::{Color, Modifier, Style},
+  text::Span,
+};
+use std::collections::HashSet;
+
+/// Lifecycle of a pipe across the row it sits in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PipeKind {
+  /// A pipe arriving from above that ends on the current row's commit.
+  Terminates,
+  /// A pipe starting from the current row's commit, heading downward
+  /// toward one of its parents.
+  Starts,
+  /// A pipe that arrived from above and continues below — passing
+  /// through the current row, possibly shifting columns left/right.
+  Continues,
+}
+
+#[derive(Debug, Clone)]
+pub struct Pipe {
+  pub from_pos: i16,
+  pub to_pos: i16,
+  pub from_hash: String,
+  pub to_hash: String,
+  pub kind: PipeKind,
+}
+
+impl Pipe {
+  #[inline]
+  fn left(&self) -> i16 {
+    self.from_pos.min(self.to_pos)
+  }
+  #[inline]
+  fn right(&self) -> i16 {
+    self.from_pos.max(self.to_pos)
+  }
+}
+
+/// What a cell represents at render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellType {
+  Connection,
+  Commit,
+  Merge,
+}
+
+#[derive(Debug, Clone)]
+struct Cell {
+  up: bool,
+  down: bool,
+  left: bool,
+  right: bool,
+  cell_type: CellType,
+}
+
+impl Cell {
+  fn new_connection() -> Self {
+    Self {
+      up: false,
+      down: false,
+      left: false,
+      right: false,
+      cell_type: CellType::Connection,
+    }
+  }
+  fn set_up(&mut self) {
+    self.up = true;
+  }
+  fn set_down(&mut self) {
+    self.down = true;
+  }
+  fn set_left(&mut self) {
+    self.left = true;
+  }
+  fn set_right(&mut self) {
+    self.right = true;
+  }
+  fn set_type(&mut self, t: CellType) {
+    self.cell_type = t;
+  }
+}
+
+/// Port of lazygit's 16-case `getBoxDrawingChars` truth table
+/// (`cell.go:147-183`). Returns `(glyph, right_filler)` — each cell emits
+/// two characters so a continuous horizontal stroke can be drawn by
+/// chaining `─` fillers across columns.
+///
+/// Glyphs are all in the U+2500 light-box-drawing block.
+pub fn box_drawing_chars(up: bool, down: bool, left: bool, right: bool) -> (char, char) {
+  match (up, down, left, right) {
+    (true, true, true, true) => ('│', '─'),
+    (true, true, true, false) => ('│', ' '),
+    (true, true, false, true) => ('│', '─'),
+    (true, true, false, false) => ('│', ' '),
+    (true, false, true, true) => ('┴', '─'),
+    (true, false, true, false) => ('╯', ' '),
+    (true, false, false, true) => ('╰', '─'),
+    (true, false, false, false) => ('╵', ' '),
+    (false, true, true, true) => ('┬', '─'),
+    (false, true, true, false) => ('╮', ' '),
+    (false, true, false, true) => ('╭', '─'),
+    (false, true, false, false) => ('╷', ' '),
+    (false, false, true, true) => ('─', '─'),
+    (false, false, true, false) => ('─', ' '),
+    (false, false, false, true) => ('╶', '─'),
+    (false, false, false, false) => (' ', ' '),
+  }
+}
+
+/// Seed sentinel hash used by lazygit for the pipe that ends on the
+/// very first commit (`graph.go:36`). The actual value is opaque — it
+/// just must never equal any real SHA-1.
+const START_HASH: &str = "__GWM_GRAPH_START__";
+
+/// Walk `commits` once, producing the per-row pipe sets. This is the
+/// Rust translation of lazygit's `GetPipeSets` (`graph.go:60-69`).
+pub fn build_pipe_sets(commits: &[CommitRow]) -> Vec<Vec<Pipe>> {
+  if commits.is_empty() {
+    return Vec::new();
+  }
+  let mut pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: START_HASH.to_string(),
+    to_hash: commits[0].hash.clone(),
+    kind: PipeKind::Starts,
+  }];
+  let mut out = Vec::with_capacity(commits.len());
+  for commit in commits {
+    pipes = get_next_pipes(&pipes, commit);
+    out.push(pipes.clone());
+  }
+  out
+}
+
+/// Per-row transition. Port of lazygit's `getNextPipes`
+/// (`graph.go:109-273`). Given the previous row's pipes and the current
+/// commit, produces the current row's pipe set.
+fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
+  let max_pos: i16 = prev_pipes.iter().map(|p| p.to_pos).max().unwrap_or(0);
+
+  // Pipes that terminated last row do not carry into this one.
+  let current_pipes: Vec<&Pipe> = prev_pipes.iter().filter(|p| p.kind != PipeKind::Terminates).collect();
+
+  // Default to a brand-new commit column. Falls back to the column of
+  // any descendant pipe pointing at us.
+  let mut pos: i16 = max_pos + 1;
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      pos = pipe.to_pos;
+      break;
+    }
+  }
+
+  let mut new_pipes: Vec<Pipe> = Vec::with_capacity(current_pipes.len() + commit.parents.len());
+
+  // Emit the STARTS pipe for the *first* parent (or empty-tree sentinel
+  // when this is the root commit).
+  let first_parent = commit.parents.first().cloned().unwrap_or_else(|| String::from(""));
+  new_pipes.push(Pipe {
+    from_pos: pos,
+    to_pos: pos,
+    from_hash: commit.hash.clone(),
+    to_hash: first_parent,
+    kind: PipeKind::Starts,
+  });
+
+  // Shared mutable state for the per-pipe loops below.
+  let mut taken_spots: HashSet<i16> = HashSet::new();
+  let mut traversed_spots: HashSet<i16> = HashSet::new();
+
+  // Pre-compute the spots that continuing pipes already occupy — a new
+  // merge-parent pipe must not land on top of them.
+  let mut traversed_spots_for_continuing: HashSet<i16> = HashSet::new();
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash {
+      traversed_spots_for_continuing.insert(pipe.to_pos);
+    }
+  }
+
+  // Helper closures need shared borrows of the spot sets, so inline
+  // them as plain `fn`-style helpers operating on locals here.
+  fn next_free(spots: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while spots.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn next_free_for_new(taken: &HashSet<i16>, traversed_for_continuing: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while taken.contains(&i) || traversed_for_continuing.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn traverse(taken: &mut HashSet<i16>, traversed: &mut HashSet<i16>, from: i16, to: i16) {
+    let (l, r) = if from <= to { (from, to) } else { (to, from) };
+    for i in l..=r {
+      traversed.insert(i);
+    }
+    taken.insert(to);
+  }
+
+  // Phase 1: terminating + leftward-continuing pipes from the previous row.
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      // pipe ends on this commit
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: pos,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Terminates,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, pos);
+    } else if pipe.to_pos < pos {
+      // pipe continues; pick the next free column to its right
+      let avail = next_free(&traversed_spots);
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: avail,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, avail);
+    }
+  }
+
+  // Phase 2: extra parents of a merge commit each open a new column.
+  if commit.parents.len() >= 2 {
+    for parent in commit.parents.iter().skip(1) {
+      let avail = next_free_for_new(&taken_spots, &traversed_spots_for_continuing);
+      new_pipes.push(Pipe {
+        from_pos: pos,
+        to_pos: avail,
+        from_hash: commit.hash.clone(),
+        to_hash: parent.clone(),
+        kind: PipeKind::Starts,
+      });
+      taken_spots.insert(avail);
+    }
+  }
+
+  // Phase 3: continuing pipes from the *right* of the commit. They may
+  // shift leftward to fill blank columns.
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash && pipe.to_pos > pos {
+      let mut last = pipe.to_pos;
+      let mut i = pipe.to_pos;
+      while i > pos {
+        i -= 1;
+        if taken_spots.contains(&i) || traversed_spots.contains(&i) {
+          break;
+        }
+        last = i;
+      }
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: last,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, last);
+    }
+  }
+
+  // Stable ordering by to_pos, then kind (matches lazygit's sort).
+  new_pipes.sort_by(|a, b| {
+    if a.to_pos == b.to_pos {
+      a.kind.cmp(&b.kind)
+    } else {
+      a.to_pos.cmp(&b.to_pos)
+    }
+  });
+
+  new_pipes
+}
+
+/// Render a single pipe set into ratatui spans, two spans per cell. Port
+/// of lazygit's `renderPipeSet` (`graph.go:275-385`).
+pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
+  let mut max_pos: i16 = 0;
+  let mut commit_pos: i16 = 0;
+  let mut start_count: usize = 0;
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      start_count += 1;
+      commit_pos = pipe.from_pos;
+    } else if pipe.kind == PipeKind::Terminates {
+      commit_pos = pipe.to_pos;
+    }
+    if pipe.right() > max_pos {
+      max_pos = pipe.right();
+    }
+  }
+  let is_merge = start_count > 1;
+
+  let mut cells: Vec<Cell> = (0..=max_pos).map(|_| Cell::new_connection()).collect();
+
+  // First pass: STARTS pipes paint their downward stroke + any leftward
+  // continuation. Done first so subsequent passes can layer on top.
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+  // Second pass: TERMINATES and CONTINUES (except the trivial commit-
+  // on-commit terminate that would erase the commit cell glyph).
+  for pipe in pipes {
+    if pipe.kind != PipeKind::Starts
+      && !(pipe.kind == PipeKind::Terminates && pipe.from_pos == commit_pos && pipe.to_pos == commit_pos)
+    {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+
+  // Mark the commit cell.
+  if let Some(c) = cells.get_mut(commit_pos as usize) {
+    c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
+  }
+
+  let connector_style = Style::default().fg(Color::DarkGray);
+  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+
+  let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
+  for cell in &cells {
+    let (glyph, filler) = box_drawing_chars(cell.up, cell.down, cell.left, cell.right);
+    let render_glyph: String = match cell.cell_type {
+      CellType::Connection => glyph.to_string(),
+      CellType::Commit => '○'.to_string(),
+      CellType::Merge => '◎'.to_string(),
+    };
+    let style = if matches!(cell.cell_type, CellType::Commit | CellType::Merge) {
+      node_style
+    } else {
+      connector_style
+    };
+    out.push(Span::styled(render_glyph, style));
+    // The right filler is always a connector (never a node), so it
+    // keeps the connector style.
+    out.push(Span::styled(filler.to_string(), connector_style));
+  }
+  out
+}
+
+fn apply_pipe(cells: &mut [Cell], pipe: &Pipe) {
+  let left = pipe.left();
+  let right = pipe.right();
+
+  if left != right {
+    for i in (left + 1)..right {
+      if let Some(c) = cells.get_mut(i as usize) {
+        c.set_left();
+        c.set_right();
+      }
+    }
+    if let Some(c) = cells.get_mut(left as usize) {
+      c.set_right();
+    }
+    if let Some(c) = cells.get_mut(right as usize) {
+      c.set_left();
+    }
+  }
+
+  match pipe.kind {
+    PipeKind::Starts | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.to_pos as usize) {
+        c.set_down();
+      }
+    }
+    PipeKind::Terminates => {}
+  }
+  match pipe.kind {
+    PipeKind::Terminates | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.from_pos as usize) {
+        c.set_up();
+      }
+    }
+    PipeKind::Starts => {}
+  }
+}
+
+/// One-shot helper: compute pipe sets for the commit list and render
+/// each row's spans. Output length matches `commits.len()`.
+pub fn render_commits(commits: &[CommitRow]) -> Vec<Vec<Span<'static>>> {
+  build_pipe_sets(commits)
+    .into_iter()
+    .map(|pipes| render_pipe_set(&pipes))
+    .collect()
+}
+
+/// Convenience constructor for tests — builds a `CommitRow` with the
+/// minimum data the graph algorithm needs.
+#[doc(hidden)]
+pub fn test_row(hash: &str, parents: &[&str]) -> CommitRow {
+  CommitRow {
+    hash: hash.into(),
+    author: String::new(),
+    parents: parents.iter().map(|s| s.to_string()).collect(),
+    subject: String::new(),
+  }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,10 @@
 mod app;
+/// Commit-graph topology renderer, ported from lazygit. **Not part of the
+/// public SemVer surface** — exposed only so the integration tests under
+/// `tests/` can pin the algorithm. Use `gwm::tui::recent_commits_lines`
+/// (re-exported below) for the stable entry point that callers should
+/// actually depend on.
+#[doc(hidden)]
 pub mod commit_graph;
 mod ui;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod commit_graph;
 mod ui;
 
 use crate::error::Result;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,8 +16,8 @@ pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
 pub use ui::{
-  build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line, tilde_compress_with_home,
-  SidebarSections,
+  author_initials, build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line,
+  recent_commits_lines, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run() -> Result<()> {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,12 +448,15 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <subject>
+/// <8-char hash>  <author initials>  <node>  <subject>
 /// ```
 ///
-/// The subject is **not** truncated here — the renderer relies on ratatui's
-/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
-/// commit per visual line, overflow cut at the right edge without `…`.
+/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
+/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
+/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
+/// truncated here — the renderer relies on ratatui's view-level
+/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
+/// per visual line, overflow cut at the right edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
     Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,18 +448,30 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <node>  <subject>
+/// <8-char hash>  <author initials>  <graph>  <subject>
 /// ```
 ///
-/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
-/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
-/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
-/// truncated here — the renderer relies on ratatui's view-level
-/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
-/// per visual line, overflow cut at the right edge without `…`.
+/// where `<graph>` is the per-row output of the topology renderer in
+/// [`super::commit_graph`] — a sequence of `2 * (max_pos + 1)` cells
+/// drawing `○` / `◎` nodes plus the `│ ─ ╮ ╭ ╯ ╰ …` connectors that
+/// link consecutive commits across branch / merge boundaries. The
+/// graph width is deterministic on the commit list — independent of
+/// terminal width — so the cache stays valid across resizes.
+///
+/// The subject is **not** truncated here — the renderer relies on
+/// ratatui's view-level hard-clip (no `Wrap`) to match lazygit's gocui
+/// behaviour: one commit per visual line, overflow cut at the right
+/// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
-    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
+    Ok(rows) if !rows.is_empty() => {
+      let graphs = super::commit_graph::render_commits(&rows);
+      rows
+        .into_iter()
+        .zip(graphs)
+        .map(|(row, graph_spans)| commit_row_line(row, graph_spans))
+        .collect()
+    }
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -471,42 +483,21 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
   }
 }
 
-fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+fn commit_row_line(row: worktree::CommitRow, graph: Vec<Span<'static>>) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
-  let marker = commit_node_marker(&row);
-  Line::from(vec![
-    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
-    Span::raw("  "),
-    Span::styled(
-      format!("{:<2}", initials),
-      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-    ),
-    Span::raw("  "),
-    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
-    Span::raw("  "),
-    Span::raw(row.subject),
-  ])
-}
-
-/// Glyph that marks a commit node in the Recent Commits graph column.
-/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
-/// (`pkg/gui/presentation/graph/cell.go:11-14`):
-///
-/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
-///   no parents).
-/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
-///
-/// gwm renders a single graph column without inter-row connectors
-/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
-/// rows and would clutter a narrow sidebar. The node-only column is
-/// the most readable subset for a previewer.
-fn commit_node_marker(row: &worktree::CommitRow) -> char {
-  if row.parents.len() >= 2 {
-    '◎'
-  } else {
-    '○'
-  }
+  let mut spans: Vec<Span<'static>> = Vec::with_capacity(5 + graph.len());
+  spans.push(Span::styled(short_hash, Style::default().fg(Color::Yellow)));
+  spans.push(Span::raw("  "));
+  spans.push(Span::styled(
+    format!("{:<2}", initials),
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  ));
+  spans.push(Span::raw("  "));
+  spans.extend(graph);
+  spans.push(Span::raw(" "));
+  spans.push(Span::raw(row.subject));
+  Line::from(spans)
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -471,6 +471,7 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
 fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
+  let marker = commit_node_marker(&row);
   Line::from(vec![
     Span::styled(short_hash, Style::default().fg(Color::Yellow)),
     Span::raw("  "),
@@ -479,8 +480,30 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
       Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
     ),
     Span::raw("  "),
+    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
+    Span::raw("  "),
     Span::raw(row.subject),
   ])
+}
+
+/// Glyph that marks a commit node in the Recent Commits graph column.
+/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
+/// (`pkg/gui/presentation/graph/cell.go:11-14`):
+///
+/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
+///   no parents).
+/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
+///
+/// gwm renders a single graph column without inter-row connectors
+/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
+/// rows and would clutter a narrow sidebar. The node-only column is
+/// the most readable subset for a previewer.
+fn commit_node_marker(row: &worktree::CommitRow) -> char {
+  if row.parents.len() >= 2 {
+    '◎'
+  } else {
+    '○'
+  }
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -483,17 +483,27 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   ])
 }
 
-/// Derive lazygit-style author initials from a full name. Mirrors
-/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+/// Derive lazygit-style author initials from a full name. Closely
+/// mirrors `getInitials` in lazygit's
+/// `pkg/gui/presentation/authors/authors.go`:
 ///
-/// - Empty → empty.
-/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
-/// - Single word → first 2 chars of that word.
-/// - ≥ 2 words → first char of split[0] + first char of split[1].
+/// - Empty / whitespace-only → empty.
+/// - Single word → first 2 Unicode scalar values of that word.
+/// - ≥ 2 words → first scalar of split[0] + first scalar of split[1].
 ///
-/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
-/// grapheme then char[0] of split[1]). Capped at 2 visible chars
-/// (`CommitAuthorShortLength` in lazygit).
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C`.
+/// Capped at 2 visible characters (`CommitAuthorShortLength` in
+/// lazygit).
+///
+/// **Divergence from lazygit** (PR #72 review, Copilot): lazygit uses
+/// `uniseg.FirstGraphemeClusterInString` and keeps multi-scalar
+/// grapheme clusters intact (e.g. regional-indicator flags like
+/// "🇫🇷"). gwm slices on Unicode scalar values via `str::chars()`,
+/// so the French flag is split into its two regional indicators and
+/// only the first survives. We accept this divergence intentionally
+/// — pulling in `unicode-segmentation` for a near-zero-impact author
+/// renderer would inflate the dependency tree without user-visible
+/// benefit on the typical "FirstName LastName" pattern.
 pub fn author_initials(author: &str) -> String {
   let trimmed = author.trim();
   if trimmed.is_empty() {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -255,18 +255,36 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     .constraints(constraints)
     .split(area);
 
-  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0);
-  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0);
-  render_section(f, chunks[2], " Working Tree ", sections.working_tree, border_color, 0);
+  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0, None);
+  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
+  render_section(
+    f,
+    chunks[2],
+    " Working Tree ",
+    sections.working_tree,
+    border_color,
+    0,
+    None,
+  );
 
   // Recent Commits is the only scrollable section. Clamp the scroll
   // offset to its visible area so `j` / `k` can't scroll past the end.
+  // The block's bottom-right title mirrors lazygit's footer
+  // ("<i+1> of <N>") so the user can tell at a glance how much history
+  // is queued and where the viewport sits.
   let commits_area = chunks[3];
   let commits_visible = commits_area.height.saturating_sub(2);
-  app.sidebar_max_scroll = (sections.recent_commits.len() as u16).saturating_sub(commits_visible);
+  let commits_len = sections.recent_commits.len() as u16;
+  app.sidebar_max_scroll = commits_len.saturating_sub(commits_visible);
   if app.sidebar_scroll > app.sidebar_max_scroll {
     app.sidebar_scroll = app.sidebar_max_scroll;
   }
+  let footer = if commits_len == 0 {
+    None
+  } else {
+    let bottom = app.sidebar_scroll.saturating_add(commits_visible).min(commits_len);
+    Some(format!(" {} of {} ", bottom, commits_len))
+  };
   render_section(
     f,
     commits_area,
@@ -274,6 +292,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     sections.recent_commits,
     border_color,
     app.sidebar_scroll,
+    footer,
   );
 }
 
@@ -284,12 +303,16 @@ fn render_section(
   lines: Vec<Line<'static>>,
   border_color: Color,
   scroll: u16,
+  footer: Option<String>,
 ) {
-  let block = Block::default()
+  let mut block = Block::default()
     .borders(Borders::ALL)
     .border_type(BorderType::Rounded)
     .title(title)
     .border_style(Style::default().fg(border_color));
+  if let Some(f) = footer {
+    block = block.title_bottom(ratatui::text::Line::from(f).right_aligned());
+  }
   // Pad content with one leading space per line for breathing room against
   // the left border. Cheap and avoids per-call `format!` churn.
   let padded: Vec<Line<'static>> = lines
@@ -301,10 +324,10 @@ fn render_section(
       Line::from(spans)
     })
     .collect();
-  let paragraph = Paragraph::new(padded)
-    .block(block)
-    .wrap(Wrap { trim: false })
-    .scroll((scroll, 0));
+  // No `Wrap`: every section now relies on ratatui's view-level hard-clip,
+  // matching lazygit's commits panel and ensuring 1 logical row = 1 visual
+  // row (so the layout's `Constraint::Length` always matches what we draw).
+  let paragraph = Paragraph::new(padded).block(block).scroll((scroll, 0));
   f.render_widget(paragraph, area);
 }
 
@@ -317,7 +340,7 @@ pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
   SidebarSections {
     worktree: worktree_identity_lines(w),
     working_tree: working_tree_lines(w),
-    recent_commits: recent_commits_lines(w),
+    recent_commits: recent_commits_lines(w, RECENT_COMMITS_LIMIT),
   }
 }
 
@@ -411,9 +434,29 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   }
 }
 
-fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
-  match worktree::git_log_oneline(&w.path, 10) {
-    Ok(s) if !s.trim().is_empty() => s.lines().map(|l| Line::from(l.to_string())).collect(),
+/// Default number of commits pulled into the Recent Commits block — chosen
+/// to match lazygit's initial `git log -300` window so the panel stays
+/// dense on tall terminals without paginating.
+pub const RECENT_COMMITS_LIMIT: usize = 300;
+
+/// Number of hex chars rendered for each commit's SHA in the sidebar.
+/// Matches lazygit's `Gui.CommitHashLength` default of 8.
+pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
+
+/// Produce the styled rows of the Recent Commits sidebar block for a
+/// worktree, limited to `limit` entries. Each `Line` mirrors lazygit's
+/// per-row format:
+///
+/// ```text
+/// <8-char hash>  <author initials>  <subject>
+/// ```
+///
+/// The subject is **not** truncated here — the renderer relies on ratatui's
+/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
+/// commit per visual line, overflow cut at the right edge without `…`.
+pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
+  match worktree::git_log_with_author(&w.path, limit) {
+    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -422,6 +465,49 @@ fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
       format!("! {}", e),
       Style::default().fg(Color::Red),
     ))],
+  }
+}
+
+fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+  let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
+  let initials = author_initials(&row.author);
+  Line::from(vec![
+    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
+    Span::raw("  "),
+    Span::styled(
+      format!("{:<2}", initials),
+      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    ),
+    Span::raw("  "),
+    Span::raw(row.subject),
+  ])
+}
+
+/// Derive lazygit-style author initials from a full name. Mirrors
+/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+///
+/// - Empty → empty.
+/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
+/// - Single word → first 2 chars of that word.
+/// - ≥ 2 words → first char of split[0] + first char of split[1].
+///
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
+/// grapheme then char[0] of split[1]). Capped at 2 visible chars
+/// (`CommitAuthorShortLength` in lazygit).
+pub fn author_initials(author: &str) -> String {
+  let trimmed = author.trim();
+  if trimmed.is_empty() {
+    return String::new();
+  }
+  let mut parts = trimmed.split_whitespace();
+  let first = parts.next().unwrap_or("");
+  match parts.next() {
+    Some(second) => {
+      let a: String = first.chars().take(1).collect();
+      let b: String = second.chars().take(1).collect();
+      format!("{}{}", a, b)
+    }
+    None => first.chars().take(2).collect(),
   }
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -256,9 +256,12 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// A commit row pulled from `git log` for the Recent Commits sidebar block.
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
-/// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
-/// a merge commit, which the renderer marks with `◎` instead of `○`.
+/// 40-char SHAs; the renderer trims them on display to a fixed length
+/// (the `COMMIT_HASH_DISPLAY_LEN` constant in `src/tui/ui.rs`, currently
+/// 8 chars, matching lazygit's `Gui.CommitHashLength` default). Not
+/// user-configurable today — change the constant to retune.
+/// `parents.len() >= 2` flags a merge commit, which the renderer marks
+/// with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -257,24 +257,28 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
 /// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit).
+/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
+/// a merge commit, which the renderer marks with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,
   pub author: String,
+  pub parents: Vec<String>,
   pub subject: String,
 }
 
-/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
-/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
-/// this for the Recent Commits block — the NUL separator avoids ambiguity
-/// when a subject contains the usual ` `, `|`, or tab characters lazygit
-/// also relies on.
+/// Shell out to `git log --format='%H%x00%aN%x00%P%x00%s' -n <n>` inside
+/// `path` and parse the NUL-separated output into [`CommitRow`]s. The TUI
+/// sidebar uses this for the Recent Commits block — the NUL separator
+/// avoids ambiguity when a subject contains the usual ` `, `|`, or tab
+/// characters lazygit also relies on. The `%P` field carries the
+/// space-separated list of parent SHAs (empty for the seed commit, one for
+/// a normal commit, two-plus for a merge).
 pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let output = Command::new("git")
     .arg("-C")
     .arg(path)
-    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .args(["log", "--format=%H%x00%aN%x00%P%x00%s", "-n"])
     .arg(n.to_string())
     .output()
     .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
@@ -288,14 +292,21 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let raw = String::from_utf8_lossy(&output.stdout).into_owned();
   let mut rows = Vec::new();
   for line in raw.lines() {
-    let mut parts = line.splitn(3, '\u{0}');
+    let mut parts = line.splitn(4, '\u{0}');
     let hash = parts.next().unwrap_or("").to_string();
     let author = parts.next().unwrap_or("").to_string();
+    let parents_field = parts.next().unwrap_or("");
     let subject = parts.next().unwrap_or("").to_string();
     if hash.is_empty() {
       continue;
     }
-    rows.push(CommitRow { hash, author, subject });
+    let parents: Vec<String> = parents_field.split_whitespace().map(|s| s.to_string()).collect();
+    rows.push(CommitRow {
+      hash,
+      author,
+      parents,
+      subject,
+    });
   }
   Ok(rows)
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -253,6 +253,53 @@ pub fn prune(repo: &Repository) -> Result<usize> {
   Ok(pruned)
 }
 
+/// A commit row pulled from `git log` for the Recent Commits sidebar block.
+/// Mirrors lazygit's columnar layout (hash + author + subject) so the
+/// renderer can lay out one commit per visual line. Hashes are full
+/// 40-char SHAs; the renderer trims them to the configured display
+/// length (default 8 chars, à la lazygit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRow {
+  pub hash: String,
+  pub author: String,
+  pub subject: String,
+}
+
+/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
+/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
+/// this for the Recent Commits block — the NUL separator avoids ambiguity
+/// when a subject contains the usual ` `, `|`, or tab characters lazygit
+/// also relies on.
+pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .arg(n.to_string())
+    .output()
+    .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::Other(format!(
+      "git log exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+  let mut rows = Vec::new();
+  for line in raw.lines() {
+    let mut parts = line.splitn(3, '\u{0}');
+    let hash = parts.next().unwrap_or("").to_string();
+    let author = parts.next().unwrap_or("").to_string();
+    let subject = parts.next().unwrap_or("").to_string();
+    if hash.is_empty() {
+      continue;
+    }
+    rows.push(CommitRow { hash, author, subject });
+  }
+  Ok(rows)
+}
+
 /// Shell out to `git log --oneline -n <n>` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview recent commits of the selected worktree.
 pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1882,6 +1882,171 @@ fn recent_commits_line_marks_merge_commit_with_bullseye() {
   );
 }
 
+// ---- Commit graph topology (lazygit port — pipes + connectors) ---------
+
+use gwm::tui::commit_graph::{box_drawing_chars, build_pipe_sets, render_commits, render_pipe_set, test_row, PipeKind};
+
+fn spans_to_text(spans: &[ratatui::text::Span<'static>]) -> String {
+  spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+#[allow(clippy::type_complexity)]
+fn graph_glyph_table_matches_lazygit_truth_table() {
+  // 16-case ground truth ported verbatim from
+  // `lazygit/pkg/gui/presentation/graph/cell.go::getBoxDrawingChars`.
+  // If any of these flip, the entire graph rendering will silently shift.
+  let cases: &[((bool, bool, bool, bool), (char, char))] = &[
+    ((true, true, true, true), ('│', '─')),
+    ((true, true, true, false), ('│', ' ')),
+    ((true, true, false, true), ('│', '─')),
+    ((true, true, false, false), ('│', ' ')),
+    ((true, false, true, true), ('┴', '─')),
+    ((true, false, true, false), ('╯', ' ')),
+    ((true, false, false, true), ('╰', '─')),
+    ((true, false, false, false), ('╵', ' ')),
+    ((false, true, true, true), ('┬', '─')),
+    ((false, true, true, false), ('╮', ' ')),
+    ((false, true, false, true), ('╭', '─')),
+    ((false, true, false, false), ('╷', ' ')),
+    ((false, false, true, true), ('─', '─')),
+    ((false, false, true, false), ('─', ' ')),
+    ((false, false, false, true), ('╶', '─')),
+    ((false, false, false, false), (' ', ' ')),
+  ];
+  for &((u, d, l, r), expected) in cases {
+    assert_eq!(
+      box_drawing_chars(u, d, l, r),
+      expected,
+      "case ({}, {}, {}, {}) — expected {:?}",
+      u,
+      d,
+      l,
+      r,
+      expected
+    );
+  }
+}
+
+#[test]
+fn graph_linear_history_emits_single_column_circles() {
+  // Three commits, each pointing at the next: c (parent b) → b (parent a) → a (no parent).
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  assert_eq!(graphs.len(), 3);
+  // Each row should be a 2-cell render (one column → 2 chars).
+  for (idx, g) in graphs.iter().enumerate() {
+    let text = spans_to_text(g);
+    assert!(
+      text.contains('○'),
+      "linear history row {} must carry a ○ node, got {:?}",
+      idx,
+      text
+    );
+    assert!(
+      !text.contains('◎'),
+      "linear history row {} must NOT carry a ◎ merge node, got {:?}",
+      idx,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_merge_commit_carries_bullseye_and_branch_corners() {
+  // Topology:
+  //   c (merge: parents = a, b)
+  //   b (parent a)         ← side branch
+  //   a (no parent)        ← trunk root
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  // Row 0 = merge commit, must carry ◎.
+  let merge_text = spans_to_text(&graphs[0]);
+  assert!(merge_text.contains('◎'), "merge row must carry ◎, got {:?}", merge_text);
+  // Row 1 (the side branch) must spawn somewhere outside column 0 —
+  // there should be a `╮` corner on row 0 to drop the second parent
+  // into a fresh column.
+  assert!(
+    merge_text.contains('╮') || merge_text.contains('─'),
+    "merge row must carry a corner / horizontal stroke into the new branch column, got {:?}",
+    merge_text
+  );
+}
+
+#[test]
+fn graph_pipe_set_first_commit_seeds_starts_pipe() {
+  // Internal invariant: the first row's pipe set must contain a STARTS
+  // pipe for the first commit, regardless of how many parents it has.
+  let rows = vec![test_row("a", &["b"])];
+  let pipes = build_pipe_sets(&rows);
+  assert_eq!(pipes.len(), 1);
+  assert!(
+    pipes[0]
+      .iter()
+      .any(|p| p.kind == PipeKind::Starts && p.from_hash == "a"),
+    "first row must contain a STARTS pipe whose from_hash is the commit itself, got {:?}",
+    pipes[0]
+  );
+}
+
+#[test]
+fn graph_pipe_set_merge_commit_emits_extra_starts_per_parent() {
+  // A merge with 2 parents should emit 2 STARTS pipes whose from_pos is
+  // the commit's column and to_pos points at distinct columns.
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let pipes = build_pipe_sets(&rows);
+  let row0 = &pipes[0];
+  let starts: Vec<_> = row0.iter().filter(|p| p.kind == PipeKind::Starts).collect();
+  assert_eq!(
+    starts.len(),
+    2,
+    "merge row must emit 2 STARTS pipes (one per parent), got {} ({:?})",
+    starts.len(),
+    starts
+  );
+}
+
+#[test]
+fn graph_render_pipe_set_empty_input_returns_empty() {
+  let graphs = render_commits(&[]);
+  assert!(graphs.is_empty());
+}
+
+#[test]
+fn graph_row_width_is_deterministic_on_commit_list() {
+  // The graph width is `2 * (max_pos + 1)` chars, derived from pipe
+  // topology — it must NOT depend on terminal width or external state.
+  // Snapshot the linear-history width so a regression caught quickly.
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  for g in &graphs {
+    let text = spans_to_text(g);
+    let chars = text.chars().count();
+    assert!(
+      (1..=8).contains(&chars),
+      "linear-history row must render in ≤ 8 chars, got {} ({:?})",
+      chars,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_render_pipe_set_handles_single_pipe_starts() {
+  use gwm::tui::commit_graph::Pipe;
+  let pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: "a".into(),
+    to_hash: "b".into(),
+    kind: PipeKind::Starts,
+  }];
+  let spans = render_pipe_set(&pipes);
+  let text = spans_to_text(&spans);
+  // Cell 0: ○ + filler (space, since right has no neighbor)
+  assert!(text.starts_with('○'), "expected ○ glyph at column 0, got {:?}", text);
+}
+
 #[test]
 fn recent_commits_line_marks_normal_commit_with_open_circle() {
   let (dir, _repo) = init_repo();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1772,6 +1772,23 @@ fn author_initials_empty_returns_empty() {
 }
 
 #[test]
+fn author_initials_takes_first_unicode_scalar_per_token() {
+  // Documented divergence from lazygit (PR #72 Copilot review): gwm's
+  // `author_initials` uses `str::chars()` and slices on Unicode scalar
+  // values, NOT grapheme clusters. Single-scalar emoji ("🦀") survive
+  // intact, but multi-scalar grapheme clusters like the French flag
+  // "🇫🇷" (two regional indicators) are split — only the first scalar
+  // makes it into the initials. Pinning this so a future contributor
+  // doesn't quietly break it by adopting a grapheme-aware crate.
+  assert_eq!(author_initials("🦀 Crab"), "🦀C");
+  assert_eq!(
+    author_initials("🇫🇷 Bardini"),
+    "🇫B",
+    "two-scalar grapheme cluster (flag) is intentionally split per scalar"
+  );
+}
+
+#[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly
   // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1858,7 +1858,10 @@ fn commit_row_carries_parent_hashes() {
 }
 
 #[test]
-fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+fn recent_commits_line_marks_merge_commit_with_bullseye() {
+  // U+25CE ◎ is named "BULLSEYE" in Unicode — it is what lazygit uses
+  // for `MergeSymbol`. The previous test name said "diamond" which
+  // was geometrically wrong; this name pins the actual glyph.
   let (dir, repo) = init_repo();
   add_merge_commit(&repo);
   let w = worktree_pointing_at_dir(dir.path());
@@ -1874,7 +1877,7 @@ fn recent_commits_line_marks_merge_commit_with_open_diamond() {
   let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
   assert!(
     joined.contains('◎'),
-    "merge row must carry the ◎ marker, got: {}",
+    "merge row must carry the ◎ bullseye marker, got: {}",
     joined
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1648,3 +1648,188 @@ fn issue_summary_line_truncates_error_state_to_budget() {
   let width = line_visible_width(&line);
   assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
 }
+
+// ---- Recent Commits panel: lazygit-style fill + clip (issue #71) ---------
+
+use gwm::tui::{recent_commits_lines, RECENT_COMMITS_LIMIT};
+
+fn add_commits(repo: &git2::Repository, count: usize) {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  for i in 0..count {
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(Some("HEAD"), &sig, &sig, &format!("commit-{}", i), &tree, &[&parent])
+      .unwrap();
+  }
+}
+
+fn worktree_pointing_at_dir(dir: &std::path::Path) -> WorktreeInfo {
+  WorktreeInfo {
+    name: "test".into(),
+    path: dir.to_path_buf(),
+    branch: Some("main".into()),
+    head: None,
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus::default(),
+  }
+}
+
+#[test]
+fn recent_commits_lines_respects_limit_when_repo_has_more() {
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 14); // 15 total commits (1 seed + 14)
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 5);
+  assert_eq!(
+    lines.len(),
+    5,
+    "limit=5 must produce exactly 5 lines, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+fn recent_commits_lines_returns_all_when_under_limit() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 100);
+  assert_eq!(
+    lines.len(),
+    1,
+    "init_repo has 1 commit, asking for 100 should still return 1, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+#[allow(clippy::assertions_on_constants)] // intentional const pin
+fn recent_commits_default_limit_fills_modern_terminal_heights() {
+  // Regression: the previous hardcoded limit of 10 left the bottom of tall
+  // sidebars empty. On a 50-line terminal, the Recent Commits block gets
+  // ~12–18 rows after the small fixed sections take their slice; on a
+  // 100-line terminal it gets ~70+. Keep the default generous so the
+  // block fills the panel without re-shelling git on scroll. A future
+  // contributor that lowers the constant will trip this test.
+  assert!(
+    RECENT_COMMITS_LIMIT >= 50,
+    "RECENT_COMMITS_LIMIT must be ≥ 50 to fill a typical sidebar, got {}",
+    RECENT_COMMITS_LIMIT
+  );
+}
+
+#[test]
+fn build_sidebar_sections_fetches_up_to_default_recent_commits_limit() {
+  // Wire-up smoke: build_sidebar_sections must use RECENT_COMMITS_LIMIT (or
+  // higher) so the cached section is dense enough to fill a tall panel.
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 30); // 31 total commits
+  let w = worktree_pointing_at_dir(dir.path());
+  let sections = build_sidebar_sections(&w);
+  assert_eq!(
+    sections.recent_commits.len(),
+    31,
+    "expected all 31 commits to be cached (default limit ≥ 50 ≥ 31), got {}",
+    sections.recent_commits.len()
+  );
+}
+
+// ---- lazygit-style row format (hash + initials + subject) ----------------
+
+use gwm::tui::{author_initials, COMMIT_HASH_DISPLAY_LEN};
+
+#[test]
+fn author_initials_two_word_name_picks_first_letters_of_each() {
+  assert_eq!(author_initials("Kylian Bardini"), "KB");
+  assert_eq!(author_initials("Jesse Duffield"), "JD");
+}
+
+#[test]
+fn author_initials_single_word_takes_first_two_chars() {
+  assert_eq!(author_initials("Linus"), "Li");
+  assert_eq!(author_initials("kb"), "kb");
+}
+
+#[test]
+fn author_initials_three_or_more_words_only_uses_first_two() {
+  // Lazygit caps the result at 2 chars regardless of token count.
+  assert_eq!(author_initials("Jean-Paul Marie Dupont"), "JM");
+}
+
+#[test]
+fn author_initials_strips_leading_whitespace() {
+  assert_eq!(author_initials("  Kylian Bardini"), "KB");
+}
+
+#[test]
+fn author_initials_empty_returns_empty() {
+  assert_eq!(author_initials(""), "");
+  assert_eq!(author_initials("   "), "");
+}
+
+#[test]
+fn recent_commits_line_starts_with_short_hash() {
+  // The first span of every row must be a hash of exactly
+  // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  assert_eq!(lines.len(), 1, "init_repo should produce 1 commit");
+  let head_span = lines[0]
+    .spans
+    .first()
+    .expect("commit row must carry at least the hash span");
+  assert_eq!(
+    head_span.content.chars().count(),
+    COMMIT_HASH_DISPLAY_LEN,
+    "expected hash span of {} chars, got {:?}",
+    COMMIT_HASH_DISPLAY_LEN,
+    head_span.content
+  );
+  // Must be all-hex.
+  assert!(
+    head_span.content.chars().all(|c| c.is_ascii_hexdigit()),
+    "expected hex hash, got {:?}",
+    head_span.content
+  );
+}
+
+#[test]
+fn recent_commits_line_includes_author_initials_after_hash() {
+  // init_repo signs commits as "gwm-test" — a single token → first 2 chars.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  // Initials live as a styled span after the hash + double space.
+  assert!(
+    joined.contains("gw"),
+    "expected 'gw' initials from 'gwm-test', got {:?}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_carries_subject_unclipped() {
+  // The renderer relies on ratatui's view-level clip — `recent_commits_lines`
+  // itself must NOT pre-truncate the subject (otherwise scrollback / wider
+  // sidebars would lose information). Verify the full subject is preserved.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains("init"),
+    "expected the seed 'init' subject, got {:?}",
+    joined
+  );
+  assert!(
+    !joined.contains('…'),
+    "must not pre-emptively truncate with ellipsis: {:?}",
+    joined
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1788,6 +1788,115 @@ fn author_initials_takes_first_unicode_scalar_per_token() {
   );
 }
 
+// ---- Graph node markers (○ commit, ◎ merge) -----------------------------
+
+fn add_merge_commit(repo: &git2::Repository) -> git2::Oid {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+
+  // Start from current HEAD. Create a sibling branch with one commit, then
+  // merge it back into HEAD with a true 2-parent merge commit.
+  let base = repo.head().unwrap().peel_to_commit().unwrap();
+  let branch_name = "tmp-side";
+  repo.branch(branch_name, &base, false).unwrap();
+  // Side commit.
+  let side_oid = {
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(
+        Some(&format!("refs/heads/{}", branch_name)),
+        &sig,
+        &sig,
+        "side",
+        &tree,
+        &[&base],
+      )
+      .unwrap()
+  };
+  let side = repo.find_commit(side_oid).unwrap();
+  // Merge commit on HEAD with two parents.
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo
+    .commit(
+      Some("HEAD"),
+      &sig,
+      &sig,
+      "merge: side into trunk",
+      &tree,
+      &[&base, &side],
+    )
+    .unwrap()
+}
+
+#[test]
+fn commit_row_carries_parent_hashes() {
+  // Regression: the renderer needs the parent count to pick ○ vs ◎.
+  // git_log_with_author must surface the parent list, not flatten it.
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo); // adds two extra commits (side + merge)
+  let rows = gwm::worktree::git_log_with_author(dir.path(), 10).unwrap();
+  // First row = merge commit (HEAD), should have 2 parents.
+  assert!(!rows.is_empty(), "expected at least 1 commit");
+  assert_eq!(
+    rows[0].parents.len(),
+    2,
+    "HEAD is a merge commit and must surface both parents, got {:?}",
+    rows[0].parents
+  );
+  // The seed `init` commit has no parent.
+  let seed = rows
+    .iter()
+    .find(|r| r.subject == "init")
+    .expect("seed commit must be in log");
+  assert!(
+    seed.parents.is_empty(),
+    "seed commit has no parents, got {:?}",
+    seed.parents
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo);
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 10);
+  // Find the merge commit row by subject; assert it carries ◎ somewhere.
+  let merge = lines
+    .iter()
+    .find(|l| {
+      let joined: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+      joined.contains("merge: side into trunk")
+    })
+    .expect("merge row must be present");
+  let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('◎'),
+    "merge row must carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_normal_commit_with_open_circle() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('○'),
+    "non-merge row must carry the ○ marker, got: {}",
+    joined
+  );
+  assert!(
+    !joined.contains('◎'),
+    "non-merge row must NOT carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
 #[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly


### PR DESCRIPTION
## Description

Reworks the Recent Commits sidebar block introduced by #70 so it matches `lazygit`'s commits-panel UX: one commit per visual line, hard-clip on overflow, 300-commit buffer, lazygit row format, right-aligned `N of M` footer. Closes the two complaints in #71 (subjects wrap onto two rows; panel hardcoded at 10 commits).

Closes #71

**Stacked on top of #70** — base branch is `feat/#69-tui-details-redesign`, so the diff shown here only contains the Recent Commits changes. Merge after #70.

## Type of change

- [x] 🐛 Fix (bug fix)
- [ ] ✨ Feature
- [ ] 🚑️ Hotfix
- [ ] ♻️ Refactor
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

Behaviour mirrors `lazygit/pkg/gui/presentation/commits.go`:

- **One row per commit.** `Paragraph::wrap` is removed from every sidebar section (the new bordered layout's `Constraint::Length` budget assumes 1 logical row = 1 visual row everywhere — wrap silently broke that). Subjects are hard-clipped on overflow, no ellipsis, à la `lazygit/pkg/gui/presentation/commits.go:451` where the subject is passed raw to `theme.DefaultTextColor.Sprint(name)` and gocui does the view-level clip.
- **Panel fills.** `RECENT_COMMITS_LIMIT = 300` (was 10) — matches `lazygit/pkg/commands/git_commands/commit_loader.go:597` (`git log -300`).
- **Per-row format** = `<8-char hash>  <author initials>  <subject>` :
  - Hash: 8 chars, yellow. `COMMIT_HASH_DISPLAY_LEN = 8` matches `lazygit/pkg/config/user_config.go:831` (`Gui.CommitHashLength: 8`).
  - Initials: 2 chars, cyan bold. New `author_initials()` mirrors `lazygit/pkg/gui/presentation/authors/authors.go::getInitials` — `"Kylian Bardini"` → `KB`, single-word names get `first[..2]`.
  - Subject: raw, default fg.
- **Bottom-right footer** `<viewport-bottom> of <total>` on the Recent Commits block, à la lazygit's panel footer (`pkg/gui/context/list_context_trait.go:83-89`).

Internals:

- New `worktree::CommitRow { hash, author, subject }` + `git_log_with_author(path, n)` parallel to existing `git_log_oneline`. Uses `git log --format='%H%x00%aN%x00%s'` (NUL-separated like lazygit) so subjects with `|`, tabs, quotes can't corrupt the parse.
- `recent_commits_lines(w, limit)` promoted to `pub`. Callers pass `RECENT_COMMITS_LIMIT` by default; tests pass a custom budget.
- `render_section` gains an `Option<String>` footer parameter.
- `build_sidebar_sections` wires `RECENT_COMMITS_LIMIT` through.

## Tests

- [x] `cargo test` passes locally — **343 passed, 0 failed** (was 331 → +12 sidebar tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: 12 tests authored against the new contract, failed against missing exports / hardcoded limit, then implementation made them green)

New tests in `tests/tui_app_tests.rs`:

Recent Commits behaviour:
- `recent_commits_lines_respects_limit_when_repo_has_more`
- `recent_commits_lines_returns_all_when_under_limit`
- `recent_commits_default_limit_fills_modern_terminal_heights`
- `build_sidebar_sections_fetches_up_to_default_recent_commits_limit`

Row format:
- `recent_commits_line_starts_with_short_hash`
- `recent_commits_line_includes_author_initials_after_hash`
- `recent_commits_line_carries_subject_unclipped`

Author initials (pure):
- `author_initials_two_word_name_picks_first_letters_of_each`
- `author_initials_single_word_takes_first_two_chars`
- `author_initials_three_or_more_words_only_uses_first_two`
- `author_initials_strips_leading_whitespace`
- `author_initials_empty_returns_empty`

## Screenshots / TUI captures

**Before** (from the linked issue):

```
Recent Commits
8c637da fix(tui): clip issue/PR summary lines to    ← wraps
sidebar width
12c0eb9 fix(tui): enforce path-separator boundary    ← wraps
in tilde_compress
...
                                                      ← bottom empty
```

**After**:

```
Recent Commits
8c637da  KB  fix(tui): clip issue/PR summary lines to sidebar width
12c0eb9  KB  fix(tui): enforce path-separator boundary in tilde_compress
2d1d3ae  KB  fix(tui): drop misleading ✓ sigil on diverged worktree…
5ac1313  KB  docs(changelog): record TUI sidebar redesign under [Un…
fce6817  KB  docs(skill): refresh skills/SKILL.md for 0.6.0-rc.1 st…
8b809c3  KB  test(tui): pin sidebar sections structure
749ed0a  KB  feat(tui): redesign Details sidebar with bordered subs…
…  (up to 300 commits, scrollable)
                                                              7 of 14
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` → `fix/#71-recent-commits-clip-and-fill`
- [x] Commits follow Gitmoji + Conventional Commits — 2 atomic commits (`feat` + `docs(changelog)`)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — N/A
- [ ] `examples/gwm.toml.example` updated if config schema changed — N/A
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #71
- Related PR: #70 (base — adds the bordered sidebar that this PR refines)
- Lazygit reference files: `pkg/gui/presentation/commits.go`, `pkg/gui/presentation/authors/authors.go`, `pkg/commands/git_commands/commit_loader.go`, `pkg/config/user_config.go`, `pkg/gui/context/list_context_trait.go`