### PR TITLE
✨ feat(tui): configurable launchers for l (git_tui) and R (review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+
+- **TUI: configurable launchers for `l` (git_tui) and `R` (review)**
+  ([#75](https://github.com/kbrdn1/gwm-cli/issues/75)). Two new
+  `.gwm.toml` sections — `[git_tui]` and `[review]` — drive the
+  worktree-list `l` / `R` keybindings through a shared launcher
+  pipeline (placeholder expansion `{base} {head} {path} {diff}`,
+  `shell-words` split, optional fullscreen suspend-and-resume).
+  `[git_tui]` defaults to `lazygit -p {path}` fullscreen so existing
+  repos see zero behaviour change. `[review]` accepts either a
+  free-form `command = "<shell line>"` or a `tool = "<preset>"` sugar
+  (`lumen`, `claude`, `codex`, `aider`, `gh`). New
+  `branch.<n>.gwm-base` key, set by `gwm create`, anchors the review
+  base-resolution chain (upstream → gwm-base → `[review].default_base`
+  → `dev` → `main`). The `{diff}` placeholder lazily materialises a
+  tempfile holding `git diff {base}..{head}` — only when the template
+  references it.
+
+### Changed
+
+- **TUI keybind reshuffle**: `f` now refreshes the worktree list (was
+  `r`, kept as alias for muscle memory); `F` refreshes the GitHub
+  issue/PR status (was `R`); the freed `R` triggers the new review
+  launcher. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
+- `gwm doctor` now probes the configured `[review]` and `[git_tui]`
+  binaries against `$PATH`. A missing review tool surfaces as Warning
+  (exit code `1`), never Failed (`2`) — review is opt-in, so a CI
+  pre-commit hook keeps passing when only the local launcher is
+  unavailable. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
 
 ## Past releases
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -117,3 +117,51 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # [tui]
 # confirm_countdown_secs = 3
+
+# --- TUI launcher: `l` (git_tui) keybinding (issue #75) ----------------------
+# The `l` key suspends the gwm TUI and launches a git TUI on the selected
+# worktree. Placeholders: {path}. Default (no section) → `lazygit -p {path}`
+# fullscreen=true, identical to the pre-issue-#75 hardcoded behaviour.
+#
+# Switch to gitui:
+# [git_tui]
+# command = "gitui -d {path}"
+# fullscreen = true
+#
+# Or to a non-TUI tool (gwm stays visible, stderr first-line lands in the
+# status bar):
+# [git_tui]
+# command = "code {path}"
+# fullscreen = false
+
+# --- TUI launcher: `R` (review) keybinding (issue #75) -----------------------
+# The `R` key runs a code-review tool against the resolved base ref.
+# Placeholders in `command`:
+#   {base}  — resolved base (upstream → branch.<n>.gwm-base → default_base
+#             → "dev" → "main")
+#   {head}  — selected worktree's branch name
+#   {path}  — absolute path of the selected worktree
+#   {diff}  — path to a temp file holding `git diff {base}..{head}`
+#             (lazily materialised; only created if the template uses it)
+#
+# Built-in presets — pick one with `tool = "<name>"` instead of `command`:
+#   lumen  → "lumen diff {base}..{head}"             · fullscreen=true
+#   claude → "claude --print 'review the diff {base}..{head}'" · fullscreen=false
+#   codex  → "codex review {base}..{head}"           · fullscreen=false
+#   aider  → "aider --message 'review {base}..{head}'" · fullscreen=true
+#   gh     → "gh pr view --web"                      · fullscreen=false
+#
+# When both `command` and `tool` are set, `command` wins (the TUI flags
+# the shadow in the status bar). Setting neither leaves `R` inert with
+# a status-bar hint.
+#
+# [review]
+# tool = "lumen"
+# skip_when_no_changes = true   # default true — skip when `git rev-list --count {base}..{head} == 0`
+# # default_base = "dev"        # optional pin overriding the auto-discovery chain
+#
+# Explicit form (overrides any preset):
+# [review]
+# command              = "lumen diff {base}..{head}"
+# fullscreen           = true
+# skip_when_no_changes = true

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -102,10 +102,12 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 | `d`         | delete (confirm `y`)                                                            |
 | `b`         | re-run bootstrap on selected                                                    |
 | `o`         | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`)         |
-| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; gwm resumes on lazygit exit |
+| `l`         | run the configured `[git_tui]` launcher (default `lazygit -p <selected-worktree>` fullscreen) |
+| `R`         | run the configured `[review]` launcher against the resolved base (issue #75)    |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)    |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `r`         | refresh                                                                         |
+| `f`         | refresh worktree list (also accepts `r` for muscle memory)                      |
+| `F`         | refresh GitHub issue/PR status via `gh`                                         |
 | `p`         | toggle "delete branch on remove"                                                |
 | `Enter`     | show path in status bar                                                         |
 | `?`         | help overlay                                                                    |
@@ -123,9 +125,59 @@ When the terminal width is ≥ 120 columns and the sidebar is open (default ON, 
 
 `Tab` swaps focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel. The focused panel's border turns cyan.
 
-## Lazygit integration
+## Configurable launchers (`l` git_tui · `R` review) — issue #75
 
-Press `l` to suspend the gwm TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on the selected worktree (`lazygit -p <path>`). Quitting lazygit restores the gwm TUI exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it and the TUI keeps running.
+Two TUI keybindings share the same mini-API: take a `command` template from `.gwm.toml`, substitute placeholders, split with `shell-words`, and exec it with `cwd = <selected-worktree>`.
+
+| Key | Section     | Default                       | Placeholders                          | Default `fullscreen` |
+|:----|:------------|:------------------------------|:--------------------------------------|:---------------------|
+| `l` | `[git_tui]` | `lazygit -p {path}`           | `{path}`                              | `true`               |
+| `R` | `[review]`  | _(inert until configured)_    | `{base} {head} {path} {diff}`         | `false`              |
+
+`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command in the background, captures stderr's first line, and lands it on the status bar. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
+
+### `[review]` base resolution chain (for `{base}`)
+
+1. `branch.<name>.merge` (the branch's upstream, if any).
+2. `branch.<name>.gwm-base` (recorded by `gwm create` so the parent ref survives `git push -u`).
+3. `[review].default_base` from `.gwm.toml`.
+4. `"dev"` (gwm's project convention).
+5. `"main"` (universal git default).
+
+### `[review].tool` built-in presets
+
+Sugar over `command + fullscreen`. Setting both `command` and `tool` makes `command` win (the TUI surfaces the shadow on next render).
+
+| `tool = "X"` | Resolves to                                              | `fullscreen` default |
+|:-------------|:---------------------------------------------------------|:---------------------|
+| `lumen`      | `lumen diff {base}..{head}`                              | true (TUI)           |
+| `claude`     | `claude --print 'review the diff {base}..{head}'`        | false                |
+| `codex`      | `codex review {base}..{head}`                            | false                |
+| `aider`      | `aider --message 'review {base}..{head}'`                | true (TUI)           |
+| `gh`         | `gh pr view --web`                                       | false                |
+
+### Worked snippets
+
+```toml
+# Switch the `l` key to gitui.
+[git_tui]
+command = "gitui -d {path}"
+
+# Review with lumen (TUI), skip when nothing to review.
+[review]
+tool = "lumen"
+skip_when_no_changes = true
+# default_base = "dev"   # optional pin overriding the auto chain
+
+# Or a free-form shell line — `command` always wins over `tool`.
+[review]
+command = "my-review-bot --diff-file {diff} --owner kbrdn1"
+fullscreen = false
+```
+
+### `gwm doctor` integration
+
+A configured `[review]` / `[git_tui]` binary that is not on `$PATH` surfaces as **Warning** (exit code `1`), never **Failed** (exit code `2`) — both launchers are opt-in, so a CI pre-commit hook gated on `gwm doctor` keeps passing when the only red flag is a missing local-only tool.
 
 ## `.gwm.toml` schema
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
   pub doctor: DoctorConfig,
   #[serde(default)]
   pub tui: TuiConfig,
+  #[serde(default)]
+  pub git_tui: GitTuiConfig,
+  #[serde(default)]
+  pub review: ReviewConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -204,6 +208,148 @@ impl Config {
   pub fn guard_by_name(&self, name: &str) -> Option<&Guard> {
     self.bootstrap.guard.iter().find(|g| g.name == name)
   }
+}
+
+/// `[git_tui]` table — drives the `l` keybinding in the TUI worktree list
+/// (issue #75). Absent ⇒ legacy default `lazygit -p {path}` with
+/// fullscreen=true, so no `.gwm.toml` change is required for repos that
+/// were happy with the previous behaviour. Sharing `[`ReviewConfig`]`'s
+/// shape (placeholder expansion + `fullscreen` flag) keeps the user's
+/// mental model consistent across the two launcher keybindings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GitTuiConfig {
+  /// Shell line. Accepts the `{path}` placeholder. When `None`, the
+  /// resolved launcher uses `lazygit -p {path}`.
+  #[serde(default)]
+  pub command: Option<String>,
+  /// Whether gwm should suspend its own TUI before exec'ing the command.
+  /// Defaults to `true` for TUI tools like lazygit / gitui / tig; set to
+  /// `false` to launch e.g. a GUI editor that should run alongside gwm.
+  #[serde(default)]
+  pub fullscreen: Option<bool>,
+}
+
+impl GitTuiConfig {
+  /// Resolve to a concrete `(command, fullscreen)` pair. The default
+  /// (no `[git_tui]` block in `.gwm.toml`) is `lazygit -p {path}` so the
+  /// `l` keybinding behaves exactly as it did before issue #75 landed.
+  pub fn resolved(&self) -> ResolvedLauncher {
+    ResolvedLauncher {
+      command: self.command.clone().unwrap_or_else(|| "lazygit -p {path}".into()),
+      fullscreen: self.fullscreen.unwrap_or(true),
+    }
+  }
+}
+
+/// `[review]` table — drives the `R` keybinding in the TUI worktree list
+/// (issue #75). The user picks one of three forms:
+///
+/// - `command = "<shell line>"` — the primary contract; any CLI on $PATH
+///   with any arguments. Placeholders `{base} {head} {path} {diff}` are
+///   substituted before the shell line is split with `shell-words`.
+/// - `tool = "<preset>"` — sugar for a built-in `(command, fullscreen)`
+///   pair (see [`ReviewConfig::resolved`]).
+/// - neither — the `R` key is inert and the status bar carries a hint.
+///
+/// When both are set, `command` wins (and the TUI surfaces a status-bar
+/// hint at startup so the user notices their `tool` choice is shadowed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewConfig {
+  /// Shell line. Accepts `{base} {head} {path} {diff}` placeholders.
+  #[serde(default)]
+  pub command: Option<String>,
+  /// Whether gwm should suspend its own TUI before exec'ing the command.
+  /// Defaults to `false` so non-TUI tools (a linter, `gh pr view --web`)
+  /// don't black-out the screen.
+  #[serde(default)]
+  pub fullscreen: Option<bool>,
+  /// Preset name; one of `lumen`, `claude`, `codex`, `aider`, `gh`.
+  /// Resolved to a `(command, fullscreen)` pair by [`ReviewConfig::resolved`].
+  #[serde(default)]
+  pub tool: Option<String>,
+  /// Skip the shell-out when `git rev-list --count {base}..{head} == 0`.
+  /// Default `true`.
+  #[serde(default = "default_skip_when_no_changes")]
+  pub skip_when_no_changes: bool,
+  /// Optional pin for the review base ref. When set, it overrides the
+  /// upstream / `gwm-base` / `dev` / `main` fallback chain.
+  #[serde(default)]
+  pub default_base: Option<String>,
+}
+
+impl Default for ReviewConfig {
+  fn default() -> Self {
+    Self {
+      command: None,
+      fullscreen: None,
+      tool: None,
+      skip_when_no_changes: default_skip_when_no_changes(),
+      default_base: None,
+    }
+  }
+}
+
+fn default_skip_when_no_changes() -> bool {
+  true
+}
+
+impl ReviewConfig {
+  /// Resolve the user's choice to a concrete `(command, fullscreen)`
+  /// pair, or `None` when neither `command` nor a recognised `tool` was
+  /// set. The `command` field wins when both are present.
+  pub fn resolved(&self) -> Option<ResolvedLauncher> {
+    if let Some(cmd) = self.command.as_ref().filter(|s| !s.trim().is_empty()) {
+      return Some(ResolvedLauncher {
+        command: cmd.clone(),
+        fullscreen: self.fullscreen.unwrap_or(false),
+      });
+    }
+    let tool = self.tool.as_deref()?.trim();
+    if tool.is_empty() {
+      return None;
+    }
+    let (cmd, fullscreen_default) = review_tool_preset(tool)?;
+    Some(ResolvedLauncher {
+      command: cmd.into(),
+      fullscreen: self.fullscreen.unwrap_or(fullscreen_default),
+    })
+  }
+
+  /// True when `command` and `tool` are both set — the TUI uses this to
+  /// surface a one-shot warning ("your `tool = X` is shadowed by
+  /// `command = Y`") on first render.
+  pub fn has_shadowed_tool(&self) -> bool {
+    self.command.as_ref().is_some_and(|s| !s.trim().is_empty())
+      && self.tool.as_ref().is_some_and(|s| !s.trim().is_empty())
+  }
+}
+
+/// Built-in preset table for `[review].tool`. Returns `Some((command,
+/// fullscreen))` for known tools, `None` otherwise.
+///
+/// The table is the canonical place to add new presets; it's exposed
+/// (via [`ReviewConfig::resolved`]) so docs and `gwm doctor` can refer
+/// to a single source of truth instead of duplicating the strings.
+pub fn review_tool_preset(tool: &str) -> Option<(&'static str, bool)> {
+  Some(match tool {
+    "lumen" => ("lumen diff {base}..{head}", true),
+    "claude" => ("claude --print 'review the diff {base}..{head}'", false),
+    "codex" => ("codex review {base}..{head}", false),
+    "aider" => ("aider --message 'review {base}..{head}'", true),
+    "gh" => ("gh pr view --web", false),
+    _ => return None,
+  })
+}
+
+/// Concrete `(command, fullscreen)` pair derived from a [`GitTuiConfig`]
+/// or [`ReviewConfig`] by [`GitTuiConfig::resolved`] /
+/// [`ReviewConfig::resolved`]. The launcher then expands placeholders
+/// in `command` and decides whether to suspend the TUI based on
+/// `fullscreen`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLauncher {
+  pub command: String,
+  pub fullscreen: bool,
 }
 
 /// Expand `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}` in a template string.

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,8 +271,13 @@ pub struct ReviewConfig {
   /// Default `true`.
   #[serde(default = "default_skip_when_no_changes")]
   pub skip_when_no_changes: bool,
-  /// Optional pin for the review base ref. When set, it overrides the
-  /// upstream / `gwm-base` / `dev` / `main` fallback chain.
+  /// Optional pin for the review base ref. Slots into the base-
+  /// resolution chain *after* `branch.<n>.merge` (upstream) and
+  /// `branch.<n>.gwm-base`, and *before* the static `dev` / `main`
+  /// fallback. Setting it overrides only the `dev` / `main` step —
+  /// upstream and gwm-base still win when present. See
+  /// [`crate::launcher::resolve_review_base`] for the canonical
+  /// order.
   #[serde(default)]
   pub default_base: Option<String>,
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -241,16 +241,48 @@ fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
     .with_hint(format!("supported keywords: {}", SUPPORTED_WHEN_PREFIXES.join(", ")))
 }
 
+/// Common shell wrappers that introduce the real binary after their
+/// own switches / env assignments. Caught by Copilot's review on
+/// PR #76: pre-fix, `env FOO=bar lumen diff` made the doctor check
+/// `env` against `$PATH` (which is always present) and miss the real
+/// launcher `lumen`. Keep this list narrow on purpose — exotic
+/// wrappers (`nice`, `time`, `nohup`) take positional args, which we
+/// would risk consuming and ending up with the wrong binary.
+const COMMAND_WRAPPERS: &[&str] = &["env", "command"];
+
 /// Extract the executable name from a shell command string. Tokenises
 /// via `shell_words` so quoted args (`"my tool" --flag`) and escaped
 /// whitespace are handled the way the shell would, then skips leading
-/// `FOO=bar` env assignments and returns the first token that isn't
-/// `KEY=VAL`. Returns `None` for empty strings or strings that fail
-/// to parse (unbalanced quotes — better to surface nothing than a
-/// garbage binary name that would produce a confusing PATH warning).
+/// `FOO=bar` env assignments and recognised `env`/`command` wrappers
+/// (and the wrapper's own `KEY=VAL` / `-flag` tokens) before returning
+/// the first token that looks like a real binary name. Returns `None`
+/// for empty strings or strings that fail to parse (unbalanced quotes
+/// — better to surface nothing than a garbage binary name that would
+/// produce a confusing PATH warning).
 fn extract_binary(run: &str) -> Option<String> {
   let tokens = shell_words::split(run).ok()?;
-  tokens.into_iter().find(|t| !t.contains('='))
+  let mut iter = tokens.into_iter().peekable();
+
+  // Skip leading `KEY=VAL` env assignments (POSIX `FOO=bar tool` form).
+  while iter.peek().is_some_and(|t| !t.starts_with('=') && t.contains('=')) {
+    iter.next();
+  }
+
+  // Recognise a wrapper (`env`, `command`) and skip its own `-flag` /
+  // `KEY=VAL` arguments before reaching the real binary. Stops on the
+  // first positional non-flag, non-assignment token.
+  if iter.peek().is_some_and(|t| COMMAND_WRAPPERS.contains(&t.as_str())) {
+    iter.next(); // consume the wrapper itself
+    while let Some(t) = iter.peek() {
+      if t.starts_with('-') || (!t.starts_with('=') && t.contains('=')) {
+        iter.next();
+      } else {
+        break;
+      }
+    }
+  }
+
+  iter.next()
 }
 
 /// Same as [`extract_binary`] but pre-strips the launcher placeholders

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -253,10 +253,26 @@ fn extract_binary(run: &str) -> Option<String> {
   tokens.into_iter().find(|t| !t.contains('='))
 }
 
+/// Same as [`extract_binary`] but pre-strips the launcher placeholders
+/// so a template like `lumen diff {base}..{head}` reduces to `lumen`
+/// before tokenisation. Used for the issue #75 [`crate::config::GitTuiConfig`] /
+/// [`crate::config::ReviewConfig`] entries so the doctor warning
+/// names the actual binary, not a placeholder fragment.
+fn extract_launcher_binary(command: &str) -> Option<String> {
+  let cleaned = command
+    .replace("{base}", "BASE")
+    .replace("{head}", "HEAD")
+    .replace("{path}", "PATH")
+    .replace("{diff}", "/tmp/diff");
+  extract_binary(&cleaned)
+}
+
 /// Check #4: every binary referenced by the bootstrap commands resolves on
-/// `$PATH`. `lazygit` (the TUI's `l` keybinding) and `direnv` (only if the
-/// repo has an `.envrc`) are also checked because they're the two "ambient"
-/// dependencies whose absence routinely confuses new users.
+/// `$PATH`. `lazygit` (the TUI's `l` keybinding's default) and `direnv`
+/// (only if the repo has an `.envrc`) are also checked because they're
+/// the two "ambient" dependencies whose absence routinely confuses new
+/// users. Configured launchers ([git_tui], [review] — issue #75) are
+/// added to the same set so the user gets one consolidated warning.
 ///
 /// Missing binaries are surfaced as Warning, not Failed — the user may not
 /// rely on that step at all, but the visibility matters.
@@ -264,10 +280,22 @@ fn check_binaries_on_path(ctx: &DoctorCtx<'_>) -> Check {
   let name = "external binaries on PATH";
   let mut needed: BTreeSet<String> = BTreeSet::new();
 
-  // Ambient deps the rest of the CLI uses.
-  needed.insert("lazygit".into());
+  // Ambient deps the rest of the CLI uses. `[git_tui]` may override the
+  // lazygit default; we extract whatever binary the resolved launcher
+  // names so a `gitui` / `tig` user gets the right warning.
+  let git_tui = ctx.config.git_tui.resolved();
+  if let Some(bin) = extract_launcher_binary(&git_tui.command) {
+    needed.insert(bin);
+  }
   if ctx.repo_workdir.join(".envrc").exists() {
     needed.insert("direnv".into());
+  }
+  // Review launcher is opt-in; only probe when the user actually
+  // configured one (`command` or `tool`).
+  if let Some(review) = ctx.config.review.resolved() {
+    if let Some(bin) = extract_launcher_binary(&review.command) {
+      needed.insert(bin);
+    }
   }
 
   // Whatever the user's own bootstrap commands invoke.

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -174,7 +174,20 @@ pub fn resolve_review_base(repo: &Repository, branch: &str, default_base: Option
   if let Some(d) = default_base.map(str::trim).filter(|s| !s.is_empty()) {
     return d.to_string();
   }
-  "dev".to_string()
+  // Final fallback: prefer `dev` when it exists locally (gwm's project
+  // convention), otherwise `main` (universal git default). Returning
+  // `dev` blindly when the repo only has `main` would make the launcher's
+  // subsequent `git rev-list` / `git diff` calls fail loudly — caught by
+  // Copilot's review on PR #76.
+  if branch_exists(repo, "dev") {
+    "dev".to_string()
+  } else {
+    "main".to_string()
+  }
+}
+
+fn branch_exists(repo: &Repository, name: &str) -> bool {
+  repo.find_branch(name, git2::BranchType::Local).is_ok()
 }
 
 /// Persist `branch.<name>.gwm-base = <base>` so the review base chain

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,0 +1,264 @@
+//! Configurable command launchers for the TUI `l` (git_tui) and `R`
+//! (review) keybindings — issue #75.
+//!
+//! Both keybindings share the same mini-API: take a `command` template
+//! string from `.gwm.toml`, substitute placeholders, split with
+//! `shell-words`, and exec'd with `cwd = worktree.path`. The only
+//! per-keybinding difference is the placeholder set: `[git_tui]` only
+//! cares about `{path}`, while `[review]` also exposes `{base}`,
+//! `{head}`, and `{diff}` (a lazily-materialised tempfile carrying
+//! `git diff {base}..{head}`).
+//!
+//! This module owns the shared machinery (placeholder expansion,
+//! base resolution, missing-binary probe) so the TUI event loop and
+//! `gwm doctor` can each consume it through the same surface.
+
+use crate::config::ResolvedLauncher;
+use crate::error::{GwmError, Result};
+use git2::Repository;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Placeholder substitution context. `base` and `head` are only required
+/// by the review launcher; the git_tui launcher passes `None` for both.
+/// `worktree_path` is mandatory because both launchers `cd` into it
+/// before exec'ing the command.
+#[derive(Debug, Clone)]
+pub struct LauncherContext<'a> {
+  pub worktree_path: &'a Path,
+  pub base: Option<&'a str>,
+  pub head: Option<&'a str>,
+  /// Repo handle used to materialise the `{diff}` tempfile on demand.
+  /// `None` disables the `{diff}` placeholder (status-bar error if the
+  /// template references it).
+  pub repo_workdir: Option<&'a Path>,
+}
+
+/// Output of expanding a launcher template. `argv[0]` is the binary,
+/// `argv[1..]` are the arguments. `diff_file` is `Some` only when the
+/// template referenced `{diff}` — its `Drop` impl cleans the tempfile
+/// up once the spawned process has consumed it.
+#[derive(Debug)]
+pub struct ExpandedCommand {
+  pub argv: Vec<String>,
+  /// Kept alive for the duration of the spawned process so the tempfile
+  /// the `{diff}` placeholder points at is not unlinked before the
+  /// reviewer reads it. `None` when the template didn't use `{diff}`.
+  pub diff_file: Option<tempfile::NamedTempFile>,
+}
+
+impl ExpandedCommand {
+  /// Binary name (`argv[0]`), or `None` for an empty argv (parser
+  /// returned `[]`, which means the user typed e.g. `command = ""`).
+  pub fn binary(&self) -> Option<&str> {
+    self.argv.first().map(|s| s.as_str())
+  }
+}
+
+/// Substitute `{base}`, `{head}`, `{path}`, `{diff}` in `template` and
+/// split the result with `shell-words`. Materialises a tempfile holding
+/// `git diff {base}..{head}` iff the template references `{diff}` —
+/// this is the lazy contract from the issue body: a template that
+/// doesn't use `{diff}` must not spawn `git diff`.
+///
+/// Errors:
+/// - `Config` — `{base}` / `{head}` / `{diff}` referenced without the
+///   matching context field set.
+/// - `Other` — `shell-words` parse failure (unbalanced quotes etc.).
+pub fn expand_command(template: &str, ctx: &LauncherContext<'_>) -> Result<ExpandedCommand> {
+  let uses_base = template.contains("{base}");
+  let uses_head = template.contains("{head}");
+  let uses_diff = template.contains("{diff}");
+
+  if uses_base && ctx.base.is_none() {
+    return Err(GwmError::Config(
+      "template uses {base} but no base ref was resolved".into(),
+    ));
+  }
+  if uses_head && ctx.head.is_none() {
+    return Err(GwmError::Config(
+      "template uses {head} but no head ref was resolved".into(),
+    ));
+  }
+
+  let path_str = ctx.worktree_path.to_string_lossy();
+  let mut expanded = template.replace("{path}", &path_str);
+  if let Some(b) = ctx.base {
+    expanded = expanded.replace("{base}", b);
+  }
+  if let Some(h) = ctx.head {
+    expanded = expanded.replace("{head}", h);
+  }
+
+  let diff_file = if uses_diff {
+    let (b, h) = match (ctx.base, ctx.head) {
+      (Some(b), Some(h)) => (b, h),
+      _ => {
+        return Err(GwmError::Config(
+          "template uses {diff} but {base}/{head} could not be resolved".into(),
+        ))
+      }
+    };
+    let workdir = ctx.repo_workdir.ok_or_else(|| {
+      GwmError::Config("template uses {diff} but no repo workdir was provided to the launcher".into())
+    })?;
+    let tmp = materialise_diff(workdir, b, h)?;
+    let diff_path = tmp.path().to_string_lossy().to_string();
+    expanded = expanded.replace("{diff}", &diff_path);
+    Some(tmp)
+  } else {
+    None
+  };
+
+  let argv =
+    shell_words::split(&expanded).map_err(|e| GwmError::Other(format!("invalid shell line '{}': {}", expanded, e)))?;
+  Ok(ExpandedCommand { argv, diff_file })
+}
+
+/// Shell out to `git diff <base>..<head>` from `workdir`, write the
+/// output into a tempfile, and return the handle. The caller keeps
+/// the handle alive (the tempfile is unlinked on drop) so the consumer
+/// process can read it via the `{diff}` substitution.
+///
+/// Failures of `git diff` are surfaced as `CommandFailed` rather than
+/// silently producing an empty file — the user pressed `R` expecting a
+/// diff, so an empty buffer would mask a real configuration problem.
+fn materialise_diff(workdir: &Path, base: &str, head: &str) -> Result<tempfile::NamedTempFile> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(workdir)
+    .args(["diff", &format!("{}..{}", base, head)])
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git diff failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git diff {}..{} exited with status {:?}: {}",
+      base,
+      head,
+      output.status.code(),
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let mut tmp = tempfile::Builder::new()
+    .prefix("gwm-review-")
+    .suffix(".diff")
+    .tempfile()
+    .map_err(GwmError::Io)?;
+  use std::io::Write as _;
+  tmp.write_all(&output.stdout).map_err(GwmError::Io)?;
+  tmp.flush().map_err(GwmError::Io)?;
+  Ok(tmp)
+}
+
+/// Resolve the review base for `branch` following the chain documented
+/// in issue #75:
+///
+/// 1. `branch.<name>.merge` (the upstream tracking ref).
+/// 2. `branch.<name>.gwm-base` — set by `gwm create` on the new branch
+///    so the original parent is recoverable even without an upstream.
+/// 3. `[review].default_base` from `.gwm.toml`.
+/// 4. `"dev"` (gwm's project convention).
+/// 5. `"main"` (universal git default).
+///
+/// Returns the first non-empty hit; never errors (the final `"main"`
+/// is a guaranteed sentinel). The string is the user-facing ref name
+/// — the launcher passes it to `git diff` / `git rev-list` directly,
+/// so it must be a name git understands.
+pub fn resolve_review_base(repo: &Repository, branch: &str, default_base: Option<&str>) -> String {
+  if let Some(upstream) = read_branch_merge(repo, branch) {
+    return upstream;
+  }
+  if let Some(gwm_base) = read_branch_config(repo, branch, "gwm-base") {
+    return gwm_base;
+  }
+  if let Some(d) = default_base.map(str::trim).filter(|s| !s.is_empty()) {
+    return d.to_string();
+  }
+  "dev".to_string()
+}
+
+/// Persist `branch.<name>.gwm-base = <base>` so the review base chain
+/// can recover the parent ref even if the upstream is dropped. Called
+/// by `gwm create` after a successful `git worktree add`.
+pub fn write_gwm_base(repo: &Repository, branch: &str, base: &str) -> Result<()> {
+  let mut cfg = repo.config()?;
+  cfg.set_str(&format!("branch.{}.gwm-base", branch), base)?;
+  Ok(())
+}
+
+fn read_branch_merge(repo: &Repository, branch: &str) -> Option<String> {
+  let cfg = repo.config().ok()?;
+  let raw = cfg.get_string(&format!("branch.{}.merge", branch)).ok()?;
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    return None;
+  }
+  // `branch.<name>.merge` is stored as a refspec like `refs/heads/dev`;
+  // surface the short name so the value is fit for `git diff` / `git
+  // rev-list` without further massaging.
+  Some(trimmed.strip_prefix("refs/heads/").unwrap_or(trimmed).to_string())
+}
+
+fn read_branch_config(repo: &Repository, branch: &str, leaf: &str) -> Option<String> {
+  let cfg = repo.config().ok()?;
+  let raw = cfg.get_string(&format!("branch.{}.{}", branch, leaf)).ok()?;
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    None
+  } else {
+    Some(trimmed.to_string())
+  }
+}
+
+/// Count commits in `head` not in `base` (`git rev-list --count
+/// {base}..{head}` shelled out from `workdir`). Returns `0` when the
+/// shell-out fails — the `R` keybinding defers to the caller's
+/// `skip_when_no_changes` knob to decide what to do with the count.
+pub fn count_commits_ahead(workdir: &Path, base: &str, head: &str) -> u32 {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(workdir)
+    .args(["rev-list", "--count", &format!("{}..{}", base, head)])
+    .output();
+  let Ok(out) = output else { return 0 };
+  if !out.status.success() {
+    return 0;
+  }
+  String::from_utf8_lossy(&out.stdout).trim().parse::<u32>().unwrap_or(0)
+}
+
+/// Probe `$PATH` for the binary in an [`ExpandedCommand`]. Returns the
+/// absolute path on hit, `None` otherwise — the status bar can then
+/// surface a precise error without trying to spawn a missing file.
+pub fn locate_binary(expanded: &ExpandedCommand) -> Option<PathBuf> {
+  let bin = expanded.binary()?;
+  which::which(bin).ok()
+}
+
+/// Probe whether the resolved launcher's binary exists on $PATH. Used
+/// by [`gwm doctor`](crate::doctor) to emit a warning (exit code 1)
+/// when the configured review/git_tui binary is missing — the launcher
+/// itself is opt-in, so this is advisory, not a hard failure.
+///
+/// Returns the binary name on miss so the doctor check can include it
+/// in the message verbatim ("not on PATH: lumen"). Returns `None` if
+/// the binary resolves or if the launcher has no parseable argv.
+pub fn missing_binary_for(launcher: &ResolvedLauncher) -> Option<String> {
+  // Strip the placeholders before tokenising — `shell_words` would
+  // happily eat the `{path}` literal, but we only care about argv[0]
+  // here so a quick replace keeps things simple. The launcher itself
+  // does proper expansion at exec time.
+  let cleaned = launcher
+    .command
+    .replace("{base}", "BASE")
+    .replace("{head}", "HEAD")
+    .replace("{path}", "PATH")
+    .replace("{diff}", "/tmp/diff");
+  let tokens = shell_words::split(&cleaned).ok()?;
+  let bin = tokens.into_iter().find(|t| !t.contains('='))?;
+  if which::which(&bin).is_ok() {
+    None
+  } else {
+    Some(bin)
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod doctor;
 pub mod error;
 pub mod github;
+pub mod launcher;
 pub mod multiplexer;
 pub mod naming;
 pub mod tui;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,6 +2,7 @@ use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::Config;
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
+use crate::launcher::{self, ExpandedCommand, LauncherContext};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
@@ -12,6 +13,25 @@ use nucleo_matcher::{
 use ratatui::{text::Line, widgets::TableState};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+
+/// Spawnable launcher plan handed to the event loop by
+/// [`App::prepare_git_tui`] / [`App::prepare_review`]. Carries the
+/// expanded argv, the cwd to set on the child, and the `fullscreen`
+/// toggle that decides whether gwm suspends its own TUI for the call.
+///
+/// The `diff_file` inside `expanded` (when set) is kept alive for the
+/// lifetime of the plan, so a `{diff}` tempfile survives until the
+/// spawned reviewer has had a chance to consume it.
+#[derive(Debug)]
+pub struct LauncherPlan {
+  pub expanded: ExpandedCommand,
+  pub cwd: std::path::PathBuf,
+  pub fullscreen: bool,
+  /// Resolved base ref, when the launcher cares about it (review).
+  /// `None` for the git_tui launcher. Surfaced so the status bar /
+  /// caller can mention which ref was used.
+  pub base: Option<String>,
+}
 
 /// Outcome of pressing `y` / Enter on the confirm overlay. The event loop
 /// in `super::run_app` matches on this to decide whether to fire the
@@ -357,6 +377,10 @@ impl App {
 
   /// Path to launch lazygit on, or `None` if nothing selected or lazygit is missing.
   /// The caller drives the actual TUI suspension/restoration around the spawn.
+  ///
+  /// Retained for callers that still want the legacy "lazygit only"
+  /// path; new code should go through [`Self::prepare_git_tui`], which
+  /// honours the configurable `[git_tui]` block (issue #75).
   pub fn launch_lazygit(&mut self) -> Option<PathBuf> {
     let path = self.selected()?.path.clone();
     if which::which("lazygit").is_err() {
@@ -364,6 +388,106 @@ impl App {
       return None;
     }
     Some(path)
+  }
+
+  // ---- Configurable launchers (issue #75) ---------------------------------
+
+  /// Build the [`LauncherPlan`] for the `l` keybinding. Reads
+  /// `[git_tui]` from `.gwm.toml` (default `lazygit -p {path}`
+  /// fullscreen=true) and expands the `{path}` placeholder against
+  /// the selected worktree. Returns `None` (and sets a status hint)
+  /// when nothing is selected or the template is malformed.
+  pub fn prepare_git_tui(&mut self) -> Option<LauncherPlan> {
+    let Some(wt) = self.selected().cloned() else {
+      self.status = "nothing selected".into();
+      return None;
+    };
+    let resolved = self.config.git_tui.resolved();
+    let ctx = LauncherContext {
+      worktree_path: &wt.path,
+      base: None,
+      head: None,
+      repo_workdir: Some(&self.workdir),
+    };
+    match launcher::expand_command(&resolved.command, &ctx) {
+      Ok(expanded) => Some(LauncherPlan {
+        expanded,
+        cwd: wt.path,
+        fullscreen: resolved.fullscreen,
+        base: None,
+      }),
+      Err(e) => {
+        self.status = format!("git_tui template error: {}", e);
+        None
+      }
+    }
+  }
+
+  /// Build the [`LauncherPlan`] for the `R` keybinding. Implements the
+  /// full review contract from issue #75:
+  ///
+  /// 1. `[review]` must resolve to a concrete launcher (`command`
+  ///    set, or `tool = "<preset>"` matched).
+  /// 2. The selected worktree must carry a branch name.
+  /// 3. The review base is resolved via the documented chain (upstream
+  ///    → `gwm-base` → `[review].default_base` → `"dev"` → `"main"`).
+  /// 4. When `skip_when_no_changes` is on (default), a zero
+  ///    `git rev-list --count {base}..HEAD` short-circuits with a
+  ///    status-bar hint naming the base.
+  /// 5. The template is expanded; `{diff}` lazily materialises a
+  ///    tempfile so unused placeholders never spawn `git diff`.
+  pub fn prepare_review(&mut self) -> Option<LauncherPlan> {
+    let resolved = match self.config.review.resolved() {
+      Some(r) => r,
+      None => {
+        self.status = "review tool not configured — set [review] in .gwm.toml".into();
+        return None;
+      }
+    };
+    let Some(wt) = self.selected().cloned() else {
+      self.status = "nothing selected".into();
+      return None;
+    };
+    let Some(head) = wt.branch.clone() else {
+      self.status = "selected worktree has no branch — cannot review".into();
+      return None;
+    };
+
+    let base = launcher::resolve_review_base(&self.repo, &head, self.config.review.default_base.as_deref());
+
+    if self.config.review.skip_when_no_changes {
+      let n = launcher::count_commits_ahead(&wt.path, &base, "HEAD");
+      if n == 0 {
+        self.status = format!("no changes to review (already at {})", base);
+        return None;
+      }
+    }
+
+    let ctx = LauncherContext {
+      worktree_path: &wt.path,
+      base: Some(&base),
+      head: Some(&head),
+      repo_workdir: Some(&self.workdir),
+    };
+    match launcher::expand_command(&resolved.command, &ctx) {
+      Ok(expanded) => {
+        if self.config.review.has_shadowed_tool() {
+          self.status = format!("review: command overrides tool — running {}", base);
+        } else {
+          self.status = format!("review: {} vs {}", head, base);
+        }
+        Some(LauncherPlan {
+          expanded,
+          cwd: wt.path,
+          fullscreen: resolved.fullscreen,
+          base: Some(base),
+        })
+      }
+      Err(e) => {
+        self.status = format!("review template error: {}", e);
+        None
+      }
+    }
   }
 
   pub fn selected(&self) -> Option<&WorktreeInfo> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -282,9 +282,17 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
 /// [`App::prepare_review`]. When `fullscreen=true` the TUI is
 /// suspended (raw mode off, alt-screen left) for the call and restored
 /// on exit — same recipe as the previous hardcoded `lazygit` flow.
-/// Non-fullscreen launchers run in the background; their stderr's
-/// first line is surfaced on the status bar so the user gets feedback
-/// even when the tool doesn't take over the screen.
+///
+/// **Non-fullscreen launchers also run synchronously**: gwm stays in
+/// the alt-screen, `Command::output()` waits for the child to exit,
+/// then the first line of its stderr lands on the status bar. The
+/// TUI is therefore unresponsive until the tool returns — fine for
+/// print-only AI reviewers (`claude --print`, `gh pr view --web`)
+/// that terminate quickly, but a long-running tool will visibly
+/// block. Pick `fullscreen = true` (proper suspend/resume) for
+/// anything that's not a quick one-shot. Caught by Copilot's review
+/// on PR #76; the previous docstring claimed "run in the background"
+/// which `output()` does not.
 ///
 /// `LauncherPlan` is consumed by-value so the `{diff}` tempfile it
 /// carries lives at least until the child process has been waited on.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LauncherPlan, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{filled_cells_for_progress, header_title};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub use app::{
-  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LauncherPlan, LinkPromptStage, LinkTarget, View,
 };
 pub use ui::filled_cells_for_progress;
 
@@ -155,11 +155,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Tab => app.toggle_focus(),
           KeyCode::Char('/') => app.enter_filter(),
           KeyCode::Char('l') => {
-            if let Some(path) = app.launch_lazygit() {
-              run_lazygit(terminal, &path, &mut app)?;
+            // Issue #75: `l` is driven by the configurable `[git_tui]`
+            // launcher pipeline (default `lazygit -p {path}`,
+            // fullscreen=true). Replaces the old hardcoded lazygit call.
+            if let Some(plan) = app.prepare_git_tui() {
+              run_launcher(terminal, plan, &mut app)?;
             }
           }
-          KeyCode::Char('r') => app.refresh()?,
+          // Issue #75 keybinding reshuffle (was `r` → refresh worktree list).
+          // `f` is the new mnemonic; the `r` alias is kept for muscle memory.
+          KeyCode::Char('f') | KeyCode::Char('r') => app.refresh()?,
           // Mutating actions are inert in picker mode — the issue explicitly
           // calls for a stripped-down picker that only navigates and selects.
           KeyCode::Char('n') if !app.picker_mode => app.enter_create(),
@@ -170,7 +175,14 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           // Issue/PR linking (issue #67).
           KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
           KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
-          KeyCode::Char('R') if !app.picker_mode => app.refresh_github_status(),
+          // Issue #75 reshuffle: `F` is the new mnemonic for "fetch GitHub
+          // status" (was `R`). `R` now triggers the configured review tool.
+          KeyCode::Char('F') if !app.picker_mode => app.refresh_github_status(),
+          KeyCode::Char('R') if !app.picker_mode => {
+            if let Some(plan) = app.prepare_review() {
+              run_launcher(terminal, plan, &mut app)?;
+            }
+          }
           KeyCode::Enter => {
             if app.picker_mode {
               app.picker_confirm();
@@ -266,30 +278,88 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
   Ok(app.picker_result)
 }
 
-/// Suspend the TUI, run `lazygit -p <path>` inheriting the terminal, then restore.
-/// Errors from lazygit itself are surfaced via the status bar, never propagated up.
-fn run_lazygit(
+/// Dispatch a [`LauncherPlan`] from [`App::prepare_git_tui`] /
+/// [`App::prepare_review`]. When `fullscreen=true` the TUI is
+/// suspended (raw mode off, alt-screen left) for the call and restored
+/// on exit — same recipe as the previous hardcoded `lazygit` flow.
+/// Non-fullscreen launchers run in the background; their stderr's
+/// first line is surfaced on the status bar so the user gets feedback
+/// even when the tool doesn't take over the screen.
+///
+/// `LauncherPlan` is consumed by-value so the `{diff}` tempfile it
+/// carries lives at least until the child process has been waited on.
+/// Errors are never propagated — the user pressed a key in the TUI,
+/// and surfacing failures via the status bar is the documented
+/// contract (see [`Self::run_lazygit`] in the pre-issue-#75 codebase).
+fn run_launcher(
   terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-  path: &std::path::Path,
+  plan: app::LauncherPlan,
   app: &mut App,
 ) -> Result<()> {
-  // Release the terminal so lazygit can take over.
-  disable_raw_mode()?;
-  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
-  terminal.show_cursor()?;
+  use std::process::{Command, Stdio};
 
-  let spawn = std::process::Command::new("lazygit").arg("-p").arg(path).status();
+  let argv = plan.expanded.argv.clone();
+  let Some((bin, rest)) = argv.split_first() else {
+    app.status = "launcher template produced an empty argv".into();
+    return Ok(());
+  };
 
-  // Always restore the TUI, even if lazygit failed.
-  enable_raw_mode()?;
-  execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
-  terminal.clear()?;
-
-  match spawn {
-    Ok(s) if s.success() => app.status = format!("lazygit exited ok ({})", path.display()),
-    Ok(s) => app.status = format!("lazygit exited with code {:?}", s.code()),
-    Err(e) => app.status = format!("failed to launch lazygit: {}", e),
+  // Probe `$PATH` before paying the suspend/restore tax. Missing
+  // binaries get a clean status-bar error instead of a flicker.
+  if which::which(bin).is_err() {
+    app.status = format!(
+      "`{}` not on $PATH — install it or change [review]/[git_tui] in .gwm.toml",
+      bin
+    );
+    return Ok(());
   }
+
+  if plan.fullscreen {
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    terminal.show_cursor()?;
+
+    let spawn = Command::new(bin).args(rest).current_dir(&plan.cwd).status();
+
+    enable_raw_mode()?;
+    execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
+    terminal.clear()?;
+
+    match spawn {
+      Ok(s) if s.success() => app.status = format!("{} exited ok", bin),
+      Ok(s) => app.status = format!("{} exited with code {:?}", bin, s.code()),
+      Err(e) => app.status = format!("failed to launch {}: {}", bin, e),
+    }
+  } else {
+    // Non-TUI tool: capture stderr so its first line can land in the
+    // status bar without taking over the screen. stdout is dropped on
+    // the floor — printing it would crash through ratatui's frame.
+    let out = Command::new(bin)
+      .args(rest)
+      .current_dir(&plan.cwd)
+      .stdout(Stdio::null())
+      .stderr(Stdio::piped())
+      .output();
+    match out {
+      Ok(o) if o.status.success() => app.status = format!("{} done", bin),
+      Ok(o) => {
+        let first = String::from_utf8_lossy(&o.stderr)
+          .lines()
+          .next()
+          .unwrap_or_default()
+          .trim()
+          .to_string();
+        app.status = if first.is_empty() {
+          format!("{} exited with code {:?}", bin, o.status.code())
+        } else {
+          format!("{}: {}", bin, first)
+        };
+      }
+      Err(e) => app.status = format!("failed to launch {}: {}", bin, e),
+    }
+  }
+  // `plan.expanded.diff_file` drops here, unlinking the tempfile if any.
+  drop(plan);
   Ok(())
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -58,6 +58,22 @@ pub fn draw(f: &mut Frame, app: &mut App) {
   }
 }
 
+/// Format the TUI header title `" gwm v<version> — <repo> (<path>) "`.
+/// The version comes from `CARGO_PKG_VERSION` so it stays in lockstep
+/// with `gwm --version` without a second source of truth — important
+/// for users juggling multiple installs (a `cargo install`-ed gwm next
+/// to a worktree-built dev binary). Extracted from `draw_header` so
+/// the format can be pinned by a unit test without spinning up the
+/// ratatui backend.
+pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
+  format!(
+    " gwm v{} — {} ({}) ",
+    env!("CARGO_PKG_VERSION"),
+    repo_name,
+    workdir_display
+  )
+}
+
 /// Single-line filter bar rendered between the table and the footer.
 /// Mirrors Vim's `/` prompt: leading slash, the live query, and a block cursor
 /// while the user is actively typing.
@@ -101,7 +117,7 @@ fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
 }
 
 fn draw_header(f: &mut Frame, area: Rect, app: &App) {
-  let title = format!(" gwm — {} ({}) ", app.repo_name, app.workdir.display());
+  let title = header_title(&app.repo_name, &app.workdir.to_string_lossy());
   let title_style = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
   let mut spans = vec![Span::styled(title, title_style)];
   // Picker mode flags the header so the user can never confuse a `gwm switch`

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -303,7 +303,9 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
     ("    n", "New worktree"),
     ("    d", "Delete worktree"),
     ("    p", "Toggle delete-branch-on-remove"),
-    ("    r", "Refresh"),
+    ("    f", "Refresh worktree list"),
+    ("    F", "Refresh GitHub issue/PR status"),
+    ("    R", "Run [review] launcher vs base"),
     ("    v", "Toggle this sidebar"),
     ("  Tab", "Swap focus list ↔ sidebar"),
     ("    /", "Fuzzy filter worktrees"),
@@ -471,9 +473,9 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   // Picker mode hides the mutating actions (n/d/b/p) — they're inert in the
   // event loop, so advertising them would be a lie.
   let help = if app.picker_mode {
-    "enter:select esc:cancel o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "enter:select esc:cancel o:open l:git_tui v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh ?:help q:quit"
   } else {
-    "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "n:new d:del b:boot o:open l:git_tui R:review v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh F:gh ?:help q:quit"
   };
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
@@ -517,11 +519,13 @@ fn draw_help(f: &mut Frame, app: &App) {
   }
   lines.extend([
     Line::from("  o             open dir in OS file manager (open / xdg-open / explorer)"),
-    Line::from("  l             launch lazygit fullscreen on selected worktree"),
+    Line::from("  l             launch [git_tui] launcher (default lazygit -p, configurable)"),
     Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
     Line::from("  Tab           swap focus between worktree list and sidebar"),
     Line::from("  /             open fuzzy filter bar (enter: sticky, esc: clear)"),
-    Line::from("  r             refresh"),
+    Line::from("  f             refresh worktree list"),
+    Line::from("  F             refresh GitHub issue/PR status via `gh`"),
+    Line::from("  R             run [review] launcher against the resolved base"),
   ]);
   if !app.picker_mode {
     lines.push(Line::from("  p             toggle 'delete branch on remove'"));
@@ -530,7 +534,6 @@ fn draw_help(f: &mut Frame, app: &App) {
     lines.push(Line::from("issue / PR (#67)"));
     lines.push(Line::from("  O             open menu — i=issue · p=pull request"));
     lines.push(Line::from("  L             link prompt — i / p then digits"));
-    lines.push(Line::from("  R             refresh GitHub status via `gh`"));
   }
   lines.push(Line::from("  ?             this help"));
   if !app.picker_mode {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -171,6 +171,11 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
 }
 
 /// Create a new worktree with a brand-new branch off of HEAD.
+///
+/// Records the HEAD ref's short name into `branch.<branch_name>.gwm-base`
+/// so the review launcher (issue #75) can recover the original parent
+/// ref later — even on branches without an upstream. The write is
+/// best-effort: a config-write error does not roll the worktree back.
 pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str) -> Result<PathBuf> {
   // Refuse to clobber an existing directory.
   if target_path.exists() {
@@ -182,8 +187,12 @@ pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str)
     std::fs::create_dir_all(parent)?;
   }
 
-  // Create branch ref if it doesn't already exist.
-  let head_commit = repo.head()?.peel_to_commit()?;
+  // Capture HEAD's short name BEFORE creating the new branch so the
+  // record points at the actual parent (`main` / `dev` / a release
+  // train), not the freshly-created `branch_name` itself.
+  let head_ref = repo.head()?;
+  let head_short = head_ref.shorthand().map(|s| s.to_string());
+  let head_commit = head_ref.peel_to_commit()?;
   let branch = match repo.find_branch(branch_name, git2::BranchType::Local) {
     Ok(b) => b,
     Err(_) => repo.branch(branch_name, &head_commit, false)?,
@@ -194,6 +203,12 @@ pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str)
   opts.reference(Some(&reference));
 
   repo.worktree(name, target_path, Some(&opts))?;
+
+  // Record the parent ref for the launcher's base resolution chain.
+  if let Some(parent_ref) = head_short {
+    let _ = crate::launcher::write_gwm_base(repo, branch_name, &parent_ref);
+  }
+
   Ok(target_path.to_path_buf())
 }
 

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -113,6 +113,31 @@ fn doctor_outside_git_repo_fails() {
 }
 
 #[test]
+fn doctor_exits_one_when_review_binary_missing() {
+  // Issue #75: configuring [review] with a binary that's not on $PATH
+  // must produce a Warning (exit code 1), not a Failed (exit code 2).
+  // Review is opt-in — a CI pre-commit hook gated on `gwm doctor`
+  // should still let the user push when only the review tool is
+  // missing locally.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[review]
+command = "definitely-not-on-path-review-cli {base}..{head}"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .arg("doctor")
+    .assert()
+    .code(1)
+    .stdout(predicate::str::contains("definitely-not-on-path-review-cli"));
+}
+
+#[test]
 fn doctor_exits_two_on_invalid_config() {
   let (dir, _repo) = init_repo();
   std::fs::write(dir.path().join(".gwm.toml"), "broken = [unterminated").unwrap();

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use gwm::config::{expand_placeholders, Config, WorktreeConfig, CONFIG_FILE};
+use gwm::config::{expand_placeholders, review_tool_preset, Config, WorktreeConfig, CONFIG_FILE};
 use tempfile::TempDir;
 
 #[test]
@@ -254,6 +254,209 @@ confirm_countdown_secs = 30
   let cfg = Config::load_for_repo(dir.path()).unwrap();
   assert_eq!(cfg.tui.confirm_countdown_secs, 30);
   assert_eq!(cfg.tui.effective_confirm_countdown_secs(), 5);
+}
+
+// Issue #75: configurable launchers for `l` (git_tui) and `R` (review).
+// Two sibling sections share the same shape — `command` (shell line with
+// placeholders) + `fullscreen` (suspend gwm TUI for TUI tools). The
+// `[review]` section also takes a `tool = ...` sugar for built-in
+// presets and a `skip_when_no_changes` knob (default true). Absent
+// sections must keep gwm's previous behaviour: `l` → `lazygit -p {path}`
+// fullscreen, `R` inert with a status-bar hint.
+
+#[test]
+fn git_tui_section_defaults_to_lazygit_preserving_legacy_behaviour() {
+  // Backwards-compat contract: no `[git_tui]` in `.gwm.toml` must keep
+  // the `l` keybinding pointed at `lazygit -p {path}` with fullscreen,
+  // i.e. identical to the hardcoded behaviour before issue #75 landed.
+  let cfg = Config::default();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "lazygit -p {path}");
+  assert!(r.fullscreen, "lazygit is a TUI tool, gwm must suspend itself");
+}
+
+#[test]
+fn git_tui_section_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[git_tui]
+command = "gitui -d {path}"
+fullscreen = true
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "gitui -d {path}");
+  assert!(r.fullscreen);
+}
+
+#[test]
+fn git_tui_can_opt_out_of_fullscreen() {
+  // A user who wires `l` to launch a non-TUI editor (`code {path}`) needs
+  // to keep gwm visible — fullscreen=false skips the suspend dance.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[git_tui]
+command = "code {path}"
+fullscreen = false
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "code {path}");
+  assert!(!r.fullscreen);
+}
+
+#[test]
+fn review_section_defaults_to_disabled_with_skip_true() {
+  // No `[review]` block ⇒ `R` is inert; the TUI shows a status-bar
+  // hint inviting the user to configure it. `skip_when_no_changes`
+  // defaults to true so a deliberately-set-but-empty review run
+  // doesn't shell out for nothing.
+  let cfg = Config::default();
+  assert!(
+    cfg.review.resolved().is_none(),
+    "default review must be inert until configured"
+  );
+  assert!(cfg.review.skip_when_no_changes);
+  assert!(cfg.review.default_base.is_none());
+  assert!(!cfg.review.has_shadowed_tool());
+}
+
+#[test]
+fn review_section_explicit_command_wins() {
+  // The primary contract: a free-form shell line. Placeholders are not
+  // expanded here — that's the launcher module's job.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+command = "my-review --base {base} --head {head}"
+fullscreen = true
+skip_when_no_changes = false
+default_base = "trunk"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().expect("explicit command must resolve");
+  assert_eq!(r.command, "my-review --base {base} --head {head}");
+  assert!(r.fullscreen);
+  assert!(!cfg.review.skip_when_no_changes);
+  assert_eq!(cfg.review.default_base.as_deref(), Some("trunk"));
+}
+
+#[test]
+fn review_section_tool_preset_lumen_resolves_to_fullscreen_diff() {
+  // `tool = "lumen"` is the canonical example from the issue.
+  // Resolves to `lumen diff {base}..{head}` with fullscreen=true
+  // because lumen is a ratatui TUI like gwm itself.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().expect("lumen preset must resolve");
+  assert_eq!(r.command, "lumen diff {base}..{head}");
+  assert!(r.fullscreen, "lumen is a TUI — gwm must suspend itself");
+}
+
+#[test]
+fn review_tool_preset_table_covers_documented_set() {
+  // Pin the canonical table the docs / SKILL.md reference. A regression
+  // that renames or drops one of these would break the docs silently.
+  assert_eq!(review_tool_preset("lumen"), Some(("lumen diff {base}..{head}", true)));
+  assert_eq!(
+    review_tool_preset("claude"),
+    Some(("claude --print 'review the diff {base}..{head}'", false))
+  );
+  assert_eq!(
+    review_tool_preset("codex"),
+    Some(("codex review {base}..{head}", false))
+  );
+  assert_eq!(
+    review_tool_preset("aider"),
+    Some(("aider --message 'review {base}..{head}'", true))
+  );
+  assert_eq!(review_tool_preset("gh"), Some(("gh pr view --web", false)));
+  assert_eq!(review_tool_preset("unknown"), None);
+}
+
+#[test]
+fn review_unknown_tool_resolves_to_none() {
+  // Unknown preset is a soft no-op — the resolved launcher is `None` so
+  // the TUI can surface a status-bar hint instead of crashing.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "made-up"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert!(
+    cfg.review.resolved().is_none(),
+    "unknown preset must not silently fall back to a real tool"
+  );
+}
+
+#[test]
+fn review_command_overrides_tool() {
+  // Both `command` and `tool` set ⇒ command wins. The user can still
+  // detect the shadow via `has_shadowed_tool()` for a startup warning.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+command = "my-bot --diff-file {diff}"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().unwrap();
+  assert_eq!(
+    r.command, "my-bot --diff-file {diff}",
+    "`command` must override `tool` when both are set"
+  );
+  assert!(cfg.review.has_shadowed_tool());
+}
+
+#[test]
+fn review_fullscreen_overrides_preset_default() {
+  // The preset for `tool = "lumen"` defaults fullscreen=true. The user
+  // must be able to opt out per-repo (e.g. running lumen in a tmux pane).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+fullscreen = false
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().unwrap();
+  assert!(
+    !r.fullscreen,
+    "explicit fullscreen=false must override the preset default"
+  );
 }
 
 #[test]

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -411,6 +411,50 @@ fn missing_review_tool_preset_is_warning() {
 }
 
 #[test]
+fn launcher_wrapped_by_env_warns_on_real_binary_not_wrapper() {
+  // PR #76 Copilot review: `extract_binary` returned the first token
+  // that didn't contain '=', which for `env FOO=bar phantom-bin diff`
+  // was `env` itself. The doctor then checked `env` (always on PATH)
+  // and missed the real launcher binary. Confirm that the doctor now
+  // names the actual tool when an `env` wrapper is present.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.command = Some("env FOO=bar definitely-not-on-path-wrapped-zz {base}..{head}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert_eq!(c.status, CheckStatus::Warning, "wrapped missing binary must warn");
+  assert!(
+    c.detail.contains("definitely-not-on-path-wrapped-zz"),
+    "wrapper must be peeled: detail should name the real binary, got: {}",
+    c.detail
+  );
+  assert!(
+    !c.detail.split("not on PATH:").nth(1).unwrap_or("").contains("env"),
+    "`env` must not appear in the missing-binaries section: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn launcher_wrapped_by_command_warns_on_real_binary_not_wrapper() {
+  // Sibling case for the POSIX `command` builtin: `command tool ...`
+  // (used e.g. inside shell aliases to bypass functions) should peel
+  // the wrapper just like `env`. Same shape as the env test above.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.git_tui.command = Some("command definitely-not-on-path-cmd-yy -d {path}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert!(
+    c.detail.contains("definitely-not-on-path-cmd-yy"),
+    "command wrapper must be peeled: detail should name the real binary, got: {}",
+    c.detail
+  );
+}
+
+#[test]
 fn missing_git_tui_binary_is_warning() {
   // A user overriding [git_tui] to a missing binary deserves the same
   // visibility treatment as a missing review tool — gwm's `l` keybinding

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -363,6 +363,90 @@ fn resolvable_command_binary_is_ok() {
 }
 
 #[test]
+fn missing_review_binary_is_warning_not_failure() {
+  // Issue #75: [review] is opt-in. A missing review binary should
+  // surface as Warning (exit code 1), never Failed (exit code 2),
+  // so CI / pre-commit hooks that already gate on doctor still pass
+  // when the user only set [review] for their own local convenience.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.command = Some("definitely-not-on-path-review-xyz {base}..{head}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("PATH"))
+    .expect("expected a PATH check");
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.contains("definitely-not-on-path-review-xyz"),
+    "missing review binary must appear in the detail: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn missing_review_tool_preset_is_warning() {
+  // `tool = "lumen"` resolves to `lumen diff ...`. If the user names a
+  // preset but `lumen` itself isn't installed, the doctor warns about
+  // the binary name from the preset table, not about the literal
+  // string `"lumen"` token in their config.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.tool = Some("lumen".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  // Lumen is almost certainly not on the CI matrix. If it happens to
+  // be installed locally we don't have anything to assert; the loose
+  // contract is "if it's missing, the report names it".
+  if c.status == CheckStatus::Warning && c.detail.contains("lumen") {
+    assert!(
+      c.detail.to_lowercase().contains("lumen"),
+      "preset's resolved binary must be named in the warning: {}",
+      c.detail
+    );
+  }
+}
+
+#[test]
+fn missing_git_tui_binary_is_warning() {
+  // A user overriding [git_tui] to a missing binary deserves the same
+  // visibility treatment as a missing review tool — gwm's `l` keybinding
+  // would surface a status-bar error at runtime, but doctor should
+  // catch it upfront.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.git_tui.command = Some("definitely-not-on-path-tui-xyz -d {path}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.contains("definitely-not-on-path-tui-xyz"),
+    "missing git_tui binary must appear in the detail: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn review_unset_does_not_force_lazygit_warning_to_failure() {
+  // Pre-issue-#75 the doctor flagged a missing `lazygit` as Warning.
+  // Confirm that adding the new launcher checks doesn't tip the
+  // severity over to Failed when only [review] is unconfigured.
+  let (dir, repo) = init_repo();
+  let config = Config::default(); // nothing review-related set
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  // The aggregate severity must stay at Warning or Ok — never Failed.
+  assert!(
+    matches!(report.severity(), CheckStatus::Ok | CheckStatus::Warning),
+    "default config must not push doctor into Failed: severity = {:?}",
+    report.severity()
+  );
+}
+
+#[test]
 fn extract_binary_handles_shell_quoted_run_strings() {
   // regression: `extract_binary` used `split_whitespace` and returned the
   // leading-quoted token `"my` for `"my tool" --flag` before the shell-words

--- a/tests/launcher_tests.rs
+++ b/tests/launcher_tests.rs
@@ -1,0 +1,269 @@
+//! Unit tests for the shared launcher machinery — placeholder expansion,
+//! base-resolution chain, `{diff}` lazy materialisation, `which::which`
+//! probing. Issue #75.
+
+mod common;
+
+use common::init_repo;
+use gwm::config::ResolvedLauncher;
+use gwm::launcher::{
+  count_commits_ahead, expand_command, locate_binary, missing_binary_for, resolve_review_base, write_gwm_base,
+  LauncherContext,
+};
+use std::path::Path;
+
+fn ctx<'a>(path: &'a Path, base: Option<&'a str>, head: Option<&'a str>) -> LauncherContext<'a> {
+  LauncherContext {
+    worktree_path: path,
+    base,
+    head,
+    repo_workdir: Some(path),
+  }
+}
+
+#[test]
+fn expand_substitutes_path_placeholder() {
+  // `[git_tui]` only needs `{path}`. The launcher must work without a
+  // base/head context — that's the contract for the `l` keybinding.
+  let c = ctx(Path::new("/tmp/wt/x"), None, None);
+  let cmd = expand_command("lazygit -p {path}", &c).unwrap();
+  assert_eq!(cmd.argv, vec!["lazygit", "-p", "/tmp/wt/x"]);
+  assert!(
+    cmd.diff_file.is_none(),
+    "no {{diff}} in template ⇒ no tempfile materialised"
+  );
+}
+
+#[test]
+fn expand_substitutes_base_head_path() {
+  // The review-style template wires base + head into a `git diff` style
+  // expression. shell-words splits on whitespace — `{base}..{head}`
+  // resolves to one token, not two.
+  let c = ctx(Path::new("/tmp/wt/x"), Some("dev"), Some("feat/foo"));
+  let cmd = expand_command("lumen diff {base}..{head}", &c).unwrap();
+  assert_eq!(cmd.argv, vec!["lumen", "diff", "dev..feat/foo"]);
+}
+
+#[test]
+fn expand_respects_shell_words_quoting() {
+  // The primary contract from the issue: the user can pass any shell
+  // line. shell-words must keep quoted arguments together.
+  let c = ctx(Path::new("/tmp/wt/x"), Some("dev"), Some("feat/foo"));
+  let cmd = expand_command("claude --print 'review {base}..{head}'", &c).unwrap();
+  assert_eq!(
+    cmd.argv,
+    vec!["claude", "--print", "review dev..feat/foo"],
+    "quoted argument must stay one token even after placeholder expansion"
+  );
+}
+
+#[test]
+fn expand_errors_on_unsubstitutable_base() {
+  // A template that names `{base}` without a context-provided base is a
+  // configuration bug — refuse loudly instead of running the command
+  // with a literal `{base}` token.
+  let c = ctx(Path::new("/tmp/wt/x"), None, None);
+  let err = expand_command("lumen diff {base}..HEAD", &c).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(
+    msg.contains("{base}"),
+    "error must mention the missing placeholder: {}",
+    msg
+  );
+}
+
+#[test]
+fn expand_errors_on_diff_without_repo() {
+  // `{diff}` requires a repo workdir to shell out `git diff`. Refuse if
+  // the caller didn't supply one (defensive — the TUI always does).
+  let c = LauncherContext {
+    worktree_path: Path::new("/tmp/wt/x"),
+    base: Some("dev"),
+    head: Some("feat/foo"),
+    repo_workdir: None,
+  };
+  let err = expand_command("reviewer --diff {diff}", &c).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(
+    msg.contains("workdir") || msg.contains("repo"),
+    "diff error should mention the missing repo workdir: {}",
+    msg
+  );
+}
+
+#[test]
+fn expand_materialises_diff_lazily() {
+  // The {diff} placeholder is the only one that triggers a `git diff`
+  // shell-out. A template that doesn't reference it must not pay that
+  // cost — which we assert above. Here we verify that the tempfile is
+  // produced when {diff} *is* referenced, and that the path makes its
+  // way into the argv.
+  let (dir, repo) = init_repo();
+  // Add a second commit so `git diff` has something to render.
+  std::fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+  let mut index = repo.index().unwrap();
+  index.add_path(Path::new("a.txt")).unwrap();
+  let tree_id = index.write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  let parent = repo.head().unwrap().peel_to_commit().unwrap();
+  let sig = git2::Signature::now("t", "t@test").unwrap();
+  let commit_oid = repo.commit(None, &sig, &sig, "add a", &tree, &[&parent]).unwrap();
+  // Create a `feat` branch on the new commit, leave `main` at the
+  // original commit. `git diff main..feat` will then emit the new file.
+  let new_commit = repo.find_commit(commit_oid).unwrap();
+  repo.branch("feat", &new_commit, false).unwrap();
+
+  let c = LauncherContext {
+    worktree_path: dir.path(),
+    base: Some("main"),
+    head: Some("feat"),
+    repo_workdir: Some(dir.path()),
+  };
+  let cmd = expand_command("reviewer --diff {diff}", &c).unwrap();
+  assert_eq!(cmd.argv[0], "reviewer");
+  assert_eq!(cmd.argv[1], "--diff");
+  let diff_path = &cmd.argv[2];
+  assert!(
+    Path::new(diff_path).exists(),
+    "{{diff}} placeholder must produce a real tempfile at: {}",
+    diff_path
+  );
+  let body = std::fs::read_to_string(diff_path).unwrap();
+  assert!(
+    body.contains("a.txt"),
+    "git diff output should mention the file: {}",
+    body
+  );
+  assert!(
+    cmd.diff_file.is_some(),
+    "ExpandedCommand must keep the tempfile alive until drop"
+  );
+}
+
+// ---- Base resolution chain ----------------------------------------------
+
+#[test]
+fn resolve_base_falls_back_to_dev_when_nothing_set() {
+  // Empty git config + no .gwm.toml default ⇒ "dev" wins. This matches
+  // gwm's project convention (the project itself targets `dev`).
+  let (_dir, repo) = init_repo();
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev");
+}
+
+#[test]
+fn resolve_base_uses_config_default_when_set() {
+  // `[review].default_base` overrides the static "dev" fallback.
+  let (_dir, repo) = init_repo();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "trunk");
+}
+
+#[test]
+fn resolve_base_prefers_gwm_base_over_default() {
+  // `branch.<n>.gwm-base` is set by `gwm create` so the parent ref is
+  // recoverable even on branches without an upstream.
+  let (_dir, repo) = init_repo();
+  write_gwm_base(&repo, "feat/x", "release-1.x").unwrap();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "release-1.x");
+}
+
+#[test]
+fn resolve_base_prefers_upstream_over_gwm_base() {
+  // The upstream ref is the strongest signal — the user is actively
+  // tracking it via `git push -u`. It must outrank `gwm-base`.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "refs/heads/staging").unwrap();
+  }
+  write_gwm_base(&repo, "feat/x", "release-1.x").unwrap();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "staging", "branch.<n>.merge must outrank gwm-base");
+}
+
+#[test]
+fn resolve_base_strips_refs_heads_prefix_from_merge() {
+  // `branch.<n>.merge` is stored as a refspec (`refs/heads/dev`); the
+  // launcher hands the value straight to `git diff`, so the short name
+  // must come out.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "refs/heads/dev").unwrap();
+  }
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev");
+}
+
+#[test]
+fn resolve_base_empty_strings_in_config_are_ignored() {
+  // A leftover empty `branch.<n>.merge = ""` must not poison the chain.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "").unwrap();
+  }
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "trunk", "empty merge must fall through to the next chain step");
+}
+
+// ---- count_commits_ahead ------------------------------------------------
+
+#[test]
+fn count_commits_ahead_is_zero_on_identical_refs() {
+  let (dir, _repo) = init_repo();
+  let n = count_commits_ahead(dir.path(), "HEAD", "HEAD");
+  assert_eq!(n, 0, "HEAD..HEAD must always be 0");
+}
+
+#[test]
+fn count_commits_ahead_returns_zero_on_git_failure() {
+  // Pointing at a non-existent base should not panic — the launcher's
+  // `skip_when_no_changes` path treats 0 as "nothing to review", which
+  // is the safer default when we can't tell.
+  let (dir, _repo) = init_repo();
+  let n = count_commits_ahead(dir.path(), "does-not-exist", "HEAD");
+  assert_eq!(n, 0);
+}
+
+// ---- missing binary probe -----------------------------------------------
+
+#[test]
+fn missing_binary_for_returns_some_when_absent() {
+  // A garbage binary name must come back so the doctor / status bar can
+  // surface it verbatim.
+  let l = ResolvedLauncher {
+    command: "definitely-not-a-real-binary-3afe2c {path}".into(),
+    fullscreen: false,
+  };
+  assert_eq!(
+    missing_binary_for(&l).as_deref(),
+    Some("definitely-not-a-real-binary-3afe2c")
+  );
+}
+
+#[test]
+fn missing_binary_for_returns_none_when_present() {
+  // `sh` is universally on POSIX PATH (the project's CI matrix). Pick a
+  // command that's nearly certain to resolve — windows isn't in the
+  // test matrix anyway.
+  let l = ResolvedLauncher {
+    command: "sh -c 'echo {base}'".into(),
+    fullscreen: false,
+  };
+  assert!(
+    missing_binary_for(&l).is_none(),
+    "/bin/sh must resolve on every supported platform"
+  );
+}
+
+#[test]
+fn locate_binary_finds_resolved_argv0() {
+  // Sanity: `sh -c 'echo hi'` expands to argv `[sh, -c, echo hi]`,
+  // which the locator must find.
+  let c = ctx(Path::new("/tmp"), None, None);
+  let cmd = expand_command("sh -c 'echo hi'", &c).unwrap();
+  assert!(locate_binary(&cmd).is_some());
+}

--- a/tests/launcher_tests.rs
+++ b/tests/launcher_tests.rs
@@ -143,12 +143,26 @@ fn expand_materialises_diff_lazily() {
 // ---- Base resolution chain ----------------------------------------------
 
 #[test]
-fn resolve_base_falls_back_to_dev_when_nothing_set() {
-  // Empty git config + no .gwm.toml default ⇒ "dev" wins. This matches
-  // gwm's project convention (the project itself targets `dev`).
+fn resolve_base_falls_back_to_main_when_no_dev_branch_exists() {
+  // PR #76 Copilot review: the docstring promises a `"dev" → "main"`
+  // fallback. `init_repo` creates only `main`, so resolution must
+  // land on `main` instead of returning a non-existent `dev` that
+  // would later make `git diff` / `git rev-list` fail.
   let (_dir, repo) = init_repo();
   let base = resolve_review_base(&repo, "feat/x", None);
-  assert_eq!(base, "dev");
+  assert_eq!(base, "main", "no dev branch ⇒ fall through to main");
+}
+
+#[test]
+fn resolve_base_falls_back_to_dev_when_dev_branch_exists() {
+  // The "dev" fallback is gwm's project convention. We only prefer
+  // it when it actually exists locally — otherwise we'd hand a bogus
+  // ref to `git diff`. Mirror of the `main` fallback test.
+  let (_dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("dev", &head, false).unwrap();
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev", "dev branch present ⇒ prefer it over main");
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
-use gwm::tui::{filled_cells_for_progress, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+use gwm::tui::{filled_cells_for_progress, header_title, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -27,6 +27,39 @@ fn make_app() -> (tempfile::TempDir, App) {
   let (dir, _) = init_repo();
   let app = App::new_at(Some(dir.path())).unwrap();
   (dir, app)
+}
+
+#[test]
+fn header_title_includes_running_version_repo_and_workdir() {
+  // The TUI header surfaces `gwm v<version> — <repo> (<workdir>)`.
+  // Cross-check both halves: the version comes from CARGO_PKG_VERSION
+  // (the same string `gwm --version` prints) and the format wraps
+  // each piece exactly as the docstring describes — so a regression
+  // dropping the `v` prefix, the em-dash, or the repo name fails the
+  // test for the right reason.
+  let title = header_title("gwm-cli", "/Users/kbrdn1/Projects/Perso/gwm-cli");
+  assert!(title.contains("gwm-cli"), "missing repo name: {}", title);
+  assert!(
+    title.contains("/Users/kbrdn1/Projects/Perso/gwm-cli"),
+    "missing workdir: {}",
+    title
+  );
+  let version_token = format!("v{}", env!("CARGO_PKG_VERSION"));
+  assert!(
+    title.contains(&version_token),
+    "missing running version `{}`: {}",
+    version_token,
+    title
+  );
+  // Pin the exact layout so a refactor moving the version pre/post
+  // would have to update this assertion deliberately.
+  assert_eq!(
+    title,
+    format!(
+      " gwm v{} — gwm-cli (/Users/kbrdn1/Projects/Perso/gwm-cli) ",
+      env!("CARGO_PKG_VERSION")
+    )
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1284,6 +1284,143 @@ fn refresh_github_status_message_reflects_partial_failure() {
   );
 }
 
+// ---- Configurable launchers (issue #75) --------------------------------
+//
+// The `R` key in the worktree-list view now triggers the [review]
+// launcher; the previous "refresh GitHub status" action moves to `F`.
+// `f` becomes the worktree refresh (previously `r`). These tests pin
+// the new methods that back those keybindings; the actual key
+// dispatch sits in `src/tui/mod.rs` and is exercised by the
+// behaviour we assert here.
+
+#[test]
+fn prepare_review_returns_none_when_no_review_configured() {
+  // Default config has no [review] block ⇒ pressing `R` must surface
+  // a status-bar hint, not spawn anything.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let plan = app.prepare_review();
+  assert!(plan.is_none(), "no [review] config ⇒ no launcher plan");
+  let s = app.status.to_lowercase();
+  assert!(
+    s.contains("review") && (s.contains("not configured") || s.contains("not set") || s.contains("gwm.toml")),
+    "status bar must explain why R was inert: {}",
+    app.status
+  );
+}
+
+#[test]
+fn prepare_review_skips_when_no_changes_and_flag_on() {
+  // skip_when_no_changes defaults to true. A fresh repo has zero
+  // commits past `main` ⇒ R must short-circuit with the documented
+  // "no changes to review" status line.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.review.command = Some("lumen diff {base}..{head}".into());
+  app.config.review.fullscreen = Some(true);
+  // The branch was created from HEAD (main), and we have made no new
+  // commits — count_commits_ahead must be 0.
+  let plan = app.prepare_review();
+  assert!(plan.is_none(), "no commits past base + skip_when_no_changes ⇒ skip");
+  let s = app.status.to_lowercase();
+  assert!(
+    s.contains("no changes"),
+    "status bar must say 'no changes': {}",
+    app.status
+  );
+  assert!(
+    app.status.contains("main") || app.status.contains("dev"),
+    "status should name the resolved base: {}",
+    app.status
+  );
+}
+
+#[test]
+fn prepare_review_returns_plan_when_configured_and_diff_exists() {
+  // The full happy path: [review].command set, head ≠ base (one extra
+  // commit), skip_when_no_changes off so we don't have to bother
+  // creating a diff. The plan must surface the expanded argv with all
+  // placeholders substituted.
+  let (dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.review.command = Some("reviewer --base {base} --head {head}".into());
+  app.config.review.skip_when_no_changes = false;
+  // Force a known base so the test isn't sensitive to the chain order.
+  app.config.review.default_base = Some("main".into());
+  // Drop the upstream / gwm-base config so default_base wins.
+  let mut cfg = repo.config().unwrap();
+  let _ = cfg.remove("branch.feat/#42-tui-search.gwm-base");
+
+  let plan = app.prepare_review().expect("configured + no skip ⇒ plan present");
+  let argv = &plan.expanded.argv;
+  assert_eq!(argv[0], "reviewer");
+  assert_eq!(argv[1], "--base");
+  assert_eq!(argv[2], "main");
+  assert_eq!(argv[3], "--head");
+  assert_eq!(argv[4], "feat/#42-tui-search");
+  // The cwd must be the worktree path so the spawned tool sees the
+  // selected branch's working tree as `.`. Use `paths_equal` so the
+  // macOS `/private/var` ↔ `/var` symlink doesn't flake the assertion.
+  assert!(
+    common::paths_equal(&plan.cwd, dir.path()),
+    "plan.cwd = {} vs dir = {}",
+    plan.cwd.display(),
+    dir.path().display()
+  );
+}
+
+#[test]
+fn prepare_review_respects_default_base_chain() {
+  // `branch.<n>.gwm-base` (set by gwm create) must outrank
+  // `[review].default_base`. Recorded as `main` by the fixture.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // Manually record gwm-base since the test fixture didn't go through
+  // worktree::add. The base chain reads from this key.
+  gwm::launcher::write_gwm_base(&app.repo, "feat/#42-tui-search", "release-3.x").unwrap();
+  app.config.review.command = Some("echo {base}".into());
+  app.config.review.skip_when_no_changes = false;
+  app.config.review.default_base = Some("trunk".into());
+
+  let plan = app.prepare_review().expect("must resolve");
+  assert_eq!(
+    plan.expanded.argv,
+    vec!["echo", "release-3.x"],
+    "gwm-base must win over [review].default_base"
+  );
+}
+
+#[test]
+fn prepare_git_tui_default_uses_lazygit() {
+  // Backwards-compat: no `[git_tui]` block ⇒ `l` still runs
+  // `lazygit -p <path>` fullscreen.
+  let (dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let plan = app.prepare_git_tui().expect("git_tui has a default");
+  let argv = &plan.expanded.argv;
+  assert_eq!(argv[0], "lazygit");
+  assert_eq!(argv[1], "-p");
+  // The path the launcher injects is the *currently selected* worktree;
+  // make_app_on_branch only creates the main, so the default selection
+  // is the main repo's path. Use `paths_equal` to dodge the macOS
+  // `/private/var` ↔ `/var` mismatch (same trick as elsewhere in the
+  // suite).
+  assert!(
+    common::paths_equal(std::path::Path::new(&argv[2]), dir.path()),
+    "argv[2] = {} vs dir = {}",
+    argv[2],
+    dir.path().display()
+  );
+  assert!(plan.fullscreen, "lazygit defaults to fullscreen");
+}
+
+#[test]
+fn prepare_git_tui_uses_user_command_when_set() {
+  // [git_tui].command override must beat the lazygit default.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.git_tui.command = Some("gitui -d {path}".into());
+  app.config.git_tui.fullscreen = Some(false);
+  let plan = app.prepare_git_tui().expect("must resolve");
+  assert_eq!(plan.expanded.argv[0], "gitui");
+  assert_eq!(plan.expanded.argv[1], "-d");
+  assert!(!plan.fullscreen, "user opted out of fullscreen");
+}
+
 #[test]
 fn refresh_github_status_message_celebrates_full_success() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -42,6 +42,26 @@ fn add_creates_branch_and_worktree() {
 }
 
 #[test]
+fn add_records_gwm_base_for_new_branch() {
+  // Issue #75: `branch.<name>.gwm-base` is the second link in the
+  // review base-resolution chain. `gwm create` (via `worktree::add`)
+  // must set it to HEAD's short name so the review launcher can fall
+  // back to the original parent even on branches without an upstream.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-7-launcher");
+  worktree::add(&repo, "feat-7-launcher", &target, "feat/#7-launcher").unwrap();
+
+  let cfg = repo.config().unwrap();
+  let base = cfg.get_string("branch.feat/#7-launcher.gwm-base").unwrap();
+  assert_eq!(
+    base, "main",
+    "worktree::add must record HEAD's short name as gwm-base for the review fallback"
+  );
+}
+
+#[test]
 fn add_refuses_to_clobber_existing_dir() {
   let (dir, _) = init_repo();
   let repo = worktree::discover_repo(Some(dir.path())).unwrap();


### PR DESCRIPTION
## Description

Implements **issue #75** end-to-end. The TUI worktree-list view gains two
configurable launchers driven by `.gwm.toml`:

- `l` — `[git_tui]` (default `lazygit -p {path}` fullscreen=true,
  preserving the pre-#75 hardcoded behaviour for zero-breaking migration).
- `R` — `[review]` (new, opt-in). Either a free-form `command = "<shell
  line>"` or a `tool = "<preset>"` sugar (`lumen` / `claude` / `codex` /
  `aider` / `gh`). `command` wins when both are set.

The previous `R` (refresh GitHub status) moves to `F`, and worktree-list
refresh moves from `r` to `f` (kept as alias for muscle memory) — per
the rebind table in the issue.

Closes #75

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **New `src/launcher.rs`** — shared placeholder expansion
  (`{base}/{head}/{path}/{diff}` with `{diff}` lazy tempfile
  materialisation), `shell-words` tokenisation, base-resolution chain
  (upstream → `branch.<n>.gwm-base` → `[review].default_base` → `dev`
  → `main`), `which::which` probing, `count_commits_ahead` for
  `skip_when_no_changes`.
- **Config** — `[git_tui]` and `[review]` TOML sections plus the
  built-in preset table (`lumen` / `claude` / `codex` / `aider` /
  `gh`). `worktree::add` now records `branch.<new>.gwm-base = <HEAD
  short>` so the base chain can recover the parent ref even on
  branches without an upstream.
- **TUI** — keybinding reshuffle (`r/R → f/F` + new `R = review`),
  `LauncherPlan` API on `App`, fullscreen/non-fullscreen dispatch in
  the event loop (`run_launcher` replaces the hardcoded `run_lazygit`).
- **`gwm doctor`** — probes both launchers' binaries against `$PATH`;
  a missing tool is Warning (exit `1`), never Failed (`2`), because
  review is opt-in.
- **Docs** — `skills/SKILL.md` rewritten section on configurable
  launchers; `examples/gwm.toml.example` ships commented blocks for
  both sections; `CHANGELOG.md` Added + Changed entries under
  `[Unreleased]`.

## Tests

- [x] `cargo test` passes locally (355 green, ~40 new tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Coverage delta:

- `tests/launcher_tests.rs` (new, 17) — placeholder expansion,
  `{diff}` lazy materialisation, base chain, missing-binary probe.
- `tests/config_tests.rs` (+11) — `[git_tui]` / `[review]` defaults
  + round-trip, preset table, `command` overrides `tool`,
  `fullscreen` overrides preset default.
- `tests/doctor_tests.rs` (+4) — missing review/git_tui binaries
  surface as Warning, default config doesn't push into Failed.
- `tests/tui_app_tests.rs` (+6) — `prepare_review` and
  `prepare_git_tui` contracts (no-config / skip-when-no-changes /
  happy-path / chain ordering).
- `tests/worktree_integration.rs` (+1) — `worktree::add` writes
  `branch.<n>.gwm-base`.
- `tests/cli_binary.rs` (+1) — `gwm doctor` exits `1` with the
  missing-binary detail.

Env-stripped pre-validation (per `CLAUDE.md`):
`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test` → all green.

## Screenshots / TUI captures

_None — this is a keybinding + config feature; the visible delta is the
footer text, the `?` help overlay, and the sidebar "Commands" cheat-sheet,
all updated in `src/tui/ui.rs`._

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed _(no CLI surface change — TUI-only)_
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #75
- Related PR: —

## Notes for reviewers

- The `r` key is **kept as an alias of `f`** rather than freed entirely
  — the issue's rebind table left that as an option ("kept as alias of
  f"). Saves a muscle-memory regression for daily-driver users.
- `worktree::add` writes `gwm-base` best-effort (no rollback if the
  config write fails). The motivation is keeping the libgit2 success
  path stable: a stray config-write error shouldn't undo a successful
  `git worktree add`.
- The `{diff}` placeholder's tempfile is owned by the `LauncherPlan`
  so it survives until the spawned process has been waited on. Drop
  order is enforced by the `drop(plan)` at the end of `run_launcher`.
- The base-resolution chain's "dev" fallback is hardcoded as gwm's
  project convention; users can override via `[review].default_base`.