### PR TITLE
📝 docs: sync README/SKILL/changelog with v0.6.0 surface + migrate to docs/ tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,479 +5,62 @@
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![rust](https://img.shields.io/badge/rust-1.80%2B-orange?logo=rust)](https://www.rust-lang.org/)
 
-Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2` (no `gwq` / `git` CLI dependency), per-repo configurable bootstrap (file copies, regex guards, shell hooks), single binary, portable.
+Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2` (vendored — no `gwq` / `git` CLI dependency), per-repo configurable bootstrap (file copies, regex guards, shell hooks), single binary, portable.
 
-Born as a rewrite of a project-specific `tools/worktree-manager.sh` script — the bash version was tied to Laravel/PHP and one repo's incident history. `gwm` keeps the lessons, makes them configurable, and works the same way in every repo.
-
-## features
-
-- **Native worktree ops** via `libgit2` (vendored). `git worktree add/list/remove/prune` without shelling out.
-- **CLI + TUI**: `gwm <subcommand>` for scripts and hooks, `gwm` alone opens a ratatui interface.
-- **Per-repo config** in `.gwm.toml`: branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
-- **Branch convention**: `<type>/#<issue>-<description>` by default (`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`). Overridable per repo.
-- **Safety guards**: deny-list regexes on copied files (e.g. refuse to inherit a `.env` pointing at AWS RDS). Pluggable actions: `abort` or `seed-from-example`.
-- **Bootstrap hooks**: shell commands gated by composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||`) and arbitrary `env` injection.
-- **Fuzzy lookup**: `gwm remove auth` matches `feat-123-user-authentication` if unambiguous.
-- **Branch status column**: dirty / clean / `↑N ↓M` vs upstream, color-coded in TUI and CLI output.
+> **Full documentation lives in [`docs/`](docs/).** This README is the landing page; every feature has a dedicated section in the doc tree.
 
 ## install
 
-### from source
+| Channel        | Command                                                              |
+|:---------------|:---------------------------------------------------------------------|
+| Cargo (source) | `cargo install --path .`                                              |
+| Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                          |
+| Nix flake      | `nix profile install github:kbrdn1/gwm-cli`                          |
+| Prebuilt       | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
+
+Full install matrix and verification steps: [`docs/getting-started/install.md`](docs/1.getting-started/1.install.md).
+
+## the 30-second tour
 
 ```bash
-git clone https://github.com/kbrdn1/gwm-cli.git
-cd gwm-cli
-cargo install --path .
+cd /path/to/your/repo
+gwm init                                          # write a default .gwm.toml
+gwm create feat 42 user-authentication            # → ~/cc-worktree/<repo>/feat-42-user-authentication
+                                                  # → branch feat/#42-user-authentication
+gwm                                               # opens the TUI on the current repo
+gcd auth                                          # fuzzy-jump into the worktree (needs `gwm shell-init`)
 ```
 
-The binary lands in `~/.cargo/bin/gwm`.
+Step-by-step walkthrough: [`docs/getting-started/first-worktree.md`](docs/1.getting-started/2.first-worktree.md).
 
-### via Homebrew (macOS)
+## what gwm does
 
-```bash
-brew tap kbrdn1/tap
-brew install gwm
-```
+- **Native worktree ops** via vendored `libgit2` — `git worktree add/list/remove/prune` without shelling out.
+- **CLI + ratatui TUI** — `gwm <subcommand>` for scripts, bare `gwm` opens the interactive interface.
+- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
+- **Configurable launchers** — drive the TUI's `l` (git TUI) and `R` (review) keybindings through `[git_tui]` and `[review]` sections in `.gwm.toml`.
+- **GitHub issue / PR linking** — branches matching `<type>/#<N>-<slug>` auto-link to their issue; live status surfaces in the TUI sidebar via `gh`.
+- **Safety guards** — deny-list regexes on copied files (the original "no AWS RDS in `.env`" incident, generalised), plus a confirm-overlay countdown when destructive branch-deletion is armed.
 
-The formula lives at [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap) (`Formula/gwm.rb`) and is refreshed automatically on every stable release of `gwm-cli` by the `homebrew-tap-update` job in [`release.yml`](.github/workflows/release.yml). The canonical formula source lives at [`packaging/homebrew/gwm.rb.template`](packaging/homebrew/gwm.rb.template) — pre-release tags (`-rc.N`, `-alpha.N`, `-beta.N`) are filtered out so `brew install gwm` always points at a stable build.
+## documentation
 
-### prebuilt binaries
+The full tree lives under [`docs/`](docs/) — structured for [Nuxt Content](https://content.nuxt.com/) (numeric prefixes for sidebar order, frontmatter on every page) and ready to drop into the future static site.
 
-Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship Linux (x86_64 + aarch64), macOS (Intel + Apple Silicon), and Windows binaries with `.sha256` sidecars.
+| Section                                                         | Read this when …                                                              |
+|:----------------------------------------------------------------|:------------------------------------------------------------------------------|
+| [Getting Started](docs/1.getting-started/index.md)              | you want to install gwm and create your first worktree                        |
+| [TUI](docs/2.tui/index.md)                                      | you live in the ratatui interface — keymap, sidebar, launchers, filter        |
+| [CLI](docs/3.cli/index.md)                                      | you script gwm from shells, CI jobs, or `gh` aliases                          |
+| [Configuration](docs/4.configuration/index.md)                  | you're writing or extending `.gwm.toml` — bootstrap, guards, predicates       |
+| [Integrations](docs/5.integrations/index.md)                    | you wire gwm with `gh`, `lazygit`, AI reviewers, Homebrew, Nix, or `gwm doctor` in CI |
+| [Development](docs/6.development/index.md)                      | you're contributing — test layout, conventions, dev shell                     |
+| [Roadmap](docs/7.roadmap.md)                                    | you want to know what shipped and what comes next                             |
 
-### via Nix flake
+The [`docs/README.md`](docs/README.md) page documents the authoring conventions (frontmatter contract, numeric-prefix routing, link semantics) for anyone editing the tree.
 
-A `flake.nix` lives at the repo root. With flakes enabled:
+## history
 
-```bash
-# one-shot run, no clone
-nix run github:kbrdn1/gwm-cli -- list
-
-# install into your profile
-nix profile install github:kbrdn1/gwm-cli
-
-# in a NixOS / nix-darwin config, via the overlay
-nixpkgs.overlays = [ inputs.gwm.overlays.default ];
-environment.systemPackages = [ pkgs.gwm ];
-```
-
-The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
-
-## usage
-
-### TUI (interactive)
-
-```bash
-cd <a-git-repo>
-gwm                # opens the TUI on the current repo
-```
-
-Key bindings:
-
-| Key         | Action                                                                          |
-|:------------|:--------------------------------------------------------------------------------|
-| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                       |
-| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
-| `gg`        | jump to the first worktree                                                      |
-| `G`         | jump to the last worktree                                                       |
-| `n`         | new worktree (form: type → issue → description)                                 |
-| `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
-| `b`         | re-run bootstrap on the selected worktree                                       |
-| `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
-| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
-| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
-| `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
-| `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `/`         | open the fuzzy filter bar (`Enter` confirms sticky filter · `Esc` clears)       |
-| `r`         | refresh                                                                         |
-| `p`         | toggle "delete branch on remove"                                                |
-| `Enter`     | show selected path in status bar                                                |
-| `?`         | help overlay                                                                    |
-| `q`         | quit                                                                            |
-| `Esc`       | clear a sticky filter if any, otherwise quit                                    |
-
-### details sidebar
-
-When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree:
-
-- **Header** — `● <worktree-name>`, with the `●` colour tracking the linked PR / issue state (open=green, draft=gray, merged=magenta, closed=red, neutral=darkgray when nothing's linked).
-- **Basic Settings** — branch (coloured by status: synced=green, ahead/behind=yellow, dirty=red, unpublished=magenta, unknown=darkgray), path, head (short OID), **Created** (branch age in compact `2d` / `3w` / `1M` form, coloured by freshness), main / locked / prunable flags, branch status.
-- **Recent commits** — `git log --oneline -n 10`.
-- **Working tree** — `git status --short` (`✓ clean` when empty).
-- **Commands** — keybindings cheat-sheet.
-
-Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
-
-#### open dispatch
-
-The `o` key dispatches on `[tui.open]` in `.gwm.toml`:
-
-```toml
-[tui.open]
-mode = "shell"          # "shell" (default) | "editor" | "finder"
-shell_cmd = ""           # override $SHELL; empty = unset
-editor_cmd = "hx"        # override $EDITOR; empty = unset
-```
-
-- `shell` (default, **changed in v0.6**): suspend the TUI and spawn `$SHELL` with `cwd` set to the worktree — same lifecycle as `l: lazygit`. Exit the shell, the TUI restores.
-- `editor`: suspend the TUI and run `$EDITOR <worktree-path>`.
-- `finder`: pre-v0.6 behaviour — hand off to the OS file manager (`open` / `xdg-open` / `explorer`) without suspending the TUI.
-
-Unknown `mode` values are a hard config error at load time, surfaced before the TUI opens.
-
-### fuzzy filter
-
-Press `/` to open an inline filter bar at the bottom of the worktree table. As you type, the table narrows in real time using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) — the same fuzzy engine used by Helix and Zellij. Matches are ranked by how tight the hit is (contiguous substring beats spread-out subsequence), so the most likely candidate sits on top.
-
-```
-/                            → filter bar opens
-auth                         → table now shows feat-99-user-authentication only
-<Enter>                       → filter sticks, navigation back on the table
-<Esc>                         → clears filter, full list back
-```
-
-The filter is sticky between Enter and Esc: `j` / `k` / `gg` / `G` continue to work on the filtered subset, and the table title shows `worktrees (N/M)` (visible / total). Hit `/` again to re-open the bar and refine the query. `Esc` from the list view clears the sticky filter before it considers quitting, so you can't accidentally quit when you meant to drop the filter.
-
-### confirm-overlay countdown ([#30](https://github.com/kbrdn1/gwm-cli/issues/30))
-
-The `d` confirm overlay has two modes, picked automatically based on whether `p` was pressed earlier in the session:
-
-- **Classic** (`delete branch on remove` is OFF): single keystroke. `y` / `Enter` fires the delete; `n` / `Esc` cancels. Same as the pre-#30 behaviour.
-- **Countdown** (`delete branch on remove` is ON): the overlay shows the branch about to disappear plus an `arm` step. `y` / `Enter` *arms* a safety countdown (default 3s, visualised by a progress bar); the actual delete only fires once the bar fills. `Esc` / `n` cancels at any time; pressing `y` again during the countdown disarms it without firing.
-
-The countdown duration is configurable via `[tui].confirm_countdown_secs` in `.gwm.toml`. Accepted range: `0..=5`. Setting it to `0` keeps the classic single-keystroke modal even when `delete branch on remove` is armed; values above `5` are clamped to `5` on read.
-
-```toml
-[tui]
-# 3s default. Set to 0 to disable the countdown (classic modal even when p is armed).
-confirm_countdown_secs = 3
-```
-
-### lazygit integration
-
-Press `l` on any worktree to suspend the TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on that worktree (`lazygit -p <path>`). When you quit lazygit, the gwm TUI is restored exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it without crashing.
-
-### CLI
-
-```bash
-gwm init                                    # write .gwm.toml in the current repo
-gwm types                                   # list valid branch types
-gwm create feat 123 "user-authentication"   # → feat/#123-user-authentication
-gwm create feat 123 foo --no-bootstrap      # skip the .gwm.toml bootstrap stages
-gwm list                                    # list all worktrees of the current repo
-gwm list --format=names                     # one worktree name per line (for shell completion)
-gwm path auth                               # print the resolved path (use $(gwm path ...))
-gwm cd auth                                 # same — primitive for the `gcd` wrapper
-gwm switch                                  # interactive picker — prints chosen path on stdout
-gwm s                                       # short alias for `switch`
-gwm bootstrap                               # re-run bootstrap on the CWD worktree
-gwm bootstrap auth                          # ...or on a named one
-gwm remove auth                             # remove (fuzzy match) — keeps the branch
-gwm remove auth --delete-branch             # remove + drop the branch
-gwm prune                                   # clean stale .git/worktrees entries
-gwm completions zsh                         # print a zsh / bash / fish / powershell / elvish script
-gwm shell-init zsh                          # print a `gcd <pattern>` shell wrapper (one-line cd)
-gwm tmux auth                               # open the matched worktree in a new tmux window
-gwm tmux auth -p                            # ...or in a split of the current pane
-gwm zellij auth                             # same, but for zellij — new tab via `--cwd`
-gwm zellij auth -p                          # ...or in a new pane of the current tab
-gwm doctor                                  # diagnose config + env + worktree state (exit 0/1/2)
-gwm link issue 42                           # link an issue to the current worktree
-gwm link pr 61                              # link a PR
-gwm unlink issue                            # remove the issue link (auto-detect resurfaces)
-gwm open issue                              # open the linked issue in the browser
-gwm open pr --print-url                     # print the URL on stdout instead of spawning
-gwm status                                  # show link + live state via `gh`
-gwm status --json                           # machine-readable JSON of the status
-```
-
-### Issue / PR linking ([#67](https://github.com/kbrdn1/gwm-cli/issues/67))
-
-Every worktree can be linked to a GitHub issue and / or pull request:
-
-- Branches following `<type>/#<N>-<slug>` are auto-linked to issue `#N` — zero setup.
-- Explicit overrides land in `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, no extra file).
-- `gwm status` shells out to `gh issue view` / `gh pr view` to fetch the live state, title, labels, and CI rollup. Without `gh` (or outside a GitHub remote), only the local link is shown.
-
-In the TUI:
-
-- `O` — open menu (`i` open issue, `p` open PR) in the browser.
-- `L` — link prompt (`i` issue, `p` pr, then type the number).
-- `R` — refresh the GitHub status (synchronous fetch).
-- The right details panel renders a live block: `Issue #42 [open] TUI: fuzzy search` / `PR #61 [draft] · checks 2/3`.
-
-### multiplexer integration (`gwm tmux` / `gwm zellij`)
-
-Inside an already-running tmux session, `gwm tmux <pattern>` shells out to `tmux new-window -n <name> -c <path>` so the new window's shell lands directly inside the matched worktree. `-p` (or `--split`) swaps the verb for `split-window` — same `-c`, current window's layout. `gwm zellij <pattern>` does the same for zellij via `zellij action new-tab --name <name> --cwd <path>` (or `new-pane --cwd` with `-p`); the `--cwd` flag on `new-tab` needs zellij ≥ 0.40.
-
-Both require the corresponding multiplexer to actually be running (i.e. `$TMUX` / `$ZELLIJ` set in the calling environment). Outside a session the command refuses with a clear error rather than spawning a stray server.
-
-### diagnose your setup
-
-`gwm doctor` runs a series of cheap checks and reports each with `✓ / ! / ✗`, then exits `0` (all green), `1` (any warning), or `2` (any failure) — so it can be wired into CI or a pre-commit hook.
-
-```bash
-$ gwm doctor
-✓ .gwm.toml parses
-    /path/to/repo/.gwm.toml parses cleanly
-✓ guard references resolve
-    2 guard reference(s) resolve
-✓ `when` predicates supported
-    1 predicate(s) recognised
-✓ external binaries on PATH
-    3/3 binaries found
-✓ no prunable worktrees
-    5 worktree(s) tracked, none prunable
-✓ no orphan gwm branches
-    7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
-✓ base directory writable
-    /home/you/cc-worktree/myrepo is writable
-```
-
-If a real orphan (unmerged feature branch with no worktree) or a prunable entry exists, the doctor surfaces them as Warning with a remediation hint:
-
-```bash
-! no prunable worktrees
-    1 prunable entry: feat-12-old
-    → run `gwm prune` to clear them
-! no orphan gwm branches
-    1 unmerged orphan branch(es): feat/#99-wip-experiment
-    → git branch -d feat/#99-wip-experiment
-```
-
-Checks performed:
-
-1. **`.gwm.toml` parses** — Ok if it parses (or absent, defaults assumed); Failed if the TOML is broken.
-2. **guard references resolve** — every `[[bootstrap.copy]].guards = [...]` points at an existing `[[bootstrap.guard]]`.
-3. **`when` predicates supported** — every `[[bootstrap.command]].when` uses one of the known keyword prefixes (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`). Boolean composition via `!`, `&&`, `||` (precedence `!` > `&&` > `||`) is allowed inside the expression.
-4. **external binaries on PATH** — `lazygit` (TUI `l` keybinding), `direnv` (only if `.envrc` exists), and the first executable token of every `[[bootstrap.command]].run`.
-5. **no prunable worktrees** — `.git/worktrees/` entries whose working dir was removed manually.
-6. **no orphan gwm branches** — local branches matching `<type>/#<issue>-<desc>` (created by `gwm create`) with no worktree. User-managed branches (`main`, `release-*`, `dependabot/...`) are ignored.
-7. **base directory writable** — the configured `[worktree].base` exists and is writable, or its parent is (gwm creates the base lazily on first `gwm create`).
-
-### one-line cd into a worktree
-
-The binary itself cannot change the parent shell's directory. `gwm shell-init <shell>` prints a function (`gcd`) that bridges two flows in one wrapper:
-
-- **`gcd <pattern>`** → `gwm cd <pattern>` (fuzzy resolve, exits `0` on a hit, `1` on miss / ambiguous / not in a repo).
-- **`gcd`** (no argument) → `gwm switch` (interactive picker — `Enter` to commit, `Esc` / `Ctrl-C` / `q` to cancel with exit code `1`).
-
-In both cases the wrapper only performs the `cd` after a successful exit code, so a cancelled picker or a missed pattern never strands you in `$HOME`.
-
-`eval` the wrapper in your rc file:
-
-```bash
-# zsh
-echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc
-# bash
-echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
-# fish (also persist by adding to ~/.config/fish/config.fish)
-gwm shell-init fish | source
-# PowerShell (current session)
-Invoke-Expression (& gwm shell-init powershell | Out-String)
-# PowerShell (persist via $PROFILE)
-gwm shell-init powershell | Out-File -Append -Encoding utf8 $PROFILE
-```
-
-Then:
-
-```bash
-gcd auth   # → cd $(gwm cd auth) → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
-gcd        # → cd $(gwm switch)  → opens the picker, cd's into the chosen worktree
-```
-
-### interactive picker (`gwm switch`)
-
-When you can't remember the exact pattern, `gwm switch` opens the worktree TUI in picker mode — same table, fuzzy filter bar pre-open, create / delete / bootstrap disabled. `Enter` confirms the highlighted row and prints its path on stdout; `Esc` / `q` / `Ctrl-C` cancels with exit code `1`.
-
-The recommended invocation is via the `gcd` wrapper from [one-line cd into a worktree](#one-line-cd-into-a-worktree) — bare `gcd` (no argument) routes to `gwm switch` and cd's into the chosen worktree in one keystroke. If you haven't installed the wrapper, the raw form is:
-
-```bash
-cd "$(gwm switch)"   # open picker, type to narrow, Enter to commit
-gwm s                # same, via the alias
-```
-
-### shell completions
-
-`gwm completions <shell>` prints a static completion script (generated from the live clap argument tree, so it never drifts from the actual subcommands). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`.
-
-```bash
-# zsh — drop into the first writable fpath entry
-gwm completions zsh > "${fpath[1]}/_gwm"
-
-# bash — system-wide
-gwm completions bash | sudo tee /etc/bash_completion.d/gwm > /dev/null
-# bash — per-user
-gwm completions bash > ~/.local/share/bash-completion/completions/gwm
-
-# fish
-gwm completions fish > ~/.config/fish/completions/gwm.fish
-
-# PowerShell — load into the current session (ephemeral)
-gwm completions powershell | Out-String | Invoke-Expression
-# PowerShell — persist by appending to $PROFILE
-gwm completions powershell | Out-File -Append -Encoding utf8 $PROFILE
-```
-
-For dynamic completion of worktree names (the `<pattern>` arg of `path` / `remove` / `bootstrap`), wire a custom completer to `gwm list --format=names` — e.g. in zsh:
-
-```zsh
-_gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
-compdef _gwm_worktrees gwm-path gwm-remove gwm-bootstrap
-```
-
-## configuration
-
-`.gwm.toml` at the repo root, see `examples/gwm.toml.example` for the annotated full version.
-
-```toml
-[worktree]
-base         = "{home}/cc-worktree/{repo}"
-path_pattern = "{type}-{issue}-{desc}"
-branch_pattern = "{type}/#{issue}-{desc}"
-
-# file copies main → worktree
-[[bootstrap.copy]]
-from = ".env.testing"
-to   = ".env.testing"
-required = true
-fallback = "inline"
-
-[[bootstrap.copy]]
-from = ".env"
-to   = ".env"
-required = false
-guards = ["no-aws-rds"]
-
-# regex guards on copied files
-[[bootstrap.guard]]
-name = "no-aws-rds"
-deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
-on_match      = "seed-from-example"
-example_file  = ".env.example"
-
-# inline fallback when a required source is missing
-[bootstrap.fallback.env_testing]
-target  = ".env.testing"
-content = """
-APP_ENV=testing
-DB_CONNECTION=sqlite
-DB_DATABASE=:memory:
-"""
-
-# refuse to inherit symlinks (vendor/, node_modules/)
-[[bootstrap.no_symlink]]
-path = "vendor"
-
-# post-copy commands
-[[bootstrap.command]]
-name = "composer install"
-run  = "composer install --no-interaction --prefer-dist"
-when = "file_exists:composer.json"
-env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
-
-# composable when predicates: pick `bun install` if bun is on PATH,
-# fall back to `npm ci` otherwise, and skip the noisy step in CI.
-[[bootstrap.command]]
-name = "install (bun)"
-run  = "bun install"
-when = "file_exists:package.json && cmd_exists:bun"
-
-[[bootstrap.command]]
-name = "install (npm fallback)"
-run  = "npm ci"
-when = "file_exists:package.json && !cmd_exists:bun"
-
-[[bootstrap.command]]
-name = "build docs"
-run  = "./scripts/full-build.sh"
-when = "glob_exists:docs/**/*.md && !env_set:CI"
-```
-
-`when` predicates recognised by the evaluator:
-
-| Predicate                    | True when …                                                  |
-|:-----------------------------|:-------------------------------------------------------------|
-| `file_exists:<path>`         | `<worktree>/<path>` resolves on disk                          |
-| `cmd_exists:<binary>`        | `<binary>` resolves on `$PATH` (`which` lookup)              |
-| `env_set:<NAME>`             | `std::env::var(NAME)` returns `Ok`                            |
-| `env_eq:<NAME>=<value>`      | `NAME` is set and its value matches `<value>` exactly         |
-| `glob_exists:<pattern>`      | at least one path under the worktree matches `<pattern>` (supports `**`) |
-
-Combine atoms with `!` (NOT), `&&` (AND), `||` (OR), conventional precedence `!` > `&&` > `||`. Whitespace around operators is tolerated. Unknown keywords default to `true` so old configs keep running while `gwm doctor` surfaces them.
-
-Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/...`) is also expanded.
-
-### defaults without `.gwm.toml`
-
-| Setting          | Default                          |
-|:-----------------|:---------------------------------|
-| `base`           | `{home}/cc-worktree/{repo}`      |
-| `path_pattern`   | `{type}-{issue}-{desc}`          |
-| `branch_pattern` | `{type}/#{issue}-{desc}`         |
-| bootstrap        | none — just `git worktree add`   |
-
-### supported branch types
-
-`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
-
-## differences vs. the original bash script
-
-| Capability                          | bash + gwq           | gwm                              |
-|:------------------------------------|:---------------------|:---------------------------------|
-| worktree engine                     | `gwq` (CLI external) | `libgit2` (vendored)             |
-| bootstrap                           | hardcoded in bash    | declarative in `.gwm.toml`       |
-| multi-repo portability              | per-project script   | one binary, per-repo config      |
-| TUI                                 | linear bash menu     | full ratatui screen              |
-| anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 190 tests (config / naming / bootstrap / doctor / flake / worktree / TUI / CLI) |
-
-## development
-
-```bash
-cargo build              # debug build
-cargo test               # 190 tests
-cargo fmt && cargo clippy -- -D warnings
-cargo run                # opens TUI in the current repo
-cargo install --path .   # install locally
-```
-
-Nix users can drop into a pinned dev shell — Rust toolchain, `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the libgit2 build deps — without touching the host system:
-
-```bash
-nix develop              # bundled toolchain + LSP + linter + formatter
-```
-
-All tests live under `tests/`:
-
-```
-tests/
-├── common/                       # shared helpers (init_repo, paths_equal)
-├── config_tests.rs               # .gwm.toml parsing + write_default
-├── naming_tests.rs               # kebab, branch validation, parse roundtrip
-├── bootstrap_tests.rs            # copies / guards / no-symlink / commands
-├── bootstrap_when_tests.rs       # `when:` predicate grammar (file/cmd/env/glob + boolean ops)
-├── doctor_tests.rs               # `gwm doctor` checks + severity arithmetic
-├── flake_tests.rs                # Nix flake structure (build, devShell, app)
-├── worktree_integration.rs       # git2 add/list/remove/prune
-├── tui_app_tests.rs              # state transitions (ratatui-free)
-└── cli_binary.rs                 # assert_cmd end-to-end
-```
-
-Sentinel tests (pinned to catch a specific regression) are prefixed with a
-`// regression: <one-line>` tag inside the test body so the target incident
-is discoverable without `git blame`. Suite hygiene was last audited in
-[`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md).
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branch / commit / PR conventions.
-
-## roadmap
-
-The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](ROADMAP.md). Highlights for the next minor:
-
-- Shell completions ([#18](https://github.com/kbrdn1/gwm-cli/issues/18)), `gwm cd` + `shell-init` ([#19](https://github.com/kbrdn1/gwm-cli/issues/19)), `gwm doctor` ([#20](https://github.com/kbrdn1/gwm-cli/issues/20)), TUI fuzzy filter ([#21](https://github.com/kbrdn1/gwm-cli/issues/21)).
-
-Contributions welcome — open a [feature request issue](.github/ISSUE_TEMPLATE/feature_request.yml) or pick an item from [`ROADMAP.md`](ROADMAP.md).
+gwm started as a Rust rewrite of `tools/worktree-manager.sh` — a bash script tied to one team's Laravel stack and one repo's incident history. The Rust version keeps the lessons, makes them configurable per repo, and ships as a single binary so it works in every repo without per-project shell-script copies. Full background under [Development → Contributing → history](docs/6.development/2.contributing.md#history).
 
 ## license
 
@@ -485,9 +68,10 @@ MIT — see [LICENSE.md](LICENSE.md).
 
 ## related docs
 
-- [`CHANGELOG.md`](CHANGELOG.md)
-- [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- [`ROADMAP.md`](ROADMAP.md)
+- [`CHANGELOG.md`](CHANGELOG.md) — release index (root = `[Unreleased]`; per-version archives under [`changelogs/`](changelogs/))
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR conventions
+- [`ROADMAP.md`](ROADMAP.md) — long-form roadmap with grouped categories
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - [`.github/LABELS.md`](.github/LABELS.md)
-- [`examples/gwm.toml.example`](examples/gwm.toml.example)
+- [`examples/gwm.toml.example`](examples/gwm.toml.example) — annotated full config
+- [`skills/SKILL.md`](skills/SKILL.md) — the bundled Claude Code skill manifest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,78 +4,95 @@ This document tracks where `gwm` is heading. It complements [CHANGELOG.md](CHANG
 
 Each item below links to its GitHub issue. The scope, alternatives considered, and acceptance criteria live there — this file is the map, not the spec.
 
-## Current state — v0.2.0
+## Current state — v0.6.0
 
-The 0.2.x line ships:
+The 0.6.x line ships:
 
 - **Native worktree ops via libgit2 (vendored)** — single binary, no `gwq` / `git` CLI dependency.
 - **CLI + ratatui TUI** — `gwm <subcommand>` for scripts, `gwm` alone opens the interactive interface.
-- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
-- **Responsive details sidebar** — auto-shown when terminal width ≥ 120 cols, lazyssh-style with branch / path / head / status / recent commits / working-tree summary / commands cheat-sheet.
-- **Lazygit fullscreen launch** (`l`) — suspends the gwm TUI, runs `lazygit -p <path>`, restores the TUI on exit.
-- **Vim motions** — `gg` / `G` jump to first / last; `Tab` swaps focus between the list and the sidebar.
-- **Release pipeline** — `release.yml` on `vX.Y.Z` tags, `pre-release.yml` on `vX.Y.Z-rc.N` / `-alpha.N` / `-beta.N` tags, 5-target build matrix (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64).
-- **74 tests** across config, naming, bootstrap, worktree (libgit2 integration), TUI state, and CLI end-to-end.
+- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards (`abort` or `seed-from-example`), shell hooks gated by `when:` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||` composition), no-symlink invariants.
+- **Lazygit-style details sidebar** — four bordered subsections (Worktree / Issue · PR / Working Tree / Recent Commits), status-coloured branch names, header status dot tracking linked PR / issue state, 300-commit Recent Commits buffer with the full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
+- **Configurable launchers** — `[git_tui]` drives `l` (default `lazygit -p {path}`), `[review]` drives `R` (presets: `lumen` / `claude` / `codex` / `aider` / `gh`, plus free-form `command =`). Placeholders `{base} {head} {path} {diff}` with lazy diff materialisation.
+- **GitHub issue / PR linking** — branches matching `<type>/#<N>-<slug>` auto-link to their issue; CLI `link / unlink / open / status` for explicit overrides; live state surfaces in the TUI sidebar via `gh`.
+- **`[tui.open]` dispatch** — `o` key now spawns `$SHELL` in the worktree by default; opt back to OS file manager via `mode = "finder"`.
+- **`y: yank`** — copy the selected worktree's path to the clipboard (pbcopy / wl-copy / xclip / xsel / clip).
+- **Vim motions** — `gg` / `G` jump to first / last; `Tab` swaps focus between the list and the sidebar; `j` / `k` / `↑` / `↓` move selection or scroll the focused panel.
+- **Fuzzy filter (`/`)** — sticky `nucleo-matcher` filter on the worktree list; smart-case, AND on spaces, contiguous beats spread-out; same engine powers `gwm switch` (picker mode), `gwm path / cd / remove / bootstrap` (fuzzy CLI lookup).
+- **One-line `cd`** — `gwm shell-init <shell>` wires up a `gcd <pattern>` (resolve + cd) and bare `gcd` (picker + cd) for zsh / bash / fish / PowerShell.
+- **Shell completions** — `gwm completions <shell>` for zsh / bash / fish / PowerShell / elvish (static script generated from the live clap argument tree).
+- **Multiplexer integration** — `gwm tmux <pattern> [-p]` and `gwm zellij <pattern> [-p]` open the worktree in a new window / pane / tab; refuse to spawn outside an active session.
+- **`gwm doctor`** — 7 checks (parses / guard refs / `when` predicates / external binaries / prunable / orphan branches / base writable), exit codes `0/1/2` for CI.
+- **Confirm-overlay countdown** — safety countdown on the delete-confirm overlay when `p` (delete-branch-on-remove) is armed; duration tunable via `[tui].confirm_countdown_secs` (0..=5, clamped).
+- **Release pipeline** — `release.yml` on `vX.Y.Z` tags, `pre-release.yml` on `-rc.N` / `-alpha.N` / `-beta.N` tags, 5-target build matrix (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64), automatic Homebrew tap update on stable releases, Nix flake at the repo root.
+- **433 tests** — 15 integration files + colocated unit tests covering config, naming, bootstrap, doctor, github linking, launcher, multiplexer, homebrew formula, pre-commit hook, TUI state, worktree (libgit2 integration), and CLI end-to-end.
 
-See [CHANGELOG.md](CHANGELOG.md#020---2026-05-18) for the full release notes.
+See [`changelogs/0.6.0.md`](changelogs/0.6.0.md) for the full v0.6.0 release notes, and [`changelogs/`](changelogs/) for the per-version archive.
+
+## Shipped — pre-v0.6.0
+
+For reference (each linked to its closing PR):
+
+| Issue | Shipped in | Feature                                                                         |
+|:------|:-----------|:--------------------------------------------------------------------------------|
+| [#18](https://github.com/kbrdn1/gwm-cli/issues/18) | v0.3.0 | Shell completions (zsh / bash / fish / powershell / elvish)                     |
+| [#19](https://github.com/kbrdn1/gwm-cli/issues/19) | v0.3.0 | `gwm cd <pattern>` + `gwm shell-init <shell>` (the `gcd` wrapper)               |
+| [#20](https://github.com/kbrdn1/gwm-cli/issues/20) | v0.3.0 | `gwm doctor` (initial check set)                                                |
+| [#21](https://github.com/kbrdn1/gwm-cli/issues/21) | v0.3.0 | TUI fuzzy filter (`/`)                                                          |
+| [#22](https://github.com/kbrdn1/gwm-cli/issues/22) | v0.4.0 | `gwm switch` (picker UI printing the chosen path on stdout)                     |
+| [#23](https://github.com/kbrdn1/gwm-cli/issues/23) | v0.4.0 | Tmux / Zellij integration (`gwm tmux` / `gwm zellij`)                           |
+| [#25](https://github.com/kbrdn1/gwm-cli/issues/25) | v0.4.0 | Extended `when:` predicates (`cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!` / `&&` / `\|\|`) |
+| [#26](https://github.com/kbrdn1/gwm-cli/issues/26) | v0.5.0 | Homebrew tap (`brew tap kbrdn1/tap && brew install gwm`)                        |
+| [#28](https://github.com/kbrdn1/gwm-cli/issues/28) | v0.5.0 | Nix flake (`nix profile install github:kbrdn1/gwm-cli`)                         |
+| [#30](https://github.com/kbrdn1/gwm-cli/issues/30) | v0.5.0 | TUI confirm-overlay countdown                                                   |
+| [#47](https://github.com/kbrdn1/gwm-cli/issues/47) | v0.5.0 | `gwm doctor`: skip merged gwm-style branches in the orphan check                |
+| [#59](https://github.com/kbrdn1/gwm-cli/issues/59) | v0.5.0 | `[doctor].trunks` config knob                                                   |
+| [#67](https://github.com/kbrdn1/gwm-cli/issues/67) ([PR #68](https://github.com/kbrdn1/gwm-cli/pull/68)) | v0.6.0-rc.1 | Issue / PR linking — CLI + TUI controls, `gh`-backed live status     |
+| [#69](https://github.com/kbrdn1/gwm-cli/issues/69) ([PR #70](https://github.com/kbrdn1/gwm-cli/pull/70)) | v0.6.0 | TUI Details sidebar redesign (four bordered subsections)            |
+| [#71](https://github.com/kbrdn1/gwm-cli/issues/71) ([PR #72](https://github.com/kbrdn1/gwm-cli/pull/72)) | v0.6.0 | TUI Recent Commits panel — lazygit-style layout + full topology renderer |
+| [#73](https://github.com/kbrdn1/gwm-cli/issues/73) ([PR #74](https://github.com/kbrdn1/gwm-cli/pull/74)) | v0.6.0 | Lazygit-style sidebar facelift (`Created` row, status colours, `[tui.open]`, `y: yank`) |
+| [#75](https://github.com/kbrdn1/gwm-cli/issues/75) ([PR #76](https://github.com/kbrdn1/gwm-cli/pull/76)) | v0.6.0 | Configurable launchers (`[git_tui]` + `[review]`) — keymap reshuffle `r/R → f/F`, new `R` |
+| [#77](https://github.com/kbrdn1/gwm-cli/issues/77) | v0.6.0 | Docs restructure into `docs/` tree (Nuxt Content conventions) + README shrunk to landing |
+
+If an issue still shows `open` on GitHub even though its work shipped, it's a tracking issue waiting for a follow-up audit — check the CHANGELOG and the linked PR before reopening scope work on it.
 
 ## Quick wins
 
 Small, well-scoped items with high daily-usage payoff. Likely picks for the next minor.
 
-- [#18](https://github.com/kbrdn1/gwm-cli/issues/18) — **Shell completions** (zsh / bash / fish / powershell) via `clap_complete`, with dynamic completion of worktree names for `gwm path / remove / bootstrap`.
-- [#19](https://github.com/kbrdn1/gwm-cli/issues/19) — **`gwm cd <pattern>` + `gwm shell-init <shell>`** to officialise the `cd "$(gwm path ...)"` workflow as a one-liner sourced from the rc file.
-- [#20](https://github.com/kbrdn1/gwm-cli/issues/20) — **`gwm doctor`** to validate `.gwm.toml`, surface missing dependencies (`lazygit`, `direnv`, command binaries), and catch orphan branches / prunable worktrees.
-- [#21](https://github.com/kbrdn1/gwm-cli/issues/21) — **TUI fuzzy filter** — press `/` in the list view to filter worktrees in real time (already on the README roadmap, lifted into the issue tracker).
-
-## Power user
-
-Workflow accelerators for daily use.
-
-- [#22](https://github.com/kbrdn1/gwm-cli/issues/22) — **`gwm switch`** — a stripped-down picker UI that prints the selected worktree's path on `Enter` (paired with the `gwm cd` flow).
-- [#23](https://github.com/kbrdn1/gwm-cli/issues/23) — **Tmux / Zellij integration** — `gwm tmux <pattern>` / `gwm zellij <pattern>` open the worktree in a new window or pane.
 - [#24](https://github.com/kbrdn1/gwm-cli/issues/24) — **`gwm sync`** — fetch + rebase (or merge) the selected worktree's branch against its upstream, with conflict detection.
-- [#25](https://github.com/kbrdn1/gwm-cli/issues/25) — **Extended bootstrap `when` predicates** — `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `&&` / `||` / `!` composition.
-
-## Distribution
-
-Lower the install friction by meeting users on their preferred channel.
-
-- [#26](https://github.com/kbrdn1/gwm-cli/issues/26) — **Homebrew tap** (`brew tap kbrdn1/tap && brew install gwm`), auto-updated by `release.yml`.
-- [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive.
-- [#28](https://github.com/kbrdn1/gwm-cli/issues/28) — **Nix flake** — `nix profile install github:kbrdn1/gwm-cli` + a `devShell` for contributors.
+- [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive instead of compiling from source.
+- [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — **`--dry-run` on `gwm remove` and `gwm prune`** — show the resolved target / planned actions, no side effects. Pairs nicely with the safety stance of [#29](https://github.com/kbrdn1/gwm-cli/issues/29) below.
 
 ## Safety & UX
 
 Defensive features for a tool that performs destructive operations.
 
-- [#29](https://github.com/kbrdn1/gwm-cli/issues/29) — **`gwm undo` + `gwm history`** — operation journal at `$XDG_DATA_HOME/gwm/history.toml` with branch-OID recovery.
-- [#30](https://github.com/kbrdn1/gwm-cli/issues/30) — **TUI confirm overlay with a countdown** when `delete_branch_on_remove` is armed.
-- [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — **`--dry-run` on `gwm remove` and `gwm prune`** — show the resolved target / planned actions, no side effects.
+- [#29](https://github.com/kbrdn1/gwm-cli/issues/29) — **`gwm undo` + `gwm history`** — operation journal at `$XDG_DATA_HOME/gwm/history.toml` with branch-OID recovery so a fat-finger `gwm remove --delete-branch` is recoverable beyond `git reflog`.
 
 ## TUI polish
 
 Refinements that make the interface more discoverable and customisable.
 
-- [#32](https://github.com/kbrdn1/gwm-cli/issues/32) — **Command palette `:`** — Helix / Vim-style command bar with fuzzy completion across every TUI action.
+- [#32](https://github.com/kbrdn1/gwm-cli/issues/32) — **Command palette `:`** — Helix / Vim-style command bar with fuzzy completion across every TUI action, complementing the existing `?` overlay and `/` filter.
 - [#33](https://github.com/kbrdn1/gwm-cli/issues/33) — **Themes** — configurable colour scheme via `.gwm.toml` `[theme]`, with built-in presets (Catppuccin, Gruvbox, Tokyo Night, Solarized).
-- [#34](https://github.com/kbrdn1/gwm-cli/issues/34) — **Sidebar stash mode** — press `s` to cycle the Details panel between commits-and-status (current) and stashes.
+- [#34](https://github.com/kbrdn1/gwm-cli/issues/34) — **Sidebar stash mode** — press `s` to cycle the Details panel between the current view and a stashes view.
 
 ## Ambitious
 
 Larger investments with strategic payoff. Gated by user demand or a concrete first consumer.
 
-- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — **PTY-embedded lazygit panel** — render lazygit live in a right-hand pane (`portable-pty` + `tui-term`), beside the worktree list and the Details sidebar.
+- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — **PTY-embedded lazygit panel** — render lazygit live in a right-hand pane (`portable-pty` + `tui-term`), beside the worktree list and the Details sidebar. Distinct from the existing `l` launcher: this one would render lazygit **inside** gwm rather than handing the alt-screen over.
 - [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — **Multi-repo workspace mode** — `gwm --workspace ~/Projects` shows worktrees across every child repo in one TUI.
-- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks.
-- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.
+- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks instead of the generic default.
+- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC / gRPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.
 
 ## How to contribute
 
 1. Pick an item that interests you and read its issue for scope details.
 2. Comment on the issue if you intend to work on it (avoids parallel duplication).
-3. Open a PR targeting `dev` following the conventions in [CONTRIBUTING.md](CONTRIBUTING.md) (Gitmoji + Conventional Commits, tests required, never squash).
-4. The issue is the source of truth — this roadmap is updated to reflect what ships in each release.
+3. `gwm create <type> <issue> <slug>` to spin up an isolated worktree (the issue auto-links itself — see [`docs/integrations/github-linking.md`](docs/5.integrations/1.github-linking.md)).
+4. Open a PR targeting `dev` following the conventions in [CONTRIBUTING.md](CONTRIBUTING.md) (Gitmoji + Conventional Commits, tests required, never squash; full docs version at [`docs/development/contributing.md`](docs/6.development/2.contributing.md)).
+5. The issue is the source of truth — this roadmap is updated to reflect what ships in each release.
 
 Items marked `good first issue` (when applicable) are intentionally scoped so a newcomer can land them without a deep dive into the codebase.
 

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -37,8 +37,9 @@ Promotes `v0.6.0-rc.1` to stable and bundles four additional feature PRs (#70, #
 
 ### Docs
 
-- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
-- `README.md` — new "Issue / PR linking" section (carried forward from `v0.6.0-rc.1`) and updated TUI key map for the new bindings.
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout. Also corrects the launcher concurrency wording (non-fullscreen launchers run **synchronously**, not "in the background" — aligned with the `src/tui/mod.rs::run_launcher` docstring caught by Copilot on PR #76).
+- **User docs restructured into a `docs/` tree** ([#77](https://github.com/kbrdn1/gwm-cli/issues/77)) — the previously-inline README reference (TUI keymap, sidebar, CLI surface, `.gwm.toml` schema, doctor, completions) is migrated into seven structured sections under `docs/` (Getting Started, TUI, CLI, Configuration, Integrations, Development, Roadmap). Pages use Nuxt Content conventions (numeric prefixes for sidebar order, frontmatter title/description), so the tree is ready to drop straight into a future static-site build. The README is reduced to a 77-line landing page that links into `docs/`.
+- `README.md` — shrunk to a landing page (install matrix, 30-second tour, feature bullets, documentation map). The pre-v0.6 reference content moved into `docs/`.
 
 ### Dependencies
 

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -37,7 +37,7 @@ Promotes `v0.6.0-rc.1` to stable and bundles four additional feature PRs (#70, #
 
 ### Docs
 
-- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.7.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
 - `README.md` — new "Issue / PR linking" section (carried forward from `v0.6.0-rc.1`) and updated TUI key map for the new bindings.
 
 ### Dependencies

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -1,0 +1,8 @@
+---
+title: Install
+description: Install gwm from source, Homebrew, prebuilt binaries, or a Nix flake.
+---
+
+# Install
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -5,4 +5,65 @@ description: Install gwm from source, Homebrew, prebuilt binaries, or a Nix flak
 
 # Install
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+gwm ships a single self-contained binary. Pick whichever channel fits your workflow — all four produce the same `gwm` executable.
+
+## from source
+
+```bash
+git clone https://github.com/kbrdn1/gwm-cli.git
+cd gwm-cli
+cargo install --path .
+```
+
+The binary lands in `~/.cargo/bin/gwm`. Requires a recent stable Rust toolchain (1.80+).
+
+## via Homebrew (macOS)
+
+```bash
+brew tap kbrdn1/tap
+brew install gwm
+```
+
+The formula lives at [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap) (`Formula/gwm.rb`) and is refreshed automatically on every **stable** release of `gwm-cli` by the `homebrew-tap-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). The canonical formula template is at [`packaging/homebrew/gwm.rb.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/homebrew/gwm.rb.template). Pre-release tags (`-rc.N`, `-alpha.N`, `-beta.N`) are filtered out, so `brew install gwm` always points at a stable build.
+
+## prebuilt binaries
+
+Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries with `.sha256` sidecars for:
+
+- Linux (`x86_64`, `aarch64`)
+- macOS (Intel, Apple Silicon)
+- Windows (`x86_64`)
+
+Drop the binary on your `$PATH`, mark it executable, and you're done.
+
+## via Nix flake
+
+A `flake.nix` lives at the repo root. With flakes enabled:
+
+```bash
+# one-shot run, no clone
+nix run github:kbrdn1/gwm-cli -- list
+
+# install into your profile
+nix profile install github:kbrdn1/gwm-cli
+
+# in a NixOS / nix-darwin config, via the overlay
+nixpkgs.overlays = [ inputs.gwm.overlays.default ];
+environment.systemPackages = [ pkgs.gwm ];
+```
+
+The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
+
+## verify the install
+
+```bash
+gwm --version
+gwm doctor                     # run a battery of sanity checks
+```
+
+If `gwm doctor` returns non-zero, jump to [`gwm doctor`](/integrations/doctor) for the per-check remediation hints.
+
+## next
+
+- [Create your first worktree](/getting-started/first-worktree)
+- [Wire up `gcd` for one-line `cd` into a worktree](/getting-started/shell-init)

--- a/docs/1.getting-started/2.first-worktree.md
+++ b/docs/1.getting-started/2.first-worktree.md
@@ -5,4 +5,71 @@ description: Walkthrough of `gwm create` — branch naming, path layout, and the
 
 # First worktree
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+This page walks through what `gwm create` does end-to-end on a fresh repo: where the worktree lands on disk, how the branch is named, and what the bootstrap pipeline runs (if any).
+
+## the one-line version
+
+```bash
+cd /path/to/your/repo
+gwm create feat 42 user-authentication
+```
+
+This creates:
+
+- A worktree at `~/cc-worktree/<repo>/feat-42-user-authentication`
+- A branch named `feat/#42-user-authentication`
+- A `branch.feat/#42-user-authentication.gwm-base` git config entry, anchoring the [review-base resolution chain](/tui/launchers#base-resolution) at the trunk you branched from
+
+The `gwm create` form is `gwm create <type> <issue> <description>`. Supported `<type>` values are documented in [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#supported-branch-types) — `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build` by default.
+
+## branch and path conventions
+
+The defaults — and how to override them — are TOML-driven:
+
+```toml
+[worktree]
+base           = "{home}/cc-worktree/{repo}"
+path_pattern   = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+```
+
+Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/…`) is also expanded. Override anything in your `.gwm.toml` to match your team's branch convention — see [Configuration → `.gwm.toml` schema](/configuration/gwm-toml).
+
+The `{desc}` slot is **kebab-case normalised** by gwm — `"User Authentication"`, `"user authentication"`, and `"User_Authentication"` all become `user-authentication` on disk and in the branch name. This keeps shell completion and fuzzy lookup deterministic.
+
+## the bootstrap pipeline
+
+If a `.gwm.toml` is present at the repo root, `gwm create` runs its bootstrap pipeline immediately after the `git worktree add`:
+
+1. **Copies** — `[[bootstrap.copy]]` rules duplicate files from the main checkout into the new worktree (e.g. `.env.testing`, `.envrc`, vendored secrets).
+2. **Guards** — `[[bootstrap.guard]]` rules vet each copied file against regex deny-lists. A match triggers either an `abort` (refuse to create the worktree) or `seed-from-example` (substitute a known-good fallback). The original use case was refusing to inherit a `.env` pointing at AWS RDS.
+3. **No-symlink check** — `[[bootstrap.no_symlink]]` rules verify that listed paths (typically `vendor/`, `node_modules/`) are **not** symlinks back into the main checkout, since a stray symlink would silently pollute the main repo's build output.
+4. **Fallback files** — `[bootstrap.fallback.*]` blocks materialise inline contents when a required source file is missing (the `seed-from-example` path).
+5. **Commands** — `[[bootstrap.command]]` shell hooks run last, gated by [`when:` predicates](/configuration/when-predicates) (`file_exists:`, `cmd_exists:`, `env_set:`, …).
+
+The bootstrap report prints inline with `✓` (success), `!` (warning, non-blocking), or `✗` (failure, blocks the worktree) sigils per step — same convention as `gwm doctor`. A `✗` aborts and the worktree is rolled back.
+
+Skip bootstrap entirely with `--no-bootstrap`:
+
+```bash
+gwm create feat 42 foo --no-bootstrap
+```
+
+Re-run it later (e.g. after editing `.gwm.toml`) without recreating the worktree:
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # ...or on a fuzzy-matched name
+```
+
+## what's stored where
+
+- The worktree lives at `<base>/<path_pattern>` — outside the main checkout by default, so it survives `git clean -fdx` and IDE reindex storms on the main tree.
+- The branch is a normal local branch — visible in `git branch`, ignored by no special config.
+- `branch.<name>.gwm-base` records the trunk this branch was cut from. It's used by the [review launcher](/tui/launchers#base-resolution) to compute `git diff base..head` even after the branch's upstream is gone.
+- If you used the auto-link convention (`<type>/#<N>-<slug>`), the GitHub issue link is derived on the fly — no extra config needed. See [Integrations → GitHub issue / PR linking](/integrations/github-linking).
+
+## next
+
+- [Wire up `gcd`](/getting-started/shell-init) so you can `cd` into the new worktree in one keystroke
+- [Tour the TUI](/tui) — bare `gwm` now opens onto your fresh worktree

--- a/docs/1.getting-started/2.first-worktree.md
+++ b/docs/1.getting-started/2.first-worktree.md
@@ -1,0 +1,8 @@
+---
+title: First worktree
+description: Walkthrough of `gwm create` — branch naming, path layout, and the bootstrap pipeline.
+---
+
+# First worktree
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/3.shell-init.md
+++ b/docs/1.getting-started/3.shell-init.md
@@ -1,0 +1,8 @@
+---
+title: Shell init (gcd helper)
+description: Wire up `gwm shell-init` so `gcd <pattern>` and `gcd` (no arg) cd into a worktree in one keystroke.
+---
+
+# Shell init (gcd helper)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/3.shell-init.md
+++ b/docs/1.getting-started/3.shell-init.md
@@ -3,6 +3,61 @@ title: Shell init (gcd helper)
 description: Wire up `gwm shell-init` so `gcd <pattern>` and `gcd` (no arg) cd into a worktree in one keystroke.
 ---
 
-# Shell init (gcd helper)
+# Shell init (`gcd` helper)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+A binary by itself cannot change the parent shell's current directory — only the shell can. `gwm shell-init <shell>` prints a function (named `gcd`) that bridges two flows into one wrapper:
+
+- `gcd <pattern>` → `gwm cd <pattern>` (fuzzy resolve, exits `0` on a hit, `1` on miss / ambiguous / not in a repo).
+- `gcd` (no argument) → `gwm switch` (interactive picker; `Enter` to commit, `Esc` / `Ctrl-C` / `q` to cancel with exit code `1`).
+
+In both cases the wrapper only performs the `cd` after a successful exit code, so a cancelled picker or a missed pattern never strands you in `$HOME`.
+
+## install
+
+`eval` the wrapper in your shell's rc file:
+
+```bash
+# zsh
+echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc
+
+# bash
+echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
+
+# fish — also persist by adding to ~/.config/fish/config.fish
+gwm shell-init fish | source
+
+# PowerShell — current session only
+Invoke-Expression (& gwm shell-init powershell | Out-String)
+# PowerShell — persist via $PROFILE
+gwm shell-init powershell | Out-File -Append -Encoding utf8 $PROFILE
+```
+
+Open a fresh shell (or `source` the rc file) and `gcd` is on your `$PATH` as a shell function.
+
+## use
+
+```bash
+gcd auth                       # → cd $(gwm cd auth)
+                               #   → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
+
+gcd                            # → cd $(gwm switch)
+                               #   → opens the picker, cd's into the chosen worktree
+```
+
+The pattern is matched with the same fuzzy engine used by the TUI filter ([nucleo-matcher](https://docs.rs/nucleo-matcher)) — `auth` matches `feat-99-user-authentication`, `mig` matches `chore-12-rails-migration`, etc. Ambiguity (two worktrees match equally well) exits `1` and prints both candidates so the wrapper does not `cd`.
+
+## raw form (no wrapper)
+
+If you don't want to install the wrapper, the raw forms work too:
+
+```bash
+cd "$(gwm cd auth)"            # fuzzy resolve, $(...) captures the path
+cd "$(gwm switch)"             # open picker, type to narrow, Enter to commit
+gwm s                          # alias for `switch`
+```
+
+## related
+
+- [TUI → Fuzzy filter](/tui/filter) — same engine, same matching rules
+- [CLI → Subcommand reference](/cli/reference#cd) — full `gwm cd` and `gwm switch` flags
+- [CLI → Shell completions](/cli/completions) — drop a `_gwm` completer that knows about worktree names

--- a/docs/1.getting-started/index.md
+++ b/docs/1.getting-started/index.md
@@ -1,0 +1,16 @@
+---
+title: Getting Started
+description: Install gwm, create your first worktree, and wire up the one-line cd helper.
+navigation:
+  title: Getting Started
+---
+
+# Getting Started
+
+Three steps to a working gwm setup:
+
+1. **[Install](/getting-started/install)** — from source, Homebrew, prebuilt binary, or a Nix flake.
+2. **[Create your first worktree](/getting-started/first-worktree)** — `gwm create feat 42 user-auth` and what it does.
+3. **[Wire up `gcd`](/getting-started/shell-init)** — one-line `cd` into any worktree from anywhere.
+
+If you've used [`gwq`](https://github.com/d-kuro/gwq) or the in-house `tools/worktree-manager.sh` bash script before, gwm is the Rust-native rewrite — same workflow, configurable per repo, no external CLI dependencies. The conceptual [differences vs. the bash script](/development#vs-bash-script) live in the development section.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -5,4 +5,85 @@ description: Every key the TUI listens to — list, sidebar, filter, confirm ove
 
 # Keybindings
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The full key map for `gwm`'s ratatui interface. Press `?` at any time for the same table as an in-app overlay.
+
+## list view (default)
+
+| Key         | Action                                                                                            |
+|:------------|:--------------------------------------------------------------------------------------------------|
+| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                                         |
+| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                                             |
+| `gg`        | jump to the first worktree                                                                        |
+| `G`         | jump to the last worktree                                                                         |
+| `n`         | new worktree (form: type → issue → description)                                                   |
+| `d`         | delete selected (confirm `y` · countdown when `p` is armed — see [confirm-overlay](/tui/confirm-countdown)) |
+| `b`         | re-run bootstrap on the selected worktree                                                         |
+| `o`         | open the worktree per [`[tui.open]`](/tui/open-dispatch) — `shell` (default) / `editor` / `finder` |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
+| `l`         | launch the configured [`[git_tui]`](/tui/launchers) command (default `lazygit -p {path}`, fullscreen) |
+| `R`         | launch the configured [`[review]`](/tui/launchers) command — AI / web reviewer over `git diff base..head` |
+| `O`         | open menu for the linked issue / PR (`i` issue, `p` pr → spawns browser)                          |
+| `L`         | link prompt — type `i` or `p`, then digits, to attach an issue / PR                               |
+| `F`         | refresh the GitHub issue / PR status (synchronous `gh` fetch)                                     |
+| `f`         | refresh the worktree list (alias: `r`)                                                            |
+| `v`         | toggle the details sidebar (auto-hidden when terminal width < 120 cols)                           |
+| `Tab`       | swap focus between the worktree list and the sidebar                                              |
+| `/`         | open the [fuzzy filter](/tui/filter) bar (`Enter` confirms · `Esc` clears)                        |
+| `p`         | toggle "delete branch on remove"                                                                  |
+| `Enter`     | show selected path in status bar                                                                  |
+| `?`         | help overlay                                                                                      |
+| `q`         | quit                                                                                              |
+| `Esc`       | clear a sticky filter if any, otherwise quit                                                      |
+
+## confirm-delete overlay
+
+| Key                  | Action                                                                          |
+|:---------------------|:--------------------------------------------------------------------------------|
+| `y` / `Enter`        | confirm (classic) or arm the countdown (when `p` is armed — see [countdown](/tui/confirm-countdown)) |
+| `y` / `Enter` again  | during an armed countdown, **disarms** it without firing                        |
+| `n` / `Esc`          | cancel                                                                          |
+
+## create overlay
+
+| Key                       | Action                                                  |
+|:--------------------------|:--------------------------------------------------------|
+| `Tab` / `↓`               | next field                                              |
+| `Shift+Tab` / `↑`         | previous field                                          |
+| `Enter` (on last field)   | submit and bootstrap                                    |
+| `Esc`                     | cancel                                                  |
+
+## issue / PR link prompt (`L`)
+
+| Stage              | Key       | Action                            |
+|:-------------------|:----------|:----------------------------------|
+| target choice      | `i`       | link an issue                     |
+| target choice      | `p`       | link a PR                         |
+| number input       | digits    | type the issue / PR number        |
+| number input       | `Enter`   | commit the link                   |
+| any stage          | `Esc`     | cancel                            |
+
+## issue / PR open menu (`O`)
+
+| Key       | Action                                |
+|:----------|:--------------------------------------|
+| `i`       | open the linked issue in the browser  |
+| `p`       | open the linked PR in the browser     |
+| `Esc` / `q` | dismiss                             |
+
+## help overlay (`?`)
+
+| Key                          | Action               |
+|:-----------------------------|:---------------------|
+| `Esc` / `q` / `?` / `Enter`  | dismiss              |
+
+## v0.6 rebind summary
+
+Three keys moved when [#75 (configurable launchers)](https://github.com/kbrdn1/gwm-cli/issues/75) landed. Update muscle memory accordingly:
+
+| Pre-v0.6 | v0.6+ | Why                                                                                       |
+|:---------|:------|:------------------------------------------------------------------------------------------|
+| `r`      | `f`   | `r` kept as **alias** for muscle memory, but the documented mnemonic is now `f`           |
+| `R`      | `F`   | freed `R` for the new review launcher; `F` does the GitHub refresh `R` used to do         |
+| _(none)_ | `R`   | launch the configured `[review]` command (lumen / claude / codex / aider / gh / custom)   |
+
+If you wired any of these into a custom script (unlikely — they're TUI-only), nothing breaks; this is purely about the in-app overlay.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -1,0 +1,8 @@
+---
+title: Keybindings
+description: Every key the TUI listens to — list, sidebar, filter, confirm overlay, link prompts.
+---
+
+# Keybindings
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -5,4 +5,90 @@ description: The four-bordered subsection layout on the right pane — Worktree 
 
 # Details sidebar
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree.
+
+The pane is composed of **four independent rounded-border subsections** — section titles live on the borders themselves, so there are no inline `Basic Settings:` / `Recent commits:` lines anymore. Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+## header
+
+```
+● <worktree-name>
+```
+
+- The `●` colour tracks the linked PR / issue state:
+  - **green** — open
+  - **gray** — draft
+  - **magenta** — merged
+  - **red** — closed
+  - **darkgray** — nothing linked / unknown
+- The worktree name itself is coloured by `BranchStatus` (worst-state wins):
+  - **red** — dirty (uncommitted changes)
+  - **yellow** — ahead / behind upstream
+  - **magenta** — unpublished (no upstream)
+  - **green** — synced
+  - **darkgray** — unknown
+
+The same colour is applied to the `BRANCH` column in the worktree table, so the header and the table stay visually in sync.
+
+## `Worktree` block
+
+The first block holds the worktree-level facts:
+
+- `branch` — coloured by status (same scheme as the header)
+- `path` — the absolute path on disk (tilde-compressed)
+- `head` — short OID of the current commit
+- **`Created`** — branch age in compact relative form (`2d`, `3w`, `1M`), colour-coded by freshness: **green** < 7d, **yellow** < 30d, **darkgray** otherwise. Added by [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+- flags — `main`, `locked`, `prunable`, etc.
+- `branch status` — the textual long form of the column shown in the table (`clean`, `dirty (N files)`, `↑N ↓M`, `unpublished`, …)
+
+## `Issue / PR` block
+
+Hidden when nothing is linked to the selected worktree. Otherwise renders one or two live lines fetched via `gh`:
+
+```
+Issue #42 [open] TUI: fuzzy search
+PR #61 [draft] · checks 2/3
+```
+
+- The bracketed state is `gh`'s view (`open` / `closed` / `merged` / `draft`).
+- The trailing `· checks 2/3` only shows up for PRs and reflects the rollup of required GitHub check runs.
+- Refresh on demand with the `F` key — the fetch is **synchronous** and updates the status bar with success / per-fetch error detail.
+
+The block is auto-rebuilt every selection change, so it never shows stale data from a previously selected worktree. See [GitHub issue / PR linking](/integrations/github-linking) for the linking model.
+
+## `Working Tree` block
+
+The `git status --short` output for the selected worktree:
+
+```
+M  src/tui/app.rs
+?? docs/
+```
+
+Empty checkout renders as `✓ clean`.
+
+## `Recent Commits` block
+
+A lazygit-style commit graph that fills the available height. Added by [#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72) and finished in [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+
+Per-row format:
+
+```
+<8-char hash>  <author initials>  <node>  <subject>
+```
+
+- `<node>` is `○` for a normal commit, `◎` for a merge commit.
+- Subjects are **hard-clipped at the panel's right edge** — no wrapping, exactly one visual line per commit.
+- A right-aligned footer `<viewport-bottom> of <total>` lives at the bottom of the block.
+- Default buffer is **300 commits** (matches lazygit's `git log -300`).
+
+The full topology renderer draws the diverging branches with `│` (vertical pipe), `╮ ╭ ╯ ╰` (corners), `┴ ┬` (junctions), `─` (horizontal stroke). Linear history collapses to a single `○`-stack column; merges spawn fresh columns to the right. The algorithm is width-deterministic on the commit list — the same input always produces the same output regardless of terminal width.
+
+The pre-v0.6 `Commands` cheat-sheet block was dropped — press `?` for the full key map overlay instead. The 15-line block duplicated the `?` overlay and pushed the `Issue / PR` block off-screen on common terminal sizes.
+
+## focus and scrolling
+
+- Hit `Tab` to move focus into the sidebar. The currently focused panel's border switches to cyan.
+- With the sidebar focused, `j` / `k` (or arrow keys) scroll its content — useful for long `Recent Commits` lists.
+- Hit `Tab` again to return focus to the worktree list.
+- `v` toggles the entire sidebar on/off (useful when the terminal is narrow but ≥ 120 cols, or when you need maximum table width).

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -1,0 +1,8 @@
+---
+title: Details sidebar
+description: The four-bordered subsection layout on the right pane — Worktree / Issue · PR / Working Tree / Recent Commits.
+---
+
+# Details sidebar
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/3.filter.md
+++ b/docs/2.tui/3.filter.md
@@ -5,4 +5,42 @@ description: The `/` filter bar — nucleo-matcher, sticky filters, Esc semantic
 
 # Fuzzy filter
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Press `/` to open an inline filter bar at the bottom of the worktree table. As you type, the table narrows in real time using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) — the same fuzzy engine used by Helix and Zellij. Matches are ranked by how tight the hit is (contiguous substring beats spread-out subsequence), so the most likely candidate sits on top.
+
+## flow
+
+```
+/                            → filter bar opens
+auth                         → table now shows feat-99-user-authentication only
+<Enter>                       → filter sticks, navigation back on the table
+<Esc>                         → clears filter, full list back
+```
+
+## sticky filters
+
+The filter is sticky between `Enter` and `Esc`:
+
+- `j` / `k` / `gg` / `G` continue to work on the **filtered subset** — selection stays inside the visible rows.
+- The table title shows `worktrees (N/M)` (visible / total) so you always know how much is hidden.
+- Hit `/` again to re-open the bar and **refine** the existing query — the bar pre-fills with the current filter.
+- `Esc` from the list view clears the sticky filter before it considers quitting, so you cannot accidentally quit when you meant to drop the filter.
+
+## matching rules
+
+`nucleo-matcher` is a smart-case subsequence matcher:
+
+- All lowercase query → case-insensitive (`auth` matches `Authentication`)
+- Mixed-case query → case-sensitive (`Auth` only matches `Auth…`)
+- Spaces in the query are **AND** separators (`mig db` matches `chore-12-db-migration` because both `mig` and `db` are present, in any order)
+- Contiguous substrings score higher than spread-out subsequences (`auth` beats `aXuXtXh`)
+
+The matcher works on the worktree name (path basename), not on the branch name. If your branch convention is `<type>/#<N>-<slug>` and `[worktree].path_pattern = "{type}-{issue}-{desc}"` (the default), they're equivalent.
+
+## picker mode
+
+When you launch `gwm switch` (or hit bare `gcd` with the [shell-init helper](/getting-started/shell-init) installed), the same filter bar opens **immediately** at startup — the picker is the filter view by default. Create / delete / bootstrap keys are disabled in picker mode; `Enter` confirms the highlighted row and prints its path on stdout, `Esc` / `q` / `Ctrl-C` cancels with exit code `1`.
+
+## related
+
+- [Keybindings → list view](/tui/keybindings#list-view-default) — every key the filter view listens to
+- [Getting Started → Shell init](/getting-started/shell-init) — wire up `gcd` for one-keystroke worktree jumping

--- a/docs/2.tui/3.filter.md
+++ b/docs/2.tui/3.filter.md
@@ -1,0 +1,8 @@
+---
+title: Fuzzy filter
+description: The `/` filter bar — nucleo-matcher, sticky filters, Esc semantics.
+---
+
+# Fuzzy filter
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/4.confirm-countdown.md
+++ b/docs/2.tui/4.confirm-countdown.md
@@ -5,4 +5,47 @@ description: The safety countdown that gates branch deletion when `p` is armed.
 
 # Confirm-overlay countdown
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#30](https://github.com/kbrdn1/gwm-cli/issues/30).
+
+The `d` confirm overlay has two modes, picked automatically based on whether `p` (toggle "delete branch on remove") was pressed earlier in the session.
+
+## classic mode — `delete branch on remove` OFF
+
+Single keystroke:
+
+- `y` / `Enter` → fires the delete immediately.
+- `n` / `Esc` → cancels.
+
+Same as the pre-#30 behaviour. Removing a worktree without dropping its branch is cheap (just an entry in `.git/worktrees/`) and the branch survives, so there's nothing to safeguard against.
+
+## countdown mode — `delete branch on remove` ON
+
+When `p` is armed, the overlay shows the branch about to disappear plus a two-stage `arm` step:
+
+1. `y` / `Enter` → **arms** a safety countdown (default 3s, visualised by a progress bar).
+2. The actual delete fires once the bar fills.
+3. `y` / `Enter` again **during** the countdown disarms it without firing.
+4. `Esc` / `n` cancels at any time, armed or not.
+
+The reasoning: dropping a branch is **destructive** (the branch is gone from `git branch`, only `git reflog` can resurrect it). The countdown forces a sub-second pause where you can change your mind, especially useful when muscle memory says `dyy` and you didn't notice `p` was still armed from earlier in the session.
+
+## configuration
+
+The countdown duration is configurable via `[tui].confirm_countdown_secs` in `.gwm.toml`. Accepted range: `0..=5`.
+
+```toml
+[tui]
+# 3s default. Set to 0 to disable the countdown (classic modal even when p is armed).
+confirm_countdown_secs = 3
+```
+
+- `0` → keeps the classic single-keystroke modal even when `delete branch on remove` is armed.
+- `1..=5` → the visualised countdown length, in seconds.
+- Values above `5` are silently clamped to `5` on read.
+
+See [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#tui) for the full `[tui]` block.
+
+## related
+
+- [Keybindings → confirm-delete overlay](/tui/keybindings#confirm-delete-overlay) — the keys this page describes
+- [CLI → `gwm remove`](/cli/reference#remove) — same destructive action, but from the CLI (no countdown; the flag is `--delete-branch` explicit)

--- a/docs/2.tui/4.confirm-countdown.md
+++ b/docs/2.tui/4.confirm-countdown.md
@@ -1,0 +1,8 @@
+---
+title: Confirm-overlay countdown
+description: The safety countdown that gates branch deletion when `p` is armed.
+---
+
+# Confirm-overlay countdown
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/5.launchers.md
+++ b/docs/2.tui/5.launchers.md
@@ -3,6 +3,121 @@ title: Configurable launchers (l and R)
 description: `[git_tui]` and `[review]` sections — placeholder expansion, fullscreen semantics, base resolution chain.
 ---
 
-# Configurable launchers (l and R)
+# Configurable launchers (`l` and `R`)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [#76](https://github.com/kbrdn1/gwm-cli/pull/76).
+
+Two TUI keybindings — `l` (git TUI launcher) and `R` (review launcher) — are driven by user-configurable `.gwm.toml` sections sharing the same mini-API. Both take a `command` template string, substitute placeholders, split with [`shell-words`](https://docs.rs/shell-words), and exec the result with `cwd = worktree.path`.
+
+## the shared pipeline
+
+| Step | What happens                                                                                       |
+|:-----|:---------------------------------------------------------------------------------------------------|
+| 1    | Read the `[git_tui]` or `[review]` section from `.gwm.toml` (defaults below).                       |
+| 2    | Resolve placeholders: `{path}`, `{base}`, `{head}`, `{diff}`.                                       |
+| 3    | Split the result into `argv` with `shell-words` (handles quoting like a POSIX shell).                |
+| 4    | Probe `argv[0]` against `$PATH`. Missing binary → status-bar error, no spawn, no flicker.            |
+| 5    | If `fullscreen = true` → suspend the TUI (raw mode off, alt-screen left), spawn `Command::status()`, restore on exit. |
+| 6    | If `fullscreen = false` → keep the TUI in the alt-screen, spawn `Command::output()`, **block** until exit, drop the first line of stderr on the status bar. |
+
+The `{diff}` placeholder is **lazy** — gwm only materialises a tempfile holding `git diff {base}..{head}` when the template references `{diff}`. The tempfile's lifetime is bound to the spawned process (its `Drop` impl unlinks on completion), so the reviewer always sees a consistent snapshot.
+
+> **`fullscreen = false` is synchronous.** The TUI is **unresponsive** until the child process exits — `Command::output()` waits for it. Fine for quick print-only tools (`claude --print`, `gh pr view --web`); pick `fullscreen = true` for anything long-running so the TUI is properly suspended and your terminal stays usable.
+
+## `[git_tui]` — bound to `l`
+
+Default: `lazygit -p {path}`, fullscreen.
+
+```toml
+[git_tui]
+# command template (single placeholder: {path}). Pre-v0.6 behaviour
+# is the default — your existing configs see zero change.
+command = "lazygit -p {path}"
+
+# suspend the TUI for the call (recommended for TUIs that own the alt-screen)
+fullscreen = true
+```
+
+Examples — any tool that takes a worktree path works:
+
+```toml
+[git_tui]
+command = "gitui -d {path}"        # gitui
+
+[git_tui]
+command = "tig --all"              # tig (run inside the worktree)
+fullscreen = true
+
+[git_tui]
+command = "code -n {path}"         # VS Code in a new window
+fullscreen = false                  # IDE forks, don't suspend
+```
+
+## `[review]` — bound to `R`
+
+No default — `R` is inert until configured.
+
+Two equivalent ways to configure it:
+
+### a) free-form `command` (full control)
+
+```toml
+[review]
+command = "claude --print 'review the diff {base}..{head}'"
+fullscreen = false
+default_base = "main"               # optional, see "base resolution chain" below
+```
+
+### b) `tool = "<preset>"` (sugar)
+
+```toml
+[review]
+tool = "lumen"                      # shorthand for the table below
+```
+
+| Preset    | Expanded `command`                                       | `fullscreen` |
+|:----------|:---------------------------------------------------------|:-------------|
+| `lumen`   | `lumen diff {base}..{head}`                              | `true`       |
+| `claude`  | `claude --print 'review the diff {base}..{head}'`        | `false`      |
+| `codex`   | `codex review {base}..{head}`                            | `false`      |
+| `aider`   | `aider --message 'review {base}..{head}'`                | `true`       |
+| `gh`      | `gh pr view --web`                                       | `false`      |
+
+If both `command` and `tool` are set in the same block, `command` wins and the TUI shows a one-shot warning at startup ("your `tool = X` is shadowed by `command`") so you notice the dead config.
+
+## placeholders
+
+| Placeholder | Available in       | Expanded to                                                                          |
+|:------------|:-------------------|:-------------------------------------------------------------------------------------|
+| `{path}`    | both               | absolute path of the selected worktree                                               |
+| `{base}`    | `[review]` only    | result of the [base resolution chain](#base-resolution)                              |
+| `{head}`    | `[review]` only    | the current branch name (`branch.<name>` in git config)                              |
+| `{diff}`    | `[review]` only    | absolute path of a tempfile holding `git diff {base}..{head}` (lazy — see above)    |
+
+Referencing `{diff}` in a `[git_tui]` template is a config error caught at load time (the git TUI launcher doesn't carry the repo handle needed to materialise the diff).
+
+## base resolution
+
+The `{base}` placeholder follows this chain — first non-empty hit wins:
+
+1. **`branch.<name>.merge`** — the branch's upstream tracking ref, if any.
+2. **`branch.<name>.gwm-base`** — set automatically by `gwm create` so the original parent stays recoverable even when the upstream is dropped.
+3. **`[review].default_base`** — the user-configured fallback in `.gwm.toml`.
+4. **`dev`** — gwm's project convention (only if `dev` exists locally).
+5. **`main`** — universal git default (final sentinel — guaranteed non-empty).
+
+The chain is implemented in [`src/launcher.rs::resolve_review_base`](https://github.com/kbrdn1/gwm-cli/blob/main/src/launcher.rs#L167-L187). The fallback prefers `dev` only when it exists locally — returning `dev` blindly when the repo only has `main` would make the launcher's subsequent `git rev-list` / `git diff` calls fail loudly (caught by Copilot's review on PR #76).
+
+## interaction with `gwm doctor`
+
+`gwm doctor` (post-v0.6) probes the resolved `[git_tui]` and `[review]` binaries against `$PATH`:
+
+- Missing **git TUI** binary → **Failed** (exit code `2`) — `l` is a documented core keybinding.
+- Missing **review** binary → **Warning** (exit code `1`) — review is opt-in; a CI pre-commit hook keeps passing when only the local launcher is unavailable.
+
+See [Integrations → `gwm doctor`](/integrations/doctor) for the full check breakdown.
+
+## related
+
+- [Keybindings](/tui/keybindings) — where `l` and `R` live in the key map, plus the v0.6 rebind summary
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#git_tui-and-review) — full field listing with types and defaults

--- a/docs/2.tui/5.launchers.md
+++ b/docs/2.tui/5.launchers.md
@@ -1,0 +1,8 @@
+---
+title: Configurable launchers (l and R)
+description: `[git_tui]` and `[review]` sections — placeholder expansion, fullscreen semantics, base resolution chain.
+---
+
+# Configurable launchers (l and R)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/6.open-dispatch.md
+++ b/docs/2.tui/6.open-dispatch.md
@@ -3,6 +3,70 @@ title: Open dispatch (o)
 description: `[tui.open]` controls what `o` does — shell, editor, or finder.
 ---
 
-# Open dispatch (o)
+# Open dispatch (`o`)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+
+The `o` key dispatches on the `[tui.open]` section in `.gwm.toml`. Three modes are supported.
+
+## configuration
+
+```toml
+[tui.open]
+mode = "shell"          # "shell" (default) | "editor" | "finder"
+shell_cmd = ""           # override $SHELL; empty = use $SHELL
+editor_cmd = "hx"        # override $EDITOR; empty = use $EDITOR
+```
+
+Unknown `mode` values are a **hard config error at load time**, surfaced before the TUI opens — no silent fallback. The error names the file, the line, and the supported values, so the fix is one keystroke.
+
+## modes
+
+### `shell` (default — changed in v0.6)
+
+Suspend the TUI and spawn `$SHELL` (or `shell_cmd` if set) with `cwd` set to the worktree — same lifecycle as the `l: git_tui` launcher. When you exit the shell, the gwm TUI restores exactly where you left it.
+
+```
+o   →   $SHELL    inside /Users/you/cc-worktree/myrepo/feat-42-user-auth
+exit→   gwm TUI restored
+```
+
+This is the lazygit-style flow — drop into a shell, run whatever, come back to the TUI without losing selection or filter state.
+
+### `editor`
+
+Suspend the TUI and run `$EDITOR <worktree-path>` (or `editor_cmd <worktree-path>` if set). Useful for terminal editors that own the alt-screen (helix, nvim, micro):
+
+```toml
+[tui.open]
+mode = "editor"
+editor_cmd = "hx"        # override $EDITOR for this repo
+```
+
+For GUI editors that fork off the terminal, prefer `mode = "shell"` with a custom `shell_cmd` that launches the editor — that way the TUI doesn't suspend uselessly while the GUI runs.
+
+### `finder` — pre-v0.6 behaviour
+
+Hand off to the OS file manager **without** suspending the TUI:
+
+- macOS: `open <path>`
+- Linux: `xdg-open <path>`
+- Windows: `explorer <path>`
+
+This is the pre-v0.6 default; opt back in with `mode = "finder"`. Useful when the worktree carries binary assets you actually want to inspect in the OS file picker.
+
+## why the default changed
+
+The pre-v0.6 `o` opened the OS file manager unconditionally, but the most common follow-up was "now I want a shell here" — so most users ended up either ignoring `o` entirely or wiring it through a `yank-path-and-cd` workaround. v0.6 makes the common case the default.
+
+Existing users see a one-line behaviour change. Opt back into the old flow with two lines in `.gwm.toml`:
+
+```toml
+[tui.open]
+mode = "finder"
+```
+
+## related
+
+- [Keybindings](/tui/keybindings) — where `o` and `y` (yank to clipboard) live in the key map
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#tui-open) — full `[tui.open]` field list

--- a/docs/2.tui/6.open-dispatch.md
+++ b/docs/2.tui/6.open-dispatch.md
@@ -1,0 +1,8 @@
+---
+title: Open dispatch (o)
+description: `[tui.open]` controls what `o` does — shell, editor, or finder.
+---
+
+# Open dispatch (o)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/index.md
+++ b/docs/2.tui/index.md
@@ -1,0 +1,19 @@
+---
+title: TUI
+description: The ratatui interface — keybindings, sidebar layout, configurable launchers, fuzzy filter, and confirm-overlay countdown.
+navigation:
+  title: TUI
+---
+
+# TUI
+
+Bare `gwm` (no arguments) opens the ratatui interface on the current repo. From there you can create, delete, bootstrap, and jump between worktrees without leaving the terminal.
+
+- **[Keybindings](/tui/keybindings)** — the full key map, including the v0.6 additions (`R`, `F`, `O`, `L`, `f`, `y`).
+- **[Details sidebar](/tui/sidebar)** — the four-bordered subsections on the right pane, the lazygit-style commit graph, the live Issue / PR block.
+- **[Fuzzy filter](/tui/filter)** — `/` opens the inline filter bar; nucleo-matcher under the hood.
+- **[Confirm-overlay countdown](/tui/confirm-countdown)** — the safety countdown that prevents accidental branch deletions when `p` is armed.
+- **[Configurable launchers](/tui/launchers)** — `[git_tui]` (`l`) and `[review]` (`R`), with `{base} {head} {path} {diff}` placeholders.
+- **[Open dispatch](/tui/open-dispatch)** — `[tui.open]` controls what `o` does (`shell` / `editor` / `finder`).
+
+The picker variant (`gwm switch`, alias `gwm s`) reuses the same TUI but disables create / delete / bootstrap, then prints the chosen worktree's path on stdout — meant to be `eval`d by the `gcd` shell wrapper.

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -1,0 +1,8 @@
+---
+title: Subcommand reference
+description: Every `gwm` subcommand with synopsis, flags, exit codes, and examples.
+---
+
+# Subcommand reference
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -5,4 +5,198 @@ description: Every `gwm` subcommand with synopsis, flags, exit codes, and exampl
 
 # Subcommand reference
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm <subcommand>` is the scriptable face of gwm. Every command exits with a meaningful code (`0` ok, `1` warning, `2` failure) so you can wire `gwm doctor` into CI without parsing stdout.
+
+Bare `gwm` (no subcommand) opens the [TUI](/tui) on the current repo.
+
+## `gwm init`
+
+Write a default `.gwm.toml` to the current repo.
+
+```bash
+gwm init
+# → wrote /path/to/repo/.gwm.toml
+```
+
+Refuses to overwrite an existing `.gwm.toml`. Tweak the generated file and re-run `gwm doctor` to validate.
+
+## `gwm types`
+
+List the supported branch types (the `<type>` slot of `gwm create`).
+
+```bash
+gwm types
+# → feat
+#   fix
+#   hotfix
+#   docs
+#   …
+```
+
+Override per repo via `[worktree].branch_types` in `.gwm.toml`.
+
+## `gwm create <type> <issue> <desc>`
+
+Create a worktree and matching branch.
+
+```bash
+gwm create feat 123 user-authentication
+#   → branch feat/#123-user-authentication
+#   → worktree ~/cc-worktree/<repo>/feat-123-user-authentication
+
+gwm create feat 123 foo --no-bootstrap     # skip the bootstrap pipeline
+```
+
+| Flag             | Action                                                              |
+|:-----------------|:--------------------------------------------------------------------|
+| `--no-bootstrap` | Skip the `.gwm.toml` bootstrap stages (copies / guards / commands)  |
+
+End-to-end walkthrough lives in [Getting Started → First worktree](/getting-started/first-worktree).
+
+## `gwm list [--format=table|names]`
+
+List the worktrees in the current repo.
+
+```bash
+gwm list                       # human-readable table
+gwm list --format=names        # one worktree name per line (for shell completion)
+```
+
+The `names` format excludes the main workdir — `gwm path / remove / bootstrap` never accept it as a target, so emitting it as a completion candidate would be misleading.
+
+## `gwm path <pattern>` (alias: `gwm cd <pattern>`)
+
+Print the on-disk path of a worktree matching `<pattern>` (fuzzy). Use with `$(...)` to `cd`:
+
+```bash
+cd "$(gwm path auth)"
+cd "$(gwm cd auth)"            # same — framing for the cd flow
+```
+
+Both forms share semantics: fuzzy resolve, exit `0` on a unique hit, `1` on miss / ambiguous / not in a repo. Pair with `gwm shell-init` for the `gcd` one-liner — see [Getting Started → Shell init](/getting-started/shell-init).
+
+## `gwm switch` (alias: `gwm s`)
+
+Open the TUI in **picker mode** — same table as bare `gwm`, fuzzy filter bar pre-open, create / delete / bootstrap disabled. Press `Enter` to print the highlighted worktree's path on stdout, `Esc` / `q` / `Ctrl-C` to cancel with exit code `1`.
+
+```bash
+cd "$(gwm switch)"             # open picker, type to narrow, Enter to commit
+gcd                            # same, via the `gwm shell-init` wrapper
+```
+
+## `gwm bootstrap [<pattern>]`
+
+Re-run the `.gwm.toml` bootstrap pipeline on a worktree without recreating it.
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # on a fuzzy-matched name
+```
+
+Useful after editing `.gwm.toml` or adding new `[[bootstrap.copy]]` rules. Same `✓ / ! / ✗` report as `gwm create`.
+
+## `gwm remove <pattern> [--delete-branch]`
+
+Remove a worktree by fuzzy match. The branch survives by default.
+
+```bash
+gwm remove auth                            # remove the worktree, keep the branch
+gwm remove auth --delete-branch            # remove the worktree AND drop the branch
+```
+
+The CLI form has no countdown (the TUI's [`d` confirm-overlay countdown](/tui/confirm-countdown) is TUI-only). `--delete-branch` is destructive — only `git reflog` can resurrect a dropped branch.
+
+## `gwm prune`
+
+Clear stale entries in `.git/worktrees/` whose working directory was removed manually (e.g. `rm -rf` outside gwm).
+
+```bash
+gwm prune
+```
+
+`gwm doctor` flags prunable entries as a Warning; `gwm prune` is the documented remediation.
+
+## `gwm completions <shell>`
+
+Print a static completion script. Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. See [Shell completions](/cli/completions) for installation per shell.
+
+## `gwm shell-init <shell>`
+
+Print the `gcd` shell wrapper. Supported shells: `zsh`, `bash`, `fish`, `powershell`. See [Getting Started → Shell init](/getting-started/shell-init).
+
+## `gwm tmux <pattern> [-p|--split]`
+
+Open the matched worktree in a new tmux window of the **current** session. `--split` substitutes `split-window` for `new-window`. Requires `$TMUX` to be set.
+
+```bash
+gwm tmux auth                  # new tmux window inside the matched worktree
+gwm tmux auth -p               # split the current pane instead
+```
+
+Outside a tmux session, exits non-zero with a clear error (does not spawn a stray server).
+
+## `gwm zellij <pattern> [-p|--split]`
+
+Same as `gwm tmux` but for zellij. Uses `zellij action new-tab --cwd <path>` (requires zellij ≥ 0.40 for the `--cwd` flag) or `new-pane --cwd` with `-p`. Requires `$ZELLIJ`.
+
+See [CLI → Multiplexer integration](/cli/multiplexer) for the full surface and edge cases.
+
+## `gwm link {issue|pr} <N> [--worktree <pattern>]`
+
+Link the current (or named) worktree to a GitHub issue or PR.
+
+```bash
+gwm link issue 42              # link the current worktree to issue #42
+gwm link pr 61                 # link a PR
+gwm link issue 42 --worktree feat-auth      # ...or to a fuzzy-matched worktree
+```
+
+The link is stored in `git config branch.<name>.gwm-issue` / `gwm-pr` — local, per-branch, no extra file. Issue numbers are **auto-detected** from `<type>/#<N>-<slug>` branches, so `gwm link issue <N>` is only needed for explicit overrides. PR numbers are not auto-detected.
+
+## `gwm unlink {issue|pr} [--worktree <pattern>]`
+
+Remove the explicit link override on the current (or named) worktree.
+
+```bash
+gwm unlink issue               # remove the issue link (auto-detect resurfaces)
+gwm unlink pr                  # remove the PR link
+```
+
+Idempotent — safe to run when nothing is linked.
+
+## `gwm open {issue|pr} [--worktree <pattern>] [--print-url]`
+
+Open the linked issue / PR in the browser via the OS opener.
+
+```bash
+gwm open issue                 # spawn the OS opener on the linked issue URL
+gwm open pr --print-url        # print the URL on stdout, no spawn
+```
+
+Useful in headless shells and tests with `--print-url`.
+
+## `gwm status [--worktree <pattern>] [--json]`
+
+Show the link plus (when `gh` is available) live GitHub state.
+
+```bash
+gwm status
+# → Issue #42 [open] TUI: fuzzy search
+# → PR #61 [draft] · checks 2/3
+
+gwm status --json              # stable schema for scripts
+```
+
+Degrades gracefully to local-link-only output when `gh` is missing or the repo has no GitHub remote.
+
+## `gwm doctor`
+
+Run 7 health checks; report each with `✓ / ! / ✗`; exit `0 / 1 / 2`. Designed for CI and pre-commit hooks. See [Integrations → `gwm doctor`](/integrations/doctor) for the per-check breakdown.
+
+## exit codes
+
+| Code | Meaning                                                                |
+|:-----|:-----------------------------------------------------------------------|
+| `0`  | success — also "all green" for `gwm doctor`                            |
+| `1`  | recoverable failure — fuzzy miss, ambiguous match, doctor Warning      |
+| `2`  | hard failure — bootstrap `✗`, doctor Failure, unrecoverable git error  |

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -1,0 +1,8 @@
+---
+title: Shell completions
+description: `gwm completions <shell>` and dynamic worktree-name completion via `gwm list --format=names`.
+---
+
+# Shell completions
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -5,4 +5,64 @@ description: `gwm completions <shell>` and dynamic worktree-name completion via 
 
 # Shell completions
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm completions <shell>` prints a static completion script (generated from the live clap argument tree, so it never drifts from the actual subcommands). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`.
+
+## install
+
+```bash
+# zsh — drop into the first writable fpath entry
+gwm completions zsh > "${fpath[1]}/_gwm"
+
+# bash — system-wide
+gwm completions bash | sudo tee /etc/bash_completion.d/gwm > /dev/null
+# bash — per-user
+gwm completions bash > ~/.local/share/bash-completion/completions/gwm
+
+# fish
+gwm completions fish > ~/.config/fish/completions/gwm.fish
+
+# PowerShell — load into the current session (ephemeral)
+gwm completions powershell | Out-String | Invoke-Expression
+# PowerShell — persist by appending to $PROFILE
+gwm completions powershell | Out-File -Append -Encoding utf8 $PROFILE
+
+# elvish
+gwm completions elvish > ~/.config/elvish/lib/gwm.elv
+```
+
+Open a fresh shell (or `source` your rc file) and tab completion is live for every subcommand, flag, and value-enum (e.g. `gwm list --format=<TAB>` offers `table` / `names`).
+
+## dynamic worktree-name completion
+
+The static script knows about subcommands and flags but **not** about the worktrees in your repo — those change every time you run `gwm create / remove`. Wire a custom completer to `gwm list --format=names` for live completion of the `<pattern>` arg on `path` / `cd` / `remove` / `bootstrap` / `tmux` / `zellij`.
+
+### zsh
+
+```zsh
+_gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
+compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-tmux gwm-zellij
+```
+
+(`gwm-path`, `gwm-cd`, etc. are the auto-generated function names the static `_gwm` completer registers per-subcommand.)
+
+### bash
+
+```bash
+_gwm_worktrees() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$(gwm list --format=names 2>/dev/null)" -- "$cur"))
+}
+complete -F _gwm_worktrees -o default gwm
+```
+
+### fish
+
+```fish
+complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap tmux zellij" \
+  -f -a "(gwm list --format=names 2>/dev/null)"
+```
+
+## see also
+
+- [Getting Started → Shell init](/getting-started/shell-init) — the `gcd` wrapper that ships alongside `completions`
+- [CLI → Subcommand reference](/cli/reference#gwm-list---formattabel-names) — the `--format=names` output used by the completers

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -1,0 +1,8 @@
+---
+title: tmux / zellij integration
+description: `gwm tmux` / `gwm zellij` to open a worktree in a new window, pane, or tab.
+---
+
+# tmux / zellij integration
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -5,4 +5,56 @@ description: `gwm tmux` / `gwm zellij` to open a worktree in a new window, pane,
 
 # tmux / zellij integration
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Inside an already-running multiplexer session, `gwm tmux` and `gwm zellij` spawn a new window / pane / tab whose shell starts inside the matched worktree — no manual `cd` round-trip needed.
+
+## tmux
+
+```bash
+gwm tmux auth                  # new tmux window inside the matched worktree
+gwm tmux auth -p               # split the current pane instead
+gwm tmux auth --split          # ...long form of -p
+```
+
+Under the hood:
+
+- **new window** (default): `tmux new-window -n <name> -c <path>`
+- **split** (`-p` / `--split`): `tmux split-window -c <path>` (current window's layout, current pane's direction)
+
+The `-n <name>` arg names the new window after the worktree slug so it stands out in the status bar.
+
+## zellij
+
+```bash
+gwm zellij auth                # new zellij tab inside the matched worktree
+gwm zellij auth -p             # new pane in the current tab instead
+```
+
+Under the hood:
+
+- **new tab** (default): `zellij action new-tab --name <name> --cwd <path>`
+- **new pane** (`-p` / `--split`): `zellij action new-pane --cwd <path>`
+
+The `--cwd` flag on `new-tab` requires **zellij ≥ 0.40**; older versions error out. `new-pane --cwd` has been stable longer — use `-p` if you're stuck on an older zellij.
+
+## required session
+
+Both commands require the corresponding multiplexer to actually be running:
+
+- `gwm tmux` checks for `$TMUX` in the environment.
+- `gwm zellij` checks for `$ZELLIJ`.
+
+Outside a session, the command **refuses** with a clear error rather than spawning a stray server — the alternative (spawning detached) leads to orphaned sessions that the user never sees.
+
+```bash
+$ gwm tmux auth
+gwm tmux requires an active tmux session ($TMUX is not set).
+```
+
+## fuzzy matching
+
+The `<pattern>` arg uses the same fuzzy matcher as `gwm path / remove / bootstrap` ([nucleo-matcher](https://docs.rs/nucleo-matcher)). Ambiguous matches exit `1` and print both candidates without spawning anything.
+
+## see also
+
+- [TUI → Fuzzy filter](/tui/filter) — the matcher's case-sensitivity and scoring rules
+- [CLI → Subcommand reference](/cli/reference#gwm-tmux-pattern--p--split) — flags and exit codes

--- a/docs/3.cli/index.md
+++ b/docs/3.cli/index.md
@@ -1,0 +1,16 @@
+---
+title: CLI
+description: Every gwm subcommand, with synopsis, flags, and shell-friendly examples.
+navigation:
+  title: CLI
+---
+
+# CLI
+
+`gwm <subcommand>` is the scriptable side of gwm — designed to be safe in pipelines, shell completions, and pre-commit hooks. Every subcommand exits with a meaningful code (`0` ok, `1` warning, `2` failure) so you can wire `gwm doctor` into CI without parsing stdout.
+
+- **[Reference](/cli/reference)** — every subcommand, exhaustive (`init`, `create`, `list`, `path`, `cd`, `switch`, `bootstrap`, `remove`, `prune`, `link`, `unlink`, `open`, `status`, `doctor`, `tmux`, `zellij`, `completions`, `shell-init`).
+- **[Shell completions](/cli/completions)** — generate completion scripts for zsh / bash / fish / PowerShell / elvish, plus dynamic worktree-name completion via `gwm list --format=names`.
+- **[Multiplexer integration](/cli/multiplexer)** — `gwm tmux` / `gwm zellij` to open a worktree in a new tab or pane of the current session.
+
+The CLI never spawns a TUI of its own — every subcommand is non-interactive and prints to stdout/stderr. The only TUI surface is bare `gwm` (or `gwm switch` in picker mode), covered in the [TUI section](/tui).

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -1,0 +1,8 @@
+---
+title: .gwm.toml schema
+description: Every section: worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
+---
+
+# .gwm.toml schema
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -1,8 +1,199 @@
 ---
 title: .gwm.toml schema
-description: Every section: worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
+description: Every section — worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
 ---
 
-# .gwm.toml schema
+# `.gwm.toml` schema
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`.gwm.toml` lives at the repo root. Without one, gwm uses sensible defaults (path = `~/cc-worktree/<repo>/<type>-<issue>-<desc>`, no bootstrap, `lazygit -p {path}` as `l`). With one, you can configure every facet: branch naming, file copies, security guards, launcher commands, TUI behaviour, and doctor checks.
+
+The annotated full version lives at [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) — `gwm init` writes that file unchanged to your repo root.
+
+## `[worktree]`
+
+Branch and path conventions.
+
+```toml
+[worktree]
+base           = "{home}/cc-worktree/{repo}"
+path_pattern   = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+```
+
+Placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/…`) is also expanded.
+
+### supported branch types
+
+`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Override per repo if your team uses something else.
+
+## `[[bootstrap.copy]]`
+
+File copies from the main checkout into the new worktree.
+
+```toml
+[[bootstrap.copy]]
+from = ".env.testing"
+to   = ".env.testing"
+required = true
+fallback = "inline"        # inline | skip | abort (default: skip when required=false)
+
+[[bootstrap.copy]]
+from = ".env"
+to   = ".env"
+required = false
+guards = ["no-aws-rds"]    # reference into [[bootstrap.guard]]
+```
+
+| Field      | Type            | Default | Meaning                                                                  |
+|:-----------|:----------------|:--------|:-------------------------------------------------------------------------|
+| `from`     | string          | —       | source path, relative to the main checkout                               |
+| `to`       | string          | —       | destination path, relative to the new worktree                           |
+| `required` | bool            | `false` | when `true`, missing source aborts the bootstrap unless `fallback` saves |
+| `guards`   | list of strings | `[]`    | names of `[[bootstrap.guard]]` rules to apply after the copy             |
+| `fallback` | string          | none    | `inline` (use `[bootstrap.fallback.<key>]`), `skip`, or `abort`          |
+
+See [Bootstrap pipeline](/configuration/bootstrap) for execution order.
+
+## `[[bootstrap.guard]]`
+
+Regex deny-lists on copied files — the original "no AWS RDS in `.env`" use case, generalised.
+
+```toml
+[[bootstrap.guard]]
+name = "no-aws-rds"
+deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
+on_match      = "seed-from-example"     # abort | seed-from-example
+example_file  = ".env.example"
+```
+
+See [Regex guards](/configuration/guards) for the full pattern API.
+
+## `[bootstrap.fallback.<key>]`
+
+Inline content used when a required `[[bootstrap.copy]]` source is missing and `fallback = "inline"`.
+
+```toml
+[bootstrap.fallback.env_testing]
+target  = ".env.testing"
+content = """
+APP_ENV=testing
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+"""
+```
+
+The `<key>` is referenced implicitly by matching `target` to a copy step's `to`. Multiple fallbacks may coexist.
+
+## `[[bootstrap.no_symlink]]`
+
+Refuse to inherit a symlink at the listed path (typically `vendor/`, `node_modules/`) — stops a stray symlink from polluting the main repo's build output.
+
+```toml
+[[bootstrap.no_symlink]]
+path = "vendor"
+
+[[bootstrap.no_symlink]]
+path = "node_modules"
+```
+
+## `[[bootstrap.command]]`
+
+Shell hooks run after copies / guards / no-symlink.
+
+```toml
+[[bootstrap.command]]
+name = "composer install"
+run  = "composer install --no-interaction --prefer-dist"
+when = "file_exists:composer.json"
+env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
+```
+
+| Field  | Type                  | Meaning                                                              |
+|:-------|:----------------------|:---------------------------------------------------------------------|
+| `name` | string                | shown in the bootstrap report                                         |
+| `run`  | string                | shell line to exec (split via `sh -c`)                                |
+| `when` | string                | [`when:` predicate](/configuration/when-predicates) (optional)        |
+| `env`  | table of string→string | extra env vars injected for this command (optional)                  |
+
+## `[git_tui]` and `[review]`
+
+The TUI launcher bindings. Full schema lives in [TUI → Configurable launchers](/tui/launchers).
+
+```toml
+# l keybinding — pre-v0.6 default kept implicit when omitted
+[git_tui]
+command    = "lazygit -p {path}"
+fullscreen = true
+
+# R keybinding — inert until configured
+[review]
+tool         = "lumen"                # OR command = "<your line>"
+fullscreen   = true                   # only honoured when command is set
+default_base = "main"                 # optional override for the base resolution chain
+```
+
+## `[tui]`
+
+Runtime knobs for the worktree TUI.
+
+```toml
+[tui]
+# Safety countdown (in seconds) for the delete-confirm overlay when `p` is armed.
+# Accepts 0..=5; values above 5 are clamped on read. Setting it to 0 keeps the
+# classic single-keystroke modal even when delete-branch-on-remove is armed.
+confirm_countdown_secs = 3
+```
+
+See [TUI → Confirm-overlay countdown](/tui/confirm-countdown).
+
+## `[tui.open]`
+
+What the `o` key does. Full details in [TUI → Open dispatch](/tui/open-dispatch).
+
+```toml
+[tui.open]
+mode = "shell"          # shell (default) | editor | finder
+shell_cmd  = ""          # override $SHELL when mode=shell; empty = unset
+editor_cmd = "hx"        # override $EDITOR when mode=editor; empty = unset
+```
+
+Unknown `mode` values are a **hard config error at load time**, not a silent fallback.
+
+## `[doctor]`
+
+Knobs for `gwm doctor`. Currently exposes the trunk list used by the orphan-branch check.
+
+```toml
+[doctor]
+# Branches the orphan check treats as "merge destinations". A gwm-style
+# branch fully reachable from one of these is preserved per CONTRIBUTING
+# ("never delete the source branch after merge") and NOT flagged as orphan.
+# Empty list → every unclaimed gwm-style branch is flagged.
+trunks = ["dev", "main"]
+```
+
+Repos using a non-default trunk (`master`, `trunk`, `release-1.x`, …) must list it here to keep the orphan check meaningful.
+
+## defaults without `.gwm.toml`
+
+| Setting                              | Default                          |
+|:-------------------------------------|:---------------------------------|
+| `[worktree].base`                    | `{home}/cc-worktree/{repo}`      |
+| `[worktree].path_pattern`            | `{type}-{issue}-{desc}`          |
+| `[worktree].branch_pattern`          | `{type}/#{issue}-{desc}`         |
+| `[[bootstrap.*]]`                    | empty — no pipeline              |
+| `[git_tui].command`                  | `lazygit -p {path}`              |
+| `[git_tui].fullscreen`               | `true`                           |
+| `[review]`                           | inert (`R` does nothing)         |
+| `[tui].confirm_countdown_secs`       | `3`                              |
+| `[tui.open].mode`                    | `shell` (v0.6 — was `finder`)    |
+| `[doctor].trunks`                    | `["dev", "main"]`                |
+
+## validation rules
+
+- Unknown TOML keys are silently ignored (forward-compatible with new fields).
+- Unknown `[tui.open].mode` values **error at load time**.
+- `[[bootstrap.guard]]` references in `[[bootstrap.copy]].guards` are validated by `gwm doctor` (check #2).
+- `[[bootstrap.command]].when` predicates with unknown keywords default to `true` (so old configs keep running); `gwm doctor` (check #3) surfaces them.
+
+Run `gwm doctor` after every edit to catch the catchable mistakes — see [Integrations → `gwm doctor`](/integrations/doctor).

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -1,8 +1,95 @@
 ---
 title: Bootstrap pipeline
-description: Execution order: file copies → regex guards → fallbacks → no-symlink check → shell commands.
+description: Execution order — file copies → regex guards → fallbacks → no-symlink check → shell commands.
 ---
 
 # Bootstrap pipeline
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The bootstrap pipeline runs **after** `git worktree add` succeeds, on every `gwm create` (unless `--no-bootstrap` is set) and on every `gwm bootstrap`. It is also re-runnable from inside the TUI via the `b` key.
+
+Five stages, in this order:
+
+```
+gwm create / gwm bootstrap
+       ↓
+(1) [[bootstrap.copy]]                  duplicate files from main → worktree
+       ↓
+(2) [[bootstrap.guard]]                 regex deny-list each copied file
+       ↓
+(3) [bootstrap.fallback.*]              materialise inline content when a
+                                          required source is missing
+       ↓
+(4) [[bootstrap.no_symlink]]            refuse to inherit listed symlinks
+       ↓
+(5) [[bootstrap.command]]               shell hooks gated by when: predicates
+       ↓
+✓ worktree ready, status bar reports per-step ✓ / ! / ✗
+```
+
+Stages **1 → 4** are tightly coupled — a guard `seed-from-example` action triggers a fallback (stage 3) inline, and the no-symlink check (stage 4) runs after copies so it can refuse links that the copy step would have followed.
+
+## stage reports
+
+Each step prints one line with a sigil — same convention as `gwm doctor`:
+
+| Sigil | Severity  | Effect on the worktree                              |
+|:------|:----------|:----------------------------------------------------|
+| `✓`   | success   | nothing                                              |
+| `!`   | warning   | step is skipped or partial; pipeline continues       |
+| `✗`   | failure   | pipeline aborts; the new worktree is rolled back     |
+
+Example output (from `gwm create feat 42 user-auth` with a typical config):
+
+```
+creating worktree:
+  branch : feat/#42-user-auth
+  dir    : feat-42-user-auth
+  path   : /Users/you/cc-worktree/myrepo/feat-42-user-auth
+✓ worktree created at /Users/you/cc-worktree/myrepo/feat-42-user-auth
+
+bootstrap report:
+  ✓ copy .env.testing
+  ! no-symlink vendor
+      target not present
+  ✓ guard no-aws-rds on .env
+  ✓ run composer install
+  · run direnv allow
+      when condition 'file_exists:.envrc' false
+```
+
+The `·` sigil (used by some predicate skips) is a "step did not run" indicator and is purely informational — no severity attached.
+
+## skipping bootstrap
+
+```bash
+gwm create feat 42 user-auth --no-bootstrap     # skip the whole pipeline
+```
+
+Useful when:
+- You're scripting bulk creation and want bootstrap as a separate step.
+- The repo's `.gwm.toml` is in transition and bootstrap would fail predictably.
+- You want to inspect the bare worktree before any side-effects land.
+
+Re-run bootstrap later without recreating:
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # ...on a fuzzy-matched name
+```
+
+## why this order
+
+The order is **not arbitrary**. It encodes the original safety lessons that motivated gwm:
+
+1. **Copies first** — gives guards something to inspect.
+2. **Guards immediately after** — fail fast on a `.env` containing AWS RDS endpoints **before** the worktree's shell hooks pull in real production data.
+3. **Fallbacks** — when a guard fires `seed-from-example`, the substitution happens before the no-symlink check looks at the result.
+4. **No-symlink** — runs last among the file-level stages, so it catches any link created by a `cp -R` that followed indirections.
+5. **Shell commands** — the only stage that can have arbitrary side-effects on external systems (composer install, npm ci, etc.). Placed last so the file-level invariants hold by the time it runs.
+
+## related
+
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml) — the TOML surface of every bootstrap section
+- [Regex guards](/configuration/guards) — how stage 2 works in detail
+- [when: predicates](/configuration/when-predicates) — how stage 5 conditionalises commands
+- [Integrations → `gwm doctor`](/integrations/doctor) — validates that bootstrap config is internally consistent (guard refs, predicate grammar)

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -1,0 +1,8 @@
+---
+title: Bootstrap pipeline
+description: Execution order: file copies → regex guards → fallbacks → no-symlink check → shell commands.
+---
+
+# Bootstrap pipeline
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/3.guards.md
+++ b/docs/4.configuration/3.guards.md
@@ -1,0 +1,8 @@
+---
+title: Regex guards
+description: Deny-list patterns on copied files — the original "no AWS RDS in .env" incident, generalised.
+---
+
+# Regex guards
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/3.guards.md
+++ b/docs/4.configuration/3.guards.md
@@ -5,4 +5,102 @@ description: Deny-list patterns on copied files — the original "no AWS RDS in 
 
 # Regex guards
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`[[bootstrap.guard]]` rules vet each file produced by stage 1 of the [bootstrap pipeline](/configuration/bootstrap) against a list of regex deny-patterns. A match triggers either an abort or a substitution from a known-good fallback.
+
+## the origin story
+
+The original incident: someone created a worktree from a repo with `.env` pointing at the **production** AWS RDS host, then ran `php artisan migrate:fresh --seed` in the worktree thinking it was the local DB. The migration ran against prod.
+
+The fix was institutional: never copy a `.env` blindly across worktrees. The mechanism is `[[bootstrap.guard]]`.
+
+## schema
+
+```toml
+[[bootstrap.guard]]
+name = "no-aws-rds"
+deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
+on_match      = "seed-from-example"        # or "abort"
+example_file  = ".env.example"             # required when on_match=seed-from-example
+```
+
+| Field           | Type            | Default   | Meaning                                                                                |
+|:----------------|:----------------|:----------|:---------------------------------------------------------------------------------------|
+| `name`          | string          | —         | referenced by `[[bootstrap.copy]].guards = [...]`                                       |
+| `deny_patterns` | list of strings | `[]`      | Rust regex patterns (`regex` crate syntax). Matches anywhere in the file are flagged.   |
+| `on_match`     | string          | `"abort"` | `"abort"` or `"seed-from-example"`                                                      |
+| `example_file` | string          | none      | path (relative to main checkout) of the file to substitute when `on_match=seed-from-example` |
+
+## wiring a guard into a copy
+
+The guard runs only when a `[[bootstrap.copy]]` step references it by name:
+
+```toml
+[[bootstrap.copy]]
+from = ".env"
+to   = ".env"
+required = false
+guards = ["no-aws-rds"]            # ← referenced here
+```
+
+A guard with no copy references it is dead config — `gwm doctor` (check #2) does not flag this (yet), so audit by hand or run `grep guards .gwm.toml` to spot orphans.
+
+## `on_match` semantics
+
+### `abort` (default)
+
+A match halts the entire bootstrap with `✗`. The worktree itself was already created (stage 1 succeeded), so gwm rolls it back: removes the worktree directory and the branch.
+
+```
+bootstrap report:
+  ✗ guard no-aws-rds on .env
+      pattern 'amazonaws\.com' matched on line 12
+      → bootstrap aborted, worktree rolled back
+```
+
+The user sees the offending pattern, the line, and the fact that nothing was left behind. Re-run is safe.
+
+### `seed-from-example`
+
+A match triggers a substitution: gwm overwrites the offending file with the contents of `example_file` (still relative to the **main** checkout, since the worktree is fresh and unlikely to have its own example). Reported as `!` (warning), pipeline continues.
+
+```
+bootstrap report:
+  ! guard no-aws-rds on .env
+      pattern 'amazonaws\.com' matched on line 12
+      → substituted from .env.example
+```
+
+Useful when `.env` is genuinely sensitive but you want the worktree to have **some** working config (e.g. local sqlite) — the substitution lands you in a known-safe baseline you can iterate from.
+
+## regex syntax
+
+Patterns use the [`regex` crate](https://docs.rs/regex) — Perl-ish, no look-around. Anchors:
+
+- No anchor → matches anywhere in the file.
+- `^…$` with the multi-line flag `(?m)` → matches per-line.
+
+Common patterns:
+
+```toml
+deny_patterns = [
+  "amazonaws\\.com",                # AWS endpoints
+  "(?m)^DB_PASSWORD=(?!$|\"\"$)",   # any non-empty DB_PASSWORD line
+  "BEGIN .* PRIVATE KEY",           # accidental SSH keys
+  "sk_live_[A-Za-z0-9]{20,}",       # Stripe live secret keys
+]
+```
+
+Backslashes must be doubled inside TOML strings. Use TOML's literal strings (`'...'`) for raw regex if you have many backslashes:
+
+```toml
+deny_patterns = ['amazonaws\.com', '\.rds\.']
+```
+
+## doctor coverage
+
+`gwm doctor` check **#2** (`guard references resolve`) validates that every `[[bootstrap.copy]].guards = [...]` name points at an existing `[[bootstrap.guard]]`. Catches typos at config-time instead of waiting for the next `gwm create` to fail. See [Integrations → `gwm doctor`](/integrations/doctor).
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — where guards sit in the execution order
+- [`.gwm.toml` schema](/configuration/gwm-toml) — full type reference

--- a/docs/4.configuration/4.when-predicates.md
+++ b/docs/4.configuration/4.when-predicates.md
@@ -1,0 +1,8 @@
+---
+title: when: predicates
+description: file_exists / cmd_exists / env_set / env_eq / glob_exists, with !, &&, || composition.
+---
+
+# when: predicates
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/4.when-predicates.md
+++ b/docs/4.configuration/4.when-predicates.md
@@ -3,6 +3,91 @@ title: when: predicates
 description: file_exists / cmd_exists / env_set / env_eq / glob_exists, with !, &&, || composition.
 ---
 
-# when: predicates
+# `when:` predicates
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The `when:` field on `[[bootstrap.command]]` conditionalises shell hooks. Predicates compose with boolean operators, so a single step can express "run `bun install` if `package.json` exists AND `bun` is on `$PATH`, but never in CI".
+
+## supported atoms
+
+| Atom                          | True when …                                                                          |
+|:------------------------------|:-------------------------------------------------------------------------------------|
+| `file_exists:<path>`          | `<worktree>/<path>` resolves on disk                                                  |
+| `cmd_exists:<binary>`         | `<binary>` resolves on `$PATH` (`which` lookup)                                       |
+| `env_set:<NAME>`              | `std::env::var(NAME)` returns `Ok` (the var is **defined**, possibly empty)           |
+| `env_eq:<NAME>=<value>`       | `NAME` is set and its value equals `<value>` **exactly**                              |
+| `glob_exists:<pattern>`       | at least one path under the worktree matches `<pattern>` (supports `**`)              |
+
+Atoms are case-sensitive. Whitespace around the colon and around boolean operators is tolerated. Unknown keywords default to `true` so old configs keep running while `gwm doctor` (check #3) surfaces them as Warning.
+
+## boolean composition
+
+| Operator | Meaning | Precedence       |
+|:---------|:--------|:-----------------|
+| `!`      | NOT     | highest          |
+| `&&`     | AND     | middle           |
+| `\|\|`   | OR      | lowest           |
+
+So `!a && b || c` parses as `((!a) && b) || c` — same as in most languages.
+
+Whitespace around operators is tolerated, but operators themselves must be exactly `!`, `&&`, `||` — no `not`, `and`, `or`, no Unicode.
+
+## examples
+
+```toml
+# Run only when composer.json exists at the worktree root.
+[[bootstrap.command]]
+name = "composer install"
+run  = "composer install --no-interaction --prefer-dist"
+when = "file_exists:composer.json"
+
+# Prefer bun if available, otherwise fall back to npm — and never in CI.
+[[bootstrap.command]]
+name = "install (bun)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun && !env_set:CI"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run  = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun && !env_set:CI"
+
+# Build docs only when there's something to build and we're not in CI.
+[[bootstrap.command]]
+name = "build docs"
+run  = "./scripts/full-build.sh"
+when = "glob_exists:docs/**/*.md && !env_set:CI"
+
+# Apply staging-only seeds when APP_ENV is exactly "staging".
+[[bootstrap.command]]
+name = "staging seed"
+run  = "php artisan db:seed --class=StagingSeeder"
+when = "file_exists:artisan && env_eq:APP_ENV=staging"
+
+# Allow a long-running prep step only when the user opts in via env.
+[[bootstrap.command]]
+name = "warm up cache"
+run  = "./scripts/warmup.sh"
+when = "env_eq:GWM_WARMUP=1"
+```
+
+## omitted `when:`
+
+A step without `when:` runs unconditionally — equivalent to `when = "true"` (which is not a literal you can type; just omit the field). Common for housekeeping commands like `git lfs pull` that are cheap and always safe.
+
+## doctor coverage
+
+`gwm doctor` check **#3** (``when` predicates supported`) parses every `[[bootstrap.command]].when` and surfaces unknown keywords:
+
+```
+! `when` predicates supported
+    1 unsupported keyword: file_exits
+    → did you mean file_exists?
+```
+
+Note the **`!`** (Warning) — the offending command still runs (defaults to `true`), so the bootstrap is not blocked, but the user sees the typo at config-time instead of waiting for a confused failure.
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — where the `[[bootstrap.command]]` step sits
+- [`.gwm.toml` schema](/configuration/gwm-toml#bootstrap-command) — the full field listing
+- [Integrations → `gwm doctor`](/integrations/doctor) — checks #2 (guard refs) and #3 (predicate grammar)

--- a/docs/4.configuration/index.md
+++ b/docs/4.configuration/index.md
@@ -1,0 +1,17 @@
+---
+title: Configuration
+description: The .gwm.toml schema — worktree conventions, bootstrap pipeline, regex guards, when-predicates, and the v0.6 launcher / open-dispatch sections.
+navigation:
+  title: Configuration
+---
+
+# Configuration
+
+gwm reads `.gwm.toml` from the repo root. Without a config, it falls back to sensible defaults (`~/cc-worktree/<repo>/<type>-<issue>-<desc>`, no bootstrap). With one, it can copy files, run shell hooks, refuse to inherit dangerous secrets, and configure the TUI launchers.
+
+- **[`.gwm.toml` schema](/configuration/gwm-toml)** — every section: `[worktree]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[bootstrap.fallback.*]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[git_tui]`, `[review]`, `[tui]`, `[tui.open]`, `[doctor]`.
+- **[Bootstrap pipeline](/configuration/bootstrap)** — execution order: copies → guards → fallbacks → no-symlink check → commands.
+- **[Regex guards](/configuration/guards)** — deny-list patterns on copied files (the original "no AWS RDS in `.env`" incident).
+- **[`when` predicates](/configuration/when-predicates)** — `file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||` composition.
+
+Run `gwm init` in a fresh repo to write a default `.gwm.toml`. For the full annotated example with every field commented, see [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) in the repo.

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -5,4 +5,134 @@ description: Auto-link branches to issues, fetch live state via `gh`, surface in
 
 # GitHub issue / PR linking
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://github.com/kbrdn1/gwm-cli/pull/68); refined in v0.6 by [#75](https://github.com/kbrdn1/gwm-cli/issues/75).
+
+Every worktree can be linked to a GitHub issue and / or pull request. The link drives the live `Issue / PR` block in the [TUI sidebar](/tui/sidebar#issue--pr-block) and surfaces in `gwm status` for scripting.
+
+## storage model
+
+Links live in **git config**, scoped to the branch, never in a file gwm owns:
+
+- `git config branch.<name>.gwm-issue` — the linked issue number
+- `git config branch.<name>.gwm-pr` — the linked PR number
+
+This means:
+
+- The link **survives worktree moves** (`gwm` rewriting `.git/worktrees/<name>/HEAD` doesn't touch branch config).
+- The link is **per-branch, local** — not committed, not pushed, not shared with the repo's other clones.
+- `git config --unset branch.<name>.gwm-issue` is a 100% valid alternative to `gwm unlink issue`.
+
+## auto-detection
+
+Branches following the gwm naming convention `<type>/#<N>-<slug>` derive the issue number from the branch name — zero config needed.
+
+```
+feat/#42-user-auth          → issue #42 auto-linked
+fix/#117-leak               → issue #117 auto-linked
+chore/#5-rename             → issue #5 auto-linked
+release-1.x                 → no auto-link (no #N pattern)
+```
+
+PR numbers are **not** auto-detected — there's no convention that maps a branch to a PR number. Link them explicitly:
+
+```bash
+gwm link pr 61
+```
+
+## explicit linking
+
+```bash
+# Link the current (CWD) worktree
+gwm link issue 42
+gwm link pr 61
+
+# Link a fuzzy-matched worktree from anywhere
+gwm link issue 42 --worktree feat-auth
+
+# Remove an explicit override (auto-detect resurfaces for issues)
+gwm unlink issue
+gwm unlink pr
+
+# Open the link in the browser via the OS opener
+gwm open issue
+gwm open pr --print-url        # print the URL on stdout instead
+
+# Inspect the current state
+gwm status                     # human-readable
+gwm status --json              # stable schema for scripts
+```
+
+See [CLI → Subcommand reference](/cli/reference#gwm-link-issuepr-n---worktree-pattern) for the flag tables.
+
+## live status via `gh`
+
+`gwm status` (and the TUI's `F` key) shells out to `gh issue view` and `gh pr view` to fetch state, title, labels, and CI rollup:
+
+```
+$ gwm status
+Issue #42 [open] TUI: fuzzy search
+PR #61 [draft] · checks 2/3
+```
+
+| Bracketed value | Source                                              |
+|:----------------|:----------------------------------------------------|
+| `[open]`        | `gh`'s `state`                                       |
+| `[closed]`     | `gh`'s `state`                                       |
+| `[merged]`     | `gh`'s `state` (PR only)                             |
+| `[draft]`      | `gh`'s `isDraft` (PR only)                           |
+| `checks N/M`   | `gh`'s `statusCheckRollup` (PR only)                 |
+
+Without `gh` (or outside a repo with a GitHub remote), gwm degrades gracefully — only the local link is shown, no error:
+
+```
+$ gwm status
+Issue #42 (gh not available — local link only)
+```
+
+## TUI surface
+
+In the worktree list view, the right details panel renders a **live `Issue / PR` block** for the selected worktree (hidden when nothing is linked). Three keybindings drive it:
+
+| Key | Action                                                                              |
+|:----|:------------------------------------------------------------------------------------|
+| `O` | open menu (`i` open issue in browser, `p` open PR in browser)                       |
+| `L` | link prompt (`i` issue or `p` pr → type the number → Enter to commit)               |
+| `F` | refresh the GitHub status (synchronous `gh` fetch, updates the status bar)          |
+
+> The `F` keybinding was `R` pre-v0.6 — rebound by [#75](https://github.com/kbrdn1/gwm-cli/issues/75) when `R` was claimed by the [review launcher](/tui/launchers). See [Keybindings → v0.6 rebind summary](/tui/keybindings#v06-rebind-summary).
+
+The `Issue / PR` block is **rebuilt on every selection change**, so navigating with `j` / `k` never surfaces stale data from the previously selected worktree.
+
+## sidebar header status dot
+
+The header `● <worktree-name>` line carries a coloured `●` that tracks the linked PR / issue state:
+
+- **green** — open
+- **gray** — draft
+- **magenta** — merged
+- **red** — closed
+- **darkgray** — nothing linked / unknown state
+
+The dot is rebuilt from cached `gh` fetch state on every frame, so it follows live status without invalidating the rest of the sidebar's git-preview cache. Hit `F` to force a refresh.
+
+## URL derivation
+
+gwm derives the issue / PR URL from the repo's GitHub remote:
+
+```
+https://github.com/<owner>/<repo>/issues/<N>
+https://github.com/<owner>/<repo>/pull/<N>
+```
+
+The owner/repo extraction handles a few quirks:
+
+- Trailing `/` on the remote URL (`https://github.com/owner/repo.git/`) — fixed in #68 by Copilot's review; the `.git` suffix is now stripped after normalising trailing slashes.
+- SSH form (`git@github.com:owner/repo.git`) — parsed identically.
+
+If the remote is not GitHub, `gwm open` exits with an error rather than guessing a URL.
+
+## related
+
+- [TUI → Sidebar](/tui/sidebar#issue--pr-block) — where the live block renders
+- [TUI → Keybindings](/tui/keybindings#issue--pr-link-prompt-l) — `O` / `L` / `F` overlays
+- [CLI → Subcommand reference](/cli/reference#gwm-link-issuepr-n---worktree-pattern) — every command and flag

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -1,0 +1,8 @@
+---
+title: GitHub issue / PR linking
+description: Auto-link branches to issues, fetch live state via `gh`, surface in the TUI sidebar.
+---
+
+# GitHub issue / PR linking
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -3,6 +3,144 @@ title: gwm doctor
 description: 7 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
 ---
 
-# gwm doctor
+# `gwm doctor`
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm doctor` runs a battery of cheap checks against the current repo, prints a per-check report, and exits with a meaningful code so it can be wired into CI or a pre-commit hook without parsing stdout.
+
+## exit codes
+
+| Code | Meaning      | Triggered by                                         |
+|:-----|:-------------|:-----------------------------------------------------|
+| `0`  | all green    | every check returns `✓`                              |
+| `1`  | warning      | at least one `!`, no `✗`                              |
+| `2`  | failure      | at least one `✗`                                      |
+
+The Warning / Failure split matches the bootstrap pipeline's sigil convention — see [Bootstrap pipeline](/configuration/bootstrap#stage-reports).
+
+## sample output
+
+```bash
+$ gwm doctor
+✓ .gwm.toml parses
+    /path/to/repo/.gwm.toml parses cleanly
+✓ guard references resolve
+    2 guard reference(s) resolve
+✓ `when` predicates supported
+    1 predicate(s) recognised
+✓ external binaries on PATH
+    3/3 binaries found
+✓ no prunable worktrees
+    5 worktree(s) tracked, none prunable
+✓ no orphan gwm branches
+    7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
+✓ base directory writable
+    /home/you/cc-worktree/myrepo is writable
+```
+
+A run with issues:
+
+```
+! no prunable worktrees
+    1 prunable entry: feat-12-old
+    → run `gwm prune` to clear them
+! no orphan gwm branches
+    1 unmerged orphan branch(es): feat/#99-wip-experiment
+    → git branch -d feat/#99-wip-experiment
+```
+
+Each Warning / Failure carries a one-line remediation hint, copy-pasteable.
+
+## checks performed
+
+### 1. `.gwm.toml` parses
+
+Reads `.gwm.toml` from the repo root.
+
+- **`✓`** — file parses cleanly, **OR** file is absent (defaults assumed)
+- **`✗`** — TOML is malformed, or contains an unknown `[tui.open].mode` value
+
+The "absent" case is intentionally a `✓` — `gwm` works without `.gwm.toml` and the user-facing message says so.
+
+### 2. guard references resolve
+
+Walks every `[[bootstrap.copy]].guards = [...]` and verifies that each name resolves to an existing `[[bootstrap.guard]]`.
+
+- **`✓`** — every reference points at a real guard
+- **`✗`** — at least one reference is dangling
+
+Catches typos like `guards = ["no-aws-dbs"]` when the guard is `no-aws-rds`.
+
+### 3. `when` predicates supported
+
+Parses every `[[bootstrap.command]].when` and reports unknown keywords.
+
+- **`✓`** — every atom uses a recognised keyword
+- **`!`** — at least one keyword is unrecognised (Warning, not Failure — the offending command still runs, defaulting to `true`)
+
+Recognised keywords: `file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`. Boolean composition (`!`, `&&`, `||`) is also validated. See [`when:` predicates](/configuration/when-predicates).
+
+### 4. external binaries on PATH
+
+Probes `$PATH` for every binary gwm or `.gwm.toml` plans to spawn:
+
+- **`lazygit`** — only if `[git_tui]` doesn't override the command
+- **the first token of `[git_tui].command`** — when overridden
+- **the first token of `[review].command` / preset**
+- **`direnv`** — only if `.envrc` exists in the worktree (the `seed-from-example` action may try `direnv allow`)
+- **the first executable token of every `[[bootstrap.command]].run`**
+
+Reporting:
+
+- **`✓`** — all probed binaries resolved
+- **`!`** — `[review]` binary missing (review is opt-in; a CI pre-commit hook keeps passing)
+- **`✗`** — `[git_tui]` binary missing or a bootstrap command's binary missing
+
+> The v0.6 update to this check (probing `[git_tui]` and `[review]`) landed with [#75](https://github.com/kbrdn1/gwm-cli/issues/75). Pre-v0.6, only `lazygit` and `direnv` were checked.
+
+### 5. no prunable worktrees
+
+Looks at `.git/worktrees/` and flags entries whose working directory was removed manually (e.g. someone `rm -rf`'d the worktree directory outside gwm).
+
+- **`✓`** — every tracked entry points at a real directory
+- **`!`** — at least one stale entry, with `gwm prune` as the remediation
+
+### 6. no orphan gwm branches
+
+Walks local branches matching `<type>/#<N>-<slug>` and flags those with no associated worktree.
+
+- **`✓`** — every gwm-style branch is either active (has a worktree) or merged into a trunk
+- **`!`** — at least one **unmerged** orphan, with `git branch -d <name>` as the remediation
+
+The "merged into a trunk" exemption respects `CONTRIBUTING.md`'s "never delete the source branch after merge" rule — merged branches are preserved, not flagged. The trunk list is configurable via `[doctor].trunks` (default `["dev", "main"]`); empty list disables the exemption.
+
+User-managed branches (`main`, `release-*`, `dependabot/...`, anything not matching the gwm pattern) are silently ignored.
+
+### 7. base directory writable
+
+Checks that the configured `[worktree].base` exists and is writable, or — if it doesn't exist yet — that its **parent** is writable. gwm creates the base lazily on the first `gwm create`, so a non-existent base is fine as long as it can be created.
+
+- **`✓`** — base (or its parent) is writable
+- **`✗`** — neither is writable (gwm cannot create worktrees here)
+
+## CI integration
+
+```yaml
+# .github/workflows/ci.yml
+- name: gwm health
+  run: gwm doctor                    # exits 1 on Warning, 2 on Failure
+```
+
+Or as a pre-commit hook:
+
+```bash
+# .git/hooks/pre-commit (or via pre-commit framework)
+gwm doctor || { echo "gwm doctor reported issues, see above"; exit 1; }
+```
+
+Because `[review]` missing only triggers a Warning (exit `1`), a pre-commit hook can choose to allow Warnings (`gwm doctor; [ $? -le 1 ]`) and only block on Failures.
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — same `✓ / ! / ✗` convention used by stage reports
+- [TUI → Configurable launchers](/tui/launchers#interaction-with-gwm-doctor) — why the review launcher's missing-binary is a Warning, not a Failure
+- [`.gwm.toml` schema → `[doctor]`](/configuration/gwm-toml#doctor) — the `trunks` knob

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -1,0 +1,8 @@
+---
+title: gwm doctor
+description: 7 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
+---
+
+# gwm doctor
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/3.homebrew-nix.md
+++ b/docs/5.integrations/3.homebrew-nix.md
@@ -1,0 +1,8 @@
+---
+title: Homebrew and Nix
+description: Packaging surface — Homebrew tap, Nix flake, prebuilt binaries.
+---
+
+# Homebrew and Nix
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/3.homebrew-nix.md
+++ b/docs/5.integrations/3.homebrew-nix.md
@@ -5,4 +5,89 @@ description: Packaging surface — Homebrew tap, Nix flake, prebuilt binaries.
 
 # Homebrew and Nix
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+gwm ships through three managed channels in addition to `cargo install` — pick whichever fits your environment. End-user install instructions live in [Getting Started → Install](/getting-started/install); this page covers the **packaging surface** for contributors, maintainers, and downstream packagers.
+
+## Homebrew tap
+
+Tap and formula:
+
+- Tap: [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap)
+- Formula: `Formula/gwm.rb`
+- Canonical source: [`packaging/homebrew/gwm.rb.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/homebrew/gwm.rb.template) in this repo
+
+The tap is refreshed **automatically on every stable release** by the `homebrew-tap-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). The job:
+
+1. Reads the freshly-tagged version (e.g. `v0.6.0`).
+2. Filters out pre-release tags — `-rc.N`, `-alpha.N`, `-beta.N` — so `brew install gwm` always resolves to a stable build. Pre-releases are still published to the GitHub releases page; they just don't update the tap.
+3. Substitutes version, SHA, and archive URLs into the template.
+4. Opens a PR (or pushes directly, depending on the tap's branch protection) against `kbrdn1/homebrew-tap`.
+
+End-user install:
+
+```bash
+brew tap kbrdn1/tap
+brew install gwm
+```
+
+## Nix flake
+
+`flake.nix` lives at the repo root. The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
+
+End-user install:
+
+```bash
+# one-shot run, no clone
+nix run github:kbrdn1/gwm-cli -- list
+
+# install into your profile
+nix profile install github:kbrdn1/gwm-cli
+
+# in a NixOS / nix-darwin config, via the overlay
+nixpkgs.overlays = [ inputs.gwm.overlays.default ];
+environment.systemPackages = [ pkgs.gwm ];
+```
+
+The flake exports:
+
+- `packages.<system>.gwm` — the executable
+- `packages.<system>.default` — alias for `gwm`
+- `apps.<system>.default` — `nix run` entry point
+- `overlays.default` — for downstream NixOS / nix-darwin configs
+- `devShells.<system>.default` — pinned Rust toolchain + `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the libgit2 build deps. Used by [Development → Testing](/development/testing).
+
+Test the flake locally before pushing changes:
+
+```bash
+nix flake check
+nix build .#gwm
+./result/bin/gwm --version
+```
+
+## prebuilt binaries
+
+Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries with `.sha256` sidecars for:
+
+- Linux (`x86_64`, `aarch64`)
+- macOS (Intel, Apple Silicon)
+- Windows (`x86_64`)
+
+The build matrix is the `release` workflow in [`.github/workflows/release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). Each tag-push triggers a parallel build across the matrix, with `.sha256` sidecars computed in the same job. Release notes are sourced from the **per-version changelog** (`changelogs/<version>.md`), not from the root `CHANGELOG.md`, which only holds the current `[Unreleased]` section + index.
+
+## the release pipeline at a glance
+
+```
+git tag v0.6.0 && git push origin v0.6.0
+         ↓
+.github/workflows/release.yml
+    ├─ build matrix (5 targets)         → release assets + .sha256
+    ├─ pre-release.yml gate              → skip on -rc / -alpha / -beta
+    └─ homebrew-tap-update job           → only on stable tags
+         ↓
+github.com/kbrdn1/gwm-cli/releases   ← binaries
+github.com/kbrdn1/homebrew-tap        ← formula bump PR
+```
+
+## related
+
+- [Getting Started → Install](/getting-started/install) — end-user install for the four channels
+- [Development → Contributing](/development/contributing) — branch / commit / PR conventions and the CHANGELOG split rules

--- a/docs/5.integrations/index.md
+++ b/docs/5.integrations/index.md
@@ -1,0 +1,16 @@
+---
+title: Integrations
+description: Wire gwm with GitHub (gh), lazygit, AI reviewers, doctor in CI, and the packaged distributions (Homebrew, Nix).
+navigation:
+  title: Integrations
+---
+
+# Integrations
+
+gwm is small on purpose — it shells out to the tools you already use rather than reimplementing them. These pages cover the supported integration points.
+
+- **[GitHub issue / PR linking](/integrations/github-linking)** — auto-link branches matching `<type>/#<N>-<slug>` to their issue, fetch live state via `gh`, surface in the TUI sidebar.
+- **[`gwm doctor`](/integrations/doctor)** — the 7 health checks, exit-code semantics (`0 / 1 / 2`), and the v0.6 update that now probes the configured launcher binaries.
+- **[Homebrew & Nix](/integrations/homebrew-nix)** — the packaging surface: how releases flow into the Homebrew tap and the Nix flake.
+
+The TUI-side integrations (the configurable launchers for `l` and `R`, the `[tui.open]` dispatch) live under [TUI → Configurable launchers](/tui/launchers) and [TUI → Open dispatch](/tui/open-dispatch).

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -5,4 +5,104 @@ description: 15 integration test files, 433 tests, sentinel-test convention, and
 
 # Testing
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`cargo test` runs **433 tests** across 15 integration files plus the unit tests embedded in `src/`. Average run on a recent laptop: ~1 second.
+
+## quick reference
+
+```bash
+cargo test                            # full suite (433 tests)
+cargo test --test tui_app_tests       # one integration file
+cargo test refresh_github             # name-substring filter across the whole suite
+cargo test -- --nocapture             # let println! / dbg! through
+cargo test --release                  # opt-level=3, same suite
+```
+
+The `--test <name>` filter is by **integration file**, not by module — `cargo test --test tui_app_tests` runs everything inside `tests/tui_app_tests.rs`.
+
+## integration test layout
+
+All integration tests live under `tests/`:
+
+```
+tests/
+├── common/                       # shared helpers (init_repo, paths_equal)
+├── bootstrap_tests.rs            # copy / guard / no-symlink / commands
+├── bootstrap_when_tests.rs       # `when:` predicate grammar (file/cmd/env/glob + boolean ops)
+├── cli_binary.rs                 # end-to-end assert_cmd coverage of the CLI surface
+├── config_tests.rs               # .gwm.toml parsing + write_default + defaults
+├── doctor_tests.rs               # gwm doctor checks + severity arithmetic
+├── error_tests.rs                # GwmError variants + Display + From impls
+├── flake_tests.rs                # Nix flake structure (build, devShell, app, overlay)
+├── github_tests.rs               # issue/PR linking + trim_git_suffix + URL derivation
+├── homebrew_formula_tests.rs     # Homebrew formula template substitution
+├── launcher_tests.rs             # [git_tui] / [review] placeholder expansion + base resolution
+├── multiplexer_tests.rs          # gwm tmux / gwm zellij argv construction + $TMUX guard
+├── naming_tests.rs               # kebab normalisation + branch validation + parse roundtrip
+├── precommit_hook_tests.rs       # pre-commit hook scaffolding
+├── tui_app_tests.rs              # App state transitions (ratatui-free)
+└── worktree_integration.rs       # git2 add / list / remove / prune
+```
+
+## sentinel tests
+
+Tests pinned to catch a specific regression are prefixed with a `// regression: <one-line>` comment inside the test body, so the original incident is discoverable without `git blame`:
+
+```rust
+#[test]
+fn trim_git_suffix_handles_trailing_slash() {
+  // regression: PR #68 Copilot review — owner/repo.git/ left ".git" in the slug
+  assert_eq!(trim_git_suffix("https://github.com/owner/repo.git/"), "owner/repo");
+}
+```
+
+Find them all:
+
+```bash
+grep -rn "regression:" tests/
+```
+
+Suite hygiene (sentinel coverage vs incident catalogue) was last audited in [`claudedocs/test-audit-0.4.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/claudedocs/test-audit-0.4.0.md). Re-run the audit after each minor — drift accumulates fast around the launcher and GitHub-linking surfaces.
+
+## unit tests
+
+In addition to the 15 integration files, `src/` carries unit tests inside `#[cfg(test)] mod tests { … }` blocks colocated with the code under test. They cover:
+
+- Pure functions (kebab normalisation, slug parsing, sigil arithmetic)
+- Serde round-trips on every `Config` sub-struct
+- Internal predicates not exposed on the public surface
+
+`cargo test` runs them alongside the integration suite — they don't need a separate invocation.
+
+## what to run before pushing
+
+The minimum bar enforced by the pre-commit hook (and by CI):
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All three must be green. The pre-commit hook lives in [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit); enable it with:
+
+```bash
+git config core.hooksPath tools/git-hooks
+```
+
+(or via the bundled bootstrap if your repo's `.gwm.toml` wires it in).
+
+## dev shell
+
+The Nix flake exports a pinned dev shell — Rust toolchain (pinned to the same `rust-toolchain.toml` version used in CI), `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the `libgit2` build deps — without touching the host system:
+
+```bash
+nix develop                # drops you in the shell
+cargo test                 # everything works out of the box
+```
+
+See [Integrations → Homebrew and Nix](/integrations/homebrew-nix#nix-flake) for the full flake surface.
+
+## related
+
+- [Contributing](/development/contributing) — conventions for adding tests and the regression-comment format
+- [Roadmap](/roadmap) — upcoming areas that will need new test coverage

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -1,0 +1,8 @@
+---
+title: Testing
+description: 15 integration test files, 433 tests, sentinel-test convention, and how to run a subset.
+---
+
+# Testing
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/6.development/2.contributing.md
+++ b/docs/6.development/2.contributing.md
@@ -1,0 +1,8 @@
+---
+title: Contributing
+description: Gitmoji + Conventional Commits, branch naming, PR checklist, CHANGELOG split rules.
+---
+
+# Contributing
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/6.development/2.contributing.md
+++ b/docs/6.development/2.contributing.md
@@ -5,4 +5,118 @@ description: Gitmoji + Conventional Commits, branch naming, PR checklist, CHANGE
 
 # Contributing
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+This page summarises the repo's contribution conventions. The full long-form lives in [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) at the repo root; this page exists so the docs site can carry the same info without forking the source of truth.
+
+## branch naming
+
+```
+<type>/#<issue>-<short-description>
+```
+
+Examples:
+
+```
+feat/#42-user-auth
+fix/#117-leak
+docs/#77-sync-v0-6-0-docs
+chore/#56-precommit-hook
+```
+
+- `<type>` — one of `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
+- `<issue>` — the GitHub issue number (digits only). One issue per branch keeps the auto-link working (see [GitHub linking](/integrations/github-linking#auto-detection)).
+- `<short-description>` — kebab-case, ~3-4 words, normalised automatically by `gwm create`.
+
+Never work directly on `main` or `dev`. `gwm create <type> <N> <slug>` produces a conformant branch + worktree in one step.
+
+## commit format
+
+Gitmoji + Conventional Commits — one commit per concern, atomic, descriptive:
+
+```
+<emoji> <type>(<scope>)<!>: <subject>
+
+<body — optional, wrap at 72>
+
+refs #N            ← intermediate commits
+closes #N          ← ONLY on the last commit of the series
+```
+
+### emoji + type table
+
+| Emoji  | Type     | Use for                                                  |
+|:-------|:---------|:---------------------------------------------------------|
+| ✨     | `feat`   | new capability                                            |
+| 🐛     | `fix`    | bug fix                                                   |
+| ♻️     | `refactor` | restructuring without behaviour change                  |
+| ✅     | `test`   | tests added or fixed                                      |
+| 📝     | `docs`   | README / CHANGELOG / inline doc / this very tree         |
+| 🔧     | `chore`  | tooling, config, deps                                     |
+| 🏗️     | `build`  | release / cut / version bump                              |
+| 👷     | `ci`     | workflows                                                 |
+| ⚡     | `perf`   | measured performance improvement                          |
+| 🚑️     | `hotfix` | urgent fix shipped outside the normal release cadence     |
+| 🔥     | `chore(remove)` | dead code / file removal                           |
+| ⬆️     | `chore(bump)`   | dependency bump                                    |
+| 🔒     | `security` | security-relevant fix                                   |
+
+### scopes (gwm-cli)
+
+`config`, `naming`, `worktree`, `bootstrap`, `cli`, `tui`, `tests`, `docs`, `ci`, `structure`, `launcher`, `github`, `doctor`, `skill`, `changelog`. Pick whichever subsystem the diff touches; add new ones sparingly.
+
+### breaking changes
+
+Append `!` after the type and add a `BREAKING CHANGE:` footer:
+
+```
+✨ feat(config)!: rename [worktree.base] to [worktree.root]
+
+BREAKING CHANGE: rename [worktree.base] to [worktree.root]. Existing
+configs continue to parse but emit a one-shot deprecation warning;
+the alias will be removed in v1.0.
+```
+
+## CHANGELOG split
+
+The repo uses a **root + per-version** split:
+
+- [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) at the root holds **only**:
+  - `## [Unreleased]` — the in-progress section new commits add to (`Added / Changed / Fixed / Docs / Dependencies`)
+  - `## Past releases` — a one-line index of every stable + pre-release, pointing at `changelogs/<version>.md`
+- [`changelogs/<version>.md`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs) — one file per release, with the full notes.
+  - Pre-release notes (`-rc.N`, `-alpha.N`, `-beta.N`) live under `changelogs/pre-releases/<version>.md`.
+
+When you ship a feature mid-cycle, append a bullet to `[Unreleased]` in the root file:
+
+```md
+## [Unreleased]
+
+### Added
+
+- ✨ **TUI yank** (`y`) — copy the selected worktree's path to the system clipboard. ([#73](https://github.com/kbrdn1/gwm-cli/issues/73))
+```
+
+At release time (cut by a `🏗️ build: cut vX.Y.Z` commit), `[Unreleased]` is moved into a new `changelogs/<version>.md` and the root section is reset to empty. The CI `release.yml` job sources its release notes from `changelogs/<version>.md`, never from the root file — fixed by commit `4a76a3d` after an earlier release used a wrong source.
+
+## pull-request checklist
+
+Every PR should tick:
+
+- Branch follows `<type>/#<issue>-<description>`
+- Commits follow Gitmoji + Conventional Commits, atomic
+- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` all green
+- CHANGELOG.md updated under `[Unreleased]` (or N/A for pure refactors with no observable change)
+- `gwm doctor` runs cleanly on a fresh worktree of the branch
+
+The PR template ([`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/PULL_REQUEST_TEMPLATE.md)) carries the full version.
+
+## history
+
+gwm started as a Rust rewrite of `tools/worktree-manager.sh` — a bash script tied to one team's Laravel stack and one incident history (the `.env`-pointing-at-AWS-RDS incident behind [Regex guards](/configuration/guards#the-origin-story)). The Rust version keeps the lessons, makes them configurable per repo, and ships as a single binary so it works in every repo without per-project shell-script copies.
+
+The bash heritage is still visible in places — the `✓ / ! / ✗` sigils in bootstrap and doctor reports, the kebab-case slug normalisation, the no-symlink invariants on `vendor/` and `node_modules/` — all carried over from the original script. The Rust rewrite added the TUI, the configurability surface (`.gwm.toml`), the `when:` predicate grammar, the GitHub linking, and the configurable launchers.
+
+## related
+
+- [Testing](/development/testing) — what to run before pushing, sentinel-test convention
+- [Roadmap](/roadmap) — open items contributors can pick up
+- [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) — the long-form source of truth

--- a/docs/6.development/index.md
+++ b/docs/6.development/index.md
@@ -1,0 +1,37 @@
+---
+title: Development
+description: Building gwm from source, the test suite layout, and the contributing conventions (branches, commits, PRs).
+navigation:
+  title: Development
+---
+
+# Development
+
+gwm is a small Rust crate (single binary). Build, test, and ship workflows are documented here.
+
+- **[Testing](/development/testing)** — the 15 integration test files (433 tests as of v0.6.0), how to run a subset, and the `// regression:` sentinel-test convention.
+- **[Contributing](/development/contributing)** — the Gitmoji + Conventional-Commit format, branch naming, the PR checklist, and the rules around the `CHANGELOG.md` / `changelogs/<version>.md` split.
+
+## quick reference
+
+```bash
+cargo build              # debug build
+cargo test               # 433 tests across 15 integration files + unit tests
+cargo fmt && cargo clippy -- -D warnings
+cargo run                # opens TUI in the current repo
+cargo install --path .   # install locally
+```
+
+A Nix dev shell is pinned in [`flake.nix`](https://github.com/kbrdn1/gwm-cli/blob/main/flake.nix) — toolchain, `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the `libgit2` build deps — without touching the host system:
+
+```bash
+nix develop
+```
+
+## vs. bash script
+
+The full background — what changed from the original `tools/worktree-manager.sh` and why — lives in the contributing page under "[history](/development/contributing#history)".
+
+## changelog
+
+Released versions live under [`changelogs/<version>.md`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs); the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) only holds the current `[Unreleased]` section plus an index of past releases.

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -5,4 +5,33 @@ description: What ships next — post-v0.6.0 priorities and the link to the issu
 
 # Roadmap
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
+
+## shipped in v0.6.0
+
+For reference — what made it into the current stable line:
+
+- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://github.com/kbrdn1/gwm-cli/pull/68)) — `gwm link / unlink / open / status`, auto-detect from `<type>/#<N>-<slug>`, live status in the TUI sidebar via `gh`. See [GitHub linking](/integrations/github-linking).
+- **TUI Details sidebar redesign** ([#69](https://github.com/kbrdn1/gwm-cli/issues/69) / [#70](https://github.com/kbrdn1/gwm-cli/pull/70)) — four independent rounded-border subsections (Worktree / Issue · PR / Working Tree / Recent Commits). See [Sidebar](/tui/sidebar).
+- **TUI Recent Commits panel — lazygit-style layout** ([#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72)) — 300-commit buffer, hard-clipped subjects, full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
+- **TUI sidebar lazygit-style facelift** ([#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74)) — `Created` branch-age column, status-coloured branch names, header status dot, `o`/`y` rebinds, `[tui.open]` dispatch.
+- **TUI configurable launchers** ([#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [#76](https://github.com/kbrdn1/gwm-cli/pull/76)) — `[git_tui]` and `[review]` sections with `{base} {head} {path} {diff}` placeholders. See [Configurable launchers](/tui/launchers).
+
+The full v0.6.0 release notes (with the Changed / Fixed / Removed sections, Dependencies, and PR-by-PR breakdown) live at [`changelogs/0.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.6.0.md).
+
+## what's next
+
+Post-v0.6.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:
+
+- [Open issues — `enhancement`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aenhancement)
+- [Open issues — `good first issue`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+- [Open issues — `roadmap`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aroadmap)
+
+`[Unreleased]` in the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) reflects what's accumulated on `dev` since the last release — check there for the merged-but-not-yet-shipped surface.
+
+## how to contribute
+
+1. Pick an issue or open a new one with `--label enhancement` / `--label bug` describing the scope.
+2. `gwm create <type> <issue> <slug>` to spin up an isolated worktree (the issue auto-links itself — see [GitHub linking](/integrations/github-linking#auto-detection)).
+3. Follow the conventions in [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) — see [Contributing](/development/contributing) for the docs-site version.
+4. Open a PR targeting `dev`. Stable releases ship via a `dev → main` merge PR following the convention `🔀 chore(release): merge dev → main for vX.Y.Z`.

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,0 +1,8 @@
+---
+title: Roadmap
+description: What ships next — post-v0.6.0 priorities and the link to the issue tracker.
+---
+
+# Roadmap
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+---
+title: docs/ — authoring conventions
+description: How the gwm documentation tree is organised for Nuxt Content (or any other SSG).
+navigation: false
+---
+
+# `docs/` — authoring conventions
+
+This tree is the source of truth for the gwm user docs and the future static documentation site. It is structured to drop straight into [Nuxt Content](https://content.nuxt.com/) (or any SSG that follows the same numeric-prefix routing convention).
+
+## layout
+
+```
+docs/
+├── index.md                              # → /
+├── 1.getting-started/                    # → /getting-started
+│   ├── index.md
+│   ├── 1.install.md                      # → /getting-started/install
+│   ├── 2.first-worktree.md
+│   └── 3.shell-init.md
+├── 2.tui/                                # → /tui
+├── 3.cli/                                # → /cli
+├── 4.configuration/                      # → /configuration
+├── 5.integrations/                       # → /integrations
+├── 6.development/                        # → /development
+└── 7.roadmap.md                          # → /roadmap
+```
+
+Numeric prefixes (`1.`, `2.`, `3.`) drive **sidebar ordering** in Nuxt Content and are stripped from the resulting URL. Add a new page anywhere in the tree by giving it the next free prefix in its parent folder.
+
+## frontmatter contract
+
+Every page (including section `index.md` files) carries this minimal frontmatter:
+
+```yaml
+---
+title: <page title — rendered as <h1> and in <title>>
+description: <one-sentence teaser, used for SEO and search>
+---
+```
+
+Optional fields:
+
+- `navigation.title` — short label for the sidebar when the full title is too long.
+- `navigation.icon` — Iconify name (e.g. `lucide:terminal`) for SSGs that render section icons.
+- `navigation: false` — hide the page from the auto-generated sidebar (use for this README only).
+
+## links between docs pages
+
+Use **repo-relative paths from this `docs/` root** so the same links resolve on GitHub and inside the future site:
+
+```md
+See [Configurable launchers](/tui/launchers) for the `[git_tui]` / `[review]` schema.
+```
+
+(Nuxt Content rewrites bare `/segment` paths against the content root; on GitHub they render as broken-but-readable cross-references — acceptable until the site is live, at which point a relative-link audit can lift them all in one pass.)
+
+## images & assets
+
+When pages need screenshots or diagrams, drop them under `docs/<section>/_assets/` and reference them with a relative path (`![keymap](./_assets/tui-keymap.png)`). Keep this README out of the generated sidebar via `navigation: false`.
+
+## see also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branch / commit / PR conventions
+- [`CHANGELOG.md`](../CHANGELOG.md) — release notes (root = `[Unreleased]`, per-version archives under `changelogs/`)
+- [`examples/gwm.toml.example`](../examples/gwm.toml.example) — annotated config reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+---
+title: gwm — git worktree manager
+description: Rust CLI + ratatui TUI to manage git worktrees across projects. Native libgit2, per-repo configurable bootstrap, single binary.
+---
+
+# gwm
+
+Rust CLI + ratatui TUI to manage git worktrees across projects.
+
+- Native `libgit2` (vendored) — no `gwq` / `git` CLI dependency.
+- `gwm <subcommand>` for scripts and hooks; bare `gwm` opens a ratatui interface.
+- Per-repo `.gwm.toml`: branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
+- Branch convention `<type>/#<issue>-<description>` by default; overridable per repo.
+- Configurable launchers for the `l` (git TUI) and `R` (review) keybindings.
+- First-class GitHub issue / PR linking — branches matching the naming convention auto-link to their issue.
+
+## documentation map
+
+| Section                                            | Read this when …                                                              |
+|:---------------------------------------------------|:------------------------------------------------------------------------------|
+| [Getting Started](/getting-started)                | you want to install gwm and create your first worktree                        |
+| [TUI](/tui)                                        | you live in the ratatui interface — keymap, sidebar, launchers, filter        |
+| [CLI](/cli)                                        | you script gwm from shells, CI jobs, or `gh` aliases                          |
+| [Configuration](/configuration)                    | you're writing or extending `.gwm.toml` — bootstrap, guards, predicates       |
+| [Integrations](/integrations)                      | you wire gwm with `gh`, `lazygit`, Homebrew, Nix, or `gwm doctor` in CI       |
+| [Development](/development)                        | you're contributing — test layout, conventions, dev shell                     |
+| [Roadmap](/roadmap)                                | you want to know what ships next                                              |
+
+## the 30-second tour
+
+```bash
+# install
+cargo install --path .
+# or: brew tap kbrdn1/tap && brew install gwm
+
+# bootstrap a per-repo config (optional but recommended)
+cd /path/to/your/repo
+gwm init
+
+# create a worktree on a feature branch
+gwm create feat 42 user-authentication
+# → ~/cc-worktree/<repo>/feat-42-user-authentication
+# → branch feat/#42-user-authentication
+
+# open the TUI on the current repo
+gwm
+
+# fuzzy-jump back into an existing worktree (with `gwm shell-init` wired up)
+gcd auth
+```
+
+## why gwm
+
+The bash version (`tools/worktree-manager.sh` in some of our repos) was tied to one project's stack and one team's incident history. `gwm` keeps the lessons — anti-RDS guards, `.env.testing` copies, post-create hooks — and makes them configurable per repo. One binary, same behaviour everywhere.
+
+The full background lives in [the changelog](/development#changelog) and in the issue-tracker history at [github.com/kbrdn1/gwm-cli](https://github.com/kbrdn1/gwm-cli).

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -280,7 +280,7 @@ Two TUI keybindings share the same mini-API: take a `command` template from `.gw
 | `l` | `[git_tui]` | `lazygit -p {path}`           | `{path}`                              | `true`               |
 | `R` | `[review]`  | _(inert until configured)_    | `{base} {head} {path} {diff}`         | `false`              |
 
-`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command in the background, captures stderr's first line, and lands it on the status bar. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
+`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command **synchronously in-place** — gwm stays in the alt-screen, `Command::output()` blocks the TUI until the child exits, and the first line of stderr lands on the status bar. Fine for quick print-only tools (`claude --print`, `gh pr view --web`); pick `fullscreen = true` for anything long-running so the TUI is properly suspended and restored. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
 
 ### `[review]` base resolution chain (for `{base}`)
 


### PR DESCRIPTION
## Description

Brings the user-facing docs in sync with what actually shipped in v0.6.0, then restructures everything into a `docs/` tree ready for a future Nuxt Content static site. Audit basis: `git log --oneline main..dev` (~60 commits since v0.5.0).

Closes #77

## Type of change

- [x] 📝 Docs

## Changes

**Pure fixes (commits 1-2):**

- 🔧 `changelogs/0.6.0.md` — `0.7.0 surface` → `0.6.0 surface` (typo in the Docs bullet).
- 🔧 `skills/SKILL.md` — non-fullscreen launcher concurrency wording: `"in the background"` → `"synchronously (blocks the TUI)"`, aligned with `src/tui/mod.rs:329-338` (caught by Copilot's review on PR #76).

**`docs/` migration (commits 3-9 + 11):**

- 📁 Scaffold a `docs/` tree using Nuxt Content conventions: numeric prefixes (`1.getting-started/`, `2.tui/`, …) for sidebar ordering, frontmatter (`title`, `description`) on every leaf, section `index.md` files own the section landing.
- 7 sections, 30 markdown files total:
  - **Getting Started** — install (4 channels), first-worktree walkthrough, `gcd` shell helper.
  - **TUI** — keybindings (full v0.6 map incl. `R` / `F` / `O` / `L` / `f`), sidebar (4-bordered subsections), filter, confirm-countdown, configurable launchers (`[git_tui]` / `[review]` with placeholders + base resolution chain + synchronous semantics for `fullscreen=false`), open dispatch.
  - **CLI** — exhaustive subcommand reference, completions (with dynamic worktree-name completer recipes), multiplexer (`gwm tmux` / `gwm zellij`).
  - **Configuration** — full `.gwm.toml` schema (incl. the new `[git_tui]` / `[review]` / `[tui.open]` / `[doctor]` sections), bootstrap pipeline order, regex guards (origin story + on_match semantics), `when:` predicate grammar.
  - **Integrations** — GitHub issue/PR linking (storage model, auto-detect, `gh` shell-out, sidebar status dot, URL derivation), `gwm doctor` (7 checks with severity rules), Homebrew + Nix packaging surface for maintainers.
  - **Development** — testing (433 tests, 15 integration files, sentinel-test convention), contributing (conventions in detail), `nix develop`.
  - **Roadmap** — points at refreshed `ROADMAP.md`, summarises v0.6.0 deltas, links the open-issue queries.
- `docs/README.md` documents the authoring conventions (frontmatter contract, numeric-prefix routing, link semantics) for future editors.

**Surrounding doc updates (commits 10 + 12):**

- 📉 `README.md` shrunk from 493 → 77 lines: install matrix, 30-second tour, feature bullets, documentation map. The old inline reference (TUI keymap, sidebar, CLI surface, schema, doctor) now lives in `docs/`.
- 📝 `ROADMAP.md` refreshed from `Current state — v0.2.0` (the old header that listed #18-#21 as "Quick wins" — all shipped in v0.3.0) to a current `Current state — v0.6.0` section, plus a 19-row `Shipped — pre-v0.6.0` table organised by minor, and trimmed Quick Wins / TUI Polish / Ambitious sections that only list currently-open issues.
- 📝 `changelogs/0.6.0.md` Docs section records the migration so the release notes reflect what shipped.

## Tests

- [x] `cargo test` passes locally — **433 tests** (was 190 before #75 introduced the launcher / github / homebrew_formula / launcher / multiplexer / precommit_hook test files, plus expansions of the others).
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] No new tests added (pure docs PR; no behavioural code changes)

## Screenshots / TUI captures

N/A — docs-only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` — `docs/#77-sync-v0-6-0-docs` (gwm sanitised `0.6.0` → `0-6-0` in the slug; convention preserved)
- [x] Commits follow Gitmoji + Conventional Commits — 12 atomic commits grouped by section (changelog typo / SKILL fix / docs scaffold / getting-started / TUI / CLI / Configuration / Integrations / Development+Roadmap / README shrink / changelog record / ROADMAP refresh)
- [x] CHANGELOG.md updated under `## [Unreleased]` — N/A here; the docs work belongs in v0.6.0 release notes (added under `Docs` in `changelogs/0.6.0.md` since v0.6.0 is the next merge to `main`)
- [x] README updated — yes, shrunk to a landing page
- [x] `examples/gwm.toml.example` updated if config schema changed — N/A, no schema change (the docs were the drift, not the schema)
- [x] No `unwrap()` on user-facing paths — N/A
- [x] No `println!` in TUI render code — N/A

## Linked issues / docs

- Issue: #77
- Related PRs: #68 (issue/PR linking), #70 (sidebar redesign), #72 (recent commits), #74 (sidebar facelift), #76 (configurable launchers) — the v0.6.0 work this PR documents.

## Notes for reviewers

The PR is large by line count (~1900 added, ~470 removed) but trivially reviewable per-commit:

- **Commits 1-2** are 1-line fixes — review as typo corrections.
- **Commit 3** (scaffold) is pure structural — 30 new files, but every leaf is a stub pointing back to README until the per-section commits replace it.
- **Commits 4-9** each replace 3-6 stubs with full content for one section. Per-commit reviews focus on a single concern (Getting Started OR TUI OR CLI OR Configuration OR Integrations OR Development+Roadmap).
- **Commit 10** is the README rewrite — review side-by-side against the previous version. Every removed section now lives in `docs/`.
- **Commits 11-12** are 1-page edits — record in the changelog, refresh the root ROADMAP.

Skim suggestion: read the section `index.md` files first (they each summarise what's in their leaves), then deep-dive into the leaves that touch features you care about. `docs/2.tui/5.launchers.md` and `docs/5.integrations/1.github-linking.md` are the densest pages and the most v0.6-specific.