### PR TITLE
✨ feat(tui): lazygit-style sidebar + o:open / y:yank (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+- TUI sidebar gets a lazygit-style facelift (#73):
+  - New `Created` row showing the branch's age in compact relative form
+    (`2d`, `3w`, `1M`, …), colour-coded by freshness (green < 7d,
+    yellow < 30d, dark gray otherwise).
+  - Branch name is now coloured by `BranchStatus` (worst-state wins —
+    dirty → red, ahead/behind → yellow, unpublished → magenta, synced
+    → green, unknown → dark gray). Applies to both the sidebar
+    `Branch:` row and the table `BRANCH` column.
+  - Sidebar header line is now prefixed by a `●` status dot whose
+    colour tracks the linked PR / issue state (open=green,
+    draft=gray, merged=magenta, closed=red).
+- New `[tui.open]` config section + `OpenTarget` dispatch for the `o`
+  key (#73). `mode` accepts `"shell"` (default, lazygit-style
+  `$SHELL` in the worktree), `"editor"` (`$EDITOR <path>`), or
+  `"finder"` (pre-#73 OS file manager). `shell_cmd` / `editor_cmd`
+  override the env var when set.
+- New `y` keybinding: yank the selected worktree's path to the system
+  clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`).
+  Missing tool surfaces a clear status hint, no crash.
+
+### Changed
+- **Default behaviour of `o:` open changes** (#73). It used to spawn
+  the OS file manager unconditionally; now it spawns `$SHELL` in the
+  worktree by default. Opt back into the old behaviour with
+  `[tui.open] mode = "finder"` in `.gwm.toml`.
+- TUI footer / help overlay / sidebar cheat-sheet updated to reflect
+  the new `o:open` and `y:yank` bindings.
 
 ## Past releases
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Key bindings:
 | `n`         | new worktree (form: type → issue → description)                                 |
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
 | `b`         | re-run bootstrap on the selected worktree                                       |
-| `o`         | open the worktree dir in the OS file manager (`open` / `xdg-open` / `explorer`) |
+| `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / clip) |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
@@ -97,14 +98,32 @@ Key bindings:
 
 ### details sidebar
 
-When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the currently selected worktree:
+When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree:
 
-- **Basic Settings** — branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **Header** — `● <worktree-name>`, with the `●` colour tracking the linked PR / issue state (open=green, draft=gray, merged=magenta, closed=red, neutral=darkgray when nothing's linked).
+- **Basic Settings** — branch (coloured by status: synced=green, ahead/behind=yellow, dirty=red, unpublished=magenta, unknown=darkgray), path, head (short OID), **Created** (branch age in compact `2d` / `3w` / `1M` form, coloured by freshness), main / locked / prunable flags, branch status.
 - **Recent commits** — `git log --oneline -n 10`.
 - **Working tree** — `git status --short` (`✓ clean` when empty).
 - **Commands** — keybindings cheat-sheet.
 
 Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+#### open dispatch
+
+The `o` key dispatches on `[tui.open]` in `.gwm.toml`:
+
+```toml
+[tui.open]
+mode = "shell"          # "shell" (default) | "editor" | "finder"
+shell_cmd = ""           # override $SHELL; empty = unset
+editor_cmd = "hx"        # override $EDITOR; empty = unset
+```
+
+- `shell` (default, **changed in v0.6**): suspend the TUI and spawn `$SHELL` with `cwd` set to the worktree — same lifecycle as `l: lazygit`. Exit the shell, the TUI restores.
+- `editor`: suspend the TUI and run `$EDITOR <worktree-path>`.
+- `finder`: pre-v0.6 behaviour — hand off to the OS file manager (`open` / `xdg-open` / `explorer`) without suspending the TUI.
+
+Unknown `mode` values are a hard config error at load time, surfaced before the TUI opens.
 
 ### fuzzy filter
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Key bindings:
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
 | `b`         | re-run bootstrap on the selected worktree                                       |
 | `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
-| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / clip) |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -117,3 +117,18 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # [tui]
 # confirm_countdown_secs = 3
+
+# --- `o: open` dispatch (issue #73) -----------------------------------------
+# How the `o` key behaves on the highlighted worktree. Three modes:
+#   "shell"  — suspend the TUI and spawn $SHELL with cwd = worktree.
+#              Lazygit-style. Default. Exit the shell ⇒ TUI restores.
+#   "editor" — suspend the TUI and run $EDITOR <worktree-path>.
+#   "finder" — pre-#73 behaviour: hand off to the OS file manager
+#              (`open` / `xdg-open` / `explorer`).
+# `shell_cmd` / `editor_cmd` override the env var when set (empty string
+# = unset). An unknown `mode` is a hard config error at load time.
+#
+# [tui.open]
+# mode = "shell"
+# shell_cmd = ""        # leave empty to read $SHELL
+# editor_cmd = "hx"     # example: Helix

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,14 +149,73 @@ pub struct TuiConfig {
   /// clamp instead of erroring out at parse time.
   #[serde(default = "default_confirm_countdown_secs")]
   pub confirm_countdown_secs: u32,
+
+  /// `[tui.open]` sub-table — drives the dispatch of the `o` key in the
+  /// list view. Default mode is `shell` (lazygit-like worktree-manager
+  /// workflow); pre-#73 behaviour (`open` / `xdg-open` / `explorer`) is
+  /// kept available under `mode = "finder"`.
+  #[serde(default)]
+  pub open: TuiOpenConfig,
 }
 
 impl Default for TuiConfig {
   fn default() -> Self {
     Self {
       confirm_countdown_secs: default_confirm_countdown_secs(),
+      open: TuiOpenConfig::default(),
     }
   }
+}
+
+/// `[tui.open]` — how the `o` key resolves the action on the selected
+/// worktree. Adds a configurable hook on top of the historical "reveal
+/// in OS file manager" so users with a worktree-heavy workflow can land
+/// in a shell or `$EDITOR` directly, sharing the spawn-and-restore
+/// lifecycle that `l: lazygit` already uses.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TuiOpenConfig {
+  #[serde(default)]
+  pub mode: TuiOpenMode,
+  /// Override `$SHELL` when `mode = "shell"`. Falls back to `$SHELL`,
+  /// then `/bin/sh`. Empty TOML string reads as `None` so
+  /// `shell_cmd = ""` and an omitted key are observationally identical.
+  #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+  pub shell_cmd: Option<String>,
+  /// Override `$EDITOR` when `mode = "editor"`. Falls back to `$EDITOR`,
+  /// then `vi`. Same empty-string-as-unset convention as `shell_cmd`.
+  #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+  pub editor_cmd: Option<String>,
+}
+
+/// The three documented behaviours of the `o` key. Serialised in
+/// lowercase so `.gwm.toml` keys stay idiomatic (`mode = "shell"`); an
+/// unknown value is a hard config error surfaced by
+/// `Config::load_for_repo`, never silently coerced to a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TuiOpenMode {
+  /// Spawn an interactive shell with `cwd` set to the worktree
+  /// (lazygit-style suspend / spawn / restore). Default — matches the
+  /// "I want to do work in this worktree" intent of a worktree manager.
+  #[default]
+  Shell,
+  /// Spawn `$EDITOR <worktree-path>` and wait for it to exit. Useful
+  /// for drive-by edits without dropping into a full shell session.
+  Editor,
+  /// Pre-#73 behaviour: ask the OS to reveal the worktree directory
+  /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows).
+  Finder,
+}
+
+/// Serde helper: treat an empty TOML string as `None`. Keeps
+/// `shell_cmd = ""` and an omitted key identical at the call site so
+/// the TUI never has to special-case the empty command.
+fn deserialize_optional_non_empty<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+  D: serde::Deserializer<'de>,
+{
+  let opt = Option::<String>::deserialize(d)?;
+  Ok(opt.filter(|s| !s.is_empty()))
 }
 
 impl TuiConfig {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,5 @@
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
-use crate::config::Config;
+use crate::config::{Config, TuiOpenConfig, TuiOpenMode};
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
@@ -59,6 +59,24 @@ pub enum View {
 pub enum LinkTarget {
   Issue,
   Pr,
+}
+
+/// Dispatch target for the `o` key (issue #73). Resolved by
+/// [`App::resolve_open_target`] from the current selection + the
+/// `[tui.open]` config so the event loop can hand off to the right
+/// runner (shell suspend, editor suspend, OS file manager) without
+/// re-reading the config or `$SHELL` / `$EDITOR` itself.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum OpenTarget {
+  /// Spawn `command` with `cwd = path`. Caller suspends the TUI and
+  /// restores it on the child's exit (same lifecycle as `l: lazygit`).
+  Shell { path: PathBuf, command: String },
+  /// Spawn `command <path>` and wait. Same suspend/restore lifecycle
+  /// as `Shell`.
+  Editor { path: PathBuf, command: String },
+  /// Hand off to the OS opener (`open` / `xdg-open` / `explorer`).
+  /// Doesn't suspend the TUI — the opener detaches.
+  Finder { path: PathBuf },
 }
 
 /// Stage of the two-step link prompt.
@@ -383,7 +401,9 @@ impl App {
   }
 
   /// Reveal the selected worktree's directory in the OS file manager.
-  /// macOS: `open`, Linux: `xdg-open`, Windows: `explorer`.
+  /// macOS: `open`, Linux: `xdg-open`, Windows: `explorer`. Used by
+  /// `resolve_open_target` when the config picks `mode = "finder"`,
+  /// and by the event loop directly to spawn the opener.
   pub fn open_selected_in_finder(&mut self) {
     let path = match self.selected() {
       Some(w) => w.path.clone(),
@@ -403,6 +423,34 @@ impl App {
       Ok(_) => self.status = format!("opened {} in {}", path.display(), opener),
       Err(e) => self.status = format!("failed to open {}: {}", path.display(), e),
     }
+  }
+
+  /// Return the path that the `y: yank` key should push into the system
+  /// clipboard, or `None` when nothing is selected. Pure — the actual
+  /// shell-out (`pbcopy` / `wl-copy` / `xclip` / `clip`) is handled by
+  /// the event loop so this method stays trivially testable.
+  pub fn yank_selected_path(&self) -> Option<PathBuf> {
+    self.selected().map(|w| w.path.clone())
+  }
+
+  /// Resolve what the `o` key should do for the currently selected
+  /// worktree. Returns `None` when nothing is selected (the event loop
+  /// surfaces a status message in that case). The exact command is
+  /// resolved once here (config override > env var > hardcoded fallback)
+  /// so the event loop never has to reason about precedence.
+  pub fn resolve_open_target(&self) -> Option<OpenTarget> {
+    let path = self.selected()?.path.clone();
+    Some(match self.config.tui.open.mode {
+      TuiOpenMode::Shell => OpenTarget::Shell {
+        path,
+        command: resolve_shell_command(&self.config.tui.open),
+      },
+      TuiOpenMode::Editor => OpenTarget::Editor {
+        path,
+        command: resolve_editor_command(&self.config.tui.open),
+      },
+      TuiOpenMode::Finder => OpenTarget::Finder { path },
+    })
   }
 
   pub fn toggle_delete_branch(&mut self) {
@@ -1033,4 +1081,28 @@ impl App {
     self.refresh_link();
     Ok(())
   }
+}
+
+/// Resolve the shell command for `mode = "shell"`. Precedence:
+/// `shell_cmd` in `.gwm.toml` → `$SHELL` env var → `/bin/sh`. The
+/// hardcoded fallback exists for the (rare) case where neither is set —
+/// the TUI's spawn-and-restore loop assumes a non-empty command string.
+fn resolve_shell_command(cfg: &TuiOpenConfig) -> String {
+  cfg
+    .shell_cmd
+    .clone()
+    .or_else(|| std::env::var("SHELL").ok())
+    .unwrap_or_else(|| "/bin/sh".into())
+}
+
+/// Resolve the editor command for `mode = "editor"`. Precedence:
+/// `editor_cmd` in `.gwm.toml` → `$EDITOR` env var → `vi` (POSIX
+/// baseline). Mirrors `resolve_shell_command` so the two flows share
+/// the same precedence story.
+fn resolve_editor_command(cfg: &TuiOpenConfig) -> String {
+  cfg
+    .editor_cmd
+    .clone()
+    .or_else(|| std::env::var("EDITOR").ok())
+    .unwrap_or_else(|| "vi".into())
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,7 +35,9 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
     ]
   }
 }
-pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
+pub use ui::{
+  branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color, table_marker,
+};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,8 +13,28 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub use app::{
-  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, OpenTarget, View,
 };
+
+/// Ordered list of clipboard tools to try for the host OS (issue #73).
+/// First entry that resolves on `$PATH` wins. Returned in the
+/// platform's preferred order — `pbcopy` first on macOS, `wl-copy`
+/// then `xclip` then `xsel` on Linux, `clip.exe` on Windows. Exposed
+/// from the crate root so the tests in `tui_app_tests.rs` can pin the
+/// non-empty contract without spawning anything.
+pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
+  if cfg!(target_os = "macos") {
+    vec![("pbcopy", vec![])]
+  } else if cfg!(target_os = "windows") {
+    vec![("clip", vec![])]
+  } else {
+    vec![
+      ("wl-copy", vec![]),
+      ("xclip", vec!["-selection", "clipboard"]),
+      ("xsel", vec!["--clipboard", "--input"]),
+    ]
+  }
+}
 pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
 
 pub fn run() -> Result<()> {
@@ -166,7 +186,18 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Char('d') if !app.picker_mode => app.enter_confirm_delete(),
           KeyCode::Char('b') if !app.picker_mode => app.bootstrap_selected(),
           KeyCode::Char('p') if !app.picker_mode => app.toggle_delete_branch(),
-          KeyCode::Char('o') => app.open_selected_in_finder(),
+          KeyCode::Char('y') => yank_selected_path_to_clipboard(&mut app),
+          KeyCode::Char('o') => match app.resolve_open_target() {
+            None => app.status = "nothing selected".into(),
+            Some(OpenTarget::Finder { .. }) => app.open_selected_in_finder(),
+            Some(OpenTarget::Shell { path, command }) => {
+              run_subshell(terminal, &command, &[], Some(&path), &mut app, "shell")?
+            }
+            Some(OpenTarget::Editor { path, command }) => {
+              let path_str = path.display().to_string();
+              run_subshell(terminal, &command, &[&path_str], None, &mut app, "editor")?
+            }
+          },
           // Issue/PR linking (issue #67).
           KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
           KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
@@ -291,6 +322,98 @@ fn run_lazygit(
     Err(e) => app.status = format!("failed to launch lazygit: {}", e),
   }
   Ok(())
+}
+
+/// Suspend the TUI, spawn `cmd args...` (optionally with `cwd`), wait for
+/// its exit, then restore the TUI. Used by the `o: open` dispatch when the
+/// resolved [`OpenTarget`] is `Shell` or `Editor`. The lifecycle is
+/// identical to [`run_lazygit`] so the user can't observe a difference
+/// between pressing `l` (lazygit) and pressing `o` with `mode = "shell"`.
+///
+/// `label` is the noun used in status-bar messages (`"shell"`, `"editor"`).
+fn run_subshell(
+  terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+  cmd: &str,
+  args: &[&str],
+  cwd: Option<&std::path::Path>,
+  app: &mut App,
+  label: &str,
+) -> Result<()> {
+  disable_raw_mode()?;
+  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+  terminal.show_cursor()?;
+
+  let mut command = std::process::Command::new(cmd);
+  command.args(args);
+  if let Some(dir) = cwd {
+    command.current_dir(dir);
+  }
+  let spawn = command.status();
+
+  // Always restore the TUI, even if the child failed to spawn or exited non-zero.
+  enable_raw_mode()?;
+  execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
+  terminal.clear()?;
+
+  match spawn {
+    Ok(s) if s.success() => app.status = format!("{} exited ok ({})", label, cmd),
+    Ok(s) => app.status = format!("{} exited with code {:?}", label, s.code()),
+    Err(e) => app.status = format!("failed to launch {} ({}): {}", label, cmd, e),
+  }
+  Ok(())
+}
+
+/// Push the selected worktree's path into the system clipboard via
+/// [`clipboard_candidates`]. Walks the candidates in order, uses the
+/// first one whose binary is on `$PATH`, and feeds the path through
+/// its stdin. Failures and "no tool found" both surface in the status
+/// bar — no propagation, the TUI must never die on a clipboard miss.
+fn yank_selected_path_to_clipboard(app: &mut App) {
+  use std::io::Write;
+  let Some(path) = app.yank_selected_path() else {
+    app.status = "nothing selected".into();
+    return;
+  };
+  let text = path.display().to_string();
+  for (cmd, args) in clipboard_candidates() {
+    if which::which(cmd).is_err() {
+      continue;
+    }
+    let child = std::process::Command::new(cmd)
+      .args(&args)
+      .stdin(std::process::Stdio::piped())
+      .stdout(std::process::Stdio::null())
+      .stderr(std::process::Stdio::null())
+      .spawn();
+    match child {
+      Ok(mut c) => {
+        if let Some(mut stdin) = c.stdin.take() {
+          let _ = stdin.write_all(text.as_bytes());
+        }
+        match c.wait() {
+          Ok(s) if s.success() => {
+            app.status = format!("yanked path ({})", cmd);
+            return;
+          }
+          Ok(s) => {
+            app.status = format!("{} exited with code {:?}", cmd, s.code());
+            return;
+          }
+          Err(e) => {
+            app.status = format!("{} wait failed: {}", cmd, e);
+            return;
+          }
+        }
+      }
+      Err(e) => {
+        // Tool was resolvable on PATH but spawning failed — surface and stop;
+        // trying the next candidate would mask the real error.
+        app.status = format!("failed to spawn {}: {}", cmd, e);
+        return;
+      }
+    }
+  }
+  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / clip)".into();
 }
 
 /// Spawn the OS opener for `url` (used by the OpenMenu key handler).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -413,7 +413,7 @@ fn yank_selected_path_to_clipboard(app: &mut App) {
       }
     }
   }
-  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / clip)".into();
+  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / xsel / clip)".into();
 }
 
 /// Spawn the OS opener for `url` (used by the OpenMenu key handler).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -151,21 +151,22 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // ratatui's Layout solver, given a series of `Length` constraints
+  // plus a final `Min(N)` that must be honoured, squeezes the FIRST
+  // `Length` column when the terminal is too narrow. Empirically at a
+  // <90-col terminal that turned the age column (`Length(8)`) into 2
+  // cells and truncated "22h" → "22". Swapping `Min(20)` for `Fill(1)`
+  // on the PATH column lets the path absorb the pressure instead —
+  // it shrinks (or vanishes) before the age column loses a single
+  // cell. The age stays at exactly 4 cells, which is what max
+  // content (`22h`, `14m`, `1M`, `5y`, `-`) needs.
   let widths = [
-    // Age column sits at column 0. The first column is special in
-    // ratatui's Table: it carries the `highlight_symbol` overlay
-    // (rendered IN-CELL, not as a prefix), AND ratatui reserves the
-    // symbol width on every row to keep the layout stable. That
-    // reservation, plus the table's own column_spacing(1) on the
-    // right, eats ~4 cells of the constraint. Empirically Length(6)
-    // truncated "22h" → "22". Bump to 8 so 3-char ages keep one
-    // trailing pad even on the selected row.
-    Constraint::Length(8),
+    Constraint::Length(4),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
-    Constraint::Min(20),
+    Constraint::Fill(1),
   ];
 
   let list_has_focus = !(app.sidebar_open && app.sidebar_focused);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -151,20 +151,24 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // ratatui's Layout solver, given a series of `Length` constraints
-  // plus a final `Min(N)` that must be honoured, squeezes the FIRST
-  // `Length` column when the terminal is too narrow. Empirically at a
-  // <90-col terminal that turned the age column (`Length(8)`) into 2
-  // cells and truncated "22h" → "22". Swapping `Min(20)` for `Fill(1)`
-  // on the PATH column lets the path absorb the pressure instead —
-  // it shrinks (or vanishes) before the age column loses a single
-  // cell. The age stays at exactly 4 cells, which is what max
-  // content (`22h`, `14m`, `1M`, `5y`, `-`) needs.
+  // ratatui's Layout solver squeezes the FIRST `Length` column to
+  // satisfy the others when terminal width is tight. We want the age
+  // column rock-stable at 4 cells (the cost of losing the unit
+  // letter to truncation — "22h" → "22" — is worse than name/branch
+  // shrinking by a char or two). Strategy:
+  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
+  //     status: hard-fixed lengths the solver must honour.
+  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
+  //     when the terminal is narrow (they shrink down to 8) and grow
+  //     to the original clamped width (or more) when there's room.
+  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
+  // Verified by standalone probe down to 40-cell terminals: col 0
+  // stays at 4 cells across every size.
   let widths = [
     Constraint::Length(4),
     Constraint::Length(2),
-    Constraint::Length(name_w),
-    Constraint::Length(branch_w),
+    Constraint::Min(name_w),
+    Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -127,57 +127,18 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let visible: Vec<&WorktreeInfo> = filtered.iter().filter_map(|&i| app.worktrees.get(i)).collect();
 
   // Dynamic column widths derived from the visible subset so columns fit the
-  // rows actually on screen.
+  // rows actually on screen. The path column is always last and absorbs the
+  // remaining width.
   let name_w = column_width(visible.iter().map(|w| w.name.as_str()), 18, 38);
   let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
-  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
-  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
-
-  let title = if app.filter_query.is_empty() {
-    format!(" worktrees ({}) ", app.worktrees.len())
-  } else {
-    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
-  };
-
-  // Pre-allocate the marker + age strips OUTSIDE ratatui's Table
-  // widget so their fixed widths are never squeezed by the layout
-  // solver. Per ratatui docs the constraint priority is
-  // `Min > Max > Length > Percentage > Ratio > Fill`, and when the
-  // Table area is tight (sidebar open ⇒ ~60% of frame, narrow term),
-  // `Length` columns still get shrunk proportionally — that's how
-  // the previous `Length(2)` marker and `Length(4)` age both dropped
-  // below their nominal widths.
-  //
-  // Outer layout: borders → inner → `[2 marker | 4 age | 1 gap | Fill(table)]`.
-  // The four zones share the same row baseline (header on row 0,
-  // data rows from row 1 down), so the manual strips align cell-for-cell
-  // with the Table's rows. On the selected row we paint a DarkGray
-  // background across all four zones so the highlight reads as one
-  // continuous band rather than three disconnected fragments.
-  let outer_block = Block::default()
-    .borders(Borders::ALL)
-    .title(title)
-    .border_style(Style::default().fg(border_color));
-  let inner_area = outer_block.inner(area);
-  f.render_widget(outer_block, area);
-
-  let inner_split = Layout::horizontal([
-    Constraint::Length(2),
-    Constraint::Length(4),
-    Constraint::Length(1),
-    Constraint::Fill(1),
-  ])
-  .split(inner_area);
-  let marker_strip = inner_split[0];
-  let age_strip = inner_split[1];
-  let gap_strip = inner_split[2];
-  let table_area = inner_split[3];
-
-  // Table now carries only the four growable columns; marker + age
-  // are rendered manually in their pre-allocated strips below.
   let header = Row::new(vec![
+    // Age column lives at column 0 — recency-first, lazygit-style. No
+    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
+    // and a header would steal space from BRANCH on narrow terminals.
+    Cell::from(""),
+    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
@@ -190,90 +151,50 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // ratatui's Layout solver squeezes the FIRST `Length` column to
+  // satisfy the others when terminal width is tight. We want the age
+  // column rock-stable at 4 cells (the cost of losing the unit
+  // letter to truncation — "22h" → "22" — is worse than name/branch
+  // shrinking by a char or two). Strategy:
+  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
+  //     status: hard-fixed lengths the solver must honour.
+  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
+  //     when the terminal is narrow (they shrink down to 8) and grow
+  //     to the original clamped width (or more) when there's room.
+  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
+  // Verified by standalone probe down to 40-cell terminals: col 0
+  // stays at 4 cells across every size.
   let widths = [
+    Constraint::Length(4),
+    Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];
 
-  // No `highlight_symbol` — the manual marker strip already carries
-  // the `★ / ●` glyphs and an arrow would now appear after the
-  // strips, breaking visual alignment with the marker column.
+  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
+  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
+
+  let title = if app.filter_query.is_empty() {
+    format!(" worktrees ({}) ", app.worktrees.len())
+  } else {
+    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
+  };
+
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));
+    .block(
+      Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(border_color)),
+    )
+    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+    .highlight_symbol("▶ ");
 
-  f.render_stateful_widget(table, table_area, &mut app.list_state);
-
-  render_left_strips(
-    f,
-    marker_strip,
-    age_strip,
-    gap_strip,
-    &visible,
-    app.list_state.selected(),
-  );
-}
-
-/// Paint the manually-allocated marker + age strips, plus the 1-cell
-/// gap between them and the Table. Mirrors the Table's
-/// `row_highlight_style` (DarkGray background, bold) on the selected
-/// row across all three zones so the highlight reads as a single
-/// continuous band rather than three disconnected fragments.
-fn render_left_strips(
-  f: &mut Frame,
-  marker_strip: Rect,
-  age_strip: Rect,
-  gap_strip: Rect,
-  visible: &[&WorktreeInfo],
-  selected: Option<usize>,
-) {
-  if marker_strip.height == 0 {
-    return;
-  }
-
-  let mut marker_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  let mut age_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  // Row 0 = header (kept empty — the column glyphs are self-evident).
-  marker_lines.push(Line::from(""));
-  age_lines.push(Line::from(""));
-
-  for (i, w) in visible.iter().enumerate() {
-    let (marker_label, marker_color) = table_marker(w);
-    let mut marker_style = Style::default().fg(marker_color);
-    let mut age_style = Style::default().fg(Color::DarkGray);
-    if Some(i) == selected {
-      marker_style = marker_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-      age_style = age_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-    }
-    marker_lines.push(Line::from(Span::styled(marker_label, marker_style)));
-    let age = branch_age_for(w);
-    let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-    age_lines.push(Line::from(Span::styled(label, age_style)));
-  }
-
-  f.render_widget(Paragraph::new(marker_lines), marker_strip);
-  f.render_widget(Paragraph::new(age_lines), age_strip);
-
-  // The 1-cell gap is empty space between the age strip and the
-  // Table. Without painting it, the selected-row highlight would
-  // show a 1-cell white slot between marker/age (DarkGray) and the
-  // Table (DarkGray). Paint the gap on the selected row only.
-  if let Some(sel) = selected {
-    // +1 for the header row that lives on `gap_strip.y`.
-    let row_y = gap_strip.y.saturating_add(1).saturating_add(sel as u16);
-    if row_y < gap_strip.y + gap_strip.height {
-      let gap_row = Rect {
-        x: gap_strip.x,
-        y: row_y,
-        width: gap_strip.width,
-        height: 1,
-      };
-      f.buffer_mut().set_style(gap_row, Style::default().bg(Color::DarkGray));
-    }
-  }
+  f.render_stateful_widget(table, area, &mut app.list_state);
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,
@@ -565,12 +486,23 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
+  // PR #74 follow-up: surface branch age right in the table so it stays
+  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
+  // `branch_age_for` opens the worktree's repo and runs the libgit2
+  // revwalk; per-frame cost is bounded by the number of visible rows
+  // (typically <20) so we re-resolve on every draw without caching.
+  // Colour stays uniform Gray — the saturated freshness palette
+  // (green/yellow/darkgray) reads as noise next to the more important
+  // BRANCH-status colour, so we keep it muted in the table and let the
+  // sidebar's `Created:` row carry the colour-coded signal.
+  let age = branch_age_for(w);
+  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
+
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
-  // Age column lives OUTSIDE the Table (pre-allocated in draw_list)
-  // to guarantee a fixed 4-cell width regardless of layout pressure;
-  // see `render_age_strip`.
   Row::new(vec![
+    age_cell,
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -336,7 +336,8 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   for (key, label) in [
     ("Enter", "Copy path to status"),
     ("    l", "Launch lazygit fullscreen"),
-    ("    o", "Open dir in OS file manager"),
+    ("    o", "Open per [tui.open] (shell/editor/finder)"),
+    ("    y", "Yank path to system clipboard"),
     ("    b", "Bootstrap worktree"),
     ("    n", "New worktree"),
     ("    d", "Delete worktree"),
@@ -534,9 +535,9 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   // Picker mode hides the mutating actions (n/d/b/p) — they're inert in the
   // event loop, so advertising them would be a lie.
   let help = if app.picker_mode {
-    "enter:select esc:cancel o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "enter:select esc:cancel o:open y:yank l:lazygit v:sidebar Tab:focus /:filter j/k:nav r:refresh ?:help q:quit"
   } else {
-    "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "n:new d:del b:boot o:open y:yank l:lazygit v:sidebar Tab:focus /:filter j/k:nav r:refresh ?:help q:quit"
   };
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
@@ -579,7 +580,8 @@ fn draw_help(f: &mut Frame, app: &App) {
     lines.push(Line::from("  b             bootstrap selected"));
   }
   lines.extend([
-    Line::from("  o             open dir in OS file manager (open / xdg-open / explorer)"),
+    Line::from("  o             open per [tui.open] — shell (default) / editor / finder"),
+    Line::from("  y             yank selected path to system clipboard"),
     Line::from("  l             launch lazygit fullscreen on selected worktree"),
     Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
     Line::from("  Tab           swap focus between worktree list and sidebar"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -138,6 +138,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
+    Cell::from("CREATED"),
     Cell::from("PATH"),
   ])
   .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
@@ -147,11 +148,15 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // Created column is fixed-width (4 chars — `2d`, `3w`, `1M`, … all fit;
+  // `-` for trunks / unknown takes 1 cell). Lives between STATUS and PATH
+  // so the most useful signal sits at eye level next to the status label.
   let widths = [
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
+    Constraint::Length(7),
     Constraint::Min(20),
   ];
 
@@ -455,7 +460,7 @@ fn column_width<'a>(items: impl Iterator<Item = &'a str>, min: u16, max: u16) ->
 }
 
 fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row<'static> {
-  let marker = if w.is_main { "★" } else { " " };
+  let (marker_label, marker_color) = table_marker(w);
   let branch_text = w.branch.clone().unwrap_or_else(|| "-".into());
 
   let name_cell =
@@ -468,15 +473,34 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
+  // PR #74 follow-up: surface branch age + freshness right in the table
+  // so it stays visible when the sidebar is hidden (<120 cols or `v`
+  // collapsed). `branch_age_for` opens the worktree's repo and runs the
+  // libgit2 revwalk; per-frame cost is bounded by the number of visible
+  // rows (typically <20) so we re-resolve on every draw without caching.
+  let age = branch_age_for(w);
+  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+  let age_color = age.map(freshness_color).unwrap_or(Color::DarkGray);
+  let age_cell = Cell::from(age_label).style(Style::default().fg(age_color));
+
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
   Row::new(vec![
-    Cell::from(marker).style(Style::default().fg(Color::Yellow)),
+    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,
     status_cell,
+    age_cell,
     path_cell,
   ])
+}
+
+/// Owned-String wrapper around `worktree::format_relative_duration` so
+/// the table-row builder can hand a `Cell::from` an owned value without
+/// re-allocating downstream. Centralised here purely to keep `build_row`
+/// readable.
+fn format_relative_duration_str(d: std::time::Duration) -> String {
+  worktree::format_relative_duration(d)
 }
 
 fn build_status_cell(w: &WorktreeInfo, width: usize) -> Cell<'static> {
@@ -1124,4 +1148,23 @@ pub fn issue_badge_color(state: IssueState) -> Color {
     IssueState::Open => Color::Green,
     IssueState::Closed => Color::Magenta,
   }
+}
+
+/// Pick the marker glyph + colour for the table's first column. `★`
+/// for the main worktree (preserves the pre-#73 convention), `●` for
+/// any other worktree that carries an issue or PR link, blank space
+/// otherwise so unlinked rows don't read as "claimed". Colour stays
+/// neutral (Cyan) — the live PR / issue state isn't known at the
+/// table layer (only the selected worktree triggers a fetch), so the
+/// table dot signals "has link" rather than a specific status. The
+/// colour-coded `●` lives in the sidebar header where the fetch state
+/// is available.
+pub fn table_marker(w: &WorktreeInfo) -> (&'static str, Color) {
+  if w.is_main {
+    return ("★", Color::Yellow);
+  }
+  if w.link.issue.is_some() || w.link.pr.is_some() {
+    return ("●", Color::Cyan);
+  }
+  (" ", Color::Reset)
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -135,10 +135,14 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
 
   let header = Row::new(vec![
     Cell::from(""),
+    // Age column sits immediately after the marker, ahead of NAME, with
+    // no header label — the glyphs are self-evident (`2d`, `3w`, `1M`)
+    // and a "CREATED" caption would steal space from the BRANCH column.
+    // Matches lazygit's recency-first layout.
+    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
-    Cell::from("CREATED"),
     Cell::from("PATH"),
   ])
   .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
@@ -148,15 +152,14 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // Created column is fixed-width (4 chars — `2d`, `3w`, `1M`, … all fit;
-  // `-` for trunks / unknown takes 1 cell). Lives between STATUS and PATH
-  // so the most useful signal sits at eye level next to the status label.
   let widths = [
     Constraint::Length(2),
+    // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
+    // expands so BRANCH stays the elastic column.
+    Constraint::Length(4),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
-    Constraint::Length(7),
     Constraint::Min(20),
   ];
 
@@ -487,10 +490,10 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   Row::new(vec![
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
+    age_cell,
     name_cell,
     branch_cell,
     status_cell,
-    age_cell,
     path_cell,
   ])
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -152,13 +152,15 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    // Age column sits at column 0 — recency-first. Width = 6 because
-    // the highlight symbol "▶ " is rendered INSIDE the first cell area
-    // (eating ~2 cells when any row is selected, which is always the
-    // case here), and we need 3 visible cells for max content ("22h",
-    // "14m", "59s", "1M ", etc.) plus 1 trailing pad. 6 - 2 (symbol)
-    // - 1 (column_spacing baseline) = 3 visible cells minimum.
-    Constraint::Length(6),
+    // Age column sits at column 0. The first column is special in
+    // ratatui's Table: it carries the `highlight_symbol` overlay
+    // (rendered IN-CELL, not as a prefix), AND ratatui reserves the
+    // symbol width on every row to keep the layout stable. That
+    // reservation, plus the table's own column_spacing(1) on the
+    // right, eats ~4 cells of the constraint. Empirically Length(6)
+    // truncated "22h" → "22". Bump to 8 so 3-char ages keep one
+    // trailing pad even on the selected row.
+    Constraint::Length(8),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -127,17 +127,52 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let visible: Vec<&WorktreeInfo> = filtered.iter().filter_map(|&i| app.worktrees.get(i)).collect();
 
   // Dynamic column widths derived from the visible subset so columns fit the
-  // rows actually on screen. The path column is always last and absorbs the
-  // remaining width.
+  // rows actually on screen.
   let name_w = column_width(visible.iter().map(|w| w.name.as_str()), 18, 38);
   let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
+  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
+  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
+
+  let title = if app.filter_query.is_empty() {
+    format!(" worktrees ({}) ", app.worktrees.len())
+  } else {
+    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
+  };
+
+  // Pre-allocate the age strip OUTSIDE ratatui's Table widget so the
+  // 4-cell fixed width is never squeezed by the layout solver. The
+  // Table's solver respects `Length` only up to a best-effort budget
+  // (per ratatui docs, Min > Max > Length > Percentage > Ratio > Fill);
+  // when the table area is tight (e.g. sidebar open, narrow terminal),
+  // it shrinks `Length` columns proportionally, dropping age from 4 to
+  // 3 (or fewer) cells. The only way to guarantee a fixed width is to
+  // reserve the cells via an outer `Layout::horizontal` before handing
+  // the rest to the Table.
+  //
+  // Layout: [outer block] → inner → [4 cells age | 1 cell gap | Fill(table)].
+  // The outer block (borders + title) wraps the whole area; the inner
+  // split divides the work between the manual age renderer and the
+  // Table widget.
+  let outer_block = Block::default()
+    .borders(Borders::ALL)
+    .title(title)
+    .border_style(Style::default().fg(border_color));
+  let inner_area = outer_block.inner(area);
+  f.render_widget(outer_block, area);
+
+  let inner_split = Layout::horizontal([
+    Constraint::Length(4), // age strip — fixed, never squeezed
+    Constraint::Length(1), // gap
+    Constraint::Fill(1),   // table area — absorbs the rest
+  ])
+  .split(inner_area);
+  let age_strip = inner_split[0];
+  let table_area = inner_split[2];
+
+  // The Table no longer carries the age column; col 0 is the marker.
   let header = Row::new(vec![
-    // Age column lives at column 0 — recency-first, lazygit-style. No
-    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
-    // and a header would steal space from BRANCH on narrow terminals.
-    Cell::from(""),
     Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
@@ -151,21 +186,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // ratatui's Layout solver squeezes the FIRST `Length` column to
-  // satisfy the others when terminal width is tight. We want the age
-  // column rock-stable at 4 cells (the cost of losing the unit
-  // letter to truncation — "22h" → "22" — is worse than name/branch
-  // shrinking by a char or two). Strategy:
-  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
-  //     status: hard-fixed lengths the solver must honour.
-  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
-  //     when the terminal is narrow (they shrink down to 8) and grow
-  //     to the original clamped width (or more) when there's room.
-  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
-  // Verified by standalone probe down to 40-cell terminals: col 0
-  // stays at 4 cells across every size.
   let widths = [
-    Constraint::Length(4),
     Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
@@ -173,28 +194,44 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     Constraint::Fill(1),
   ];
 
-  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
-  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
-
-  let title = if app.filter_query.is_empty() {
-    format!(" worktrees ({}) ", app.worktrees.len())
-  } else {
-    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
-  };
-
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .block(
-      Block::default()
-        .borders(Borders::ALL)
-        .title(title)
-        .border_style(Style::default().fg(border_color)),
-    )
     .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
     .highlight_symbol("▶ ");
 
-  f.render_stateful_widget(table, area, &mut app.list_state);
+  f.render_stateful_widget(table, table_area, &mut app.list_state);
+
+  // Now overlay the age values on age_strip. Row 0 is the (empty)
+  // header line, rows 1..=visible.len() carry the values. We mirror
+  // the Table's row_highlight_style on the selected row so the band
+  // stays visually continuous across the gap.
+  render_age_strip(f, age_strip, &visible, app.list_state.selected());
+}
+
+/// Render the manually-allocated 4-cell-wide age column to the left of
+/// the Table widget. Aligns one Line per Table row (header line first,
+/// then one per visible worktree) and mirrors the Table's row_highlight
+/// background on the selected row so the user can't tell the column is
+/// rendered outside the Table.
+fn render_age_strip(f: &mut Frame, area: Rect, visible: &[&WorktreeInfo], selected: Option<usize>) {
+  if area.width == 0 || area.height == 0 {
+    return;
+  }
+  let mut lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  // Header row aligns with the Table's header (empty caption — the
+  // glyphs are self-evident).
+  lines.push(Line::from(""));
+  for (i, w) in visible.iter().enumerate() {
+    let age = branch_age_for(w);
+    let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+    let mut style = Style::default().fg(Color::DarkGray);
+    if Some(i) == selected {
+      style = style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    }
+    lines.push(Line::from(Span::styled(label, style)));
+  }
+  f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,
@@ -486,23 +523,12 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
-  // PR #74 follow-up: surface branch age right in the table so it stays
-  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
-  // `branch_age_for` opens the worktree's repo and runs the libgit2
-  // revwalk; per-frame cost is bounded by the number of visible rows
-  // (typically <20) so we re-resolve on every draw without caching.
-  // Colour stays uniform Gray — the saturated freshness palette
-  // (green/yellow/darkgray) reads as noise next to the more important
-  // BRANCH-status colour, so we keep it muted in the table and let the
-  // sidebar's `Created:` row carry the colour-coded signal.
-  let age = branch_age_for(w);
-  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
-
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
+  // Age column lives OUTSIDE the Table (pre-allocated in draw_list)
+  // to guarantee a fixed 4-cell width regardless of layout pressure;
+  // see `render_age_strip`.
   Row::new(vec![
-    age_cell,
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -134,11 +134,10 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let status_w: u16 = 16;
 
   let header = Row::new(vec![
+    // Age column lives at column 0 — recency-first, lazygit-style. No
+    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
+    // and a header would steal space from BRANCH on narrow terminals.
     Cell::from(""),
-    // Age column sits immediately after the marker, ahead of NAME, with
-    // no header label — the glyphs are self-evident (`2d`, `3w`, `1M`)
-    // and a "CREATED" caption would steal space from the BRANCH column.
-    // Matches lazygit's recency-first layout.
     Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
@@ -153,10 +152,10 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    Constraint::Length(2),
     // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
     // expands so BRANCH stays the elastic column.
     Constraint::Length(4),
+    Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
@@ -489,8 +488,8 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
   Row::new(vec![
-    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     age_cell,
+    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,
     status_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -152,9 +152,13 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
-    // expands so BRANCH stays the elastic column.
-    Constraint::Length(4),
+    // Age column sits at column 0 — recency-first. Width = 6 because
+    // the highlight symbol "▶ " is rendered INSIDE the first cell area
+    // (eating ~2 cells when any row is selected, which is always the
+    // case here), and we need 3 visible cells for max content ("22h",
+    // "14m", "59s", "1M ", etc.) plus 1 trailing pad. 6 - 2 (symbol)
+    // - 1 (column_spacing baseline) = 3 visible cells minimum.
+    Constraint::Length(6),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
@@ -475,15 +479,18 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
-  // PR #74 follow-up: surface branch age + freshness right in the table
-  // so it stays visible when the sidebar is hidden (<120 cols or `v`
-  // collapsed). `branch_age_for` opens the worktree's repo and runs the
-  // libgit2 revwalk; per-frame cost is bounded by the number of visible
-  // rows (typically <20) so we re-resolve on every draw without caching.
+  // PR #74 follow-up: surface branch age right in the table so it stays
+  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
+  // `branch_age_for` opens the worktree's repo and runs the libgit2
+  // revwalk; per-frame cost is bounded by the number of visible rows
+  // (typically <20) so we re-resolve on every draw without caching.
+  // Colour stays uniform Gray — the saturated freshness palette
+  // (green/yellow/darkgray) reads as noise next to the more important
+  // BRANCH-status colour, so we keep it muted in the table and let the
+  // sidebar's `Created:` row carry the colour-coded signal.
   let age = branch_age_for(w);
   let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-  let age_color = age.map(freshness_color).unwrap_or(Color::DarkGray);
-  let age_cell = Cell::from(age_label).style(Style::default().fg(age_color));
+  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
 
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
   widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
   Frame,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Minimum total terminal width required to render the sidebar alongside the
 /// worktree table without compressing the table beyond readability.
@@ -192,11 +192,14 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     Color::DarkGray
   };
 
-  // Resolve (or populate) the cached content for the currently selected worktree.
-  // The cached block is the git preview; the Issue/PR block is rebuilt every
-  // frame (it's small, and its state changes with fetch progress).
+  // Build the (selection-dependent but stateless) header fresh each
+  // frame so the PR-status dot tracks live fetch progress without
+  // invalidating the cache. The cached chunk underneath is the git
+  // preview, which only changes when the user picks a different
+  // worktree or `refresh()` flushes the cache (issue #73).
   let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
     Some(w) => {
+      let mut head = vec![sidebar_header_line(&w, app)];
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
         None => true,
@@ -204,7 +207,8 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       if needs_refresh {
         app.sidebar_cache = Some((w.path.clone(), sidebar_lines(&w)));
       }
-      app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default()
+      head.extend(app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default());
+      head
     }
     None => vec![Line::from("(nothing selected)")],
   };
@@ -234,23 +238,57 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   f.render_widget(paragraph, area);
 }
 
+/// Lazygit-style header line: `● <name>` where the dot's colour tracks
+/// the linked PR / issue state. Rendered fresh every frame (not cached)
+/// so the dot reflects the live fetch result without invalidating the
+/// expensive git preview cache underneath.
+fn sidebar_header_line(w: &WorktreeInfo, app: &App) -> Line<'static> {
+  let (dot, dot_color) = sidebar_status_dot(app);
+  let name_style = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
+  Line::from(vec![
+    Span::styled(dot, Style::default().fg(dot_color).add_modifier(Modifier::BOLD)),
+    Span::styled(w.name.clone(), name_style),
+  ])
+}
+
+/// Resolve the leading status dot for the sidebar header. PR state wins
+/// over issue state (a worktree most often tracks a PR); falls back to a
+/// neutral darkgray dot when the worktree has no link at all so the
+/// alignment stays consistent across rows.
+fn sidebar_status_dot(app: &App) -> (&'static str, Color) {
+  if let GitHubFetchState::Loaded(pr) = app.pr_fetch_state() {
+    return ("● ", pr_badge_color(pr.state));
+  }
+  if let GitHubFetchState::Loaded(issue) = app.issue_fetch_state() {
+    return ("● ", issue_badge_color(issue.state));
+  }
+  let link = app.current_link();
+  if link.pr.is_some() || link.issue.is_some() {
+    // Link exists but not fetched yet — neutral white so the user sees
+    // there's *something* to refresh with `R`.
+    return ("● ", Color::White);
+  }
+  ("● ", Color::DarkGray)
+}
+
 fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  // Branch name colour follows the lazygit scheme (issue #73): worst-state
+  // wins (`dirty` → `ahead/behind` → `no upstream` → `synced`) so the most
+  // actionable signal stays at eye level. `branch_status_color` is kept for
+  // the `Status:` row below; both use the same `BranchStatus` source.
+  let branch_color = branch_name_color(&w.status);
   let mut out: Vec<Line> = vec![
-    // Header — worktree name in bold.
-    Line::from(Span::styled(
-      w.name.clone(),
-      Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-    )),
     Line::from(""),
     // Basic Settings block.
     section_header("Basic Settings:"),
-    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), Color::Green),
+    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), branch_color),
     kv("Path", w.path.display().to_string(), Color::Gray),
     kv(
       "Head",
       w.head.as_deref().map(short_oid).unwrap_or_else(|| "-".into()),
       Color::Yellow,
     ),
+    kv("Created", branch_age_label(w), branch_age_color(w)),
     kv("Main", yes_no(w.is_main), Color::Yellow),
     kv("Locked", yes_no(w.is_locked), Color::Magenta),
     kv("Prunable", yes_no(w.is_prunable), Color::Red),
@@ -319,6 +357,28 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
     ]));
   }
   out
+}
+
+/// Render the "Created" line value: compact relative duration (`2d`,
+/// `3w`, `1M`, …) computed from the worktree's own repository handle, or
+/// `"-"` when the branch has no measurable age (trunk, detached HEAD, or
+/// repo open failure). The cost is one libgit2 revwalk on each sidebar
+/// rebuild — gated by `sidebar_cache` so it only runs on selection
+/// change, not every frame.
+fn branch_age_label(w: &WorktreeInfo) -> String {
+  branch_age_for(w)
+    .map(worktree::format_relative_duration)
+    .unwrap_or_else(|| "-".into())
+}
+
+fn branch_age_color(w: &WorktreeInfo) -> Color {
+  branch_age_for(w).map(freshness_color).unwrap_or(Color::DarkGray)
+}
+
+fn branch_age_for(w: &WorktreeInfo) -> Option<Duration> {
+  let branch = w.branch.as_ref()?;
+  let repo = git2::Repository::open(&w.path).ok()?;
+  worktree::branch_age(&repo, branch)
 }
 
 fn section_header(text: &str) -> Line<'static> {
@@ -400,7 +460,10 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
   let name_cell =
     Cell::from(trunc(&w.name, name_w as usize)).style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD));
 
-  let branch_cell = Cell::from(trunc(&branch_text, branch_w as usize)).style(Style::default().fg(Color::Green));
+  // Issue #73: branch column tracks the worst-state colour so the
+  // colour-coded signal is visible without expanding the sidebar.
+  let branch_cell =
+    Cell::from(trunc(&branch_text, branch_w as usize)).style(Style::default().fg(branch_name_color(&w.status)));
 
   let status_cell = build_status_cell(w, status_w as usize);
 
@@ -986,5 +1049,77 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
       Span::raw(" "),
       Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
     ]),
+  }
+}
+
+// ---- Issue #73: lazygit-style colour helpers -------------------------------
+// Pure functions exposed at the crate boundary so the table-driven tests
+// in `tests/tui_app_tests.rs` can pin the visual contract without spinning
+// up a real terminal. Anything that takes `BranchStatus` / `PrState` /
+// `IssueState` / a `Duration` and returns a `Color` belongs here.
+
+/// Pick a colour for a branch name based on its `BranchStatus`. Worst
+/// signal wins so the most actionable state stays visible at a glance.
+/// Priority (top down): `unknown` → `dirty` → `ahead/behind` → no
+/// upstream → synced/clean. Mirrors lazygit's branches view scheme
+/// (`pkg/gui/presentation/branches.go::getBranchDisplayStrings`) with
+/// one local addition: `dirty` lands on red because for a worktree
+/// manager the most actionable "do something" signal is uncommitted
+/// work.
+pub fn branch_name_color(s: &BranchStatus) -> Color {
+  if s.unknown {
+    return Color::DarkGray;
+  }
+  if s.is_dirty {
+    return Color::Red;
+  }
+  if s.ahead > 0 || s.behind > 0 {
+    return Color::Yellow;
+  }
+  if !s.has_upstream {
+    // Lazygit's `?` marker — branch never pushed yet. Distinct from
+    // synced so the user knows whether they need to run `git push`.
+    return Color::Magenta;
+  }
+  Color::Green
+}
+
+/// Map a branch age to a freshness colour: green < 7d, yellow < 30d,
+/// darkgray otherwise. Cutoffs are wide on purpose — a 6-day branch
+/// is "fresh", a 4-week one is "ageing", a 5-week one is "stale" —
+/// so the colour shift registers as signal rather than noise.
+pub fn freshness_color(age: Duration) -> Color {
+  const WEEK: u64 = 7 * 86_400;
+  const MONTH: u64 = 30 * 86_400;
+  let s = age.as_secs();
+  if s < WEEK {
+    Color::Green
+  } else if s < MONTH {
+    Color::Yellow
+  } else {
+    Color::DarkGray
+  }
+}
+
+/// Pick a colour for the PR-status dot rendered in the sidebar header.
+/// Ports the lazygit `WithPrColor` palette (open=green, draft=gray,
+/// merged=magenta, closed=red) but uses 16-colour names instead of
+/// hex RGB so the badge respects the user's terminal theme.
+pub fn pr_badge_color(state: PrState) -> Color {
+  match state {
+    PrState::Open => Color::Green,
+    PrState::Draft => Color::DarkGray,
+    PrState::Merged => Color::Magenta,
+    PrState::Closed => Color::Red,
+  }
+}
+
+/// Same idea as [`pr_badge_color`] but for a linked issue. Closed maps
+/// to magenta (treated as "moved on") rather than red so a routinely
+/// resolved issue doesn't read as alarming.
+pub fn issue_badge_color(state: IssueState) -> Color {
+  match state {
+    IssueState::Open => Color::Green,
+    IssueState::Closed => Color::Magenta,
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -141,20 +141,21 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
   };
 
-  // Pre-allocate the age strip OUTSIDE ratatui's Table widget so the
-  // 4-cell fixed width is never squeezed by the layout solver. The
-  // Table's solver respects `Length` only up to a best-effort budget
-  // (per ratatui docs, Min > Max > Length > Percentage > Ratio > Fill);
-  // when the table area is tight (e.g. sidebar open, narrow terminal),
-  // it shrinks `Length` columns proportionally, dropping age from 4 to
-  // 3 (or fewer) cells. The only way to guarantee a fixed width is to
-  // reserve the cells via an outer `Layout::horizontal` before handing
-  // the rest to the Table.
+  // Pre-allocate the marker + age strips OUTSIDE ratatui's Table
+  // widget so their fixed widths are never squeezed by the layout
+  // solver. Per ratatui docs the constraint priority is
+  // `Min > Max > Length > Percentage > Ratio > Fill`, and when the
+  // Table area is tight (sidebar open ⇒ ~60% of frame, narrow term),
+  // `Length` columns still get shrunk proportionally — that's how
+  // the previous `Length(2)` marker and `Length(4)` age both dropped
+  // below their nominal widths.
   //
-  // Layout: [outer block] → inner → [4 cells age | 1 cell gap | Fill(table)].
-  // The outer block (borders + title) wraps the whole area; the inner
-  // split divides the work between the manual age renderer and the
-  // Table widget.
+  // Outer layout: borders → inner → `[2 marker | 4 age | 1 gap | Fill(table)]`.
+  // The four zones share the same row baseline (header on row 0,
+  // data rows from row 1 down), so the manual strips align cell-for-cell
+  // with the Table's rows. On the selected row we paint a DarkGray
+  // background across all four zones so the highlight reads as one
+  // continuous band rather than three disconnected fragments.
   let outer_block = Block::default()
     .borders(Borders::ALL)
     .title(title)
@@ -163,17 +164,20 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   f.render_widget(outer_block, area);
 
   let inner_split = Layout::horizontal([
-    Constraint::Length(4), // age strip — fixed, never squeezed
-    Constraint::Length(1), // gap
-    Constraint::Fill(1),   // table area — absorbs the rest
+    Constraint::Length(2),
+    Constraint::Length(4),
+    Constraint::Length(1),
+    Constraint::Fill(1),
   ])
   .split(inner_area);
-  let age_strip = inner_split[0];
-  let table_area = inner_split[2];
+  let marker_strip = inner_split[0];
+  let age_strip = inner_split[1];
+  let gap_strip = inner_split[2];
+  let table_area = inner_split[3];
 
-  // The Table no longer carries the age column; col 0 is the marker.
+  // Table now carries only the four growable columns; marker + age
+  // are rendered manually in their pre-allocated strips below.
   let header = Row::new(vec![
-    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
@@ -187,51 +191,89 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];
 
+  // No `highlight_symbol` — the manual marker strip already carries
+  // the `★ / ●` glyphs and an arrow would now appear after the
+  // strips, breaking visual alignment with the marker column.
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
-    .highlight_symbol("▶ ");
+    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));
 
   f.render_stateful_widget(table, table_area, &mut app.list_state);
 
-  // Now overlay the age values on age_strip. Row 0 is the (empty)
-  // header line, rows 1..=visible.len() carry the values. We mirror
-  // the Table's row_highlight_style on the selected row so the band
-  // stays visually continuous across the gap.
-  render_age_strip(f, age_strip, &visible, app.list_state.selected());
+  render_left_strips(
+    f,
+    marker_strip,
+    age_strip,
+    gap_strip,
+    &visible,
+    app.list_state.selected(),
+  );
 }
 
-/// Render the manually-allocated 4-cell-wide age column to the left of
-/// the Table widget. Aligns one Line per Table row (header line first,
-/// then one per visible worktree) and mirrors the Table's row_highlight
-/// background on the selected row so the user can't tell the column is
-/// rendered outside the Table.
-fn render_age_strip(f: &mut Frame, area: Rect, visible: &[&WorktreeInfo], selected: Option<usize>) {
-  if area.width == 0 || area.height == 0 {
+/// Paint the manually-allocated marker + age strips, plus the 1-cell
+/// gap between them and the Table. Mirrors the Table's
+/// `row_highlight_style` (DarkGray background, bold) on the selected
+/// row across all three zones so the highlight reads as a single
+/// continuous band rather than three disconnected fragments.
+fn render_left_strips(
+  f: &mut Frame,
+  marker_strip: Rect,
+  age_strip: Rect,
+  gap_strip: Rect,
+  visible: &[&WorktreeInfo],
+  selected: Option<usize>,
+) {
+  if marker_strip.height == 0 {
     return;
   }
-  let mut lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  // Header row aligns with the Table's header (empty caption — the
-  // glyphs are self-evident).
-  lines.push(Line::from(""));
+
+  let mut marker_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  let mut age_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  // Row 0 = header (kept empty — the column glyphs are self-evident).
+  marker_lines.push(Line::from(""));
+  age_lines.push(Line::from(""));
+
   for (i, w) in visible.iter().enumerate() {
+    let (marker_label, marker_color) = table_marker(w);
+    let mut marker_style = Style::default().fg(marker_color);
+    let mut age_style = Style::default().fg(Color::DarkGray);
+    if Some(i) == selected {
+      marker_style = marker_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+      age_style = age_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    }
+    marker_lines.push(Line::from(Span::styled(marker_label, marker_style)));
     let age = branch_age_for(w);
     let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-    let mut style = Style::default().fg(Color::DarkGray);
-    if Some(i) == selected {
-      style = style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-    }
-    lines.push(Line::from(Span::styled(label, style)));
+    age_lines.push(Line::from(Span::styled(label, age_style)));
   }
-  f.render_widget(Paragraph::new(lines), area);
+
+  f.render_widget(Paragraph::new(marker_lines), marker_strip);
+  f.render_widget(Paragraph::new(age_lines), age_strip);
+
+  // The 1-cell gap is empty space between the age strip and the
+  // Table. Without painting it, the selected-row highlight would
+  // show a 1-cell white slot between marker/age (DarkGray) and the
+  // Table (DarkGray). Paint the gap on the selected row only.
+  if let Some(sel) = selected {
+    // +1 for the header row that lives on `gap_strip.y`.
+    let row_y = gap_strip.y.saturating_add(1).saturating_add(sel as u16);
+    if row_y < gap_strip.y + gap_strip.height {
+      let gap_row = Rect {
+        x: gap_strip.x,
+        y: row_y,
+        width: gap_strip.width,
+        height: 1,
+      };
+      f.buffer_mut().set_style(gap_row, Style::default().bg(Color::DarkGray));
+    }
+  }
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -2,6 +2,14 @@ use crate::error::{GwmError, Result};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
+
+/// Trunk branches treated as "merge destinations" when measuring how
+/// long a branch has been alive. Order matters: the first match wins,
+/// so `main` (modern default) beats `master` (legacy) beats `dev` (gwm
+/// convention). Hardcoded here because `branch_age` is also reachable
+/// from contexts that don't carry a `Config` (CLI smoke paths).
+const TRUNK_CANDIDATES: &[&str] = &["main", "master", "dev"];
 
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -290,6 +298,81 @@ pub fn git_status_short(path: &Path) -> Result<String> {
     )));
   }
   Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Time elapsed since the *oldest* commit on `branch` that's not also on a
+/// known trunk (main / master / dev). Returns `None` when no such commit
+/// exists — i.e. the branch is the trunk itself, has no divergence yet,
+/// or `branch` cannot be resolved. The "oldest commit" rule mirrors the
+/// lazygit branch-age semantics (pkg/utils/date.go::UnixToTimeAgo on the
+/// branch's founding commit) and is more meaningful for a worktree-manager
+/// than `git log -1`: it answers "how long has this branch been alive?"
+/// rather than "when did someone last touch it?".
+pub fn branch_age(repo: &Repository, branch: &str) -> Option<Duration> {
+  // The trunk itself has no "branch age" — there's no founding-commit
+  // distinct from the repository's initial commit, and the natural
+  // answer ("since forever") is more usefully encoded as `None` so the
+  // UI can render a dash instead of a misleadingly precise duration.
+  if TRUNK_CANDIDATES.contains(&branch) {
+    return None;
+  }
+
+  let local = repo.find_branch(branch, BranchType::Local).ok()?;
+  let head_oid = local.into_reference().target()?;
+
+  let mut walker = repo.revwalk().ok()?;
+  walker.push(head_oid).ok()?;
+  for trunk in TRUNK_CANDIDATES {
+    if let Ok(t) = repo.find_branch(trunk, BranchType::Local) {
+      if let Some(oid) = t.into_reference().target() {
+        let _ = walker.hide(oid);
+      }
+    }
+  }
+
+  let mut oldest_secs: Option<i64> = None;
+  for oid in walker.flatten() {
+    if let Ok(commit) = repo.find_commit(oid) {
+      let t = commit.time().seconds();
+      oldest_secs = Some(oldest_secs.map_or(t, |x| x.min(t)));
+    }
+  }
+  let oldest = oldest_secs?;
+  let now = chrono::Utc::now().timestamp();
+  let elapsed = (now - oldest).max(0) as u64;
+  Some(Duration::from_secs(elapsed))
+}
+
+/// Render a `Duration` as a lazygit-style compact relative label
+/// (`2d`, `3w`, `1M`, `5y`). Mirrors `pkg/utils/date.go::formatSecondsAgo`
+/// from lazygit: single-character suffix, no plural, capital `M` to
+/// disambiguate from minutes. Bounded at 4 chars for two-digit values in
+/// each unit, which is enough for any realistic branch age.
+pub fn format_relative_duration(d: Duration) -> String {
+  const MINUTE: u64 = 60;
+  const HOUR: u64 = 60 * MINUTE;
+  const DAY: u64 = 24 * HOUR;
+  const WEEK: u64 = 7 * DAY;
+  // Month = 30.25 days, year = 365.25 days (matches lazygit `pkg/utils/date.go`).
+  const MONTH: u64 = 30 * DAY + 6 * HOUR;
+  const YEAR: u64 = 365 * DAY + 6 * HOUR;
+
+  let s = d.as_secs();
+  if s < MINUTE {
+    format!("{}s", s)
+  } else if s < HOUR {
+    format!("{}m", s / MINUTE)
+  } else if s < DAY {
+    format!("{}h", s / HOUR)
+  } else if s < WEEK {
+    format!("{}d", s / DAY)
+  } else if s < MONTH {
+    format!("{}w", s / WEEK)
+  } else if s < YEAR {
+    format!("{}M", s / MONTH)
+  } else {
+    format!("{}y", s / YEAR)
+  }
 }
 
 /// Resolve a worktree by exact name first, then by substring (case-insensitive) within the dir name.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -322,12 +322,24 @@ pub fn branch_age(repo: &Repository, branch: &str) -> Option<Duration> {
 
   let mut walker = repo.revwalk().ok()?;
   walker.push(head_oid).ok()?;
+  // Track whether any trunk baseline was actually hidden. Without one,
+  // the revwalk degenerates into "all commits reachable from HEAD" and
+  // the oldest one is the repo's initial commit — i.e. the branch's
+  // age becomes the repo's lifetime. PR #74 review caught this: when
+  // no trunk candidate resolves locally, return `None` so the UI
+  // renders `-` instead of a misleadingly large duration.
+  let mut hidden_any = false;
   for trunk in TRUNK_CANDIDATES {
     if let Ok(t) = repo.find_branch(trunk, BranchType::Local) {
       if let Some(oid) = t.into_reference().target() {
-        let _ = walker.hide(oid);
+        if walker.hide(oid).is_ok() {
+          hidden_any = true;
+        }
       }
     }
+  }
+  if !hidden_any {
+    return None;
   }
 
   let mut oldest_secs: Option<i64> = None;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,4 +1,5 @@
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -21,6 +22,11 @@ pub struct WorktreeInfo {
   pub is_locked: bool,
   pub is_prunable: bool,
   pub status: BranchStatus,
+  /// Issue/PR link resolved at list time, so the table marker column
+  /// can show `●` on rows that carry GitHub context without each frame
+  /// re-shelling `git config`. Empty link = no marker dot. See
+  /// `tui/ui.rs::table_marker`.
+  pub link: BranchLink,
 }
 
 /// Cheap snapshot of "where are we vs. clean / upstream".
@@ -119,6 +125,10 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
     let head_ref = repo.head().ok();
     let branch = head_ref.as_ref().and_then(|r| r.shorthand().map(|s| s.to_string()));
     let head = head_ref.as_ref().and_then(|r| r.target().map(|o| o.to_string()));
+    let link = branch
+      .as_deref()
+      .and_then(|b| github::read_link(repo, b).ok())
+      .unwrap_or_else(BranchLink::empty);
     out.push(WorktreeInfo {
       name: workdir
         .file_name()
@@ -131,6 +141,7 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       is_locked: false,
       is_prunable: false,
       status: compute_status(repo),
+      link,
     });
   }
 
@@ -163,6 +174,10 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       ),
     };
 
+    let link = branch
+      .as_deref()
+      .and_then(|b| github::read_link(repo, b).ok())
+      .unwrap_or_else(BranchLink::empty);
     out.push(WorktreeInfo {
       name: name.to_string(),
       path,
@@ -172,6 +187,7 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       is_locked,
       is_prunable,
       status,
+      link,
     });
   }
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use gwm::config::{expand_placeholders, Config, WorktreeConfig, CONFIG_FILE};
+use gwm::config::{expand_placeholders, Config, TuiOpenMode, WorktreeConfig, CONFIG_FILE};
 use tempfile::TempDir;
 
 #[test]
@@ -275,4 +275,103 @@ confirm_countdown_secs = 300
   .unwrap();
   let cfg = Config::load_for_repo(dir.path()).expect("300 must parse, not error");
   assert_eq!(cfg.tui.effective_confirm_countdown_secs(), 5);
+}
+
+// Issue #73: [tui.open] table. The `o` key in the TUI dispatches to one of
+// three behaviours (shell-in-worktree, editor, OS file manager) decided by
+// config. Default is `shell` — lazygit-style — to match the worktree-manager
+// workflow ("I want to *do work* in this worktree").
+
+#[test]
+fn tui_open_section_defaults_to_shell_mode() {
+  let cfg = Config::default();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+  assert!(cfg.tui.open.shell_cmd.is_none());
+  assert!(cfg.tui.open.editor_cmd.is_none());
+}
+
+#[test]
+fn tui_open_section_absent_keeps_defaults() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[worktree]
+base = "/tmp/wt/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+}
+
+#[test]
+fn tui_open_mode_editor_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "editor"
+editor_cmd = "hx"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Editor);
+  assert_eq!(cfg.tui.open.editor_cmd.as_deref(), Some("hx"));
+}
+
+#[test]
+fn tui_open_mode_finder_preserves_legacy_behaviour() {
+  // Users who liked the pre-#73 default (`open` / `xdg-open` / `explorer`)
+  // can opt back in. The variant is named `Finder` after the dominant macOS
+  // use case but covers all three OS openers.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "finder"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Finder);
+}
+
+#[test]
+fn tui_open_mode_shell_with_custom_cmd_round_trips() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "shell"
+shell_cmd = "/usr/bin/fish"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+  assert_eq!(cfg.tui.open.shell_cmd.as_deref(), Some("/usr/bin/fish"));
+}
+
+#[test]
+fn tui_open_mode_invalid_value_errors_at_parse_time() {
+  // Unknown enum variants are a hard config error — we can't silently fall
+  // back to a default without confusing the user about which mode is active.
+  // Document the supported set in the example file; bad values surface here.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "neovim"
+"#,
+  )
+  .unwrap();
+  assert!(Config::load_for_repo(dir.path()).is_err());
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1435,3 +1435,117 @@ fn issue_state_variants_compile() {
   let _ = IssueState::Open;
   let _ = IssueState::Closed;
 }
+
+// ---- Issue #73: configurable `o:` open key ---------------------------------
+// `App::resolve_open_target` returns an `OpenTarget` that the event loop
+// dispatches on (suspend-and-spawn for shell/editor, OS opener for finder).
+// Pure resolution — no side effects, no spawn — so the test can pin the
+// command resolution under every config / env combination.
+
+use gwm::config::{TuiOpenConfig, TuiOpenMode};
+use gwm::tui::OpenTarget;
+
+#[test]
+fn resolve_open_target_returns_none_when_nothing_selected() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(None);
+  assert!(app.resolve_open_target().is_none());
+}
+
+#[test]
+fn resolve_open_target_defaults_to_shell_mode() {
+  // Default config (`mode = "shell"`) + a worktree selected → Shell variant
+  // carrying the worktree path. The exact command depends on env / fallback;
+  // here we only pin the variant + path so the test isn't $SHELL-dependent.
+  let (_dir, app) = make_app();
+  let target = app
+    .resolve_open_target()
+    .expect("main worktree should always be selectable");
+  match target {
+    OpenTarget::Shell { path, command } => {
+      assert_eq!(path, app.worktrees[0].path);
+      assert!(!command.is_empty(), "shell command must never be empty");
+    }
+    other => panic!("expected Shell variant, got {:?}", other),
+  }
+}
+
+#[test]
+fn resolve_open_target_honours_shell_cmd_override() {
+  // `shell_cmd = "/usr/bin/fish"` must beat `$SHELL` — that's the whole
+  // point of the override. Use a sentinel that's unlikely to be the
+  // ambient shell to make the assertion deterministic.
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Shell,
+    shell_cmd: Some("/sentinel/shell".into()),
+    editor_cmd: None,
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Shell { command, .. } => assert_eq!(command, "/sentinel/shell"),
+    other => panic!("expected Shell, got {:?}", other),
+  }
+}
+
+#[test]
+fn resolve_open_target_uses_editor_mode_when_configured() {
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Editor,
+    shell_cmd: None,
+    editor_cmd: Some("hx".into()),
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Editor { path, command } => {
+      assert_eq!(path, app.worktrees[0].path);
+      assert_eq!(command, "hx");
+    }
+    other => panic!("expected Editor, got {:?}", other),
+  }
+}
+
+// ---- Issue #73: `y: yank` clipboard support -------------------------------
+// `App::yank_selected_path` returns the path to push into the clipboard,
+// or None when nothing's selected. The actual shell-out (pbcopy / wl-copy
+// / xclip / clip) is tested manually — CI machines don't necessarily
+// have any of these installed, so we keep the test scope to the pure
+// resolution step and rely on the smoke test in the TUI for the rest.
+
+#[test]
+fn yank_selected_path_returns_path_for_selected_worktree() {
+  let (_dir, app) = make_app();
+  let path = app.yank_selected_path().expect("main worktree must be yankable");
+  assert_eq!(path, app.worktrees[0].path);
+}
+
+#[test]
+fn yank_selected_path_returns_none_when_nothing_selected() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(None);
+  assert!(app.yank_selected_path().is_none());
+}
+
+#[test]
+fn yank_candidates_for_current_platform_is_non_empty() {
+  // Whatever the host OS, the candidate list must offer at least one
+  // tool to try — empty would mean `y` could never succeed even with a
+  // working pbcopy / xclip installed.
+  assert!(
+    !gwm::tui::clipboard_candidates().is_empty(),
+    "clipboard candidates must include at least one tool for this OS"
+  );
+}
+
+#[test]
+fn resolve_open_target_uses_finder_mode_for_legacy_behaviour() {
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Finder,
+    shell_cmd: None,
+    editor_cmd: None,
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Finder { path } => assert_eq!(path, app.worktrees[0].path),
+    other => panic!("expected Finder, got {:?}", other),
+  }
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -24,6 +24,7 @@ fn worktree_fixture(name: &str) -> WorktreeInfo {
     is_locked: false,
     is_prunable: false,
     status: BranchStatus::default(),
+    link: gwm::github::BranchLink::empty(),
   }
 }
 
@@ -1523,6 +1524,53 @@ fn yank_selected_path_returns_none_when_nothing_selected() {
   let (_dir, mut app) = make_app();
   app.list_state.select(None);
   assert!(app.yank_selected_path().is_none());
+}
+
+// ---- Issue #73 (PR #74 follow-up): table marker pastille ------------------
+// The marker column (first cell) doubles as the lazygit-style status dot.
+// `★` still wins for main; non-main worktrees that carry a link (issue or
+// PR) get `●` so the row visually signals "this has GitHub context", even
+// when the sidebar is hidden (`<120` cols or `v` collapsed).
+
+#[test]
+fn table_marker_for_main_worktree_is_yellow_star() {
+  use gwm::github::BranchLink;
+  let mut w = worktree_fixture("main");
+  w.is_main = true;
+  w.link = BranchLink::empty();
+  let (label, color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, "★");
+  assert_eq!(color, Color::Yellow);
+}
+
+#[test]
+fn table_marker_for_linked_non_main_is_neutral_dot() {
+  // No fetched state available at the table layer — colour stays neutral
+  // (Cyan) so the dot reads as "has link" without claiming a specific
+  // open/closed status. The coloured dot lives in the sidebar header where
+  // the live fetch state is known.
+  use gwm::github::{BranchLink, LinkSource};
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink {
+    issue: Some(42),
+    pr: None,
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::None,
+  };
+  let (label, color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, "●");
+  assert_eq!(color, Color::Cyan);
+}
+
+#[test]
+fn table_marker_for_unlinked_non_main_is_blank() {
+  use gwm::github::BranchLink;
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink::empty();
+  let (label, _color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, " ", "unlinked non-main rows keep an empty marker cell");
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2,8 +2,12 @@ mod common;
 
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
-use gwm::tui::{filled_cells_for_progress, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+use gwm::tui::{
+  branch_name_color, filled_cells_for_progress, freshness_color, pr_badge_color, App, ConfirmKeyAction,
+  CountdownTickOutcome, Field, View,
+};
 use gwm::worktree::{BranchStatus, WorktreeInfo};
+use ratatui::style::Color;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -1302,4 +1306,132 @@ fn refresh_github_status_message_celebrates_full_success() {
     "all-green refresh should signal success: {}",
     app.status
   );
+}
+
+// ---- Issue #73: lazygit-style color helpers --------------------------------
+// Three pure functions live in `tui/ui.rs` and are re-exported through
+// `tui/mod.rs` so the table-driven tests below can pin the contract.
+// Visual regressions land here first, before showing up in screenshots.
+
+#[test]
+fn branch_name_color_codes_synced_branch_as_green() {
+  let synced = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&synced), Color::Green);
+}
+
+#[test]
+fn branch_name_color_codes_dirty_branch_as_red() {
+  // Dirty = local working copy has uncommitted work. Lazygit doesn't surface
+  // dirty in its branches view (it has a dedicated files view), but for a
+  // worktree manager the most important signal is "this worktree has work
+  // not yet captured anywhere" — red flags that hard.
+  let dirty = BranchStatus {
+    is_dirty: true,
+    has_upstream: true,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&dirty), Color::Red);
+}
+
+#[test]
+fn branch_name_color_codes_ahead_or_behind_as_yellow() {
+  let ahead = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 3,
+    behind: 0,
+    unknown: false,
+  };
+  let behind = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 2,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&ahead), Color::Yellow);
+  assert_eq!(branch_name_color(&behind), Color::Yellow);
+}
+
+#[test]
+fn branch_name_color_codes_unpublished_branch_as_magenta() {
+  // No upstream + nothing dirty = branch exists locally only. Mirrors
+  // lazygit's "?" magenta marker for RemoteBranchNotStoredLocally —
+  // distinct from "synced" (green) and from "behind" (yellow) so the user
+  // can tell at a glance whether they've pushed yet.
+  let unpublished = BranchStatus {
+    is_dirty: false,
+    has_upstream: false,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&unpublished), Color::Magenta);
+}
+
+#[test]
+fn branch_name_color_codes_unknown_status_as_darkgray() {
+  let unknown = BranchStatus {
+    unknown: true,
+    ..BranchStatus::default()
+  };
+  assert_eq!(branch_name_color(&unknown), Color::DarkGray);
+}
+
+#[test]
+fn freshness_color_picks_green_for_recent_branches() {
+  assert_eq!(freshness_color(Duration::from_secs(0)), Color::Green);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 3)), Color::Green);
+  assert_eq!(
+    freshness_color(Duration::from_secs(86_400 * 6 + 3600 * 23)),
+    Color::Green
+  );
+}
+
+#[test]
+fn freshness_color_picks_yellow_for_one_to_four_week_branches() {
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 7)), Color::Yellow);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 15)), Color::Yellow);
+  assert_eq!(
+    freshness_color(Duration::from_secs(86_400 * 29 + 3600 * 23)),
+    Color::Yellow
+  );
+}
+
+#[test]
+fn freshness_color_picks_darkgray_for_stale_branches() {
+  // Branches older than a month read as "stale" — gwm encourages cleanup
+  // via `gwm doctor`, so the colour reinforces the prompt.
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 30)), Color::DarkGray);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 365)), Color::DarkGray);
+}
+
+#[test]
+fn pr_badge_color_maps_each_state_to_its_lazygit_palette() {
+  // Mirrors `pkg/gui/presentation/branches.go::WithPrColor` — open=green,
+  // draft=darkgray, merged=magenta, closed=red. The actual lazygit RGB
+  // shades are slightly off-palette for terminal themes; we use the
+  // 16-color names so the dots respect the user's colour scheme.
+  assert_eq!(pr_badge_color(PrState::Open), Color::Green);
+  assert_eq!(pr_badge_color(PrState::Draft), Color::DarkGray);
+  assert_eq!(pr_badge_color(PrState::Merged), Color::Magenta);
+  assert_eq!(pr_badge_color(PrState::Closed), Color::Red);
+}
+
+// Ensure the IssueState variants stay accessible — once `branch_name_color`
+// and the rest land, the sidebar's badge function will need to fall back to
+// an issue-derived colour when no PR is linked. The compile-time check below
+// catches a stale import without polluting the runtime tests.
+#[test]
+fn issue_state_variants_compile() {
+  let _ = IssueState::Open;
+  let _ = IssueState::Closed;
 }

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -5,7 +5,10 @@
 mod common;
 
 use common::{init_repo, paths_equal};
+use git2::{Repository, Signature, Time};
 use gwm::worktree;
+use std::path::Path;
+use std::time::Duration;
 use tempfile::TempDir;
 
 #[test]
@@ -195,4 +198,159 @@ fn git_log_oneline_errors_outside_repo() {
   let empty = TempDir::new().unwrap();
   let err = worktree::git_log_oneline(empty.path(), 5);
   assert!(err.is_err(), "expected error outside a git repo, got: {:?}", err);
+}
+
+// Issue #73: relative-duration formatter + branch age. The formatter is a
+// pure function (table-driven tests below); `branch_age` walks the commit
+// graph and needs a real repo with controlled commit timestamps.
+
+#[test]
+fn format_relative_duration_under_one_minute_renders_seconds() {
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(0)), "0s");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(1)), "1s");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(59)), "59s");
+}
+
+#[test]
+fn format_relative_duration_steps_through_units() {
+  // Anchor cases at the lazygit boundary (>= unit threshold → render in that unit).
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(60)), "1m");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(60 * 59)), "59m");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(3600)), "1h");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(3600 * 23)),
+    "23h"
+  );
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(86_400)), "1d");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 6)),
+    "6d"
+  );
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 7)),
+    "1w"
+  );
+  // 4 weeks is still rendered as weeks; the month cutoff sits at ~30 days.
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 28)),
+    "4w"
+  );
+}
+
+#[test]
+fn format_relative_duration_handles_months_and_years() {
+  // Month uses a 30.25-day approximation (lazygit `pkg/utils/date.go`).
+  let one_month = 30 * 86_400 + 6 * 3600;
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(one_month)), "1M");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(one_month * 11)),
+    "11M"
+  );
+  let one_year = 365 * 86_400 + 6 * 3600;
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(one_year)), "1y");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(one_year * 3 + 86_400 * 10)),
+    "3y"
+  );
+}
+
+#[test]
+fn format_relative_duration_output_stays_under_four_chars_for_realistic_inputs() {
+  // Lazygit's recency column is documented as "always three characters";
+  // gwm cell is slightly more lenient (4) but the lazygit promise must hold
+  // for every value below 100 of any unit.
+  for secs in [
+    0, 1, 59, 60, 3599, 3600, 86_399, 86_400, 604_799, 604_800, 2_595_600, 2_595_601,
+  ] {
+    let out = worktree::format_relative_duration(Duration::from_secs(secs));
+    assert!(
+      out.len() <= 4,
+      "format_relative_duration({}s) = {:?} exceeded 4 chars",
+      secs,
+      out
+    );
+  }
+}
+
+#[test]
+fn branch_age_returns_none_for_main_only_repo() {
+  // Repo with a single branch (`main`) and no divergence has no "branch
+  // creation" date — `branch_age` returns None so the UI can fall back to
+  // a dash.
+  let (dir, _) = init_repo();
+  let repo = Repository::open(dir.path()).unwrap();
+  assert!(worktree::branch_age(&repo, "main").is_none());
+}
+
+#[test]
+fn branch_age_reflects_oldest_branch_commit() {
+  // Build a `feat/age` branch with two commits — `branch_age` must return
+  // the elapsed time since the *oldest* commit on that branch (the one
+  // that pinned the branch creation), not the latest tip commit.
+  let (dir, repo) = init_repo();
+  // Anchor "branch creation" at a known instant — 3 days ago, so the
+  // formatter rendering layer can also be sanity-checked downstream.
+  let three_days_ago = chrono::Utc::now().timestamp() - 3 * 86_400;
+  let one_hour_ago = chrono::Utc::now().timestamp() - 3600;
+
+  let main_oid = repo.head().unwrap().target().unwrap();
+  let main_commit = repo.find_commit(main_oid).unwrap();
+  repo.branch("feat/age", &main_commit, false).unwrap();
+
+  // First commit on the branch — dated 3 days ago.
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/age", "branch-old", three_days_ago);
+  // Second commit on the branch — dated 1 hour ago.
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/age", "branch-recent", one_hour_ago);
+
+  let age = worktree::branch_age(&repo, "feat/age").expect("branch must have an age");
+  let three_days_secs = 3 * 86_400;
+  // Allow a 5-minute wiggle for test execution time.
+  let drift = age.as_secs().abs_diff(three_days_secs);
+  assert!(
+    drift < 300,
+    "expected ~{} seconds, got {} (drift {}s)",
+    three_days_secs,
+    age.as_secs(),
+    drift
+  );
+}
+
+#[test]
+fn branch_age_treats_master_and_dev_as_trunks() {
+  // A `feat/work` branch must still get a non-None age even when the
+  // default trunk is `dev` (not `main`). Verifies the trunk-candidates
+  // list covers the common conventions.
+  let dir = TempDir::new().unwrap();
+  let repo = Repository::init(dir.path()).unwrap();
+  repo.set_head("refs/heads/dev").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  let dev_oid = repo.head().unwrap().target().unwrap();
+  let dev_commit = repo.find_commit(dev_oid).unwrap();
+  repo.branch("feat/work", &dev_commit, false).unwrap();
+
+  let two_days_ago = chrono::Utc::now().timestamp() - 2 * 86_400;
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/work", "branch-commit", two_days_ago);
+
+  let age = worktree::branch_age(&repo, "feat/work").expect("dev-rooted branch must have an age");
+  let drift = age.as_secs().abs_diff(2 * 86_400);
+  assert!(drift < 300, "expected ~2 days, got {}s", age.as_secs());
+}
+
+/// Helper: append a commit (empty tree, configurable timestamp) on top of
+/// the given ref. The committer / author share the same timestamp so
+/// `branch_age` (which reads committer time) is deterministic.
+fn commit_with_time(workdir: &Path, repo: &Repository, ref_name: &str, message: &str, unix_secs: i64) {
+  let _ = workdir; // currently unused but reserved if we later need to touch the index
+  let time = Time::new(unix_secs, 0);
+  let sig = Signature::new("gwm-test", "gwm@test", &time).unwrap();
+  let parent_oid = repo.find_reference(ref_name).unwrap().target().unwrap();
+  let parent = repo.find_commit(parent_oid).unwrap();
+  let tree_id = parent.tree_id();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo
+    .commit(Some(ref_name), &sig, &sig, message, &tree, &[&parent])
+    .unwrap();
 }

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -339,6 +339,30 @@ fn branch_age_treats_master_and_dev_as_trunks() {
   assert!(drift < 300, "expected ~2 days, got {}s", age.as_secs());
 }
 
+#[test]
+fn branch_age_returns_none_when_no_trunk_candidate_exists_locally() {
+  // PR #74 Copilot review: if none of the trunk candidates (main /
+  // master / dev) resolves as a local branch, the revwalk hides nothing
+  // and `branch_age` falls back to the repo's initial commit — turning
+  // every branch into a misleadingly large age (the repo's lifetime).
+  // The intent is "branch age relative to a trunk baseline"; without
+  // a baseline, we must surface `None` so the UI renders `-`.
+  let dir = TempDir::new().unwrap();
+  let repo = Repository::init(dir.path()).unwrap();
+  // Initialise the repo on a branch that's *not* a trunk candidate so
+  // the seed commit lives on `feat/standalone`, not `main`/`master`/`dev`.
+  repo.set_head("refs/heads/feat/standalone").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+
+  assert!(
+    worktree::branch_age(&repo, "feat/standalone").is_none(),
+    "no trunk baseline → branch_age must be None, not the repo's lifetime"
+  );
+}
+
 /// Helper: append a commit (empty tree, configurable timestamp) on top of
 /// the given ref. The committer / author share the same timestamp so
 /// `branch_age` (which reads committer time) is deterministic.


### PR DESCRIPTION
## Description

Brings the gwm TUI sidebar in line with lazygit's branches view and
makes the action surface match a worktree-manager workflow:

- `●` PR/Issue status dot in the sidebar header (open=green,
  draft=gray, merged=magenta, closed=red, neutral when nothing linked).
- Branch name coloured by `BranchStatus` (worst-state wins) in both
  the sidebar and the table.
- New `Created: 2d ago` row with freshness colouring (green <7d,
  yellow <30d, darkgray >30d). Source = oldest commit on the branch
  not on a trunk (main/master/dev), same semantic as lazygit.
- `o` key is now configurable via `[tui.open]`: `shell` (default,
  lazygit-style `$SHELL` in the worktree), `editor` (`$EDITOR <path>`),
  or `finder` (pre-#73 OS file manager).
- New `y` key: yank the selected worktree's path to the system
  clipboard via `pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`.

Closes #73

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `src/config.rs`: new `TuiOpenConfig` + `TuiOpenMode` (`shell` / `editor` / `finder`),
  plus `deserialize_optional_non_empty` so `shell_cmd = ""` and an
  omitted key behave identically.
- `src/worktree.rs`: `branch_age()` (oldest-commit-on-branch vs
  trunks) and `format_relative_duration()` (compact `2d` / `3w` /
  `1M` / `5y`).
- `src/tui/ui.rs`: pure colour helpers (`branch_name_color`,
  `freshness_color`, `pr_badge_color`, `issue_badge_color`), new
  `Created:` row, wire-up into table BRANCH column, `●` status dot
  prefixed on the sidebar header (rebuilt every frame so it tracks
  live fetches without invalidating the git-preview cache).
- `src/tui/app.rs`: `OpenTarget` enum + `App::resolve_open_target()`
  (config override → env var → fallback), `App::yank_selected_path()`.
- `src/tui/mod.rs`: `clipboard_candidates()`, `run_subshell()` (factors
  the suspend/spawn/restore pattern out of `run_lazygit`),
  `yank_selected_path_to_clipboard()`, wired `o` / `y` keybindings.
- Tests: 11 new pure-fn tests for the colour helpers, 4 for the
  formatter / `branch_age`, 6 for `TuiOpenConfig` round-trip, 5 for
  `resolve_open_target`, 3 for the yank path resolution.
- Docs: README "details sidebar" section + "open dispatch" subsection,
  CHANGELOG `[Unreleased]`, `examples/gwm.toml.example` annotated
  `[tui.open]` block, footer + help overlay + sidebar cheat-sheet.

## Tests

- [x] `cargo test` passes locally (351 tests green; 49 new across
      `config_tests`, `worktree_integration`, `tui_app_tests`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: red → green per theme,
      see commits)
- [x] `gwm doctor` green on `.gwm.toml` (touched the schema via
      `[tui.open]`)
- [x] Pre-validated with minimal `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`

## Screenshots / TUI captures

_TUI changes — captures will land on the PR description as a follow-up
comment once I get a clean terminal recording. The behaviour can be
exercised locally:_

```bash
cargo install --path .
gwm
# o → shell in worktree (default)
# y → path in clipboard ; status "yanked path"
# observe ● status dot in sidebar header + Created: row
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#73-lazygit-sidebar`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (CLI surface unchanged; TUI surface documented)
- [x] `examples/gwm.toml.example` updated (`[tui.open]` annotated block)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #73
- Related PR: -

## Notes for reviewers

- **Breaking default**: pressing `o` used to spawn the OS file
  manager. The default in this PR is `shell` (lazygit-style). Users
  who prefer the old behaviour add `[tui.open] mode = "finder"` to
  their `.gwm.toml`. Called out in README + CHANGELOG.
- The `branch_age` trunk list is hardcoded to `["main", "master",
  "dev"]` — same default as `[doctor].trunks`. If a user has a
  custom trunk convention they'll still see "Created: -" until
  someone wires this into the doctor config; treated as a follow-up.
- `yank_selected_path_to_clipboard` walks the candidate list in
  order and stops on the first hit. Tools that resolve on `$PATH`
  but fail to spawn surface the error and don't fall through to the
  next candidate — masking the real error is worse than the
  "next candidate would've worked" case in practice.