### PR TITLE
🔀 chore(release): merge dev → main for v0.6.0

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -149,12 +149,30 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # Release notes come from the per-rc file under `changelogs/pre-releases/`,
+      # not the top-level `CHANGELOG.md` (which is only the in-progress
+      # index — RC entries land in `changelogs/pre-releases/X.Y.Z-rc.N.md`
+      # when the RC is cut). Sourcing from the index would publish an
+      # empty body, as observed for v0.6.0-rc.1 before this fix.
+      - name: resolve changelog path
+        id: changelog
+        shell: bash
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          VERSION="${TAG#v}"
+          CHANGELOG_PATH="changelogs/pre-releases/${VERSION}.md"
+          if [ ! -f "${CHANGELOG_PATH}" ]; then
+            echo "::error::Expected ${CHANGELOG_PATH} to exist for tag ${TAG} — release notes would otherwise fall back to the empty CHANGELOG.md index."
+            exit 1
+          fi
+          echo "path=${CHANGELOG_PATH}" >> "$GITHUB_OUTPUT"
+
       - name: publish pre-release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.name }}
           name: ${{ steps.tag.outputs.name }}
-          body_path: CHANGELOG.md
+          body_path: ${{ steps.changelog.outputs.path }}
           files: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,12 +111,31 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # Release notes come from the per-version file under `changelogs/`,
+      # not the top-level `CHANGELOG.md` (which is only the in-progress
+      # index — entries get moved into `changelogs/X.Y.Z.md` when the
+      # release is cut). Sourcing from the index would publish an empty
+      # body with the past-releases list, as observed for v0.6.0 / v0.6.0-rc.1
+      # before this fix.
+      - name: resolve changelog path
+        id: changelog
+        shell: bash
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          CHANGELOG_PATH="changelogs/${VERSION}.md"
+          if [ ! -f "${CHANGELOG_PATH}" ]; then
+            echo "::error::Expected ${CHANGELOG_PATH} to exist for tag ${TAG} — release notes would otherwise fall back to the empty CHANGELOG.md index."
+            exit 1
+          fi
+          echo "path=${CHANGELOG_PATH}" >> "$GITHUB_OUTPUT"
+
       - name: publish release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body_path: CHANGELOG.md
+          body_path: ${{ steps.changelog.outputs.path }}
           files: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256

--- a/.gwm.toml
+++ b/.gwm.toml
@@ -30,3 +30,10 @@ when = "file_exists:.envrc"
 name = "cargo fetch"
 run  = "cargo fetch"
 when = "file_exists:Cargo.toml"
+
+# -- TUI `R: review` launcher (issue #75) ------------------------------------
+# Press `R` in the worktree list to review the selected branch against its
+# resolved base (upstream → branch.<n>.gwm-base → default_base → dev → main).
+# `lumen` preset = `lumen diff {base}..{head}` fullscreen suspend-and-resume.
+[review]
+tool = "lumen"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Changed
+
+- **TUI Details sidebar redesign** (#69) — the right pane is now made of four
+  independent rounded-border subsections (`Worktree` / `Issue / PR` /
+  `Working Tree` / `Recent Commits`) instead of one big `Details` block with
+  flat `Label:` headers. The outer `Details` frame is dropped to reclaim
+  vertical space. Section titles live on the block borders, so the inline
+  `Basic Settings:` / `Recent commits:` / `Working tree:` content lines are
+  gone. The redundant `─── Issue / PR ───` content header is removed in
+  favour of the block title.
+
+### Removed
+
+- **`Commands:` cheat-sheet from the Details sidebar** — the 15-line
+  keybindings list duplicated the `?` help overlay and pushed the
+  `Issue / PR` block off-screen on common terminal sizes. Press `?` for the
+  full key map. (#69)
+
+### Docs
+
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to
+  match the current `0.6.0-rc.1` surface: new subcommands (`doctor`,
+  `switch`, `tmux`, `zellij`, `link` / `unlink` / `open` / `status`,
+  `completions`, `shell-init`), composable `when` predicates, `[doctor]` /
+  `[tui]` config sections, opt-in pre-commit hook at `.githooks/pre-commit`,
+  updated triggers / TUI key map / troubleshooting.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`). gwm renders the node column only
-  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
-  sidebar and need cross-row topology tracking.
+  lazygit's initial `git log -300`). Includes the full graph topology
+  renderer — vertical pipes `│`, corners `╮ ╭ ╯ ╰`, junctions `┴ ┬`,
+  horizontal strokes `─` — driven by a Rust port of lazygit's
+  `pkg/gui/presentation/graph/` package (`graph.go` / `cell.go`).
+  Linear history collapses to a single `○`-stack column; merges spawn
+  fresh columns to the right, and the algorithm is width-deterministic
+  on the commit list (independent of terminal width).
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now occupies exactly **one visual line** (was wrapping onto two on long
   subjects), and the block **fills the available height** instead of
   showing a hardcoded 10 entries. Per-row format mirrors lazygit:
-  `<8-char hash>  <author initials>  <subject>` (initials follow the
-  same `KB`-from-`Kylian Bardini` rule as
-  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  `<8-char hash>  <author initials>  <node>  <subject>`, where `<node>`
+  is `○` for a normal commit and `◎` for a merge commit (matches
+  `lazygit/pkg/gui/presentation/graph/cell.go` constants
+  `CommitSymbol` / `MergeSymbol`). Initials follow the same
+  `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`. Subjects are
   **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
   disabled across every sidebar block now, so the `Constraint::Length`
   budget always matches the rendered height. A right-aligned footer
   `<viewport-bottom> of <total>` lives at the bottom of the block, à la
   lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`).
+  lazygit's initial `git log -300`). gwm renders the node column only
+  — full inter-row connectors (`│ ╮ ╭ ╯ ╰`) would clutter a narrow
+  sidebar and need cross-row topology tracking.
 
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,107 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **TUI: configurable launchers for `l` (git_tui) and `R` (review)**
-  ([#75](https://github.com/kbrdn1/gwm-cli/issues/75)). Two new
-  `.gwm.toml` sections — `[git_tui]` and `[review]` — drive the
-  worktree-list `l` / `R` keybindings through a shared launcher
-  pipeline (placeholder expansion `{base} {head} {path} {diff}`,
-  `shell-words` split, optional fullscreen suspend-and-resume).
-  `[git_tui]` defaults to `lazygit -p {path}` fullscreen so existing
-  repos see zero behaviour change. `[review]` accepts either a
-  free-form `command = "<shell line>"` or a `tool = "<preset>"` sugar
-  (`lumen`, `claude`, `codex`, `aider`, `gh`). New
-  `branch.<n>.gwm-base` key, set by `gwm create`, anchors the review
-  base-resolution chain (upstream → gwm-base → `[review].default_base`
-  → `dev` → `main`). The `{diff}` placeholder lazily materialises a
-  tempfile holding `git diff {base}..{head}` — only when the template
-  references it.
-- TUI sidebar gets a lazygit-style facelift (#73):
-  - New `Created` row showing the branch's age in compact relative form
-    (`2d`, `3w`, `1M`, …), colour-coded by freshness (green < 7d,
-    yellow < 30d, dark gray otherwise).
-  - Branch name is now coloured by `BranchStatus` (worst-state wins —
-    dirty → red, ahead/behind → yellow, unpublished → magenta, synced
-    → green, unknown → dark gray). Applies to both the sidebar
-    `Branch:` row and the table `BRANCH` column.
-  - Sidebar header line is now prefixed by a `●` status dot whose
-    colour tracks the linked PR / issue state (open=green,
-    draft=gray, merged=magenta, closed=red).
-- New `[tui.open]` config section + `OpenTarget` dispatch for the `o`
-  key (#73). `mode` accepts `"shell"` (default, lazygit-style
-  `$SHELL` in the worktree), `"editor"` (`$EDITOR <path>`), or
-  `"finder"` (pre-#73 OS file manager). `shell_cmd` / `editor_cmd`
-  override the env var when set.
-- New `y` keybinding: yank the selected worktree's path to the system
-  clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`).
-  Missing tool surfaces a clear status hint, no crash.
-
-### Changed
-- **TUI keybind reshuffle**: `f` now refreshes the worktree list (was
-  `r`, kept as alias for muscle memory); `F` refreshes the GitHub
-  issue/PR status (was `R`); the freed `R` triggers the new review
-  launcher. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
-- `gwm doctor` now probes the configured `[review]` and `[git_tui]`
-  binaries against `$PATH`. A missing review tool surfaces as Warning
-  (exit code `1`), never Failed (`2`) — review is opt-in, so a CI
-  pre-commit hook keeps passing when only the local launcher is
-  unavailable. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
-- **Default behaviour of `o:` open changes** (#73). It used to spawn
-  the OS file manager unconditionally; now it spawns `$SHELL` in the
-  worktree by default. Opt back into the old behaviour with
-  `[tui.open] mode = "finder"` in `.gwm.toml`.
-- TUI footer / help overlay / sidebar cheat-sheet updated to reflect
-  the new `o:open` and `y:yank` bindings.
-- **TUI Recent Commits panel — lazygit-style layout** (#71) — each commit
-  now occupies exactly **one visual line** (was wrapping onto two on long
-  subjects), and the block **fills the available height** instead of
-  showing a hardcoded 10 entries. Per-row format mirrors lazygit:
-  `<8-char hash>  <author initials>  <node>  <subject>`, where `<node>`
-  is `○` for a normal commit and `◎` for a merge commit (matches
-  `lazygit/pkg/gui/presentation/graph/cell.go` constants
-  `CommitSymbol` / `MergeSymbol`). Initials follow the same
-  `KB`-from-`Kylian Bardini` rule as
-  `lazygit/pkg/gui/presentation/authors/authors.go`. Subjects are
-  **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
-  disabled across every sidebar block now, so the `Constraint::Length`
-  budget always matches the rendered height. A right-aligned footer
-  `<viewport-bottom> of <total>` lives at the bottom of the block, à la
-  lazygit's panel footer. Default buffer is **300 commits** (same as
-  lazygit's initial `git log -300`). Includes the full graph topology
-  renderer — vertical pipes `│`, corners `╮ ╭ ╯ ╰`, junctions `┴ ┬`,
-  horizontal strokes `─` — driven by a Rust port of lazygit's
-  `pkg/gui/presentation/graph/` package (`graph.go` / `cell.go`).
-  Linear history collapses to a single `○`-stack column; merges spawn
-  fresh columns to the right, and the algorithm is width-deterministic
-  on the commit list (independent of terminal width).
-- **TUI Details sidebar redesign** (#69) — the right pane is now made of four
-  independent rounded-border subsections (`Worktree` / `Issue / PR` /
-  `Working Tree` / `Recent Commits`) instead of one big `Details` block with
-  flat `Label:` headers. The outer `Details` frame is dropped to reclaim
-  vertical space. Section titles live on the block borders, so the inline
-  `Basic Settings:` / `Recent commits:` / `Working tree:` content lines are
-  gone. The redundant `─── Issue / PR ───` content header is removed in
-  favour of the block title.
-
-### Removed
-- **`Commands:` cheat-sheet from the Details sidebar** — the 15-line
-  keybindings list duplicated the `?` help overlay and pushed the
-  `Issue / PR` block off-screen on common terminal sizes. Press `?` for the
-  full key map. (#69)
-
-### Docs
-- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to
-  match the current `0.6.0-rc.1` surface: new subcommands (`doctor`,
-  `switch`, `tmux`, `zellij`, `link` / `unlink` / `open` / `status`,
-  `completions`, `shell-init`), composable `when` predicates, `[doctor]` /
-  `[tui]` config sections, opt-in pre-commit hook at `.githooks/pre-commit`,
-  updated triggers / TUI key map / troubleshooting.
+_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
 
 ## Past releases
 
 In reverse chronological order:
 
+- [`0.6.0`](changelogs/0.6.0.md) — 2026-05-21
 - [`0.5.0`](changelogs/0.5.0.md) — 2026-05-20
 - [`0.4.0`](changelogs/0.4.0.md) — 2026-05-19
 - [`0.3.0`](changelogs/0.3.0.md) — 2026-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+- TUI sidebar gets a lazygit-style facelift (#73):
+  - New `Created` row showing the branch's age in compact relative form
+    (`2d`, `3w`, `1M`, …), colour-coded by freshness (green < 7d,
+    yellow < 30d, dark gray otherwise).
+  - Branch name is now coloured by `BranchStatus` (worst-state wins —
+    dirty → red, ahead/behind → yellow, unpublished → magenta, synced
+    → green, unknown → dark gray). Applies to both the sidebar
+    `Branch:` row and the table `BRANCH` column.
+  - Sidebar header line is now prefixed by a `●` status dot whose
+    colour tracks the linked PR / issue state (open=green,
+    draft=gray, merged=magenta, closed=red).
+- New `[tui.open]` config section + `OpenTarget` dispatch for the `o`
+  key (#73). `mode` accepts `"shell"` (default, lazygit-style
+  `$SHELL` in the worktree), `"editor"` (`$EDITOR <path>`), or
+  `"finder"` (pre-#73 OS file manager). `shell_cmd` / `editor_cmd`
+  override the env var when set.
+- New `y` keybinding: yank the selected worktree's path to the system
+  clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`).
+  Missing tool surfaces a clear status hint, no crash.
+
+### Changed
+- **Default behaviour of `o:` open changes** (#73). It used to spawn
+  the OS file manager unconditionally; now it spawns `$SHELL` in the
+  worktree by default. Opt back into the old behaviour with
+  `[tui.open] mode = "finder"` in `.gwm.toml`.
+- TUI footer / help overlay / sidebar cheat-sheet updated to reflect
+  the new `o:open` and `y:yank` bindings.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+
+- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67)) — link the current worktree to a GitHub issue and / or pull request, open them in the browser, and surface their status in the TUI details panel.
+  - New CLI subcommands: `gwm link {issue|pr} <N>`, `gwm unlink {issue|pr}`, `gwm open {issue|pr} [--print-url]`, `gwm status [--json]`.
+  - Storage: `git config branch.<name>.gwm-issue` and `branch.<name>.gwm-pr` (local, per-branch, survives worktree moves).
+  - Auto-detection: branches following `<type>/#<N>-<slug>` derive the issue automatically; explicit `gwm link issue <N>` overrides.
+  - TUI key bindings: `O` open menu (issue / pr), `L` link prompt, `R` refresh GitHub status.
+  - Right-panel status: live issue state (open / closed) and PR state (open / draft / closed / merged) with CI check rollup (`checks N/M`). Fetched via `gh issue view` / `gh pr view`.
+
+### Dependencies
+
+- Add `serde_json = "1"` for parsing the `gh` CLI JSON output.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+
+- **TUI: configurable launchers for `l` (git_tui) and `R` (review)**
+  ([#75](https://github.com/kbrdn1/gwm-cli/issues/75)). Two new
+  `.gwm.toml` sections — `[git_tui]` and `[review]` — drive the
+  worktree-list `l` / `R` keybindings through a shared launcher
+  pipeline (placeholder expansion `{base} {head} {path} {diff}`,
+  `shell-words` split, optional fullscreen suspend-and-resume).
+  `[git_tui]` defaults to `lazygit -p {path}` fullscreen so existing
+  repos see zero behaviour change. `[review]` accepts either a
+  free-form `command = "<shell line>"` or a `tool = "<preset>"` sugar
+  (`lumen`, `claude`, `codex`, `aider`, `gh`). New
+  `branch.<n>.gwm-base` key, set by `gwm create`, anchors the review
+  base-resolution chain (upstream → gwm-base → `[review].default_base`
+  → `dev` → `main`). The `{diff}` placeholder lazily materialises a
+  tempfile holding `git diff {base}..{head}` — only when the template
+  references it.
+
+### Changed
+
+- **TUI keybind reshuffle**: `f` now refreshes the worktree list (was
+  `r`, kept as alias for muscle memory); `F` refreshes the GitHub
+  issue/PR status (was `R`); the freed `R` triggers the new review
+  launcher. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
+- `gwm doctor` now probes the configured `[review]` and `[git_tui]`
+  binaries against `$PATH`. A missing review tool surfaces as Warning
+  (exit code `1`), never Failed (`2`) — review is opt-in, so a CI
+  pre-commit hook keeps passing when only the local launcher is
+  unavailable. ([#75](https://github.com/kbrdn1/gwm-cli/issues/75))
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67)) — link the current worktree to a GitHub issue and / or pull request, open them in the browser, and surface their status in the TUI details panel.
-  - New CLI subcommands: `gwm link {issue|pr} <N>`, `gwm unlink {issue|pr}`, `gwm open {issue|pr} [--print-url]`, `gwm status [--json]`.
-  - Storage: `git config branch.<name>.gwm-issue` and `branch.<name>.gwm-pr` (local, per-branch, survives worktree moves).
-  - Auto-detection: branches following `<type>/#<N>-<slug>` derive the issue automatically; explicit `gwm link issue <N>` overrides.
-  - TUI key bindings: `O` open menu (issue / pr), `L` link prompt, `R` refresh GitHub status.
-  - Right-panel status: live issue state (open / closed) and PR state (open / draft / closed / merged) with CI check rollup (`checks N/M`). Fetched via `gh issue view` / `gh pr view`.
-
-### Dependencies
-
-- Add `serde_json = "1"` for parsing the `gh` CLI JSON output.
+_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
 
 ## Past releases
 
@@ -37,6 +26,7 @@ In reverse chronological order:
 
 Per-RC notes covering only the delta against the previous RC (or against the previous stable, for `rc.1`):
 
+- [`0.6.0-rc.1`](changelogs/pre-releases/0.6.0-rc.1.md) — 2026-05-20
 - [`0.5.0-rc.2`](changelogs/pre-releases/0.5.0-rc.2.md) — 2026-05-19
 - [`0.5.0-rc.1`](changelogs/pre-releases/0.5.0-rc.1.md) — 2026-05-19
 - [`0.3.0-rc.3`](changelogs/pre-releases/0.3.0-rc.3.md) — 2026-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TUI Recent Commits panel — lazygit-style layout** (#71) — each commit
+  now occupies exactly **one visual line** (was wrapping onto two on long
+  subjects), and the block **fills the available height** instead of
+  showing a hardcoded 10 entries. Per-row format mirrors lazygit:
+  `<8-char hash>  <author initials>  <subject>` (initials follow the
+  same `KB`-from-`Kylian Bardini` rule as
+  `lazygit/pkg/gui/presentation/authors/authors.go`). Subjects are
+  **hard-clipped** at the panel's right edge — `Paragraph::wrap` is
+  disabled across every sidebar block now, so the `Constraint::Length`
+  budget always matches the rendered height. A right-aligned footer
+  `<viewport-bottom> of <total>` lives at the bottom of the block, à la
+  lazygit's panel footer. Default buffer is **300 commits** (same as
+  lazygit's initial `git log -300`).
+
 - **TUI Details sidebar redesign** (#69) — the right pane is now made of four
   independent rounded-border subsections (`Worktree` / `Issue / PR` /
   `Working Tree` / `Recent Commits`) instead of one big `Details` block with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,18 @@ exception; codify the manual test as an integration test.
   feature PRs (#51, #52, #53) because this check was skipped —
   forced an immediate v0.4.0 promotion 38 minutes later. Two
   minutes upfront beats a rushed follow-up release.
+- **Release notes are per-version, never the index.** The release
+  workflows (`release.yml` / `pre-release.yml`) source their
+  `body_path` from `changelogs/<version>.md` (stable) or
+  `changelogs/pre-releases/<version>.md` (rc/alpha/beta), NOT from
+  the top-level `CHANGELOG.md` (which is the in-progress index —
+  entries get moved into the per-version file when the release is
+  cut, so the index is empty at tag time). Before tagging, verify
+  the per-version file exists and contains the release contents;
+  the workflow now hard-fails if the file is missing rather than
+  silently publishing the empty index (witnessed on v0.6.0 /
+  v0.6.0-rc.1 — both releases had to be re-edited post-hoc via
+  `gh release edit --notes-file`).
 - **Pre-validate environment-dependent tests.** Any test that reads
   `$PATH`, the user's home directory, or other ambient state must be
   pre-validated locally against a stripped environment before the test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
  "ratatui",
  "regex",
  "serde",
+ "serde_json",
  "shell-words",
  "shellexpand",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm"
-version = "0.5.0"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ratatui = "0.30"
 crossterm = "0.29"
 git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "1.1"
 anyhow = "1"
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwm"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 edition = "2021"
 description = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 authors = ["Kylian Bardini"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwm"
-version = "0.5.0"
+version = "0.6.0-rc.1"
 edition = "2021"
 description = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 authors = ["Kylian Bardini"]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Key bindings:
 | `n`         | new worktree (form: type → issue → description)                                 |
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
 | `b`         | re-run bootstrap on the selected worktree                                       |
-| `o`         | open the worktree dir in the OS file manager (`open` / `xdg-open` / `explorer`) |
+| `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / clip) |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
@@ -97,14 +98,32 @@ Key bindings:
 
 ### details sidebar
 
-When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the currently selected worktree:
+When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree:
 
-- **Basic Settings** — branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **Header** — `● <worktree-name>`, with the `●` colour tracking the linked PR / issue state (open=green, draft=gray, merged=magenta, closed=red, neutral=darkgray when nothing's linked).
+- **Basic Settings** — branch (coloured by status: synced=green, ahead/behind=yellow, dirty=red, unpublished=magenta, unknown=darkgray), path, head (short OID), **Created** (branch age in compact `2d` / `3w` / `1M` form, coloured by freshness), main / locked / prunable flags, branch status.
 - **Recent commits** — `git log --oneline -n 10`.
 - **Working tree** — `git status --short` (`✓ clean` when empty).
 - **Commands** — keybindings cheat-sheet.
 
 Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+#### open dispatch
+
+The `o` key dispatches on `[tui.open]` in `.gwm.toml`:
+
+```toml
+[tui.open]
+mode = "shell"          # "shell" (default) | "editor" | "finder"
+shell_cmd = ""           # override $SHELL; empty = unset
+editor_cmd = "hx"        # override $EDITOR; empty = unset
+```
+
+- `shell` (default, **changed in v0.6**): suspend the TUI and spawn `$SHELL` with `cwd` set to the worktree — same lifecycle as `l: lazygit`. Exit the shell, the TUI restores.
+- `editor`: suspend the TUI and run `$EDITOR <worktree-path>`.
+- `finder`: pre-v0.6 behaviour — hand off to the OS file manager (`open` / `xdg-open` / `explorer`) without suspending the TUI.
+
+Unknown `mode` values are a hard config error at load time, surfaced before the TUI opens.
 
 ### fuzzy filter
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,29 @@ gwm tmux auth -p                            # ...or in a split of the current pa
 gwm zellij auth                             # same, but for zellij — new tab via `--cwd`
 gwm zellij auth -p                          # ...or in a new pane of the current tab
 gwm doctor                                  # diagnose config + env + worktree state (exit 0/1/2)
+gwm link issue 42                           # link an issue to the current worktree
+gwm link pr 61                              # link a PR
+gwm unlink issue                            # remove the issue link (auto-detect resurfaces)
+gwm open issue                              # open the linked issue in the browser
+gwm open pr --print-url                     # print the URL on stdout instead of spawning
+gwm status                                  # show link + live state via `gh`
+gwm status --json                           # machine-readable JSON of the status
 ```
+
+### Issue / PR linking ([#67](https://github.com/kbrdn1/gwm-cli/issues/67))
+
+Every worktree can be linked to a GitHub issue and / or pull request:
+
+- Branches following `<type>/#<N>-<slug>` are auto-linked to issue `#N` — zero setup.
+- Explicit overrides land in `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, no extra file).
+- `gwm status` shells out to `gh issue view` / `gh pr view` to fetch the live state, title, labels, and CI rollup. Without `gh` (or outside a GitHub remote), only the local link is shown.
+
+In the TUI:
+
+- `O` — open menu (`i` open issue, `p` open PR) in the browser.
+- `L` — link prompt (`i` issue, `p` pr, then type the number).
+- `R` — refresh the GitHub status (synchronous fetch).
+- The right details panel renders a live block: `Issue #42 [open] TUI: fuzzy search` / `PR #61 [draft] · checks 2/3`.
 
 ### multiplexer integration (`gwm tmux` / `gwm zellij`)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Key bindings:
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
 | `b`         | re-run bootstrap on the selected worktree                                       |
 | `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
-| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / clip) |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |

--- a/README.md
+++ b/README.md
@@ -5,479 +5,62 @@
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![rust](https://img.shields.io/badge/rust-1.80%2B-orange?logo=rust)](https://www.rust-lang.org/)
 
-Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2` (no `gwq` / `git` CLI dependency), per-repo configurable bootstrap (file copies, regex guards, shell hooks), single binary, portable.
+Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2` (vendored — no `gwq` / `git` CLI dependency), per-repo configurable bootstrap (file copies, regex guards, shell hooks), single binary, portable.
 
-Born as a rewrite of a project-specific `tools/worktree-manager.sh` script — the bash version was tied to Laravel/PHP and one repo's incident history. `gwm` keeps the lessons, makes them configurable, and works the same way in every repo.
-
-## features
-
-- **Native worktree ops** via `libgit2` (vendored). `git worktree add/list/remove/prune` without shelling out.
-- **CLI + TUI**: `gwm <subcommand>` for scripts and hooks, `gwm` alone opens a ratatui interface.
-- **Per-repo config** in `.gwm.toml`: branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
-- **Branch convention**: `<type>/#<issue>-<description>` by default (`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`). Overridable per repo.
-- **Safety guards**: deny-list regexes on copied files (e.g. refuse to inherit a `.env` pointing at AWS RDS). Pluggable actions: `abort` or `seed-from-example`.
-- **Bootstrap hooks**: shell commands gated by composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||`) and arbitrary `env` injection.
-- **Fuzzy lookup**: `gwm remove auth` matches `feat-123-user-authentication` if unambiguous.
-- **Branch status column**: dirty / clean / `↑N ↓M` vs upstream, color-coded in TUI and CLI output.
+> **Full documentation lives in [`docs/`](docs/).** This README is the landing page; every feature has a dedicated section in the doc tree.
 
 ## install
 
-### from source
+| Channel        | Command                                                              |
+|:---------------|:---------------------------------------------------------------------|
+| Cargo (source) | `cargo install --path .`                                              |
+| Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                          |
+| Nix flake      | `nix profile install github:kbrdn1/gwm-cli`                          |
+| Prebuilt       | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
+
+Full install matrix and verification steps: [`docs/getting-started/install.md`](docs/1.getting-started/1.install.md).
+
+## the 30-second tour
 
 ```bash
-git clone https://github.com/kbrdn1/gwm-cli.git
-cd gwm-cli
-cargo install --path .
+cd /path/to/your/repo
+gwm init                                          # write a default .gwm.toml
+gwm create feat 42 user-authentication            # → ~/cc-worktree/<repo>/feat-42-user-authentication
+                                                  # → branch feat/#42-user-authentication
+gwm                                               # opens the TUI on the current repo
+gcd auth                                          # fuzzy-jump into the worktree (needs `gwm shell-init`)
 ```
 
-The binary lands in `~/.cargo/bin/gwm`.
+Step-by-step walkthrough: [`docs/getting-started/first-worktree.md`](docs/1.getting-started/2.first-worktree.md).
 
-### via Homebrew (macOS)
+## what gwm does
 
-```bash
-brew tap kbrdn1/tap
-brew install gwm
-```
+- **Native worktree ops** via vendored `libgit2` — `git worktree add/list/remove/prune` without shelling out.
+- **CLI + ratatui TUI** — `gwm <subcommand>` for scripts, bare `gwm` opens the interactive interface.
+- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
+- **Configurable launchers** — drive the TUI's `l` (git TUI) and `R` (review) keybindings through `[git_tui]` and `[review]` sections in `.gwm.toml`.
+- **GitHub issue / PR linking** — branches matching `<type>/#<N>-<slug>` auto-link to their issue; live status surfaces in the TUI sidebar via `gh`.
+- **Safety guards** — deny-list regexes on copied files (the original "no AWS RDS in `.env`" incident, generalised), plus a confirm-overlay countdown when destructive branch-deletion is armed.
 
-The formula lives at [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap) (`Formula/gwm.rb`) and is refreshed automatically on every stable release of `gwm-cli` by the `homebrew-tap-update` job in [`release.yml`](.github/workflows/release.yml). The canonical formula source lives at [`packaging/homebrew/gwm.rb.template`](packaging/homebrew/gwm.rb.template) — pre-release tags (`-rc.N`, `-alpha.N`, `-beta.N`) are filtered out so `brew install gwm` always points at a stable build.
+## documentation
 
-### prebuilt binaries
+The full tree lives under [`docs/`](docs/) — structured for [Nuxt Content](https://content.nuxt.com/) (numeric prefixes for sidebar order, frontmatter on every page) and ready to drop into the future static site.
 
-Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship Linux (x86_64 + aarch64), macOS (Intel + Apple Silicon), and Windows binaries with `.sha256` sidecars.
+| Section                                                         | Read this when …                                                              |
+|:----------------------------------------------------------------|:------------------------------------------------------------------------------|
+| [Getting Started](docs/1.getting-started/index.md)              | you want to install gwm and create your first worktree                        |
+| [TUI](docs/2.tui/index.md)                                      | you live in the ratatui interface — keymap, sidebar, launchers, filter        |
+| [CLI](docs/3.cli/index.md)                                      | you script gwm from shells, CI jobs, or `gh` aliases                          |
+| [Configuration](docs/4.configuration/index.md)                  | you're writing or extending `.gwm.toml` — bootstrap, guards, predicates       |
+| [Integrations](docs/5.integrations/index.md)                    | you wire gwm with `gh`, `lazygit`, AI reviewers, Homebrew, Nix, or `gwm doctor` in CI |
+| [Development](docs/6.development/index.md)                      | you're contributing — test layout, conventions, dev shell                     |
+| [Roadmap](docs/7.roadmap.md)                                    | you want to know what shipped and what comes next                             |
 
-### via Nix flake
+The [`docs/README.md`](docs/README.md) page documents the authoring conventions (frontmatter contract, numeric-prefix routing, link semantics) for anyone editing the tree.
 
-A `flake.nix` lives at the repo root. With flakes enabled:
+## history
 
-```bash
-# one-shot run, no clone
-nix run github:kbrdn1/gwm-cli -- list
-
-# install into your profile
-nix profile install github:kbrdn1/gwm-cli
-
-# in a NixOS / nix-darwin config, via the overlay
-nixpkgs.overlays = [ inputs.gwm.overlays.default ];
-environment.systemPackages = [ pkgs.gwm ];
-```
-
-The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
-
-## usage
-
-### TUI (interactive)
-
-```bash
-cd <a-git-repo>
-gwm                # opens the TUI on the current repo
-```
-
-Key bindings:
-
-| Key         | Action                                                                          |
-|:------------|:--------------------------------------------------------------------------------|
-| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                       |
-| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
-| `gg`        | jump to the first worktree                                                      |
-| `G`         | jump to the last worktree                                                       |
-| `n`         | new worktree (form: type → issue → description)                                 |
-| `d`         | delete selected (confirm `y` · countdown when `p` is armed — see below)         |
-| `b`         | re-run bootstrap on the selected worktree                                       |
-| `o`         | open the worktree per [`[tui.open]`](#open-dispatch) — `shell` (default) / `editor` / `finder` |
-| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
-| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; resume the TUI on exit      |
-| `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)     |
-| `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `/`         | open the fuzzy filter bar (`Enter` confirms sticky filter · `Esc` clears)       |
-| `r`         | refresh                                                                         |
-| `p`         | toggle "delete branch on remove"                                                |
-| `Enter`     | show selected path in status bar                                                |
-| `?`         | help overlay                                                                    |
-| `q`         | quit                                                                            |
-| `Esc`       | clear a sticky filter if any, otherwise quit                                    |
-
-### details sidebar
-
-When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree:
-
-- **Header** — `● <worktree-name>`, with the `●` colour tracking the linked PR / issue state (open=green, draft=gray, merged=magenta, closed=red, neutral=darkgray when nothing's linked).
-- **Basic Settings** — branch (coloured by status: synced=green, ahead/behind=yellow, dirty=red, unpublished=magenta, unknown=darkgray), path, head (short OID), **Created** (branch age in compact `2d` / `3w` / `1M` form, coloured by freshness), main / locked / prunable flags, branch status.
-- **Recent commits** — `git log --oneline -n 10`.
-- **Working tree** — `git status --short` (`✓ clean` when empty).
-- **Commands** — keybindings cheat-sheet.
-
-Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
-
-#### open dispatch
-
-The `o` key dispatches on `[tui.open]` in `.gwm.toml`:
-
-```toml
-[tui.open]
-mode = "shell"          # "shell" (default) | "editor" | "finder"
-shell_cmd = ""           # override $SHELL; empty = unset
-editor_cmd = "hx"        # override $EDITOR; empty = unset
-```
-
-- `shell` (default, **changed in v0.6**): suspend the TUI and spawn `$SHELL` with `cwd` set to the worktree — same lifecycle as `l: lazygit`. Exit the shell, the TUI restores.
-- `editor`: suspend the TUI and run `$EDITOR <worktree-path>`.
-- `finder`: pre-v0.6 behaviour — hand off to the OS file manager (`open` / `xdg-open` / `explorer`) without suspending the TUI.
-
-Unknown `mode` values are a hard config error at load time, surfaced before the TUI opens.
-
-### fuzzy filter
-
-Press `/` to open an inline filter bar at the bottom of the worktree table. As you type, the table narrows in real time using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) — the same fuzzy engine used by Helix and Zellij. Matches are ranked by how tight the hit is (contiguous substring beats spread-out subsequence), so the most likely candidate sits on top.
-
-```
-/                            → filter bar opens
-auth                         → table now shows feat-99-user-authentication only
-<Enter>                       → filter sticks, navigation back on the table
-<Esc>                         → clears filter, full list back
-```
-
-The filter is sticky between Enter and Esc: `j` / `k` / `gg` / `G` continue to work on the filtered subset, and the table title shows `worktrees (N/M)` (visible / total). Hit `/` again to re-open the bar and refine the query. `Esc` from the list view clears the sticky filter before it considers quitting, so you can't accidentally quit when you meant to drop the filter.
-
-### confirm-overlay countdown ([#30](https://github.com/kbrdn1/gwm-cli/issues/30))
-
-The `d` confirm overlay has two modes, picked automatically based on whether `p` was pressed earlier in the session:
-
-- **Classic** (`delete branch on remove` is OFF): single keystroke. `y` / `Enter` fires the delete; `n` / `Esc` cancels. Same as the pre-#30 behaviour.
-- **Countdown** (`delete branch on remove` is ON): the overlay shows the branch about to disappear plus an `arm` step. `y` / `Enter` *arms* a safety countdown (default 3s, visualised by a progress bar); the actual delete only fires once the bar fills. `Esc` / `n` cancels at any time; pressing `y` again during the countdown disarms it without firing.
-
-The countdown duration is configurable via `[tui].confirm_countdown_secs` in `.gwm.toml`. Accepted range: `0..=5`. Setting it to `0` keeps the classic single-keystroke modal even when `delete branch on remove` is armed; values above `5` are clamped to `5` on read.
-
-```toml
-[tui]
-# 3s default. Set to 0 to disable the countdown (classic modal even when p is armed).
-confirm_countdown_secs = 3
-```
-
-### lazygit integration
-
-Press `l` on any worktree to suspend the TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on that worktree (`lazygit -p <path>`). When you quit lazygit, the gwm TUI is restored exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it without crashing.
-
-### CLI
-
-```bash
-gwm init                                    # write .gwm.toml in the current repo
-gwm types                                   # list valid branch types
-gwm create feat 123 "user-authentication"   # → feat/#123-user-authentication
-gwm create feat 123 foo --no-bootstrap      # skip the .gwm.toml bootstrap stages
-gwm list                                    # list all worktrees of the current repo
-gwm list --format=names                     # one worktree name per line (for shell completion)
-gwm path auth                               # print the resolved path (use $(gwm path ...))
-gwm cd auth                                 # same — primitive for the `gcd` wrapper
-gwm switch                                  # interactive picker — prints chosen path on stdout
-gwm s                                       # short alias for `switch`
-gwm bootstrap                               # re-run bootstrap on the CWD worktree
-gwm bootstrap auth                          # ...or on a named one
-gwm remove auth                             # remove (fuzzy match) — keeps the branch
-gwm remove auth --delete-branch             # remove + drop the branch
-gwm prune                                   # clean stale .git/worktrees entries
-gwm completions zsh                         # print a zsh / bash / fish / powershell / elvish script
-gwm shell-init zsh                          # print a `gcd <pattern>` shell wrapper (one-line cd)
-gwm tmux auth                               # open the matched worktree in a new tmux window
-gwm tmux auth -p                            # ...or in a split of the current pane
-gwm zellij auth                             # same, but for zellij — new tab via `--cwd`
-gwm zellij auth -p                          # ...or in a new pane of the current tab
-gwm doctor                                  # diagnose config + env + worktree state (exit 0/1/2)
-gwm link issue 42                           # link an issue to the current worktree
-gwm link pr 61                              # link a PR
-gwm unlink issue                            # remove the issue link (auto-detect resurfaces)
-gwm open issue                              # open the linked issue in the browser
-gwm open pr --print-url                     # print the URL on stdout instead of spawning
-gwm status                                  # show link + live state via `gh`
-gwm status --json                           # machine-readable JSON of the status
-```
-
-### Issue / PR linking ([#67](https://github.com/kbrdn1/gwm-cli/issues/67))
-
-Every worktree can be linked to a GitHub issue and / or pull request:
-
-- Branches following `<type>/#<N>-<slug>` are auto-linked to issue `#N` — zero setup.
-- Explicit overrides land in `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, no extra file).
-- `gwm status` shells out to `gh issue view` / `gh pr view` to fetch the live state, title, labels, and CI rollup. Without `gh` (or outside a GitHub remote), only the local link is shown.
-
-In the TUI:
-
-- `O` — open menu (`i` open issue, `p` open PR) in the browser.
-- `L` — link prompt (`i` issue, `p` pr, then type the number).
-- `R` — refresh the GitHub status (synchronous fetch).
-- The right details panel renders a live block: `Issue #42 [open] TUI: fuzzy search` / `PR #61 [draft] · checks 2/3`.
-
-### multiplexer integration (`gwm tmux` / `gwm zellij`)
-
-Inside an already-running tmux session, `gwm tmux <pattern>` shells out to `tmux new-window -n <name> -c <path>` so the new window's shell lands directly inside the matched worktree. `-p` (or `--split`) swaps the verb for `split-window` — same `-c`, current window's layout. `gwm zellij <pattern>` does the same for zellij via `zellij action new-tab --name <name> --cwd <path>` (or `new-pane --cwd` with `-p`); the `--cwd` flag on `new-tab` needs zellij ≥ 0.40.
-
-Both require the corresponding multiplexer to actually be running (i.e. `$TMUX` / `$ZELLIJ` set in the calling environment). Outside a session the command refuses with a clear error rather than spawning a stray server.
-
-### diagnose your setup
-
-`gwm doctor` runs a series of cheap checks and reports each with `✓ / ! / ✗`, then exits `0` (all green), `1` (any warning), or `2` (any failure) — so it can be wired into CI or a pre-commit hook.
-
-```bash
-$ gwm doctor
-✓ .gwm.toml parses
-    /path/to/repo/.gwm.toml parses cleanly
-✓ guard references resolve
-    2 guard reference(s) resolve
-✓ `when` predicates supported
-    1 predicate(s) recognised
-✓ external binaries on PATH
-    3/3 binaries found
-✓ no prunable worktrees
-    5 worktree(s) tracked, none prunable
-✓ no orphan gwm branches
-    7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
-✓ base directory writable
-    /home/you/cc-worktree/myrepo is writable
-```
-
-If a real orphan (unmerged feature branch with no worktree) or a prunable entry exists, the doctor surfaces them as Warning with a remediation hint:
-
-```bash
-! no prunable worktrees
-    1 prunable entry: feat-12-old
-    → run `gwm prune` to clear them
-! no orphan gwm branches
-    1 unmerged orphan branch(es): feat/#99-wip-experiment
-    → git branch -d feat/#99-wip-experiment
-```
-
-Checks performed:
-
-1. **`.gwm.toml` parses** — Ok if it parses (or absent, defaults assumed); Failed if the TOML is broken.
-2. **guard references resolve** — every `[[bootstrap.copy]].guards = [...]` points at an existing `[[bootstrap.guard]]`.
-3. **`when` predicates supported** — every `[[bootstrap.command]].when` uses one of the known keyword prefixes (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`). Boolean composition via `!`, `&&`, `||` (precedence `!` > `&&` > `||`) is allowed inside the expression.
-4. **external binaries on PATH** — `lazygit` (TUI `l` keybinding), `direnv` (only if `.envrc` exists), and the first executable token of every `[[bootstrap.command]].run`.
-5. **no prunable worktrees** — `.git/worktrees/` entries whose working dir was removed manually.
-6. **no orphan gwm branches** — local branches matching `<type>/#<issue>-<desc>` (created by `gwm create`) with no worktree. User-managed branches (`main`, `release-*`, `dependabot/...`) are ignored.
-7. **base directory writable** — the configured `[worktree].base` exists and is writable, or its parent is (gwm creates the base lazily on first `gwm create`).
-
-### one-line cd into a worktree
-
-The binary itself cannot change the parent shell's directory. `gwm shell-init <shell>` prints a function (`gcd`) that bridges two flows in one wrapper:
-
-- **`gcd <pattern>`** → `gwm cd <pattern>` (fuzzy resolve, exits `0` on a hit, `1` on miss / ambiguous / not in a repo).
-- **`gcd`** (no argument) → `gwm switch` (interactive picker — `Enter` to commit, `Esc` / `Ctrl-C` / `q` to cancel with exit code `1`).
-
-In both cases the wrapper only performs the `cd` after a successful exit code, so a cancelled picker or a missed pattern never strands you in `$HOME`.
-
-`eval` the wrapper in your rc file:
-
-```bash
-# zsh
-echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc
-# bash
-echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
-# fish (also persist by adding to ~/.config/fish/config.fish)
-gwm shell-init fish | source
-# PowerShell (current session)
-Invoke-Expression (& gwm shell-init powershell | Out-String)
-# PowerShell (persist via $PROFILE)
-gwm shell-init powershell | Out-File -Append -Encoding utf8 $PROFILE
-```
-
-Then:
-
-```bash
-gcd auth   # → cd $(gwm cd auth) → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
-gcd        # → cd $(gwm switch)  → opens the picker, cd's into the chosen worktree
-```
-
-### interactive picker (`gwm switch`)
-
-When you can't remember the exact pattern, `gwm switch` opens the worktree TUI in picker mode — same table, fuzzy filter bar pre-open, create / delete / bootstrap disabled. `Enter` confirms the highlighted row and prints its path on stdout; `Esc` / `q` / `Ctrl-C` cancels with exit code `1`.
-
-The recommended invocation is via the `gcd` wrapper from [one-line cd into a worktree](#one-line-cd-into-a-worktree) — bare `gcd` (no argument) routes to `gwm switch` and cd's into the chosen worktree in one keystroke. If you haven't installed the wrapper, the raw form is:
-
-```bash
-cd "$(gwm switch)"   # open picker, type to narrow, Enter to commit
-gwm s                # same, via the alias
-```
-
-### shell completions
-
-`gwm completions <shell>` prints a static completion script (generated from the live clap argument tree, so it never drifts from the actual subcommands). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`.
-
-```bash
-# zsh — drop into the first writable fpath entry
-gwm completions zsh > "${fpath[1]}/_gwm"
-
-# bash — system-wide
-gwm completions bash | sudo tee /etc/bash_completion.d/gwm > /dev/null
-# bash — per-user
-gwm completions bash > ~/.local/share/bash-completion/completions/gwm
-
-# fish
-gwm completions fish > ~/.config/fish/completions/gwm.fish
-
-# PowerShell — load into the current session (ephemeral)
-gwm completions powershell | Out-String | Invoke-Expression
-# PowerShell — persist by appending to $PROFILE
-gwm completions powershell | Out-File -Append -Encoding utf8 $PROFILE
-```
-
-For dynamic completion of worktree names (the `<pattern>` arg of `path` / `remove` / `bootstrap`), wire a custom completer to `gwm list --format=names` — e.g. in zsh:
-
-```zsh
-_gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
-compdef _gwm_worktrees gwm-path gwm-remove gwm-bootstrap
-```
-
-## configuration
-
-`.gwm.toml` at the repo root, see `examples/gwm.toml.example` for the annotated full version.
-
-```toml
-[worktree]
-base         = "{home}/cc-worktree/{repo}"
-path_pattern = "{type}-{issue}-{desc}"
-branch_pattern = "{type}/#{issue}-{desc}"
-
-# file copies main → worktree
-[[bootstrap.copy]]
-from = ".env.testing"
-to   = ".env.testing"
-required = true
-fallback = "inline"
-
-[[bootstrap.copy]]
-from = ".env"
-to   = ".env"
-required = false
-guards = ["no-aws-rds"]
-
-# regex guards on copied files
-[[bootstrap.guard]]
-name = "no-aws-rds"
-deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
-on_match      = "seed-from-example"
-example_file  = ".env.example"
-
-# inline fallback when a required source is missing
-[bootstrap.fallback.env_testing]
-target  = ".env.testing"
-content = """
-APP_ENV=testing
-DB_CONNECTION=sqlite
-DB_DATABASE=:memory:
-"""
-
-# refuse to inherit symlinks (vendor/, node_modules/)
-[[bootstrap.no_symlink]]
-path = "vendor"
-
-# post-copy commands
-[[bootstrap.command]]
-name = "composer install"
-run  = "composer install --no-interaction --prefer-dist"
-when = "file_exists:composer.json"
-env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
-
-# composable when predicates: pick `bun install` if bun is on PATH,
-# fall back to `npm ci` otherwise, and skip the noisy step in CI.
-[[bootstrap.command]]
-name = "install (bun)"
-run  = "bun install"
-when = "file_exists:package.json && cmd_exists:bun"
-
-[[bootstrap.command]]
-name = "install (npm fallback)"
-run  = "npm ci"
-when = "file_exists:package.json && !cmd_exists:bun"
-
-[[bootstrap.command]]
-name = "build docs"
-run  = "./scripts/full-build.sh"
-when = "glob_exists:docs/**/*.md && !env_set:CI"
-```
-
-`when` predicates recognised by the evaluator:
-
-| Predicate                    | True when …                                                  |
-|:-----------------------------|:-------------------------------------------------------------|
-| `file_exists:<path>`         | `<worktree>/<path>` resolves on disk                          |
-| `cmd_exists:<binary>`        | `<binary>` resolves on `$PATH` (`which` lookup)              |
-| `env_set:<NAME>`             | `std::env::var(NAME)` returns `Ok`                            |
-| `env_eq:<NAME>=<value>`      | `NAME` is set and its value matches `<value>` exactly         |
-| `glob_exists:<pattern>`      | at least one path under the worktree matches `<pattern>` (supports `**`) |
-
-Combine atoms with `!` (NOT), `&&` (AND), `||` (OR), conventional precedence `!` > `&&` > `||`. Whitespace around operators is tolerated. Unknown keywords default to `true` so old configs keep running while `gwm doctor` surfaces them.
-
-Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/...`) is also expanded.
-
-### defaults without `.gwm.toml`
-
-| Setting          | Default                          |
-|:-----------------|:---------------------------------|
-| `base`           | `{home}/cc-worktree/{repo}`      |
-| `path_pattern`   | `{type}-{issue}-{desc}`          |
-| `branch_pattern` | `{type}/#{issue}-{desc}`         |
-| bootstrap        | none — just `git worktree add`   |
-
-### supported branch types
-
-`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
-
-## differences vs. the original bash script
-
-| Capability                          | bash + gwq           | gwm                              |
-|:------------------------------------|:---------------------|:---------------------------------|
-| worktree engine                     | `gwq` (CLI external) | `libgit2` (vendored)             |
-| bootstrap                           | hardcoded in bash    | declarative in `.gwm.toml`       |
-| multi-repo portability              | per-project script   | one binary, per-repo config      |
-| TUI                                 | linear bash menu     | full ratatui screen              |
-| anti-RDS guard                      | hardcoded            | configurable regex deny-list     |
-| tests                               | none                 | 190 tests (config / naming / bootstrap / doctor / flake / worktree / TUI / CLI) |
-
-## development
-
-```bash
-cargo build              # debug build
-cargo test               # 190 tests
-cargo fmt && cargo clippy -- -D warnings
-cargo run                # opens TUI in the current repo
-cargo install --path .   # install locally
-```
-
-Nix users can drop into a pinned dev shell — Rust toolchain, `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the libgit2 build deps — without touching the host system:
-
-```bash
-nix develop              # bundled toolchain + LSP + linter + formatter
-```
-
-All tests live under `tests/`:
-
-```
-tests/
-├── common/                       # shared helpers (init_repo, paths_equal)
-├── config_tests.rs               # .gwm.toml parsing + write_default
-├── naming_tests.rs               # kebab, branch validation, parse roundtrip
-├── bootstrap_tests.rs            # copies / guards / no-symlink / commands
-├── bootstrap_when_tests.rs       # `when:` predicate grammar (file/cmd/env/glob + boolean ops)
-├── doctor_tests.rs               # `gwm doctor` checks + severity arithmetic
-├── flake_tests.rs                # Nix flake structure (build, devShell, app)
-├── worktree_integration.rs       # git2 add/list/remove/prune
-├── tui_app_tests.rs              # state transitions (ratatui-free)
-└── cli_binary.rs                 # assert_cmd end-to-end
-```
-
-Sentinel tests (pinned to catch a specific regression) are prefixed with a
-`// regression: <one-line>` tag inside the test body so the target incident
-is discoverable without `git blame`. Suite hygiene was last audited in
-[`claudedocs/test-audit-0.4.0.md`](claudedocs/test-audit-0.4.0.md).
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branch / commit / PR conventions.
-
-## roadmap
-
-The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](ROADMAP.md). Highlights for the next minor:
-
-- Shell completions ([#18](https://github.com/kbrdn1/gwm-cli/issues/18)), `gwm cd` + `shell-init` ([#19](https://github.com/kbrdn1/gwm-cli/issues/19)), `gwm doctor` ([#20](https://github.com/kbrdn1/gwm-cli/issues/20)), TUI fuzzy filter ([#21](https://github.com/kbrdn1/gwm-cli/issues/21)).
-
-Contributions welcome — open a [feature request issue](.github/ISSUE_TEMPLATE/feature_request.yml) or pick an item from [`ROADMAP.md`](ROADMAP.md).
+gwm started as a Rust rewrite of `tools/worktree-manager.sh` — a bash script tied to one team's Laravel stack and one repo's incident history. The Rust version keeps the lessons, makes them configurable per repo, and ships as a single binary so it works in every repo without per-project shell-script copies. Full background under [Development → Contributing → history](docs/6.development/2.contributing.md#history).
 
 ## license
 
@@ -485,9 +68,10 @@ MIT — see [LICENSE.md](LICENSE.md).
 
 ## related docs
 
-- [`CHANGELOG.md`](CHANGELOG.md)
-- [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- [`ROADMAP.md`](ROADMAP.md)
+- [`CHANGELOG.md`](CHANGELOG.md) — release index (root = `[Unreleased]`; per-version archives under [`changelogs/`](changelogs/))
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR conventions
+- [`ROADMAP.md`](ROADMAP.md) — long-form roadmap with grouped categories
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - [`.github/LABELS.md`](.github/LABELS.md)
-- [`examples/gwm.toml.example`](examples/gwm.toml.example)
+- [`examples/gwm.toml.example`](examples/gwm.toml.example) — annotated full config
+- [`skills/SKILL.md`](skills/SKILL.md) — the bundled Claude Code skill manifest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,78 +4,95 @@ This document tracks where `gwm` is heading. It complements [CHANGELOG.md](CHANG
 
 Each item below links to its GitHub issue. The scope, alternatives considered, and acceptance criteria live there — this file is the map, not the spec.
 
-## Current state — v0.2.0
+## Current state — v0.6.0
 
-The 0.2.x line ships:
+The 0.6.x line ships:
 
 - **Native worktree ops via libgit2 (vendored)** — single binary, no `gwq` / `git` CLI dependency.
 - **CLI + ratatui TUI** — `gwm <subcommand>` for scripts, `gwm` alone opens the interactive interface.
-- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
-- **Responsive details sidebar** — auto-shown when terminal width ≥ 120 cols, lazyssh-style with branch / path / head / status / recent commits / working-tree summary / commands cheat-sheet.
-- **Lazygit fullscreen launch** (`l`) — suspends the gwm TUI, runs `lazygit -p <path>`, restores the TUI on exit.
-- **Vim motions** — `gg` / `G` jump to first / last; `Tab` swaps focus between the list and the sidebar.
-- **Release pipeline** — `release.yml` on `vX.Y.Z` tags, `pre-release.yml` on `vX.Y.Z-rc.N` / `-alpha.N` / `-beta.N` tags, 5-target build matrix (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64).
-- **74 tests** across config, naming, bootstrap, worktree (libgit2 integration), TUI state, and CLI end-to-end.
+- **Per-repo `.gwm.toml`** — branch / path conventions, file copies, regex guards (`abort` or `seed-from-example`), shell hooks gated by `when:` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||` composition), no-symlink invariants.
+- **Lazygit-style details sidebar** — four bordered subsections (Worktree / Issue · PR / Working Tree / Recent Commits), status-coloured branch names, header status dot tracking linked PR / issue state, 300-commit Recent Commits buffer with the full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
+- **Configurable launchers** — `[git_tui]` drives `l` (default `lazygit -p {path}`), `[review]` drives `R` (presets: `lumen` / `claude` / `codex` / `aider` / `gh`, plus free-form `command =`). Placeholders `{base} {head} {path} {diff}` with lazy diff materialisation.
+- **GitHub issue / PR linking** — branches matching `<type>/#<N>-<slug>` auto-link to their issue; CLI `link / unlink / open / status` for explicit overrides; live state surfaces in the TUI sidebar via `gh`.
+- **`[tui.open]` dispatch** — `o` key now spawns `$SHELL` in the worktree by default; opt back to OS file manager via `mode = "finder"`.
+- **`y: yank`** — copy the selected worktree's path to the clipboard (pbcopy / wl-copy / xclip / xsel / clip).
+- **Vim motions** — `gg` / `G` jump to first / last; `Tab` swaps focus between the list and the sidebar; `j` / `k` / `↑` / `↓` move selection or scroll the focused panel.
+- **Fuzzy filter (`/`)** — sticky `nucleo-matcher` filter on the worktree list; smart-case, AND on spaces, contiguous beats spread-out; same engine powers `gwm switch` (picker mode), `gwm path / cd / remove / bootstrap` (fuzzy CLI lookup).
+- **One-line `cd`** — `gwm shell-init <shell>` wires up a `gcd <pattern>` (resolve + cd) and bare `gcd` (picker + cd) for zsh / bash / fish / PowerShell.
+- **Shell completions** — `gwm completions <shell>` for zsh / bash / fish / PowerShell / elvish (static script generated from the live clap argument tree).
+- **Multiplexer integration** — `gwm tmux <pattern> [-p]` and `gwm zellij <pattern> [-p]` open the worktree in a new window / pane / tab; refuse to spawn outside an active session.
+- **`gwm doctor`** — 7 checks (parses / guard refs / `when` predicates / external binaries / prunable / orphan branches / base writable), exit codes `0/1/2` for CI.
+- **Confirm-overlay countdown** — safety countdown on the delete-confirm overlay when `p` (delete-branch-on-remove) is armed; duration tunable via `[tui].confirm_countdown_secs` (0..=5, clamped).
+- **Release pipeline** — `release.yml` on `vX.Y.Z` tags, `pre-release.yml` on `-rc.N` / `-alpha.N` / `-beta.N` tags, 5-target build matrix (Linux x86_64 + aarch64, macOS Intel + Apple Silicon, Windows x86_64), automatic Homebrew tap update on stable releases, Nix flake at the repo root.
+- **433 tests** — 15 integration files + colocated unit tests covering config, naming, bootstrap, doctor, github linking, launcher, multiplexer, homebrew formula, pre-commit hook, TUI state, worktree (libgit2 integration), and CLI end-to-end.
 
-See [CHANGELOG.md](CHANGELOG.md#020---2026-05-18) for the full release notes.
+See [`changelogs/0.6.0.md`](changelogs/0.6.0.md) for the full v0.6.0 release notes, and [`changelogs/`](changelogs/) for the per-version archive.
+
+## Shipped — pre-v0.6.0
+
+For reference (each linked to its closing PR):
+
+| Issue | Shipped in | Feature                                                                         |
+|:------|:-----------|:--------------------------------------------------------------------------------|
+| [#18](https://github.com/kbrdn1/gwm-cli/issues/18) | v0.3.0 | Shell completions (zsh / bash / fish / powershell / elvish)                     |
+| [#19](https://github.com/kbrdn1/gwm-cli/issues/19) | v0.3.0 | `gwm cd <pattern>` + `gwm shell-init <shell>` (the `gcd` wrapper)               |
+| [#20](https://github.com/kbrdn1/gwm-cli/issues/20) | v0.3.0 | `gwm doctor` (initial check set)                                                |
+| [#21](https://github.com/kbrdn1/gwm-cli/issues/21) | v0.3.0 | TUI fuzzy filter (`/`)                                                          |
+| [#22](https://github.com/kbrdn1/gwm-cli/issues/22) | v0.4.0 | `gwm switch` (picker UI printing the chosen path on stdout)                     |
+| [#23](https://github.com/kbrdn1/gwm-cli/issues/23) | v0.4.0 | Tmux / Zellij integration (`gwm tmux` / `gwm zellij`)                           |
+| [#25](https://github.com/kbrdn1/gwm-cli/issues/25) | v0.4.0 | Extended `when:` predicates (`cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!` / `&&` / `\|\|`) |
+| [#26](https://github.com/kbrdn1/gwm-cli/issues/26) | v0.5.0 | Homebrew tap (`brew tap kbrdn1/tap && brew install gwm`)                        |
+| [#28](https://github.com/kbrdn1/gwm-cli/issues/28) | v0.5.0 | Nix flake (`nix profile install github:kbrdn1/gwm-cli`)                         |
+| [#30](https://github.com/kbrdn1/gwm-cli/issues/30) | v0.5.0 | TUI confirm-overlay countdown                                                   |
+| [#47](https://github.com/kbrdn1/gwm-cli/issues/47) | v0.5.0 | `gwm doctor`: skip merged gwm-style branches in the orphan check                |
+| [#59](https://github.com/kbrdn1/gwm-cli/issues/59) | v0.5.0 | `[doctor].trunks` config knob                                                   |
+| [#67](https://github.com/kbrdn1/gwm-cli/issues/67) ([PR #68](https://github.com/kbrdn1/gwm-cli/pull/68)) | v0.6.0-rc.1 | Issue / PR linking — CLI + TUI controls, `gh`-backed live status     |
+| [#69](https://github.com/kbrdn1/gwm-cli/issues/69) ([PR #70](https://github.com/kbrdn1/gwm-cli/pull/70)) | v0.6.0 | TUI Details sidebar redesign (four bordered subsections)            |
+| [#71](https://github.com/kbrdn1/gwm-cli/issues/71) ([PR #72](https://github.com/kbrdn1/gwm-cli/pull/72)) | v0.6.0 | TUI Recent Commits panel — lazygit-style layout + full topology renderer |
+| [#73](https://github.com/kbrdn1/gwm-cli/issues/73) ([PR #74](https://github.com/kbrdn1/gwm-cli/pull/74)) | v0.6.0 | Lazygit-style sidebar facelift (`Created` row, status colours, `[tui.open]`, `y: yank`) |
+| [#75](https://github.com/kbrdn1/gwm-cli/issues/75) ([PR #76](https://github.com/kbrdn1/gwm-cli/pull/76)) | v0.6.0 | Configurable launchers (`[git_tui]` + `[review]`) — keymap reshuffle `r/R → f/F`, new `R` |
+| [#77](https://github.com/kbrdn1/gwm-cli/issues/77) | v0.6.0 | Docs restructure into `docs/` tree (Nuxt Content conventions) + README shrunk to landing |
+
+If an issue still shows `open` on GitHub even though its work shipped, it's a tracking issue waiting for a follow-up audit — check the CHANGELOG and the linked PR before reopening scope work on it.
 
 ## Quick wins
 
 Small, well-scoped items with high daily-usage payoff. Likely picks for the next minor.
 
-- [#18](https://github.com/kbrdn1/gwm-cli/issues/18) — **Shell completions** (zsh / bash / fish / powershell) via `clap_complete`, with dynamic completion of worktree names for `gwm path / remove / bootstrap`.
-- [#19](https://github.com/kbrdn1/gwm-cli/issues/19) — **`gwm cd <pattern>` + `gwm shell-init <shell>`** to officialise the `cd "$(gwm path ...)"` workflow as a one-liner sourced from the rc file.
-- [#20](https://github.com/kbrdn1/gwm-cli/issues/20) — **`gwm doctor`** to validate `.gwm.toml`, surface missing dependencies (`lazygit`, `direnv`, command binaries), and catch orphan branches / prunable worktrees.
-- [#21](https://github.com/kbrdn1/gwm-cli/issues/21) — **TUI fuzzy filter** — press `/` in the list view to filter worktrees in real time (already on the README roadmap, lifted into the issue tracker).
-
-## Power user
-
-Workflow accelerators for daily use.
-
-- [#22](https://github.com/kbrdn1/gwm-cli/issues/22) — **`gwm switch`** — a stripped-down picker UI that prints the selected worktree's path on `Enter` (paired with the `gwm cd` flow).
-- [#23](https://github.com/kbrdn1/gwm-cli/issues/23) — **Tmux / Zellij integration** — `gwm tmux <pattern>` / `gwm zellij <pattern>` open the worktree in a new window or pane.
 - [#24](https://github.com/kbrdn1/gwm-cli/issues/24) — **`gwm sync`** — fetch + rebase (or merge) the selected worktree's branch against its upstream, with conflict detection.
-- [#25](https://github.com/kbrdn1/gwm-cli/issues/25) — **Extended bootstrap `when` predicates** — `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `&&` / `||` / `!` composition.
-
-## Distribution
-
-Lower the install friction by meeting users on their preferred channel.
-
-- [#26](https://github.com/kbrdn1/gwm-cli/issues/26) — **Homebrew tap** (`brew tap kbrdn1/tap && brew install gwm`), auto-updated by `release.yml`.
-- [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive.
-- [#28](https://github.com/kbrdn1/gwm-cli/issues/28) — **Nix flake** — `nix profile install github:kbrdn1/gwm-cli` + a `devShell` for contributors.
+- [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive instead of compiling from source.
+- [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — **`--dry-run` on `gwm remove` and `gwm prune`** — show the resolved target / planned actions, no side effects. Pairs nicely with the safety stance of [#29](https://github.com/kbrdn1/gwm-cli/issues/29) below.
 
 ## Safety & UX
 
 Defensive features for a tool that performs destructive operations.
 
-- [#29](https://github.com/kbrdn1/gwm-cli/issues/29) — **`gwm undo` + `gwm history`** — operation journal at `$XDG_DATA_HOME/gwm/history.toml` with branch-OID recovery.
-- [#30](https://github.com/kbrdn1/gwm-cli/issues/30) — **TUI confirm overlay with a countdown** when `delete_branch_on_remove` is armed.
-- [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — **`--dry-run` on `gwm remove` and `gwm prune`** — show the resolved target / planned actions, no side effects.
+- [#29](https://github.com/kbrdn1/gwm-cli/issues/29) — **`gwm undo` + `gwm history`** — operation journal at `$XDG_DATA_HOME/gwm/history.toml` with branch-OID recovery so a fat-finger `gwm remove --delete-branch` is recoverable beyond `git reflog`.
 
 ## TUI polish
 
 Refinements that make the interface more discoverable and customisable.
 
-- [#32](https://github.com/kbrdn1/gwm-cli/issues/32) — **Command palette `:`** — Helix / Vim-style command bar with fuzzy completion across every TUI action.
+- [#32](https://github.com/kbrdn1/gwm-cli/issues/32) — **Command palette `:`** — Helix / Vim-style command bar with fuzzy completion across every TUI action, complementing the existing `?` overlay and `/` filter.
 - [#33](https://github.com/kbrdn1/gwm-cli/issues/33) — **Themes** — configurable colour scheme via `.gwm.toml` `[theme]`, with built-in presets (Catppuccin, Gruvbox, Tokyo Night, Solarized).
-- [#34](https://github.com/kbrdn1/gwm-cli/issues/34) — **Sidebar stash mode** — press `s` to cycle the Details panel between commits-and-status (current) and stashes.
+- [#34](https://github.com/kbrdn1/gwm-cli/issues/34) — **Sidebar stash mode** — press `s` to cycle the Details panel between the current view and a stashes view.
 
 ## Ambitious
 
 Larger investments with strategic payoff. Gated by user demand or a concrete first consumer.
 
-- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — **PTY-embedded lazygit panel** — render lazygit live in a right-hand pane (`portable-pty` + `tui-term`), beside the worktree list and the Details sidebar.
+- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — **PTY-embedded lazygit panel** — render lazygit live in a right-hand pane (`portable-pty` + `tui-term`), beside the worktree list and the Details sidebar. Distinct from the existing `l` launcher: this one would render lazygit **inside** gwm rather than handing the alt-screen over.
 - [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — **Multi-repo workspace mode** — `gwm --workspace ~/Projects` shows worktrees across every child repo in one TUI.
-- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks.
-- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.
+- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks instead of the generic default.
+- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC / gRPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.
 
 ## How to contribute
 
 1. Pick an item that interests you and read its issue for scope details.
 2. Comment on the issue if you intend to work on it (avoids parallel duplication).
-3. Open a PR targeting `dev` following the conventions in [CONTRIBUTING.md](CONTRIBUTING.md) (Gitmoji + Conventional Commits, tests required, never squash).
-4. The issue is the source of truth — this roadmap is updated to reflect what ships in each release.
+3. `gwm create <type> <issue> <slug>` to spin up an isolated worktree (the issue auto-links itself — see [`docs/integrations/github-linking.md`](docs/5.integrations/1.github-linking.md)).
+4. Open a PR targeting `dev` following the conventions in [CONTRIBUTING.md](CONTRIBUTING.md) (Gitmoji + Conventional Commits, tests required, never squash; full docs version at [`docs/development/contributing.md`](docs/6.development/2.contributing.md)).
+5. The issue is the source of truth — this roadmap is updated to reflect what ships in each release.
 
 Items marked `good first issue` (when applicable) are intentionally scoped so a newcomer can land them without a deep dive into the codebase.
 

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,47 @@
+# [0.6.0] - 2026-05-21
+
+Promotes `v0.6.0-rc.1` to stable and bundles four additional feature PRs (#70, #72, #74, #76) merged on `dev` after the RC was cut. The RC's `gh`-linking work and the four new TUI feature PRs ship together under `0.6.0`.
+
+### Added
+
+- **Issue / PR linking** ([#68](https://github.com/kbrdn1/gwm-cli/pull/68), closes [#67](https://github.com/kbrdn1/gwm-cli/issues/67)) — first-class link between a worktree, its branch, and the GitHub issue / pull request it serves. Carried forward from `v0.6.0-rc.1`.
+  - **CLI** — `gwm link {issue|pr} <N>` writes `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, survives worktree moves). `gwm unlink {issue|pr}` removes the explicit override. `gwm open {issue|pr} [--print-url]` spawns the OS opener on the linked URL. `gwm status [--json]` shells out to `gh issue view` / `gh pr view` to fetch state, title, labels, and CI rollup; degrades gracefully to local-link-only output when `gh` is missing.
+  - **TUI** — `O` opens the issue/PR menu, `L` runs a two-stage link prompt (target → digits), `F` refreshes the GitHub status (was `R` pre-#75 — rebound to free `R` for the new review launcher).
+  - **Auto-detect** — branches following the `<type>/#<N>-<slug>` convention derive the issue number automatically.
+- **TUI Details sidebar redesign** ([#69](https://github.com/kbrdn1/gwm-cli/issues/69), PR [#70](https://github.com/kbrdn1/gwm-cli/pull/70)) — the right pane is now four independent rounded-border subsections (`Worktree` / `Issue / PR` / `Working Tree` / `Recent Commits`) instead of one big `Details` block. Section titles live on the block borders so the inline `Basic Settings:` / `Recent commits:` / `Working tree:` content lines are gone. The outer `Details` frame is dropped to reclaim vertical space.
+- **TUI Recent Commits panel — lazygit-style layout** ([#71](https://github.com/kbrdn1/gwm-cli/issues/71), PR [#72](https://github.com/kbrdn1/gwm-cli/pull/72)) — each commit occupies exactly one visual line (was wrapping onto two on long subjects), and the block fills the available height instead of showing a hardcoded 10 entries. Per-row format mirrors lazygit: `<8-char hash>  <author initials>  <node>  <subject>`, where `<node>` is `○` for a normal commit and `◎` for a merge commit. Subjects are hard-clipped at the panel's right edge; a right-aligned footer `<viewport-bottom> of <total>` lives at the bottom of the block. Default buffer is 300 commits (matches lazygit's initial `git log -300`). Includes the full graph topology renderer — vertical pipes `│`, corners `╮ ╭ ╯ ╰`, junctions `┴ ┬`, horizontal strokes `─` — driven by a Rust port of lazygit's `pkg/gui/presentation/graph/` package; linear history collapses to a single `○`-stack column, merges spawn fresh columns to the right, and the algorithm is width-deterministic on the commit list (independent of terminal width).
+- **TUI sidebar lazygit-style facelift** ([#73](https://github.com/kbrdn1/gwm-cli/issues/73), PR [#74](https://github.com/kbrdn1/gwm-cli/pull/74)):
+  - New `Created` row in the Worktree block showing the branch's age in compact relative form (`2d`, `3w`, `1M`, …), colour-coded by freshness (green < 7d, yellow < 30d, dark gray otherwise).
+  - Branch name is now coloured by `BranchStatus` — worst-state wins: dirty → red, ahead/behind → yellow, unpublished → magenta, synced → green, unknown → dark gray. Applies to both the sidebar header and the table `BRANCH` column.
+  - Sidebar header line is now prefixed by a `●` status dot whose colour tracks the linked PR / issue state (open=green, draft=gray, merged=magenta, closed=red); rebuilt fresh every frame so it follows live `gh` fetch state without invalidating the git-preview cache.
+- **`[tui.open]` config section + `OpenTarget` dispatch for the `o` key** (#73). `mode` accepts `"shell"` (default, lazygit-style `$SHELL` in the worktree), `"editor"` (`$EDITOR <path>`), or `"finder"` (pre-#73 OS file manager). `shell_cmd` / `editor_cmd` override the env var when set.
+- **New `y` keybinding** (#73) — yank the selected worktree's path to the system clipboard (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip`). Missing tool surfaces a clear status hint, no crash.
+- **TUI configurable launchers for `l` (git_tui) and `R` (review)** ([#75](https://github.com/kbrdn1/gwm-cli/issues/75), PR [#76](https://github.com/kbrdn1/gwm-cli/pull/76)). Two new `.gwm.toml` sections — `[git_tui]` and `[review]` — drive the worktree-list `l` / `R` keybindings through a shared launcher pipeline (placeholder expansion `{base} {head} {path} {diff}`, `shell-words` split, optional fullscreen suspend-and-resume). `[git_tui]` defaults to `lazygit -p {path}` fullscreen so existing repos see zero behaviour change. `[review]` accepts either a free-form `command = "<shell line>"` or a `tool = "<preset>"` sugar (`lumen`, `claude`, `codex`, `aider`, `gh`). New `branch.<n>.gwm-base` key, set by `gwm create`, anchors the review base-resolution chain (upstream → gwm-base → `[review].default_base` → `dev` → `main`). The `{diff}` placeholder lazily materialises a tempfile holding `git diff {base}..{head}` — only when the template references it.
+
+### Changed
+
+- **TUI keybind reshuffle** (#75): `f` now refreshes the worktree list (was `r`, kept as alias for muscle memory); `F` refreshes the GitHub issue/PR status (was `R` pre-#75); the freed `R` triggers the new review launcher.
+- **Default behaviour of `o:` open changes** (#73). It used to spawn the OS file manager unconditionally; now it spawns `$SHELL` in the worktree by default. Opt back into the old behaviour with `[tui.open] mode = "finder"` in `.gwm.toml`.
+- `gwm doctor` now probes the configured `[review]` and `[git_tui]` binaries against `$PATH` (#75). A missing review tool surfaces as Warning (exit code `1`), never Failed (`2`) — review is opt-in, so a CI pre-commit hook keeps passing when only the local launcher is unavailable.
+- TUI footer / help overlay updated to reflect the new `o:open`, `y:yank`, `l:git_tui`, `R:review`, `f:refresh`, `F:gh` bindings.
+
+### Fixed
+
+- `src/github.rs::trim_git_suffix` (carried forward from `v0.6.0-rc.1`, originally PR #68 Copilot review) — `https://github.com/owner/repo.git/` previously left `.git` in the parsed slug because the trailing `/` made `strip_suffix(".git")` fail. The fix normalises trailing slashes first, then strips the suffix.
+- `src/tui/app.rs` selection-change handling (#68 follow-up) — `next` / `prev` / `first` / `last` / filter typing / `refresh` now re-resolve the cached link & slug. The right-panel Issue/PR block previously showed stale data from the previously selected worktree.
+- `src/tui/app.rs::refresh_github_status` (#68 follow-up) — the status bar no longer claims `"github status refreshed"` when one or both `gh` fetches errored. The new `report_github_refresh_status` helper picks a precise message based on each side's `GitHubFetchState`.
+
+### Removed
+
+- **`Commands:` cheat-sheet from the Details sidebar** (#69) — the 15-line keybindings list duplicated the `?` help overlay and pushed the `Issue / PR` block off-screen on common terminal sizes. Press `?` for the full key map.
+
+### Docs
+
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.7.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
+- `README.md` — new "Issue / PR linking" section (carried forward from `v0.6.0-rc.1`) and updated TUI key map for the new bindings.
+
+### Dependencies
+
+- Add `serde_json = "1"` for parsing `gh` CLI JSON output (carried forward from `v0.6.0-rc.1`).
+- Add `shell-words` and `tempfile` (#75) for launcher placeholder tokenisation and lazy `{diff}` materialisation.
+- Add `which` (#75) for `$PATH` probing of launcher binaries in `gwm doctor`.

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -37,8 +37,9 @@ Promotes `v0.6.0-rc.1` to stable and bundles four additional feature PRs (#70, #
 
 ### Docs
 
-- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
-- `README.md` — new "Issue / PR linking" section (carried forward from `v0.6.0-rc.1`) and updated TUI key map for the new bindings.
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout. Also corrects the launcher concurrency wording (non-fullscreen launchers run **synchronously**, not "in the background" — aligned with the `src/tui/mod.rs::run_launcher` docstring caught by Copilot on PR #76).
+- **User docs restructured into a `docs/` tree** ([#77](https://github.com/kbrdn1/gwm-cli/issues/77)) — the previously-inline README reference (TUI keymap, sidebar, CLI surface, `.gwm.toml` schema, doctor, completions) is migrated into seven structured sections under `docs/` (Getting Started, TUI, CLI, Configuration, Integrations, Development, Roadmap). Pages use Nuxt Content conventions (numeric prefixes for sidebar order, frontmatter title/description), so the tree is ready to drop straight into a future static-site build. The README is reduced to a 77-line landing page that links into `docs/`.
+- `README.md` — shrunk to a landing page (install matrix, 30-second tour, feature bullets, documentation map). The pre-v0.6 reference content moved into `docs/`.
 
 ### Dependencies
 

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -37,7 +37,7 @@ Promotes `v0.6.0-rc.1` to stable and bundles four additional feature PRs (#70, #
 
 ### Docs
 
-- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.7.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
+- **`skills/SKILL.md` refresh** — the bundled `gwm` Skill is updated to match the new `0.6.0` surface: configurable launchers (`[git_tui]` / `[review]`), `[tui.open]` dispatch modes, `y: yank`, the `o` / `f` / `F` / `R` rebind table, and the new sidebar layout.
 - `README.md` — new "Issue / PR linking" section (carried forward from `v0.6.0-rc.1`) and updated TUI key map for the new bindings.
 
 ### Dependencies

--- a/changelogs/pre-releases/0.6.0-rc.1.md
+++ b/changelogs/pre-releases/0.6.0-rc.1.md
@@ -1,0 +1,25 @@
+# [0.6.0-rc.1] - 2026-05-20
+
+Delta against v0.5.0 stable. Merged PRs: #68.
+
+### Added
+
+- **Issue / PR linking** ([#68](https://github.com/kbrdn1/gwm-cli/pull/68), closes [#67](https://github.com/kbrdn1/gwm-cli/issues/67)) — first-class link between a worktree, its branch, and the GitHub issue / pull request it serves. Surfaced via four new CLI subcommands and three new TUI key bindings.
+  - **CLI** — `gwm link {issue|pr} <N>` writes `git config branch.<name>.gwm-issue` / `gwm-pr` (local, per-branch, survives worktree moves). `gwm unlink {issue|pr}` removes the explicit override (branch-name auto-detect resurfaces). `gwm open {issue|pr} [--print-url]` spawns the OS opener on the linked URL (or prints it on stdout for piping). `gwm status [--json]` shells out to `gh issue view` / `gh pr view` to fetch state, title, labels, and CI rollup; degrades gracefully to local-link-only output when `gh` is missing or the remote isn't GitHub.
+  - **TUI** — `O` opens the issue/PR menu, `L` runs a two-stage link prompt (target → digits), `R` refreshes the GitHub status. The right-panel "Details" sidebar gains a live `─── Issue / PR ───` block rendering the state badge (open / closed / draft / merged) and CI check rollup (`checks N/M`).
+  - **Auto-detect** — branches following the `<type>/#<N>-<slug>` convention derive the issue number automatically (zero-conf for the happy path); explicit `gwm link issue <N>` overrides the implicit value.
+
+### Fixed
+
+- `src/github.rs::trim_git_suffix` (#68 Copilot review) — `https://github.com/owner/repo.git/` previously left `.git` in the parsed slug because the trailing `/` made `strip_suffix(".git")` fail. The fix normalises trailing slashes first, then strips the suffix. Two regression tests pin the edge case.
+- `src/tui/app.rs` (#68 Copilot review) — selection changes (`next` / `prev` / `first` / `last` / filter typing / `refresh`) now re-resolve the cached link & slug via `refresh_link()`. The right-panel Issue/PR block previously showed stale data from the previously selected worktree. Six regression tests cover each navigation primitive.
+- `src/tui/app.rs::refresh_github_status` (#68 Copilot review) — the status bar no longer claims `"github status refreshed"` when one or both `gh` fetches errored. The new `report_github_refresh_status` helper picks a precise message based on each side's `GitHubFetchState`: green → "refreshed", issue err only → `"issue fetch failed: <reason>"`, pr err only → `"pr fetch failed: <reason>"`, both → `"issue + pr fetch failed — issue: A · pr: B"`.
+
+### Docs
+
+- `src/github.rs::find_pr_for_branch` (#68 Copilot review) — doc comment said "Returns Ok(Some(N)) if exactly one open PR is found" but the implementation calls `gh pr list … --state all`. Doc now matches the actual behaviour (most-recent PR regardless of state) and steers callers towards `fetch_pr` for state-aware filtering.
+- `README.md` — new "Issue / PR linking" section explaining storage, auto-detect, the four CLI subcommands, and the three TUI key bindings.
+
+### Dependencies
+
+- Add `serde_json = "1"` for parsing `gh` CLI JSON output.

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -1,0 +1,8 @@
+---
+title: Install
+description: Install gwm from source, Homebrew, prebuilt binaries, or a Nix flake.
+---
+
+# Install
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -5,4 +5,65 @@ description: Install gwm from source, Homebrew, prebuilt binaries, or a Nix flak
 
 # Install
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+gwm ships a single self-contained binary. Pick whichever channel fits your workflow — all four produce the same `gwm` executable.
+
+## from source
+
+```bash
+git clone https://github.com/kbrdn1/gwm-cli.git
+cd gwm-cli
+cargo install --path .
+```
+
+The binary lands in `~/.cargo/bin/gwm`. Requires a recent stable Rust toolchain (1.80+).
+
+## via Homebrew (macOS)
+
+```bash
+brew tap kbrdn1/tap
+brew install gwm
+```
+
+The formula lives at [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap) (`Formula/gwm.rb`) and is refreshed automatically on every **stable** release of `gwm-cli` by the `homebrew-tap-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). The canonical formula template is at [`packaging/homebrew/gwm.rb.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/homebrew/gwm.rb.template). Pre-release tags (`-rc.N`, `-alpha.N`, `-beta.N`) are filtered out, so `brew install gwm` always points at a stable build.
+
+## prebuilt binaries
+
+Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries with `.sha256` sidecars for:
+
+- Linux (`x86_64`, `aarch64`)
+- macOS (Intel, Apple Silicon)
+- Windows (`x86_64`)
+
+Drop the binary on your `$PATH`, mark it executable, and you're done.
+
+## via Nix flake
+
+A `flake.nix` lives at the repo root. With flakes enabled:
+
+```bash
+# one-shot run, no clone
+nix run github:kbrdn1/gwm-cli -- list
+
+# install into your profile
+nix profile install github:kbrdn1/gwm-cli
+
+# in a NixOS / nix-darwin config, via the overlay
+nixpkgs.overlays = [ inputs.gwm.overlays.default ];
+environment.systemPackages = [ pkgs.gwm ];
+```
+
+The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
+
+## verify the install
+
+```bash
+gwm --version
+gwm doctor                     # run a battery of sanity checks
+```
+
+If `gwm doctor` returns non-zero, jump to [`gwm doctor`](/integrations/doctor) for the per-check remediation hints.
+
+## next
+
+- [Create your first worktree](/getting-started/first-worktree)
+- [Wire up `gcd` for one-line `cd` into a worktree](/getting-started/shell-init)

--- a/docs/1.getting-started/2.first-worktree.md
+++ b/docs/1.getting-started/2.first-worktree.md
@@ -5,4 +5,71 @@ description: Walkthrough of `gwm create` — branch naming, path layout, and the
 
 # First worktree
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+This page walks through what `gwm create` does end-to-end on a fresh repo: where the worktree lands on disk, how the branch is named, and what the bootstrap pipeline runs (if any).
+
+## the one-line version
+
+```bash
+cd /path/to/your/repo
+gwm create feat 42 user-authentication
+```
+
+This creates:
+
+- A worktree at `~/cc-worktree/<repo>/feat-42-user-authentication`
+- A branch named `feat/#42-user-authentication`
+- A `branch.feat/#42-user-authentication.gwm-base` git config entry, anchoring the [review-base resolution chain](/tui/launchers#base-resolution) at the trunk you branched from
+
+The `gwm create` form is `gwm create <type> <issue> <description>`. Supported `<type>` values are documented in [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#supported-branch-types) — `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build` by default.
+
+## branch and path conventions
+
+The defaults — and how to override them — are TOML-driven:
+
+```toml
+[worktree]
+base           = "{home}/cc-worktree/{repo}"
+path_pattern   = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+```
+
+Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/…`) is also expanded. Override anything in your `.gwm.toml` to match your team's branch convention — see [Configuration → `.gwm.toml` schema](/configuration/gwm-toml).
+
+The `{desc}` slot is **kebab-case normalised** by gwm — `"User Authentication"`, `"user authentication"`, and `"User_Authentication"` all become `user-authentication` on disk and in the branch name. This keeps shell completion and fuzzy lookup deterministic.
+
+## the bootstrap pipeline
+
+If a `.gwm.toml` is present at the repo root, `gwm create` runs its bootstrap pipeline immediately after the `git worktree add`:
+
+1. **Copies** — `[[bootstrap.copy]]` rules duplicate files from the main checkout into the new worktree (e.g. `.env.testing`, `.envrc`, vendored secrets).
+2. **Guards** — `[[bootstrap.guard]]` rules vet each copied file against regex deny-lists. A match triggers either an `abort` (refuse to create the worktree) or `seed-from-example` (substitute a known-good fallback). The original use case was refusing to inherit a `.env` pointing at AWS RDS.
+3. **No-symlink check** — `[[bootstrap.no_symlink]]` rules verify that listed paths (typically `vendor/`, `node_modules/`) are **not** symlinks back into the main checkout, since a stray symlink would silently pollute the main repo's build output.
+4. **Fallback files** — `[bootstrap.fallback.*]` blocks materialise inline contents when a required source file is missing (the `seed-from-example` path).
+5. **Commands** — `[[bootstrap.command]]` shell hooks run last, gated by [`when:` predicates](/configuration/when-predicates) (`file_exists:`, `cmd_exists:`, `env_set:`, …).
+
+The bootstrap report prints inline with `✓` (success), `!` (warning, non-blocking), or `✗` (failure, blocks the worktree) sigils per step — same convention as `gwm doctor`. A `✗` aborts and the worktree is rolled back.
+
+Skip bootstrap entirely with `--no-bootstrap`:
+
+```bash
+gwm create feat 42 foo --no-bootstrap
+```
+
+Re-run it later (e.g. after editing `.gwm.toml`) without recreating the worktree:
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # ...or on a fuzzy-matched name
+```
+
+## what's stored where
+
+- The worktree lives at `<base>/<path_pattern>` — outside the main checkout by default, so it survives `git clean -fdx` and IDE reindex storms on the main tree.
+- The branch is a normal local branch — visible in `git branch`, ignored by no special config.
+- `branch.<name>.gwm-base` records the trunk this branch was cut from. It's used by the [review launcher](/tui/launchers#base-resolution) to compute `git diff base..head` even after the branch's upstream is gone.
+- If you used the auto-link convention (`<type>/#<N>-<slug>`), the GitHub issue link is derived on the fly — no extra config needed. See [Integrations → GitHub issue / PR linking](/integrations/github-linking).
+
+## next
+
+- [Wire up `gcd`](/getting-started/shell-init) so you can `cd` into the new worktree in one keystroke
+- [Tour the TUI](/tui) — bare `gwm` now opens onto your fresh worktree

--- a/docs/1.getting-started/2.first-worktree.md
+++ b/docs/1.getting-started/2.first-worktree.md
@@ -1,0 +1,8 @@
+---
+title: First worktree
+description: Walkthrough of `gwm create` — branch naming, path layout, and the bootstrap pipeline.
+---
+
+# First worktree
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/3.shell-init.md
+++ b/docs/1.getting-started/3.shell-init.md
@@ -1,0 +1,8 @@
+---
+title: Shell init (gcd helper)
+description: Wire up `gwm shell-init` so `gcd <pattern>` and `gcd` (no arg) cd into a worktree in one keystroke.
+---
+
+# Shell init (gcd helper)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/1.getting-started/3.shell-init.md
+++ b/docs/1.getting-started/3.shell-init.md
@@ -3,6 +3,61 @@ title: Shell init (gcd helper)
 description: Wire up `gwm shell-init` so `gcd <pattern>` and `gcd` (no arg) cd into a worktree in one keystroke.
 ---
 
-# Shell init (gcd helper)
+# Shell init (`gcd` helper)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+A binary by itself cannot change the parent shell's current directory — only the shell can. `gwm shell-init <shell>` prints a function (named `gcd`) that bridges two flows into one wrapper:
+
+- `gcd <pattern>` → `gwm cd <pattern>` (fuzzy resolve, exits `0` on a hit, `1` on miss / ambiguous / not in a repo).
+- `gcd` (no argument) → `gwm switch` (interactive picker; `Enter` to commit, `Esc` / `Ctrl-C` / `q` to cancel with exit code `1`).
+
+In both cases the wrapper only performs the `cd` after a successful exit code, so a cancelled picker or a missed pattern never strands you in `$HOME`.
+
+## install
+
+`eval` the wrapper in your shell's rc file:
+
+```bash
+# zsh
+echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc
+
+# bash
+echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
+
+# fish — also persist by adding to ~/.config/fish/config.fish
+gwm shell-init fish | source
+
+# PowerShell — current session only
+Invoke-Expression (& gwm shell-init powershell | Out-String)
+# PowerShell — persist via $PROFILE
+gwm shell-init powershell | Out-File -Append -Encoding utf8 $PROFILE
+```
+
+Open a fresh shell (or `source` the rc file) and `gcd` is on your `$PATH` as a shell function.
+
+## use
+
+```bash
+gcd auth                       # → cd $(gwm cd auth)
+                               #   → e.g. ~/cc-worktree/myrepo/feat-99-user-authentication
+
+gcd                            # → cd $(gwm switch)
+                               #   → opens the picker, cd's into the chosen worktree
+```
+
+The pattern is matched with the same fuzzy engine used by the TUI filter ([nucleo-matcher](https://docs.rs/nucleo-matcher)) — `auth` matches `feat-99-user-authentication`, `mig` matches `chore-12-rails-migration`, etc. Ambiguity (two worktrees match equally well) exits `1` and prints both candidates so the wrapper does not `cd`.
+
+## raw form (no wrapper)
+
+If you don't want to install the wrapper, the raw forms work too:
+
+```bash
+cd "$(gwm cd auth)"            # fuzzy resolve, $(...) captures the path
+cd "$(gwm switch)"             # open picker, type to narrow, Enter to commit
+gwm s                          # alias for `switch`
+```
+
+## related
+
+- [TUI → Fuzzy filter](/tui/filter) — same engine, same matching rules
+- [CLI → Subcommand reference](/cli/reference#cd) — full `gwm cd` and `gwm switch` flags
+- [CLI → Shell completions](/cli/completions) — drop a `_gwm` completer that knows about worktree names

--- a/docs/1.getting-started/index.md
+++ b/docs/1.getting-started/index.md
@@ -1,0 +1,16 @@
+---
+title: Getting Started
+description: Install gwm, create your first worktree, and wire up the one-line cd helper.
+navigation:
+  title: Getting Started
+---
+
+# Getting Started
+
+Three steps to a working gwm setup:
+
+1. **[Install](/getting-started/install)** — from source, Homebrew, prebuilt binary, or a Nix flake.
+2. **[Create your first worktree](/getting-started/first-worktree)** — `gwm create feat 42 user-auth` and what it does.
+3. **[Wire up `gcd`](/getting-started/shell-init)** — one-line `cd` into any worktree from anywhere.
+
+If you've used [`gwq`](https://github.com/d-kuro/gwq) or the in-house `tools/worktree-manager.sh` bash script before, gwm is the Rust-native rewrite — same workflow, configurable per repo, no external CLI dependencies. The conceptual [differences vs. the bash script](/development#vs-bash-script) live in the development section.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -5,4 +5,85 @@ description: Every key the TUI listens to — list, sidebar, filter, confirm ove
 
 # Keybindings
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The full key map for `gwm`'s ratatui interface. Press `?` at any time for the same table as an in-app overlay.
+
+## list view (default)
+
+| Key         | Action                                                                                            |
+|:------------|:--------------------------------------------------------------------------------------------------|
+| `↑` / `k`   | previous worktree (scrolls the sidebar when it has focus)                                         |
+| `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                                             |
+| `gg`        | jump to the first worktree                                                                        |
+| `G`         | jump to the last worktree                                                                         |
+| `n`         | new worktree (form: type → issue → description)                                                   |
+| `d`         | delete selected (confirm `y` · countdown when `p` is armed — see [confirm-overlay](/tui/confirm-countdown)) |
+| `b`         | re-run bootstrap on the selected worktree                                                         |
+| `o`         | open the worktree per [`[tui.open]`](/tui/open-dispatch) — `shell` (default) / `editor` / `finder` |
+| `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
+| `l`         | launch the configured [`[git_tui]`](/tui/launchers) command (default `lazygit -p {path}`, fullscreen) |
+| `R`         | launch the configured [`[review]`](/tui/launchers) command — AI / web reviewer over `git diff base..head` |
+| `O`         | open menu for the linked issue / PR (`i` issue, `p` pr → spawns browser)                          |
+| `L`         | link prompt — type `i` or `p`, then digits, to attach an issue / PR                               |
+| `F`         | refresh the GitHub issue / PR status (synchronous `gh` fetch)                                     |
+| `f`         | refresh the worktree list (alias: `r`)                                                            |
+| `v`         | toggle the details sidebar (auto-hidden when terminal width < 120 cols)                           |
+| `Tab`       | swap focus between the worktree list and the sidebar                                              |
+| `/`         | open the [fuzzy filter](/tui/filter) bar (`Enter` confirms · `Esc` clears)                        |
+| `p`         | toggle "delete branch on remove"                                                                  |
+| `Enter`     | show selected path in status bar                                                                  |
+| `?`         | help overlay                                                                                      |
+| `q`         | quit                                                                                              |
+| `Esc`       | clear a sticky filter if any, otherwise quit                                                      |
+
+## confirm-delete overlay
+
+| Key                  | Action                                                                          |
+|:---------------------|:--------------------------------------------------------------------------------|
+| `y` / `Enter`        | confirm (classic) or arm the countdown (when `p` is armed — see [countdown](/tui/confirm-countdown)) |
+| `y` / `Enter` again  | during an armed countdown, **disarms** it without firing                        |
+| `n` / `Esc`          | cancel                                                                          |
+
+## create overlay
+
+| Key                       | Action                                                  |
+|:--------------------------|:--------------------------------------------------------|
+| `Tab` / `↓`               | next field                                              |
+| `Shift+Tab` / `↑`         | previous field                                          |
+| `Enter` (on last field)   | submit and bootstrap                                    |
+| `Esc`                     | cancel                                                  |
+
+## issue / PR link prompt (`L`)
+
+| Stage              | Key       | Action                            |
+|:-------------------|:----------|:----------------------------------|
+| target choice      | `i`       | link an issue                     |
+| target choice      | `p`       | link a PR                         |
+| number input       | digits    | type the issue / PR number        |
+| number input       | `Enter`   | commit the link                   |
+| any stage          | `Esc`     | cancel                            |
+
+## issue / PR open menu (`O`)
+
+| Key       | Action                                |
+|:----------|:--------------------------------------|
+| `i`       | open the linked issue in the browser  |
+| `p`       | open the linked PR in the browser     |
+| `Esc` / `q` | dismiss                             |
+
+## help overlay (`?`)
+
+| Key                          | Action               |
+|:-----------------------------|:---------------------|
+| `Esc` / `q` / `?` / `Enter`  | dismiss              |
+
+## v0.6 rebind summary
+
+Three keys moved when [#75 (configurable launchers)](https://github.com/kbrdn1/gwm-cli/issues/75) landed. Update muscle memory accordingly:
+
+| Pre-v0.6 | v0.6+ | Why                                                                                       |
+|:---------|:------|:------------------------------------------------------------------------------------------|
+| `r`      | `f`   | `r` kept as **alias** for muscle memory, but the documented mnemonic is now `f`           |
+| `R`      | `F`   | freed `R` for the new review launcher; `F` does the GitHub refresh `R` used to do         |
+| _(none)_ | `R`   | launch the configured `[review]` command (lumen / claude / codex / aider / gh / custom)   |
+
+If you wired any of these into a custom script (unlikely — they're TUI-only), nothing breaks; this is purely about the in-app overlay.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -1,0 +1,8 @@
+---
+title: Keybindings
+description: Every key the TUI listens to — list, sidebar, filter, confirm overlay, link prompts.
+---
+
+# Keybindings
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -5,4 +5,90 @@ description: The four-bordered subsection layout on the right pane — Worktree 
 
 # Details sidebar
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+When the terminal is at least **120 columns wide** and the sidebar is enabled (default ON, toggle with `v`), the right pane shows a lazygit-style details panel for the currently selected worktree.
+
+The pane is composed of **four independent rounded-border subsections** — section titles live on the borders themselves, so there are no inline `Basic Settings:` / `Recent commits:` lines anymore. Press `Tab` to focus the sidebar; `j` / `k` (or arrow keys) then scroll it instead of moving the worktree selection. The focused panel's border turns cyan.
+
+## header
+
+```
+● <worktree-name>
+```
+
+- The `●` colour tracks the linked PR / issue state:
+  - **green** — open
+  - **gray** — draft
+  - **magenta** — merged
+  - **red** — closed
+  - **darkgray** — nothing linked / unknown
+- The worktree name itself is coloured by `BranchStatus` (worst-state wins):
+  - **red** — dirty (uncommitted changes)
+  - **yellow** — ahead / behind upstream
+  - **magenta** — unpublished (no upstream)
+  - **green** — synced
+  - **darkgray** — unknown
+
+The same colour is applied to the `BRANCH` column in the worktree table, so the header and the table stay visually in sync.
+
+## `Worktree` block
+
+The first block holds the worktree-level facts:
+
+- `branch` — coloured by status (same scheme as the header)
+- `path` — the absolute path on disk (tilde-compressed)
+- `head` — short OID of the current commit
+- **`Created`** — branch age in compact relative form (`2d`, `3w`, `1M`), colour-coded by freshness: **green** < 7d, **yellow** < 30d, **darkgray** otherwise. Added by [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+- flags — `main`, `locked`, `prunable`, etc.
+- `branch status` — the textual long form of the column shown in the table (`clean`, `dirty (N files)`, `↑N ↓M`, `unpublished`, …)
+
+## `Issue / PR` block
+
+Hidden when nothing is linked to the selected worktree. Otherwise renders one or two live lines fetched via `gh`:
+
+```
+Issue #42 [open] TUI: fuzzy search
+PR #61 [draft] · checks 2/3
+```
+
+- The bracketed state is `gh`'s view (`open` / `closed` / `merged` / `draft`).
+- The trailing `· checks 2/3` only shows up for PRs and reflects the rollup of required GitHub check runs.
+- Refresh on demand with the `F` key — the fetch is **synchronous** and updates the status bar with success / per-fetch error detail.
+
+The block is auto-rebuilt every selection change, so it never shows stale data from a previously selected worktree. See [GitHub issue / PR linking](/integrations/github-linking) for the linking model.
+
+## `Working Tree` block
+
+The `git status --short` output for the selected worktree:
+
+```
+M  src/tui/app.rs
+?? docs/
+```
+
+Empty checkout renders as `✓ clean`.
+
+## `Recent Commits` block
+
+A lazygit-style commit graph that fills the available height. Added by [#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72) and finished in [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+
+Per-row format:
+
+```
+<8-char hash>  <author initials>  <node>  <subject>
+```
+
+- `<node>` is `○` for a normal commit, `◎` for a merge commit.
+- Subjects are **hard-clipped at the panel's right edge** — no wrapping, exactly one visual line per commit.
+- A right-aligned footer `<viewport-bottom> of <total>` lives at the bottom of the block.
+- Default buffer is **300 commits** (matches lazygit's `git log -300`).
+
+The full topology renderer draws the diverging branches with `│` (vertical pipe), `╮ ╭ ╯ ╰` (corners), `┴ ┬` (junctions), `─` (horizontal stroke). Linear history collapses to a single `○`-stack column; merges spawn fresh columns to the right. The algorithm is width-deterministic on the commit list — the same input always produces the same output regardless of terminal width.
+
+The pre-v0.6 `Commands` cheat-sheet block was dropped — press `?` for the full key map overlay instead. The 15-line block duplicated the `?` overlay and pushed the `Issue / PR` block off-screen on common terminal sizes.
+
+## focus and scrolling
+
+- Hit `Tab` to move focus into the sidebar. The currently focused panel's border switches to cyan.
+- With the sidebar focused, `j` / `k` (or arrow keys) scroll its content — useful for long `Recent Commits` lists.
+- Hit `Tab` again to return focus to the worktree list.
+- `v` toggles the entire sidebar on/off (useful when the terminal is narrow but ≥ 120 cols, or when you need maximum table width).

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -1,0 +1,8 @@
+---
+title: Details sidebar
+description: The four-bordered subsection layout on the right pane — Worktree / Issue · PR / Working Tree / Recent Commits.
+---
+
+# Details sidebar
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/3.filter.md
+++ b/docs/2.tui/3.filter.md
@@ -5,4 +5,42 @@ description: The `/` filter bar — nucleo-matcher, sticky filters, Esc semantic
 
 # Fuzzy filter
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Press `/` to open an inline filter bar at the bottom of the worktree table. As you type, the table narrows in real time using [`nucleo-matcher`](https://docs.rs/nucleo-matcher) — the same fuzzy engine used by Helix and Zellij. Matches are ranked by how tight the hit is (contiguous substring beats spread-out subsequence), so the most likely candidate sits on top.
+
+## flow
+
+```
+/                            → filter bar opens
+auth                         → table now shows feat-99-user-authentication only
+<Enter>                       → filter sticks, navigation back on the table
+<Esc>                         → clears filter, full list back
+```
+
+## sticky filters
+
+The filter is sticky between `Enter` and `Esc`:
+
+- `j` / `k` / `gg` / `G` continue to work on the **filtered subset** — selection stays inside the visible rows.
+- The table title shows `worktrees (N/M)` (visible / total) so you always know how much is hidden.
+- Hit `/` again to re-open the bar and **refine** the existing query — the bar pre-fills with the current filter.
+- `Esc` from the list view clears the sticky filter before it considers quitting, so you cannot accidentally quit when you meant to drop the filter.
+
+## matching rules
+
+`nucleo-matcher` is a smart-case subsequence matcher:
+
+- All lowercase query → case-insensitive (`auth` matches `Authentication`)
+- Mixed-case query → case-sensitive (`Auth` only matches `Auth…`)
+- Spaces in the query are **AND** separators (`mig db` matches `chore-12-db-migration` because both `mig` and `db` are present, in any order)
+- Contiguous substrings score higher than spread-out subsequences (`auth` beats `aXuXtXh`)
+
+The matcher works on the worktree name (path basename), not on the branch name. If your branch convention is `<type>/#<N>-<slug>` and `[worktree].path_pattern = "{type}-{issue}-{desc}"` (the default), they're equivalent.
+
+## picker mode
+
+When you launch `gwm switch` (or hit bare `gcd` with the [shell-init helper](/getting-started/shell-init) installed), the same filter bar opens **immediately** at startup — the picker is the filter view by default. Create / delete / bootstrap keys are disabled in picker mode; `Enter` confirms the highlighted row and prints its path on stdout, `Esc` / `q` / `Ctrl-C` cancels with exit code `1`.
+
+## related
+
+- [Keybindings → list view](/tui/keybindings#list-view-default) — every key the filter view listens to
+- [Getting Started → Shell init](/getting-started/shell-init) — wire up `gcd` for one-keystroke worktree jumping

--- a/docs/2.tui/3.filter.md
+++ b/docs/2.tui/3.filter.md
@@ -1,0 +1,8 @@
+---
+title: Fuzzy filter
+description: The `/` filter bar — nucleo-matcher, sticky filters, Esc semantics.
+---
+
+# Fuzzy filter
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/4.confirm-countdown.md
+++ b/docs/2.tui/4.confirm-countdown.md
@@ -5,4 +5,47 @@ description: The safety countdown that gates branch deletion when `p` is armed.
 
 # Confirm-overlay countdown
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#30](https://github.com/kbrdn1/gwm-cli/issues/30).
+
+The `d` confirm overlay has two modes, picked automatically based on whether `p` (toggle "delete branch on remove") was pressed earlier in the session.
+
+## classic mode — `delete branch on remove` OFF
+
+Single keystroke:
+
+- `y` / `Enter` → fires the delete immediately.
+- `n` / `Esc` → cancels.
+
+Same as the pre-#30 behaviour. Removing a worktree without dropping its branch is cheap (just an entry in `.git/worktrees/`) and the branch survives, so there's nothing to safeguard against.
+
+## countdown mode — `delete branch on remove` ON
+
+When `p` is armed, the overlay shows the branch about to disappear plus a two-stage `arm` step:
+
+1. `y` / `Enter` → **arms** a safety countdown (default 3s, visualised by a progress bar).
+2. The actual delete fires once the bar fills.
+3. `y` / `Enter` again **during** the countdown disarms it without firing.
+4. `Esc` / `n` cancels at any time, armed or not.
+
+The reasoning: dropping a branch is **destructive** (the branch is gone from `git branch`, only `git reflog` can resurrect it). The countdown forces a sub-second pause where you can change your mind, especially useful when muscle memory says `dyy` and you didn't notice `p` was still armed from earlier in the session.
+
+## configuration
+
+The countdown duration is configurable via `[tui].confirm_countdown_secs` in `.gwm.toml`. Accepted range: `0..=5`.
+
+```toml
+[tui]
+# 3s default. Set to 0 to disable the countdown (classic modal even when p is armed).
+confirm_countdown_secs = 3
+```
+
+- `0` → keeps the classic single-keystroke modal even when `delete branch on remove` is armed.
+- `1..=5` → the visualised countdown length, in seconds.
+- Values above `5` are silently clamped to `5` on read.
+
+See [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#tui) for the full `[tui]` block.
+
+## related
+
+- [Keybindings → confirm-delete overlay](/tui/keybindings#confirm-delete-overlay) — the keys this page describes
+- [CLI → `gwm remove`](/cli/reference#remove) — same destructive action, but from the CLI (no countdown; the flag is `--delete-branch` explicit)

--- a/docs/2.tui/4.confirm-countdown.md
+++ b/docs/2.tui/4.confirm-countdown.md
@@ -1,0 +1,8 @@
+---
+title: Confirm-overlay countdown
+description: The safety countdown that gates branch deletion when `p` is armed.
+---
+
+# Confirm-overlay countdown
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/5.launchers.md
+++ b/docs/2.tui/5.launchers.md
@@ -3,6 +3,121 @@ title: Configurable launchers (l and R)
 description: `[git_tui]` and `[review]` sections — placeholder expansion, fullscreen semantics, base resolution chain.
 ---
 
-# Configurable launchers (l and R)
+# Configurable launchers (`l` and `R`)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [#76](https://github.com/kbrdn1/gwm-cli/pull/76).
+
+Two TUI keybindings — `l` (git TUI launcher) and `R` (review launcher) — are driven by user-configurable `.gwm.toml` sections sharing the same mini-API. Both take a `command` template string, substitute placeholders, split with [`shell-words`](https://docs.rs/shell-words), and exec the result with `cwd = worktree.path`.
+
+## the shared pipeline
+
+| Step | What happens                                                                                       |
+|:-----|:---------------------------------------------------------------------------------------------------|
+| 1    | Read the `[git_tui]` or `[review]` section from `.gwm.toml` (defaults below).                       |
+| 2    | Resolve placeholders: `{path}`, `{base}`, `{head}`, `{diff}`.                                       |
+| 3    | Split the result into `argv` with `shell-words` (handles quoting like a POSIX shell).                |
+| 4    | Probe `argv[0]` against `$PATH`. Missing binary → status-bar error, no spawn, no flicker.            |
+| 5    | If `fullscreen = true` → suspend the TUI (raw mode off, alt-screen left), spawn `Command::status()`, restore on exit. |
+| 6    | If `fullscreen = false` → keep the TUI in the alt-screen, spawn `Command::output()`, **block** until exit, drop the first line of stderr on the status bar. |
+
+The `{diff}` placeholder is **lazy** — gwm only materialises a tempfile holding `git diff {base}..{head}` when the template references `{diff}`. The tempfile's lifetime is bound to the spawned process (its `Drop` impl unlinks on completion), so the reviewer always sees a consistent snapshot.
+
+> **`fullscreen = false` is synchronous.** The TUI is **unresponsive** until the child process exits — `Command::output()` waits for it. Fine for quick print-only tools (`claude --print`, `gh pr view --web`); pick `fullscreen = true` for anything long-running so the TUI is properly suspended and your terminal stays usable.
+
+## `[git_tui]` — bound to `l`
+
+Default: `lazygit -p {path}`, fullscreen.
+
+```toml
+[git_tui]
+# command template (single placeholder: {path}). Pre-v0.6 behaviour
+# is the default — your existing configs see zero change.
+command = "lazygit -p {path}"
+
+# suspend the TUI for the call (recommended for TUIs that own the alt-screen)
+fullscreen = true
+```
+
+Examples — any tool that takes a worktree path works:
+
+```toml
+[git_tui]
+command = "gitui -d {path}"        # gitui
+
+[git_tui]
+command = "tig --all"              # tig (run inside the worktree)
+fullscreen = true
+
+[git_tui]
+command = "code -n {path}"         # VS Code in a new window
+fullscreen = false                  # IDE forks, don't suspend
+```
+
+## `[review]` — bound to `R`
+
+No default — `R` is inert until configured.
+
+Two equivalent ways to configure it:
+
+### a) free-form `command` (full control)
+
+```toml
+[review]
+command = "claude --print 'review the diff {base}..{head}'"
+fullscreen = false
+default_base = "main"               # optional, see "base resolution chain" below
+```
+
+### b) `tool = "<preset>"` (sugar)
+
+```toml
+[review]
+tool = "lumen"                      # shorthand for the table below
+```
+
+| Preset    | Expanded `command`                                       | `fullscreen` |
+|:----------|:---------------------------------------------------------|:-------------|
+| `lumen`   | `lumen diff {base}..{head}`                              | `true`       |
+| `claude`  | `claude --print 'review the diff {base}..{head}'`        | `false`      |
+| `codex`   | `codex review {base}..{head}`                            | `false`      |
+| `aider`   | `aider --message 'review {base}..{head}'`                | `true`       |
+| `gh`      | `gh pr view --web`                                       | `false`      |
+
+If both `command` and `tool` are set in the same block, `command` wins and the TUI shows a one-shot warning at startup ("your `tool = X` is shadowed by `command`") so you notice the dead config.
+
+## placeholders
+
+| Placeholder | Available in       | Expanded to                                                                          |
+|:------------|:-------------------|:-------------------------------------------------------------------------------------|
+| `{path}`    | both               | absolute path of the selected worktree                                               |
+| `{base}`    | `[review]` only    | result of the [base resolution chain](#base-resolution)                              |
+| `{head}`    | `[review]` only    | the current branch name (`branch.<name>` in git config)                              |
+| `{diff}`    | `[review]` only    | absolute path of a tempfile holding `git diff {base}..{head}` (lazy — see above)    |
+
+Referencing `{diff}` in a `[git_tui]` template is a config error caught at load time (the git TUI launcher doesn't carry the repo handle needed to materialise the diff).
+
+## base resolution
+
+The `{base}` placeholder follows this chain — first non-empty hit wins:
+
+1. **`branch.<name>.merge`** — the branch's upstream tracking ref, if any.
+2. **`branch.<name>.gwm-base`** — set automatically by `gwm create` so the original parent stays recoverable even when the upstream is dropped.
+3. **`[review].default_base`** — the user-configured fallback in `.gwm.toml`.
+4. **`dev`** — gwm's project convention (only if `dev` exists locally).
+5. **`main`** — universal git default (final sentinel — guaranteed non-empty).
+
+The chain is implemented in [`src/launcher.rs::resolve_review_base`](https://github.com/kbrdn1/gwm-cli/blob/main/src/launcher.rs#L167-L187). The fallback prefers `dev` only when it exists locally — returning `dev` blindly when the repo only has `main` would make the launcher's subsequent `git rev-list` / `git diff` calls fail loudly (caught by Copilot's review on PR #76).
+
+## interaction with `gwm doctor`
+
+`gwm doctor` (post-v0.6) probes the resolved `[git_tui]` and `[review]` binaries against `$PATH`:
+
+- Missing **git TUI** binary → **Failed** (exit code `2`) — `l` is a documented core keybinding.
+- Missing **review** binary → **Warning** (exit code `1`) — review is opt-in; a CI pre-commit hook keeps passing when only the local launcher is unavailable.
+
+See [Integrations → `gwm doctor`](/integrations/doctor) for the full check breakdown.
+
+## related
+
+- [Keybindings](/tui/keybindings) — where `l` and `R` live in the key map, plus the v0.6 rebind summary
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#git_tui-and-review) — full field listing with types and defaults

--- a/docs/2.tui/5.launchers.md
+++ b/docs/2.tui/5.launchers.md
@@ -1,0 +1,8 @@
+---
+title: Configurable launchers (l and R)
+description: `[git_tui]` and `[review]` sections — placeholder expansion, fullscreen semantics, base resolution chain.
+---
+
+# Configurable launchers (l and R)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/6.open-dispatch.md
+++ b/docs/2.tui/6.open-dispatch.md
@@ -3,6 +3,70 @@ title: Open dispatch (o)
 description: `[tui.open]` controls what `o` does — shell, editor, or finder.
 ---
 
-# Open dispatch (o)
+# Open dispatch (`o`)
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).
+
+The `o` key dispatches on the `[tui.open]` section in `.gwm.toml`. Three modes are supported.
+
+## configuration
+
+```toml
+[tui.open]
+mode = "shell"          # "shell" (default) | "editor" | "finder"
+shell_cmd = ""           # override $SHELL; empty = use $SHELL
+editor_cmd = "hx"        # override $EDITOR; empty = use $EDITOR
+```
+
+Unknown `mode` values are a **hard config error at load time**, surfaced before the TUI opens — no silent fallback. The error names the file, the line, and the supported values, so the fix is one keystroke.
+
+## modes
+
+### `shell` (default — changed in v0.6)
+
+Suspend the TUI and spawn `$SHELL` (or `shell_cmd` if set) with `cwd` set to the worktree — same lifecycle as the `l: git_tui` launcher. When you exit the shell, the gwm TUI restores exactly where you left it.
+
+```
+o   →   $SHELL    inside /Users/you/cc-worktree/myrepo/feat-42-user-auth
+exit→   gwm TUI restored
+```
+
+This is the lazygit-style flow — drop into a shell, run whatever, come back to the TUI without losing selection or filter state.
+
+### `editor`
+
+Suspend the TUI and run `$EDITOR <worktree-path>` (or `editor_cmd <worktree-path>` if set). Useful for terminal editors that own the alt-screen (helix, nvim, micro):
+
+```toml
+[tui.open]
+mode = "editor"
+editor_cmd = "hx"        # override $EDITOR for this repo
+```
+
+For GUI editors that fork off the terminal, prefer `mode = "shell"` with a custom `shell_cmd` that launches the editor — that way the TUI doesn't suspend uselessly while the GUI runs.
+
+### `finder` — pre-v0.6 behaviour
+
+Hand off to the OS file manager **without** suspending the TUI:
+
+- macOS: `open <path>`
+- Linux: `xdg-open <path>`
+- Windows: `explorer <path>`
+
+This is the pre-v0.6 default; opt back in with `mode = "finder"`. Useful when the worktree carries binary assets you actually want to inspect in the OS file picker.
+
+## why the default changed
+
+The pre-v0.6 `o` opened the OS file manager unconditionally, but the most common follow-up was "now I want a shell here" — so most users ended up either ignoring `o` entirely or wiring it through a `yank-path-and-cd` workaround. v0.6 makes the common case the default.
+
+Existing users see a one-line behaviour change. Opt back into the old flow with two lines in `.gwm.toml`:
+
+```toml
+[tui.open]
+mode = "finder"
+```
+
+## related
+
+- [Keybindings](/tui/keybindings) — where `o` and `y` (yank to clipboard) live in the key map
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml#tui-open) — full `[tui.open]` field list

--- a/docs/2.tui/6.open-dispatch.md
+++ b/docs/2.tui/6.open-dispatch.md
@@ -1,0 +1,8 @@
+---
+title: Open dispatch (o)
+description: `[tui.open]` controls what `o` does — shell, editor, or finder.
+---
+
+# Open dispatch (o)
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/2.tui/index.md
+++ b/docs/2.tui/index.md
@@ -1,0 +1,19 @@
+---
+title: TUI
+description: The ratatui interface — keybindings, sidebar layout, configurable launchers, fuzzy filter, and confirm-overlay countdown.
+navigation:
+  title: TUI
+---
+
+# TUI
+
+Bare `gwm` (no arguments) opens the ratatui interface on the current repo. From there you can create, delete, bootstrap, and jump between worktrees without leaving the terminal.
+
+- **[Keybindings](/tui/keybindings)** — the full key map, including the v0.6 additions (`R`, `F`, `O`, `L`, `f`, `y`).
+- **[Details sidebar](/tui/sidebar)** — the four-bordered subsections on the right pane, the lazygit-style commit graph, the live Issue / PR block.
+- **[Fuzzy filter](/tui/filter)** — `/` opens the inline filter bar; nucleo-matcher under the hood.
+- **[Confirm-overlay countdown](/tui/confirm-countdown)** — the safety countdown that prevents accidental branch deletions when `p` is armed.
+- **[Configurable launchers](/tui/launchers)** — `[git_tui]` (`l`) and `[review]` (`R`), with `{base} {head} {path} {diff}` placeholders.
+- **[Open dispatch](/tui/open-dispatch)** — `[tui.open]` controls what `o` does (`shell` / `editor` / `finder`).
+
+The picker variant (`gwm switch`, alias `gwm s`) reuses the same TUI but disables create / delete / bootstrap, then prints the chosen worktree's path on stdout — meant to be `eval`d by the `gcd` shell wrapper.

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -1,0 +1,8 @@
+---
+title: Subcommand reference
+description: Every `gwm` subcommand with synopsis, flags, exit codes, and examples.
+---
+
+# Subcommand reference
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -5,4 +5,198 @@ description: Every `gwm` subcommand with synopsis, flags, exit codes, and exampl
 
 # Subcommand reference
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm <subcommand>` is the scriptable face of gwm. Every command exits with a meaningful code (`0` ok, `1` warning, `2` failure) so you can wire `gwm doctor` into CI without parsing stdout.
+
+Bare `gwm` (no subcommand) opens the [TUI](/tui) on the current repo.
+
+## `gwm init`
+
+Write a default `.gwm.toml` to the current repo.
+
+```bash
+gwm init
+# → wrote /path/to/repo/.gwm.toml
+```
+
+Refuses to overwrite an existing `.gwm.toml`. Tweak the generated file and re-run `gwm doctor` to validate.
+
+## `gwm types`
+
+List the supported branch types (the `<type>` slot of `gwm create`).
+
+```bash
+gwm types
+# → feat
+#   fix
+#   hotfix
+#   docs
+#   …
+```
+
+Override per repo via `[worktree].branch_types` in `.gwm.toml`.
+
+## `gwm create <type> <issue> <desc>`
+
+Create a worktree and matching branch.
+
+```bash
+gwm create feat 123 user-authentication
+#   → branch feat/#123-user-authentication
+#   → worktree ~/cc-worktree/<repo>/feat-123-user-authentication
+
+gwm create feat 123 foo --no-bootstrap     # skip the bootstrap pipeline
+```
+
+| Flag             | Action                                                              |
+|:-----------------|:--------------------------------------------------------------------|
+| `--no-bootstrap` | Skip the `.gwm.toml` bootstrap stages (copies / guards / commands)  |
+
+End-to-end walkthrough lives in [Getting Started → First worktree](/getting-started/first-worktree).
+
+## `gwm list [--format=table|names]`
+
+List the worktrees in the current repo.
+
+```bash
+gwm list                       # human-readable table
+gwm list --format=names        # one worktree name per line (for shell completion)
+```
+
+The `names` format excludes the main workdir — `gwm path / remove / bootstrap` never accept it as a target, so emitting it as a completion candidate would be misleading.
+
+## `gwm path <pattern>` (alias: `gwm cd <pattern>`)
+
+Print the on-disk path of a worktree matching `<pattern>` (fuzzy). Use with `$(...)` to `cd`:
+
+```bash
+cd "$(gwm path auth)"
+cd "$(gwm cd auth)"            # same — framing for the cd flow
+```
+
+Both forms share semantics: fuzzy resolve, exit `0` on a unique hit, `1` on miss / ambiguous / not in a repo. Pair with `gwm shell-init` for the `gcd` one-liner — see [Getting Started → Shell init](/getting-started/shell-init).
+
+## `gwm switch` (alias: `gwm s`)
+
+Open the TUI in **picker mode** — same table as bare `gwm`, fuzzy filter bar pre-open, create / delete / bootstrap disabled. Press `Enter` to print the highlighted worktree's path on stdout, `Esc` / `q` / `Ctrl-C` to cancel with exit code `1`.
+
+```bash
+cd "$(gwm switch)"             # open picker, type to narrow, Enter to commit
+gcd                            # same, via the `gwm shell-init` wrapper
+```
+
+## `gwm bootstrap [<pattern>]`
+
+Re-run the `.gwm.toml` bootstrap pipeline on a worktree without recreating it.
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # on a fuzzy-matched name
+```
+
+Useful after editing `.gwm.toml` or adding new `[[bootstrap.copy]]` rules. Same `✓ / ! / ✗` report as `gwm create`.
+
+## `gwm remove <pattern> [--delete-branch]`
+
+Remove a worktree by fuzzy match. The branch survives by default.
+
+```bash
+gwm remove auth                            # remove the worktree, keep the branch
+gwm remove auth --delete-branch            # remove the worktree AND drop the branch
+```
+
+The CLI form has no countdown (the TUI's [`d` confirm-overlay countdown](/tui/confirm-countdown) is TUI-only). `--delete-branch` is destructive — only `git reflog` can resurrect a dropped branch.
+
+## `gwm prune`
+
+Clear stale entries in `.git/worktrees/` whose working directory was removed manually (e.g. `rm -rf` outside gwm).
+
+```bash
+gwm prune
+```
+
+`gwm doctor` flags prunable entries as a Warning; `gwm prune` is the documented remediation.
+
+## `gwm completions <shell>`
+
+Print a static completion script. Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`. See [Shell completions](/cli/completions) for installation per shell.
+
+## `gwm shell-init <shell>`
+
+Print the `gcd` shell wrapper. Supported shells: `zsh`, `bash`, `fish`, `powershell`. See [Getting Started → Shell init](/getting-started/shell-init).
+
+## `gwm tmux <pattern> [-p|--split]`
+
+Open the matched worktree in a new tmux window of the **current** session. `--split` substitutes `split-window` for `new-window`. Requires `$TMUX` to be set.
+
+```bash
+gwm tmux auth                  # new tmux window inside the matched worktree
+gwm tmux auth -p               # split the current pane instead
+```
+
+Outside a tmux session, exits non-zero with a clear error (does not spawn a stray server).
+
+## `gwm zellij <pattern> [-p|--split]`
+
+Same as `gwm tmux` but for zellij. Uses `zellij action new-tab --cwd <path>` (requires zellij ≥ 0.40 for the `--cwd` flag) or `new-pane --cwd` with `-p`. Requires `$ZELLIJ`.
+
+See [CLI → Multiplexer integration](/cli/multiplexer) for the full surface and edge cases.
+
+## `gwm link {issue|pr} <N> [--worktree <pattern>]`
+
+Link the current (or named) worktree to a GitHub issue or PR.
+
+```bash
+gwm link issue 42              # link the current worktree to issue #42
+gwm link pr 61                 # link a PR
+gwm link issue 42 --worktree feat-auth      # ...or to a fuzzy-matched worktree
+```
+
+The link is stored in `git config branch.<name>.gwm-issue` / `gwm-pr` — local, per-branch, no extra file. Issue numbers are **auto-detected** from `<type>/#<N>-<slug>` branches, so `gwm link issue <N>` is only needed for explicit overrides. PR numbers are not auto-detected.
+
+## `gwm unlink {issue|pr} [--worktree <pattern>]`
+
+Remove the explicit link override on the current (or named) worktree.
+
+```bash
+gwm unlink issue               # remove the issue link (auto-detect resurfaces)
+gwm unlink pr                  # remove the PR link
+```
+
+Idempotent — safe to run when nothing is linked.
+
+## `gwm open {issue|pr} [--worktree <pattern>] [--print-url]`
+
+Open the linked issue / PR in the browser via the OS opener.
+
+```bash
+gwm open issue                 # spawn the OS opener on the linked issue URL
+gwm open pr --print-url        # print the URL on stdout, no spawn
+```
+
+Useful in headless shells and tests with `--print-url`.
+
+## `gwm status [--worktree <pattern>] [--json]`
+
+Show the link plus (when `gh` is available) live GitHub state.
+
+```bash
+gwm status
+# → Issue #42 [open] TUI: fuzzy search
+# → PR #61 [draft] · checks 2/3
+
+gwm status --json              # stable schema for scripts
+```
+
+Degrades gracefully to local-link-only output when `gh` is missing or the repo has no GitHub remote.
+
+## `gwm doctor`
+
+Run 7 health checks; report each with `✓ / ! / ✗`; exit `0 / 1 / 2`. Designed for CI and pre-commit hooks. See [Integrations → `gwm doctor`](/integrations/doctor) for the per-check breakdown.
+
+## exit codes
+
+| Code | Meaning                                                                |
+|:-----|:-----------------------------------------------------------------------|
+| `0`  | success — also "all green" for `gwm doctor`                            |
+| `1`  | recoverable failure — fuzzy miss, ambiguous match, doctor Warning      |
+| `2`  | hard failure — bootstrap `✗`, doctor Failure, unrecoverable git error  |

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -1,0 +1,8 @@
+---
+title: Shell completions
+description: `gwm completions <shell>` and dynamic worktree-name completion via `gwm list --format=names`.
+---
+
+# Shell completions
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -5,4 +5,64 @@ description: `gwm completions <shell>` and dynamic worktree-name completion via 
 
 # Shell completions
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm completions <shell>` prints a static completion script (generated from the live clap argument tree, so it never drifts from the actual subcommands). Supported shells: `zsh`, `bash`, `fish`, `powershell`, `elvish`.
+
+## install
+
+```bash
+# zsh — drop into the first writable fpath entry
+gwm completions zsh > "${fpath[1]}/_gwm"
+
+# bash — system-wide
+gwm completions bash | sudo tee /etc/bash_completion.d/gwm > /dev/null
+# bash — per-user
+gwm completions bash > ~/.local/share/bash-completion/completions/gwm
+
+# fish
+gwm completions fish > ~/.config/fish/completions/gwm.fish
+
+# PowerShell — load into the current session (ephemeral)
+gwm completions powershell | Out-String | Invoke-Expression
+# PowerShell — persist by appending to $PROFILE
+gwm completions powershell | Out-File -Append -Encoding utf8 $PROFILE
+
+# elvish
+gwm completions elvish > ~/.config/elvish/lib/gwm.elv
+```
+
+Open a fresh shell (or `source` your rc file) and tab completion is live for every subcommand, flag, and value-enum (e.g. `gwm list --format=<TAB>` offers `table` / `names`).
+
+## dynamic worktree-name completion
+
+The static script knows about subcommands and flags but **not** about the worktrees in your repo — those change every time you run `gwm create / remove`. Wire a custom completer to `gwm list --format=names` for live completion of the `<pattern>` arg on `path` / `cd` / `remove` / `bootstrap` / `tmux` / `zellij`.
+
+### zsh
+
+```zsh
+_gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
+compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-tmux gwm-zellij
+```
+
+(`gwm-path`, `gwm-cd`, etc. are the auto-generated function names the static `_gwm` completer registers per-subcommand.)
+
+### bash
+
+```bash
+_gwm_worktrees() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$(gwm list --format=names 2>/dev/null)" -- "$cur"))
+}
+complete -F _gwm_worktrees -o default gwm
+```
+
+### fish
+
+```fish
+complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap tmux zellij" \
+  -f -a "(gwm list --format=names 2>/dev/null)"
+```
+
+## see also
+
+- [Getting Started → Shell init](/getting-started/shell-init) — the `gcd` wrapper that ships alongside `completions`
+- [CLI → Subcommand reference](/cli/reference#gwm-list---formattabel-names) — the `--format=names` output used by the completers

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -1,0 +1,8 @@
+---
+title: tmux / zellij integration
+description: `gwm tmux` / `gwm zellij` to open a worktree in a new window, pane, or tab.
+---
+
+# tmux / zellij integration
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -5,4 +5,56 @@ description: `gwm tmux` / `gwm zellij` to open a worktree in a new window, pane,
 
 # tmux / zellij integration
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Inside an already-running multiplexer session, `gwm tmux` and `gwm zellij` spawn a new window / pane / tab whose shell starts inside the matched worktree — no manual `cd` round-trip needed.
+
+## tmux
+
+```bash
+gwm tmux auth                  # new tmux window inside the matched worktree
+gwm tmux auth -p               # split the current pane instead
+gwm tmux auth --split          # ...long form of -p
+```
+
+Under the hood:
+
+- **new window** (default): `tmux new-window -n <name> -c <path>`
+- **split** (`-p` / `--split`): `tmux split-window -c <path>` (current window's layout, current pane's direction)
+
+The `-n <name>` arg names the new window after the worktree slug so it stands out in the status bar.
+
+## zellij
+
+```bash
+gwm zellij auth                # new zellij tab inside the matched worktree
+gwm zellij auth -p             # new pane in the current tab instead
+```
+
+Under the hood:
+
+- **new tab** (default): `zellij action new-tab --name <name> --cwd <path>`
+- **new pane** (`-p` / `--split`): `zellij action new-pane --cwd <path>`
+
+The `--cwd` flag on `new-tab` requires **zellij ≥ 0.40**; older versions error out. `new-pane --cwd` has been stable longer — use `-p` if you're stuck on an older zellij.
+
+## required session
+
+Both commands require the corresponding multiplexer to actually be running:
+
+- `gwm tmux` checks for `$TMUX` in the environment.
+- `gwm zellij` checks for `$ZELLIJ`.
+
+Outside a session, the command **refuses** with a clear error rather than spawning a stray server — the alternative (spawning detached) leads to orphaned sessions that the user never sees.
+
+```bash
+$ gwm tmux auth
+gwm tmux requires an active tmux session ($TMUX is not set).
+```
+
+## fuzzy matching
+
+The `<pattern>` arg uses the same fuzzy matcher as `gwm path / remove / bootstrap` ([nucleo-matcher](https://docs.rs/nucleo-matcher)). Ambiguous matches exit `1` and print both candidates without spawning anything.
+
+## see also
+
+- [TUI → Fuzzy filter](/tui/filter) — the matcher's case-sensitivity and scoring rules
+- [CLI → Subcommand reference](/cli/reference#gwm-tmux-pattern--p--split) — flags and exit codes

--- a/docs/3.cli/index.md
+++ b/docs/3.cli/index.md
@@ -1,0 +1,16 @@
+---
+title: CLI
+description: Every gwm subcommand, with synopsis, flags, and shell-friendly examples.
+navigation:
+  title: CLI
+---
+
+# CLI
+
+`gwm <subcommand>` is the scriptable side of gwm — designed to be safe in pipelines, shell completions, and pre-commit hooks. Every subcommand exits with a meaningful code (`0` ok, `1` warning, `2` failure) so you can wire `gwm doctor` into CI without parsing stdout.
+
+- **[Reference](/cli/reference)** — every subcommand, exhaustive (`init`, `create`, `list`, `path`, `cd`, `switch`, `bootstrap`, `remove`, `prune`, `link`, `unlink`, `open`, `status`, `doctor`, `tmux`, `zellij`, `completions`, `shell-init`).
+- **[Shell completions](/cli/completions)** — generate completion scripts for zsh / bash / fish / PowerShell / elvish, plus dynamic worktree-name completion via `gwm list --format=names`.
+- **[Multiplexer integration](/cli/multiplexer)** — `gwm tmux` / `gwm zellij` to open a worktree in a new tab or pane of the current session.
+
+The CLI never spawns a TUI of its own — every subcommand is non-interactive and prints to stdout/stderr. The only TUI surface is bare `gwm` (or `gwm switch` in picker mode), covered in the [TUI section](/tui).

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -1,0 +1,8 @@
+---
+title: .gwm.toml schema
+description: Every section: worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
+---
+
+# .gwm.toml schema
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -1,8 +1,199 @@
 ---
 title: .gwm.toml schema
-description: Every section: worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
+description: Every section — worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
 ---
 
-# .gwm.toml schema
+# `.gwm.toml` schema
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`.gwm.toml` lives at the repo root. Without one, gwm uses sensible defaults (path = `~/cc-worktree/<repo>/<type>-<issue>-<desc>`, no bootstrap, `lazygit -p {path}` as `l`). With one, you can configure every facet: branch naming, file copies, security guards, launcher commands, TUI behaviour, and doctor checks.
+
+The annotated full version lives at [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) — `gwm init` writes that file unchanged to your repo root.
+
+## `[worktree]`
+
+Branch and path conventions.
+
+```toml
+[worktree]
+base           = "{home}/cc-worktree/{repo}"
+path_pattern   = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+```
+
+Placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde (`~/…`) is also expanded.
+
+### supported branch types
+
+`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Override per repo if your team uses something else.
+
+## `[[bootstrap.copy]]`
+
+File copies from the main checkout into the new worktree.
+
+```toml
+[[bootstrap.copy]]
+from = ".env.testing"
+to   = ".env.testing"
+required = true
+fallback = "inline"        # inline | skip | abort (default: skip when required=false)
+
+[[bootstrap.copy]]
+from = ".env"
+to   = ".env"
+required = false
+guards = ["no-aws-rds"]    # reference into [[bootstrap.guard]]
+```
+
+| Field      | Type            | Default | Meaning                                                                  |
+|:-----------|:----------------|:--------|:-------------------------------------------------------------------------|
+| `from`     | string          | —       | source path, relative to the main checkout                               |
+| `to`       | string          | —       | destination path, relative to the new worktree                           |
+| `required` | bool            | `false` | when `true`, missing source aborts the bootstrap unless `fallback` saves |
+| `guards`   | list of strings | `[]`    | names of `[[bootstrap.guard]]` rules to apply after the copy             |
+| `fallback` | string          | none    | `inline` (use `[bootstrap.fallback.<key>]`), `skip`, or `abort`          |
+
+See [Bootstrap pipeline](/configuration/bootstrap) for execution order.
+
+## `[[bootstrap.guard]]`
+
+Regex deny-lists on copied files — the original "no AWS RDS in `.env`" use case, generalised.
+
+```toml
+[[bootstrap.guard]]
+name = "no-aws-rds"
+deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
+on_match      = "seed-from-example"     # abort | seed-from-example
+example_file  = ".env.example"
+```
+
+See [Regex guards](/configuration/guards) for the full pattern API.
+
+## `[bootstrap.fallback.<key>]`
+
+Inline content used when a required `[[bootstrap.copy]]` source is missing and `fallback = "inline"`.
+
+```toml
+[bootstrap.fallback.env_testing]
+target  = ".env.testing"
+content = """
+APP_ENV=testing
+DB_CONNECTION=sqlite
+DB_DATABASE=:memory:
+"""
+```
+
+The `<key>` is referenced implicitly by matching `target` to a copy step's `to`. Multiple fallbacks may coexist.
+
+## `[[bootstrap.no_symlink]]`
+
+Refuse to inherit a symlink at the listed path (typically `vendor/`, `node_modules/`) — stops a stray symlink from polluting the main repo's build output.
+
+```toml
+[[bootstrap.no_symlink]]
+path = "vendor"
+
+[[bootstrap.no_symlink]]
+path = "node_modules"
+```
+
+## `[[bootstrap.command]]`
+
+Shell hooks run after copies / guards / no-symlink.
+
+```toml
+[[bootstrap.command]]
+name = "composer install"
+run  = "composer install --no-interaction --prefer-dist"
+when = "file_exists:composer.json"
+env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
+```
+
+| Field  | Type                  | Meaning                                                              |
+|:-------|:----------------------|:---------------------------------------------------------------------|
+| `name` | string                | shown in the bootstrap report                                         |
+| `run`  | string                | shell line to exec (split via `sh -c`)                                |
+| `when` | string                | [`when:` predicate](/configuration/when-predicates) (optional)        |
+| `env`  | table of string→string | extra env vars injected for this command (optional)                  |
+
+## `[git_tui]` and `[review]`
+
+The TUI launcher bindings. Full schema lives in [TUI → Configurable launchers](/tui/launchers).
+
+```toml
+# l keybinding — pre-v0.6 default kept implicit when omitted
+[git_tui]
+command    = "lazygit -p {path}"
+fullscreen = true
+
+# R keybinding — inert until configured
+[review]
+tool         = "lumen"                # OR command = "<your line>"
+fullscreen   = true                   # only honoured when command is set
+default_base = "main"                 # optional override for the base resolution chain
+```
+
+## `[tui]`
+
+Runtime knobs for the worktree TUI.
+
+```toml
+[tui]
+# Safety countdown (in seconds) for the delete-confirm overlay when `p` is armed.
+# Accepts 0..=5; values above 5 are clamped on read. Setting it to 0 keeps the
+# classic single-keystroke modal even when delete-branch-on-remove is armed.
+confirm_countdown_secs = 3
+```
+
+See [TUI → Confirm-overlay countdown](/tui/confirm-countdown).
+
+## `[tui.open]`
+
+What the `o` key does. Full details in [TUI → Open dispatch](/tui/open-dispatch).
+
+```toml
+[tui.open]
+mode = "shell"          # shell (default) | editor | finder
+shell_cmd  = ""          # override $SHELL when mode=shell; empty = unset
+editor_cmd = "hx"        # override $EDITOR when mode=editor; empty = unset
+```
+
+Unknown `mode` values are a **hard config error at load time**, not a silent fallback.
+
+## `[doctor]`
+
+Knobs for `gwm doctor`. Currently exposes the trunk list used by the orphan-branch check.
+
+```toml
+[doctor]
+# Branches the orphan check treats as "merge destinations". A gwm-style
+# branch fully reachable from one of these is preserved per CONTRIBUTING
+# ("never delete the source branch after merge") and NOT flagged as orphan.
+# Empty list → every unclaimed gwm-style branch is flagged.
+trunks = ["dev", "main"]
+```
+
+Repos using a non-default trunk (`master`, `trunk`, `release-1.x`, …) must list it here to keep the orphan check meaningful.
+
+## defaults without `.gwm.toml`
+
+| Setting                              | Default                          |
+|:-------------------------------------|:---------------------------------|
+| `[worktree].base`                    | `{home}/cc-worktree/{repo}`      |
+| `[worktree].path_pattern`            | `{type}-{issue}-{desc}`          |
+| `[worktree].branch_pattern`          | `{type}/#{issue}-{desc}`         |
+| `[[bootstrap.*]]`                    | empty — no pipeline              |
+| `[git_tui].command`                  | `lazygit -p {path}`              |
+| `[git_tui].fullscreen`               | `true`                           |
+| `[review]`                           | inert (`R` does nothing)         |
+| `[tui].confirm_countdown_secs`       | `3`                              |
+| `[tui.open].mode`                    | `shell` (v0.6 — was `finder`)    |
+| `[doctor].trunks`                    | `["dev", "main"]`                |
+
+## validation rules
+
+- Unknown TOML keys are silently ignored (forward-compatible with new fields).
+- Unknown `[tui.open].mode` values **error at load time**.
+- `[[bootstrap.guard]]` references in `[[bootstrap.copy]].guards` are validated by `gwm doctor` (check #2).
+- `[[bootstrap.command]].when` predicates with unknown keywords default to `true` (so old configs keep running); `gwm doctor` (check #3) surfaces them.
+
+Run `gwm doctor` after every edit to catch the catchable mistakes — see [Integrations → `gwm doctor`](/integrations/doctor).

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -1,8 +1,95 @@
 ---
 title: Bootstrap pipeline
-description: Execution order: file copies → regex guards → fallbacks → no-symlink check → shell commands.
+description: Execution order — file copies → regex guards → fallbacks → no-symlink check → shell commands.
 ---
 
 # Bootstrap pipeline
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The bootstrap pipeline runs **after** `git worktree add` succeeds, on every `gwm create` (unless `--no-bootstrap` is set) and on every `gwm bootstrap`. It is also re-runnable from inside the TUI via the `b` key.
+
+Five stages, in this order:
+
+```
+gwm create / gwm bootstrap
+       ↓
+(1) [[bootstrap.copy]]                  duplicate files from main → worktree
+       ↓
+(2) [[bootstrap.guard]]                 regex deny-list each copied file
+       ↓
+(3) [bootstrap.fallback.*]              materialise inline content when a
+                                          required source is missing
+       ↓
+(4) [[bootstrap.no_symlink]]            refuse to inherit listed symlinks
+       ↓
+(5) [[bootstrap.command]]               shell hooks gated by when: predicates
+       ↓
+✓ worktree ready, status bar reports per-step ✓ / ! / ✗
+```
+
+Stages **1 → 4** are tightly coupled — a guard `seed-from-example` action triggers a fallback (stage 3) inline, and the no-symlink check (stage 4) runs after copies so it can refuse links that the copy step would have followed.
+
+## stage reports
+
+Each step prints one line with a sigil — same convention as `gwm doctor`:
+
+| Sigil | Severity  | Effect on the worktree                              |
+|:------|:----------|:----------------------------------------------------|
+| `✓`   | success   | nothing                                              |
+| `!`   | warning   | step is skipped or partial; pipeline continues       |
+| `✗`   | failure   | pipeline aborts; the new worktree is rolled back     |
+
+Example output (from `gwm create feat 42 user-auth` with a typical config):
+
+```
+creating worktree:
+  branch : feat/#42-user-auth
+  dir    : feat-42-user-auth
+  path   : /Users/you/cc-worktree/myrepo/feat-42-user-auth
+✓ worktree created at /Users/you/cc-worktree/myrepo/feat-42-user-auth
+
+bootstrap report:
+  ✓ copy .env.testing
+  ! no-symlink vendor
+      target not present
+  ✓ guard no-aws-rds on .env
+  ✓ run composer install
+  · run direnv allow
+      when condition 'file_exists:.envrc' false
+```
+
+The `·` sigil (used by some predicate skips) is a "step did not run" indicator and is purely informational — no severity attached.
+
+## skipping bootstrap
+
+```bash
+gwm create feat 42 user-auth --no-bootstrap     # skip the whole pipeline
+```
+
+Useful when:
+- You're scripting bulk creation and want bootstrap as a separate step.
+- The repo's `.gwm.toml` is in transition and bootstrap would fail predictably.
+- You want to inspect the bare worktree before any side-effects land.
+
+Re-run bootstrap later without recreating:
+
+```bash
+gwm bootstrap                  # on the CWD worktree
+gwm bootstrap auth             # ...on a fuzzy-matched name
+```
+
+## why this order
+
+The order is **not arbitrary**. It encodes the original safety lessons that motivated gwm:
+
+1. **Copies first** — gives guards something to inspect.
+2. **Guards immediately after** — fail fast on a `.env` containing AWS RDS endpoints **before** the worktree's shell hooks pull in real production data.
+3. **Fallbacks** — when a guard fires `seed-from-example`, the substitution happens before the no-symlink check looks at the result.
+4. **No-symlink** — runs last among the file-level stages, so it catches any link created by a `cp -R` that followed indirections.
+5. **Shell commands** — the only stage that can have arbitrary side-effects on external systems (composer install, npm ci, etc.). Placed last so the file-level invariants hold by the time it runs.
+
+## related
+
+- [Configuration → `.gwm.toml` schema](/configuration/gwm-toml) — the TOML surface of every bootstrap section
+- [Regex guards](/configuration/guards) — how stage 2 works in detail
+- [when: predicates](/configuration/when-predicates) — how stage 5 conditionalises commands
+- [Integrations → `gwm doctor`](/integrations/doctor) — validates that bootstrap config is internally consistent (guard refs, predicate grammar)

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -1,0 +1,8 @@
+---
+title: Bootstrap pipeline
+description: Execution order: file copies → regex guards → fallbacks → no-symlink check → shell commands.
+---
+
+# Bootstrap pipeline
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/3.guards.md
+++ b/docs/4.configuration/3.guards.md
@@ -1,0 +1,8 @@
+---
+title: Regex guards
+description: Deny-list patterns on copied files — the original "no AWS RDS in .env" incident, generalised.
+---
+
+# Regex guards
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/3.guards.md
+++ b/docs/4.configuration/3.guards.md
@@ -5,4 +5,102 @@ description: Deny-list patterns on copied files — the original "no AWS RDS in 
 
 # Regex guards
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`[[bootstrap.guard]]` rules vet each file produced by stage 1 of the [bootstrap pipeline](/configuration/bootstrap) against a list of regex deny-patterns. A match triggers either an abort or a substitution from a known-good fallback.
+
+## the origin story
+
+The original incident: someone created a worktree from a repo with `.env` pointing at the **production** AWS RDS host, then ran `php artisan migrate:fresh --seed` in the worktree thinking it was the local DB. The migration ran against prod.
+
+The fix was institutional: never copy a `.env` blindly across worktrees. The mechanism is `[[bootstrap.guard]]`.
+
+## schema
+
+```toml
+[[bootstrap.guard]]
+name = "no-aws-rds"
+deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
+on_match      = "seed-from-example"        # or "abort"
+example_file  = ".env.example"             # required when on_match=seed-from-example
+```
+
+| Field           | Type            | Default   | Meaning                                                                                |
+|:----------------|:----------------|:----------|:---------------------------------------------------------------------------------------|
+| `name`          | string          | —         | referenced by `[[bootstrap.copy]].guards = [...]`                                       |
+| `deny_patterns` | list of strings | `[]`      | Rust regex patterns (`regex` crate syntax). Matches anywhere in the file are flagged.   |
+| `on_match`     | string          | `"abort"` | `"abort"` or `"seed-from-example"`                                                      |
+| `example_file` | string          | none      | path (relative to main checkout) of the file to substitute when `on_match=seed-from-example` |
+
+## wiring a guard into a copy
+
+The guard runs only when a `[[bootstrap.copy]]` step references it by name:
+
+```toml
+[[bootstrap.copy]]
+from = ".env"
+to   = ".env"
+required = false
+guards = ["no-aws-rds"]            # ← referenced here
+```
+
+A guard with no copy references it is dead config — `gwm doctor` (check #2) does not flag this (yet), so audit by hand or run `grep guards .gwm.toml` to spot orphans.
+
+## `on_match` semantics
+
+### `abort` (default)
+
+A match halts the entire bootstrap with `✗`. The worktree itself was already created (stage 1 succeeded), so gwm rolls it back: removes the worktree directory and the branch.
+
+```
+bootstrap report:
+  ✗ guard no-aws-rds on .env
+      pattern 'amazonaws\.com' matched on line 12
+      → bootstrap aborted, worktree rolled back
+```
+
+The user sees the offending pattern, the line, and the fact that nothing was left behind. Re-run is safe.
+
+### `seed-from-example`
+
+A match triggers a substitution: gwm overwrites the offending file with the contents of `example_file` (still relative to the **main** checkout, since the worktree is fresh and unlikely to have its own example). Reported as `!` (warning), pipeline continues.
+
+```
+bootstrap report:
+  ! guard no-aws-rds on .env
+      pattern 'amazonaws\.com' matched on line 12
+      → substituted from .env.example
+```
+
+Useful when `.env` is genuinely sensitive but you want the worktree to have **some** working config (e.g. local sqlite) — the substitution lands you in a known-safe baseline you can iterate from.
+
+## regex syntax
+
+Patterns use the [`regex` crate](https://docs.rs/regex) — Perl-ish, no look-around. Anchors:
+
+- No anchor → matches anywhere in the file.
+- `^…$` with the multi-line flag `(?m)` → matches per-line.
+
+Common patterns:
+
+```toml
+deny_patterns = [
+  "amazonaws\\.com",                # AWS endpoints
+  "(?m)^DB_PASSWORD=(?!$|\"\"$)",   # any non-empty DB_PASSWORD line
+  "BEGIN .* PRIVATE KEY",           # accidental SSH keys
+  "sk_live_[A-Za-z0-9]{20,}",       # Stripe live secret keys
+]
+```
+
+Backslashes must be doubled inside TOML strings. Use TOML's literal strings (`'...'`) for raw regex if you have many backslashes:
+
+```toml
+deny_patterns = ['amazonaws\.com', '\.rds\.']
+```
+
+## doctor coverage
+
+`gwm doctor` check **#2** (`guard references resolve`) validates that every `[[bootstrap.copy]].guards = [...]` name points at an existing `[[bootstrap.guard]]`. Catches typos at config-time instead of waiting for the next `gwm create` to fail. See [Integrations → `gwm doctor`](/integrations/doctor).
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — where guards sit in the execution order
+- [`.gwm.toml` schema](/configuration/gwm-toml) — full type reference

--- a/docs/4.configuration/4.when-predicates.md
+++ b/docs/4.configuration/4.when-predicates.md
@@ -1,0 +1,8 @@
+---
+title: when: predicates
+description: file_exists / cmd_exists / env_set / env_eq / glob_exists, with !, &&, || composition.
+---
+
+# when: predicates
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/4.configuration/4.when-predicates.md
+++ b/docs/4.configuration/4.when-predicates.md
@@ -3,6 +3,91 @@ title: when: predicates
 description: file_exists / cmd_exists / env_set / env_eq / glob_exists, with !, &&, || composition.
 ---
 
-# when: predicates
+# `when:` predicates
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The `when:` field on `[[bootstrap.command]]` conditionalises shell hooks. Predicates compose with boolean operators, so a single step can express "run `bun install` if `package.json` exists AND `bun` is on `$PATH`, but never in CI".
+
+## supported atoms
+
+| Atom                          | True when …                                                                          |
+|:------------------------------|:-------------------------------------------------------------------------------------|
+| `file_exists:<path>`          | `<worktree>/<path>` resolves on disk                                                  |
+| `cmd_exists:<binary>`         | `<binary>` resolves on `$PATH` (`which` lookup)                                       |
+| `env_set:<NAME>`              | `std::env::var(NAME)` returns `Ok` (the var is **defined**, possibly empty)           |
+| `env_eq:<NAME>=<value>`       | `NAME` is set and its value equals `<value>` **exactly**                              |
+| `glob_exists:<pattern>`       | at least one path under the worktree matches `<pattern>` (supports `**`)              |
+
+Atoms are case-sensitive. Whitespace around the colon and around boolean operators is tolerated. Unknown keywords default to `true` so old configs keep running while `gwm doctor` (check #3) surfaces them as Warning.
+
+## boolean composition
+
+| Operator | Meaning | Precedence       |
+|:---------|:--------|:-----------------|
+| `!`      | NOT     | highest          |
+| `&&`     | AND     | middle           |
+| `\|\|`   | OR      | lowest           |
+
+So `!a && b || c` parses as `((!a) && b) || c` — same as in most languages.
+
+Whitespace around operators is tolerated, but operators themselves must be exactly `!`, `&&`, `||` — no `not`, `and`, `or`, no Unicode.
+
+## examples
+
+```toml
+# Run only when composer.json exists at the worktree root.
+[[bootstrap.command]]
+name = "composer install"
+run  = "composer install --no-interaction --prefer-dist"
+when = "file_exists:composer.json"
+
+# Prefer bun if available, otherwise fall back to npm — and never in CI.
+[[bootstrap.command]]
+name = "install (bun)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun && !env_set:CI"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run  = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun && !env_set:CI"
+
+# Build docs only when there's something to build and we're not in CI.
+[[bootstrap.command]]
+name = "build docs"
+run  = "./scripts/full-build.sh"
+when = "glob_exists:docs/**/*.md && !env_set:CI"
+
+# Apply staging-only seeds when APP_ENV is exactly "staging".
+[[bootstrap.command]]
+name = "staging seed"
+run  = "php artisan db:seed --class=StagingSeeder"
+when = "file_exists:artisan && env_eq:APP_ENV=staging"
+
+# Allow a long-running prep step only when the user opts in via env.
+[[bootstrap.command]]
+name = "warm up cache"
+run  = "./scripts/warmup.sh"
+when = "env_eq:GWM_WARMUP=1"
+```
+
+## omitted `when:`
+
+A step without `when:` runs unconditionally — equivalent to `when = "true"` (which is not a literal you can type; just omit the field). Common for housekeeping commands like `git lfs pull` that are cheap and always safe.
+
+## doctor coverage
+
+`gwm doctor` check **#3** (``when` predicates supported`) parses every `[[bootstrap.command]].when` and surfaces unknown keywords:
+
+```
+! `when` predicates supported
+    1 unsupported keyword: file_exits
+    → did you mean file_exists?
+```
+
+Note the **`!`** (Warning) — the offending command still runs (defaults to `true`), so the bootstrap is not blocked, but the user sees the typo at config-time instead of waiting for a confused failure.
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — where the `[[bootstrap.command]]` step sits
+- [`.gwm.toml` schema](/configuration/gwm-toml#bootstrap-command) — the full field listing
+- [Integrations → `gwm doctor`](/integrations/doctor) — checks #2 (guard refs) and #3 (predicate grammar)

--- a/docs/4.configuration/index.md
+++ b/docs/4.configuration/index.md
@@ -1,0 +1,17 @@
+---
+title: Configuration
+description: The .gwm.toml schema — worktree conventions, bootstrap pipeline, regex guards, when-predicates, and the v0.6 launcher / open-dispatch sections.
+navigation:
+  title: Configuration
+---
+
+# Configuration
+
+gwm reads `.gwm.toml` from the repo root. Without a config, it falls back to sensible defaults (`~/cc-worktree/<repo>/<type>-<issue>-<desc>`, no bootstrap). With one, it can copy files, run shell hooks, refuse to inherit dangerous secrets, and configure the TUI launchers.
+
+- **[`.gwm.toml` schema](/configuration/gwm-toml)** — every section: `[worktree]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[bootstrap.fallback.*]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[git_tui]`, `[review]`, `[tui]`, `[tui.open]`, `[doctor]`.
+- **[Bootstrap pipeline](/configuration/bootstrap)** — execution order: copies → guards → fallbacks → no-symlink check → commands.
+- **[Regex guards](/configuration/guards)** — deny-list patterns on copied files (the original "no AWS RDS in `.env`" incident).
+- **[`when` predicates](/configuration/when-predicates)** — `file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||` composition.
+
+Run `gwm init` in a fresh repo to write a default `.gwm.toml`. For the full annotated example with every field commented, see [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) in the repo.

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -5,4 +5,134 @@ description: Auto-link branches to issues, fetch live state via `gh`, surface in
 
 # GitHub issue / PR linking
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+Added by [#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://github.com/kbrdn1/gwm-cli/pull/68); refined in v0.6 by [#75](https://github.com/kbrdn1/gwm-cli/issues/75).
+
+Every worktree can be linked to a GitHub issue and / or pull request. The link drives the live `Issue / PR` block in the [TUI sidebar](/tui/sidebar#issue--pr-block) and surfaces in `gwm status` for scripting.
+
+## storage model
+
+Links live in **git config**, scoped to the branch, never in a file gwm owns:
+
+- `git config branch.<name>.gwm-issue` — the linked issue number
+- `git config branch.<name>.gwm-pr` — the linked PR number
+
+This means:
+
+- The link **survives worktree moves** (`gwm` rewriting `.git/worktrees/<name>/HEAD` doesn't touch branch config).
+- The link is **per-branch, local** — not committed, not pushed, not shared with the repo's other clones.
+- `git config --unset branch.<name>.gwm-issue` is a 100% valid alternative to `gwm unlink issue`.
+
+## auto-detection
+
+Branches following the gwm naming convention `<type>/#<N>-<slug>` derive the issue number from the branch name — zero config needed.
+
+```
+feat/#42-user-auth          → issue #42 auto-linked
+fix/#117-leak               → issue #117 auto-linked
+chore/#5-rename             → issue #5 auto-linked
+release-1.x                 → no auto-link (no #N pattern)
+```
+
+PR numbers are **not** auto-detected — there's no convention that maps a branch to a PR number. Link them explicitly:
+
+```bash
+gwm link pr 61
+```
+
+## explicit linking
+
+```bash
+# Link the current (CWD) worktree
+gwm link issue 42
+gwm link pr 61
+
+# Link a fuzzy-matched worktree from anywhere
+gwm link issue 42 --worktree feat-auth
+
+# Remove an explicit override (auto-detect resurfaces for issues)
+gwm unlink issue
+gwm unlink pr
+
+# Open the link in the browser via the OS opener
+gwm open issue
+gwm open pr --print-url        # print the URL on stdout instead
+
+# Inspect the current state
+gwm status                     # human-readable
+gwm status --json              # stable schema for scripts
+```
+
+See [CLI → Subcommand reference](/cli/reference#gwm-link-issuepr-n---worktree-pattern) for the flag tables.
+
+## live status via `gh`
+
+`gwm status` (and the TUI's `F` key) shells out to `gh issue view` and `gh pr view` to fetch state, title, labels, and CI rollup:
+
+```
+$ gwm status
+Issue #42 [open] TUI: fuzzy search
+PR #61 [draft] · checks 2/3
+```
+
+| Bracketed value | Source                                              |
+|:----------------|:----------------------------------------------------|
+| `[open]`        | `gh`'s `state`                                       |
+| `[closed]`     | `gh`'s `state`                                       |
+| `[merged]`     | `gh`'s `state` (PR only)                             |
+| `[draft]`      | `gh`'s `isDraft` (PR only)                           |
+| `checks N/M`   | `gh`'s `statusCheckRollup` (PR only)                 |
+
+Without `gh` (or outside a repo with a GitHub remote), gwm degrades gracefully — only the local link is shown, no error:
+
+```
+$ gwm status
+Issue #42 (gh not available — local link only)
+```
+
+## TUI surface
+
+In the worktree list view, the right details panel renders a **live `Issue / PR` block** for the selected worktree (hidden when nothing is linked). Three keybindings drive it:
+
+| Key | Action                                                                              |
+|:----|:------------------------------------------------------------------------------------|
+| `O` | open menu (`i` open issue in browser, `p` open PR in browser)                       |
+| `L` | link prompt (`i` issue or `p` pr → type the number → Enter to commit)               |
+| `F` | refresh the GitHub status (synchronous `gh` fetch, updates the status bar)          |
+
+> The `F` keybinding was `R` pre-v0.6 — rebound by [#75](https://github.com/kbrdn1/gwm-cli/issues/75) when `R` was claimed by the [review launcher](/tui/launchers). See [Keybindings → v0.6 rebind summary](/tui/keybindings#v06-rebind-summary).
+
+The `Issue / PR` block is **rebuilt on every selection change**, so navigating with `j` / `k` never surfaces stale data from the previously selected worktree.
+
+## sidebar header status dot
+
+The header `● <worktree-name>` line carries a coloured `●` that tracks the linked PR / issue state:
+
+- **green** — open
+- **gray** — draft
+- **magenta** — merged
+- **red** — closed
+- **darkgray** — nothing linked / unknown state
+
+The dot is rebuilt from cached `gh` fetch state on every frame, so it follows live status without invalidating the rest of the sidebar's git-preview cache. Hit `F` to force a refresh.
+
+## URL derivation
+
+gwm derives the issue / PR URL from the repo's GitHub remote:
+
+```
+https://github.com/<owner>/<repo>/issues/<N>
+https://github.com/<owner>/<repo>/pull/<N>
+```
+
+The owner/repo extraction handles a few quirks:
+
+- Trailing `/` on the remote URL (`https://github.com/owner/repo.git/`) — fixed in #68 by Copilot's review; the `.git` suffix is now stripped after normalising trailing slashes.
+- SSH form (`git@github.com:owner/repo.git`) — parsed identically.
+
+If the remote is not GitHub, `gwm open` exits with an error rather than guessing a URL.
+
+## related
+
+- [TUI → Sidebar](/tui/sidebar#issue--pr-block) — where the live block renders
+- [TUI → Keybindings](/tui/keybindings#issue--pr-link-prompt-l) — `O` / `L` / `F` overlays
+- [CLI → Subcommand reference](/cli/reference#gwm-link-issuepr-n---worktree-pattern) — every command and flag

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -1,0 +1,8 @@
+---
+title: GitHub issue / PR linking
+description: Auto-link branches to issues, fetch live state via `gh`, surface in the TUI sidebar.
+---
+
+# GitHub issue / PR linking
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -3,6 +3,144 @@ title: gwm doctor
 description: 7 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
 ---
 
-# gwm doctor
+# `gwm doctor`
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`gwm doctor` runs a battery of cheap checks against the current repo, prints a per-check report, and exits with a meaningful code so it can be wired into CI or a pre-commit hook without parsing stdout.
+
+## exit codes
+
+| Code | Meaning      | Triggered by                                         |
+|:-----|:-------------|:-----------------------------------------------------|
+| `0`  | all green    | every check returns `✓`                              |
+| `1`  | warning      | at least one `!`, no `✗`                              |
+| `2`  | failure      | at least one `✗`                                      |
+
+The Warning / Failure split matches the bootstrap pipeline's sigil convention — see [Bootstrap pipeline](/configuration/bootstrap#stage-reports).
+
+## sample output
+
+```bash
+$ gwm doctor
+✓ .gwm.toml parses
+    /path/to/repo/.gwm.toml parses cleanly
+✓ guard references resolve
+    2 guard reference(s) resolve
+✓ `when` predicates supported
+    1 predicate(s) recognised
+✓ external binaries on PATH
+    3/3 binaries found
+✓ no prunable worktrees
+    5 worktree(s) tracked, none prunable
+✓ no orphan gwm branches
+    7 merged gwm-style branch(es) preserved per CONTRIBUTING, no unmerged orphans
+✓ base directory writable
+    /home/you/cc-worktree/myrepo is writable
+```
+
+A run with issues:
+
+```
+! no prunable worktrees
+    1 prunable entry: feat-12-old
+    → run `gwm prune` to clear them
+! no orphan gwm branches
+    1 unmerged orphan branch(es): feat/#99-wip-experiment
+    → git branch -d feat/#99-wip-experiment
+```
+
+Each Warning / Failure carries a one-line remediation hint, copy-pasteable.
+
+## checks performed
+
+### 1. `.gwm.toml` parses
+
+Reads `.gwm.toml` from the repo root.
+
+- **`✓`** — file parses cleanly, **OR** file is absent (defaults assumed)
+- **`✗`** — TOML is malformed, or contains an unknown `[tui.open].mode` value
+
+The "absent" case is intentionally a `✓` — `gwm` works without `.gwm.toml` and the user-facing message says so.
+
+### 2. guard references resolve
+
+Walks every `[[bootstrap.copy]].guards = [...]` and verifies that each name resolves to an existing `[[bootstrap.guard]]`.
+
+- **`✓`** — every reference points at a real guard
+- **`✗`** — at least one reference is dangling
+
+Catches typos like `guards = ["no-aws-dbs"]` when the guard is `no-aws-rds`.
+
+### 3. `when` predicates supported
+
+Parses every `[[bootstrap.command]].when` and reports unknown keywords.
+
+- **`✓`** — every atom uses a recognised keyword
+- **`!`** — at least one keyword is unrecognised (Warning, not Failure — the offending command still runs, defaulting to `true`)
+
+Recognised keywords: `file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`. Boolean composition (`!`, `&&`, `||`) is also validated. See [`when:` predicates](/configuration/when-predicates).
+
+### 4. external binaries on PATH
+
+Probes `$PATH` for every binary gwm or `.gwm.toml` plans to spawn:
+
+- **`lazygit`** — only if `[git_tui]` doesn't override the command
+- **the first token of `[git_tui].command`** — when overridden
+- **the first token of `[review].command` / preset**
+- **`direnv`** — only if `.envrc` exists in the worktree (the `seed-from-example` action may try `direnv allow`)
+- **the first executable token of every `[[bootstrap.command]].run`**
+
+Reporting:
+
+- **`✓`** — all probed binaries resolved
+- **`!`** — `[review]` binary missing (review is opt-in; a CI pre-commit hook keeps passing)
+- **`✗`** — `[git_tui]` binary missing or a bootstrap command's binary missing
+
+> The v0.6 update to this check (probing `[git_tui]` and `[review]`) landed with [#75](https://github.com/kbrdn1/gwm-cli/issues/75). Pre-v0.6, only `lazygit` and `direnv` were checked.
+
+### 5. no prunable worktrees
+
+Looks at `.git/worktrees/` and flags entries whose working directory was removed manually (e.g. someone `rm -rf`'d the worktree directory outside gwm).
+
+- **`✓`** — every tracked entry points at a real directory
+- **`!`** — at least one stale entry, with `gwm prune` as the remediation
+
+### 6. no orphan gwm branches
+
+Walks local branches matching `<type>/#<N>-<slug>` and flags those with no associated worktree.
+
+- **`✓`** — every gwm-style branch is either active (has a worktree) or merged into a trunk
+- **`!`** — at least one **unmerged** orphan, with `git branch -d <name>` as the remediation
+
+The "merged into a trunk" exemption respects `CONTRIBUTING.md`'s "never delete the source branch after merge" rule — merged branches are preserved, not flagged. The trunk list is configurable via `[doctor].trunks` (default `["dev", "main"]`); empty list disables the exemption.
+
+User-managed branches (`main`, `release-*`, `dependabot/...`, anything not matching the gwm pattern) are silently ignored.
+
+### 7. base directory writable
+
+Checks that the configured `[worktree].base` exists and is writable, or — if it doesn't exist yet — that its **parent** is writable. gwm creates the base lazily on the first `gwm create`, so a non-existent base is fine as long as it can be created.
+
+- **`✓`** — base (or its parent) is writable
+- **`✗`** — neither is writable (gwm cannot create worktrees here)
+
+## CI integration
+
+```yaml
+# .github/workflows/ci.yml
+- name: gwm health
+  run: gwm doctor                    # exits 1 on Warning, 2 on Failure
+```
+
+Or as a pre-commit hook:
+
+```bash
+# .git/hooks/pre-commit (or via pre-commit framework)
+gwm doctor || { echo "gwm doctor reported issues, see above"; exit 1; }
+```
+
+Because `[review]` missing only triggers a Warning (exit `1`), a pre-commit hook can choose to allow Warnings (`gwm doctor; [ $? -le 1 ]`) and only block on Failures.
+
+## related
+
+- [Bootstrap pipeline](/configuration/bootstrap) — same `✓ / ! / ✗` convention used by stage reports
+- [TUI → Configurable launchers](/tui/launchers#interaction-with-gwm-doctor) — why the review launcher's missing-binary is a Warning, not a Failure
+- [`.gwm.toml` schema → `[doctor]`](/configuration/gwm-toml#doctor) — the `trunks` knob

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -1,0 +1,8 @@
+---
+title: gwm doctor
+description: 7 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
+---
+
+# gwm doctor
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/3.homebrew-nix.md
+++ b/docs/5.integrations/3.homebrew-nix.md
@@ -1,0 +1,8 @@
+---
+title: Homebrew and Nix
+description: Packaging surface — Homebrew tap, Nix flake, prebuilt binaries.
+---
+
+# Homebrew and Nix
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/5.integrations/3.homebrew-nix.md
+++ b/docs/5.integrations/3.homebrew-nix.md
@@ -5,4 +5,89 @@ description: Packaging surface — Homebrew tap, Nix flake, prebuilt binaries.
 
 # Homebrew and Nix
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+gwm ships through three managed channels in addition to `cargo install` — pick whichever fits your environment. End-user install instructions live in [Getting Started → Install](/getting-started/install); this page covers the **packaging surface** for contributors, maintainers, and downstream packagers.
+
+## Homebrew tap
+
+Tap and formula:
+
+- Tap: [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-tap)
+- Formula: `Formula/gwm.rb`
+- Canonical source: [`packaging/homebrew/gwm.rb.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/homebrew/gwm.rb.template) in this repo
+
+The tap is refreshed **automatically on every stable release** by the `homebrew-tap-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). The job:
+
+1. Reads the freshly-tagged version (e.g. `v0.6.0`).
+2. Filters out pre-release tags — `-rc.N`, `-alpha.N`, `-beta.N` — so `brew install gwm` always resolves to a stable build. Pre-releases are still published to the GitHub releases page; they just don't update the tap.
+3. Substitutes version, SHA, and archive URLs into the template.
+4. Opens a PR (or pushes directly, depending on the tap's branch protection) against `kbrdn1/homebrew-tap`.
+
+End-user install:
+
+```bash
+brew tap kbrdn1/tap
+brew install gwm
+```
+
+## Nix flake
+
+`flake.nix` lives at the repo root. The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
+
+End-user install:
+
+```bash
+# one-shot run, no clone
+nix run github:kbrdn1/gwm-cli -- list
+
+# install into your profile
+nix profile install github:kbrdn1/gwm-cli
+
+# in a NixOS / nix-darwin config, via the overlay
+nixpkgs.overlays = [ inputs.gwm.overlays.default ];
+environment.systemPackages = [ pkgs.gwm ];
+```
+
+The flake exports:
+
+- `packages.<system>.gwm` — the executable
+- `packages.<system>.default` — alias for `gwm`
+- `apps.<system>.default` — `nix run` entry point
+- `overlays.default` — for downstream NixOS / nix-darwin configs
+- `devShells.<system>.default` — pinned Rust toolchain + `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the libgit2 build deps. Used by [Development → Testing](/development/testing).
+
+Test the flake locally before pushing changes:
+
+```bash
+nix flake check
+nix build .#gwm
+./result/bin/gwm --version
+```
+
+## prebuilt binaries
+
+Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries with `.sha256` sidecars for:
+
+- Linux (`x86_64`, `aarch64`)
+- macOS (Intel, Apple Silicon)
+- Windows (`x86_64`)
+
+The build matrix is the `release` workflow in [`.github/workflows/release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml). Each tag-push triggers a parallel build across the matrix, with `.sha256` sidecars computed in the same job. Release notes are sourced from the **per-version changelog** (`changelogs/<version>.md`), not from the root `CHANGELOG.md`, which only holds the current `[Unreleased]` section + index.
+
+## the release pipeline at a glance
+
+```
+git tag v0.6.0 && git push origin v0.6.0
+         ↓
+.github/workflows/release.yml
+    ├─ build matrix (5 targets)         → release assets + .sha256
+    ├─ pre-release.yml gate              → skip on -rc / -alpha / -beta
+    └─ homebrew-tap-update job           → only on stable tags
+         ↓
+github.com/kbrdn1/gwm-cli/releases   ← binaries
+github.com/kbrdn1/homebrew-tap        ← formula bump PR
+```
+
+## related
+
+- [Getting Started → Install](/getting-started/install) — end-user install for the four channels
+- [Development → Contributing](/development/contributing) — branch / commit / PR conventions and the CHANGELOG split rules

--- a/docs/5.integrations/index.md
+++ b/docs/5.integrations/index.md
@@ -1,0 +1,16 @@
+---
+title: Integrations
+description: Wire gwm with GitHub (gh), lazygit, AI reviewers, doctor in CI, and the packaged distributions (Homebrew, Nix).
+navigation:
+  title: Integrations
+---
+
+# Integrations
+
+gwm is small on purpose — it shells out to the tools you already use rather than reimplementing them. These pages cover the supported integration points.
+
+- **[GitHub issue / PR linking](/integrations/github-linking)** — auto-link branches matching `<type>/#<N>-<slug>` to their issue, fetch live state via `gh`, surface in the TUI sidebar.
+- **[`gwm doctor`](/integrations/doctor)** — the 7 health checks, exit-code semantics (`0 / 1 / 2`), and the v0.6 update that now probes the configured launcher binaries.
+- **[Homebrew & Nix](/integrations/homebrew-nix)** — the packaging surface: how releases flow into the Homebrew tap and the Nix flake.
+
+The TUI-side integrations (the configurable launchers for `l` and `R`, the `[tui.open]` dispatch) live under [TUI → Configurable launchers](/tui/launchers) and [TUI → Open dispatch](/tui/open-dispatch).

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -5,4 +5,104 @@ description: 15 integration test files, 433 tests, sentinel-test convention, and
 
 # Testing
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+`cargo test` runs **433 tests** across 15 integration files plus the unit tests embedded in `src/`. Average run on a recent laptop: ~1 second.
+
+## quick reference
+
+```bash
+cargo test                            # full suite (433 tests)
+cargo test --test tui_app_tests       # one integration file
+cargo test refresh_github             # name-substring filter across the whole suite
+cargo test -- --nocapture             # let println! / dbg! through
+cargo test --release                  # opt-level=3, same suite
+```
+
+The `--test <name>` filter is by **integration file**, not by module — `cargo test --test tui_app_tests` runs everything inside `tests/tui_app_tests.rs`.
+
+## integration test layout
+
+All integration tests live under `tests/`:
+
+```
+tests/
+├── common/                       # shared helpers (init_repo, paths_equal)
+├── bootstrap_tests.rs            # copy / guard / no-symlink / commands
+├── bootstrap_when_tests.rs       # `when:` predicate grammar (file/cmd/env/glob + boolean ops)
+├── cli_binary.rs                 # end-to-end assert_cmd coverage of the CLI surface
+├── config_tests.rs               # .gwm.toml parsing + write_default + defaults
+├── doctor_tests.rs               # gwm doctor checks + severity arithmetic
+├── error_tests.rs                # GwmError variants + Display + From impls
+├── flake_tests.rs                # Nix flake structure (build, devShell, app, overlay)
+├── github_tests.rs               # issue/PR linking + trim_git_suffix + URL derivation
+├── homebrew_formula_tests.rs     # Homebrew formula template substitution
+├── launcher_tests.rs             # [git_tui] / [review] placeholder expansion + base resolution
+├── multiplexer_tests.rs          # gwm tmux / gwm zellij argv construction + $TMUX guard
+├── naming_tests.rs               # kebab normalisation + branch validation + parse roundtrip
+├── precommit_hook_tests.rs       # pre-commit hook scaffolding
+├── tui_app_tests.rs              # App state transitions (ratatui-free)
+└── worktree_integration.rs       # git2 add / list / remove / prune
+```
+
+## sentinel tests
+
+Tests pinned to catch a specific regression are prefixed with a `// regression: <one-line>` comment inside the test body, so the original incident is discoverable without `git blame`:
+
+```rust
+#[test]
+fn trim_git_suffix_handles_trailing_slash() {
+  // regression: PR #68 Copilot review — owner/repo.git/ left ".git" in the slug
+  assert_eq!(trim_git_suffix("https://github.com/owner/repo.git/"), "owner/repo");
+}
+```
+
+Find them all:
+
+```bash
+grep -rn "regression:" tests/
+```
+
+Suite hygiene (sentinel coverage vs incident catalogue) was last audited in [`claudedocs/test-audit-0.4.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/claudedocs/test-audit-0.4.0.md). Re-run the audit after each minor — drift accumulates fast around the launcher and GitHub-linking surfaces.
+
+## unit tests
+
+In addition to the 15 integration files, `src/` carries unit tests inside `#[cfg(test)] mod tests { … }` blocks colocated with the code under test. They cover:
+
+- Pure functions (kebab normalisation, slug parsing, sigil arithmetic)
+- Serde round-trips on every `Config` sub-struct
+- Internal predicates not exposed on the public surface
+
+`cargo test` runs them alongside the integration suite — they don't need a separate invocation.
+
+## what to run before pushing
+
+The minimum bar enforced by the pre-commit hook (and by CI):
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All three must be green. The pre-commit hook lives in [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit); enable it with:
+
+```bash
+git config core.hooksPath tools/git-hooks
+```
+
+(or via the bundled bootstrap if your repo's `.gwm.toml` wires it in).
+
+## dev shell
+
+The Nix flake exports a pinned dev shell — Rust toolchain (pinned to the same `rust-toolchain.toml` version used in CI), `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the `libgit2` build deps — without touching the host system:
+
+```bash
+nix develop                # drops you in the shell
+cargo test                 # everything works out of the box
+```
+
+See [Integrations → Homebrew and Nix](/integrations/homebrew-nix#nix-flake) for the full flake surface.
+
+## related
+
+- [Contributing](/development/contributing) — conventions for adding tests and the regression-comment format
+- [Roadmap](/roadmap) — upcoming areas that will need new test coverage

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -1,0 +1,8 @@
+---
+title: Testing
+description: 15 integration test files, 433 tests, sentinel-test convention, and how to run a subset.
+---
+
+# Testing
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/6.development/2.contributing.md
+++ b/docs/6.development/2.contributing.md
@@ -1,0 +1,8 @@
+---
+title: Contributing
+description: Gitmoji + Conventional Commits, branch naming, PR checklist, CHANGELOG split rules.
+---
+
+# Contributing
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/6.development/2.contributing.md
+++ b/docs/6.development/2.contributing.md
@@ -5,4 +5,118 @@ description: Gitmoji + Conventional Commits, branch naming, PR checklist, CHANGE
 
 # Contributing
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+This page summarises the repo's contribution conventions. The full long-form lives in [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) at the repo root; this page exists so the docs site can carry the same info without forking the source of truth.
+
+## branch naming
+
+```
+<type>/#<issue>-<short-description>
+```
+
+Examples:
+
+```
+feat/#42-user-auth
+fix/#117-leak
+docs/#77-sync-v0-6-0-docs
+chore/#56-precommit-hook
+```
+
+- `<type>` — one of `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
+- `<issue>` — the GitHub issue number (digits only). One issue per branch keeps the auto-link working (see [GitHub linking](/integrations/github-linking#auto-detection)).
+- `<short-description>` — kebab-case, ~3-4 words, normalised automatically by `gwm create`.
+
+Never work directly on `main` or `dev`. `gwm create <type> <N> <slug>` produces a conformant branch + worktree in one step.
+
+## commit format
+
+Gitmoji + Conventional Commits — one commit per concern, atomic, descriptive:
+
+```
+<emoji> <type>(<scope>)<!>: <subject>
+
+<body — optional, wrap at 72>
+
+refs #N            ← intermediate commits
+closes #N          ← ONLY on the last commit of the series
+```
+
+### emoji + type table
+
+| Emoji  | Type     | Use for                                                  |
+|:-------|:---------|:---------------------------------------------------------|
+| ✨     | `feat`   | new capability                                            |
+| 🐛     | `fix`    | bug fix                                                   |
+| ♻️     | `refactor` | restructuring without behaviour change                  |
+| ✅     | `test`   | tests added or fixed                                      |
+| 📝     | `docs`   | README / CHANGELOG / inline doc / this very tree         |
+| 🔧     | `chore`  | tooling, config, deps                                     |
+| 🏗️     | `build`  | release / cut / version bump                              |
+| 👷     | `ci`     | workflows                                                 |
+| ⚡     | `perf`   | measured performance improvement                          |
+| 🚑️     | `hotfix` | urgent fix shipped outside the normal release cadence     |
+| 🔥     | `chore(remove)` | dead code / file removal                           |
+| ⬆️     | `chore(bump)`   | dependency bump                                    |
+| 🔒     | `security` | security-relevant fix                                   |
+
+### scopes (gwm-cli)
+
+`config`, `naming`, `worktree`, `bootstrap`, `cli`, `tui`, `tests`, `docs`, `ci`, `structure`, `launcher`, `github`, `doctor`, `skill`, `changelog`. Pick whichever subsystem the diff touches; add new ones sparingly.
+
+### breaking changes
+
+Append `!` after the type and add a `BREAKING CHANGE:` footer:
+
+```
+✨ feat(config)!: rename [worktree.base] to [worktree.root]
+
+BREAKING CHANGE: rename [worktree.base] to [worktree.root]. Existing
+configs continue to parse but emit a one-shot deprecation warning;
+the alias will be removed in v1.0.
+```
+
+## CHANGELOG split
+
+The repo uses a **root + per-version** split:
+
+- [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) at the root holds **only**:
+  - `## [Unreleased]` — the in-progress section new commits add to (`Added / Changed / Fixed / Docs / Dependencies`)
+  - `## Past releases` — a one-line index of every stable + pre-release, pointing at `changelogs/<version>.md`
+- [`changelogs/<version>.md`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs) — one file per release, with the full notes.
+  - Pre-release notes (`-rc.N`, `-alpha.N`, `-beta.N`) live under `changelogs/pre-releases/<version>.md`.
+
+When you ship a feature mid-cycle, append a bullet to `[Unreleased]` in the root file:
+
+```md
+## [Unreleased]
+
+### Added
+
+- ✨ **TUI yank** (`y`) — copy the selected worktree's path to the system clipboard. ([#73](https://github.com/kbrdn1/gwm-cli/issues/73))
+```
+
+At release time (cut by a `🏗️ build: cut vX.Y.Z` commit), `[Unreleased]` is moved into a new `changelogs/<version>.md` and the root section is reset to empty. The CI `release.yml` job sources its release notes from `changelogs/<version>.md`, never from the root file — fixed by commit `4a76a3d` after an earlier release used a wrong source.
+
+## pull-request checklist
+
+Every PR should tick:
+
+- Branch follows `<type>/#<issue>-<description>`
+- Commits follow Gitmoji + Conventional Commits, atomic
+- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` all green
+- CHANGELOG.md updated under `[Unreleased]` (or N/A for pure refactors with no observable change)
+- `gwm doctor` runs cleanly on a fresh worktree of the branch
+
+The PR template ([`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/PULL_REQUEST_TEMPLATE.md)) carries the full version.
+
+## history
+
+gwm started as a Rust rewrite of `tools/worktree-manager.sh` — a bash script tied to one team's Laravel stack and one incident history (the `.env`-pointing-at-AWS-RDS incident behind [Regex guards](/configuration/guards#the-origin-story)). The Rust version keeps the lessons, makes them configurable per repo, and ships as a single binary so it works in every repo without per-project shell-script copies.
+
+The bash heritage is still visible in places — the `✓ / ! / ✗` sigils in bootstrap and doctor reports, the kebab-case slug normalisation, the no-symlink invariants on `vendor/` and `node_modules/` — all carried over from the original script. The Rust rewrite added the TUI, the configurability surface (`.gwm.toml`), the `when:` predicate grammar, the GitHub linking, and the configurable launchers.
+
+## related
+
+- [Testing](/development/testing) — what to run before pushing, sentinel-test convention
+- [Roadmap](/roadmap) — open items contributors can pick up
+- [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) — the long-form source of truth

--- a/docs/6.development/index.md
+++ b/docs/6.development/index.md
@@ -1,0 +1,37 @@
+---
+title: Development
+description: Building gwm from source, the test suite layout, and the contributing conventions (branches, commits, PRs).
+navigation:
+  title: Development
+---
+
+# Development
+
+gwm is a small Rust crate (single binary). Build, test, and ship workflows are documented here.
+
+- **[Testing](/development/testing)** — the 15 integration test files (433 tests as of v0.6.0), how to run a subset, and the `// regression:` sentinel-test convention.
+- **[Contributing](/development/contributing)** — the Gitmoji + Conventional-Commit format, branch naming, the PR checklist, and the rules around the `CHANGELOG.md` / `changelogs/<version>.md` split.
+
+## quick reference
+
+```bash
+cargo build              # debug build
+cargo test               # 433 tests across 15 integration files + unit tests
+cargo fmt && cargo clippy -- -D warnings
+cargo run                # opens TUI in the current repo
+cargo install --path .   # install locally
+```
+
+A Nix dev shell is pinned in [`flake.nix`](https://github.com/kbrdn1/gwm-cli/blob/main/flake.nix) — toolchain, `rust-analyzer`, `clippy`, `rustfmt`, `cargo-watch`, `cargo-edit`, and the `libgit2` build deps — without touching the host system:
+
+```bash
+nix develop
+```
+
+## vs. bash script
+
+The full background — what changed from the original `tools/worktree-manager.sh` and why — lives in the contributing page under "[history](/development/contributing#history)".
+
+## changelog
+
+Released versions live under [`changelogs/<version>.md`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs); the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) only holds the current `[Unreleased]` section plus an index of past releases.

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -5,4 +5,33 @@ description: What ships next — post-v0.6.0 priorities and the link to the issu
 
 # Roadmap
 
-Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.
+The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
+
+## shipped in v0.6.0
+
+For reference — what made it into the current stable line:
+
+- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://github.com/kbrdn1/gwm-cli/pull/68)) — `gwm link / unlink / open / status`, auto-detect from `<type>/#<N>-<slug>`, live status in the TUI sidebar via `gh`. See [GitHub linking](/integrations/github-linking).
+- **TUI Details sidebar redesign** ([#69](https://github.com/kbrdn1/gwm-cli/issues/69) / [#70](https://github.com/kbrdn1/gwm-cli/pull/70)) — four independent rounded-border subsections (Worktree / Issue · PR / Working Tree / Recent Commits). See [Sidebar](/tui/sidebar).
+- **TUI Recent Commits panel — lazygit-style layout** ([#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72)) — 300-commit buffer, hard-clipped subjects, full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
+- **TUI sidebar lazygit-style facelift** ([#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74)) — `Created` branch-age column, status-coloured branch names, header status dot, `o`/`y` rebinds, `[tui.open]` dispatch.
+- **TUI configurable launchers** ([#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [#76](https://github.com/kbrdn1/gwm-cli/pull/76)) — `[git_tui]` and `[review]` sections with `{base} {head} {path} {diff}` placeholders. See [Configurable launchers](/tui/launchers).
+
+The full v0.6.0 release notes (with the Changed / Fixed / Removed sections, Dependencies, and PR-by-PR breakdown) live at [`changelogs/0.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.6.0.md).
+
+## what's next
+
+Post-v0.6.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:
+
+- [Open issues — `enhancement`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aenhancement)
+- [Open issues — `good first issue`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+- [Open issues — `roadmap`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aroadmap)
+
+`[Unreleased]` in the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) reflects what's accumulated on `dev` since the last release — check there for the merged-but-not-yet-shipped surface.
+
+## how to contribute
+
+1. Pick an issue or open a new one with `--label enhancement` / `--label bug` describing the scope.
+2. `gwm create <type> <issue> <slug>` to spin up an isolated worktree (the issue auto-links itself — see [GitHub linking](/integrations/github-linking#auto-detection)).
+3. Follow the conventions in [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md) — see [Contributing](/development/contributing) for the docs-site version.
+4. Open a PR targeting `dev`. Stable releases ship via a `dev → main` merge PR following the convention `🔀 chore(release): merge dev → main for vX.Y.Z`.

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,0 +1,8 @@
+---
+title: Roadmap
+description: What ships next — post-v0.6.0 priorities and the link to the issue tracker.
+---
+
+# Roadmap
+
+Content migrates here in a subsequent commit on this branch — see [`README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/README.md) for the live source meanwhile.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+---
+title: docs/ — authoring conventions
+description: How the gwm documentation tree is organised for Nuxt Content (or any other SSG).
+navigation: false
+---
+
+# `docs/` — authoring conventions
+
+This tree is the source of truth for the gwm user docs and the future static documentation site. It is structured to drop straight into [Nuxt Content](https://content.nuxt.com/) (or any SSG that follows the same numeric-prefix routing convention).
+
+## layout
+
+```
+docs/
+├── index.md                              # → /
+├── 1.getting-started/                    # → /getting-started
+│   ├── index.md
+│   ├── 1.install.md                      # → /getting-started/install
+│   ├── 2.first-worktree.md
+│   └── 3.shell-init.md
+├── 2.tui/                                # → /tui
+├── 3.cli/                                # → /cli
+├── 4.configuration/                      # → /configuration
+├── 5.integrations/                       # → /integrations
+├── 6.development/                        # → /development
+└── 7.roadmap.md                          # → /roadmap
+```
+
+Numeric prefixes (`1.`, `2.`, `3.`) drive **sidebar ordering** in Nuxt Content and are stripped from the resulting URL. Add a new page anywhere in the tree by giving it the next free prefix in its parent folder.
+
+## frontmatter contract
+
+Every page (including section `index.md` files) carries this minimal frontmatter:
+
+```yaml
+---
+title: <page title — rendered as <h1> and in <title>>
+description: <one-sentence teaser, used for SEO and search>
+---
+```
+
+Optional fields:
+
+- `navigation.title` — short label for the sidebar when the full title is too long.
+- `navigation.icon` — Iconify name (e.g. `lucide:terminal`) for SSGs that render section icons.
+- `navigation: false` — hide the page from the auto-generated sidebar (use for this README only).
+
+## links between docs pages
+
+Use **repo-relative paths from this `docs/` root** so the same links resolve on GitHub and inside the future site:
+
+```md
+See [Configurable launchers](/tui/launchers) for the `[git_tui]` / `[review]` schema.
+```
+
+(Nuxt Content rewrites bare `/segment` paths against the content root; on GitHub they render as broken-but-readable cross-references — acceptable until the site is live, at which point a relative-link audit can lift them all in one pass.)
+
+## images & assets
+
+When pages need screenshots or diagrams, drop them under `docs/<section>/_assets/` and reference them with a relative path (`![keymap](./_assets/tui-keymap.png)`). Keep this README out of the generated sidebar via `navigation: false`.
+
+## see also
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branch / commit / PR conventions
+- [`CHANGELOG.md`](../CHANGELOG.md) — release notes (root = `[Unreleased]`, per-version archives under `changelogs/`)
+- [`examples/gwm.toml.example`](../examples/gwm.toml.example) — annotated config reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+---
+title: gwm — git worktree manager
+description: Rust CLI + ratatui TUI to manage git worktrees across projects. Native libgit2, per-repo configurable bootstrap, single binary.
+---
+
+# gwm
+
+Rust CLI + ratatui TUI to manage git worktrees across projects.
+
+- Native `libgit2` (vendored) — no `gwq` / `git` CLI dependency.
+- `gwm <subcommand>` for scripts and hooks; bare `gwm` opens a ratatui interface.
+- Per-repo `.gwm.toml`: branch / path conventions, file copies, regex guards, shell hooks, no-symlink invariants.
+- Branch convention `<type>/#<issue>-<description>` by default; overridable per repo.
+- Configurable launchers for the `l` (git TUI) and `R` (review) keybindings.
+- First-class GitHub issue / PR linking — branches matching the naming convention auto-link to their issue.
+
+## documentation map
+
+| Section                                            | Read this when …                                                              |
+|:---------------------------------------------------|:------------------------------------------------------------------------------|
+| [Getting Started](/getting-started)                | you want to install gwm and create your first worktree                        |
+| [TUI](/tui)                                        | you live in the ratatui interface — keymap, sidebar, launchers, filter        |
+| [CLI](/cli)                                        | you script gwm from shells, CI jobs, or `gh` aliases                          |
+| [Configuration](/configuration)                    | you're writing or extending `.gwm.toml` — bootstrap, guards, predicates       |
+| [Integrations](/integrations)                      | you wire gwm with `gh`, `lazygit`, Homebrew, Nix, or `gwm doctor` in CI       |
+| [Development](/development)                        | you're contributing — test layout, conventions, dev shell                     |
+| [Roadmap](/roadmap)                                | you want to know what ships next                                              |
+
+## the 30-second tour
+
+```bash
+# install
+cargo install --path .
+# or: brew tap kbrdn1/tap && brew install gwm
+
+# bootstrap a per-repo config (optional but recommended)
+cd /path/to/your/repo
+gwm init
+
+# create a worktree on a feature branch
+gwm create feat 42 user-authentication
+# → ~/cc-worktree/<repo>/feat-42-user-authentication
+# → branch feat/#42-user-authentication
+
+# open the TUI on the current repo
+gwm
+
+# fuzzy-jump back into an existing worktree (with `gwm shell-init` wired up)
+gcd auth
+```
+
+## why gwm
+
+The bash version (`tools/worktree-manager.sh` in some of our repos) was tied to one project's stack and one team's incident history. `gwm` keeps the lessons — anti-RDS guards, `.env.testing` copies, post-create hooks — and makes them configurable per repo. One binary, same behaviour everywhere.
+
+The full background lives in [the changelog](/development#changelog) and in the issue-tracker history at [github.com/kbrdn1/gwm-cli](https://github.com/kbrdn1/gwm-cli).

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -117,3 +117,51 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # [tui]
 # confirm_countdown_secs = 3
+
+# --- TUI launcher: `l` (git_tui) keybinding (issue #75) ----------------------
+# The `l` key suspends the gwm TUI and launches a git TUI on the selected
+# worktree. Placeholders: {path}. Default (no section) → `lazygit -p {path}`
+# fullscreen=true, identical to the pre-issue-#75 hardcoded behaviour.
+#
+# Switch to gitui:
+# [git_tui]
+# command = "gitui -d {path}"
+# fullscreen = true
+#
+# Or to a non-TUI tool (gwm stays visible, stderr first-line lands in the
+# status bar):
+# [git_tui]
+# command = "code {path}"
+# fullscreen = false
+
+# --- TUI launcher: `R` (review) keybinding (issue #75) -----------------------
+# The `R` key runs a code-review tool against the resolved base ref.
+# Placeholders in `command`:
+#   {base}  — resolved base (upstream → branch.<n>.gwm-base → default_base
+#             → "dev" → "main")
+#   {head}  — selected worktree's branch name
+#   {path}  — absolute path of the selected worktree
+#   {diff}  — path to a temp file holding `git diff {base}..{head}`
+#             (lazily materialised; only created if the template uses it)
+#
+# Built-in presets — pick one with `tool = "<name>"` instead of `command`:
+#   lumen  → "lumen diff {base}..{head}"             · fullscreen=true
+#   claude → "claude --print 'review the diff {base}..{head}'" · fullscreen=false
+#   codex  → "codex review {base}..{head}"           · fullscreen=false
+#   aider  → "aider --message 'review {base}..{head}'" · fullscreen=true
+#   gh     → "gh pr view --web"                      · fullscreen=false
+#
+# When both `command` and `tool` are set, `command` wins (the TUI flags
+# the shadow in the status bar). Setting neither leaves `R` inert with
+# a status-bar hint.
+#
+# [review]
+# tool = "lumen"
+# skip_when_no_changes = true   # default true — skip when `git rev-list --count {base}..{head} == 0`
+# # default_base = "dev"        # optional pin overriding the auto-discovery chain
+#
+# Explicit form (overrides any preset):
+# [review]
+# command              = "lumen diff {base}..{head}"
+# fullscreen           = true
+# skip_when_no_changes = true

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -117,3 +117,18 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # [tui]
 # confirm_countdown_secs = 3
+
+# --- `o: open` dispatch (issue #73) -----------------------------------------
+# How the `o` key behaves on the highlighted worktree. Three modes:
+#   "shell"  — suspend the TUI and spawn $SHELL with cwd = worktree.
+#              Lazygit-style. Default. Exit the shell ⇒ TUI restores.
+#   "editor" — suspend the TUI and run $EDITOR <worktree-path>.
+#   "finder" — pre-#73 behaviour: hand off to the OS file manager
+#              (`open` / `xdg-open` / `explorer`).
+# `shell_cmd` / `editor_cmd` override the env var when set (empty string
+# = unset). An unknown `mode` is a hard config error at load time.
+#
+# [tui.open]
+# mode = "shell"
+# shell_cmd = ""        # leave empty to read $SHELL
+# editor_cmd = "hx"     # example: Helix

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -102,10 +102,12 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 | `d`         | delete (confirm `y`)                                                            |
 | `b`         | re-run bootstrap on selected                                                    |
 | `o`         | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`)         |
-| `l`         | launch `lazygit -p <selected-worktree>` fullscreen; gwm resumes on lazygit exit |
+| `l`         | run the configured `[git_tui]` launcher (default `lazygit -p <selected-worktree>` fullscreen) |
+| `R`         | run the configured `[review]` launcher against the resolved base (issue #75)    |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)    |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `r`         | refresh                                                                         |
+| `f`         | refresh worktree list (also accepts `r` for muscle memory)                      |
+| `F`         | refresh GitHub issue/PR status via `gh`                                         |
 | `p`         | toggle "delete branch on remove"                                                |
 | `Enter`     | show path in status bar                                                         |
 | `?`         | help overlay                                                                    |
@@ -123,9 +125,59 @@ When the terminal width is ≥ 120 columns and the sidebar is open (default ON, 
 
 `Tab` swaps focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel. The focused panel's border turns cyan.
 
-## Lazygit integration
+## Configurable launchers (`l` git_tui · `R` review) — issue #75
 
-Press `l` to suspend the gwm TUI and open [`lazygit`](https://github.com/jesseduffield/lazygit) fullscreen on the selected worktree (`lazygit -p <path>`). Quitting lazygit restores the gwm TUI exactly where you left it. If `lazygit` is not on `$PATH`, the status bar reports it and the TUI keeps running.
+Two TUI keybindings share the same mini-API: take a `command` template from `.gwm.toml`, substitute placeholders, split with `shell-words`, and exec it with `cwd = <selected-worktree>`.
+
+| Key | Section     | Default                       | Placeholders                          | Default `fullscreen` |
+|:----|:------------|:------------------------------|:--------------------------------------|:---------------------|
+| `l` | `[git_tui]` | `lazygit -p {path}`           | `{path}`                              | `true`               |
+| `R` | `[review]`  | _(inert until configured)_    | `{base} {head} {path} {diff}`         | `false`              |
+
+`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command in the background, captures stderr's first line, and lands it on the status bar. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
+
+### `[review]` base resolution chain (for `{base}`)
+
+1. `branch.<name>.merge` (the branch's upstream, if any).
+2. `branch.<name>.gwm-base` (recorded by `gwm create` so the parent ref survives `git push -u`).
+3. `[review].default_base` from `.gwm.toml`.
+4. `"dev"` (gwm's project convention).
+5. `"main"` (universal git default).
+
+### `[review].tool` built-in presets
+
+Sugar over `command + fullscreen`. Setting both `command` and `tool` makes `command` win (the TUI surfaces the shadow on next render).
+
+| `tool = "X"` | Resolves to                                              | `fullscreen` default |
+|:-------------|:---------------------------------------------------------|:---------------------|
+| `lumen`      | `lumen diff {base}..{head}`                              | true (TUI)           |
+| `claude`     | `claude --print 'review the diff {base}..{head}'`        | false                |
+| `codex`      | `codex review {base}..{head}`                            | false                |
+| `aider`      | `aider --message 'review {base}..{head}'`                | true (TUI)           |
+| `gh`         | `gh pr view --web`                                       | false                |
+
+### Worked snippets
+
+```toml
+# Switch the `l` key to gitui.
+[git_tui]
+command = "gitui -d {path}"
+
+# Review with lumen (TUI), skip when nothing to review.
+[review]
+tool = "lumen"
+skip_when_no_changes = true
+# default_base = "dev"   # optional pin overriding the auto chain
+
+# Or a free-form shell line — `command` always wins over `tool`.
+[review]
+command = "my-review-bot --diff-file {diff} --owner kbrdn1"
+fullscreen = false
+```
+
+### `gwm doctor` integration
+
+A configured `[review]` / `[git_tui]` binary that is not on `$PATH` surfaces as **Warning** (exit code `1`), never **Failed** (exit code `2`) — both launchers are opt-in, so a CI pre-commit hook gated on `gwm doctor` keeps passing when the only red flag is a missing local-only tool.
 
 ## `.gwm.toml` schema
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -280,7 +280,7 @@ Two TUI keybindings share the same mini-API: take a `command` template from `.gw
 | `l` | `[git_tui]` | `lazygit -p {path}`           | `{path}`                              | `true`               |
 | `R` | `[review]`  | _(inert until configured)_    | `{base} {head} {path} {diff}`         | `false`              |
 
-`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command in the background, captures stderr's first line, and lands it on the status bar. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
+`fullscreen = true` suspends the gwm TUI for a TUI-style takeover (same recipe as the pre-issue-#75 `l` → lazygit flow); `fullscreen = false` runs the command **synchronously in-place** — gwm stays in the alt-screen, `Command::output()` blocks the TUI until the child exits, and the first line of stderr lands on the status bar. Fine for quick print-only tools (`claude --print`, `gh pr view --web`); pick `fullscreen = true` for anything long-running so the TUI is properly suspended and restored. The `{diff}` placeholder is **lazy** — gwm only shells out to `git diff {base}..{head}` (into a tempfile) when the template references it.
 
 ### `[review]` base resolution chain (for `{base}`)
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: gwm
-description: Manage git worktrees across any repository with the `gwm` Rust binary (CLI + ratatui TUI). Use when the user asks to create / list / remove / bootstrap worktrees, mentions `gwm`, `gwq`, `git worktree`, or asks about per-repo `.gwm.toml` config (branch conventions, file copies, regex guards on `.env`, shell hooks like composer/npm install, no-symlink invariants). Replaces project-specific `tools/worktree-manager.sh` bash wrappers. Triggers on "worktree", "gwm", "gwm create", "gwm list", "gwm bootstrap", ".gwm.toml", "bootstrap worktree", "feat/#", "fix/#".
+description: Manage git worktrees across any repository with the `gwm` Rust binary (CLI + ratatui TUI). Use when the user asks to create / list / remove / bootstrap / switch / link worktrees, diagnose with `gwm doctor`, drive tmux/zellij from a worktree, or wire `gcd` via `gwm shell-init`. Triggers on `gwm`, `gwq`, `git worktree`, `.gwm.toml`, `gwm create`, `gwm list`, `gwm bootstrap`, `gwm doctor`, `gwm switch`, `gwm tmux`, `gwm zellij`, `gwm link`, `gwm status`, `gwm shell-init`, `gcd`, `feat/#`, `fix/#`, GitHub issue/PR linking on a worktree.
 allowed-tools: Bash, Read, Edit, Write
 ---
 
 # gwm — git worktree manager (Rust CLI + TUI)
 
-Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, and a declarative per-repo bootstrap (`.gwm.toml`). Replaces project-specific bash wrappers (`tools/worktree-manager.sh`-style) with one portable binary that works in any git repo.
+Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli
+Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0-rc.1`.
 
 ## When to use this skill
 
-- User runs or asks about `gwm <subcommand>` (init / list / create / remove / path / bootstrap / prune / types).
-- User opens the TUI by running `gwm` alone in a repo.
-- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`.
+- User runs or asks about any `gwm <subcommand>`: `init`, `list`, `create`, `remove`, `path` / `cd`, `bootstrap`, `prune`, `doctor`, `types`, `completions`, `shell-init`, `switch` (alias `s`), `tmux`, `zellij`, `link`, `unlink`, `open`, `status`.
+- User opens the TUI by running `gwm` alone in a repo, or the picker via `gwm switch` / `gwm s`.
+- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[doctor]`, `[tui]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[bootstrap.fallback.*]`.
+- User asks about composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`) and the `!` / `&&` / `||` operators.
 - User wants to migrate a `tools/worktree-manager.sh` or `gwq`-based workflow to `gwm`.
 - User asks how to set up the AWS RDS guard, the safe `.env.testing` fallback, or the no-symlink invariant for `vendor/` / `node_modules/`.
 - User asks about the branch convention `<type>/#<issue>-<desc>` or its overrides.
+- User wants to link a worktree to a GitHub issue / PR, refresh GitHub status from inside the TUI, or run `gwm doctor` to validate setup before pushing.
+- User mentions `gcd <pattern>` (shell wrapper from `gwm shell-init <shell>`).
+- User wants tmux / zellij hand-off (`gwm tmux <pat>`, `gwm zellij <pat>` with optional `--split`).
 
 ## Prerequisites
 
@@ -25,6 +29,10 @@ Source: https://github.com/kbrdn1/gwm-cli
 command -v gwm           # required — installed by `cargo install --path .` from the gwm-cli repo
 command -v cargo         # required at install time (1.80+ recommended)
 command -v git           # required at runtime
+command -v gh            # OPTIONAL — needed for live `gwm status` GitHub data
+command -v tmux          # OPTIONAL — needed by `gwm tmux`
+command -v zellij        # OPTIONAL — needed by `gwm zellij` (≥ 0.40 for `--cwd` on new-tab)
+command -v lazygit       # OPTIONAL — needed by the TUI `l` hand-off
 ```
 
 `gwm` vendors `libgit2`, so no system git2 lib is needed. The binary is self-contained once compiled.
@@ -38,7 +46,7 @@ cargo install --path .         # → ~/.cargo/bin/gwm
 gwm --version
 ```
 
-Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): https://github.com/kbrdn1/gwm-cli/releases.
+Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): https://github.com/kbrdn1/gwm-cli/releases. A Homebrew formula ships under `packaging/homebrew/` and a Nix `flake.nix` is at the repo root.
 
 ## Default conventions
 
@@ -48,6 +56,8 @@ Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): ht
 | Worktree dir name   | `<type>-<issue>-<desc>`              | `.gwm.toml` `path_pattern`     |
 | Worktree base       | `~/cc-worktree/<repo>/`              | `.gwm.toml` `base`             |
 | Bootstrap           | none (just `git worktree add`)       | `.gwm.toml` `[bootstrap.*]`    |
+| Doctor trunks       | `["dev", "main"]`                    | `.gwm.toml` `[doctor] trunks`  |
+| TUI confirm timer   | `3` (clamped 0..=5)                  | `.gwm.toml` `[tui] confirm_countdown_secs` |
 
 Branch types: `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`.
 
@@ -66,12 +76,73 @@ gwm create feat 123 foo --no-bootstrap    # skip the .gwm.toml stages
 
 gwm list                                  # list worktrees of the current repo
 gwm path <pattern>                        # print path (fuzzy match) → use $(gwm path auth)
+gwm cd   <pattern>                        # alias of `gwm path`
 gwm bootstrap                             # re-run bootstrap on cwd worktree
 gwm bootstrap <pattern>                   # ...or on a named worktree
 gwm remove <pattern>                      # remove (fuzzy). Keeps the branch.
 gwm remove <pattern> --delete-branch      # also drop the local branch
 gwm prune                                 # clean stale .git/worktrees entries
+
+gwm doctor                                # diagnose setup. Exit: 0=green, 1=warn, 2=fail
+gwm completions <bash|elvish|fish|powershell|zsh>   # emit a shell-completion script on stdout
+gwm shell-init  <bash|fish|powershell|zsh>          # emit a `gcd <pattern>` wrapper to eval/source
+
+gwm switch                                # interactive picker → prints chosen path to stdout
+gwm s                                     # alias of `gwm switch`
+
+gwm tmux   <pattern> [-p|--split]         # open matched worktree in new tmux window (or split)
+gwm zellij <pattern> [-p|--split]         # open matched worktree in new zellij tab (or pane)
+
+gwm link   issue|pr <N> [--worktree PAT]  # bind a worktree to a GitHub issue or PR
+gwm unlink issue|pr      [--worktree PAT] # remove the explicit link
+gwm open   [issue|pr]    [--worktree PAT] # open the linked URL in $BROWSER
+gwm status [--worktree PAT] [--json]      # show link + live GitHub state (needs `gh`)
 ```
+
+### `gwm doctor`
+
+Runs a structured set of checks across config, environment, and worktree state. Designed for CI / pre-commit hooks:
+
+| Exit | Meaning                                                                  |
+|:-----|:-------------------------------------------------------------------------|
+| `0`  | All checks green                                                         |
+| `1`  | At least one **warning** (advisory, e.g. orphan gwm-style branch)        |
+| `2`  | At least one **failure** (broken config, prunable worktree, etc.)        |
+
+Trunk branches the orphan-branch check treats as merge destinations come from `[doctor] trunks = [...]` (default `["dev", "main"]`). Setting `trunks = []` disables the filter (every unclaimed gwm-style branch is flagged).
+
+### `gwm shell-init` → `gcd <pattern>`
+
+The emitted wrapper defines a `gcd` function that resolves a worktree by fuzzy pattern and `cd`s into it in one keystroke. Install per shell:
+
+```bash
+# zsh
+echo 'eval "$(gwm shell-init zsh)"'  >> ~/.zshrc
+# bash
+echo 'eval "$(gwm shell-init bash)"' >> ~/.bashrc
+# fish
+gwm shell-init fish | source        # also add the eval to ~/.config/fish/config.fish
+# powershell
+Invoke-Expression (& gwm shell-init powershell | Out-String)
+```
+
+`gcd` (no arg) launches `gwm switch` (the picker) and `cd`s into the chosen entry.
+
+### GitHub linking (`link` / `unlink` / `open` / `status`)
+
+Links live in **per-branch git config**:
+
+- `branch.<name>.gwm-issue` ← `gwm link issue <N>`
+- `branch.<name>.gwm-pr`    ← `gwm link pr <N>`
+
+Local, per-branch, survives worktree moves. Issue numbers are auto-detected from the `<type>/#<N>-<slug>` convention when no explicit override is set; PR numbers are **not** auto-detected and must be linked explicitly.
+
+`gwm status` shells out to `gh issue view` / `gh pr view` to fetch state, title, labels, and the CI rollup. Without `gh` (or outside a GitHub repo), it prints only the local link. `--json` emits a stable schema for scripting.
+
+### Multiplexer hand-off (`tmux` / `zellij`)
+
+- `gwm tmux <pat>` requires `$TMUX` to be set (i.e. you are already inside a tmux session) — otherwise it exits non-zero with a clear error rather than spawning a stray server. `--split` opens a horizontal split of the current pane instead of a new window.
+- `gwm zellij <pat>` requires `$ZELLIJ`. `--cwd` on `zellij action new-tab` needs zellij ≥ 0.40. `--split` opens a new pane in the current tab instead of a new tab.
 
 ## Status column
 
@@ -98,25 +169,34 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 | `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                           |
 | `gg`        | jump to the first worktree                                                      |
 | `G`         | jump to the last worktree                                                       |
+| `/`         | enter fuzzy filter mode (live narrowing as you type; `Esc` to clear)            |
 | `n`         | new worktree form (type ↑/↓, Tab between fields, Enter on desc submits)         |
-| `d`         | delete (confirm `y`)                                                            |
+| `d`         | delete (confirm `y`; under the safety countdown, `y` again cancels)             |
+| `p`         | toggle "delete branch on remove" (arms the safety countdown when ON)            |
 | `b`         | re-run bootstrap on selected                                                    |
 | `o`         | open worktree dir in OS file manager (`open` / `xdg-open` / `explorer`)         |
+| `O`         | open menu — pick issue or PR URL to open in `$BROWSER`                          |
+| `L`         | link prompt — bind selected worktree to a GitHub issue or PR number             |
+| `R`         | refresh GitHub status for the selection (re-fetches issue + PR data)            |
 | `l`         | launch `lazygit -p <selected-worktree>` fullscreen; gwm resumes on lazygit exit |
 | `v`         | toggle the git details sidebar (auto-hidden when terminal width < 120 cols)    |
 | `Tab`       | swap focus between the worktree list and the sidebar                            |
-| `r`         | refresh                                                                         |
-| `p`         | toggle "delete branch on remove"                                                |
-| `Enter`     | show path in status bar                                                         |
+| `r`         | refresh worktree list                                                           |
+| `Enter`     | show path in status bar (in picker mode: print path to stdout + exit)           |
 | `?`         | help overlay                                                                    |
-| `q` / `Esc` | quit                                                                            |
+| `q` / `Esc` | quit (Esc also exits filter / overlays without quitting)                        |
 | `Ctrl-C`    | force quit                                                                      |
+
+## Picker mode (`gwm switch` / `gcd`)
+
+`gwm switch` opens the same TUI minus the create / delete / bootstrap actions. The fuzzy filter bar opens immediately so typing narrows the list right away. `Enter` commits the highlighted pick (path → stdout). `Esc` / `Ctrl-C` / `q` exit non-zero without printing.
 
 ## Details sidebar
 
-When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a lazyssh-style details panel for the selected worktree:
+When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a details panel for the selected worktree:
 
 - **Basic Settings**: branch, path, head (short OID), main / locked / prunable flags, branch status.
+- **GitHub**: linked issue / PR with live state (open / closed / merged), title, labels, CI rollup — populated by `gh`. State machine per worktree: `Idle → Loading → Loaded(T) | Error(String)`. Refresh manually with `R`.
 - **Recent commits**: `git log --oneline -n 10` (shells out to `git`).
 - **Working tree**: `git status --short` (`✓ clean` when empty).
 - **Commands**: keybindings cheat-sheet inside the panel.
@@ -137,7 +217,7 @@ base           = "{home}/cc-worktree/{repo}"
 path_pattern   = "{type}-{issue}-{desc}"
 branch_pattern = "{type}/#{issue}-{desc}"
 
-# File copies main → worktree (run in order).
+# --- file copies main → worktree (run in order) -----------------------------
 [[bootstrap.copy]]
 from = ".env.testing"
 to   = ".env.testing"
@@ -150,15 +230,15 @@ to   = ".env"
 required = false
 guards = ["no-aws-rds"]       # references guard names
 
-# Regex guards on copied files.
+# --- regex guards on copied files -------------------------------------------
 [[bootstrap.guard]]
 name           = "no-aws-rds"
 deny_patterns  = ["amazonaws\\.com", "\\.rds\\."]
 on_match       = "seed-from-example"   # or "abort"
 example_file   = ".env.example"
 
-# Inline fallback when a required source is missing.
-# Key is the destination filename normalized: ".env.testing" → "env_testing".
+# --- inline fallback when a required source is missing ----------------------
+# Key is the destination filename normalised: ".env.testing" → "env_testing".
 [bootstrap.fallback.env_testing]
 target  = ".env.testing"
 content = """
@@ -167,24 +247,53 @@ DB_CONNECTION=sqlite
 DB_DATABASE=:memory:
 """
 
-# Symlinks to refuse (inherited from main).
+# --- symlinks to refuse (inherited from main) ------------------------------
 [[bootstrap.no_symlink]]
 path = "vendor"
 
 [[bootstrap.no_symlink]]
 path = "node_modules"
 
-# Shell commands after copies.
+# --- shell commands after copies -------------------------------------------
 [[bootstrap.command]]
 name = "composer install"
 run  = "composer install --no-interaction --prefer-dist"
-when = "file_exists:composer.json"     # only predicate supported today
+when = "file_exists:composer.json"
 env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 
+# --- composable when predicates --------------------------------------------
+# Atoms : file_exists:<path> | cmd_exists:<bin> | env_set:<VAR>
+#         env_eq:<VAR>=<value> | glob_exists:<pattern>
+# Ops   : ! (NOT) | && (AND) | || (OR)
+# Precedence: ! > && > ||
+
 [[bootstrap.command]]
-name = "direnv allow"
-run  = "direnv allow ."
-when = "file_exists:.envrc"
+name = "install (bun if available)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
+run  = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "full local build"
+run  = "./scripts/full-build.sh"
+when = "glob_exists:src/**/*.rs && !env_set:CI"
+
+# --- doctor knobs -----------------------------------------------------------
+# Trunks the orphan-branch check treats as merge destinations.
+# Default: ["dev", "main"]. `trunks = []` disables the filter entirely.
+[doctor]
+trunks = ["master", "release-3.x", "release-4.x"]
+
+# --- TUI knobs --------------------------------------------------------------
+# Safety countdown (seconds) applied to the delete-confirm overlay when
+# `delete branch on remove` (`p` in the TUI) is armed. Range 0..=5;
+# above 5 is clamped on read; 0 disables the countdown. Default: 3.
+[tui]
+confirm_countdown_secs = 3
 ```
 
 ## Bootstrap report
@@ -209,6 +318,8 @@ A run with any ✗ should be inspected before testing inside the worktree.
 3. Replace `./tools/worktree-manager.sh create feat 123 foo` with `gwm create feat 123 foo`.
 4. Replace `gwq list` / `gwq remove` / `gwq prune` with `gwm list` / `gwm remove` / `gwm prune`.
 5. Drop `gwq` from the repo's prerequisites (gwm is self-contained).
+6. Wire `gcd` into your shell: `echo 'eval "$(gwm shell-init zsh)"' >> ~/.zshrc`.
+7. Add `gwm doctor` to CI / pre-commit to catch broken setups before push.
 
 ### Setting up the AWS RDS guard (Laravel / production-safe)
 
@@ -257,7 +368,7 @@ when = "file_exists:composer.json"
 env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 ```
 
-### Node project (npm / pnpm / bun)
+### Node project (bun preferred, npm fallback)
 
 ```toml
 [[bootstrap.copy]]
@@ -269,9 +380,14 @@ required = false
 path = "node_modules"
 
 [[bootstrap.command]]
-name = "install deps"
+name = "install (bun)"
+run  = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[bootstrap.command]]
+name = "install (npm fallback)"
 run  = "npm ci"
-when = "file_exists:package-lock.json"
+when = "file_exists:package.json && !cmd_exists:bun"
 ```
 
 ### Quick create + cd
@@ -279,13 +395,63 @@ when = "file_exists:package-lock.json"
 ```bash
 gwm create feat 42 cool-thing
 cd "$(gwm path cool-thing)"
+# …or with the shell wrapper installed:
+gcd cool-thing
 ```
 
-Wrap as a shell function:
+### Picker → cd in one keystroke
 
 ```bash
-gwmcd() { cd "$(gwm path "$1")"; }
-gwmcd cool-thing
+# After `eval "$(gwm shell-init zsh)"`
+gcd            # opens the picker; cd into the chosen worktree on Enter
+```
+
+### Hand-off into tmux / zellij
+
+```bash
+# Inside tmux:
+gwm tmux api-rewrite              # new window in current session
+gwm tmux api-rewrite --split      # …or split the current pane
+
+# Inside zellij (>= 0.40):
+gwm zellij api-rewrite            # new tab
+gwm zellij api-rewrite --split    # …or new pane in current tab
+```
+
+### Link a worktree to a GitHub issue / PR
+
+```bash
+# Auto-detected from feat/#123-foo branches → no link needed.
+gwm status                                  # shows the local link + (with gh) live state
+
+# Explicit linking:
+gwm link issue 456                          # current worktree → issue #456
+gwm link pr   789  --worktree api-rewrite   # named worktree → PR #789
+gwm open      pr                            # open the PR URL in $BROWSER
+gwm unlink    issue                         # drop the explicit issue link
+
+# Scripting:
+gwm status --json
+```
+
+### Pre-push sanity check
+
+```bash
+gwm doctor && git push           # blocks the push on any warning/failure
+```
+
+### Opt-in pre-commit hook (contributors)
+
+The repo ships an opt-in hook at `.githooks/pre-commit` that combines two gates:
+
+1. **Env-dependent test pre-validation** — if any staged `tests/*.rs` file references ambient state (`assert_cmd`, `std::env::var`, `which::which`, `dirs::`, `Command::cargo_bin`), the suite is re-run under a stripped `PATH="$(dirname cargo):/usr/bin:/bin"` to catch tests that pass in a rich dev shell but fail on minimal CI.
+2. **Local `gwm doctor`** — if staged files touch `.gwm.toml`, the bootstrap / doctor modules, the example config, or their tests, `gwm doctor` runs. Exit `0` is silent, `1` is advisory (commit proceeds), `2` blocks the commit. Unknown exits fail open.
+
+Enable per-clone:
+
+```bash
+git config core.hooksPath .githooks
+git commit --no-verify        # bypass for one commit, sparingly
 ```
 
 ## Architecture (for skill agents asked to extend gwm)
@@ -295,30 +461,37 @@ src/
 ├── lib.rs               # public re-exports — tests import these
 ├── main.rs              # bin entry, dispatches to cli::run
 ├── error.rs             # GwmError (thiserror) + Result alias
-├── config.rs            # serde TOML → Config (worktree, bootstrap)
+├── config.rs            # serde TOML → Config (worktree, bootstrap, doctor, tui)
 ├── naming.rs            # BranchSpec, kebab(), parse_branch()
-├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy (all via git2)
-├── bootstrap.rs         # run(BootstrapCtx) → BootstrapReport
+├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy (libgit2)
+├── bootstrap.rs         # run(BootstrapCtx) → BootstrapReport (copies / guards / commands / when DSL)
+├── doctor.rs            # `gwm doctor` checks (config, env, orphan branches, prunable wts)
+├── github.rs            # issue / PR link storage in git config + `gh` shell-out
+├── multiplexer.rs       # tmux / zellij hand-off (window/tab/split)
 ├── cli.rs               # clap subcommands + handlers
 └── tui/
-    ├── mod.rs           # crossterm event loop
-    ├── app.rs           # App state, transitions
-    └── ui.rs            # ratatui drawing
+    ├── mod.rs           # crossterm event loop (filter, link prompt, open menu, refresh)
+    ├── app.rs           # App state, transitions, GitHubFetchState<T>, ConfirmKeyAction
+    └── ui.rs            # ratatui drawing (sidebar incl. GitHub panel)
 ```
 
-Tests under `tests/` mirror this layout. TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one.
+Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.rs`, `bootstrap_when_tests.rs`, `cli_binary.rs`, `config_tests.rs`, `doctor_tests.rs`, `error_tests.rs`, `flake_tests.rs`, `github_tests.rs`, `homebrew_formula_tests.rs`, `multiplexer_tests.rs`, `naming_tests.rs`, `precommit_hook_tests.rs`, `tui_app_tests.rs`, `worktree_integration.rs` (+ `tests/common/` helpers). **TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one** (project rule, enforced in `CLAUDE.md`).
 
 ## Differences vs. the bash + gwq stack
 
-| Capability                  | bash + gwq            | gwm                            |
-|:----------------------------|:----------------------|:-------------------------------|
-| worktree engine             | `gwq` CLI external    | `libgit2` vendored             |
-| bootstrap                   | hardcoded shell       | declarative TOML + hooks       |
-| portability across repos    | per-project script    | one binary + per-repo config   |
-| TUI                         | linear bash menu      | full ratatui screen            |
-| anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list   |
-| tests                       | 0                     | 71 (config / naming / bootstrap / worktree / TUI / CLI) |
-| install                     | `chmod +x` per repo   | `cargo install --path .`       |
+| Capability                  | bash + gwq            | gwm                                                      |
+|:----------------------------|:----------------------|:---------------------------------------------------------|
+| worktree engine             | `gwq` CLI external    | `libgit2` vendored                                       |
+| bootstrap                   | hardcoded shell       | declarative TOML + composable `when` predicates          |
+| portability across repos    | per-project script    | one binary + per-repo config                             |
+| TUI                         | linear bash menu      | full ratatui screen + filter + GitHub panel              |
+| picker                      | none                  | `gwm switch` / `gcd` shell wrapper                       |
+| multiplexer hand-off        | none                  | `gwm tmux` / `gwm zellij` (window/tab/split)             |
+| GitHub linking              | none                  | issue / PR per-branch git config + `gh` live status      |
+| diagnostics                 | none                  | `gwm doctor` (exit 0/1/2, CI-ready)                      |
+| anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list                             |
+| tests                       | 0                     | 316 across 14 test files (config / bootstrap / when DSL / doctor / github / multiplexer / TUI / CLI / homebrew / flake / pre-commit hook) |
+| install                     | `chmod +x` per repo   | `cargo install --path .` (or Homebrew / Nix / prebuilts) |
 
 ## Troubleshooting
 
@@ -332,22 +505,42 @@ Tests under `tests/` mirror this layout. TDD bar: any new behaviour ships with a
 
 **TUI shows `(prunable)` next to a worktree** — its working dir was deleted out-of-band. Run `gwm prune` (or hit `r` in the TUI after manual cleanup).
 
+**`gwm doctor` exits `2` complaining about an orphan branch** — the branch matches `<type>/#<N>-<slug>` but isn't reachable from any trunk in `[doctor] trunks`. Either delete the branch, merge it, or add its merge target to `trunks`.
+
+**`gwm tmux` says `not inside a tmux session`** — `$TMUX` is unset. Start tmux first; gwm refuses to spawn a stray server.
+
+**`gwm zellij` errors on `--cwd`** — your zellij is older than 0.40. Upgrade, or fall back to opening the path manually.
+
+**`gwm status` shows only the local link, no live data** — `gh` isn't on `$PATH` (or you're outside a GitHub repo). Install GitHub CLI and `gh auth login`.
+
 **`cargo install --path .` fails to build libgit2** — install a C toolchain (`xcode-select --install` on macOS, `build-essential` on Debian/Ubuntu). The `git2` crate uses `vendored-libgit2` so it builds from source.
 
 **`.env` was copied even though it points to prod** — the guard's regex didn't match. Test it with `echo $YOUR_HOST | grep -E '<pattern>'`. Regex syntax is Rust `regex` crate (PCRE-like, no lookaround).
 
+**`gcd` says command not found** — the shell-init wrapper isn't sourced. Re-run `eval "$(gwm shell-init <shell>)"` in your current shell and add it to your shell's rc file.
+
 ## Quick reference card
 
 ```
-gwm                        # TUI
-gwm init                   # scaffold .gwm.toml
-gwm create <t> <#> <desc>  # create + bootstrap
-gwm list                   # list worktrees
-gwm path <pat>             # print path
-gwm bootstrap [pat]        # re-run bootstrap
-gwm remove <pat> [-b]      # remove (-b drops branch)
-gwm prune                  # clean stale refs
-gwm types                  # show branch types
+gwm                          # TUI
+gwm init                     # scaffold .gwm.toml
+gwm create <t> <#> <desc>    # create + bootstrap
+gwm list                     # list worktrees
+gwm path|cd <pat>            # print path
+gwm switch | gwm s | gcd     # interactive picker (cd via shell wrapper)
+gwm bootstrap [pat]          # re-run bootstrap
+gwm remove <pat> [-b]        # remove (-b drops branch)
+gwm prune                    # clean stale refs
+gwm types                    # show branch types
+gwm doctor                   # diagnose setup (exit 0/1/2)
+gwm completions <shell>      # emit shell completion script (bash/elvish/fish/powershell/zsh)
+gwm shell-init  <shell>      # emit gcd wrapper to eval (bash/fish/powershell/zsh)
+gwm tmux   <pat> [-p]        # tmux window / split hand-off
+gwm zellij <pat> [-p]        # zellij tab / pane hand-off
+gwm link   issue|pr <N>      # bind to GitHub issue / PR
+gwm unlink issue|pr          # drop the link
+gwm open   [issue|pr]        # open URL in $BROWSER
+gwm status [--json]          # local link + live gh state
 ```
 
 ## Related
@@ -355,3 +548,4 @@ gwm types                  # show branch types
 - Repo: https://github.com/kbrdn1/gwm-cli
 - Bash predecessor: `tools/worktree-manager.sh` (skill: `worktree-wrapper`) — `gwm` is the multi-repo replacement.
 - Naming convention: `CONTRIBUTING.md` (per repo) — matches `gwm` defaults.
+- Project rules for contributors / AI agents: `CLAUDE.md` (TDD mandatory, `gwm doctor` before PRs touching `.gwm.toml` / bootstrap schema / doctor).

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -8,13 +8,13 @@ allowed-tools: Bash, Read, Edit, Write
 
 Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0-rc.1`.
+Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0`.
 
 ## When to use this skill
 
 - User runs or asks about any `gwm <subcommand>`: `init`, `list`, `create`, `remove`, `path` / `cd`, `bootstrap`, `prune`, `doctor`, `types`, `completions`, `shell-init`, `switch` (alias `s`), `tmux`, `zellij`, `link`, `unlink`, `open`, `status`.
 - User opens the TUI by running `gwm` alone in a repo, or the picker via `gwm switch` / `gwm s`.
-- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[doctor]`, `[tui]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[bootstrap.fallback.*]`.
+- User mentions `.gwm.toml` (per-repo config) or any of its sections: `[worktree]`, `[doctor]`, `[tui]`, `[tui.open]`, `[git_tui]`, `[review]`, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`, `[[bootstrap.no_symlink]]`, `[[bootstrap.command]]`, `[bootstrap.fallback.*]`.
 - User asks about composable `when` predicates (`file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`) and the `!` / `&&` / `||` operators.
 - User wants to migrate a `tools/worktree-manager.sh` or `gwq`-based workflow to `gwm`.
 - User asks how to set up the AWS RDS guard, the safe `.env.testing` fallback, or the no-symlink invariant for `vendor/` / `node_modules/`.
@@ -22,6 +22,8 @@ Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0-rc.1`.
 - User wants to link a worktree to a GitHub issue / PR, refresh GitHub status from inside the TUI, or run `gwm doctor` to validate setup before pushing.
 - User mentions `gcd <pattern>` (shell wrapper from `gwm shell-init <shell>`).
 - User wants tmux / zellij hand-off (`gwm tmux <pat>`, `gwm zellij <pat>` with optional `--split`).
+- User wants to configure the TUI `l` (git_tui) / `R` (review) launchers, the `o` (open dispatch: shell/editor/finder), or `y` (yank path to clipboard) keys.
+- User asks about the `branch.<n>.gwm-base` key (review base-resolution anchor) or any of the `lumen` / `claude` / `codex` / `aider` / `gh` review presets.
 
 ## Prerequisites
 
@@ -29,10 +31,15 @@ Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0-rc.1`.
 command -v gwm           # required — installed by `cargo install --path .` from the gwm-cli repo
 command -v cargo         # required at install time (1.80+ recommended)
 command -v git           # required at runtime
-command -v gh            # OPTIONAL — needed for live `gwm status` GitHub data
+command -v gh            # OPTIONAL — needed for live `gwm status` / TUI GitHub state / `R: review` preset
 command -v tmux          # OPTIONAL — needed by `gwm tmux`
 command -v zellij        # OPTIONAL — needed by `gwm zellij` (≥ 0.40 for `--cwd` on new-tab)
-command -v lazygit       # OPTIONAL — needed by the TUI `l` hand-off
+command -v lazygit       # OPTIONAL — default `[git_tui]` binary backing the TUI `l` key
+command -v lumen         # OPTIONAL — `[review] tool = "lumen"` preset (default review tool)
+command -v claude        # OPTIONAL — `[review] tool = "claude"` preset
+command -v codex         # OPTIONAL — `[review] tool = "codex"` preset
+command -v aider         # OPTIONAL — `[review] tool = "aider"` preset
+command -v pbcopy        # OPTIONAL — TUI `y: yank` on macOS (wl-copy/xclip/xsel on Linux, clip on Windows)
 ```
 
 `gwm` vendors `libgit2`, so no system git2 lib is needed. The binary is self-contained once compiled.
@@ -134,6 +141,7 @@ Links live in **per-branch git config**:
 
 - `branch.<name>.gwm-issue` ← `gwm link issue <N>`
 - `branch.<name>.gwm-pr`    ← `gwm link pr <N>`
+- `branch.<name>.gwm-base`  ← _written by `gwm create`_ — anchors the `[review].{base}` resolution chain so the parent ref survives even when the branch has no upstream yet. Not user-facing; surfaces only via the `R: review` launcher.
 
 Local, per-branch, survives worktree moves. Issue numbers are auto-detected from the `<type>/#<N>-<slug>` convention when no explicit override is set; PR numbers are **not** auto-detected and must be linked explicitly.
 
@@ -196,15 +204,72 @@ The TUI table and `gwm list` both expose a `STATUS` column:
 
 ## Details sidebar
 
-When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a details panel for the selected worktree:
+When the terminal width is ≥ 120 columns and the sidebar is open (default ON, toggle with `v`), the right pane shows a details panel for the selected worktree. Since the lazygit-style redesign (issues #69 / #71 / #73) the panel is **four independent rounded-border subsections** stacked vertically — no outer `Details` frame, section titles ride the block borders, no inline `Label:` content headers.
 
-- **Basic Settings**: branch, path, head (short OID), main / locked / prunable flags, branch status.
-- **GitHub**: linked issue / PR with live state (open / closed / merged), title, labels, CI rollup — populated by `gh`. State machine per worktree: `Idle → Loading → Loaded(T) | Error(String)`. Refresh manually with `R`.
-- **Recent commits**: `git log --oneline -n 10` (shells out to `git`).
-- **Working tree**: `git status --short` (`✓ clean` when empty).
-- **Commands**: keybindings cheat-sheet inside the panel.
+```
+╭─ Worktree ──────────────────────╮      ●  status dot tracks the linked PR / issue
+│ ● api-rest                      │         state (open=green, draft=darkgray,
+│ feat/#42-api-rest · 08d1029     │         merged=magenta, closed=red, white=link
+│ Created: 2d                     │         not yet fetched, darkgray=no link).
+│ ✓ synced  ★ main                │         Rebuilt fresh every frame so it tracks
+│ ~/Projects/Flippad/…/api-rest   │         live `gh` fetches without invalidating
+╰─────────────────────────────────╯         the cached git preview.
 
-`Tab` swaps focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the focused panel. The focused panel's border turns cyan.
+╭─ Issue / PR ────────────────────╮      Live `gh issue view` / `gh pr view` data:
+│ #42 · open · 3 labels           │         state + checks rollup. Refresh with `F`.
+│ checks 7/8                      │         Empty block hints "press L to link" when
+╰─────────────────────────────────╯         the worktree has no link.
+
+╭─ Working Tree ──────────────────╮      `git status --short` (`✓ clean` when empty).
+│ ✓ clean                         │
+╰─────────────────────────────────╯
+
+╭─ Recent Commits ────────────────╮      Full lazygit-style topology graph (issue #71):
+│ 08d1029  KB  ○  feat: …         │         per-row format `<hash>  <initials>  <node>
+│ 4d874e7  KB  ○  fix: …          │         <subject>`, `○` for commit, `◎` for merge,
+│ 2d1d3ae  KB  ◎  merge: …        │         vertical pipes `│`, corners `╮ ╭ ╯ ╰`,
+│ … (300 commits, scrollable)     │         junctions `┴ ┬`, horizontal strokes `─`.
+│                          7 of 14│         Subjects hard-clipped (no Wrap). Buffer =
+╰─────────────────────────────────╯         300 commits (matches lazygit's `log -300`).
+                                            Bottom-right footer: `<bottom> of <total>`.
+```
+
+Worktree block: name (bold) prefixed by the `●` dot · `branch · short-head` (branch coloured by `BranchStatus` — worst-state wins: dirty=red, ahead/behind=yellow, unpublished=magenta, synced=green, unknown=darkgray) · `Created: <age>` with freshness colour (green < 7d, yellow < 30d, darkgray ≥ 30d; `-` when undeterminable, e.g. trunk / detached HEAD) · status + flag badges (only the relevant ones — false flags stay invisible: `★ main`, `🔒 locked`, `⚠ prunable`) · tilde-compressed path.
+
+GitHub fetch state machine per worktree: `Idle → Loading → Loaded(T) | Error(String)`. Manual refresh = `F` (the legacy `R` was rebound to `R: review` in #75).
+
+`Tab` swaps focus between the worktree list and the sidebar. `j` / `k` (and arrows) scroll the Recent Commits block when the sidebar is focused — the small blocks above stay pinned. The focused panel's border turns cyan.
+
+## `o: open` dispatch — issue #73
+
+The `o` key in the TUI is controlled by `[tui.open]`. Three modes:
+
+| `mode = ` | Behaviour                                                                                  |
+|:----------|:-------------------------------------------------------------------------------------------|
+| `"shell"` _(default)_ | Suspend the TUI and spawn `$SHELL` with `cwd = <worktree>` — lazygit-style. Exiting the shell restores the TUI. |
+| `"editor"` | Suspend the TUI and run `$EDITOR <worktree-path>`.                                        |
+| `"finder"` | Pre-#73 behaviour: hand off to the OS file manager (`open` / `xdg-open` / `explorer`).    |
+
+```toml
+[tui.open]
+mode       = "shell"     # "shell" (default) | "editor" | "finder"
+shell_cmd  = ""          # override $SHELL when set ("" = read $SHELL)
+editor_cmd = "hx"        # override $EDITOR when set ("" = read $EDITOR)
+```
+
+`shell_cmd` and `editor_cmd` win over the env var when non-empty. An unknown `mode` is a hard config-load error.
+
+## `y: yank` — issue #73
+
+The `y` key copies the selected worktree's absolute path to the system clipboard. Probe order (first hit wins on `$PATH`):
+
+| OS         | Candidates (in order)                                                              |
+|:-----------|:-----------------------------------------------------------------------------------|
+| macOS      | `pbcopy`                                                                           |
+| Linux      | `wl-copy`, `xclip -selection clipboard`, `xsel --clipboard --input`                |
+| Windows    | `clip`                                                                             |
+
+Missing tool surfaces a status-bar hint, never a panic. No config knob — the probe list is built per-platform.
 
 ## Configurable launchers (`l` git_tui · `R` review) — issue #75
 
@@ -347,6 +412,33 @@ trunks = ["master", "release-3.x", "release-4.x"]
 # above 5 is clamped on read; 0 disables the countdown. Default: 3.
 [tui]
 confirm_countdown_secs = 3
+
+# --- `o: open` dispatch (issue #73) ------------------------------------------
+# Three modes: "shell" (default — $SHELL in the worktree), "editor"
+# ($EDITOR <path>), "finder" (pre-#73 OS file manager). `shell_cmd` /
+# `editor_cmd` override the env var when non-empty.
+[tui.open]
+mode       = "shell"
+shell_cmd  = ""
+editor_cmd = "hx"
+
+# --- TUI `l: git_tui` launcher (issue #75) -----------------------------------
+# Default: `lazygit -p {path}` fullscreen=true (matches pre-#75 behaviour).
+# Placeholders: {path}.
+[git_tui]
+command    = "lazygit -p {path}"
+fullscreen = true
+
+# --- TUI `R: review` launcher (issue #75) ------------------------------------
+# Either a free-form `command` (placeholders: {base} {head} {path} {diff})
+# or a `tool = "<preset>"` sugar (lumen / claude / codex / aider / gh).
+# `command` always wins when both are set. `{diff}` is lazy — only
+# materialised when the template references it. Base resolution chain:
+# upstream → branch.<n>.gwm-base → [review].default_base → "dev" → "main".
+[review]
+tool                  = "lumen"
+skip_when_no_changes  = true     # default true — `git rev-list --count {base}..{head} == 0` ⇒ skip
+# default_base        = "dev"    # optional pin overriding the auto-discovery chain
 ```
 
 ## Bootstrap report
@@ -514,21 +606,30 @@ src/
 ├── lib.rs               # public re-exports — tests import these
 ├── main.rs              # bin entry, dispatches to cli::run
 ├── error.rs             # GwmError (thiserror) + Result alias
-├── config.rs            # serde TOML → Config (worktree, bootstrap, doctor, tui)
+├── config.rs            # serde TOML → Config (worktree, bootstrap, doctor, tui, tui.open, git_tui, review)
 ├── naming.rs            # BranchSpec, kebab(), parse_branch()
-├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy (libgit2)
+├── worktree.rs          # discover_repo, list, add, remove, prune, find_fuzzy, branch_age,
+│                        # format_relative_duration, git_log_with_author (libgit2 + shell-out)
 ├── bootstrap.rs         # run(BootstrapCtx) → BootstrapReport (copies / guards / commands / when DSL)
-├── doctor.rs            # `gwm doctor` checks (config, env, orphan branches, prunable wts)
-├── github.rs            # issue / PR link storage in git config + `gh` shell-out
+├── doctor.rs            # `gwm doctor` checks (config, env, orphan branches, prunable wts, launcher PATH probes)
+├── github.rs            # issue / PR link storage in git config + `gh` shell-out, BranchLink
 ├── multiplexer.rs       # tmux / zellij hand-off (window/tab/split)
+├── launcher.rs          # shared `l` / `R` launcher pipeline — placeholder expansion
+│                        # ({base}/{head}/{path}/{diff} with lazy tempfile), shell-words split,
+│                        # base-resolution chain, count_commits_ahead, which::which probing
 ├── cli.rs               # clap subcommands + handlers
 └── tui/
-    ├── mod.rs           # crossterm event loop (filter, link prompt, open menu, refresh)
-    ├── app.rs           # App state, transitions, GitHubFetchState<T>, ConfirmKeyAction
-    └── ui.rs            # ratatui drawing (sidebar incl. GitHub panel)
+    ├── mod.rs           # crossterm event loop (filter, link prompt, open menu, refresh,
+    │                    # clipboard_candidates, run_launcher, yank_selected_path_to_clipboard)
+    ├── app.rs           # App state, transitions, GitHubFetchState<T>, ConfirmKeyAction,
+    │                    # LauncherPlan, OpenTarget, resolve_open_target, prepare_review, prepare_git_tui
+    ├── commit_graph.rs  # lazygit-style topology renderer (Rust port of pkg/gui/presentation/graph/)
+    └── ui.rs            # ratatui drawing — 4-section bordered sidebar, sidebar_header_line,
+                         # build_sidebar_sections, worktree_identity_lines, badges_line,
+                         # recent_commits_lines, branch_name_color, freshness_color, etc.
 ```
 
-Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.rs`, `bootstrap_when_tests.rs`, `cli_binary.rs`, `config_tests.rs`, `doctor_tests.rs`, `error_tests.rs`, `flake_tests.rs`, `github_tests.rs`, `homebrew_formula_tests.rs`, `multiplexer_tests.rs`, `naming_tests.rs`, `precommit_hook_tests.rs`, `tui_app_tests.rs`, `worktree_integration.rs` (+ `tests/common/` helpers). **TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one** (project rule, enforced in `CLAUDE.md`).
+Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.rs`, `bootstrap_when_tests.rs`, `cli_binary.rs`, `config_tests.rs`, `doctor_tests.rs`, `error_tests.rs`, `flake_tests.rs`, `github_tests.rs`, `homebrew_formula_tests.rs`, `launcher_tests.rs`, `multiplexer_tests.rs`, `naming_tests.rs`, `precommit_hook_tests.rs`, `tui_app_tests.rs`, `worktree_integration.rs` (+ `tests/common/` helpers). **TDD bar: any new behaviour ships with a matching test file or new assertions in an existing one** (project rule, enforced in `CLAUDE.md`).
 
 ## Differences vs. the bash + gwq stack
 
@@ -543,7 +644,7 @@ Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.
 | GitHub linking              | none                  | issue / PR per-branch git config + `gh` live status      |
 | diagnostics                 | none                  | `gwm doctor` (exit 0/1/2, CI-ready)                      |
 | anti-RDS guard              | hardcoded `grep`      | configurable regex deny-list                             |
-| tests                       | 0                     | 316 across 14 test files (config / bootstrap / when DSL / doctor / github / multiplexer / TUI / CLI / homebrew / flake / pre-commit hook) |
+| tests                       | 0                     | 430+ across 15 test files (config / bootstrap / when DSL / doctor / github / multiplexer / TUI + commit graph / launcher / CLI / homebrew / flake / pre-commit hook) |
 | install                     | `chmod +x` per repo   | `cargo install --path .` (or Homebrew / Nix / prebuilts) |
 
 ## Troubleshooting
@@ -571,6 +672,21 @@ Tests under `tests/` mirror this layout (one file per module): `bootstrap_tests.
 **`.env` was copied even though it points to prod** — the guard's regex didn't match. Test it with `echo $YOUR_HOST | grep -E '<pattern>'`. Regex syntax is Rust `regex` crate (PCRE-like, no lookaround).
 
 **`gcd` says command not found** — the shell-init wrapper isn't sourced. Re-run `eval "$(gwm shell-init <shell>)"` in your current shell and add it to your shell's rc file.
+
+**Pressing `R` in the TUI does nothing / shows a status hint** — `[review]` is opt-in. Either no `[review]` section exists in `.gwm.toml`, the resolved binary isn't on `$PATH` (`gwm doctor` flags it as Warning), or `skip_when_no_changes = true` (default) found 0 commits between `{base}..{head}`. Add a `[review] tool = "lumen"` (or another preset) to enable it.
+
+**`R: review` resolves the wrong `{base}`** — the chain is upstream → `branch.<n>.gwm-base` → `[review].default_base` → `"dev"` → `"main"`. Pin it explicitly with `[review] default_base = "<branch>"` or set the per-branch override with `git config branch.<name>.gwm-base <ref>`.
+
+**`l` launches lazygit when the repo wants gitui (or vice versa)** — `[git_tui]` defaults to `lazygit -p {path}`. Override:
+```toml
+[git_tui]
+command = "gitui -d {path}"
+fullscreen = true
+```
+
+**Pressing `o` opens a shell when you want the file manager (or vice versa)** — `[tui.open] mode = "shell"` is the new default since issue #73. Set `mode = "finder"` for the pre-#73 OS file manager hand-off, or `mode = "editor"` to spawn `$EDITOR <path>`.
+
+**Pressing `y` does nothing / status bar says "no clipboard tool found"** — install a per-OS clipboard helper: `pbcopy` (macOS, built-in), `wl-copy` (Wayland), `xclip` / `xsel` (X11), `clip` (Windows, built-in). The probe list is platform-fixed; first hit on `$PATH` wins.
 
 ## Quick reference card
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use crate::bootstrap::{self, BootstrapCtx, StepStatus};
 use crate::config::Config;
 use crate::doctor::{self, CheckStatus, DoctorCtx};
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
@@ -9,6 +10,7 @@ use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
+use git2::Repository;
 use std::io;
 use std::path::PathBuf;
 
@@ -33,6 +35,15 @@ pub enum InitShell {
   Zsh,
   Fish,
   Powershell,
+}
+
+/// Target of `gwm link / unlink / open` — issue or pull request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LinkTarget {
+  /// GitHub issue.
+  Issue,
+  /// GitHub pull request.
+  Pr,
 }
 
 #[derive(Debug, Subcommand)]
@@ -146,6 +157,66 @@ pub enum Command {
     #[arg(short = 'p', long = "split")]
     split: bool,
   },
+  /// Link the current (or named) worktree to a GitHub issue or pull request.
+  ///
+  /// The link is stored in `git config branch.<name>.gwm-issue` (or
+  /// `gwm-pr`) — local, per-branch, survives worktree moves. Issue
+  /// numbers are auto-detected from the `<type>/#<N>-<slug>` convention
+  /// when no explicit override is set; `gwm link issue <N>` overrides
+  /// that. PR numbers are not auto-detected; link them explicitly with
+  /// `gwm link pr <N>`.
+  Link {
+    /// What to link: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Number to link (digits only).
+    number: u64,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+  },
+  /// Remove the explicit issue / PR link on the current (or named) worktree.
+  ///
+  /// After `gwm unlink issue`, auto-detection from the branch name
+  /// resurfaces if the branch follows `<type>/#<N>-<slug>`. Idempotent —
+  /// safe to run when nothing is linked.
+  Unlink {
+    /// What to unlink: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+  },
+  /// Open the linked issue or PR in the browser.
+  ///
+  /// Uses the OS opener (`open` on macOS, `xdg-open` on Linux,
+  /// `explorer` on Windows). Pass `--print-url` to emit the URL on
+  /// stdout instead — useful for piping, testing, and headless shells.
+  Open {
+    /// What to open: `issue` or `pr`.
+    #[arg(value_enum)]
+    target: LinkTarget,
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+    /// Print the URL on stdout instead of spawning the browser.
+    #[arg(long)]
+    print_url: bool,
+  },
+  /// Show the issue / PR link and (when `gh` is available) live GitHub status.
+  ///
+  /// Shells out to `gh issue view` and `gh pr view` to fetch state, title,
+  /// labels, and CI rollup. Without `gh` (or outside a GitHub repo), prints
+  /// only the local link. `--json` emits a stable schema for scripting.
+  Status {
+    /// Optional worktree pattern; defaults to the current worktree (CWD).
+    #[arg(long)]
+    worktree: Option<String>,
+    /// Emit JSON instead of the human-readable summary.
+    #[arg(long)]
+    json: bool,
+  },
 }
 
 pub fn run(cli: Cli) -> Result<()> {
@@ -174,6 +245,18 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Switch => cmd_switch(),
     Command::Tmux { pattern, split } => cmd_multiplexer(Multiplexer::Tmux, pattern, split),
     Command::Zellij { pattern, split } => cmd_multiplexer(Multiplexer::Zellij, pattern, split),
+    Command::Link {
+      target,
+      number,
+      worktree,
+    } => cmd_link(target, number, worktree),
+    Command::Unlink { target, worktree } => cmd_unlink(target, worktree),
+    Command::Open {
+      target,
+      worktree,
+      print_url,
+    } => cmd_open(target, worktree, print_url),
+    Command::Status { worktree, json } => cmd_status(worktree, json),
   }
 }
 
@@ -505,6 +588,276 @@ fn spawn_multiplexer(mux: Multiplexer, argv: &[String]) -> Result<()> {
     )));
   }
   Ok(())
+}
+
+// ---- Issue / PR link commands (issue #67) -------------------------------
+
+/// Resolve the repo + branch + repo-relative path to operate on.
+///
+/// `--worktree <pattern>` overrides; otherwise we use the current directory.
+/// The returned Repository is opened *at the target worktree*, so reading
+/// HEAD gives the branch the user expects, but git config writes still land
+/// on the main repo's config (git2 propagates branch.* config up).
+fn resolve_target_repo(worktree: Option<String>) -> Result<(Repository, String, PathBuf)> {
+  let path: PathBuf = match worktree {
+    Some(pat) => {
+      // Allow either a fuzzy worktree pattern or a direct path.
+      let p = PathBuf::from(&pat);
+      if p.is_dir() {
+        p
+      } else {
+        let main = worktree::discover_repo(None)?;
+        worktree::find_fuzzy(&main, &pat)?.path
+      }
+    }
+    None => std::env::current_dir()?,
+  };
+  let repo = Repository::discover(&path).map_err(|_| GwmError::NotInGitRepo)?;
+  let branch = current_branch(&repo)?;
+  Ok((repo, branch, path))
+}
+
+fn current_branch(repo: &Repository) -> Result<String> {
+  let head = repo
+    .head()
+    .map_err(|_| GwmError::Other("HEAD is unborn or detached".into()))?;
+  head
+    .shorthand()
+    .map(|s| s.to_string())
+    .ok_or_else(|| GwmError::Other("HEAD has no shorthand (detached?)".into()))
+}
+
+fn cmd_link(target: LinkTarget, number: u64, worktree: Option<String>) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  match target {
+    LinkTarget::Issue => {
+      github::link_issue(&repo, &branch, number)?;
+      println!("✓ linked issue #{} to branch {}", number, branch);
+    }
+    LinkTarget::Pr => {
+      github::link_pr(&repo, &branch, number)?;
+      println!("✓ linked PR #{} to branch {}", number, branch);
+    }
+  }
+  Ok(())
+}
+
+fn cmd_unlink(target: LinkTarget, worktree: Option<String>) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  match target {
+    LinkTarget::Issue => {
+      github::unlink_issue(&repo, &branch)?;
+      println!("✓ unlinked issue on branch {}", branch);
+    }
+    LinkTarget::Pr => {
+      github::unlink_pr(&repo, &branch)?;
+      println!("✓ unlinked PR on branch {}", branch);
+    }
+  }
+  Ok(())
+}
+
+fn cmd_open(target: LinkTarget, worktree: Option<String>, print_url: bool) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  let link = github::read_link(&repo, &branch)?;
+  let slug = github::repo_slug(&repo)?;
+
+  let url = match target {
+    LinkTarget::Issue => {
+      let n = link
+        .issue
+        .ok_or_else(|| GwmError::Other(format!("no issue linked to branch '{}'", branch)))?;
+      github::issue_url(&slug, n)
+    }
+    LinkTarget::Pr => {
+      let n = link
+        .pr
+        .ok_or_else(|| GwmError::Other(format!("no PR linked to branch '{}'", branch)))?;
+      github::pr_url(&slug, n)
+    }
+  };
+
+  if print_url {
+    println!("{}", url);
+    return Ok(());
+  }
+  spawn_opener(&url)
+}
+
+fn spawn_opener(url: &str) -> Result<()> {
+  let opener = if cfg!(target_os = "macos") {
+    "open"
+  } else if cfg!(target_os = "windows") {
+    "explorer"
+  } else {
+    "xdg-open"
+  };
+  let status = std::process::Command::new(opener)
+    .arg(url)
+    .status()
+    .map_err(|e| GwmError::CommandFailed(format!("could not spawn {}: {}", opener, e)))?;
+  if !status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "{} exited with status {:?}",
+      opener,
+      status.code()
+    )));
+  }
+  Ok(())
+}
+
+fn cmd_status(worktree: Option<String>, json: bool) -> Result<()> {
+  let (repo, branch, _path) = resolve_target_repo(worktree)?;
+  let link = github::read_link(&repo, &branch)?;
+
+  // Slug + fetched status are best-effort: if there's no GitHub remote
+  // or `gh` isn't installed, we still print the local link.
+  let slug = github::repo_slug(&repo).ok();
+  let (issue_status, pr_status) = fetch_link_status(&link, slug.as_deref());
+
+  if json {
+    print_status_json(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
+  } else {
+    print_status_human(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
+  }
+  Ok(())
+}
+
+fn fetch_link_status(link: &BranchLink, slug: Option<&str>) -> (Option<IssueStatus>, Option<PrStatus>) {
+  let Some(slug) = slug else {
+    return (None, None);
+  };
+  // `gh` is optional — if either call fails we degrade gracefully.
+  let issue = link.issue.and_then(|n| github::fetch_issue(slug, n).ok());
+  let pr = link.pr.and_then(|n| github::fetch_pr(slug, n).ok());
+  (issue, pr)
+}
+
+fn issue_state_str(s: IssueState) -> &'static str {
+  match s {
+    IssueState::Open => "open",
+    IssueState::Closed => "closed",
+  }
+}
+
+fn pr_state_str(s: PrState) -> &'static str {
+  match s {
+    PrState::Open => "open",
+    PrState::Draft => "draft",
+    PrState::Closed => "closed",
+    PrState::Merged => "merged",
+  }
+}
+
+fn link_source_str(s: LinkSource) -> &'static str {
+  match s {
+    LinkSource::None => "none",
+    LinkSource::BranchName => "branch-name",
+    LinkSource::Explicit => "explicit",
+  }
+}
+
+fn print_status_human(
+  branch: &str,
+  slug: Option<&str>,
+  link: &BranchLink,
+  issue: &Option<IssueStatus>,
+  pr: &Option<PrStatus>,
+) {
+  println!("branch: {}", branch);
+  if let Some(s) = slug {
+    println!("repo:   {}", s);
+  }
+  println!("link:   {}", link.summary());
+
+  if let Some(n) = link.issue {
+    print!("issue:  #{}", n);
+    match issue {
+      Some(s) => println!(" [{}] {}", issue_state_str(s.state), s.title),
+      None => println!(" (status unavailable)"),
+    }
+  }
+  if let Some(n) = link.pr {
+    print!("pr:     #{}", n);
+    match pr {
+      Some(s) => {
+        let checks = if s.checks_total > 0 {
+          format!(" · checks {}/{}", s.checks_passed, s.checks_total)
+        } else {
+          String::new()
+        };
+        println!(" [{}]{} {}", pr_state_str(s.state), checks, s.title);
+      }
+      None => println!(" (status unavailable)"),
+    }
+  }
+}
+
+fn print_status_json(
+  branch: &str,
+  slug: Option<&str>,
+  link: &BranchLink,
+  issue: &Option<IssueStatus>,
+  pr: &Option<PrStatus>,
+) {
+  let mut obj = serde_json::Map::new();
+  obj.insert("branch".into(), serde_json::Value::String(branch.into()));
+  if let Some(s) = slug {
+    obj.insert("repo".into(), serde_json::Value::String(s.into()));
+  }
+  obj.insert(
+    "issue".into(),
+    match link.issue {
+      Some(n) => {
+        let mut o = serde_json::Map::new();
+        o.insert("number".into(), serde_json::Value::Number(n.into()));
+        o.insert(
+          "source".into(),
+          serde_json::Value::String(link_source_str(link.issue_source).into()),
+        );
+        if let Some(s) = issue {
+          o.insert(
+            "state".into(),
+            serde_json::Value::String(issue_state_str(s.state).into()),
+          );
+          o.insert("title".into(), serde_json::Value::String(s.title.clone()));
+          o.insert(
+            "labels".into(),
+            serde_json::Value::Array(s.labels.iter().map(|l| serde_json::Value::String(l.clone())).collect()),
+          );
+          o.insert("url".into(), serde_json::Value::String(s.url.clone()));
+        }
+        serde_json::Value::Object(o)
+      }
+      None => serde_json::Value::Null,
+    },
+  );
+  obj.insert(
+    "pr".into(),
+    match link.pr {
+      Some(n) => {
+        let mut o = serde_json::Map::new();
+        o.insert("number".into(), serde_json::Value::Number(n.into()));
+        o.insert(
+          "source".into(),
+          serde_json::Value::String(link_source_str(link.pr_source).into()),
+        );
+        if let Some(s) = pr {
+          o.insert("state".into(), serde_json::Value::String(pr_state_str(s.state).into()));
+          o.insert("title".into(), serde_json::Value::String(s.title.clone()));
+          o.insert(
+            "checks_passed".into(),
+            serde_json::Value::Number(s.checks_passed.into()),
+          );
+          o.insert("checks_total".into(), serde_json::Value::Number(s.checks_total.into()));
+          o.insert("url".into(), serde_json::Value::String(s.url.clone()));
+        }
+        serde_json::Value::Object(o)
+      }
+      None => serde_json::Value::Null,
+    },
+  );
+  println!("{}", serde_json::Value::Object(obj));
 }
 
 pub fn shell_init_script(shell: InitShell) -> &'static str {

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,14 +149,73 @@ pub struct TuiConfig {
   /// clamp instead of erroring out at parse time.
   #[serde(default = "default_confirm_countdown_secs")]
   pub confirm_countdown_secs: u32,
+
+  /// `[tui.open]` sub-table — drives the dispatch of the `o` key in the
+  /// list view. Default mode is `shell` (lazygit-like worktree-manager
+  /// workflow); pre-#73 behaviour (`open` / `xdg-open` / `explorer`) is
+  /// kept available under `mode = "finder"`.
+  #[serde(default)]
+  pub open: TuiOpenConfig,
 }
 
 impl Default for TuiConfig {
   fn default() -> Self {
     Self {
       confirm_countdown_secs: default_confirm_countdown_secs(),
+      open: TuiOpenConfig::default(),
     }
   }
+}
+
+/// `[tui.open]` — how the `o` key resolves the action on the selected
+/// worktree. Adds a configurable hook on top of the historical "reveal
+/// in OS file manager" so users with a worktree-heavy workflow can land
+/// in a shell or `$EDITOR` directly, sharing the spawn-and-restore
+/// lifecycle that `l: lazygit` already uses.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TuiOpenConfig {
+  #[serde(default)]
+  pub mode: TuiOpenMode,
+  /// Override `$SHELL` when `mode = "shell"`. Falls back to `$SHELL`,
+  /// then `/bin/sh`. Empty TOML string reads as `None` so
+  /// `shell_cmd = ""` and an omitted key are observationally identical.
+  #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+  pub shell_cmd: Option<String>,
+  /// Override `$EDITOR` when `mode = "editor"`. Falls back to `$EDITOR`,
+  /// then `vi`. Same empty-string-as-unset convention as `shell_cmd`.
+  #[serde(default, deserialize_with = "deserialize_optional_non_empty")]
+  pub editor_cmd: Option<String>,
+}
+
+/// The three documented behaviours of the `o` key. Serialised in
+/// lowercase so `.gwm.toml` keys stay idiomatic (`mode = "shell"`); an
+/// unknown value is a hard config error surfaced by
+/// `Config::load_for_repo`, never silently coerced to a default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TuiOpenMode {
+  /// Spawn an interactive shell with `cwd` set to the worktree
+  /// (lazygit-style suspend / spawn / restore). Default — matches the
+  /// "I want to do work in this worktree" intent of a worktree manager.
+  #[default]
+  Shell,
+  /// Spawn `$EDITOR <worktree-path>` and wait for it to exit. Useful
+  /// for drive-by edits without dropping into a full shell session.
+  Editor,
+  /// Pre-#73 behaviour: ask the OS to reveal the worktree directory
+  /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows).
+  Finder,
+}
+
+/// Serde helper: treat an empty TOML string as `None`. Keeps
+/// `shell_cmd = ""` and an omitted key identical at the call site so
+/// the TUI never has to special-case the empty command.
+fn deserialize_optional_non_empty<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+  D: serde::Deserializer<'de>,
+{
+  let opt = Option::<String>::deserialize(d)?;
+  Ok(opt.filter(|s| !s.is_empty()))
 }
 
 impl TuiConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,10 @@ pub struct Config {
   pub doctor: DoctorConfig,
   #[serde(default)]
   pub tui: TuiConfig,
+  #[serde(default)]
+  pub git_tui: GitTuiConfig,
+  #[serde(default)]
+  pub review: ReviewConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -204,6 +208,148 @@ impl Config {
   pub fn guard_by_name(&self, name: &str) -> Option<&Guard> {
     self.bootstrap.guard.iter().find(|g| g.name == name)
   }
+}
+
+/// `[git_tui]` table — drives the `l` keybinding in the TUI worktree list
+/// (issue #75). Absent ⇒ legacy default `lazygit -p {path}` with
+/// fullscreen=true, so no `.gwm.toml` change is required for repos that
+/// were happy with the previous behaviour. Sharing `[`ReviewConfig`]`'s
+/// shape (placeholder expansion + `fullscreen` flag) keeps the user's
+/// mental model consistent across the two launcher keybindings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GitTuiConfig {
+  /// Shell line. Accepts the `{path}` placeholder. When `None`, the
+  /// resolved launcher uses `lazygit -p {path}`.
+  #[serde(default)]
+  pub command: Option<String>,
+  /// Whether gwm should suspend its own TUI before exec'ing the command.
+  /// Defaults to `true` for TUI tools like lazygit / gitui / tig; set to
+  /// `false` to launch e.g. a GUI editor that should run alongside gwm.
+  #[serde(default)]
+  pub fullscreen: Option<bool>,
+}
+
+impl GitTuiConfig {
+  /// Resolve to a concrete `(command, fullscreen)` pair. The default
+  /// (no `[git_tui]` block in `.gwm.toml`) is `lazygit -p {path}` so the
+  /// `l` keybinding behaves exactly as it did before issue #75 landed.
+  pub fn resolved(&self) -> ResolvedLauncher {
+    ResolvedLauncher {
+      command: self.command.clone().unwrap_or_else(|| "lazygit -p {path}".into()),
+      fullscreen: self.fullscreen.unwrap_or(true),
+    }
+  }
+}
+
+/// `[review]` table — drives the `R` keybinding in the TUI worktree list
+/// (issue #75). The user picks one of three forms:
+///
+/// - `command = "<shell line>"` — the primary contract; any CLI on $PATH
+///   with any arguments. Placeholders `{base} {head} {path} {diff}` are
+///   substituted before the shell line is split with `shell-words`.
+/// - `tool = "<preset>"` — sugar for a built-in `(command, fullscreen)`
+///   pair (see [`ReviewConfig::resolved`]).
+/// - neither — the `R` key is inert and the status bar carries a hint.
+///
+/// When both are set, `command` wins (and the TUI surfaces a status-bar
+/// hint at startup so the user notices their `tool` choice is shadowed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewConfig {
+  /// Shell line. Accepts `{base} {head} {path} {diff}` placeholders.
+  #[serde(default)]
+  pub command: Option<String>,
+  /// Whether gwm should suspend its own TUI before exec'ing the command.
+  /// Defaults to `false` so non-TUI tools (a linter, `gh pr view --web`)
+  /// don't black-out the screen.
+  #[serde(default)]
+  pub fullscreen: Option<bool>,
+  /// Preset name; one of `lumen`, `claude`, `codex`, `aider`, `gh`.
+  /// Resolved to a `(command, fullscreen)` pair by [`ReviewConfig::resolved`].
+  #[serde(default)]
+  pub tool: Option<String>,
+  /// Skip the shell-out when `git rev-list --count {base}..{head} == 0`.
+  /// Default `true`.
+  #[serde(default = "default_skip_when_no_changes")]
+  pub skip_when_no_changes: bool,
+  /// Optional pin for the review base ref. When set, it overrides the
+  /// upstream / `gwm-base` / `dev` / `main` fallback chain.
+  #[serde(default)]
+  pub default_base: Option<String>,
+}
+
+impl Default for ReviewConfig {
+  fn default() -> Self {
+    Self {
+      command: None,
+      fullscreen: None,
+      tool: None,
+      skip_when_no_changes: default_skip_when_no_changes(),
+      default_base: None,
+    }
+  }
+}
+
+fn default_skip_when_no_changes() -> bool {
+  true
+}
+
+impl ReviewConfig {
+  /// Resolve the user's choice to a concrete `(command, fullscreen)`
+  /// pair, or `None` when neither `command` nor a recognised `tool` was
+  /// set. The `command` field wins when both are present.
+  pub fn resolved(&self) -> Option<ResolvedLauncher> {
+    if let Some(cmd) = self.command.as_ref().filter(|s| !s.trim().is_empty()) {
+      return Some(ResolvedLauncher {
+        command: cmd.clone(),
+        fullscreen: self.fullscreen.unwrap_or(false),
+      });
+    }
+    let tool = self.tool.as_deref()?.trim();
+    if tool.is_empty() {
+      return None;
+    }
+    let (cmd, fullscreen_default) = review_tool_preset(tool)?;
+    Some(ResolvedLauncher {
+      command: cmd.into(),
+      fullscreen: self.fullscreen.unwrap_or(fullscreen_default),
+    })
+  }
+
+  /// True when `command` and `tool` are both set — the TUI uses this to
+  /// surface a one-shot warning ("your `tool = X` is shadowed by
+  /// `command = Y`") on first render.
+  pub fn has_shadowed_tool(&self) -> bool {
+    self.command.as_ref().is_some_and(|s| !s.trim().is_empty())
+      && self.tool.as_ref().is_some_and(|s| !s.trim().is_empty())
+  }
+}
+
+/// Built-in preset table for `[review].tool`. Returns `Some((command,
+/// fullscreen))` for known tools, `None` otherwise.
+///
+/// The table is the canonical place to add new presets; it's exposed
+/// (via [`ReviewConfig::resolved`]) so docs and `gwm doctor` can refer
+/// to a single source of truth instead of duplicating the strings.
+pub fn review_tool_preset(tool: &str) -> Option<(&'static str, bool)> {
+  Some(match tool {
+    "lumen" => ("lumen diff {base}..{head}", true),
+    "claude" => ("claude --print 'review the diff {base}..{head}'", false),
+    "codex" => ("codex review {base}..{head}", false),
+    "aider" => ("aider --message 'review {base}..{head}'", true),
+    "gh" => ("gh pr view --web", false),
+    _ => return None,
+  })
+}
+
+/// Concrete `(command, fullscreen)` pair derived from a [`GitTuiConfig`]
+/// or [`ReviewConfig`] by [`GitTuiConfig::resolved`] /
+/// [`ReviewConfig::resolved`]. The launcher then expands placeholders
+/// in `command` and decides whether to suspend the TUI based on
+/// `fullscreen`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLauncher {
+  pub command: String,
+  pub fullscreen: bool,
 }
 
 /// Expand `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}` in a template string.

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,8 +271,13 @@ pub struct ReviewConfig {
   /// Default `true`.
   #[serde(default = "default_skip_when_no_changes")]
   pub skip_when_no_changes: bool,
-  /// Optional pin for the review base ref. When set, it overrides the
-  /// upstream / `gwm-base` / `dev` / `main` fallback chain.
+  /// Optional pin for the review base ref. Slots into the base-
+  /// resolution chain *after* `branch.<n>.merge` (upstream) and
+  /// `branch.<n>.gwm-base`, and *before* the static `dev` / `main`
+  /// fallback. Setting it overrides only the `dev` / `main` step —
+  /// upstream and gwm-base still win when present. See
+  /// [`crate::launcher::resolve_review_base`] for the canonical
+  /// order.
   #[serde(default)]
   pub default_base: Option<String>,
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -241,16 +241,48 @@ fn check_when_predicates(ctx: &DoctorCtx<'_>) -> Check {
     .with_hint(format!("supported keywords: {}", SUPPORTED_WHEN_PREFIXES.join(", ")))
 }
 
+/// Common shell wrappers that introduce the real binary after their
+/// own switches / env assignments. Caught by Copilot's review on
+/// PR #76: pre-fix, `env FOO=bar lumen diff` made the doctor check
+/// `env` against `$PATH` (which is always present) and miss the real
+/// launcher `lumen`. Keep this list narrow on purpose — exotic
+/// wrappers (`nice`, `time`, `nohup`) take positional args, which we
+/// would risk consuming and ending up with the wrong binary.
+const COMMAND_WRAPPERS: &[&str] = &["env", "command"];
+
 /// Extract the executable name from a shell command string. Tokenises
 /// via `shell_words` so quoted args (`"my tool" --flag`) and escaped
 /// whitespace are handled the way the shell would, then skips leading
-/// `FOO=bar` env assignments and returns the first token that isn't
-/// `KEY=VAL`. Returns `None` for empty strings or strings that fail
-/// to parse (unbalanced quotes — better to surface nothing than a
-/// garbage binary name that would produce a confusing PATH warning).
+/// `FOO=bar` env assignments and recognised `env`/`command` wrappers
+/// (and the wrapper's own `KEY=VAL` / `-flag` tokens) before returning
+/// the first token that looks like a real binary name. Returns `None`
+/// for empty strings or strings that fail to parse (unbalanced quotes
+/// — better to surface nothing than a garbage binary name that would
+/// produce a confusing PATH warning).
 fn extract_binary(run: &str) -> Option<String> {
   let tokens = shell_words::split(run).ok()?;
-  tokens.into_iter().find(|t| !t.contains('='))
+  let mut iter = tokens.into_iter().peekable();
+
+  // Skip leading `KEY=VAL` env assignments (POSIX `FOO=bar tool` form).
+  while iter.peek().is_some_and(|t| !t.starts_with('=') && t.contains('=')) {
+    iter.next();
+  }
+
+  // Recognise a wrapper (`env`, `command`) and skip its own `-flag` /
+  // `KEY=VAL` arguments before reaching the real binary. Stops on the
+  // first positional non-flag, non-assignment token.
+  if iter.peek().is_some_and(|t| COMMAND_WRAPPERS.contains(&t.as_str())) {
+    iter.next(); // consume the wrapper itself
+    while let Some(t) = iter.peek() {
+      if t.starts_with('-') || (!t.starts_with('=') && t.contains('=')) {
+        iter.next();
+      } else {
+        break;
+      }
+    }
+  }
+
+  iter.next()
 }
 
 /// Same as [`extract_binary`] but pre-strips the launcher placeholders

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -253,10 +253,26 @@ fn extract_binary(run: &str) -> Option<String> {
   tokens.into_iter().find(|t| !t.contains('='))
 }
 
+/// Same as [`extract_binary`] but pre-strips the launcher placeholders
+/// so a template like `lumen diff {base}..{head}` reduces to `lumen`
+/// before tokenisation. Used for the issue #75 [`crate::config::GitTuiConfig`] /
+/// [`crate::config::ReviewConfig`] entries so the doctor warning
+/// names the actual binary, not a placeholder fragment.
+fn extract_launcher_binary(command: &str) -> Option<String> {
+  let cleaned = command
+    .replace("{base}", "BASE")
+    .replace("{head}", "HEAD")
+    .replace("{path}", "PATH")
+    .replace("{diff}", "/tmp/diff");
+  extract_binary(&cleaned)
+}
+
 /// Check #4: every binary referenced by the bootstrap commands resolves on
-/// `$PATH`. `lazygit` (the TUI's `l` keybinding) and `direnv` (only if the
-/// repo has an `.envrc`) are also checked because they're the two "ambient"
-/// dependencies whose absence routinely confuses new users.
+/// `$PATH`. `lazygit` (the TUI's `l` keybinding's default) and `direnv`
+/// (only if the repo has an `.envrc`) are also checked because they're
+/// the two "ambient" dependencies whose absence routinely confuses new
+/// users. Configured launchers ([git_tui], [review] — issue #75) are
+/// added to the same set so the user gets one consolidated warning.
 ///
 /// Missing binaries are surfaced as Warning, not Failed — the user may not
 /// rely on that step at all, but the visibility matters.
@@ -264,10 +280,22 @@ fn check_binaries_on_path(ctx: &DoctorCtx<'_>) -> Check {
   let name = "external binaries on PATH";
   let mut needed: BTreeSet<String> = BTreeSet::new();
 
-  // Ambient deps the rest of the CLI uses.
-  needed.insert("lazygit".into());
+  // Ambient deps the rest of the CLI uses. `[git_tui]` may override the
+  // lazygit default; we extract whatever binary the resolved launcher
+  // names so a `gitui` / `tig` user gets the right warning.
+  let git_tui = ctx.config.git_tui.resolved();
+  if let Some(bin) = extract_launcher_binary(&git_tui.command) {
+    needed.insert(bin);
+  }
   if ctx.repo_workdir.join(".envrc").exists() {
     needed.insert("direnv".into());
+  }
+  // Review launcher is opt-in; only probe when the user actually
+  // configured one (`command` or `tool`).
+  if let Some(review) = ctx.config.review.resolved() {
+    if let Some(bin) = extract_launcher_binary(&review.command) {
+      needed.insert(bin);
+    }
   }
 
   // Whatever the user's own bootstrap commands invoke.

--- a/src/github.rs
+++ b/src/github.rs
@@ -169,7 +169,12 @@ fn parse_github_slug(url: &str) -> Result<String> {
 }
 
 fn trim_git_suffix(s: &str) -> &str {
-  s.strip_suffix(".git").unwrap_or(s).trim_end_matches('/')
+  // Normalise trailing slashes first so `owner/repo.git/` becomes
+  // `owner/repo.git` before the `.git` strip kicks in. Pre-fix this
+  // returned `owner/repo.git` because `.git` was sought with a trailing
+  // `/` still attached (Copilot PR #68 review).
+  let trimmed = s.trim_end_matches('/');
+  trimmed.strip_suffix(".git").unwrap_or(trimmed)
 }
 
 // ---- Issue / PR status ---------------------------------------------------

--- a/src/github.rs
+++ b/src/github.rs
@@ -336,8 +336,11 @@ pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
   parse_pr_json(&stdout)
 }
 
-/// Find the PR opened from `branch` (head ref) on the given repo. Returns
-/// `Ok(Some(N))` if exactly one open PR is found, `Ok(None)` if none.
+/// Find the most recent PR opened from `branch` (head ref) on the given
+/// repo, regardless of state. Returns `Ok(Some(N))` if at least one PR
+/// exists (open, draft, closed, or merged — `gh pr list --state all`),
+/// `Ok(None)` otherwise. Callers that need state-aware filtering should
+/// pair this with `fetch_pr` to inspect `PrState` afterwards.
 pub fn find_pr_for_branch(slug: &str, branch: &str) -> Result<Option<u64>> {
   let stdout = run_gh(&[
     "pr", "list", "--repo", slug, "--head", branch, "--state", "all", "--json", "number", "--limit", "1",

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,372 @@
+//! Issue ↔ PR ↔ branch link storage + GitHub API fetch (via `gh` CLI).
+//!
+//! Storage lives in git branch config: `branch.<name>.gwm-issue` and
+//! `branch.<name>.gwm-pr`. Issue numbers are auto-detected from the
+//! `<type>/#<N>-<slug>` branch convention when no explicit override is set.
+//!
+//! Fetch shells out to `gh` and parses its JSON output. The parsing functions
+//! (`parse_issue_json`, `parse_pr_json`) are exposed publicly so tests can
+//! cover the JSON contract without depending on a real `gh` binary.
+
+use crate::error::{GwmError, Result};
+use crate::naming::parse_branch;
+use git2::Repository;
+use serde::Deserialize;
+use std::process::Command;
+
+const ISSUE_CONFIG_KEY: &str = "gwm-issue";
+const PR_CONFIG_KEY: &str = "gwm-pr";
+
+/// Where the issue or PR number came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkSource {
+  /// No link known (no branch-name match and no explicit override).
+  None,
+  /// Inferred from a branch following `<type>/#<N>-<slug>`.
+  BranchName,
+  /// Explicit override set via `gwm link …` (lives in git branch config).
+  Explicit,
+}
+
+/// Resolved link for one branch: which issue (if any), which PR (if any),
+/// and where each number came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchLink {
+  pub issue: Option<u64>,
+  pub pr: Option<u64>,
+  pub issue_source: LinkSource,
+  pub pr_source: LinkSource,
+}
+
+impl BranchLink {
+  pub fn empty() -> Self {
+    Self {
+      issue: None,
+      pr: None,
+      issue_source: LinkSource::None,
+      pr_source: LinkSource::None,
+    }
+  }
+
+  /// One-line human-readable rendering for the CLI / TUI status bar.
+  pub fn summary(&self) -> String {
+    match (self.issue, self.pr) {
+      (None, None) => "no link".into(),
+      (Some(i), None) => format!("issue #{i}"),
+      (None, Some(p)) => format!("PR #{p}"),
+      (Some(i), Some(p)) => format!("issue #{i} · PR #{p}"),
+    }
+  }
+}
+
+/// Read the link for `branch`. Explicit overrides win over branch-name auto-detect.
+pub fn read_link(repo: &Repository, branch: &str) -> Result<BranchLink> {
+  let explicit_issue = read_branch_u64(repo, branch, ISSUE_CONFIG_KEY)?;
+  let explicit_pr = read_branch_u64(repo, branch, PR_CONFIG_KEY)?;
+
+  let (issue, issue_source) = match explicit_issue {
+    Some(n) => (Some(n), LinkSource::Explicit),
+    None => match parse_branch(branch).and_then(|s| s.issue.parse::<u64>().ok()) {
+      Some(n) => (Some(n), LinkSource::BranchName),
+      None => (None, LinkSource::None),
+    },
+  };
+
+  let (pr, pr_source) = match explicit_pr {
+    Some(n) => (Some(n), LinkSource::Explicit),
+    None => (None, LinkSource::None),
+  };
+
+  Ok(BranchLink {
+    issue,
+    pr,
+    issue_source,
+    pr_source,
+  })
+}
+
+pub fn link_issue(repo: &Repository, branch: &str, number: u64) -> Result<()> {
+  write_branch_u64(repo, branch, ISSUE_CONFIG_KEY, number)
+}
+
+pub fn link_pr(repo: &Repository, branch: &str, number: u64) -> Result<()> {
+  write_branch_u64(repo, branch, PR_CONFIG_KEY, number)
+}
+
+pub fn unlink_issue(repo: &Repository, branch: &str) -> Result<()> {
+  remove_branch_key(repo, branch, ISSUE_CONFIG_KEY)
+}
+
+pub fn unlink_pr(repo: &Repository, branch: &str) -> Result<()> {
+  remove_branch_key(repo, branch, PR_CONFIG_KEY)
+}
+
+fn config_key(branch: &str, leaf: &str) -> String {
+  format!("branch.{}.{}", branch, leaf)
+}
+
+fn read_branch_u64(repo: &Repository, branch: &str, leaf: &str) -> Result<Option<u64>> {
+  let cfg = repo.config()?;
+  let key = config_key(branch, leaf);
+  match cfg.get_string(&key) {
+    Ok(s) => s
+      .trim()
+      .parse::<u64>()
+      .map(Some)
+      .map_err(|_| GwmError::Other(format!("config '{}' is not a valid number: {}", key, s))),
+    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+    Err(e) => Err(GwmError::Git(e)),
+  }
+}
+
+fn write_branch_u64(repo: &Repository, branch: &str, leaf: &str, value: u64) -> Result<()> {
+  let mut cfg = repo.config()?;
+  cfg.set_str(&config_key(branch, leaf), &value.to_string())?;
+  Ok(())
+}
+
+fn remove_branch_key(repo: &Repository, branch: &str, leaf: &str) -> Result<()> {
+  let mut cfg = repo.config()?;
+  let key = config_key(branch, leaf);
+  match cfg.remove(&key) {
+    Ok(_) => Ok(()),
+    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+    Err(e) => Err(GwmError::Git(e)),
+  }
+}
+
+// ---- Repo slug from origin remote --------------------------------------
+
+/// Extract the `owner/repo` slug from the `origin` remote URL.
+/// Supports the two GitHub URL flavours: `git@github.com:owner/repo(.git)?`
+/// and `https://github.com/owner/repo(.git)?`.
+pub fn repo_slug(repo: &Repository) -> Result<String> {
+  let remote = repo
+    .find_remote("origin")
+    .map_err(|_| GwmError::Other("no 'origin' remote configured".into()))?;
+  let url = remote
+    .url()
+    .ok_or_else(|| GwmError::Other("origin remote has no URL (non-utf8?)".into()))?
+    .to_string();
+  parse_github_slug(&url)
+}
+
+fn parse_github_slug(url: &str) -> Result<String> {
+  // SSH: git@github.com:owner/repo(.git)?
+  if let Some(rest) = url.strip_prefix("git@github.com:") {
+    return Ok(trim_git_suffix(rest).to_string());
+  }
+  // HTTPS: https://github.com/owner/repo(.git)?
+  for prefix in ["https://github.com/", "http://github.com/"] {
+    if let Some(rest) = url.strip_prefix(prefix) {
+      return Ok(trim_git_suffix(rest).to_string());
+    }
+  }
+  Err(GwmError::Other(format!(
+    "origin '{}' is not a github URL (expected git@github.com:… or https://github.com/…)",
+    url
+  )))
+}
+
+fn trim_git_suffix(s: &str) -> &str {
+  s.strip_suffix(".git").unwrap_or(s).trim_end_matches('/')
+}
+
+// ---- Issue / PR status ---------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueState {
+  Open,
+  Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueStatus {
+  pub number: u64,
+  pub title: String,
+  pub state: IssueState,
+  pub url: String,
+  pub labels: Vec<String>,
+  pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrState {
+  Open,
+  Draft,
+  Closed,
+  Merged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrStatus {
+  pub number: u64,
+  pub title: String,
+  pub state: PrState,
+  pub url: String,
+  pub updated_at: String,
+  pub checks_passed: u32,
+  pub checks_total: u32,
+}
+
+#[derive(Deserialize)]
+struct RawIssue {
+  number: u64,
+  title: String,
+  state: String,
+  url: String,
+  #[serde(default)]
+  labels: Vec<RawLabel>,
+  #[serde(rename = "updatedAt", default)]
+  updated_at: String,
+}
+
+#[derive(Deserialize)]
+struct RawLabel {
+  name: String,
+}
+
+#[derive(Deserialize)]
+struct RawPr {
+  number: u64,
+  title: String,
+  state: String,
+  #[serde(rename = "isDraft", default)]
+  is_draft: bool,
+  url: String,
+  #[serde(rename = "updatedAt", default)]
+  updated_at: String,
+  #[serde(rename = "statusCheckRollup", default)]
+  status_check_rollup: Vec<RawCheck>,
+}
+
+#[derive(Deserialize)]
+struct RawCheck {
+  #[serde(default)]
+  status: String,
+  #[serde(default)]
+  conclusion: Option<String>,
+}
+
+pub fn parse_issue_json(s: &str) -> Result<IssueStatus> {
+  let raw: RawIssue =
+    serde_json::from_str(s).map_err(|e| GwmError::Other(format!("failed to parse issue json: {}", e)))?;
+  let state = match raw.state.as_str() {
+    "OPEN" | "open" => IssueState::Open,
+    "CLOSED" | "closed" => IssueState::Closed,
+    other => return Err(GwmError::Other(format!("unknown issue state '{}'", other))),
+  };
+  Ok(IssueStatus {
+    number: raw.number,
+    title: raw.title,
+    state,
+    url: raw.url,
+    labels: raw.labels.into_iter().map(|l| l.name).collect(),
+    updated_at: raw.updated_at,
+  })
+}
+
+pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
+  let raw: RawPr = serde_json::from_str(s).map_err(|e| GwmError::Other(format!("failed to parse PR json: {}", e)))?;
+  let state = match (raw.state.as_str(), raw.is_draft) {
+    ("MERGED" | "merged", _) => PrState::Merged,
+    ("CLOSED" | "closed", _) => PrState::Closed,
+    ("OPEN" | "open", true) => PrState::Draft,
+    ("OPEN" | "open", false) => PrState::Open,
+    (other, _) => return Err(GwmError::Other(format!("unknown PR state '{}'", other))),
+  };
+  let checks_total = raw.status_check_rollup.len() as u32;
+  let checks_passed = raw
+    .status_check_rollup
+    .iter()
+    .filter(|c| {
+      c.status.eq_ignore_ascii_case("COMPLETED")
+        && c
+          .conclusion
+          .as_deref()
+          .is_some_and(|s| s.eq_ignore_ascii_case("SUCCESS"))
+    })
+    .count() as u32;
+  Ok(PrStatus {
+    number: raw.number,
+    title: raw.title,
+    state,
+    url: raw.url,
+    updated_at: raw.updated_at,
+    checks_passed,
+    checks_total,
+  })
+}
+
+// ---- gh CLI invocation ---------------------------------------------------
+
+const ISSUE_JSON_FIELDS: &str = "number,title,state,url,labels,updatedAt";
+const PR_JSON_FIELDS: &str = "number,title,state,isDraft,url,updatedAt,statusCheckRollup";
+
+/// Run `gh issue view <n> --repo <slug> --json …` and parse the result.
+pub fn fetch_issue(slug: &str, number: u64) -> Result<IssueStatus> {
+  let stdout = run_gh(&[
+    "issue",
+    "view",
+    &number.to_string(),
+    "--repo",
+    slug,
+    "--json",
+    ISSUE_JSON_FIELDS,
+  ])?;
+  parse_issue_json(&stdout)
+}
+
+/// Run `gh pr view <n> --repo <slug> --json …` and parse the result.
+pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
+  let stdout = run_gh(&[
+    "pr",
+    "view",
+    &number.to_string(),
+    "--repo",
+    slug,
+    "--json",
+    PR_JSON_FIELDS,
+  ])?;
+  parse_pr_json(&stdout)
+}
+
+/// Find the PR opened from `branch` (head ref) on the given repo. Returns
+/// `Ok(Some(N))` if exactly one open PR is found, `Ok(None)` if none.
+pub fn find_pr_for_branch(slug: &str, branch: &str) -> Result<Option<u64>> {
+  let stdout = run_gh(&[
+    "pr", "list", "--repo", slug, "--head", branch, "--state", "all", "--json", "number", "--limit", "1",
+  ])?;
+  #[derive(Deserialize)]
+  struct PrRef {
+    number: u64,
+  }
+  let arr: Vec<PrRef> =
+    serde_json::from_str(&stdout).map_err(|e| GwmError::Other(format!("failed to parse pr list json: {}", e)))?;
+  Ok(arr.into_iter().next().map(|p| p.number))
+}
+
+fn run_gh(args: &[&str]) -> Result<String> {
+  let output = Command::new("gh")
+    .args(args)
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("gh: failed to spawn ({}). Is `gh` installed and on PATH?", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "gh exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Build the canonical GitHub URL for an issue, given the repo slug.
+pub fn issue_url(slug: &str, number: u64) -> String {
+  format!("https://github.com/{}/issues/{}", slug, number)
+}
+
+/// Build the canonical GitHub URL for a PR, given the repo slug.
+pub fn pr_url(slug: &str, number: u64) -> String {
+  format!("https://github.com/{}/pull/{}", slug, number)
+}

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -174,7 +174,20 @@ pub fn resolve_review_base(repo: &Repository, branch: &str, default_base: Option
   if let Some(d) = default_base.map(str::trim).filter(|s| !s.is_empty()) {
     return d.to_string();
   }
-  "dev".to_string()
+  // Final fallback: prefer `dev` when it exists locally (gwm's project
+  // convention), otherwise `main` (universal git default). Returning
+  // `dev` blindly when the repo only has `main` would make the launcher's
+  // subsequent `git rev-list` / `git diff` calls fail loudly — caught by
+  // Copilot's review on PR #76.
+  if branch_exists(repo, "dev") {
+    "dev".to_string()
+  } else {
+    "main".to_string()
+  }
+}
+
+fn branch_exists(repo: &Repository, name: &str) -> bool {
+  repo.find_branch(name, git2::BranchType::Local).is_ok()
 }
 
 /// Persist `branch.<name>.gwm-base = <base>` so the review base chain

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,0 +1,264 @@
+//! Configurable command launchers for the TUI `l` (git_tui) and `R`
+//! (review) keybindings — issue #75.
+//!
+//! Both keybindings share the same mini-API: take a `command` template
+//! string from `.gwm.toml`, substitute placeholders, split with
+//! `shell-words`, and exec'd with `cwd = worktree.path`. The only
+//! per-keybinding difference is the placeholder set: `[git_tui]` only
+//! cares about `{path}`, while `[review]` also exposes `{base}`,
+//! `{head}`, and `{diff}` (a lazily-materialised tempfile carrying
+//! `git diff {base}..{head}`).
+//!
+//! This module owns the shared machinery (placeholder expansion,
+//! base resolution, missing-binary probe) so the TUI event loop and
+//! `gwm doctor` can each consume it through the same surface.
+
+use crate::config::ResolvedLauncher;
+use crate::error::{GwmError, Result};
+use git2::Repository;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Placeholder substitution context. `base` and `head` are only required
+/// by the review launcher; the git_tui launcher passes `None` for both.
+/// `worktree_path` is mandatory because both launchers `cd` into it
+/// before exec'ing the command.
+#[derive(Debug, Clone)]
+pub struct LauncherContext<'a> {
+  pub worktree_path: &'a Path,
+  pub base: Option<&'a str>,
+  pub head: Option<&'a str>,
+  /// Repo handle used to materialise the `{diff}` tempfile on demand.
+  /// `None` disables the `{diff}` placeholder (status-bar error if the
+  /// template references it).
+  pub repo_workdir: Option<&'a Path>,
+}
+
+/// Output of expanding a launcher template. `argv[0]` is the binary,
+/// `argv[1..]` are the arguments. `diff_file` is `Some` only when the
+/// template referenced `{diff}` — its `Drop` impl cleans the tempfile
+/// up once the spawned process has consumed it.
+#[derive(Debug)]
+pub struct ExpandedCommand {
+  pub argv: Vec<String>,
+  /// Kept alive for the duration of the spawned process so the tempfile
+  /// the `{diff}` placeholder points at is not unlinked before the
+  /// reviewer reads it. `None` when the template didn't use `{diff}`.
+  pub diff_file: Option<tempfile::NamedTempFile>,
+}
+
+impl ExpandedCommand {
+  /// Binary name (`argv[0]`), or `None` for an empty argv (parser
+  /// returned `[]`, which means the user typed e.g. `command = ""`).
+  pub fn binary(&self) -> Option<&str> {
+    self.argv.first().map(|s| s.as_str())
+  }
+}
+
+/// Substitute `{base}`, `{head}`, `{path}`, `{diff}` in `template` and
+/// split the result with `shell-words`. Materialises a tempfile holding
+/// `git diff {base}..{head}` iff the template references `{diff}` —
+/// this is the lazy contract from the issue body: a template that
+/// doesn't use `{diff}` must not spawn `git diff`.
+///
+/// Errors:
+/// - `Config` — `{base}` / `{head}` / `{diff}` referenced without the
+///   matching context field set.
+/// - `Other` — `shell-words` parse failure (unbalanced quotes etc.).
+pub fn expand_command(template: &str, ctx: &LauncherContext<'_>) -> Result<ExpandedCommand> {
+  let uses_base = template.contains("{base}");
+  let uses_head = template.contains("{head}");
+  let uses_diff = template.contains("{diff}");
+
+  if uses_base && ctx.base.is_none() {
+    return Err(GwmError::Config(
+      "template uses {base} but no base ref was resolved".into(),
+    ));
+  }
+  if uses_head && ctx.head.is_none() {
+    return Err(GwmError::Config(
+      "template uses {head} but no head ref was resolved".into(),
+    ));
+  }
+
+  let path_str = ctx.worktree_path.to_string_lossy();
+  let mut expanded = template.replace("{path}", &path_str);
+  if let Some(b) = ctx.base {
+    expanded = expanded.replace("{base}", b);
+  }
+  if let Some(h) = ctx.head {
+    expanded = expanded.replace("{head}", h);
+  }
+
+  let diff_file = if uses_diff {
+    let (b, h) = match (ctx.base, ctx.head) {
+      (Some(b), Some(h)) => (b, h),
+      _ => {
+        return Err(GwmError::Config(
+          "template uses {diff} but {base}/{head} could not be resolved".into(),
+        ))
+      }
+    };
+    let workdir = ctx.repo_workdir.ok_or_else(|| {
+      GwmError::Config("template uses {diff} but no repo workdir was provided to the launcher".into())
+    })?;
+    let tmp = materialise_diff(workdir, b, h)?;
+    let diff_path = tmp.path().to_string_lossy().to_string();
+    expanded = expanded.replace("{diff}", &diff_path);
+    Some(tmp)
+  } else {
+    None
+  };
+
+  let argv =
+    shell_words::split(&expanded).map_err(|e| GwmError::Other(format!("invalid shell line '{}': {}", expanded, e)))?;
+  Ok(ExpandedCommand { argv, diff_file })
+}
+
+/// Shell out to `git diff <base>..<head>` from `workdir`, write the
+/// output into a tempfile, and return the handle. The caller keeps
+/// the handle alive (the tempfile is unlinked on drop) so the consumer
+/// process can read it via the `{diff}` substitution.
+///
+/// Failures of `git diff` are surfaced as `CommandFailed` rather than
+/// silently producing an empty file — the user pressed `R` expecting a
+/// diff, so an empty buffer would mask a real configuration problem.
+fn materialise_diff(workdir: &Path, base: &str, head: &str) -> Result<tempfile::NamedTempFile> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(workdir)
+    .args(["diff", &format!("{}..{}", base, head)])
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git diff failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git diff {}..{} exited with status {:?}: {}",
+      base,
+      head,
+      output.status.code(),
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let mut tmp = tempfile::Builder::new()
+    .prefix("gwm-review-")
+    .suffix(".diff")
+    .tempfile()
+    .map_err(GwmError::Io)?;
+  use std::io::Write as _;
+  tmp.write_all(&output.stdout).map_err(GwmError::Io)?;
+  tmp.flush().map_err(GwmError::Io)?;
+  Ok(tmp)
+}
+
+/// Resolve the review base for `branch` following the chain documented
+/// in issue #75:
+///
+/// 1. `branch.<name>.merge` (the upstream tracking ref).
+/// 2. `branch.<name>.gwm-base` — set by `gwm create` on the new branch
+///    so the original parent is recoverable even without an upstream.
+/// 3. `[review].default_base` from `.gwm.toml`.
+/// 4. `"dev"` (gwm's project convention).
+/// 5. `"main"` (universal git default).
+///
+/// Returns the first non-empty hit; never errors (the final `"main"`
+/// is a guaranteed sentinel). The string is the user-facing ref name
+/// — the launcher passes it to `git diff` / `git rev-list` directly,
+/// so it must be a name git understands.
+pub fn resolve_review_base(repo: &Repository, branch: &str, default_base: Option<&str>) -> String {
+  if let Some(upstream) = read_branch_merge(repo, branch) {
+    return upstream;
+  }
+  if let Some(gwm_base) = read_branch_config(repo, branch, "gwm-base") {
+    return gwm_base;
+  }
+  if let Some(d) = default_base.map(str::trim).filter(|s| !s.is_empty()) {
+    return d.to_string();
+  }
+  "dev".to_string()
+}
+
+/// Persist `branch.<name>.gwm-base = <base>` so the review base chain
+/// can recover the parent ref even if the upstream is dropped. Called
+/// by `gwm create` after a successful `git worktree add`.
+pub fn write_gwm_base(repo: &Repository, branch: &str, base: &str) -> Result<()> {
+  let mut cfg = repo.config()?;
+  cfg.set_str(&format!("branch.{}.gwm-base", branch), base)?;
+  Ok(())
+}
+
+fn read_branch_merge(repo: &Repository, branch: &str) -> Option<String> {
+  let cfg = repo.config().ok()?;
+  let raw = cfg.get_string(&format!("branch.{}.merge", branch)).ok()?;
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    return None;
+  }
+  // `branch.<name>.merge` is stored as a refspec like `refs/heads/dev`;
+  // surface the short name so the value is fit for `git diff` / `git
+  // rev-list` without further massaging.
+  Some(trimmed.strip_prefix("refs/heads/").unwrap_or(trimmed).to_string())
+}
+
+fn read_branch_config(repo: &Repository, branch: &str, leaf: &str) -> Option<String> {
+  let cfg = repo.config().ok()?;
+  let raw = cfg.get_string(&format!("branch.{}.{}", branch, leaf)).ok()?;
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    None
+  } else {
+    Some(trimmed.to_string())
+  }
+}
+
+/// Count commits in `head` not in `base` (`git rev-list --count
+/// {base}..{head}` shelled out from `workdir`). Returns `0` when the
+/// shell-out fails — the `R` keybinding defers to the caller's
+/// `skip_when_no_changes` knob to decide what to do with the count.
+pub fn count_commits_ahead(workdir: &Path, base: &str, head: &str) -> u32 {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(workdir)
+    .args(["rev-list", "--count", &format!("{}..{}", base, head)])
+    .output();
+  let Ok(out) = output else { return 0 };
+  if !out.status.success() {
+    return 0;
+  }
+  String::from_utf8_lossy(&out.stdout).trim().parse::<u32>().unwrap_or(0)
+}
+
+/// Probe `$PATH` for the binary in an [`ExpandedCommand`]. Returns the
+/// absolute path on hit, `None` otherwise — the status bar can then
+/// surface a precise error without trying to spawn a missing file.
+pub fn locate_binary(expanded: &ExpandedCommand) -> Option<PathBuf> {
+  let bin = expanded.binary()?;
+  which::which(bin).ok()
+}
+
+/// Probe whether the resolved launcher's binary exists on $PATH. Used
+/// by [`gwm doctor`](crate::doctor) to emit a warning (exit code 1)
+/// when the configured review/git_tui binary is missing — the launcher
+/// itself is opt-in, so this is advisory, not a hard failure.
+///
+/// Returns the binary name on miss so the doctor check can include it
+/// in the message verbatim ("not on PATH: lumen"). Returns `None` if
+/// the binary resolves or if the launcher has no parseable argv.
+pub fn missing_binary_for(launcher: &ResolvedLauncher) -> Option<String> {
+  // Strip the placeholders before tokenising — `shell_words` would
+  // happily eat the `{path}` literal, but we only care about argv[0]
+  // here so a quick replace keeps things simple. The launcher itself
+  // does proper expansion at exec time.
+  let cleaned = launcher
+    .command
+    .replace("{base}", "BASE")
+    .replace("{head}", "HEAD")
+    .replace("{path}", "PATH")
+    .replace("{diff}", "/tmp/diff");
+  let tokens = shell_words::split(&cleaned).ok()?;
+  let bin = tokens.into_iter().find(|t| !t.contains('='))?;
+  if which::which(&bin).is_ok() {
+    None
+  } else {
+    Some(bin)
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cli;
 pub mod config;
 pub mod doctor;
 pub mod error;
+pub mod github;
 pub mod multiplexer;
 pub mod naming;
 pub mod tui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod doctor;
 pub mod error;
 pub mod github;
+pub mod launcher;
 pub mod multiplexer;
 pub mod naming;
 pub mod tui;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,6 +2,7 @@ use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::Config;
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
+use crate::launcher::{self, ExpandedCommand, LauncherContext};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
@@ -12,6 +13,25 @@ use nucleo_matcher::{
 use ratatui::{text::Line, widgets::TableState};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+
+/// Spawnable launcher plan handed to the event loop by
+/// [`App::prepare_git_tui`] / [`App::prepare_review`]. Carries the
+/// expanded argv, the cwd to set on the child, and the `fullscreen`
+/// toggle that decides whether gwm suspends its own TUI for the call.
+///
+/// The `diff_file` inside `expanded` (when set) is kept alive for the
+/// lifetime of the plan, so a `{diff}` tempfile survives until the
+/// spawned reviewer has had a chance to consume it.
+#[derive(Debug)]
+pub struct LauncherPlan {
+  pub expanded: ExpandedCommand,
+  pub cwd: std::path::PathBuf,
+  pub fullscreen: bool,
+  /// Resolved base ref, when the launcher cares about it (review).
+  /// `None` for the git_tui launcher. Surfaced so the status bar /
+  /// caller can mention which ref was used.
+  pub base: Option<String>,
+}
 
 /// Outcome of pressing `y` / Enter on the confirm overlay. The event loop
 /// in `super::run_app` matches on this to decide whether to fire the
@@ -357,6 +377,10 @@ impl App {
 
   /// Path to launch lazygit on, or `None` if nothing selected or lazygit is missing.
   /// The caller drives the actual TUI suspension/restoration around the spawn.
+  ///
+  /// Retained for callers that still want the legacy "lazygit only"
+  /// path; new code should go through [`Self::prepare_git_tui`], which
+  /// honours the configurable `[git_tui]` block (issue #75).
   pub fn launch_lazygit(&mut self) -> Option<PathBuf> {
     let path = self.selected()?.path.clone();
     if which::which("lazygit").is_err() {
@@ -364,6 +388,106 @@ impl App {
       return None;
     }
     Some(path)
+  }
+
+  // ---- Configurable launchers (issue #75) ---------------------------------
+
+  /// Build the [`LauncherPlan`] for the `l` keybinding. Reads
+  /// `[git_tui]` from `.gwm.toml` (default `lazygit -p {path}`
+  /// fullscreen=true) and expands the `{path}` placeholder against
+  /// the selected worktree. Returns `None` (and sets a status hint)
+  /// when nothing is selected or the template is malformed.
+  pub fn prepare_git_tui(&mut self) -> Option<LauncherPlan> {
+    let Some(wt) = self.selected().cloned() else {
+      self.status = "nothing selected".into();
+      return None;
+    };
+    let resolved = self.config.git_tui.resolved();
+    let ctx = LauncherContext {
+      worktree_path: &wt.path,
+      base: None,
+      head: None,
+      repo_workdir: Some(&self.workdir),
+    };
+    match launcher::expand_command(&resolved.command, &ctx) {
+      Ok(expanded) => Some(LauncherPlan {
+        expanded,
+        cwd: wt.path,
+        fullscreen: resolved.fullscreen,
+        base: None,
+      }),
+      Err(e) => {
+        self.status = format!("git_tui template error: {}", e);
+        None
+      }
+    }
+  }
+
+  /// Build the [`LauncherPlan`] for the `R` keybinding. Implements the
+  /// full review contract from issue #75:
+  ///
+  /// 1. `[review]` must resolve to a concrete launcher (`command`
+  ///    set, or `tool = "<preset>"` matched).
+  /// 2. The selected worktree must carry a branch name.
+  /// 3. The review base is resolved via the documented chain (upstream
+  ///    → `gwm-base` → `[review].default_base` → `"dev"` → `"main"`).
+  /// 4. When `skip_when_no_changes` is on (default), a zero
+  ///    `git rev-list --count {base}..HEAD` short-circuits with a
+  ///    status-bar hint naming the base.
+  /// 5. The template is expanded; `{diff}` lazily materialises a
+  ///    tempfile so unused placeholders never spawn `git diff`.
+  pub fn prepare_review(&mut self) -> Option<LauncherPlan> {
+    let resolved = match self.config.review.resolved() {
+      Some(r) => r,
+      None => {
+        self.status = "review tool not configured — set [review] in .gwm.toml".into();
+        return None;
+      }
+    };
+    let Some(wt) = self.selected().cloned() else {
+      self.status = "nothing selected".into();
+      return None;
+    };
+    let Some(head) = wt.branch.clone() else {
+      self.status = "selected worktree has no branch — cannot review".into();
+      return None;
+    };
+
+    let base = launcher::resolve_review_base(&self.repo, &head, self.config.review.default_base.as_deref());
+
+    if self.config.review.skip_when_no_changes {
+      let n = launcher::count_commits_ahead(&wt.path, &base, "HEAD");
+      if n == 0 {
+        self.status = format!("no changes to review (already at {})", base);
+        return None;
+      }
+    }
+
+    let ctx = LauncherContext {
+      worktree_path: &wt.path,
+      base: Some(&base),
+      head: Some(&head),
+      repo_workdir: Some(&self.workdir),
+    };
+    match launcher::expand_command(&resolved.command, &ctx) {
+      Ok(expanded) => {
+        if self.config.review.has_shadowed_tool() {
+          self.status = format!("review: command overrides tool — running {}", base);
+        } else {
+          self.status = format!("review: {} vs {}", head, base);
+        }
+        Some(LauncherPlan {
+          expanded,
+          cwd: wt.path,
+          fullscreen: resolved.fullscreen,
+          base: Some(base),
+        })
+      }
+      Err(e) => {
+        self.status = format!("review template error: {}", e);
+        None
+      }
+    }
   }
 
   pub fn selected(&self) -> Option<&WorktreeInfo> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -234,6 +234,7 @@ impl App {
 
   pub fn refresh(&mut self) -> Result<()> {
     self.worktrees = worktree::list(&self.repo)?;
+    // `clamp_selection_to_filter` re-resolves the link cache for us.
     self.clamp_selection_to_filter();
     self.invalidate_sidebar_cache();
     self.status = format!("refreshed — {} worktree(s)", self.worktrees.len());
@@ -263,6 +264,7 @@ impl App {
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
     self.invalidate_sidebar_cache();
+    self.refresh_link();
   }
 
   pub fn prev(&mut self) {
@@ -281,6 +283,7 @@ impl App {
     self.list_state.select(Some(i));
     self.sidebar_scroll = 0;
     self.invalidate_sidebar_cache();
+    self.refresh_link();
   }
 
   // ---- Vim-style motions / list jumps -------------------------------------
@@ -291,6 +294,7 @@ impl App {
       self.list_state.select(Some(0));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
+      self.refresh_link();
     }
   }
 
@@ -300,6 +304,7 @@ impl App {
       self.list_state.select(Some(len - 1));
       self.sidebar_scroll = 0;
       self.invalidate_sidebar_cache();
+      self.refresh_link();
     }
   }
 
@@ -708,11 +713,15 @@ impl App {
 
   /// Reposition the selection so it stays inside the current filtered subset.
   /// Called whenever the filter mutates (`/`-mode typing, `Esc`-clear) or the
-  /// worktree list itself changes (`refresh`).
+  /// worktree list itself changes (`refresh`). Also re-resolves the issue/PR
+  /// link cache so the right-panel block tracks the new selection — PR #68
+  /// Copilot review caught that selection changes were leaving the cache
+  /// pointing at the previously selected worktree.
   fn clamp_selection_to_filter(&mut self) {
     let len = self.filtered_indices().len();
     if len == 0 {
       self.list_state.select(None);
+      self.refresh_link();
       return;
     }
     match self.list_state.selected() {
@@ -720,6 +729,7 @@ impl App {
       Some(_) => {}
       None => self.list_state.select(Some(0)),
     }
+    self.refresh_link();
   }
 
   // ---- Bootstrap flow ------------------------------------------------------

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,7 +9,7 @@ use nucleo_matcher::{
   pattern::{CaseMatching, Normalization, Pattern},
   Config as NucleoConfig, Matcher, Utf32Str,
 };
-use ratatui::{text::Line, widgets::TableState};
+use ratatui::widgets::TableState;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -108,10 +108,11 @@ pub struct App {
   pub sidebar_open: bool,
   pub sidebar_focused: bool,
   pub sidebar_scroll: u16,
-  /// Cache of rendered sidebar lines, keyed by the selected worktree path.
-  /// Prevents re-shelling `git log` / `git status` on every TUI redraw — they
-  /// only run when the selection actually changes (or on explicit refresh).
-  pub sidebar_cache: Option<(PathBuf, Vec<Line<'static>>)>,
+  /// Cache of the rendered sidebar sections, keyed by the selected worktree
+  /// path. Prevents re-shelling `git log` / `git status` on every TUI redraw
+  /// — they only run when the selection actually changes (or on explicit
+  /// refresh).
+  pub sidebar_cache: Option<(PathBuf, super::ui::SidebarSections)>,
   /// Upper bound for `sidebar_scroll`, recomputed by the renderer each frame.
   /// Keeps scrolling clamped to the rendered content height so the user can't
   /// scroll the panel entirely off-screen.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::Config;
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
@@ -47,6 +48,33 @@ pub enum View {
   Confirm,
   Report,
   Help,
+  /// Compact menu to pick which GitHub URL to open (issue / pr).
+  OpenMenu,
+  /// Two-stage prompt: pick the link kind, then enter the number.
+  LinkPrompt,
+}
+
+/// Target of an open / link action.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LinkTarget {
+  Issue,
+  Pr,
+}
+
+/// Stage of the two-step link prompt.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LinkPromptStage {
+  ChooseTarget,
+  InputNumber,
+}
+
+/// State of a background GitHub fetch (issue or PR).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitHubFetchState<T> {
+  Idle,
+  Loading,
+  Loaded(T),
+  Error(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -121,6 +149,20 @@ pub struct App {
   /// `confirm_countdown_secs = 0`), or armed-but-just-disarmed by a
   /// second `y` press.
   pub confirm_countdown_started_at: Option<Instant>,
+
+  // ---- Issue/PR linking (issue #67) -------------------------------------
+  /// Cached link for the currently selected worktree's branch.
+  link: BranchLink,
+  /// Repo slug parsed from `origin` (None when no GitHub remote).
+  link_slug: Option<String>,
+  issue_state: GitHubFetchState<IssueStatus>,
+  pr_state: GitHubFetchState<PrStatus>,
+  /// In `View::LinkPrompt`, which stage are we in.
+  link_prompt_stage: LinkPromptStage,
+  /// In `View::LinkPrompt::InputNumber`, the digits typed so far.
+  link_prompt_number: String,
+  /// In `View::LinkPrompt::InputNumber`, the chosen target.
+  link_prompt_target: Option<LinkTarget>,
 }
 
 impl App {
@@ -138,7 +180,7 @@ impl App {
     if !worktrees.is_empty() {
       state.select(Some(0));
     }
-    Ok(Self {
+    let mut out = Self {
       repo,
       repo_name,
       workdir,
@@ -165,7 +207,16 @@ impl App {
       picker_result: None,
       picker_should_exit: false,
       confirm_countdown_started_at: None,
-    })
+      link: BranchLink::empty(),
+      link_slug: None,
+      issue_state: GitHubFetchState::Idle,
+      pr_state: GitHubFetchState::Idle,
+      link_prompt_stage: LinkPromptStage::ChooseTarget,
+      link_prompt_number: String::new(),
+      link_prompt_target: None,
+    };
+    out.refresh_link();
+    Ok(out)
   }
 
   /// Constructor for `gwm switch`: same App, but picker mode is on and the
@@ -738,5 +789,202 @@ impl App {
       }
       Err(e) => self.status = format!("bootstrap error: {}", e),
     }
+  }
+
+  // ---- Issue/PR linking (issue #67) -------------------------------------
+
+  /// Re-read the link for the currently selected worktree's branch. Also
+  /// re-resolves the repo slug from the origin remote, and resets any
+  /// previously cached GitHub fetch state since it would refer to a
+  /// different (issue, pr) tuple now.
+  pub fn refresh_link(&mut self) {
+    self.link = self.read_selected_link().unwrap_or_else(BranchLink::empty);
+    self.link_slug = github::repo_slug(&self.repo).ok();
+    self.issue_state = GitHubFetchState::Idle;
+    self.pr_state = GitHubFetchState::Idle;
+  }
+
+  fn read_selected_link(&self) -> Option<BranchLink> {
+    let branch = self
+      .selected()
+      .and_then(|w| w.branch.clone())
+      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))?;
+    github::read_link(&self.repo, &branch).ok()
+  }
+
+  pub fn current_link(&self) -> &BranchLink {
+    &self.link
+  }
+
+  pub fn current_slug(&self) -> Option<&str> {
+    self.link_slug.as_deref()
+  }
+
+  pub fn issue_fetch_state(&self) -> &GitHubFetchState<IssueStatus> {
+    &self.issue_state
+  }
+
+  pub fn pr_fetch_state(&self) -> &GitHubFetchState<PrStatus> {
+    &self.pr_state
+  }
+
+  /// Drive the issue/PR fetch synchronously. Called from the event loop
+  /// when the user presses `R`. Sets states to `Loading` first so the UI
+  /// can flag the in-flight state, then runs the fetches.
+  pub fn refresh_github_status(&mut self) {
+    if self.link.issue.is_none() && self.link.pr.is_none() {
+      self.status = "nothing linked — press L to link an issue or PR".into();
+      return;
+    }
+    let Some(slug) = self.link_slug.clone() else {
+      self.status = "no GitHub remote — cannot fetch status".into();
+      return;
+    };
+    if let Some(n) = self.link.issue {
+      self.issue_state = GitHubFetchState::Loading;
+      let r = github::fetch_issue(&slug, n).map_err(|e| e.to_string());
+      self.apply_issue_fetch_result(r);
+    }
+    if let Some(n) = self.link.pr {
+      self.pr_state = GitHubFetchState::Loading;
+      let r = github::fetch_pr(&slug, n).map_err(|e| e.to_string());
+      self.apply_pr_fetch_result(r);
+    }
+    self.status = "github status refreshed".into();
+  }
+
+  pub fn apply_issue_fetch_result(&mut self, r: std::result::Result<IssueStatus, String>) {
+    self.issue_state = match r {
+      Ok(s) => GitHubFetchState::Loaded(s),
+      Err(e) => GitHubFetchState::Error(e),
+    };
+  }
+
+  pub fn apply_pr_fetch_result(&mut self, r: std::result::Result<PrStatus, String>) {
+    self.pr_state = match r {
+      Ok(s) => GitHubFetchState::Loaded(s),
+      Err(e) => GitHubFetchState::Error(e),
+    };
+  }
+
+  // ---- Open menu ----------------------------------------------------------
+
+  pub fn enter_open_menu(&mut self) {
+    // Re-resolve link + slug in case the user just linked something
+    // (`gwm link …` from a parallel terminal) or moved the origin remote.
+    self.refresh_link();
+    self.view = View::OpenMenu;
+  }
+
+  pub fn exit_open_menu(&mut self) {
+    self.view = View::List;
+  }
+
+  /// Pick a target from the open menu. Returns the URL to open, or `None`
+  /// when the link is missing (the status bar carries the explanation).
+  pub fn open_menu_pick(&mut self, target: LinkTarget) -> Option<String> {
+    self.view = View::List;
+    let Some(slug) = self.link_slug.clone() else {
+      self.status = "no GitHub remote — cannot build URL".into();
+      return None;
+    };
+    let url = match target {
+      LinkTarget::Issue => match self.link.issue {
+        Some(n) => github::issue_url(&slug, n),
+        None => {
+          self.status = "no issue linked — press L to link one".into();
+          return None;
+        }
+      },
+      LinkTarget::Pr => match self.link.pr {
+        Some(n) => github::pr_url(&slug, n),
+        None => {
+          self.status = "no PR linked — press L to link one".into();
+          return None;
+        }
+      },
+    };
+    Some(url)
+  }
+
+  // ---- Link prompt --------------------------------------------------------
+
+  pub fn enter_link_prompt(&mut self) {
+    self.view = View::LinkPrompt;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+    self.status = "link: [i]ssue / [p]r · esc cancels".into();
+  }
+
+  pub fn link_prompt_cancel(&mut self) {
+    self.view = View::List;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+  }
+
+  pub fn link_prompt_stage(&self) -> LinkPromptStage {
+    self.link_prompt_stage
+  }
+
+  pub fn link_prompt_number_input(&self) -> &str {
+    &self.link_prompt_number
+  }
+
+  pub fn link_prompt_target(&self) -> Option<LinkTarget> {
+    self.link_prompt_target
+  }
+
+  pub fn link_prompt_choose(&mut self, target: LinkTarget) {
+    self.link_prompt_target = Some(target);
+    self.link_prompt_stage = LinkPromptStage::InputNumber;
+    self.link_prompt_number.clear();
+    self.status = match target {
+      LinkTarget::Issue => "issue # — digits, enter to link, esc to cancel".into(),
+      LinkTarget::Pr => "pr # — digits, enter to link, esc to cancel".into(),
+    };
+  }
+
+  pub fn link_prompt_push_char(&mut self, c: char) {
+    if self.link_prompt_stage == LinkPromptStage::InputNumber && c.is_ascii_digit() {
+      self.link_prompt_number.push(c);
+    }
+  }
+
+  pub fn link_prompt_pop_char(&mut self) {
+    if self.link_prompt_stage == LinkPromptStage::InputNumber {
+      self.link_prompt_number.pop();
+    }
+  }
+
+  pub fn link_prompt_submit(&mut self) -> Result<()> {
+    let Some(target) = self.link_prompt_target else {
+      self.status = "no target chosen".into();
+      return Ok(());
+    };
+    let n: u64 = self
+      .link_prompt_number
+      .parse()
+      .map_err(|_| GwmError::Other("number is empty or invalid".into()))?;
+    let branch = self
+      .selected()
+      .and_then(|w| w.branch.clone())
+      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))
+      .ok_or_else(|| GwmError::Other("no branch resolved for selected worktree".into()))?;
+    match target {
+      LinkTarget::Issue => github::link_issue(&self.repo, &branch, n)?,
+      LinkTarget::Pr => github::link_pr(&self.repo, &branch, n)?,
+    }
+    self.status = match target {
+      LinkTarget::Issue => format!("linked issue #{} to {}", n, branch),
+      LinkTarget::Pr => format!("linked PR #{} to {}", n, branch),
+    };
+    self.view = View::List;
+    self.link_prompt_stage = LinkPromptStage::ChooseTarget;
+    self.link_prompt_target = None;
+    self.link_prompt_number.clear();
+    self.refresh_link();
+    Ok(())
   }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,5 @@
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
-use crate::config::Config;
+use crate::config::{Config, TuiOpenConfig, TuiOpenMode};
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::naming::{BranchSpec, BRANCH_TYPES};
@@ -59,6 +59,24 @@ pub enum View {
 pub enum LinkTarget {
   Issue,
   Pr,
+}
+
+/// Dispatch target for the `o` key (issue #73). Resolved by
+/// [`App::resolve_open_target`] from the current selection + the
+/// `[tui.open]` config so the event loop can hand off to the right
+/// runner (shell suspend, editor suspend, OS file manager) without
+/// re-reading the config or `$SHELL` / `$EDITOR` itself.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum OpenTarget {
+  /// Spawn `command` with `cwd = path`. Caller suspends the TUI and
+  /// restores it on the child's exit (same lifecycle as `l: lazygit`).
+  Shell { path: PathBuf, command: String },
+  /// Spawn `command <path>` and wait. Same suspend/restore lifecycle
+  /// as `Shell`.
+  Editor { path: PathBuf, command: String },
+  /// Hand off to the OS opener (`open` / `xdg-open` / `explorer`).
+  /// Doesn't suspend the TUI — the opener detaches.
+  Finder { path: PathBuf },
 }
 
 /// Stage of the two-step link prompt.
@@ -383,7 +401,9 @@ impl App {
   }
 
   /// Reveal the selected worktree's directory in the OS file manager.
-  /// macOS: `open`, Linux: `xdg-open`, Windows: `explorer`.
+  /// macOS: `open`, Linux: `xdg-open`, Windows: `explorer`. Used by
+  /// `resolve_open_target` when the config picks `mode = "finder"`,
+  /// and by the event loop directly to spawn the opener.
   pub fn open_selected_in_finder(&mut self) {
     let path = match self.selected() {
       Some(w) => w.path.clone(),
@@ -403,6 +423,34 @@ impl App {
       Ok(_) => self.status = format!("opened {} in {}", path.display(), opener),
       Err(e) => self.status = format!("failed to open {}: {}", path.display(), e),
     }
+  }
+
+  /// Return the path that the `y: yank` key should push into the system
+  /// clipboard, or `None` when nothing is selected. Pure — the actual
+  /// shell-out (`pbcopy` / `wl-copy` / `xclip` / `clip`) is handled by
+  /// the event loop so this method stays trivially testable.
+  pub fn yank_selected_path(&self) -> Option<PathBuf> {
+    self.selected().map(|w| w.path.clone())
+  }
+
+  /// Resolve what the `o` key should do for the currently selected
+  /// worktree. Returns `None` when nothing is selected (the event loop
+  /// surfaces a status message in that case). The exact command is
+  /// resolved once here (config override > env var > hardcoded fallback)
+  /// so the event loop never has to reason about precedence.
+  pub fn resolve_open_target(&self) -> Option<OpenTarget> {
+    let path = self.selected()?.path.clone();
+    Some(match self.config.tui.open.mode {
+      TuiOpenMode::Shell => OpenTarget::Shell {
+        path,
+        command: resolve_shell_command(&self.config.tui.open),
+      },
+      TuiOpenMode::Editor => OpenTarget::Editor {
+        path,
+        command: resolve_editor_command(&self.config.tui.open),
+      },
+      TuiOpenMode::Finder => OpenTarget::Finder { path },
+    })
   }
 
   pub fn toggle_delete_branch(&mut self) {
@@ -1033,4 +1081,28 @@ impl App {
     self.refresh_link();
     Ok(())
   }
+}
+
+/// Resolve the shell command for `mode = "shell"`. Precedence:
+/// `shell_cmd` in `.gwm.toml` → `$SHELL` env var → `/bin/sh`. The
+/// hardcoded fallback exists for the (rare) case where neither is set —
+/// the TUI's spawn-and-restore loop assumes a non-empty command string.
+fn resolve_shell_command(cfg: &TuiOpenConfig) -> String {
+  cfg
+    .shell_cmd
+    .clone()
+    .or_else(|| std::env::var("SHELL").ok())
+    .unwrap_or_else(|| "/bin/sh".into())
+}
+
+/// Resolve the editor command for `mode = "editor"`. Precedence:
+/// `editor_cmd` in `.gwm.toml` → `$EDITOR` env var → `vi` (POSIX
+/// baseline). Mirrors `resolve_shell_command` so the two flows share
+/// the same precedence story.
+fn resolve_editor_command(cfg: &TuiOpenConfig) -> String {
+  cfg
+    .editor_cmd
+    .clone()
+    .or_else(|| std::env::var("EDITOR").ok())
+    .unwrap_or_else(|| "vi".into())
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -860,7 +860,43 @@ impl App {
       let r = github::fetch_pr(&slug, n).map_err(|e| e.to_string());
       self.apply_pr_fetch_result(r);
     }
-    self.status = "github status refreshed".into();
+    self.report_github_refresh_status();
+  }
+
+  /// Compute the post-refresh status line message based on the actual
+  /// outcome of the issue / PR fetches. PR #68 Copilot review caught
+  /// that always printing "refreshed" misled users when one of the
+  /// fetches had failed.
+  pub fn report_github_refresh_status(&mut self) {
+    let issue_err = matches!(self.issue_state, GitHubFetchState::Error(_));
+    let pr_err = matches!(self.pr_state, GitHubFetchState::Error(_));
+    self.status = match (issue_err, pr_err) {
+      (false, false) => "github status refreshed".into(),
+      (true, false) => format!(
+        "issue fetch failed: {}",
+        self.issue_error_message().unwrap_or("?".into())
+      ),
+      (false, true) => format!("pr fetch failed: {}", self.pr_error_message().unwrap_or("?".into())),
+      (true, true) => format!(
+        "issue + pr fetch failed — issue: {} · pr: {}",
+        self.issue_error_message().unwrap_or("?".into()),
+        self.pr_error_message().unwrap_or("?".into())
+      ),
+    };
+  }
+
+  fn issue_error_message(&self) -> Option<String> {
+    match &self.issue_state {
+      GitHubFetchState::Error(e) => Some(e.clone()),
+      _ => None,
+    }
+  }
+
+  fn pr_error_message(&self) -> Option<String> {
+    match &self.pr_state {
+      GitHubFetchState::Error(e) => Some(e.clone()),
+      _ => None,
+    }
   }
 
   pub fn apply_issue_fetch_result(&mut self, r: std::result::Result<IssueStatus, String>) {

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -13,10 +13,12 @@
 //!
 //! Differences from lazygit, all intentional:
 //!
-//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
-//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//! - **Single green palette** — `Color::Green` for connectors and
+//!   `Color::Green` + bold for `○` / `◎` nodes. Lazygit uses per-author
 //!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
-//!   is authored by the same person, so the rainbow is wasted ink.
+//!   is authored by the same person, so the rainbow is wasted ink. The
+//!   green matches the `Worktree` block's "synced" status badge for
+//!   visual consistency across the sidebar.
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
@@ -350,8 +352,8 @@ pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
     c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
   }
 
-  let connector_style = Style::default().fg(Color::DarkGray);
-  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+  let connector_style = Style::default().fg(Color::Green);
+  let node_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
 
   let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
   for cell in &cells {

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -6,10 +6,15 @@
 //! consecutive rows, and renders each row as a fixed sequence of 2-char
 //! cells (`<glyph><filler>`).
 //!
-//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
-//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
-//! independent of terminal width — the graph is width-deterministic on
-//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//! The output is a `Vec<Span<'static>>` per row (from
+//! [`render_pipe_set`]) or a `Vec<Vec<Span<'static>>>` for the full
+//! commit list (from [`render_commits`]). Callers assemble those spans
+//! into a `ratatui::text::Line` together with the rest of the row
+//! (hash, author initials, subject) — see
+//! `src/tui/ui.rs::commit_row_line`. Each row's spans cover exactly
+//! `2 * (max_pos + 1)` cells, independent of terminal width — the
+//! graph is width-deterministic on the input commit list (lazygit
+//! caches on `(head_hash, count)` only).
 //!
 //! Differences from lazygit, all intentional:
 //!
@@ -22,9 +27,14 @@
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
-//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
-//!   target for the first commit so its `○` doesn't appear orphaned;
-//!   here we simply skip the seeded `Starts` pipe in that case.
+//! - **No empty-tree sentinel** — lazygit targets a synthetic
+//!   `EmptyTreeCommitHash` from the first commit's `Starts` pipe so
+//!   `○` doesn't look orphaned. gwm uses an empty string for the
+//!   first parent of a root commit; the rendered cell is still a
+//!   plain `○` because the seeded sentinel pipe from row 0 terminates
+//!   on it. The trivial commit-on-commit `Terminates` (where
+//!   `from_pos == to_pos == commit_pos`) is skipped in
+//!   [`render_pipe_set`] so it doesn't overwrite the node glyph.
 
 use crate::worktree::CommitRow;
 use ratatui::{

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -1,0 +1,433 @@
+//! Per-row commit graph renderer for the Recent Commits sidebar block.
+//!
+//! Direct Rust port of lazygit's `pkg/gui/presentation/graph/` package
+//! (`graph.go` + `cell.go`). The algorithm walks the commit list once,
+//! maintains a set of active "pipes" (vertical line segments) between
+//! consecutive rows, and renders each row as a fixed sequence of 2-char
+//! cells (`<glyph><filler>`).
+//!
+//! The output is a `Vec<Line<'static>>` ready to drop into a ratatui
+//! `Paragraph`. Each row's width is exactly `2 * (max_pos + 1)` chars,
+//! independent of terminal width — the graph is width-deterministic on
+//! the input commit list (lazygit caches on `(head_hash, count)` only).
+//!
+//! Differences from lazygit, all intentional:
+//!
+//! - **Single muted colour** (`Color::DarkGray`) for connectors and a
+//!   neutral `Color::Blue` for `○` / `◎` nodes. Lazygit uses per-author
+//!   MD5→HSL→RGB colours; we skip that for now — every commit on `gwm`
+//!   is authored by the same person, so the rainbow is wasted ink.
+//! - **No selected-commit override** — lazygit highlights the pipes
+//!   originating from the cursor; our sidebar's selection lives on the
+//!   *worktree* list, not on a specific commit.
+//! - **No empty-tree sentinel** — lazygit emits an `EmptyTreeCommitHash`
+//!   target for the first commit so its `○` doesn't appear orphaned;
+//!   here we simply skip the seeded `Starts` pipe in that case.
+
+use crate::worktree::CommitRow;
+use ratatui::{
+  style::{Color, Modifier, Style},
+  text::Span,
+};
+use std::collections::HashSet;
+
+/// Lifecycle of a pipe across the row it sits in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PipeKind {
+  /// A pipe arriving from above that ends on the current row's commit.
+  Terminates,
+  /// A pipe starting from the current row's commit, heading downward
+  /// toward one of its parents.
+  Starts,
+  /// A pipe that arrived from above and continues below — passing
+  /// through the current row, possibly shifting columns left/right.
+  Continues,
+}
+
+#[derive(Debug, Clone)]
+pub struct Pipe {
+  pub from_pos: i16,
+  pub to_pos: i16,
+  pub from_hash: String,
+  pub to_hash: String,
+  pub kind: PipeKind,
+}
+
+impl Pipe {
+  #[inline]
+  fn left(&self) -> i16 {
+    self.from_pos.min(self.to_pos)
+  }
+  #[inline]
+  fn right(&self) -> i16 {
+    self.from_pos.max(self.to_pos)
+  }
+}
+
+/// What a cell represents at render time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellType {
+  Connection,
+  Commit,
+  Merge,
+}
+
+#[derive(Debug, Clone)]
+struct Cell {
+  up: bool,
+  down: bool,
+  left: bool,
+  right: bool,
+  cell_type: CellType,
+}
+
+impl Cell {
+  fn new_connection() -> Self {
+    Self {
+      up: false,
+      down: false,
+      left: false,
+      right: false,
+      cell_type: CellType::Connection,
+    }
+  }
+  fn set_up(&mut self) {
+    self.up = true;
+  }
+  fn set_down(&mut self) {
+    self.down = true;
+  }
+  fn set_left(&mut self) {
+    self.left = true;
+  }
+  fn set_right(&mut self) {
+    self.right = true;
+  }
+  fn set_type(&mut self, t: CellType) {
+    self.cell_type = t;
+  }
+}
+
+/// Port of lazygit's 16-case `getBoxDrawingChars` truth table
+/// (`cell.go:147-183`). Returns `(glyph, right_filler)` — each cell emits
+/// two characters so a continuous horizontal stroke can be drawn by
+/// chaining `─` fillers across columns.
+///
+/// Glyphs are all in the U+2500 light-box-drawing block.
+pub fn box_drawing_chars(up: bool, down: bool, left: bool, right: bool) -> (char, char) {
+  match (up, down, left, right) {
+    (true, true, true, true) => ('│', '─'),
+    (true, true, true, false) => ('│', ' '),
+    (true, true, false, true) => ('│', '─'),
+    (true, true, false, false) => ('│', ' '),
+    (true, false, true, true) => ('┴', '─'),
+    (true, false, true, false) => ('╯', ' '),
+    (true, false, false, true) => ('╰', '─'),
+    (true, false, false, false) => ('╵', ' '),
+    (false, true, true, true) => ('┬', '─'),
+    (false, true, true, false) => ('╮', ' '),
+    (false, true, false, true) => ('╭', '─'),
+    (false, true, false, false) => ('╷', ' '),
+    (false, false, true, true) => ('─', '─'),
+    (false, false, true, false) => ('─', ' '),
+    (false, false, false, true) => ('╶', '─'),
+    (false, false, false, false) => (' ', ' '),
+  }
+}
+
+/// Seed sentinel hash used by lazygit for the pipe that ends on the
+/// very first commit (`graph.go:36`). The actual value is opaque — it
+/// just must never equal any real SHA-1.
+const START_HASH: &str = "__GWM_GRAPH_START__";
+
+/// Walk `commits` once, producing the per-row pipe sets. This is the
+/// Rust translation of lazygit's `GetPipeSets` (`graph.go:60-69`).
+pub fn build_pipe_sets(commits: &[CommitRow]) -> Vec<Vec<Pipe>> {
+  if commits.is_empty() {
+    return Vec::new();
+  }
+  let mut pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: START_HASH.to_string(),
+    to_hash: commits[0].hash.clone(),
+    kind: PipeKind::Starts,
+  }];
+  let mut out = Vec::with_capacity(commits.len());
+  for commit in commits {
+    pipes = get_next_pipes(&pipes, commit);
+    out.push(pipes.clone());
+  }
+  out
+}
+
+/// Per-row transition. Port of lazygit's `getNextPipes`
+/// (`graph.go:109-273`). Given the previous row's pipes and the current
+/// commit, produces the current row's pipe set.
+fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
+  let max_pos: i16 = prev_pipes.iter().map(|p| p.to_pos).max().unwrap_or(0);
+
+  // Pipes that terminated last row do not carry into this one.
+  let current_pipes: Vec<&Pipe> = prev_pipes.iter().filter(|p| p.kind != PipeKind::Terminates).collect();
+
+  // Default to a brand-new commit column. Falls back to the column of
+  // any descendant pipe pointing at us.
+  let mut pos: i16 = max_pos + 1;
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      pos = pipe.to_pos;
+      break;
+    }
+  }
+
+  let mut new_pipes: Vec<Pipe> = Vec::with_capacity(current_pipes.len() + commit.parents.len());
+
+  // Emit the STARTS pipe for the *first* parent (or empty-tree sentinel
+  // when this is the root commit).
+  let first_parent = commit.parents.first().cloned().unwrap_or_else(|| String::from(""));
+  new_pipes.push(Pipe {
+    from_pos: pos,
+    to_pos: pos,
+    from_hash: commit.hash.clone(),
+    to_hash: first_parent,
+    kind: PipeKind::Starts,
+  });
+
+  // Shared mutable state for the per-pipe loops below.
+  let mut taken_spots: HashSet<i16> = HashSet::new();
+  let mut traversed_spots: HashSet<i16> = HashSet::new();
+
+  // Pre-compute the spots that continuing pipes already occupy — a new
+  // merge-parent pipe must not land on top of them.
+  let mut traversed_spots_for_continuing: HashSet<i16> = HashSet::new();
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash {
+      traversed_spots_for_continuing.insert(pipe.to_pos);
+    }
+  }
+
+  // Helper closures need shared borrows of the spot sets, so inline
+  // them as plain `fn`-style helpers operating on locals here.
+  fn next_free(spots: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while spots.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn next_free_for_new(taken: &HashSet<i16>, traversed_for_continuing: &HashSet<i16>) -> i16 {
+    let mut i: i16 = 0;
+    while taken.contains(&i) || traversed_for_continuing.contains(&i) {
+      i += 1;
+    }
+    i
+  }
+  fn traverse(taken: &mut HashSet<i16>, traversed: &mut HashSet<i16>, from: i16, to: i16) {
+    let (l, r) = if from <= to { (from, to) } else { (to, from) };
+    for i in l..=r {
+      traversed.insert(i);
+    }
+    taken.insert(to);
+  }
+
+  // Phase 1: terminating + leftward-continuing pipes from the previous row.
+  for pipe in &current_pipes {
+    if pipe.to_hash == commit.hash {
+      // pipe ends on this commit
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: pos,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Terminates,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, pos);
+    } else if pipe.to_pos < pos {
+      // pipe continues; pick the next free column to its right
+      let avail = next_free(&traversed_spots);
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: avail,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, avail);
+    }
+  }
+
+  // Phase 2: extra parents of a merge commit each open a new column.
+  if commit.parents.len() >= 2 {
+    for parent in commit.parents.iter().skip(1) {
+      let avail = next_free_for_new(&taken_spots, &traversed_spots_for_continuing);
+      new_pipes.push(Pipe {
+        from_pos: pos,
+        to_pos: avail,
+        from_hash: commit.hash.clone(),
+        to_hash: parent.clone(),
+        kind: PipeKind::Starts,
+      });
+      taken_spots.insert(avail);
+    }
+  }
+
+  // Phase 3: continuing pipes from the *right* of the commit. They may
+  // shift leftward to fill blank columns.
+  for pipe in &current_pipes {
+    if pipe.to_hash != commit.hash && pipe.to_pos > pos {
+      let mut last = pipe.to_pos;
+      let mut i = pipe.to_pos;
+      while i > pos {
+        i -= 1;
+        if taken_spots.contains(&i) || traversed_spots.contains(&i) {
+          break;
+        }
+        last = i;
+      }
+      new_pipes.push(Pipe {
+        from_pos: pipe.to_pos,
+        to_pos: last,
+        from_hash: pipe.from_hash.clone(),
+        to_hash: pipe.to_hash.clone(),
+        kind: PipeKind::Continues,
+      });
+      traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, last);
+    }
+  }
+
+  // Stable ordering by to_pos, then kind (matches lazygit's sort).
+  new_pipes.sort_by(|a, b| {
+    if a.to_pos == b.to_pos {
+      a.kind.cmp(&b.kind)
+    } else {
+      a.to_pos.cmp(&b.to_pos)
+    }
+  });
+
+  new_pipes
+}
+
+/// Render a single pipe set into ratatui spans, two spans per cell. Port
+/// of lazygit's `renderPipeSet` (`graph.go:275-385`).
+pub fn render_pipe_set(pipes: &[Pipe]) -> Vec<Span<'static>> {
+  let mut max_pos: i16 = 0;
+  let mut commit_pos: i16 = 0;
+  let mut start_count: usize = 0;
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      start_count += 1;
+      commit_pos = pipe.from_pos;
+    } else if pipe.kind == PipeKind::Terminates {
+      commit_pos = pipe.to_pos;
+    }
+    if pipe.right() > max_pos {
+      max_pos = pipe.right();
+    }
+  }
+  let is_merge = start_count > 1;
+
+  let mut cells: Vec<Cell> = (0..=max_pos).map(|_| Cell::new_connection()).collect();
+
+  // First pass: STARTS pipes paint their downward stroke + any leftward
+  // continuation. Done first so subsequent passes can layer on top.
+  for pipe in pipes {
+    if pipe.kind == PipeKind::Starts {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+  // Second pass: TERMINATES and CONTINUES (except the trivial commit-
+  // on-commit terminate that would erase the commit cell glyph).
+  for pipe in pipes {
+    if pipe.kind != PipeKind::Starts
+      && !(pipe.kind == PipeKind::Terminates && pipe.from_pos == commit_pos && pipe.to_pos == commit_pos)
+    {
+      apply_pipe(&mut cells, pipe);
+    }
+  }
+
+  // Mark the commit cell.
+  if let Some(c) = cells.get_mut(commit_pos as usize) {
+    c.set_type(if is_merge { CellType::Merge } else { CellType::Commit });
+  }
+
+  let connector_style = Style::default().fg(Color::DarkGray);
+  let node_style = Style::default().fg(Color::Blue).add_modifier(Modifier::BOLD);
+
+  let mut out: Vec<Span<'static>> = Vec::with_capacity(cells.len() * 2);
+  for cell in &cells {
+    let (glyph, filler) = box_drawing_chars(cell.up, cell.down, cell.left, cell.right);
+    let render_glyph: String = match cell.cell_type {
+      CellType::Connection => glyph.to_string(),
+      CellType::Commit => '○'.to_string(),
+      CellType::Merge => '◎'.to_string(),
+    };
+    let style = if matches!(cell.cell_type, CellType::Commit | CellType::Merge) {
+      node_style
+    } else {
+      connector_style
+    };
+    out.push(Span::styled(render_glyph, style));
+    // The right filler is always a connector (never a node), so it
+    // keeps the connector style.
+    out.push(Span::styled(filler.to_string(), connector_style));
+  }
+  out
+}
+
+fn apply_pipe(cells: &mut [Cell], pipe: &Pipe) {
+  let left = pipe.left();
+  let right = pipe.right();
+
+  if left != right {
+    for i in (left + 1)..right {
+      if let Some(c) = cells.get_mut(i as usize) {
+        c.set_left();
+        c.set_right();
+      }
+    }
+    if let Some(c) = cells.get_mut(left as usize) {
+      c.set_right();
+    }
+    if let Some(c) = cells.get_mut(right as usize) {
+      c.set_left();
+    }
+  }
+
+  match pipe.kind {
+    PipeKind::Starts | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.to_pos as usize) {
+        c.set_down();
+      }
+    }
+    PipeKind::Terminates => {}
+  }
+  match pipe.kind {
+    PipeKind::Terminates | PipeKind::Continues => {
+      if let Some(c) = cells.get_mut(pipe.from_pos as usize) {
+        c.set_up();
+      }
+    }
+    PipeKind::Starts => {}
+  }
+}
+
+/// One-shot helper: compute pipe sets for the commit list and render
+/// each row's spans. Output length matches `commits.len()`.
+pub fn render_commits(commits: &[CommitRow]) -> Vec<Vec<Span<'static>>> {
+  build_pipe_sets(commits)
+    .into_iter()
+    .map(|pipes| render_pipe_set(&pipes))
+    .collect()
+}
+
+/// Convenience constructor for tests — builds a `CommitRow` with the
+/// minimum data the graph algorithm needs.
+#[doc(hidden)]
+pub fn test_row(hash: &str, parents: &[&str]) -> CommitRow {
+  CommitRow {
+    hash: hash.into(),
+    author: String::new(),
+    parents: parents.iter().map(|s| s.to_string()).collect(),
+    subject: String::new(),
+  }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{build_sidebar_sections, filled_cells_for_progress, SidebarSections};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,10 @@
 mod app;
+/// Commit-graph topology renderer, ported from lazygit. **Not part of the
+/// public SemVer surface** — exposed only so the integration tests under
+/// `tests/` can pin the algorithm. Use `gwm::tui::recent_commits_lines`
+/// (re-exported below) for the stable entry point that callers should
+/// actually depend on.
+#[doc(hidden)]
 pub mod commit_graph;
 mod ui;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -282,9 +282,17 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
 /// [`App::prepare_review`]. When `fullscreen=true` the TUI is
 /// suspended (raw mode off, alt-screen left) for the call and restored
 /// on exit — same recipe as the previous hardcoded `lazygit` flow.
-/// Non-fullscreen launchers run in the background; their stderr's
-/// first line is surfaced on the status bar so the user gets feedback
-/// even when the tool doesn't take over the screen.
+///
+/// **Non-fullscreen launchers also run synchronously**: gwm stays in
+/// the alt-screen, `Command::output()` waits for the child to exit,
+/// then the first line of its stderr lands on the status bar. The
+/// TUI is therefore unresponsive until the tool returns — fine for
+/// print-only AI reviewers (`claude --print`, `gh pr view --web`)
+/// that terminate quickly, but a long-running tool will visibly
+/// block. Pick `fullscreen = true` (proper suspend/resume) for
+/// anything that's not a quick one-shot. Caught by Copilot's review
+/// on PR #76; the previous docstring claimed "run in the background"
+/// which `output()` does not.
 ///
 /// `LauncherPlan` is consumed by-value so the `{diff}` tempfile it
 /// carries lives at least until the child process has been waited on.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod commit_graph;
 mod ui;
 
 use crate::error::Result;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,7 +35,9 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
     ]
   }
 }
-pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
+pub use ui::{
+  branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color, table_marker,
+};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,8 +13,28 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub use app::{
-  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, OpenTarget, View,
 };
+
+/// Ordered list of clipboard tools to try for the host OS (issue #73).
+/// First entry that resolves on `$PATH` wins. Returned in the
+/// platform's preferred order — `pbcopy` first on macOS, `wl-copy`
+/// then `xclip` then `xsel` on Linux, `clip.exe` on Windows. Exposed
+/// from the crate root so the tests in `tui_app_tests.rs` can pin the
+/// non-empty contract without spawning anything.
+pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
+  if cfg!(target_os = "macos") {
+    vec![("pbcopy", vec![])]
+  } else if cfg!(target_os = "windows") {
+    vec![("clip", vec![])]
+  } else {
+    vec![
+      ("wl-copy", vec![]),
+      ("xclip", vec!["-selection", "clipboard"]),
+      ("xsel", vec!["--clipboard", "--input"]),
+    ]
+  }
+}
 pub use ui::{branch_name_color, filled_cells_for_progress, freshness_color, issue_badge_color, pr_badge_color};
 
 pub fn run() -> Result<()> {
@@ -166,7 +186,18 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Char('d') if !app.picker_mode => app.enter_confirm_delete(),
           KeyCode::Char('b') if !app.picker_mode => app.bootstrap_selected(),
           KeyCode::Char('p') if !app.picker_mode => app.toggle_delete_branch(),
-          KeyCode::Char('o') => app.open_selected_in_finder(),
+          KeyCode::Char('y') => yank_selected_path_to_clipboard(&mut app),
+          KeyCode::Char('o') => match app.resolve_open_target() {
+            None => app.status = "nothing selected".into(),
+            Some(OpenTarget::Finder { .. }) => app.open_selected_in_finder(),
+            Some(OpenTarget::Shell { path, command }) => {
+              run_subshell(terminal, &command, &[], Some(&path), &mut app, "shell")?
+            }
+            Some(OpenTarget::Editor { path, command }) => {
+              let path_str = path.display().to_string();
+              run_subshell(terminal, &command, &[&path_str], None, &mut app, "editor")?
+            }
+          },
           // Issue/PR linking (issue #67).
           KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
           KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
@@ -291,6 +322,98 @@ fn run_lazygit(
     Err(e) => app.status = format!("failed to launch lazygit: {}", e),
   }
   Ok(())
+}
+
+/// Suspend the TUI, spawn `cmd args...` (optionally with `cwd`), wait for
+/// its exit, then restore the TUI. Used by the `o: open` dispatch when the
+/// resolved [`OpenTarget`] is `Shell` or `Editor`. The lifecycle is
+/// identical to [`run_lazygit`] so the user can't observe a difference
+/// between pressing `l` (lazygit) and pressing `o` with `mode = "shell"`.
+///
+/// `label` is the noun used in status-bar messages (`"shell"`, `"editor"`).
+fn run_subshell(
+  terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+  cmd: &str,
+  args: &[&str],
+  cwd: Option<&std::path::Path>,
+  app: &mut App,
+  label: &str,
+) -> Result<()> {
+  disable_raw_mode()?;
+  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+  terminal.show_cursor()?;
+
+  let mut command = std::process::Command::new(cmd);
+  command.args(args);
+  if let Some(dir) = cwd {
+    command.current_dir(dir);
+  }
+  let spawn = command.status();
+
+  // Always restore the TUI, even if the child failed to spawn or exited non-zero.
+  enable_raw_mode()?;
+  execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
+  terminal.clear()?;
+
+  match spawn {
+    Ok(s) if s.success() => app.status = format!("{} exited ok ({})", label, cmd),
+    Ok(s) => app.status = format!("{} exited with code {:?}", label, s.code()),
+    Err(e) => app.status = format!("failed to launch {} ({}): {}", label, cmd, e),
+  }
+  Ok(())
+}
+
+/// Push the selected worktree's path into the system clipboard via
+/// [`clipboard_candidates`]. Walks the candidates in order, uses the
+/// first one whose binary is on `$PATH`, and feeds the path through
+/// its stdin. Failures and "no tool found" both surface in the status
+/// bar — no propagation, the TUI must never die on a clipboard miss.
+fn yank_selected_path_to_clipboard(app: &mut App) {
+  use std::io::Write;
+  let Some(path) = app.yank_selected_path() else {
+    app.status = "nothing selected".into();
+    return;
+  };
+  let text = path.display().to_string();
+  for (cmd, args) in clipboard_candidates() {
+    if which::which(cmd).is_err() {
+      continue;
+    }
+    let child = std::process::Command::new(cmd)
+      .args(&args)
+      .stdin(std::process::Stdio::piped())
+      .stdout(std::process::Stdio::null())
+      .stderr(std::process::Stdio::null())
+      .spawn();
+    match child {
+      Ok(mut c) => {
+        if let Some(mut stdin) = c.stdin.take() {
+          let _ = stdin.write_all(text.as_bytes());
+        }
+        match c.wait() {
+          Ok(s) if s.success() => {
+            app.status = format!("yanked path ({})", cmd);
+            return;
+          }
+          Ok(s) => {
+            app.status = format!("{} exited with code {:?}", cmd, s.code());
+            return;
+          }
+          Err(e) => {
+            app.status = format!("{} wait failed: {}", cmd, e);
+            return;
+          }
+        }
+      }
+      Err(e) => {
+        // Tool was resolvable on PATH but spawning failed — surface and stop;
+        // trying the next candidate would mask the real error.
+        app.status = format!("failed to spawn {}: {}", cmd, e);
+        return;
+      }
+    }
+  }
+  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / clip)".into();
 }
 
 /// Spawn the OS opener for `url` (used by the OpenMenu key handler).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,7 +12,9 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+pub use app::{
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+};
 pub use ui::filled_cells_for_progress;
 
 pub fn run() -> Result<()> {
@@ -165,6 +167,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Char('b') if !app.picker_mode => app.bootstrap_selected(),
           KeyCode::Char('p') if !app.picker_mode => app.toggle_delete_branch(),
           KeyCode::Char('o') => app.open_selected_in_finder(),
+          // Issue/PR linking (issue #67).
+          KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
+          KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
+          KeyCode::Char('R') if !app.picker_mode => app.refresh_github_status(),
           KeyCode::Enter => {
             if app.picker_mode {
               app.picker_confirm();
@@ -219,6 +225,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         }
         _ => {}
       },
+      View::OpenMenu => match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => app.exit_open_menu(),
+        KeyCode::Char('i') => {
+          if let Some(url) = app.open_menu_pick(LinkTarget::Issue) {
+            open_url(&url, &mut app);
+          }
+        }
+        KeyCode::Char('p') => {
+          if let Some(url) = app.open_menu_pick(LinkTarget::Pr) {
+            open_url(&url, &mut app);
+          }
+        }
+        _ => {}
+      },
+      View::LinkPrompt => match (app.link_prompt_stage(), key.code) {
+        (_, KeyCode::Esc) => app.link_prompt_cancel(),
+        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('i')) => app.link_prompt_choose(LinkTarget::Issue),
+        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('p')) => app.link_prompt_choose(LinkTarget::Pr),
+        (app::LinkPromptStage::InputNumber, KeyCode::Enter) => {
+          if let Err(e) = app.link_prompt_submit() {
+            app.status = format!("link failed: {}", e);
+          }
+        }
+        (app::LinkPromptStage::InputNumber, KeyCode::Char(c)) => app.link_prompt_push_char(c),
+        (app::LinkPromptStage::InputNumber, KeyCode::Backspace) => app.link_prompt_pop_char(),
+        _ => {}
+      },
     }
 
     // Picker contract (Copilot PR #53): only break when the App has
@@ -258,4 +291,20 @@ fn run_lazygit(
     Err(e) => app.status = format!("failed to launch lazygit: {}", e),
   }
   Ok(())
+}
+
+/// Spawn the OS opener for `url` (used by the OpenMenu key handler).
+/// Failures land in the status bar — we never propagate up.
+fn open_url(url: &str, app: &mut App) {
+  let opener = if cfg!(target_os = "macos") {
+    "open"
+  } else if cfg!(target_os = "windows") {
+    "explorer"
+  } else {
+    "xdg-open"
+  };
+  match std::process::Command::new(opener).arg(url).spawn() {
+    Ok(_) => app.status = format!("opened {}", url),
+    Err(e) => app.status = format!("failed to open {}: {}", url, e),
+  }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,8 +16,8 @@ pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
 pub use ui::{
-  build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line, tilde_compress_with_home,
-  SidebarSections,
+  author_initials, build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line,
+  recent_commits_lines, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run() -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LauncherPlan, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::filled_cells_for_progress;
+pub use ui::{filled_cells_for_progress, header_title};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub use app::{
-  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
+  App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LauncherPlan, LinkPromptStage, LinkTarget, View,
 };
 pub use ui::filled_cells_for_progress;
 
@@ -155,11 +155,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           KeyCode::Tab => app.toggle_focus(),
           KeyCode::Char('/') => app.enter_filter(),
           KeyCode::Char('l') => {
-            if let Some(path) = app.launch_lazygit() {
-              run_lazygit(terminal, &path, &mut app)?;
+            // Issue #75: `l` is driven by the configurable `[git_tui]`
+            // launcher pipeline (default `lazygit -p {path}`,
+            // fullscreen=true). Replaces the old hardcoded lazygit call.
+            if let Some(plan) = app.prepare_git_tui() {
+              run_launcher(terminal, plan, &mut app)?;
             }
           }
-          KeyCode::Char('r') => app.refresh()?,
+          // Issue #75 keybinding reshuffle (was `r` → refresh worktree list).
+          // `f` is the new mnemonic; the `r` alias is kept for muscle memory.
+          KeyCode::Char('f') | KeyCode::Char('r') => app.refresh()?,
           // Mutating actions are inert in picker mode — the issue explicitly
           // calls for a stripped-down picker that only navigates and selects.
           KeyCode::Char('n') if !app.picker_mode => app.enter_create(),
@@ -170,7 +175,14 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           // Issue/PR linking (issue #67).
           KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
           KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
-          KeyCode::Char('R') if !app.picker_mode => app.refresh_github_status(),
+          // Issue #75 reshuffle: `F` is the new mnemonic for "fetch GitHub
+          // status" (was `R`). `R` now triggers the configured review tool.
+          KeyCode::Char('F') if !app.picker_mode => app.refresh_github_status(),
+          KeyCode::Char('R') if !app.picker_mode => {
+            if let Some(plan) = app.prepare_review() {
+              run_launcher(terminal, plan, &mut app)?;
+            }
+          }
           KeyCode::Enter => {
             if app.picker_mode {
               app.picker_confirm();
@@ -266,30 +278,88 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
   Ok(app.picker_result)
 }
 
-/// Suspend the TUI, run `lazygit -p <path>` inheriting the terminal, then restore.
-/// Errors from lazygit itself are surfaced via the status bar, never propagated up.
-fn run_lazygit(
+/// Dispatch a [`LauncherPlan`] from [`App::prepare_git_tui`] /
+/// [`App::prepare_review`]. When `fullscreen=true` the TUI is
+/// suspended (raw mode off, alt-screen left) for the call and restored
+/// on exit — same recipe as the previous hardcoded `lazygit` flow.
+/// Non-fullscreen launchers run in the background; their stderr's
+/// first line is surfaced on the status bar so the user gets feedback
+/// even when the tool doesn't take over the screen.
+///
+/// `LauncherPlan` is consumed by-value so the `{diff}` tempfile it
+/// carries lives at least until the child process has been waited on.
+/// Errors are never propagated — the user pressed a key in the TUI,
+/// and surfacing failures via the status bar is the documented
+/// contract (see [`Self::run_lazygit`] in the pre-issue-#75 codebase).
+fn run_launcher(
   terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-  path: &std::path::Path,
+  plan: app::LauncherPlan,
   app: &mut App,
 ) -> Result<()> {
-  // Release the terminal so lazygit can take over.
-  disable_raw_mode()?;
-  execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
-  terminal.show_cursor()?;
+  use std::process::{Command, Stdio};
 
-  let spawn = std::process::Command::new("lazygit").arg("-p").arg(path).status();
+  let argv = plan.expanded.argv.clone();
+  let Some((bin, rest)) = argv.split_first() else {
+    app.status = "launcher template produced an empty argv".into();
+    return Ok(());
+  };
 
-  // Always restore the TUI, even if lazygit failed.
-  enable_raw_mode()?;
-  execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
-  terminal.clear()?;
-
-  match spawn {
-    Ok(s) if s.success() => app.status = format!("lazygit exited ok ({})", path.display()),
-    Ok(s) => app.status = format!("lazygit exited with code {:?}", s.code()),
-    Err(e) => app.status = format!("failed to launch lazygit: {}", e),
+  // Probe `$PATH` before paying the suspend/restore tax. Missing
+  // binaries get a clean status-bar error instead of a flicker.
+  if which::which(bin).is_err() {
+    app.status = format!(
+      "`{}` not on $PATH — install it or change [review]/[git_tui] in .gwm.toml",
+      bin
+    );
+    return Ok(());
   }
+
+  if plan.fullscreen {
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    terminal.show_cursor()?;
+
+    let spawn = Command::new(bin).args(rest).current_dir(&plan.cwd).status();
+
+    enable_raw_mode()?;
+    execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
+    terminal.clear()?;
+
+    match spawn {
+      Ok(s) if s.success() => app.status = format!("{} exited ok", bin),
+      Ok(s) => app.status = format!("{} exited with code {:?}", bin, s.code()),
+      Err(e) => app.status = format!("failed to launch {}: {}", bin, e),
+    }
+  } else {
+    // Non-TUI tool: capture stderr so its first line can land in the
+    // status bar without taking over the screen. stdout is dropped on
+    // the floor — printing it would crash through ratatui's frame.
+    let out = Command::new(bin)
+      .args(rest)
+      .current_dir(&plan.cwd)
+      .stdout(Stdio::null())
+      .stderr(Stdio::piped())
+      .output();
+    match out {
+      Ok(o) if o.status.success() => app.status = format!("{} done", bin),
+      Ok(o) => {
+        let first = String::from_utf8_lossy(&o.stderr)
+          .lines()
+          .next()
+          .unwrap_or_default()
+          .trim()
+          .to_string();
+        app.status = if first.is_empty() {
+          format!("{} exited with code {:?}", bin, o.status.code())
+        } else {
+          format!("{}: {}", bin, first)
+        };
+      }
+      Err(e) => app.status = format!("failed to launch {}: {}", bin, e),
+    }
+  }
+  // `plan.expanded.diff_file` drops here, unlinking the tempfile if any.
+  drop(plan);
   Ok(())
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::{build_sidebar_sections, filled_cells_for_progress, SidebarSections};
+pub use ui::{build_sidebar_sections, filled_cells_for_progress, tilde_compress_with_home, SidebarSections};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -413,7 +413,7 @@ fn yank_selected_path_to_clipboard(app: &mut App) {
       }
     }
   }
-  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / clip)".into();
+  app.status = "y: no clipboard tool found (install pbcopy / wl-copy / xclip / xsel / clip)".into();
 }
 
 /// Spawn the OS opener for `url` (used by the OpenMenu key handler).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,10 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, ConfirmKeyAction, CountdownTickOutcome, Field, GitHubFetchState, LinkPromptStage, LinkTarget, View,
 };
-pub use ui::{build_sidebar_sections, filled_cells_for_progress, tilde_compress_with_home, SidebarSections};
+pub use ui::{
+  build_sidebar_sections, filled_cells_for_progress, issue_summary_line, pr_summary_line, tilde_compress_with_home,
+  SidebarSections,
+};
 
 pub fn run() -> Result<()> {
   // Construct the App BEFORE touching the terminal: if discovery / config

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -58,6 +58,22 @@ pub fn draw(f: &mut Frame, app: &mut App) {
   }
 }
 
+/// Format the TUI header title `" gwm v<version> — <repo> (<path>) "`.
+/// The version comes from `CARGO_PKG_VERSION` so it stays in lockstep
+/// with `gwm --version` without a second source of truth — important
+/// for users juggling multiple installs (a `cargo install`-ed gwm next
+/// to a worktree-built dev binary). Extracted from `draw_header` so
+/// the format can be pinned by a unit test without spinning up the
+/// ratatui backend.
+pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
+  format!(
+    " gwm v{} — {} ({}) ",
+    env!("CARGO_PKG_VERSION"),
+    repo_name,
+    workdir_display
+  )
+}
+
 /// Single-line filter bar rendered between the table and the footer.
 /// Mirrors Vim's `/` prompt: leading slash, the live query, and a block cursor
 /// while the user is actively typing.
@@ -101,7 +117,7 @@ fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
 }
 
 fn draw_header(f: &mut Frame, area: Rect, app: &App) {
-  let title = format!(" gwm — {} ({}) ", app.repo_name, app.workdir.display());
+  let title = header_title(&app.repo_name, &app.workdir.to_string_lossy());
   let title_style = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
   let mut spans = vec![Span::styled(title, title_style)];
   // Picker mode flags the header so the user can never confuse a `gwm switch`

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -151,21 +151,22 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // ratatui's Layout solver, given a series of `Length` constraints
+  // plus a final `Min(N)` that must be honoured, squeezes the FIRST
+  // `Length` column when the terminal is too narrow. Empirically at a
+  // <90-col terminal that turned the age column (`Length(8)`) into 2
+  // cells and truncated "22h" → "22". Swapping `Min(20)` for `Fill(1)`
+  // on the PATH column lets the path absorb the pressure instead —
+  // it shrinks (or vanishes) before the age column loses a single
+  // cell. The age stays at exactly 4 cells, which is what max
+  // content (`22h`, `14m`, `1M`, `5y`, `-`) needs.
   let widths = [
-    // Age column sits at column 0. The first column is special in
-    // ratatui's Table: it carries the `highlight_symbol` overlay
-    // (rendered IN-CELL, not as a prefix), AND ratatui reserves the
-    // symbol width on every row to keep the layout stable. That
-    // reservation, plus the table's own column_spacing(1) on the
-    // right, eats ~4 cells of the constraint. Empirically Length(6)
-    // truncated "22h" → "22". Bump to 8 so 3-char ages keep one
-    // trailing pad even on the selected row.
-    Constraint::Length(8),
+    Constraint::Length(4),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
-    Constraint::Min(20),
+    Constraint::Fill(1),
   ];
 
   let list_has_focus = !(app.sidebar_open && app.sidebar_focused);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,10 +7,29 @@ use ratatui::{
   layout::{Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
+  widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
   Frame,
 };
 use std::time::Instant;
+
+/// Per-section content of the worktree details sidebar. Rendered by
+/// [`draw_sidebar`] into separate rounded-border blocks (no outer
+/// `Details` frame, so each section reads as an independent card).
+///
+/// The Issue / PR section is intentionally absent here: it depends on
+/// live `App` fetch state and is built per-frame via
+/// [`github_status_lines`], not cached on the worktree.
+#[derive(Debug, Clone, Default)]
+pub struct SidebarSections {
+  /// Compact identity block: name (bold), `branch · head`, badges
+  /// (`✓ synced` / `● dirty` / `↑N` / `↓M` plus optional `★ main`,
+  /// `🔒 locked`, `⚠ prunable`), tilde-compressed path.
+  pub worktree: Vec<Line<'static>>,
+  /// `git status --short` lines, or `✓ clean`, or a load error.
+  pub working_tree: Vec<Line<'static>>,
+  /// Up to 10 oneline commits, or an empty / error notice.
+  pub recent_commits: Vec<Line<'static>>,
+}
 
 /// Minimum total terminal width required to render the sidebar alongside the
 /// worktree table without compressing the table beyond readability.
@@ -192,155 +211,218 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     Color::DarkGray
   };
 
-  // Resolve (or populate) the cached content for the currently selected worktree.
-  // The cached block is the git preview; the Issue/PR block is rebuilt every
-  // frame (it's small, and its state changes with fetch progress).
-  let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
+  // Resolve (or populate) the cached worktree sections for the current
+  // selection. Issue / PR block is rebuilt every frame (its fetch state
+  // moves independently of the worktree info).
+  let sections = match app.selected().cloned() {
     Some(w) => {
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
         None => true,
       };
       if needs_refresh {
-        app.sidebar_cache = Some((w.path.clone(), sidebar_lines(&w)));
+        app.sidebar_cache = Some((w.path.clone(), build_sidebar_sections(&w)));
       }
-      app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default()
+      app.sidebar_cache.as_ref().map(|(_, s)| s.clone()).unwrap_or_default()
     }
-    None => vec![Line::from("(nothing selected)")],
+    None => SidebarSections {
+      worktree: vec![Line::from("(nothing selected)")],
+      working_tree: vec![],
+      recent_commits: vec![],
+    },
   };
-  // Append the live Issue / PR block.
-  lines.push(Line::from(""));
-  lines.extend(github_status_lines(app));
+  let issue_pr_lines = github_status_lines(app);
 
-  // Track the maximum scrollable offset so `sidebar_scroll_down` can clamp.
-  // `area.height - 2` accounts for the top + bottom border lines.
-  let content_len = lines.len() as u16;
-  let visible = area.height.saturating_sub(2);
-  app.sidebar_max_scroll = content_len.saturating_sub(visible);
+  // Per-section block height = content rows + 2 border lines. Fixed for
+  // the small sections (worktree / issue-PR / working-tree); Recent
+  // Commits flexes to fill the rest of the sidebar height.
+  let h = |lines: usize| (lines as u16).saturating_add(2);
+  let constraints = [
+    Constraint::Length(h(sections.worktree.len())),
+    Constraint::Length(h(issue_pr_lines.len())),
+    Constraint::Length(h(sections.working_tree.len())),
+    Constraint::Min(3),
+  ];
+  let chunks = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints(constraints)
+    .split(area);
+
+  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0);
+  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0);
+  render_section(f, chunks[2], " Working Tree ", sections.working_tree, border_color, 0);
+
+  // Recent Commits is the only scrollable section. Clamp the scroll
+  // offset to its visible area so `j` / `k` can't scroll past the end.
+  let commits_area = chunks[3];
+  let commits_visible = commits_area.height.saturating_sub(2);
+  app.sidebar_max_scroll = (sections.recent_commits.len() as u16).saturating_sub(commits_visible);
   if app.sidebar_scroll > app.sidebar_max_scroll {
     app.sidebar_scroll = app.sidebar_max_scroll;
   }
+  render_section(
+    f,
+    commits_area,
+    " Recent Commits ",
+    sections.recent_commits,
+    border_color,
+    app.sidebar_scroll,
+  );
+}
 
+fn render_section(
+  f: &mut Frame,
+  area: Rect,
+  title: &'static str,
+  lines: Vec<Line<'static>>,
+  border_color: Color,
+  scroll: u16,
+) {
   let block = Block::default()
     .borders(Borders::ALL)
-    .title(" Details ")
+    .border_type(BorderType::Rounded)
+    .title(title)
     .border_style(Style::default().fg(border_color));
-
-  let paragraph = Paragraph::new(lines)
+  // Pad content with one leading space per line for breathing room against
+  // the left border. Cheap and avoids per-call `format!` churn.
+  let padded: Vec<Line<'static>> = lines
+    .into_iter()
+    .map(|l| {
+      let mut spans = Vec::with_capacity(l.spans.len() + 1);
+      spans.push(Span::raw(" "));
+      spans.extend(l.spans);
+      Line::from(spans)
+    })
+    .collect();
+  let paragraph = Paragraph::new(padded)
     .block(block)
     .wrap(Wrap { trim: false })
-    .scroll((app.sidebar_scroll, 0));
-
+    .scroll((scroll, 0));
   f.render_widget(paragraph, area);
 }
 
-fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
-  let mut out: Vec<Line> = vec![
-    // Header — worktree name in bold.
-    Line::from(Span::styled(
-      w.name.clone(),
-      Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-    )),
-    Line::from(""),
-    // Basic Settings block.
-    section_header("Basic Settings:"),
-    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), Color::Green),
-    kv("Path", w.path.display().to_string(), Color::Gray),
-    kv(
-      "Head",
-      w.head.as_deref().map(short_oid).unwrap_or_else(|| "-".into()),
-      Color::Yellow,
-    ),
-    kv("Main", yes_no(w.is_main), Color::Yellow),
-    kv("Locked", yes_no(w.is_locked), Color::Magenta),
-    kv("Prunable", yes_no(w.is_prunable), Color::Red),
-    kv("Status", branch_status_label(&w.status), branch_status_color(&w.status)),
-    Line::from(""),
-  ];
-
-  // Recent commits block.
-  out.push(section_header("Recent commits:"));
-  match worktree::git_log_oneline(&w.path, 10) {
-    Ok(s) if !s.trim().is_empty() => {
-      for line in s.lines() {
-        out.push(Line::from(format!("  {}", line)));
-      }
-    }
-    Ok(_) => out.push(Line::from(Span::styled(
-      "  (no commits)",
-      Style::default().fg(Color::DarkGray),
-    ))),
-    Err(e) => out.push(Line::from(Span::styled(
-      format!("  ! {}", e),
-      Style::default().fg(Color::Red),
-    ))),
+/// Build the per-section content of the details sidebar for one worktree.
+///
+/// The Commands cheat-sheet block is intentionally not produced here — it
+/// duplicated the `?` help overlay and consumed ~15 vertical lines for no
+/// new information. Press `?` for the full key map.
+pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
+  SidebarSections {
+    worktree: worktree_identity_lines(w),
+    working_tree: working_tree_lines(w),
+    recent_commits: recent_commits_lines(w),
   }
-  out.push(Line::from(""));
+}
 
-  // Working tree block.
-  out.push(section_header("Working tree:"));
-  match worktree::git_status_short(&w.path) {
-    Ok(s) if s.trim().is_empty() => out.push(Line::from(Span::styled("  ✓ clean", Style::default().fg(Color::Green)))),
-    Ok(s) => {
-      for line in s.lines() {
-        out.push(Line::from(format!("  {}", line)));
-      }
-    }
-    Err(e) => out.push(Line::from(Span::styled(
-      format!("  ! {}", e),
-      Style::default().fg(Color::Red),
-    ))),
-  }
-  out.push(Line::from(""));
+/// 3–4 line identity card: name, `branch · head`, status + flag badges,
+/// tilde-compressed path. Skips badges whose flags are false to avoid
+/// visual noise (`false`/`true` columns scaled poorly with the old layout).
+fn worktree_identity_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  let mut out: Vec<Line<'static>> = Vec::with_capacity(4);
 
-  // Commands cheat-sheet (lazyssh style).
-  out.push(section_header("Commands:"));
-  for (key, label) in [
-    ("Enter", "Copy path to status"),
-    ("    l", "Launch lazygit fullscreen"),
-    ("    o", "Open dir in OS file manager"),
-    ("    b", "Bootstrap worktree"),
-    ("    n", "New worktree"),
-    ("    d", "Delete worktree"),
-    ("    p", "Toggle delete-branch-on-remove"),
-    ("    r", "Refresh"),
-    ("    v", "Toggle this sidebar"),
-    ("  Tab", "Swap focus list ↔ sidebar"),
-    ("    /", "Fuzzy filter worktrees"),
-    ("   gg", "Jump to first worktree"),
-    ("    G", "Jump to last worktree"),
-    ("  j/k", "Next / Prev (or scroll sidebar)"),
-    ("    ?", "Help"),
-    ("    q", "Quit"),
-  ] {
-    out.push(Line::from(vec![
-      Span::styled(format!("  {}: ", key), Style::default().fg(Color::Cyan)),
-      Span::raw(label),
-    ]));
+  // Line 1 — worktree name in bold white.
+  out.push(Line::from(Span::styled(
+    w.name.clone(),
+    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+  )));
+
+  // Line 2 — "<branch> · <short head>". Skip head sub-span when absent.
+  let branch = w.branch.clone().unwrap_or_else(|| "-".into());
+  let mut spans = vec![Span::styled(branch, Style::default().fg(Color::Green))];
+  if let Some(head) = w.head.as_deref() {
+    spans.push(Span::styled("  ·  ".to_string(), Style::default().fg(Color::DarkGray)));
+    spans.push(Span::styled(short_oid(head), Style::default().fg(Color::Yellow)));
   }
+  out.push(Line::from(spans));
+
+  // Line 3 — status badge + optional flag badges. Only renders the badges
+  // that are *true* / *interesting*; the false cases stay invisible.
+  out.push(badges_line(w));
+
+  // Line 4 — path, tilde-compressed for compactness.
+  out.push(Line::from(Span::styled(
+    tilde_compress(&w.path.display().to_string()),
+    Style::default().fg(Color::DarkGray),
+  )));
+
   out
 }
 
-fn section_header(text: &str) -> Line<'static> {
-  Line::from(Span::styled(
-    text.to_string(),
-    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-  ))
-}
-
-fn kv(key: &str, value: String, value_color: Color) -> Line<'static> {
-  Line::from(vec![
-    Span::styled(format!("  {}: ", key), Style::default().fg(Color::DarkGray)),
-    Span::styled(value, Style::default().fg(value_color)),
-  ])
-}
-
-fn yes_no(b: bool) -> String {
-  if b {
-    "true".into()
+fn badges_line(w: &WorktreeInfo) -> Line<'static> {
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  // Status sigil: ✓ synced / clean | ● dirty | ↑N ↓M | unknown.
+  let status_label = branch_status_label(&w.status);
+  let status_color = branch_status_color(&w.status);
+  let sigil = if w.status.unknown {
+    "?"
+  } else if w.status.is_dirty {
+    "●"
   } else {
-    "false".into()
+    "✓"
+  };
+  spans.push(Span::styled(
+    format!("{} {}", sigil, status_label),
+    Style::default().fg(status_color),
+  ));
+
+  let sep = || Span::styled("  ".to_string(), Style::default().fg(Color::DarkGray));
+  if w.is_main {
+    spans.push(sep());
+    spans.push(Span::styled("★ main".to_string(), Style::default().fg(Color::Yellow)));
   }
+  if w.is_locked {
+    spans.push(sep());
+    spans.push(Span::styled(
+      "🔒 locked".to_string(),
+      Style::default().fg(Color::Magenta),
+    ));
+  }
+  if w.is_prunable {
+    spans.push(sep());
+    spans.push(Span::styled("⚠ prunable".to_string(), Style::default().fg(Color::Red)));
+  }
+  Line::from(spans)
+}
+
+fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  match worktree::git_status_short(&w.path) {
+    Ok(s) if s.trim().is_empty() => vec![Line::from(Span::styled(
+      "✓ clean".to_string(),
+      Style::default().fg(Color::Green),
+    ))],
+    Ok(s) => s.lines().map(|l| Line::from(l.to_string())).collect(),
+    Err(e) => vec![Line::from(Span::styled(
+      format!("! {}", e),
+      Style::default().fg(Color::Red),
+    ))],
+  }
+}
+
+fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  match worktree::git_log_oneline(&w.path, 10) {
+    Ok(s) if !s.trim().is_empty() => s.lines().map(|l| Line::from(l.to_string())).collect(),
+    Ok(_) => vec![Line::from(Span::styled(
+      "(no commits)".to_string(),
+      Style::default().fg(Color::DarkGray),
+    ))],
+    Err(e) => vec![Line::from(Span::styled(
+      format!("! {}", e),
+      Style::default().fg(Color::Red),
+    ))],
+  }
+}
+
+/// Replace the user's home prefix with `~` so paths render compactly in
+/// the narrow sidebar. Falls back to the raw path if `$HOME` is unset or
+/// the path doesn't live under it.
+fn tilde_compress(path: &str) -> String {
+  if let Some(home) = dirs::home_dir() {
+    let home_s = home.display().to_string();
+    if let Some(rest) = path.strip_prefix(&home_s) {
+      return format!("~{}", rest);
+    }
+  }
+  path.to_string()
 }
 
 fn short_oid(oid: &str) -> String {
@@ -874,21 +956,16 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// Append the issue/PR status block to the bottom of the sidebar. Called
-/// from `draw_sidebar` after the git preview, so it shows below the recent
-/// commits / status block.
+/// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)
+/// is supplied by [`draw_sidebar`] via the surrounding `Block`, so this
+/// function only returns the content rows.
 pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
   let link = app.current_link();
   let mut lines: Vec<Line<'static>> = Vec::new();
 
-  lines.push(Line::from(Span::styled(
-    "─── Issue / PR ───",
-    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-  )));
-
   if link.issue.is_none() && link.pr.is_none() {
     lines.push(Line::from(Span::styled(
-      "  no link · press L to link",
+      "no link · press L to link".to_string(),
       Style::default().fg(Color::DarkGray),
     )));
     return lines;
@@ -903,7 +980,7 @@ pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
   if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
   {
     lines.push(Line::from(Span::styled(
-      "  press R to fetch status",
+      "press R to fetch status".to_string(),
       Style::default().fg(Color::DarkGray),
     )));
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -151,20 +151,24 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // ratatui's Layout solver, given a series of `Length` constraints
-  // plus a final `Min(N)` that must be honoured, squeezes the FIRST
-  // `Length` column when the terminal is too narrow. Empirically at a
-  // <90-col terminal that turned the age column (`Length(8)`) into 2
-  // cells and truncated "22h" → "22". Swapping `Min(20)` for `Fill(1)`
-  // on the PATH column lets the path absorb the pressure instead —
-  // it shrinks (or vanishes) before the age column loses a single
-  // cell. The age stays at exactly 4 cells, which is what max
-  // content (`22h`, `14m`, `1M`, `5y`, `-`) needs.
+  // ratatui's Layout solver squeezes the FIRST `Length` column to
+  // satisfy the others when terminal width is tight. We want the age
+  // column rock-stable at 4 cells (the cost of losing the unit
+  // letter to truncation — "22h" → "22" — is worse than name/branch
+  // shrinking by a char or two). Strategy:
+  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
+  //     status: hard-fixed lengths the solver must honour.
+  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
+  //     when the terminal is narrow (they shrink down to 8) and grow
+  //     to the original clamped width (or more) when there's room.
+  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
+  // Verified by standalone probe down to 40-cell terminals: col 0
+  // stays at 4 cells across every size.
   let widths = [
     Constraint::Length(4),
     Constraint::Length(2),
-    Constraint::Length(name_w),
-    Constraint::Length(branch_w),
+    Constraint::Min(name_w),
+    Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,12 +448,15 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <subject>
+/// <8-char hash>  <author initials>  <node>  <subject>
 /// ```
 ///
-/// The subject is **not** truncated here — the renderer relies on ratatui's
-/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
-/// commit per visual line, overflow cut at the right edge without `…`.
+/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
+/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
+/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
+/// truncated here — the renderer relies on ratatui's view-level
+/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
+/// per visual line, overflow cut at the right edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
     Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -448,18 +448,30 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// per-row format:
 ///
 /// ```text
-/// <8-char hash>  <author initials>  <node>  <subject>
+/// <8-char hash>  <author initials>  <graph>  <subject>
 /// ```
 ///
-/// where `<node>` is `○` for a normal commit and `◎` for a merge commit
-/// (≥ 2 parents), matching `lazygit/pkg/gui/presentation/graph/cell.go`
-/// constants `CommitSymbol` / `MergeSymbol`. The subject is **not**
-/// truncated here — the renderer relies on ratatui's view-level
-/// hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one commit
-/// per visual line, overflow cut at the right edge without `…`.
+/// where `<graph>` is the per-row output of the topology renderer in
+/// [`super::commit_graph`] — a sequence of `2 * (max_pos + 1)` cells
+/// drawing `○` / `◎` nodes plus the `│ ─ ╮ ╭ ╯ ╰ …` connectors that
+/// link consecutive commits across branch / merge boundaries. The
+/// graph width is deterministic on the commit list — independent of
+/// terminal width — so the cache stays valid across resizes.
+///
+/// The subject is **not** truncated here — the renderer relies on
+/// ratatui's view-level hard-clip (no `Wrap`) to match lazygit's gocui
+/// behaviour: one commit per visual line, overflow cut at the right
+/// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
   match worktree::git_log_with_author(&w.path, limit) {
-    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
+    Ok(rows) if !rows.is_empty() => {
+      let graphs = super::commit_graph::render_commits(&rows);
+      rows
+        .into_iter()
+        .zip(graphs)
+        .map(|(row, graph_spans)| commit_row_line(row, graph_spans))
+        .collect()
+    }
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -471,42 +483,21 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
   }
 }
 
-fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+fn commit_row_line(row: worktree::CommitRow, graph: Vec<Span<'static>>) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
-  let marker = commit_node_marker(&row);
-  Line::from(vec![
-    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
-    Span::raw("  "),
-    Span::styled(
-      format!("{:<2}", initials),
-      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-    ),
-    Span::raw("  "),
-    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
-    Span::raw("  "),
-    Span::raw(row.subject),
-  ])
-}
-
-/// Glyph that marks a commit node in the Recent Commits graph column.
-/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
-/// (`pkg/gui/presentation/graph/cell.go:11-14`):
-///
-/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
-///   no parents).
-/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
-///
-/// gwm renders a single graph column without inter-row connectors
-/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
-/// rows and would clutter a narrow sidebar. The node-only column is
-/// the most readable subset for a previewer.
-fn commit_node_marker(row: &worktree::CommitRow) -> char {
-  if row.parents.len() >= 2 {
-    '◎'
-  } else {
-    '○'
-  }
+  let mut spans: Vec<Span<'static>> = Vec::with_capacity(5 + graph.len());
+  spans.push(Span::styled(short_hash, Style::default().fg(Color::Yellow)));
+  spans.push(Span::raw("  "));
+  spans.push(Span::styled(
+    format!("{:<2}", initials),
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  ));
+  spans.push(Span::raw("  "));
+  spans.extend(graph);
+  spans.push(Span::raw(" "));
+  spans.push(Span::raw(row.subject));
+  Line::from(spans)
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -127,57 +127,18 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let visible: Vec<&WorktreeInfo> = filtered.iter().filter_map(|&i| app.worktrees.get(i)).collect();
 
   // Dynamic column widths derived from the visible subset so columns fit the
-  // rows actually on screen.
+  // rows actually on screen. The path column is always last and absorbs the
+  // remaining width.
   let name_w = column_width(visible.iter().map(|w| w.name.as_str()), 18, 38);
   let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
-  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
-  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
-
-  let title = if app.filter_query.is_empty() {
-    format!(" worktrees ({}) ", app.worktrees.len())
-  } else {
-    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
-  };
-
-  // Pre-allocate the marker + age strips OUTSIDE ratatui's Table
-  // widget so their fixed widths are never squeezed by the layout
-  // solver. Per ratatui docs the constraint priority is
-  // `Min > Max > Length > Percentage > Ratio > Fill`, and when the
-  // Table area is tight (sidebar open ⇒ ~60% of frame, narrow term),
-  // `Length` columns still get shrunk proportionally — that's how
-  // the previous `Length(2)` marker and `Length(4)` age both dropped
-  // below their nominal widths.
-  //
-  // Outer layout: borders → inner → `[2 marker | 4 age | 1 gap | Fill(table)]`.
-  // The four zones share the same row baseline (header on row 0,
-  // data rows from row 1 down), so the manual strips align cell-for-cell
-  // with the Table's rows. On the selected row we paint a DarkGray
-  // background across all four zones so the highlight reads as one
-  // continuous band rather than three disconnected fragments.
-  let outer_block = Block::default()
-    .borders(Borders::ALL)
-    .title(title)
-    .border_style(Style::default().fg(border_color));
-  let inner_area = outer_block.inner(area);
-  f.render_widget(outer_block, area);
-
-  let inner_split = Layout::horizontal([
-    Constraint::Length(2),
-    Constraint::Length(4),
-    Constraint::Length(1),
-    Constraint::Fill(1),
-  ])
-  .split(inner_area);
-  let marker_strip = inner_split[0];
-  let age_strip = inner_split[1];
-  let gap_strip = inner_split[2];
-  let table_area = inner_split[3];
-
-  // Table now carries only the four growable columns; marker + age
-  // are rendered manually in their pre-allocated strips below.
   let header = Row::new(vec![
+    // Age column lives at column 0 — recency-first, lazygit-style. No
+    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
+    // and a header would steal space from BRANCH on narrow terminals.
+    Cell::from(""),
+    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
@@ -190,90 +151,50 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // ratatui's Layout solver squeezes the FIRST `Length` column to
+  // satisfy the others when terminal width is tight. We want the age
+  // column rock-stable at 4 cells (the cost of losing the unit
+  // letter to truncation — "22h" → "22" — is worse than name/branch
+  // shrinking by a char or two). Strategy:
+  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
+  //     status: hard-fixed lengths the solver must honour.
+  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
+  //     when the terminal is narrow (they shrink down to 8) and grow
+  //     to the original clamped width (or more) when there's room.
+  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
+  // Verified by standalone probe down to 40-cell terminals: col 0
+  // stays at 4 cells across every size.
   let widths = [
+    Constraint::Length(4),
+    Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];
 
-  // No `highlight_symbol` — the manual marker strip already carries
-  // the `★ / ●` glyphs and an arrow would now appear after the
-  // strips, breaking visual alignment with the marker column.
+  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
+  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
+
+  let title = if app.filter_query.is_empty() {
+    format!(" worktrees ({}) ", app.worktrees.len())
+  } else {
+    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
+  };
+
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));
+    .block(
+      Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(border_color)),
+    )
+    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
+    .highlight_symbol("▶ ");
 
-  f.render_stateful_widget(table, table_area, &mut app.list_state);
-
-  render_left_strips(
-    f,
-    marker_strip,
-    age_strip,
-    gap_strip,
-    &visible,
-    app.list_state.selected(),
-  );
-}
-
-/// Paint the manually-allocated marker + age strips, plus the 1-cell
-/// gap between them and the Table. Mirrors the Table's
-/// `row_highlight_style` (DarkGray background, bold) on the selected
-/// row across all three zones so the highlight reads as a single
-/// continuous band rather than three disconnected fragments.
-fn render_left_strips(
-  f: &mut Frame,
-  marker_strip: Rect,
-  age_strip: Rect,
-  gap_strip: Rect,
-  visible: &[&WorktreeInfo],
-  selected: Option<usize>,
-) {
-  if marker_strip.height == 0 {
-    return;
-  }
-
-  let mut marker_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  let mut age_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  // Row 0 = header (kept empty — the column glyphs are self-evident).
-  marker_lines.push(Line::from(""));
-  age_lines.push(Line::from(""));
-
-  for (i, w) in visible.iter().enumerate() {
-    let (marker_label, marker_color) = table_marker(w);
-    let mut marker_style = Style::default().fg(marker_color);
-    let mut age_style = Style::default().fg(Color::DarkGray);
-    if Some(i) == selected {
-      marker_style = marker_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-      age_style = age_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-    }
-    marker_lines.push(Line::from(Span::styled(marker_label, marker_style)));
-    let age = branch_age_for(w);
-    let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-    age_lines.push(Line::from(Span::styled(label, age_style)));
-  }
-
-  f.render_widget(Paragraph::new(marker_lines), marker_strip);
-  f.render_widget(Paragraph::new(age_lines), age_strip);
-
-  // The 1-cell gap is empty space between the age strip and the
-  // Table. Without painting it, the selected-row highlight would
-  // show a 1-cell white slot between marker/age (DarkGray) and the
-  // Table (DarkGray). Paint the gap on the selected row only.
-  if let Some(sel) = selected {
-    // +1 for the header row that lives on `gap_strip.y`.
-    let row_y = gap_strip.y.saturating_add(1).saturating_add(sel as u16);
-    if row_y < gap_strip.y + gap_strip.height {
-      let gap_row = Rect {
-        x: gap_strip.x,
-        y: row_y,
-        width: gap_strip.width,
-        height: 1,
-      };
-      f.buffer_mut().set_style(gap_row, Style::default().bg(Color::DarkGray));
-    }
-  }
+  f.render_stateful_widget(table, area, &mut app.list_state);
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,
@@ -565,12 +486,23 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
+  // PR #74 follow-up: surface branch age right in the table so it stays
+  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
+  // `branch_age_for` opens the worktree's repo and runs the libgit2
+  // revwalk; per-frame cost is bounded by the number of visible rows
+  // (typically <20) so we re-resolve on every draw without caching.
+  // Colour stays uniform Gray — the saturated freshness palette
+  // (green/yellow/darkgray) reads as noise next to the more important
+  // BRANCH-status colour, so we keep it muted in the table and let the
+  // sidebar's `Created:` row carry the colour-coded signal.
+  let age = branch_age_for(w);
+  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
+
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
-  // Age column lives OUTSIDE the Table (pre-allocated in draw_list)
-  // to guarantee a fixed 4-cell width regardless of layout pressure;
-  // see `render_age_strip`.
   Row::new(vec![
+    age_cell,
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -336,7 +336,8 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   for (key, label) in [
     ("Enter", "Copy path to status"),
     ("    l", "Launch lazygit fullscreen"),
-    ("    o", "Open dir in OS file manager"),
+    ("    o", "Open per [tui.open] (shell/editor/finder)"),
+    ("    y", "Yank path to system clipboard"),
     ("    b", "Bootstrap worktree"),
     ("    n", "New worktree"),
     ("    d", "Delete worktree"),
@@ -534,9 +535,9 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   // Picker mode hides the mutating actions (n/d/b/p) — they're inert in the
   // event loop, so advertising them would be a lie.
   let help = if app.picker_mode {
-    "enter:select esc:cancel o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "enter:select esc:cancel o:open y:yank l:lazygit v:sidebar Tab:focus /:filter j/k:nav r:refresh ?:help q:quit"
   } else {
-    "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "n:new d:del b:boot o:open y:yank l:lazygit v:sidebar Tab:focus /:filter j/k:nav r:refresh ?:help q:quit"
   };
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
@@ -579,7 +580,8 @@ fn draw_help(f: &mut Frame, app: &App) {
     lines.push(Line::from("  b             bootstrap selected"));
   }
   lines.extend([
-    Line::from("  o             open dir in OS file manager (open / xdg-open / explorer)"),
+    Line::from("  o             open per [tui.open] — shell (default) / editor / finder"),
+    Line::from("  y             yank selected path to system clipboard"),
     Line::from("  l             launch lazygit fullscreen on selected worktree"),
     Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
     Line::from("  Tab           swap focus between worktree list and sidebar"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -471,6 +471,7 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
 fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
+  let marker = commit_node_marker(&row);
   Line::from(vec![
     Span::styled(short_hash, Style::default().fg(Color::Yellow)),
     Span::raw("  "),
@@ -479,8 +480,30 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
       Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
     ),
     Span::raw("  "),
+    Span::styled(marker.to_string(), Style::default().fg(Color::Blue)),
+    Span::raw("  "),
     Span::raw(row.subject),
   ])
+}
+
+/// Glyph that marks a commit node in the Recent Commits graph column.
+/// Mirrors lazygit's `CommitSymbol` / `MergeSymbol`
+/// (`pkg/gui/presentation/graph/cell.go:11-14`):
+///
+/// - `○` (U+25CB) — normal commit (one parent, or the root commit with
+///   no parents).
+/// - `◎` (U+25CE) — merge commit (≥ 2 parents).
+///
+/// gwm renders a single graph column without inter-row connectors
+/// (`│ ╮ ╭ ╯ ╰`) — those need full graph-topology tracking across
+/// rows and would clutter a narrow sidebar. The node-only column is
+/// the most readable subset for a previewer.
+fn commit_node_marker(row: &worktree::CommitRow) -> char {
+  if row.parents.len() >= 2 {
+    '◎'
+  } else {
+    '○'
+  }
 }
 
 /// Derive lazygit-style author initials from a full name. Closely

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -483,17 +483,27 @@ fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
   ])
 }
 
-/// Derive lazygit-style author initials from a full name. Mirrors
-/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+/// Derive lazygit-style author initials from a full name. Closely
+/// mirrors `getInitials` in lazygit's
+/// `pkg/gui/presentation/authors/authors.go`:
 ///
-/// - Empty → empty.
-/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
-/// - Single word → first 2 chars of that word.
-/// - ≥ 2 words → first char of split[0] + first char of split[1].
+/// - Empty / whitespace-only → empty.
+/// - Single word → first 2 Unicode scalar values of that word.
+/// - ≥ 2 words → first scalar of split[0] + first scalar of split[1].
 ///
-/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
-/// grapheme then char[0] of split[1]). Capped at 2 visible chars
-/// (`CommitAuthorShortLength` in lazygit).
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C`.
+/// Capped at 2 visible characters (`CommitAuthorShortLength` in
+/// lazygit).
+///
+/// **Divergence from lazygit** (PR #72 review, Copilot): lazygit uses
+/// `uniseg.FirstGraphemeClusterInString` and keeps multi-scalar
+/// grapheme clusters intact (e.g. regional-indicator flags like
+/// "🇫🇷"). gwm slices on Unicode scalar values via `str::chars()`,
+/// so the French flag is split into its two regional indicators and
+/// only the first survives. We accept this divergence intentionally
+/// — pulling in `unicode-segmentation` for a near-zero-impact author
+/// renderer would inflate the dependency tree without user-visible
+/// benefit on the typical "FirstName LastName" pattern.
 pub fn author_initials(author: &str) -> String {
   let trimmed = author.trim();
   if trimmed.is_empty() {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -350,20 +350,26 @@ fn worktree_identity_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
 
 fn badges_line(w: &WorktreeInfo) -> Line<'static> {
   let mut spans: Vec<Span<'static>> = Vec::new();
-  // Status sigil: ✓ synced / clean | ● dirty | ↑N ↓M | unknown.
+  // Status sigil:
+  //   `?`     — unknown
+  //   `●`     — dirty (working tree or index)
+  //   `✓`     — synced / clean (no divergence)
+  //   (none)  — ahead / behind / both — the label already carries `↑N` /
+  //             `↓M` / `↑N ↓M`. Prefixing `✓` here would lie about
+  //             divergence (raised by PR #70 Copilot review).
   let status_label = branch_status_label(&w.status);
   let status_color = branch_status_color(&w.status);
-  let sigil = if w.status.unknown {
-    "?"
+  let is_diverged = w.status.has_upstream && (w.status.ahead > 0 || w.status.behind > 0);
+  let badge_text = if w.status.unknown {
+    format!("? {}", status_label)
   } else if w.status.is_dirty {
-    "●"
+    format!("● {}", status_label)
+  } else if is_diverged {
+    status_label
   } else {
-    "✓"
+    format!("✓ {}", status_label)
   };
-  spans.push(Span::styled(
-    format!("{} {}", sigil, status_label),
-    Style::default().fg(status_color),
-  ));
+  spans.push(Span::styled(badge_text, Style::default().fg(status_color)));
 
   let sep = || Span::styled("  ".to_string(), Style::default().fg(Color::DarkGray));
   if w.is_main {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -138,6 +138,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
+    Cell::from("CREATED"),
     Cell::from("PATH"),
   ])
   .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
@@ -147,11 +148,15 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
+  // Created column is fixed-width (4 chars — `2d`, `3w`, `1M`, … all fit;
+  // `-` for trunks / unknown takes 1 cell). Lives between STATUS and PATH
+  // so the most useful signal sits at eye level next to the status label.
   let widths = [
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
+    Constraint::Length(7),
     Constraint::Min(20),
   ];
 
@@ -455,7 +460,7 @@ fn column_width<'a>(items: impl Iterator<Item = &'a str>, min: u16, max: u16) ->
 }
 
 fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row<'static> {
-  let marker = if w.is_main { "★" } else { " " };
+  let (marker_label, marker_color) = table_marker(w);
   let branch_text = w.branch.clone().unwrap_or_else(|| "-".into());
 
   let name_cell =
@@ -468,15 +473,34 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
+  // PR #74 follow-up: surface branch age + freshness right in the table
+  // so it stays visible when the sidebar is hidden (<120 cols or `v`
+  // collapsed). `branch_age_for` opens the worktree's repo and runs the
+  // libgit2 revwalk; per-frame cost is bounded by the number of visible
+  // rows (typically <20) so we re-resolve on every draw without caching.
+  let age = branch_age_for(w);
+  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+  let age_color = age.map(freshness_color).unwrap_or(Color::DarkGray);
+  let age_cell = Cell::from(age_label).style(Style::default().fg(age_color));
+
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
   Row::new(vec![
-    Cell::from(marker).style(Style::default().fg(Color::Yellow)),
+    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,
     status_cell,
+    age_cell,
     path_cell,
   ])
+}
+
+/// Owned-String wrapper around `worktree::format_relative_duration` so
+/// the table-row builder can hand a `Cell::from` an owned value without
+/// re-allocating downstream. Centralised here purely to keep `build_row`
+/// readable.
+fn format_relative_duration_str(d: std::time::Duration) -> String {
+  worktree::format_relative_duration(d)
 }
 
 fn build_status_cell(w: &WorktreeInfo, width: usize) -> Cell<'static> {
@@ -1124,4 +1148,23 @@ pub fn issue_badge_color(state: IssueState) -> Color {
     IssueState::Open => Color::Green,
     IssueState::Closed => Color::Magenta,
   }
+}
+
+/// Pick the marker glyph + colour for the table's first column. `★`
+/// for the main worktree (preserves the pre-#73 convention), `●` for
+/// any other worktree that carries an issue or PR link, blank space
+/// otherwise so unlinked rows don't read as "claimed". Colour stays
+/// neutral (Cyan) — the live PR / issue state isn't known at the
+/// table layer (only the selected worktree triggers a fetch), so the
+/// table dot signals "has link" rather than a specific status. The
+/// colour-coded `●` lives in the sidebar header where the fetch state
+/// is available.
+pub fn table_marker(w: &WorktreeInfo) -> (&'static str, Color) {
+  if w.is_main {
+    return ("★", Color::Yellow);
+  }
+  if w.link.issue.is_some() || w.link.pr.is_some() {
+    return ("●", Color::Cyan);
+  }
+  (" ", Color::Reset)
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -231,7 +231,14 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       recent_commits: vec![],
     },
   };
-  let issue_pr_lines = github_status_lines(app);
+  // Inner width = block area − 2 border columns − 1 leading-padding column
+  // (applied by `render_section`). Summary lines trim their variable parts
+  // (title / error blob) so the total visible width fits — without this,
+  // long PR titles would either overflow the block right border or be
+  // wrapped onto a second visual row that the `Constraint::Length` below
+  // never budgeted for, breaking the layout.
+  let issue_pr_inner_width = area.width.saturating_sub(3) as usize;
+  let issue_pr_lines = github_status_lines(app, issue_pr_inner_width);
 
   // Per-section block height = content rows + 2 border lines. Fixed for
   // the small sections (worktree / issue-PR / working-tree); Recent
@@ -981,29 +988,37 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
 
 /// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)
 /// is supplied by [`draw_sidebar`] via the surrounding `Block`, so this
-/// function only returns the content rows.
-pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
+/// function only returns the content rows. `max_width` is the inner
+/// width of the Issue / PR block (chunk width minus 2 borders and the
+/// 1-char left padding applied by [`render_section`]); summary lines
+/// trim their variable parts so total visible width ≤ `max_width`.
+pub(super) fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   let link = app.current_link();
   let mut lines: Vec<Line<'static>> = Vec::new();
 
   if link.issue.is_none() && link.pr.is_none() {
     lines.push(Line::from(Span::styled(
-      "no link · press L to link".to_string(),
+      trunc("no link · press L to link", max_width),
       Style::default().fg(Color::DarkGray),
     )));
     return lines;
   }
 
   if let Some(n) = link.issue {
-    lines.push(issue_summary_line(n, link.issue_source, app.issue_fetch_state()));
+    lines.push(issue_summary_line(
+      n,
+      link.issue_source,
+      app.issue_fetch_state(),
+      max_width,
+    ));
   }
   if let Some(n) = link.pr {
-    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state()));
+    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state(), max_width));
   }
   if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
   {
     lines.push(Line::from(Span::styled(
-      "press R to fetch status".to_string(),
+      trunc("press R to fetch status", max_width),
       Style::default().fg(Color::DarkGray),
     )));
   }
@@ -1018,11 +1033,21 @@ fn source_marker(s: LinkSource) -> &'static str {
   }
 }
 
-fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::IssueStatus>) -> Line<'static> {
+/// Render the Loaded / Idle / Loading / Error variants for an issue link
+/// row in the sidebar. `max_width` is the number of columns the line is
+/// allowed to occupy (sidebar inner width minus padding); the variable
+/// part (title or error blob) is trimmed so the total visible width
+/// stays ≤ `max_width`. Fixed elements (head, badge) are preserved.
+pub fn issue_summary_line(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::IssueStatus>,
+  max_width: usize,
+) -> Line<'static> {
   let head = format!("Issue #{}{}", n, source_marker(src));
   match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
-    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
     GitHubFetchState::Loaded(s) => {
       let badge_color = match s.state {
         IssueState::Open => Color::Green,
@@ -1032,6 +1057,18 @@ fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::g
         IssueState::Open => "open",
         IssueState::Closed => "closed",
       };
+      // Fixed prefix = "<head> [<badge>] " — try to preserve in full and
+      // trim the title to whatever budget remains. If the prefix alone
+      // already exceeds the width budget (very narrow sidebar), fall
+      // back to flattening the line into a single styled string and
+      // truncating it — preserves no badge color but stays inside the
+      // block.
+      let fixed = head.chars().count() + 4 + badge.chars().count(); // " [" + badge + "] "
+      if fixed >= max_width {
+        let raw = format!("{} [{}] {}", head, badge, s.title);
+        return Line::from(trunc(&raw, max_width));
+      }
+      let budget = max_width - fixed;
       Line::from(vec![
         Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         Span::raw(" ["),
@@ -1040,22 +1077,35 @@ fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::g
           Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
         ),
         Span::raw("] "),
-        Span::raw(trunc(&s.title, 40)),
+        Span::raw(trunc(&s.title, budget)),
       ])
     }
-    GitHubFetchState::Error(e) => Line::from(vec![
-      Span::styled(head, Style::default().fg(Color::White)),
-      Span::raw(" "),
-      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
-    ]),
+    GitHubFetchState::Error(e) => {
+      let fixed = head.chars().count() + 2; // " " + "!"
+      let budget = max_width.saturating_sub(fixed);
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White)),
+        Span::raw(" "),
+        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(Color::Red)),
+      ])
+    }
   }
 }
 
-fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::PrStatus>) -> Line<'static> {
+/// Render the Loaded / Idle / Loading / Error variants for a PR link
+/// row in the sidebar. See [`issue_summary_line`] for the `max_width`
+/// contract — same idea, with a `checks N/M` segment squeezed in between
+/// badge and title when the rollup is non-zero.
+pub fn pr_summary_line(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::PrStatus>,
+  max_width: usize,
+) -> Line<'static> {
   let head = format!("PR    #{}{}", n, source_marker(src));
   match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
-    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
     GitHubFetchState::Loaded(s) => {
       let (badge, badge_color) = match s.state {
         PrState::Open => ("open", Color::Green),
@@ -1068,6 +1118,14 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
       } else {
         String::new()
       };
+      let fixed = head.chars().count() + 3 + badge.chars().count() + checks.chars().count() + 1; // " [" + badge + "]" + checks + " "
+      if fixed >= max_width {
+        // Very narrow sidebar — fall back to a single truncated string.
+        // Drops the badge color but keeps the line inside the block.
+        let raw = format!("{} [{}]{} {}", head, badge, checks, s.title);
+        return Line::from(trunc(&raw, max_width));
+      }
+      let budget = max_width - fixed;
       Line::from(vec![
         Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
         Span::raw(" ["),
@@ -1078,13 +1136,17 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
         Span::raw("]"),
         Span::raw(checks),
         Span::raw(" "),
-        Span::raw(trunc(&s.title, 36)),
+        Span::raw(trunc(&s.title, budget)),
       ])
     }
-    GitHubFetchState::Error(e) => Line::from(vec![
-      Span::styled(head, Style::default().fg(Color::White)),
-      Span::raw(" "),
-      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
-    ]),
+    GitHubFetchState::Error(e) => {
+      let fixed = head.chars().count() + 2; // " " + "!"
+      let budget = max_width.saturating_sub(fixed);
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White)),
+        Span::raw(" "),
+        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(Color::Red)),
+      ])
+    }
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -135,10 +135,14 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
 
   let header = Row::new(vec![
     Cell::from(""),
+    // Age column sits immediately after the marker, ahead of NAME, with
+    // no header label — the glyphs are self-evident (`2d`, `3w`, `1M`)
+    // and a "CREATED" caption would steal space from the BRANCH column.
+    // Matches lazygit's recency-first layout.
+    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
-    Cell::from("CREATED"),
     Cell::from("PATH"),
   ])
   .style(Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD));
@@ -148,15 +152,14 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // Created column is fixed-width (4 chars — `2d`, `3w`, `1M`, … all fit;
-  // `-` for trunks / unknown takes 1 cell). Lives between STATUS and PATH
-  // so the most useful signal sits at eye level next to the status label.
   let widths = [
     Constraint::Length(2),
+    // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
+    // expands so BRANCH stays the elastic column.
+    Constraint::Length(4),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
-    Constraint::Length(7),
     Constraint::Min(20),
   ];
 
@@ -487,10 +490,10 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   Row::new(vec![
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
+    age_cell,
     name_cell,
     branch_cell,
     status_cell,
-    age_cell,
     path_cell,
   ])
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -152,13 +152,15 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    // Age column sits at column 0 — recency-first. Width = 6 because
-    // the highlight symbol "▶ " is rendered INSIDE the first cell area
-    // (eating ~2 cells when any row is selected, which is always the
-    // case here), and we need 3 visible cells for max content ("22h",
-    // "14m", "59s", "1M ", etc.) plus 1 trailing pad. 6 - 2 (symbol)
-    // - 1 (column_spacing baseline) = 3 visible cells minimum.
-    Constraint::Length(6),
+    // Age column sits at column 0. The first column is special in
+    // ratatui's Table: it carries the `highlight_symbol` overlay
+    // (rendered IN-CELL, not as a prefix), AND ratatui reserves the
+    // symbol width on every row to keep the layout stable. That
+    // reservation, plus the table's own column_spacing(1) on the
+    // right, eats ~4 cells of the constraint. Empirically Length(6)
+    // truncated "22h" → "22". Bump to 8 so 3-char ages keep one
+    // trailing pad even on the selected row.
+    Constraint::Length(8),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -127,17 +127,52 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let visible: Vec<&WorktreeInfo> = filtered.iter().filter_map(|&i| app.worktrees.get(i)).collect();
 
   // Dynamic column widths derived from the visible subset so columns fit the
-  // rows actually on screen. The path column is always last and absorbs the
-  // remaining width.
+  // rows actually on screen.
   let name_w = column_width(visible.iter().map(|w| w.name.as_str()), 18, 38);
   let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
+  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
+  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
+
+  let title = if app.filter_query.is_empty() {
+    format!(" worktrees ({}) ", app.worktrees.len())
+  } else {
+    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
+  };
+
+  // Pre-allocate the age strip OUTSIDE ratatui's Table widget so the
+  // 4-cell fixed width is never squeezed by the layout solver. The
+  // Table's solver respects `Length` only up to a best-effort budget
+  // (per ratatui docs, Min > Max > Length > Percentage > Ratio > Fill);
+  // when the table area is tight (e.g. sidebar open, narrow terminal),
+  // it shrinks `Length` columns proportionally, dropping age from 4 to
+  // 3 (or fewer) cells. The only way to guarantee a fixed width is to
+  // reserve the cells via an outer `Layout::horizontal` before handing
+  // the rest to the Table.
+  //
+  // Layout: [outer block] → inner → [4 cells age | 1 cell gap | Fill(table)].
+  // The outer block (borders + title) wraps the whole area; the inner
+  // split divides the work between the manual age renderer and the
+  // Table widget.
+  let outer_block = Block::default()
+    .borders(Borders::ALL)
+    .title(title)
+    .border_style(Style::default().fg(border_color));
+  let inner_area = outer_block.inner(area);
+  f.render_widget(outer_block, area);
+
+  let inner_split = Layout::horizontal([
+    Constraint::Length(4), // age strip — fixed, never squeezed
+    Constraint::Length(1), // gap
+    Constraint::Fill(1),   // table area — absorbs the rest
+  ])
+  .split(inner_area);
+  let age_strip = inner_split[0];
+  let table_area = inner_split[2];
+
+  // The Table no longer carries the age column; col 0 is the marker.
   let header = Row::new(vec![
-    // Age column lives at column 0 — recency-first, lazygit-style. No
-    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
-    // and a header would steal space from BRANCH on narrow terminals.
-    Cell::from(""),
     Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
@@ -151,21 +186,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .map(|w| build_row(w, name_w, branch_w, status_w))
     .collect();
 
-  // ratatui's Layout solver squeezes the FIRST `Length` column to
-  // satisfy the others when terminal width is tight. We want the age
-  // column rock-stable at 4 cells (the cost of losing the unit
-  // letter to truncation — "22h" → "22" — is worse than name/branch
-  // shrinking by a char or two). Strategy:
-  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
-  //     status: hard-fixed lengths the solver must honour.
-  //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
-  //     when the terminal is narrow (they shrink down to 8) and grow
-  //     to the original clamped width (or more) when there's room.
-  //   - `Fill(1)` for path: takes whatever's left, vanishes last.
-  // Verified by standalone probe down to 40-cell terminals: col 0
-  // stays at 4 cells across every size.
   let widths = [
-    Constraint::Length(4),
     Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
@@ -173,28 +194,44 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     Constraint::Fill(1),
   ];
 
-  let list_has_focus = !(app.sidebar_open && app.sidebar_focused);
-  let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
-
-  let title = if app.filter_query.is_empty() {
-    format!(" worktrees ({}) ", app.worktrees.len())
-  } else {
-    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
-  };
-
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .block(
-      Block::default()
-        .borders(Borders::ALL)
-        .title(title)
-        .border_style(Style::default().fg(border_color)),
-    )
     .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
     .highlight_symbol("▶ ");
 
-  f.render_stateful_widget(table, area, &mut app.list_state);
+  f.render_stateful_widget(table, table_area, &mut app.list_state);
+
+  // Now overlay the age values on age_strip. Row 0 is the (empty)
+  // header line, rows 1..=visible.len() carry the values. We mirror
+  // the Table's row_highlight_style on the selected row so the band
+  // stays visually continuous across the gap.
+  render_age_strip(f, age_strip, &visible, app.list_state.selected());
+}
+
+/// Render the manually-allocated 4-cell-wide age column to the left of
+/// the Table widget. Aligns one Line per Table row (header line first,
+/// then one per visible worktree) and mirrors the Table's row_highlight
+/// background on the selected row so the user can't tell the column is
+/// rendered outside the Table.
+fn render_age_strip(f: &mut Frame, area: Rect, visible: &[&WorktreeInfo], selected: Option<usize>) {
+  if area.width == 0 || area.height == 0 {
+    return;
+  }
+  let mut lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  // Header row aligns with the Table's header (empty caption — the
+  // glyphs are self-evident).
+  lines.push(Line::from(""));
+  for (i, w) in visible.iter().enumerate() {
+    let age = branch_age_for(w);
+    let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
+    let mut style = Style::default().fg(Color::DarkGray);
+    if Some(i) == selected {
+      style = style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    }
+    lines.push(Line::from(Span::styled(label, style)));
+  }
+  f.render_widget(Paragraph::new(lines), area);
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,
@@ -486,23 +523,12 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
-  // PR #74 follow-up: surface branch age right in the table so it stays
-  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
-  // `branch_age_for` opens the worktree's repo and runs the libgit2
-  // revwalk; per-frame cost is bounded by the number of visible rows
-  // (typically <20) so we re-resolve on every draw without caching.
-  // Colour stays uniform Gray — the saturated freshness palette
-  // (green/yellow/darkgray) reads as noise next to the more important
-  // BRANCH-status colour, so we keep it muted in the table and let the
-  // sidebar's `Created:` row carry the colour-coded signal.
-  let age = branch_age_for(w);
-  let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
-
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
+  // Age column lives OUTSIDE the Table (pre-allocated in draw_list)
+  // to guarantee a fixed 4-cell width regardless of layout pressure;
+  // see `render_age_strip`.
   Row::new(vec![
-    age_cell,
     Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -423,8 +423,25 @@ fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
 /// the path doesn't live under it.
 fn tilde_compress(path: &str) -> String {
   if let Some(home) = dirs::home_dir() {
-    let home_s = home.display().to_string();
-    if let Some(rest) = path.strip_prefix(&home_s) {
+    tilde_compress_with_home(path, &home)
+  } else {
+    path.to_string()
+  }
+}
+
+/// Pure variant of [`tilde_compress`] that takes the home directory
+/// explicitly. Exposed for tests — the production `tilde_compress`
+/// wrapper just looks up `dirs::home_dir()` and delegates.
+///
+/// Enforces a path-separator boundary at the end of the home prefix so
+/// `/home/al` does not slice into `/home/alice/repo` and produce
+/// `~ice/repo` (raised by PR #70 Copilot review).
+pub fn tilde_compress_with_home(path: &str, home: &std::path::Path) -> String {
+  let home_s = home.display().to_string();
+  if let Some(rest) = path.strip_prefix(&home_s) {
+    // Accept exact-home (`rest.is_empty()`) and home-followed-by-separator
+    // matches. Reject prefix matches that bleed into a longer dir name.
+    if rest.is_empty() || rest.starts_with('/') || rest.starts_with(std::path::MAIN_SEPARATOR) {
       return format!("~{}", rest);
     }
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,5 +1,6 @@
-use super::app::{App, Field, View};
+use super::app::{App, Field, GitHubFetchState, LinkPromptStage, View};
 use crate::bootstrap::StepStatus;
+use crate::github::{IssueState, LinkSource, PrState};
 use crate::naming::BRANCH_TYPES;
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
@@ -51,6 +52,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::Create => draw_create(f, app),
     View::Confirm => draw_confirm(f, app),
     View::Report => draw_report(f, app),
+    View::OpenMenu => draw_open_menu(f, app),
+    View::LinkPrompt => draw_link_prompt(f, app),
     View::List => {}
   }
 }
@@ -190,7 +193,9 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   };
 
   // Resolve (or populate) the cached content for the currently selected worktree.
-  let lines: Vec<Line<'static>> = match app.selected().cloned() {
+  // The cached block is the git preview; the Issue/PR block is rebuilt every
+  // frame (it's small, and its state changes with fetch progress).
+  let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
     Some(w) => {
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
@@ -203,6 +208,9 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     }
     None => vec![Line::from("(nothing selected)")],
   };
+  // Append the live Issue / PR block.
+  lines.push(Line::from(""));
+  lines.extend(github_status_lines(app));
 
   // Track the maximum scrollable offset so `sidebar_scroll_down` can clamp.
   // `area.height - 2` accounts for the top + bottom border lines.
@@ -518,6 +526,11 @@ fn draw_help(f: &mut Frame, app: &App) {
   if !app.picker_mode {
     lines.push(Line::from("  p             toggle 'delete branch on remove'"));
     lines.push(Line::from("  enter         show path in status bar"));
+    lines.push(Line::from(""));
+    lines.push(Line::from("issue / PR (#67)"));
+    lines.push(Line::from("  O             open menu — i=issue · p=pull request"));
+    lines.push(Line::from("  L             link prompt — i / p then digits"));
+    lines.push(Line::from("  R             refresh GitHub status via `gh`"));
   }
   lines.push(Line::from("  ?             this help"));
   if !app.picker_mode {
@@ -791,5 +804,187 @@ fn trunc(s: &str, max: usize) -> String {
     let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
     out.push('…');
     out
+  }
+}
+
+// ---- Issue/PR linking (issue #67) ---------------------------------------
+
+fn draw_open_menu(f: &mut Frame, _app: &App) {
+  let area = centered(40, 22, f.area());
+  f.render_widget(Clear, area);
+  let block = Block::default()
+    .borders(Borders::ALL)
+    .title(" open ")
+    .border_style(Style::default().fg(Color::Magenta));
+  let lines = vec![
+    Line::from(Span::styled(
+      "open in browser",
+      Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+    )),
+    Line::from(""),
+    Line::from("  i   linked issue"),
+    Line::from("  p   linked pull request"),
+    Line::from(""),
+    Line::from(Span::styled("  esc to cancel", Style::default().fg(Color::DarkGray))),
+  ];
+  f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_link_prompt(f: &mut Frame, app: &App) {
+  let area = centered(50, 30, f.area());
+  f.render_widget(Clear, area);
+  let block = Block::default()
+    .borders(Borders::ALL)
+    .title(" link ")
+    .border_style(Style::default().fg(Color::Yellow));
+
+  let lines = match app.link_prompt_stage() {
+    LinkPromptStage::ChooseTarget => vec![
+      Line::from(Span::styled(
+        "link this worktree to:",
+        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+      )),
+      Line::from(""),
+      Line::from("  i   a GitHub issue"),
+      Line::from("  p   a pull request"),
+      Line::from(""),
+      Line::from(Span::styled("  esc to cancel", Style::default().fg(Color::DarkGray))),
+    ],
+    LinkPromptStage::InputNumber => {
+      let label = match app.link_prompt_target() {
+        Some(super::app::LinkTarget::Issue) => "issue #",
+        Some(super::app::LinkTarget::Pr) => "PR #",
+        None => "#",
+      };
+      vec![
+        Line::from(Span::styled(
+          format!("type the {} number", label.trim_end_matches('#').trim()),
+          Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(format!("  {}{}_", label, app.link_prompt_number_input())),
+        Line::from(""),
+        Line::from(Span::styled(
+          "  enter confirms · esc cancels · backspace deletes",
+          Style::default().fg(Color::DarkGray),
+        )),
+      ]
+    }
+  };
+  f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+/// Append the issue/PR status block to the bottom of the sidebar. Called
+/// from `draw_sidebar` after the git preview, so it shows below the recent
+/// commits / status block.
+pub(super) fn github_status_lines(app: &App) -> Vec<Line<'static>> {
+  let link = app.current_link();
+  let mut lines: Vec<Line<'static>> = Vec::new();
+
+  lines.push(Line::from(Span::styled(
+    "─── Issue / PR ───",
+    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+  )));
+
+  if link.issue.is_none() && link.pr.is_none() {
+    lines.push(Line::from(Span::styled(
+      "  no link · press L to link",
+      Style::default().fg(Color::DarkGray),
+    )));
+    return lines;
+  }
+
+  if let Some(n) = link.issue {
+    lines.push(issue_summary_line(n, link.issue_source, app.issue_fetch_state()));
+  }
+  if let Some(n) = link.pr {
+    lines.push(pr_summary_line(n, link.pr_source, app.pr_fetch_state()));
+  }
+  if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
+  {
+    lines.push(Line::from(Span::styled(
+      "  press R to fetch status",
+      Style::default().fg(Color::DarkGray),
+    )));
+  }
+  lines
+}
+
+fn source_marker(s: LinkSource) -> &'static str {
+  match s {
+    LinkSource::None => "",
+    LinkSource::BranchName => " (auto)",
+    LinkSource::Explicit => "",
+  }
+}
+
+fn issue_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::IssueStatus>) -> Line<'static> {
+  let head = format!("Issue #{}{}", n, source_marker(src));
+  match state {
+    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Loaded(s) => {
+      let badge_color = match s.state {
+        IssueState::Open => Color::Green,
+        IssueState::Closed => Color::Red,
+      };
+      let badge = match s.state {
+        IssueState::Open => "open",
+        IssueState::Closed => "closed",
+      };
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::raw(" ["),
+        Span::styled(
+          badge.to_string(),
+          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("] "),
+        Span::raw(trunc(&s.title, 40)),
+      ])
+    }
+    GitHubFetchState::Error(e) => Line::from(vec![
+      Span::styled(head, Style::default().fg(Color::White)),
+      Span::raw(" "),
+      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
+    ]),
+  }
+}
+
+fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::github::PrStatus>) -> Line<'static> {
+  let head = format!("PR    #{}{}", n, source_marker(src));
+  match state {
+    GitHubFetchState::Idle => Line::from(Span::styled(head, Style::default().fg(Color::White))),
+    GitHubFetchState::Loading => Line::from(format!("{} …loading", head)),
+    GitHubFetchState::Loaded(s) => {
+      let (badge, badge_color) = match s.state {
+        PrState::Open => ("open", Color::Green),
+        PrState::Draft => ("draft", Color::DarkGray),
+        PrState::Closed => ("closed", Color::Red),
+        PrState::Merged => ("merged", Color::Magenta),
+      };
+      let checks = if s.checks_total > 0 {
+        format!(" · checks {}/{}", s.checks_passed, s.checks_total)
+      } else {
+        String::new()
+      };
+      Line::from(vec![
+        Span::styled(head, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::raw(" ["),
+        Span::styled(
+          badge.to_string(),
+          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("]"),
+        Span::raw(checks),
+        Span::raw(" "),
+        Span::raw(trunc(&s.title, 36)),
+      ])
+    }
+    GitHubFetchState::Error(e) => Line::from(vec![
+      Span::styled(head, Style::default().fg(Color::White)),
+      Span::raw(" "),
+      Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
+    ]),
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -255,18 +255,36 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     .constraints(constraints)
     .split(area);
 
-  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0);
-  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0);
-  render_section(f, chunks[2], " Working Tree ", sections.working_tree, border_color, 0);
+  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0, None);
+  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
+  render_section(
+    f,
+    chunks[2],
+    " Working Tree ",
+    sections.working_tree,
+    border_color,
+    0,
+    None,
+  );
 
   // Recent Commits is the only scrollable section. Clamp the scroll
   // offset to its visible area so `j` / `k` can't scroll past the end.
+  // The block's bottom-right title mirrors lazygit's footer
+  // ("<i+1> of <N>") so the user can tell at a glance how much history
+  // is queued and where the viewport sits.
   let commits_area = chunks[3];
   let commits_visible = commits_area.height.saturating_sub(2);
-  app.sidebar_max_scroll = (sections.recent_commits.len() as u16).saturating_sub(commits_visible);
+  let commits_len = sections.recent_commits.len() as u16;
+  app.sidebar_max_scroll = commits_len.saturating_sub(commits_visible);
   if app.sidebar_scroll > app.sidebar_max_scroll {
     app.sidebar_scroll = app.sidebar_max_scroll;
   }
+  let footer = if commits_len == 0 {
+    None
+  } else {
+    let bottom = app.sidebar_scroll.saturating_add(commits_visible).min(commits_len);
+    Some(format!(" {} of {} ", bottom, commits_len))
+  };
   render_section(
     f,
     commits_area,
@@ -274,6 +292,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     sections.recent_commits,
     border_color,
     app.sidebar_scroll,
+    footer,
   );
 }
 
@@ -284,12 +303,16 @@ fn render_section(
   lines: Vec<Line<'static>>,
   border_color: Color,
   scroll: u16,
+  footer: Option<String>,
 ) {
-  let block = Block::default()
+  let mut block = Block::default()
     .borders(Borders::ALL)
     .border_type(BorderType::Rounded)
     .title(title)
     .border_style(Style::default().fg(border_color));
+  if let Some(f) = footer {
+    block = block.title_bottom(ratatui::text::Line::from(f).right_aligned());
+  }
   // Pad content with one leading space per line for breathing room against
   // the left border. Cheap and avoids per-call `format!` churn.
   let padded: Vec<Line<'static>> = lines
@@ -301,10 +324,10 @@ fn render_section(
       Line::from(spans)
     })
     .collect();
-  let paragraph = Paragraph::new(padded)
-    .block(block)
-    .wrap(Wrap { trim: false })
-    .scroll((scroll, 0));
+  // No `Wrap`: every section now relies on ratatui's view-level hard-clip,
+  // matching lazygit's commits panel and ensuring 1 logical row = 1 visual
+  // row (so the layout's `Constraint::Length` always matches what we draw).
+  let paragraph = Paragraph::new(padded).block(block).scroll((scroll, 0));
   f.render_widget(paragraph, area);
 }
 
@@ -317,7 +340,7 @@ pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
   SidebarSections {
     worktree: worktree_identity_lines(w),
     working_tree: working_tree_lines(w),
-    recent_commits: recent_commits_lines(w),
+    recent_commits: recent_commits_lines(w, RECENT_COMMITS_LIMIT),
   }
 }
 
@@ -411,9 +434,29 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   }
 }
 
-fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
-  match worktree::git_log_oneline(&w.path, 10) {
-    Ok(s) if !s.trim().is_empty() => s.lines().map(|l| Line::from(l.to_string())).collect(),
+/// Default number of commits pulled into the Recent Commits block — chosen
+/// to match lazygit's initial `git log -300` window so the panel stays
+/// dense on tall terminals without paginating.
+pub const RECENT_COMMITS_LIMIT: usize = 300;
+
+/// Number of hex chars rendered for each commit's SHA in the sidebar.
+/// Matches lazygit's `Gui.CommitHashLength` default of 8.
+pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
+
+/// Produce the styled rows of the Recent Commits sidebar block for a
+/// worktree, limited to `limit` entries. Each `Line` mirrors lazygit's
+/// per-row format:
+///
+/// ```text
+/// <8-char hash>  <author initials>  <subject>
+/// ```
+///
+/// The subject is **not** truncated here — the renderer relies on ratatui's
+/// view-level hard-clip (no `Wrap`) to match lazygit's gocui behaviour: one
+/// commit per visual line, overflow cut at the right edge without `…`.
+pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
+  match worktree::git_log_with_author(&w.path, limit) {
+    Ok(rows) if !rows.is_empty() => rows.into_iter().map(commit_row_line).collect(),
     Ok(_) => vec![Line::from(Span::styled(
       "(no commits)".to_string(),
       Style::default().fg(Color::DarkGray),
@@ -422,6 +465,49 @@ fn recent_commits_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
       format!("! {}", e),
       Style::default().fg(Color::Red),
     ))],
+  }
+}
+
+fn commit_row_line(row: worktree::CommitRow) -> Line<'static> {
+  let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
+  let initials = author_initials(&row.author);
+  Line::from(vec![
+    Span::styled(short_hash, Style::default().fg(Color::Yellow)),
+    Span::raw("  "),
+    Span::styled(
+      format!("{:<2}", initials),
+      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    ),
+    Span::raw("  "),
+    Span::raw(row.subject),
+  ])
+}
+
+/// Derive lazygit-style author initials from a full name. Mirrors
+/// `getInitials` in lazygit's `pkg/gui/presentation/authors/authors.go`:
+///
+/// - Empty → empty.
+/// - Multi-codepoint first grapheme (emoji / CJK) → return that grapheme.
+/// - Single word → first 2 chars of that word.
+/// - ≥ 2 words → first char of split[0] + first char of split[1].
+///
+/// "Kylian Bardini" → `KB`. "Linus" → `Li`. "🦀 Crab" → `🦀C` (first
+/// grapheme then char[0] of split[1]). Capped at 2 visible chars
+/// (`CommitAuthorShortLength` in lazygit).
+pub fn author_initials(author: &str) -> String {
+  let trimmed = author.trim();
+  if trimmed.is_empty() {
+    return String::new();
+  }
+  let mut parts = trimmed.split_whitespace();
+  let first = parts.next().unwrap_or("");
+  match parts.next() {
+    Some(second) => {
+      let a: String = first.chars().take(1).collect();
+      let b: String = second.chars().take(1).collect();
+      format!("{}{}", a, b)
+    }
+    None => first.chars().take(2).collect(),
   }
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -134,11 +134,10 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let status_w: u16 = 16;
 
   let header = Row::new(vec![
+    // Age column lives at column 0 — recency-first, lazygit-style. No
+    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
+    // and a header would steal space from BRANCH on narrow terminals.
     Cell::from(""),
-    // Age column sits immediately after the marker, ahead of NAME, with
-    // no header label — the glyphs are self-evident (`2d`, `3w`, `1M`)
-    // and a "CREATED" caption would steal space from the BRANCH column.
-    // Matches lazygit's recency-first layout.
     Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
@@ -153,10 +152,10 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    Constraint::Length(2),
     // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
     // expands so BRANCH stays the elastic column.
     Constraint::Length(4),
+    Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
     Constraint::Length(status_w),
@@ -489,8 +488,8 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 
   Row::new(vec![
-    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     age_cell,
+    Cell::from(marker_label).style(Style::default().fg(marker_color)),
     name_cell,
     branch_cell,
     status_cell,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -152,9 +152,13 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    // Fixed at 4 chars — `2d`, `3w`, `1M`, `5y`, `-` all fit; never
-    // expands so BRANCH stays the elastic column.
-    Constraint::Length(4),
+    // Age column sits at column 0 — recency-first. Width = 6 because
+    // the highlight symbol "▶ " is rendered INSIDE the first cell area
+    // (eating ~2 cells when any row is selected, which is always the
+    // case here), and we need 3 visible cells for max content ("22h",
+    // "14m", "59s", "1M ", etc.) plus 1 trailing pad. 6 - 2 (symbol)
+    // - 1 (column_spacing baseline) = 3 visible cells minimum.
+    Constraint::Length(6),
     Constraint::Length(2),
     Constraint::Length(name_w),
     Constraint::Length(branch_w),
@@ -475,15 +479,18 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
 
   let status_cell = build_status_cell(w, status_w as usize);
 
-  // PR #74 follow-up: surface branch age + freshness right in the table
-  // so it stays visible when the sidebar is hidden (<120 cols or `v`
-  // collapsed). `branch_age_for` opens the worktree's repo and runs the
-  // libgit2 revwalk; per-frame cost is bounded by the number of visible
-  // rows (typically <20) so we re-resolve on every draw without caching.
+  // PR #74 follow-up: surface branch age right in the table so it stays
+  // visible when the sidebar is hidden (<120 cols or `v` collapsed).
+  // `branch_age_for` opens the worktree's repo and runs the libgit2
+  // revwalk; per-frame cost is bounded by the number of visible rows
+  // (typically <20) so we re-resolve on every draw without caching.
+  // Colour stays uniform Gray — the saturated freshness palette
+  // (green/yellow/darkgray) reads as noise next to the more important
+  // BRANCH-status colour, so we keep it muted in the table and let the
+  // sidebar's `Created:` row carry the colour-coded signal.
   let age = branch_age_for(w);
   let age_label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-  let age_color = age.map(freshness_color).unwrap_or(Color::DarkGray);
-  let age_cell = Cell::from(age_label).style(Style::default().fg(age_color));
+  let age_cell = Cell::from(age_label).style(Style::default().fg(Color::DarkGray));
 
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(Style::default().fg(Color::Gray));
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
   widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
   Frame,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Minimum total terminal width required to render the sidebar alongside the
 /// worktree table without compressing the table beyond readability.
@@ -192,11 +192,14 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     Color::DarkGray
   };
 
-  // Resolve (or populate) the cached content for the currently selected worktree.
-  // The cached block is the git preview; the Issue/PR block is rebuilt every
-  // frame (it's small, and its state changes with fetch progress).
+  // Build the (selection-dependent but stateless) header fresh each
+  // frame so the PR-status dot tracks live fetch progress without
+  // invalidating the cache. The cached chunk underneath is the git
+  // preview, which only changes when the user picks a different
+  // worktree or `refresh()` flushes the cache (issue #73).
   let mut lines: Vec<Line<'static>> = match app.selected().cloned() {
     Some(w) => {
+      let mut head = vec![sidebar_header_line(&w, app)];
       let needs_refresh = match &app.sidebar_cache {
         Some((p, _)) => *p != w.path,
         None => true,
@@ -204,7 +207,8 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       if needs_refresh {
         app.sidebar_cache = Some((w.path.clone(), sidebar_lines(&w)));
       }
-      app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default()
+      head.extend(app.sidebar_cache.as_ref().map(|(_, l)| l.clone()).unwrap_or_default());
+      head
     }
     None => vec![Line::from("(nothing selected)")],
   };
@@ -234,23 +238,57 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   f.render_widget(paragraph, area);
 }
 
+/// Lazygit-style header line: `● <name>` where the dot's colour tracks
+/// the linked PR / issue state. Rendered fresh every frame (not cached)
+/// so the dot reflects the live fetch result without invalidating the
+/// expensive git preview cache underneath.
+fn sidebar_header_line(w: &WorktreeInfo, app: &App) -> Line<'static> {
+  let (dot, dot_color) = sidebar_status_dot(app);
+  let name_style = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
+  Line::from(vec![
+    Span::styled(dot, Style::default().fg(dot_color).add_modifier(Modifier::BOLD)),
+    Span::styled(w.name.clone(), name_style),
+  ])
+}
+
+/// Resolve the leading status dot for the sidebar header. PR state wins
+/// over issue state (a worktree most often tracks a PR); falls back to a
+/// neutral darkgray dot when the worktree has no link at all so the
+/// alignment stays consistent across rows.
+fn sidebar_status_dot(app: &App) -> (&'static str, Color) {
+  if let GitHubFetchState::Loaded(pr) = app.pr_fetch_state() {
+    return ("● ", pr_badge_color(pr.state));
+  }
+  if let GitHubFetchState::Loaded(issue) = app.issue_fetch_state() {
+    return ("● ", issue_badge_color(issue.state));
+  }
+  let link = app.current_link();
+  if link.pr.is_some() || link.issue.is_some() {
+    // Link exists but not fetched yet — neutral white so the user sees
+    // there's *something* to refresh with `R`.
+    return ("● ", Color::White);
+  }
+  ("● ", Color::DarkGray)
+}
+
 fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
+  // Branch name colour follows the lazygit scheme (issue #73): worst-state
+  // wins (`dirty` → `ahead/behind` → `no upstream` → `synced`) so the most
+  // actionable signal stays at eye level. `branch_status_color` is kept for
+  // the `Status:` row below; both use the same `BranchStatus` source.
+  let branch_color = branch_name_color(&w.status);
   let mut out: Vec<Line> = vec![
-    // Header — worktree name in bold.
-    Line::from(Span::styled(
-      w.name.clone(),
-      Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-    )),
     Line::from(""),
     // Basic Settings block.
     section_header("Basic Settings:"),
-    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), Color::Green),
+    kv("Branch", w.branch.clone().unwrap_or_else(|| "-".into()), branch_color),
     kv("Path", w.path.display().to_string(), Color::Gray),
     kv(
       "Head",
       w.head.as_deref().map(short_oid).unwrap_or_else(|| "-".into()),
       Color::Yellow,
     ),
+    kv("Created", branch_age_label(w), branch_age_color(w)),
     kv("Main", yes_no(w.is_main), Color::Yellow),
     kv("Locked", yes_no(w.is_locked), Color::Magenta),
     kv("Prunable", yes_no(w.is_prunable), Color::Red),
@@ -319,6 +357,28 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
     ]));
   }
   out
+}
+
+/// Render the "Created" line value: compact relative duration (`2d`,
+/// `3w`, `1M`, …) computed from the worktree's own repository handle, or
+/// `"-"` when the branch has no measurable age (trunk, detached HEAD, or
+/// repo open failure). The cost is one libgit2 revwalk on each sidebar
+/// rebuild — gated by `sidebar_cache` so it only runs on selection
+/// change, not every frame.
+fn branch_age_label(w: &WorktreeInfo) -> String {
+  branch_age_for(w)
+    .map(worktree::format_relative_duration)
+    .unwrap_or_else(|| "-".into())
+}
+
+fn branch_age_color(w: &WorktreeInfo) -> Color {
+  branch_age_for(w).map(freshness_color).unwrap_or(Color::DarkGray)
+}
+
+fn branch_age_for(w: &WorktreeInfo) -> Option<Duration> {
+  let branch = w.branch.as_ref()?;
+  let repo = git2::Repository::open(&w.path).ok()?;
+  worktree::branch_age(&repo, branch)
 }
 
 fn section_header(text: &str) -> Line<'static> {
@@ -400,7 +460,10 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16) -> Row
   let name_cell =
     Cell::from(trunc(&w.name, name_w as usize)).style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD));
 
-  let branch_cell = Cell::from(trunc(&branch_text, branch_w as usize)).style(Style::default().fg(Color::Green));
+  // Issue #73: branch column tracks the worst-state colour so the
+  // colour-coded signal is visible without expanding the sidebar.
+  let branch_cell =
+    Cell::from(trunc(&branch_text, branch_w as usize)).style(Style::default().fg(branch_name_color(&w.status)));
 
   let status_cell = build_status_cell(w, status_w as usize);
 
@@ -986,5 +1049,77 @@ fn pr_summary_line(n: u64, src: LinkSource, state: &GitHubFetchState<crate::gith
       Span::raw(" "),
       Span::styled(format!("!{}", trunc(e, 30)), Style::default().fg(Color::Red)),
     ]),
+  }
+}
+
+// ---- Issue #73: lazygit-style colour helpers -------------------------------
+// Pure functions exposed at the crate boundary so the table-driven tests
+// in `tests/tui_app_tests.rs` can pin the visual contract without spinning
+// up a real terminal. Anything that takes `BranchStatus` / `PrState` /
+// `IssueState` / a `Duration` and returns a `Color` belongs here.
+
+/// Pick a colour for a branch name based on its `BranchStatus`. Worst
+/// signal wins so the most actionable state stays visible at a glance.
+/// Priority (top down): `unknown` → `dirty` → `ahead/behind` → no
+/// upstream → synced/clean. Mirrors lazygit's branches view scheme
+/// (`pkg/gui/presentation/branches.go::getBranchDisplayStrings`) with
+/// one local addition: `dirty` lands on red because for a worktree
+/// manager the most actionable "do something" signal is uncommitted
+/// work.
+pub fn branch_name_color(s: &BranchStatus) -> Color {
+  if s.unknown {
+    return Color::DarkGray;
+  }
+  if s.is_dirty {
+    return Color::Red;
+  }
+  if s.ahead > 0 || s.behind > 0 {
+    return Color::Yellow;
+  }
+  if !s.has_upstream {
+    // Lazygit's `?` marker — branch never pushed yet. Distinct from
+    // synced so the user knows whether they need to run `git push`.
+    return Color::Magenta;
+  }
+  Color::Green
+}
+
+/// Map a branch age to a freshness colour: green < 7d, yellow < 30d,
+/// darkgray otherwise. Cutoffs are wide on purpose — a 6-day branch
+/// is "fresh", a 4-week one is "ageing", a 5-week one is "stale" —
+/// so the colour shift registers as signal rather than noise.
+pub fn freshness_color(age: Duration) -> Color {
+  const WEEK: u64 = 7 * 86_400;
+  const MONTH: u64 = 30 * 86_400;
+  let s = age.as_secs();
+  if s < WEEK {
+    Color::Green
+  } else if s < MONTH {
+    Color::Yellow
+  } else {
+    Color::DarkGray
+  }
+}
+
+/// Pick a colour for the PR-status dot rendered in the sidebar header.
+/// Ports the lazygit `WithPrColor` palette (open=green, draft=gray,
+/// merged=magenta, closed=red) but uses 16-colour names instead of
+/// hex RGB so the badge respects the user's terminal theme.
+pub fn pr_badge_color(state: PrState) -> Color {
+  match state {
+    PrState::Open => Color::Green,
+    PrState::Draft => Color::DarkGray,
+    PrState::Merged => Color::Magenta,
+    PrState::Closed => Color::Red,
+  }
+}
+
+/// Same idea as [`pr_badge_color`] but for a linked issue. Closed maps
+/// to magenta (treated as "moved on") rather than red so a routinely
+/// resolved issue doesn't read as alarming.
+pub fn issue_badge_color(state: IssueState) -> Color {
+  match state {
+    IssueState::Open => Color::Green,
+    IssueState::Closed => Color::Magenta,
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -303,7 +303,9 @@ fn sidebar_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
     ("    n", "New worktree"),
     ("    d", "Delete worktree"),
     ("    p", "Toggle delete-branch-on-remove"),
-    ("    r", "Refresh"),
+    ("    f", "Refresh worktree list"),
+    ("    F", "Refresh GitHub issue/PR status"),
+    ("    R", "Run [review] launcher vs base"),
     ("    v", "Toggle this sidebar"),
     ("  Tab", "Swap focus list ↔ sidebar"),
     ("    /", "Fuzzy filter worktrees"),
@@ -471,9 +473,9 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   // Picker mode hides the mutating actions (n/d/b/p) — they're inert in the
   // event loop, so advertising them would be a lie.
   let help = if app.picker_mode {
-    "enter:select esc:cancel o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "enter:select esc:cancel o:open l:git_tui v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh ?:help q:quit"
   } else {
-    "n:new d:del b:boot o:open l:lazygit v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav r:refresh ?:help q:quit"
+    "n:new d:del b:boot o:open l:git_tui R:review v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh F:gh ?:help q:quit"
   };
   let text = Line::from(vec![
     Span::styled(help, Style::default().fg(Color::DarkGray)),
@@ -517,11 +519,13 @@ fn draw_help(f: &mut Frame, app: &App) {
   }
   lines.extend([
     Line::from("  o             open dir in OS file manager (open / xdg-open / explorer)"),
-    Line::from("  l             launch lazygit fullscreen on selected worktree"),
+    Line::from("  l             launch [git_tui] launcher (default lazygit -p, configurable)"),
     Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
     Line::from("  Tab           swap focus between worktree list and sidebar"),
     Line::from("  /             open fuzzy filter bar (enter: sticky, esc: clear)"),
-    Line::from("  r             refresh"),
+    Line::from("  f             refresh worktree list"),
+    Line::from("  F             refresh GitHub issue/PR status via `gh`"),
+    Line::from("  R             run [review] launcher against the resolved base"),
   ]);
   if !app.picker_mode {
     lines.push(Line::from("  p             toggle 'delete branch on remove'"));
@@ -530,7 +534,6 @@ fn draw_help(f: &mut Frame, app: &App) {
     lines.push(Line::from("issue / PR (#67)"));
     lines.push(Line::from("  O             open menu — i=issue · p=pull request"));
     lines.push(Line::from("  L             link prompt — i / p then digits"));
-    lines.push(Line::from("  R             refresh GitHub status via `gh`"));
   }
   lines.push(Line::from("  ?             this help"));
   if !app.picker_mode {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -141,20 +141,21 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
   };
 
-  // Pre-allocate the age strip OUTSIDE ratatui's Table widget so the
-  // 4-cell fixed width is never squeezed by the layout solver. The
-  // Table's solver respects `Length` only up to a best-effort budget
-  // (per ratatui docs, Min > Max > Length > Percentage > Ratio > Fill);
-  // when the table area is tight (e.g. sidebar open, narrow terminal),
-  // it shrinks `Length` columns proportionally, dropping age from 4 to
-  // 3 (or fewer) cells. The only way to guarantee a fixed width is to
-  // reserve the cells via an outer `Layout::horizontal` before handing
-  // the rest to the Table.
+  // Pre-allocate the marker + age strips OUTSIDE ratatui's Table
+  // widget so their fixed widths are never squeezed by the layout
+  // solver. Per ratatui docs the constraint priority is
+  // `Min > Max > Length > Percentage > Ratio > Fill`, and when the
+  // Table area is tight (sidebar open ⇒ ~60% of frame, narrow term),
+  // `Length` columns still get shrunk proportionally — that's how
+  // the previous `Length(2)` marker and `Length(4)` age both dropped
+  // below their nominal widths.
   //
-  // Layout: [outer block] → inner → [4 cells age | 1 cell gap | Fill(table)].
-  // The outer block (borders + title) wraps the whole area; the inner
-  // split divides the work between the manual age renderer and the
-  // Table widget.
+  // Outer layout: borders → inner → `[2 marker | 4 age | 1 gap | Fill(table)]`.
+  // The four zones share the same row baseline (header on row 0,
+  // data rows from row 1 down), so the manual strips align cell-for-cell
+  // with the Table's rows. On the selected row we paint a DarkGray
+  // background across all four zones so the highlight reads as one
+  // continuous band rather than three disconnected fragments.
   let outer_block = Block::default()
     .borders(Borders::ALL)
     .title(title)
@@ -163,17 +164,20 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   f.render_widget(outer_block, area);
 
   let inner_split = Layout::horizontal([
-    Constraint::Length(4), // age strip — fixed, never squeezed
-    Constraint::Length(1), // gap
-    Constraint::Fill(1),   // table area — absorbs the rest
+    Constraint::Length(2),
+    Constraint::Length(4),
+    Constraint::Length(1),
+    Constraint::Fill(1),
   ])
   .split(inner_area);
-  let age_strip = inner_split[0];
-  let table_area = inner_split[2];
+  let marker_strip = inner_split[0];
+  let age_strip = inner_split[1];
+  let gap_strip = inner_split[2];
+  let table_area = inner_split[3];
 
-  // The Table no longer carries the age column; col 0 is the marker.
+  // Table now carries only the four growable columns; marker + age
+  // are rendered manually in their pre-allocated strips below.
   let header = Row::new(vec![
-    Cell::from(""),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),
@@ -187,51 +191,89 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     .collect();
 
   let widths = [
-    Constraint::Length(2),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
   ];
 
+  // No `highlight_symbol` — the manual marker strip already carries
+  // the `★ / ●` glyphs and an arrow would now appear after the
+  // strips, breaking visual alignment with the marker column.
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD))
-    .highlight_symbol("▶ ");
+    .row_highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));
 
   f.render_stateful_widget(table, table_area, &mut app.list_state);
 
-  // Now overlay the age values on age_strip. Row 0 is the (empty)
-  // header line, rows 1..=visible.len() carry the values. We mirror
-  // the Table's row_highlight_style on the selected row so the band
-  // stays visually continuous across the gap.
-  render_age_strip(f, age_strip, &visible, app.list_state.selected());
+  render_left_strips(
+    f,
+    marker_strip,
+    age_strip,
+    gap_strip,
+    &visible,
+    app.list_state.selected(),
+  );
 }
 
-/// Render the manually-allocated 4-cell-wide age column to the left of
-/// the Table widget. Aligns one Line per Table row (header line first,
-/// then one per visible worktree) and mirrors the Table's row_highlight
-/// background on the selected row so the user can't tell the column is
-/// rendered outside the Table.
-fn render_age_strip(f: &mut Frame, area: Rect, visible: &[&WorktreeInfo], selected: Option<usize>) {
-  if area.width == 0 || area.height == 0 {
+/// Paint the manually-allocated marker + age strips, plus the 1-cell
+/// gap between them and the Table. Mirrors the Table's
+/// `row_highlight_style` (DarkGray background, bold) on the selected
+/// row across all three zones so the highlight reads as a single
+/// continuous band rather than three disconnected fragments.
+fn render_left_strips(
+  f: &mut Frame,
+  marker_strip: Rect,
+  age_strip: Rect,
+  gap_strip: Rect,
+  visible: &[&WorktreeInfo],
+  selected: Option<usize>,
+) {
+  if marker_strip.height == 0 {
     return;
   }
-  let mut lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
-  // Header row aligns with the Table's header (empty caption — the
-  // glyphs are self-evident).
-  lines.push(Line::from(""));
+
+  let mut marker_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  let mut age_lines: Vec<Line<'static>> = Vec::with_capacity(visible.len() + 1);
+  // Row 0 = header (kept empty — the column glyphs are self-evident).
+  marker_lines.push(Line::from(""));
+  age_lines.push(Line::from(""));
+
   for (i, w) in visible.iter().enumerate() {
+    let (marker_label, marker_color) = table_marker(w);
+    let mut marker_style = Style::default().fg(marker_color);
+    let mut age_style = Style::default().fg(Color::DarkGray);
+    if Some(i) == selected {
+      marker_style = marker_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+      age_style = age_style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+    }
+    marker_lines.push(Line::from(Span::styled(marker_label, marker_style)));
     let age = branch_age_for(w);
     let label = age.map(format_relative_duration_str).unwrap_or_else(|| "-".into());
-    let mut style = Style::default().fg(Color::DarkGray);
-    if Some(i) == selected {
-      style = style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
-    }
-    lines.push(Line::from(Span::styled(label, style)));
+    age_lines.push(Line::from(Span::styled(label, age_style)));
   }
-  f.render_widget(Paragraph::new(lines), area);
+
+  f.render_widget(Paragraph::new(marker_lines), marker_strip);
+  f.render_widget(Paragraph::new(age_lines), age_strip);
+
+  // The 1-cell gap is empty space between the age strip and the
+  // Table. Without painting it, the selected-row highlight would
+  // show a 1-cell white slot between marker/age (DarkGray) and the
+  // Table (DarkGray). Paint the gap on the selected row only.
+  if let Some(sel) = selected {
+    // +1 for the header row that lives on `gap_strip.y`.
+    let row_y = gap_strip.y.saturating_add(1).saturating_add(sel as u16);
+    if row_y < gap_strip.y + gap_strip.height {
+      let gap_row = Rect {
+        x: gap_strip.x,
+        y: row_y,
+        width: gap_strip.width,
+        height: 1,
+      };
+      f.buffer_mut().set_style(gap_row, Style::default().bg(Color::DarkGray));
+    }
+  }
 }
 
 /// Details panel for the selected worktree — structured info, recent commits,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -2,6 +2,14 @@ use crate::error::{GwmError, Result};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
+
+/// Trunk branches treated as "merge destinations" when measuring how
+/// long a branch has been alive. Order matters: the first match wins,
+/// so `main` (modern default) beats `master` (legacy) beats `dev` (gwm
+/// convention). Hardcoded here because `branch_age` is also reachable
+/// from contexts that don't carry a `Config` (CLI smoke paths).
+const TRUNK_CANDIDATES: &[&str] = &["main", "master", "dev"];
 
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -290,6 +298,81 @@ pub fn git_status_short(path: &Path) -> Result<String> {
     )));
   }
   Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Time elapsed since the *oldest* commit on `branch` that's not also on a
+/// known trunk (main / master / dev). Returns `None` when no such commit
+/// exists — i.e. the branch is the trunk itself, has no divergence yet,
+/// or `branch` cannot be resolved. The "oldest commit" rule mirrors the
+/// lazygit branch-age semantics (pkg/utils/date.go::UnixToTimeAgo on the
+/// branch's founding commit) and is more meaningful for a worktree-manager
+/// than `git log -1`: it answers "how long has this branch been alive?"
+/// rather than "when did someone last touch it?".
+pub fn branch_age(repo: &Repository, branch: &str) -> Option<Duration> {
+  // The trunk itself has no "branch age" — there's no founding-commit
+  // distinct from the repository's initial commit, and the natural
+  // answer ("since forever") is more usefully encoded as `None` so the
+  // UI can render a dash instead of a misleadingly precise duration.
+  if TRUNK_CANDIDATES.contains(&branch) {
+    return None;
+  }
+
+  let local = repo.find_branch(branch, BranchType::Local).ok()?;
+  let head_oid = local.into_reference().target()?;
+
+  let mut walker = repo.revwalk().ok()?;
+  walker.push(head_oid).ok()?;
+  for trunk in TRUNK_CANDIDATES {
+    if let Ok(t) = repo.find_branch(trunk, BranchType::Local) {
+      if let Some(oid) = t.into_reference().target() {
+        let _ = walker.hide(oid);
+      }
+    }
+  }
+
+  let mut oldest_secs: Option<i64> = None;
+  for oid in walker.flatten() {
+    if let Ok(commit) = repo.find_commit(oid) {
+      let t = commit.time().seconds();
+      oldest_secs = Some(oldest_secs.map_or(t, |x| x.min(t)));
+    }
+  }
+  let oldest = oldest_secs?;
+  let now = chrono::Utc::now().timestamp();
+  let elapsed = (now - oldest).max(0) as u64;
+  Some(Duration::from_secs(elapsed))
+}
+
+/// Render a `Duration` as a lazygit-style compact relative label
+/// (`2d`, `3w`, `1M`, `5y`). Mirrors `pkg/utils/date.go::formatSecondsAgo`
+/// from lazygit: single-character suffix, no plural, capital `M` to
+/// disambiguate from minutes. Bounded at 4 chars for two-digit values in
+/// each unit, which is enough for any realistic branch age.
+pub fn format_relative_duration(d: Duration) -> String {
+  const MINUTE: u64 = 60;
+  const HOUR: u64 = 60 * MINUTE;
+  const DAY: u64 = 24 * HOUR;
+  const WEEK: u64 = 7 * DAY;
+  // Month = 30.25 days, year = 365.25 days (matches lazygit `pkg/utils/date.go`).
+  const MONTH: u64 = 30 * DAY + 6 * HOUR;
+  const YEAR: u64 = 365 * DAY + 6 * HOUR;
+
+  let s = d.as_secs();
+  if s < MINUTE {
+    format!("{}s", s)
+  } else if s < HOUR {
+    format!("{}m", s / MINUTE)
+  } else if s < DAY {
+    format!("{}h", s / HOUR)
+  } else if s < WEEK {
+    format!("{}d", s / DAY)
+  } else if s < MONTH {
+    format!("{}w", s / WEEK)
+  } else if s < YEAR {
+    format!("{}M", s / MONTH)
+  } else {
+    format!("{}y", s / YEAR)
+  }
 }
 
 /// Resolve a worktree by exact name first, then by substring (case-insensitive) within the dir name.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -322,12 +322,24 @@ pub fn branch_age(repo: &Repository, branch: &str) -> Option<Duration> {
 
   let mut walker = repo.revwalk().ok()?;
   walker.push(head_oid).ok()?;
+  // Track whether any trunk baseline was actually hidden. Without one,
+  // the revwalk degenerates into "all commits reachable from HEAD" and
+  // the oldest one is the repo's initial commit — i.e. the branch's
+  // age becomes the repo's lifetime. PR #74 review caught this: when
+  // no trunk candidate resolves locally, return `None` so the UI
+  // renders `-` instead of a misleadingly large duration.
+  let mut hidden_any = false;
   for trunk in TRUNK_CANDIDATES {
     if let Ok(t) = repo.find_branch(trunk, BranchType::Local) {
       if let Some(oid) = t.into_reference().target() {
-        let _ = walker.hide(oid);
+        if walker.hide(oid).is_ok() {
+          hidden_any = true;
+        }
       }
     }
+  }
+  if !hidden_any {
+    return None;
   }
 
   let mut oldest_secs: Option<i64> = None;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -256,9 +256,12 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// A commit row pulled from `git log` for the Recent Commits sidebar block.
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
-/// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
-/// a merge commit, which the renderer marks with `◎` instead of `○`.
+/// 40-char SHAs; the renderer trims them on display to a fixed length
+/// (the `COMMIT_HASH_DISPLAY_LEN` constant in `src/tui/ui.rs`, currently
+/// 8 chars, matching lazygit's `Gui.CommitHashLength` default). Not
+/// user-configurable today — change the constant to retune.
+/// `parents.len() >= 2` flags a merge commit, which the renderer marks
+/// with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -171,6 +171,11 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
 }
 
 /// Create a new worktree with a brand-new branch off of HEAD.
+///
+/// Records the HEAD ref's short name into `branch.<branch_name>.gwm-base`
+/// so the review launcher (issue #75) can recover the original parent
+/// ref later — even on branches without an upstream. The write is
+/// best-effort: a config-write error does not roll the worktree back.
 pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str) -> Result<PathBuf> {
   // Refuse to clobber an existing directory.
   if target_path.exists() {
@@ -182,8 +187,12 @@ pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str)
     std::fs::create_dir_all(parent)?;
   }
 
-  // Create branch ref if it doesn't already exist.
-  let head_commit = repo.head()?.peel_to_commit()?;
+  // Capture HEAD's short name BEFORE creating the new branch so the
+  // record points at the actual parent (`main` / `dev` / a release
+  // train), not the freshly-created `branch_name` itself.
+  let head_ref = repo.head()?;
+  let head_short = head_ref.shorthand().map(|s| s.to_string());
+  let head_commit = head_ref.peel_to_commit()?;
   let branch = match repo.find_branch(branch_name, git2::BranchType::Local) {
     Ok(b) => b,
     Err(_) => repo.branch(branch_name, &head_commit, false)?,
@@ -194,6 +203,12 @@ pub fn add(repo: &Repository, name: &str, target_path: &Path, branch_name: &str)
   opts.reference(Some(&reference));
 
   repo.worktree(name, target_path, Some(&opts))?;
+
+  // Record the parent ref for the launcher's base resolution chain.
+  if let Some(parent_ref) = head_short {
+    let _ = crate::launcher::write_gwm_base(repo, branch_name, &parent_ref);
+  }
+
   Ok(target_path.to_path_buf())
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,4 +1,5 @@
 use crate::error::{GwmError, Result};
+use crate::github::{self, BranchLink};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -21,6 +22,11 @@ pub struct WorktreeInfo {
   pub is_locked: bool,
   pub is_prunable: bool,
   pub status: BranchStatus,
+  /// Issue/PR link resolved at list time, so the table marker column
+  /// can show `●` on rows that carry GitHub context without each frame
+  /// re-shelling `git config`. Empty link = no marker dot. See
+  /// `tui/ui.rs::table_marker`.
+  pub link: BranchLink,
 }
 
 /// Cheap snapshot of "where are we vs. clean / upstream".
@@ -119,6 +125,10 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
     let head_ref = repo.head().ok();
     let branch = head_ref.as_ref().and_then(|r| r.shorthand().map(|s| s.to_string()));
     let head = head_ref.as_ref().and_then(|r| r.target().map(|o| o.to_string()));
+    let link = branch
+      .as_deref()
+      .and_then(|b| github::read_link(repo, b).ok())
+      .unwrap_or_else(BranchLink::empty);
     out.push(WorktreeInfo {
       name: workdir
         .file_name()
@@ -131,6 +141,7 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       is_locked: false,
       is_prunable: false,
       status: compute_status(repo),
+      link,
     });
   }
 
@@ -163,6 +174,10 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       ),
     };
 
+    let link = branch
+      .as_deref()
+      .and_then(|b| github::read_link(repo, b).ok())
+      .unwrap_or_else(BranchLink::empty);
     out.push(WorktreeInfo {
       name: name.to_string(),
       path,
@@ -172,6 +187,7 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
       is_locked,
       is_prunable,
       status,
+      link,
     });
   }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -257,24 +257,28 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
 /// renderer can lay out one commit per visual line. Hashes are full
 /// 40-char SHAs; the renderer trims them to the configured display
-/// length (default 8 chars, à la lazygit).
+/// length (default 8 chars, à la lazygit). `parents.len() >= 2` flags
+/// a merge commit, which the renderer marks with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
   pub hash: String,
   pub author: String,
+  pub parents: Vec<String>,
   pub subject: String,
 }
 
-/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
-/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
-/// this for the Recent Commits block — the NUL separator avoids ambiguity
-/// when a subject contains the usual ` `, `|`, or tab characters lazygit
-/// also relies on.
+/// Shell out to `git log --format='%H%x00%aN%x00%P%x00%s' -n <n>` inside
+/// `path` and parse the NUL-separated output into [`CommitRow`]s. The TUI
+/// sidebar uses this for the Recent Commits block — the NUL separator
+/// avoids ambiguity when a subject contains the usual ` `, `|`, or tab
+/// characters lazygit also relies on. The `%P` field carries the
+/// space-separated list of parent SHAs (empty for the seed commit, one for
+/// a normal commit, two-plus for a merge).
 pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let output = Command::new("git")
     .arg("-C")
     .arg(path)
-    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .args(["log", "--format=%H%x00%aN%x00%P%x00%s", "-n"])
     .arg(n.to_string())
     .output()
     .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
@@ -288,14 +292,21 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let raw = String::from_utf8_lossy(&output.stdout).into_owned();
   let mut rows = Vec::new();
   for line in raw.lines() {
-    let mut parts = line.splitn(3, '\u{0}');
+    let mut parts = line.splitn(4, '\u{0}');
     let hash = parts.next().unwrap_or("").to_string();
     let author = parts.next().unwrap_or("").to_string();
+    let parents_field = parts.next().unwrap_or("");
     let subject = parts.next().unwrap_or("").to_string();
     if hash.is_empty() {
       continue;
     }
-    rows.push(CommitRow { hash, author, subject });
+    let parents: Vec<String> = parents_field.split_whitespace().map(|s| s.to_string()).collect();
+    rows.push(CommitRow {
+      hash,
+      author,
+      parents,
+      subject,
+    });
   }
   Ok(rows)
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -253,6 +253,53 @@ pub fn prune(repo: &Repository) -> Result<usize> {
   Ok(pruned)
 }
 
+/// A commit row pulled from `git log` for the Recent Commits sidebar block.
+/// Mirrors lazygit's columnar layout (hash + author + subject) so the
+/// renderer can lay out one commit per visual line. Hashes are full
+/// 40-char SHAs; the renderer trims them to the configured display
+/// length (default 8 chars, à la lazygit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRow {
+  pub hash: String,
+  pub author: String,
+  pub subject: String,
+}
+
+/// Shell out to `git log --format='%H%x00%aN%x00%s' -n <n>` inside `path` and
+/// parse the NUL-separated output into [`CommitRow`]s. The TUI sidebar uses
+/// this for the Recent Commits block — the NUL separator avoids ambiguity
+/// when a subject contains the usual ` `, `|`, or tab characters lazygit
+/// also relies on.
+pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["log", "--format=%H%x00%aN%x00%s", "-n"])
+    .arg(n.to_string())
+    .output()
+    .map_err(|e| GwmError::Other(format!("git log failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::Other(format!(
+      "git log exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+  let mut rows = Vec::new();
+  for line in raw.lines() {
+    let mut parts = line.splitn(3, '\u{0}');
+    let hash = parts.next().unwrap_or("").to_string();
+    let author = parts.next().unwrap_or("").to_string();
+    let subject = parts.next().unwrap_or("").to_string();
+    if hash.is_empty() {
+      continue;
+    }
+    rows.push(CommitRow { hash, author, subject });
+  }
+  Ok(rows)
+}
+
 /// Shell out to `git log --oneline -n <n>` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview recent commits of the selected worktree.
 pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -33,7 +33,11 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  switch "))
     .stdout(predicate::str::contains("  tmux "))
     .stdout(predicate::str::contains("  zellij "))
-    .stdout(predicate::str::contains("  doctor "));
+    .stdout(predicate::str::contains("  doctor "))
+    .stdout(predicate::str::contains("  link "))
+    .stdout(predicate::str::contains("  unlink "))
+    .stdout(predicate::str::contains("  open "))
+    .stdout(predicate::str::contains("  status "));
 }
 
 #[test]
@@ -573,4 +577,174 @@ fn zellij_help_mentions_split_flag() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["zellij", "--help"]);
   cmd.assert().success().stdout(predicate::str::contains("--split"));
+}
+
+// --- Issue/PR linking (issue #67) ----------------------------------------
+
+#[test]
+fn link_help_documents_issue_and_pr_targets() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["link", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"));
+}
+
+#[test]
+fn unlink_help_documents_issue_and_pr_targets() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["unlink", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"));
+}
+
+#[test]
+fn open_help_documents_issue_and_pr_and_print_url() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["open", "--help"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue"))
+    .stdout(predicate::str::contains("pr"))
+    .stdout(predicate::str::contains("--print-url"));
+}
+
+#[test]
+fn status_help_documents_json_flag() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["status", "--help"]);
+  cmd.assert().success().stdout(predicate::str::contains("--json"));
+}
+
+#[test]
+fn link_outside_git_repo_fails() {
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["link", "issue", "42"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn link_issue_persists_and_status_reflects_it() {
+  // E2E: link an issue then `gwm status --json` reads it back.
+  // The repo has no remote configured so `status` runs in "local link only" mode
+  // (no GitHub fetch). The JSON output should still carry the linked number.
+  let (dir, repo) = init_repo();
+  // Need a branch that's checked out for the CWD-resolved status to find it.
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  // link
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["link", "issue", "99"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("issue #99"));
+
+  // status --json
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"issue\""))
+    .stdout(predicate::str::contains("99"));
+}
+
+#[test]
+fn unlink_issue_falls_back_to_branch_name_auto_detect() {
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  // Override then unlink.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["link", "issue", "99"])
+    .assert()
+    .success();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["unlink", "issue"])
+    .assert()
+    .success();
+
+  // After unlink the branch-name auto-detect should resurface (issue #42).
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("42"));
+}
+
+#[test]
+fn open_print_url_emits_url_without_spawning_browser() {
+  // `--print-url` is the test-friendly mode: we want to assert the URL
+  // construction without actually shelling out to `open`/`xdg-open`.
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("feat/#42-tui-search", &head, false).unwrap();
+  repo.set_head("refs/heads/feat/#42-tui-search").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["open", "issue", "--print-url"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("https://github.com/kbrdn1/gwm-cli/issues/42"));
+}
+
+#[test]
+fn open_pr_without_link_fails_clearly() {
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  // Branch without an issue number (no auto-detect) and no explicit PR link.
+  repo.branch("random-branch", &head, false).unwrap();
+  repo.set_head("refs/heads/random-branch").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["open", "pr", "--print-url"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("no PR linked"));
+}
+
+#[test]
+fn status_on_branch_with_no_link_reports_no_link() {
+  let (dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("random-branch", &head, false).unwrap();
+  repo.set_head("refs/heads/random-branch").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["status"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no link"));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -113,6 +113,31 @@ fn doctor_outside_git_repo_fails() {
 }
 
 #[test]
+fn doctor_exits_one_when_review_binary_missing() {
+  // Issue #75: configuring [review] with a binary that's not on $PATH
+  // must produce a Warning (exit code 1), not a Failed (exit code 2).
+  // Review is opt-in — a CI pre-commit hook gated on `gwm doctor`
+  // should still let the user push when only the review tool is
+  // missing locally.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[review]
+command = "definitely-not-on-path-review-cli {base}..{head}"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .arg("doctor")
+    .assert()
+    .code(1)
+    .stdout(predicate::str::contains("definitely-not-on-path-review-cli"));
+}
+
+#[test]
 fn doctor_exits_two_on_invalid_config() {
   let (dir, _repo) = init_repo();
   std::fs::write(dir.path().join(".gwm.toml"), "broken = [unterminated").unwrap();

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use gwm::config::{expand_placeholders, Config, WorktreeConfig, CONFIG_FILE};
+use gwm::config::{expand_placeholders, review_tool_preset, Config, WorktreeConfig, CONFIG_FILE};
 use tempfile::TempDir;
 
 #[test]
@@ -254,6 +254,209 @@ confirm_countdown_secs = 30
   let cfg = Config::load_for_repo(dir.path()).unwrap();
   assert_eq!(cfg.tui.confirm_countdown_secs, 30);
   assert_eq!(cfg.tui.effective_confirm_countdown_secs(), 5);
+}
+
+// Issue #75: configurable launchers for `l` (git_tui) and `R` (review).
+// Two sibling sections share the same shape — `command` (shell line with
+// placeholders) + `fullscreen` (suspend gwm TUI for TUI tools). The
+// `[review]` section also takes a `tool = ...` sugar for built-in
+// presets and a `skip_when_no_changes` knob (default true). Absent
+// sections must keep gwm's previous behaviour: `l` → `lazygit -p {path}`
+// fullscreen, `R` inert with a status-bar hint.
+
+#[test]
+fn git_tui_section_defaults_to_lazygit_preserving_legacy_behaviour() {
+  // Backwards-compat contract: no `[git_tui]` in `.gwm.toml` must keep
+  // the `l` keybinding pointed at `lazygit -p {path}` with fullscreen,
+  // i.e. identical to the hardcoded behaviour before issue #75 landed.
+  let cfg = Config::default();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "lazygit -p {path}");
+  assert!(r.fullscreen, "lazygit is a TUI tool, gwm must suspend itself");
+}
+
+#[test]
+fn git_tui_section_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[git_tui]
+command = "gitui -d {path}"
+fullscreen = true
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "gitui -d {path}");
+  assert!(r.fullscreen);
+}
+
+#[test]
+fn git_tui_can_opt_out_of_fullscreen() {
+  // A user who wires `l` to launch a non-TUI editor (`code {path}`) needs
+  // to keep gwm visible — fullscreen=false skips the suspend dance.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[git_tui]
+command = "code {path}"
+fullscreen = false
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.git_tui.resolved();
+  assert_eq!(r.command, "code {path}");
+  assert!(!r.fullscreen);
+}
+
+#[test]
+fn review_section_defaults_to_disabled_with_skip_true() {
+  // No `[review]` block ⇒ `R` is inert; the TUI shows a status-bar
+  // hint inviting the user to configure it. `skip_when_no_changes`
+  // defaults to true so a deliberately-set-but-empty review run
+  // doesn't shell out for nothing.
+  let cfg = Config::default();
+  assert!(
+    cfg.review.resolved().is_none(),
+    "default review must be inert until configured"
+  );
+  assert!(cfg.review.skip_when_no_changes);
+  assert!(cfg.review.default_base.is_none());
+  assert!(!cfg.review.has_shadowed_tool());
+}
+
+#[test]
+fn review_section_explicit_command_wins() {
+  // The primary contract: a free-form shell line. Placeholders are not
+  // expanded here — that's the launcher module's job.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+command = "my-review --base {base} --head {head}"
+fullscreen = true
+skip_when_no_changes = false
+default_base = "trunk"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().expect("explicit command must resolve");
+  assert_eq!(r.command, "my-review --base {base} --head {head}");
+  assert!(r.fullscreen);
+  assert!(!cfg.review.skip_when_no_changes);
+  assert_eq!(cfg.review.default_base.as_deref(), Some("trunk"));
+}
+
+#[test]
+fn review_section_tool_preset_lumen_resolves_to_fullscreen_diff() {
+  // `tool = "lumen"` is the canonical example from the issue.
+  // Resolves to `lumen diff {base}..{head}` with fullscreen=true
+  // because lumen is a ratatui TUI like gwm itself.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().expect("lumen preset must resolve");
+  assert_eq!(r.command, "lumen diff {base}..{head}");
+  assert!(r.fullscreen, "lumen is a TUI — gwm must suspend itself");
+}
+
+#[test]
+fn review_tool_preset_table_covers_documented_set() {
+  // Pin the canonical table the docs / SKILL.md reference. A regression
+  // that renames or drops one of these would break the docs silently.
+  assert_eq!(review_tool_preset("lumen"), Some(("lumen diff {base}..{head}", true)));
+  assert_eq!(
+    review_tool_preset("claude"),
+    Some(("claude --print 'review the diff {base}..{head}'", false))
+  );
+  assert_eq!(
+    review_tool_preset("codex"),
+    Some(("codex review {base}..{head}", false))
+  );
+  assert_eq!(
+    review_tool_preset("aider"),
+    Some(("aider --message 'review {base}..{head}'", true))
+  );
+  assert_eq!(review_tool_preset("gh"), Some(("gh pr view --web", false)));
+  assert_eq!(review_tool_preset("unknown"), None);
+}
+
+#[test]
+fn review_unknown_tool_resolves_to_none() {
+  // Unknown preset is a soft no-op — the resolved launcher is `None` so
+  // the TUI can surface a status-bar hint instead of crashing.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "made-up"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert!(
+    cfg.review.resolved().is_none(),
+    "unknown preset must not silently fall back to a real tool"
+  );
+}
+
+#[test]
+fn review_command_overrides_tool() {
+  // Both `command` and `tool` set ⇒ command wins. The user can still
+  // detect the shadow via `has_shadowed_tool()` for a startup warning.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+command = "my-bot --diff-file {diff}"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().unwrap();
+  assert_eq!(
+    r.command, "my-bot --diff-file {diff}",
+    "`command` must override `tool` when both are set"
+  );
+  assert!(cfg.review.has_shadowed_tool());
+}
+
+#[test]
+fn review_fullscreen_overrides_preset_default() {
+  // The preset for `tool = "lumen"` defaults fullscreen=true. The user
+  // must be able to opt out per-repo (e.g. running lumen in a tmux pane).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[review]
+tool = "lumen"
+fullscreen = false
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let r = cfg.review.resolved().unwrap();
+  assert!(
+    !r.fullscreen,
+    "explicit fullscreen=false must override the preset default"
+  );
 }
 
 #[test]

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use gwm::config::{expand_placeholders, Config, WorktreeConfig, CONFIG_FILE};
+use gwm::config::{expand_placeholders, Config, TuiOpenMode, WorktreeConfig, CONFIG_FILE};
 use tempfile::TempDir;
 
 #[test]
@@ -275,4 +275,103 @@ confirm_countdown_secs = 300
   .unwrap();
   let cfg = Config::load_for_repo(dir.path()).expect("300 must parse, not error");
   assert_eq!(cfg.tui.effective_confirm_countdown_secs(), 5);
+}
+
+// Issue #73: [tui.open] table. The `o` key in the TUI dispatches to one of
+// three behaviours (shell-in-worktree, editor, OS file manager) decided by
+// config. Default is `shell` — lazygit-style — to match the worktree-manager
+// workflow ("I want to *do work* in this worktree").
+
+#[test]
+fn tui_open_section_defaults_to_shell_mode() {
+  let cfg = Config::default();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+  assert!(cfg.tui.open.shell_cmd.is_none());
+  assert!(cfg.tui.open.editor_cmd.is_none());
+}
+
+#[test]
+fn tui_open_section_absent_keeps_defaults() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[worktree]
+base = "/tmp/wt/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+}
+
+#[test]
+fn tui_open_mode_editor_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "editor"
+editor_cmd = "hx"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Editor);
+  assert_eq!(cfg.tui.open.editor_cmd.as_deref(), Some("hx"));
+}
+
+#[test]
+fn tui_open_mode_finder_preserves_legacy_behaviour() {
+  // Users who liked the pre-#73 default (`open` / `xdg-open` / `explorer`)
+  // can opt back in. The variant is named `Finder` after the dominant macOS
+  // use case but covers all three OS openers.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "finder"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Finder);
+}
+
+#[test]
+fn tui_open_mode_shell_with_custom_cmd_round_trips() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "shell"
+shell_cmd = "/usr/bin/fish"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Shell);
+  assert_eq!(cfg.tui.open.shell_cmd.as_deref(), Some("/usr/bin/fish"));
+}
+
+#[test]
+fn tui_open_mode_invalid_value_errors_at_parse_time() {
+  // Unknown enum variants are a hard config error — we can't silently fall
+  // back to a default without confusing the user about which mode is active.
+  // Document the supported set in the example file; bad values surface here.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.open]
+mode = "neovim"
+"#,
+  )
+  .unwrap();
+  assert!(Config::load_for_repo(dir.path()).is_err());
 }

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -411,6 +411,50 @@ fn missing_review_tool_preset_is_warning() {
 }
 
 #[test]
+fn launcher_wrapped_by_env_warns_on_real_binary_not_wrapper() {
+  // PR #76 Copilot review: `extract_binary` returned the first token
+  // that didn't contain '=', which for `env FOO=bar phantom-bin diff`
+  // was `env` itself. The doctor then checked `env` (always on PATH)
+  // and missed the real launcher binary. Confirm that the doctor now
+  // names the actual tool when an `env` wrapper is present.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.command = Some("env FOO=bar definitely-not-on-path-wrapped-zz {base}..{head}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert_eq!(c.status, CheckStatus::Warning, "wrapped missing binary must warn");
+  assert!(
+    c.detail.contains("definitely-not-on-path-wrapped-zz"),
+    "wrapper must be peeled: detail should name the real binary, got: {}",
+    c.detail
+  );
+  assert!(
+    !c.detail.split("not on PATH:").nth(1).unwrap_or("").contains("env"),
+    "`env` must not appear in the missing-binaries section: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn launcher_wrapped_by_command_warns_on_real_binary_not_wrapper() {
+  // Sibling case for the POSIX `command` builtin: `command tool ...`
+  // (used e.g. inside shell aliases to bypass functions) should peel
+  // the wrapper just like `env`. Same shape as the env test above.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.git_tui.command = Some("command definitely-not-on-path-cmd-yy -d {path}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert!(
+    c.detail.contains("definitely-not-on-path-cmd-yy"),
+    "command wrapper must be peeled: detail should name the real binary, got: {}",
+    c.detail
+  );
+}
+
+#[test]
 fn missing_git_tui_binary_is_warning() {
   // A user overriding [git_tui] to a missing binary deserves the same
   // visibility treatment as a missing review tool — gwm's `l` keybinding

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -363,6 +363,90 @@ fn resolvable_command_binary_is_ok() {
 }
 
 #[test]
+fn missing_review_binary_is_warning_not_failure() {
+  // Issue #75: [review] is opt-in. A missing review binary should
+  // surface as Warning (exit code 1), never Failed (exit code 2),
+  // so CI / pre-commit hooks that already gate on doctor still pass
+  // when the user only set [review] for their own local convenience.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.command = Some("definitely-not-on-path-review-xyz {base}..{head}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("PATH"))
+    .expect("expected a PATH check");
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.contains("definitely-not-on-path-review-xyz"),
+    "missing review binary must appear in the detail: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn missing_review_tool_preset_is_warning() {
+  // `tool = "lumen"` resolves to `lumen diff ...`. If the user names a
+  // preset but `lumen` itself isn't installed, the doctor warns about
+  // the binary name from the preset table, not about the literal
+  // string `"lumen"` token in their config.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.review.tool = Some("lumen".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  // Lumen is almost certainly not on the CI matrix. If it happens to
+  // be installed locally we don't have anything to assert; the loose
+  // contract is "if it's missing, the report names it".
+  if c.status == CheckStatus::Warning && c.detail.contains("lumen") {
+    assert!(
+      c.detail.to_lowercase().contains("lumen"),
+      "preset's resolved binary must be named in the warning: {}",
+      c.detail
+    );
+  }
+}
+
+#[test]
+fn missing_git_tui_binary_is_warning() {
+  // A user overriding [git_tui] to a missing binary deserves the same
+  // visibility treatment as a missing review tool — gwm's `l` keybinding
+  // would surface a status-bar error at runtime, but doctor should
+  // catch it upfront.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.git_tui.command = Some("definitely-not-on-path-tui-xyz -d {path}".into());
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report.checks.iter().find(|c| c.name.contains("PATH")).unwrap();
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.contains("definitely-not-on-path-tui-xyz"),
+    "missing git_tui binary must appear in the detail: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn review_unset_does_not_force_lazygit_warning_to_failure() {
+  // Pre-issue-#75 the doctor flagged a missing `lazygit` as Warning.
+  // Confirm that adding the new launcher checks doesn't tip the
+  // severity over to Failed when only [review] is unconfigured.
+  let (dir, repo) = init_repo();
+  let config = Config::default(); // nothing review-related set
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  // The aggregate severity must stay at Warning or Ok — never Failed.
+  assert!(
+    matches!(report.severity(), CheckStatus::Ok | CheckStatus::Warning),
+    "default config must not push doctor into Failed: severity = {:?}",
+    report.severity()
+  );
+}
+
+#[test]
 fn extract_binary_handles_shell_quoted_run_strings() {
   // regression: `extract_binary` used `split_whitespace` and returned the
   // leading-quoted token `"my` for `"my tool" --flag` before the shell-words

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -1,0 +1,276 @@
+//! Unit tests for the `github` module: link storage (git branch config),
+//! repo-slug extraction from the `origin` remote, and JSON parsing of
+//! `gh issue view` / `gh pr view --json` payloads.
+
+mod common;
+
+use common::init_repo;
+use gwm::github::{self, parse_issue_json, parse_pr_json, BranchLink, IssueState, LinkSource, PrState};
+
+fn make_branch(repo: &git2::Repository, name: &str) {
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch(name, &head, false).unwrap();
+}
+
+#[test]
+fn read_link_returns_none_when_branch_name_has_no_issue() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "random-branch");
+
+  let link = github::read_link(&repo, "random-branch").unwrap();
+
+  assert_eq!(link.issue, None);
+  assert_eq!(link.pr, None);
+  assert_eq!(link.issue_source, LinkSource::None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
+fn read_link_auto_detects_issue_from_branch_name() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+  assert_eq!(link.pr, None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
+fn link_issue_writes_branch_config_overriding_auto_detect() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.issue, Some(99));
+  assert_eq!(link.issue_source, LinkSource::Explicit);
+}
+
+#[test]
+fn unlink_issue_removes_explicit_override_and_falls_back_to_branch_name() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  github::unlink_issue(&repo, "feat/#42-tui-search").unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  // Auto-detection from branch name kicks back in.
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+}
+
+#[test]
+fn unlink_issue_on_unlinked_branch_is_idempotent() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "random-branch");
+
+  // Should not error even if nothing to unlink.
+  github::unlink_issue(&repo, "random-branch").unwrap();
+  github::unlink_issue(&repo, "random-branch").unwrap();
+}
+
+#[test]
+fn link_pr_writes_branch_config() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.pr, Some(61));
+  assert_eq!(link.pr_source, LinkSource::Explicit);
+}
+
+#[test]
+fn unlink_pr_clears_the_pr_link_only() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::link_issue(&repo, "feat/#42-tui-search", 99).unwrap();
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  github::unlink_pr(&repo, "feat/#42-tui-search").unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.issue, Some(99));
+  assert_eq!(link.pr, None);
+}
+
+// --- Repo-slug extraction ------------------------------------------------
+
+fn set_origin(repo: &git2::Repository, url: &str) {
+  // remote_set_url is a no-op when the remote doesn't exist, so create it first.
+  let _ = repo.remote("origin", url);
+}
+
+#[test]
+fn repo_slug_from_ssh_origin() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "git@github.com:kbrdn1/gwm-cli.git");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_from_https_origin() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli.git");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_strips_trailing_dot_git_when_absent() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_errors_when_no_origin_remote() {
+  let (_dir, repo) = init_repo();
+
+  let err = github::repo_slug(&repo).unwrap_err();
+  let msg = err.to_string();
+  assert!(msg.contains("origin"), "error should mention origin remote: {}", msg);
+}
+
+#[test]
+fn repo_slug_errors_when_origin_is_not_github() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://gitlab.com/kbrdn1/something.git");
+
+  let err = github::repo_slug(&repo).unwrap_err();
+  let msg = err.to_string();
+  assert!(msg.contains("github"), "error should mention github: {}", msg);
+}
+
+// --- JSON parsing --------------------------------------------------------
+
+#[test]
+fn parse_issue_json_extracts_open_state_and_labels() {
+  let json = r#"{
+    "number": 42,
+    "title": "TUI: fuzzy search",
+    "state": "OPEN",
+    "url": "https://github.com/kbrdn1/gwm-cli/issues/42",
+    "labels": [
+      {"name": "feature", "color": "0e8a16"},
+      {"name": "tui", "color": "5319e7"}
+    ],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let issue = parse_issue_json(json).unwrap();
+
+  assert_eq!(issue.number, 42);
+  assert_eq!(issue.title, "TUI: fuzzy search");
+  assert_eq!(issue.state, IssueState::Open);
+  assert_eq!(issue.url, "https://github.com/kbrdn1/gwm-cli/issues/42");
+  assert_eq!(issue.labels, vec!["feature", "tui"]);
+}
+
+#[test]
+fn parse_issue_json_handles_closed_state() {
+  let json = r#"{
+    "number": 7,
+    "title": "old bug",
+    "state": "CLOSED",
+    "url": "https://github.com/x/y/issues/7",
+    "labels": [],
+    "updatedAt": "2025-01-01T00:00:00Z"
+  }"#;
+
+  let issue = parse_issue_json(json).unwrap();
+
+  assert_eq!(issue.state, IssueState::Closed);
+  assert!(issue.labels.is_empty());
+}
+
+#[test]
+fn parse_pr_json_extracts_state_draft_and_checks() {
+  // Mirror of `gh pr view <N> --json state,title,isDraft,url,statusCheckRollup,updatedAt`.
+  let json = r#"{
+    "number": 61,
+    "title": "feat(tui): fuzzy search",
+    "state": "OPEN",
+    "isDraft": true,
+    "url": "https://github.com/kbrdn1/gwm-cli/pull/61",
+    "statusCheckRollup": [
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "fmt", "status": "IN_PROGRESS", "conclusion": null}
+    ],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.number, 61);
+  assert_eq!(pr.title, "feat(tui): fuzzy search");
+  assert_eq!(pr.state, PrState::Draft);
+  assert_eq!(pr.url, "https://github.com/kbrdn1/gwm-cli/pull/61");
+  // 2 out of 3 checks completed (the IN_PROGRESS one is still running).
+  assert_eq!(pr.checks_passed, 2);
+  assert_eq!(pr.checks_total, 3);
+}
+
+#[test]
+fn parse_pr_json_merged_state_overrides_open() {
+  let json = r#"{
+    "number": 61,
+    "title": "feat(tui): fuzzy search",
+    "state": "MERGED",
+    "isDraft": false,
+    "url": "https://github.com/kbrdn1/gwm-cli/pull/61",
+    "statusCheckRollup": [],
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.state, PrState::Merged);
+  assert_eq!(pr.checks_total, 0);
+}
+
+#[test]
+fn parse_pr_json_handles_missing_status_check_rollup() {
+  let json = r#"{
+    "number": 5,
+    "title": "x",
+    "state": "OPEN",
+    "isDraft": false,
+    "url": "https://github.com/x/y/pull/5",
+    "updatedAt": "2026-05-19T10:00:00Z"
+  }"#;
+
+  let pr = parse_pr_json(json).unwrap();
+
+  assert_eq!(pr.checks_total, 0);
+  assert_eq!(pr.checks_passed, 0);
+  assert_eq!(pr.state, PrState::Open);
+}
+
+#[test]
+fn branch_link_summary_renders_human_readable() {
+  let link = BranchLink {
+    issue: Some(42),
+    pr: Some(61),
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::Explicit,
+  };
+  let s = link.summary();
+  assert!(s.contains("#42"), "summary should mention issue #42: {}", s);
+  assert!(s.contains("#61"), "summary should mention PR #61: {}", s);
+}

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -138,6 +138,29 @@ fn repo_slug_strips_trailing_dot_git_when_absent() {
 }
 
 #[test]
+fn repo_slug_handles_trailing_slash_after_dot_git() {
+  // Copilot PR #68 review: `https://…/repo.git/` previously left ".git"
+  // in the slug because we stripped `.git` before trimming `/`. The fix
+  // is to normalise trailing slashes first, then strip `.git`.
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli.git/");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
+fn repo_slug_handles_trailing_slash_without_dot_git() {
+  let (_dir, repo) = init_repo();
+  set_origin(&repo, "https://github.com/kbrdn1/gwm-cli/");
+
+  let slug = github::repo_slug(&repo).unwrap();
+
+  assert_eq!(slug, "kbrdn1/gwm-cli");
+}
+
+#[test]
 fn repo_slug_errors_when_no_origin_remote() {
   let (_dir, repo) = init_repo();
 

--- a/tests/launcher_tests.rs
+++ b/tests/launcher_tests.rs
@@ -1,0 +1,269 @@
+//! Unit tests for the shared launcher machinery — placeholder expansion,
+//! base-resolution chain, `{diff}` lazy materialisation, `which::which`
+//! probing. Issue #75.
+
+mod common;
+
+use common::init_repo;
+use gwm::config::ResolvedLauncher;
+use gwm::launcher::{
+  count_commits_ahead, expand_command, locate_binary, missing_binary_for, resolve_review_base, write_gwm_base,
+  LauncherContext,
+};
+use std::path::Path;
+
+fn ctx<'a>(path: &'a Path, base: Option<&'a str>, head: Option<&'a str>) -> LauncherContext<'a> {
+  LauncherContext {
+    worktree_path: path,
+    base,
+    head,
+    repo_workdir: Some(path),
+  }
+}
+
+#[test]
+fn expand_substitutes_path_placeholder() {
+  // `[git_tui]` only needs `{path}`. The launcher must work without a
+  // base/head context — that's the contract for the `l` keybinding.
+  let c = ctx(Path::new("/tmp/wt/x"), None, None);
+  let cmd = expand_command("lazygit -p {path}", &c).unwrap();
+  assert_eq!(cmd.argv, vec!["lazygit", "-p", "/tmp/wt/x"]);
+  assert!(
+    cmd.diff_file.is_none(),
+    "no {{diff}} in template ⇒ no tempfile materialised"
+  );
+}
+
+#[test]
+fn expand_substitutes_base_head_path() {
+  // The review-style template wires base + head into a `git diff` style
+  // expression. shell-words splits on whitespace — `{base}..{head}`
+  // resolves to one token, not two.
+  let c = ctx(Path::new("/tmp/wt/x"), Some("dev"), Some("feat/foo"));
+  let cmd = expand_command("lumen diff {base}..{head}", &c).unwrap();
+  assert_eq!(cmd.argv, vec!["lumen", "diff", "dev..feat/foo"]);
+}
+
+#[test]
+fn expand_respects_shell_words_quoting() {
+  // The primary contract from the issue: the user can pass any shell
+  // line. shell-words must keep quoted arguments together.
+  let c = ctx(Path::new("/tmp/wt/x"), Some("dev"), Some("feat/foo"));
+  let cmd = expand_command("claude --print 'review {base}..{head}'", &c).unwrap();
+  assert_eq!(
+    cmd.argv,
+    vec!["claude", "--print", "review dev..feat/foo"],
+    "quoted argument must stay one token even after placeholder expansion"
+  );
+}
+
+#[test]
+fn expand_errors_on_unsubstitutable_base() {
+  // A template that names `{base}` without a context-provided base is a
+  // configuration bug — refuse loudly instead of running the command
+  // with a literal `{base}` token.
+  let c = ctx(Path::new("/tmp/wt/x"), None, None);
+  let err = expand_command("lumen diff {base}..HEAD", &c).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(
+    msg.contains("{base}"),
+    "error must mention the missing placeholder: {}",
+    msg
+  );
+}
+
+#[test]
+fn expand_errors_on_diff_without_repo() {
+  // `{diff}` requires a repo workdir to shell out `git diff`. Refuse if
+  // the caller didn't supply one (defensive — the TUI always does).
+  let c = LauncherContext {
+    worktree_path: Path::new("/tmp/wt/x"),
+    base: Some("dev"),
+    head: Some("feat/foo"),
+    repo_workdir: None,
+  };
+  let err = expand_command("reviewer --diff {diff}", &c).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(
+    msg.contains("workdir") || msg.contains("repo"),
+    "diff error should mention the missing repo workdir: {}",
+    msg
+  );
+}
+
+#[test]
+fn expand_materialises_diff_lazily() {
+  // The {diff} placeholder is the only one that triggers a `git diff`
+  // shell-out. A template that doesn't reference it must not pay that
+  // cost — which we assert above. Here we verify that the tempfile is
+  // produced when {diff} *is* referenced, and that the path makes its
+  // way into the argv.
+  let (dir, repo) = init_repo();
+  // Add a second commit so `git diff` has something to render.
+  std::fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+  let mut index = repo.index().unwrap();
+  index.add_path(Path::new("a.txt")).unwrap();
+  let tree_id = index.write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  let parent = repo.head().unwrap().peel_to_commit().unwrap();
+  let sig = git2::Signature::now("t", "t@test").unwrap();
+  let commit_oid = repo.commit(None, &sig, &sig, "add a", &tree, &[&parent]).unwrap();
+  // Create a `feat` branch on the new commit, leave `main` at the
+  // original commit. `git diff main..feat` will then emit the new file.
+  let new_commit = repo.find_commit(commit_oid).unwrap();
+  repo.branch("feat", &new_commit, false).unwrap();
+
+  let c = LauncherContext {
+    worktree_path: dir.path(),
+    base: Some("main"),
+    head: Some("feat"),
+    repo_workdir: Some(dir.path()),
+  };
+  let cmd = expand_command("reviewer --diff {diff}", &c).unwrap();
+  assert_eq!(cmd.argv[0], "reviewer");
+  assert_eq!(cmd.argv[1], "--diff");
+  let diff_path = &cmd.argv[2];
+  assert!(
+    Path::new(diff_path).exists(),
+    "{{diff}} placeholder must produce a real tempfile at: {}",
+    diff_path
+  );
+  let body = std::fs::read_to_string(diff_path).unwrap();
+  assert!(
+    body.contains("a.txt"),
+    "git diff output should mention the file: {}",
+    body
+  );
+  assert!(
+    cmd.diff_file.is_some(),
+    "ExpandedCommand must keep the tempfile alive until drop"
+  );
+}
+
+// ---- Base resolution chain ----------------------------------------------
+
+#[test]
+fn resolve_base_falls_back_to_dev_when_nothing_set() {
+  // Empty git config + no .gwm.toml default ⇒ "dev" wins. This matches
+  // gwm's project convention (the project itself targets `dev`).
+  let (_dir, repo) = init_repo();
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev");
+}
+
+#[test]
+fn resolve_base_uses_config_default_when_set() {
+  // `[review].default_base` overrides the static "dev" fallback.
+  let (_dir, repo) = init_repo();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "trunk");
+}
+
+#[test]
+fn resolve_base_prefers_gwm_base_over_default() {
+  // `branch.<n>.gwm-base` is set by `gwm create` so the parent ref is
+  // recoverable even on branches without an upstream.
+  let (_dir, repo) = init_repo();
+  write_gwm_base(&repo, "feat/x", "release-1.x").unwrap();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "release-1.x");
+}
+
+#[test]
+fn resolve_base_prefers_upstream_over_gwm_base() {
+  // The upstream ref is the strongest signal — the user is actively
+  // tracking it via `git push -u`. It must outrank `gwm-base`.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "refs/heads/staging").unwrap();
+  }
+  write_gwm_base(&repo, "feat/x", "release-1.x").unwrap();
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "staging", "branch.<n>.merge must outrank gwm-base");
+}
+
+#[test]
+fn resolve_base_strips_refs_heads_prefix_from_merge() {
+  // `branch.<n>.merge` is stored as a refspec (`refs/heads/dev`); the
+  // launcher hands the value straight to `git diff`, so the short name
+  // must come out.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "refs/heads/dev").unwrap();
+  }
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev");
+}
+
+#[test]
+fn resolve_base_empty_strings_in_config_are_ignored() {
+  // A leftover empty `branch.<n>.merge = ""` must not poison the chain.
+  let (_dir, repo) = init_repo();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/x.merge", "").unwrap();
+  }
+  let base = resolve_review_base(&repo, "feat/x", Some("trunk"));
+  assert_eq!(base, "trunk", "empty merge must fall through to the next chain step");
+}
+
+// ---- count_commits_ahead ------------------------------------------------
+
+#[test]
+fn count_commits_ahead_is_zero_on_identical_refs() {
+  let (dir, _repo) = init_repo();
+  let n = count_commits_ahead(dir.path(), "HEAD", "HEAD");
+  assert_eq!(n, 0, "HEAD..HEAD must always be 0");
+}
+
+#[test]
+fn count_commits_ahead_returns_zero_on_git_failure() {
+  // Pointing at a non-existent base should not panic — the launcher's
+  // `skip_when_no_changes` path treats 0 as "nothing to review", which
+  // is the safer default when we can't tell.
+  let (dir, _repo) = init_repo();
+  let n = count_commits_ahead(dir.path(), "does-not-exist", "HEAD");
+  assert_eq!(n, 0);
+}
+
+// ---- missing binary probe -----------------------------------------------
+
+#[test]
+fn missing_binary_for_returns_some_when_absent() {
+  // A garbage binary name must come back so the doctor / status bar can
+  // surface it verbatim.
+  let l = ResolvedLauncher {
+    command: "definitely-not-a-real-binary-3afe2c {path}".into(),
+    fullscreen: false,
+  };
+  assert_eq!(
+    missing_binary_for(&l).as_deref(),
+    Some("definitely-not-a-real-binary-3afe2c")
+  );
+}
+
+#[test]
+fn missing_binary_for_returns_none_when_present() {
+  // `sh` is universally on POSIX PATH (the project's CI matrix). Pick a
+  // command that's nearly certain to resolve — windows isn't in the
+  // test matrix anyway.
+  let l = ResolvedLauncher {
+    command: "sh -c 'echo {base}'".into(),
+    fullscreen: false,
+  };
+  assert!(
+    missing_binary_for(&l).is_none(),
+    "/bin/sh must resolve on every supported platform"
+  );
+}
+
+#[test]
+fn locate_binary_finds_resolved_argv0() {
+  // Sanity: `sh -c 'echo hi'` expands to argv `[sh, -c, echo hi]`,
+  // which the locator must find.
+  let c = ctx(Path::new("/tmp"), None, None);
+  let cmd = expand_command("sh -c 'echo hi'", &c).unwrap();
+  assert!(locate_binary(&cmd).is_some());
+}

--- a/tests/launcher_tests.rs
+++ b/tests/launcher_tests.rs
@@ -143,12 +143,26 @@ fn expand_materialises_diff_lazily() {
 // ---- Base resolution chain ----------------------------------------------
 
 #[test]
-fn resolve_base_falls_back_to_dev_when_nothing_set() {
-  // Empty git config + no .gwm.toml default ⇒ "dev" wins. This matches
-  // gwm's project convention (the project itself targets `dev`).
+fn resolve_base_falls_back_to_main_when_no_dev_branch_exists() {
+  // PR #76 Copilot review: the docstring promises a `"dev" → "main"`
+  // fallback. `init_repo` creates only `main`, so resolution must
+  // land on `main` instead of returning a non-existent `dev` that
+  // would later make `git diff` / `git rev-list` fail.
   let (_dir, repo) = init_repo();
   let base = resolve_review_base(&repo, "feat/x", None);
-  assert_eq!(base, "dev");
+  assert_eq!(base, "main", "no dev branch ⇒ fall through to main");
+}
+
+#[test]
+fn resolve_base_falls_back_to_dev_when_dev_branch_exists() {
+  // The "dev" fallback is gwm's project convention. We only prefer
+  // it when it actually exists locally — otherwise we'd hand a bogus
+  // ref to `git diff`. Mirror of the `main` fallback test.
+  let (_dir, repo) = init_repo();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("dev", &head, false).unwrap();
+  let base = resolve_review_base(&repo, "feat/x", None);
+  assert_eq!(base, "dev", "dev branch present ⇒ prefer it over main");
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1435,3 +1435,117 @@ fn issue_state_variants_compile() {
   let _ = IssueState::Open;
   let _ = IssueState::Closed;
 }
+
+// ---- Issue #73: configurable `o:` open key ---------------------------------
+// `App::resolve_open_target` returns an `OpenTarget` that the event loop
+// dispatches on (suspend-and-spawn for shell/editor, OS opener for finder).
+// Pure resolution — no side effects, no spawn — so the test can pin the
+// command resolution under every config / env combination.
+
+use gwm::config::{TuiOpenConfig, TuiOpenMode};
+use gwm::tui::OpenTarget;
+
+#[test]
+fn resolve_open_target_returns_none_when_nothing_selected() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(None);
+  assert!(app.resolve_open_target().is_none());
+}
+
+#[test]
+fn resolve_open_target_defaults_to_shell_mode() {
+  // Default config (`mode = "shell"`) + a worktree selected → Shell variant
+  // carrying the worktree path. The exact command depends on env / fallback;
+  // here we only pin the variant + path so the test isn't $SHELL-dependent.
+  let (_dir, app) = make_app();
+  let target = app
+    .resolve_open_target()
+    .expect("main worktree should always be selectable");
+  match target {
+    OpenTarget::Shell { path, command } => {
+      assert_eq!(path, app.worktrees[0].path);
+      assert!(!command.is_empty(), "shell command must never be empty");
+    }
+    other => panic!("expected Shell variant, got {:?}", other),
+  }
+}
+
+#[test]
+fn resolve_open_target_honours_shell_cmd_override() {
+  // `shell_cmd = "/usr/bin/fish"` must beat `$SHELL` — that's the whole
+  // point of the override. Use a sentinel that's unlikely to be the
+  // ambient shell to make the assertion deterministic.
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Shell,
+    shell_cmd: Some("/sentinel/shell".into()),
+    editor_cmd: None,
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Shell { command, .. } => assert_eq!(command, "/sentinel/shell"),
+    other => panic!("expected Shell, got {:?}", other),
+  }
+}
+
+#[test]
+fn resolve_open_target_uses_editor_mode_when_configured() {
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Editor,
+    shell_cmd: None,
+    editor_cmd: Some("hx".into()),
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Editor { path, command } => {
+      assert_eq!(path, app.worktrees[0].path);
+      assert_eq!(command, "hx");
+    }
+    other => panic!("expected Editor, got {:?}", other),
+  }
+}
+
+// ---- Issue #73: `y: yank` clipboard support -------------------------------
+// `App::yank_selected_path` returns the path to push into the clipboard,
+// or None when nothing's selected. The actual shell-out (pbcopy / wl-copy
+// / xclip / clip) is tested manually — CI machines don't necessarily
+// have any of these installed, so we keep the test scope to the pure
+// resolution step and rely on the smoke test in the TUI for the rest.
+
+#[test]
+fn yank_selected_path_returns_path_for_selected_worktree() {
+  let (_dir, app) = make_app();
+  let path = app.yank_selected_path().expect("main worktree must be yankable");
+  assert_eq!(path, app.worktrees[0].path);
+}
+
+#[test]
+fn yank_selected_path_returns_none_when_nothing_selected() {
+  let (_dir, mut app) = make_app();
+  app.list_state.select(None);
+  assert!(app.yank_selected_path().is_none());
+}
+
+#[test]
+fn yank_candidates_for_current_platform_is_non_empty() {
+  // Whatever the host OS, the candidate list must offer at least one
+  // tool to try — empty would mean `y` could never succeed even with a
+  // working pbcopy / xclip installed.
+  assert!(
+    !gwm::tui::clipboard_candidates().is_empty(),
+    "clipboard candidates must include at least one tool for this OS"
+  );
+}
+
+#[test]
+fn resolve_open_target_uses_finder_mode_for_legacy_behaviour() {
+  let (_dir, mut app) = make_app();
+  app.config.tui.open = TuiOpenConfig {
+    mode: TuiOpenMode::Finder,
+    shell_cmd: None,
+    editor_cmd: None,
+  };
+  match app.resolve_open_target().unwrap() {
+    OpenTarget::Finder { path } => assert_eq!(path, app.worktrees[0].path),
+    other => panic!("expected Finder, got {:?}", other),
+  }
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
-use gwm::tui::{filled_cells_for_progress, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+use gwm::tui::{filled_cells_for_progress, header_title, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -27,6 +27,39 @@ fn make_app() -> (tempfile::TempDir, App) {
   let (dir, _) = init_repo();
   let app = App::new_at(Some(dir.path())).unwrap();
   (dir, app)
+}
+
+#[test]
+fn header_title_includes_running_version_repo_and_workdir() {
+  // The TUI header surfaces `gwm v<version> — <repo> (<workdir>)`.
+  // Cross-check both halves: the version comes from CARGO_PKG_VERSION
+  // (the same string `gwm --version` prints) and the format wraps
+  // each piece exactly as the docstring describes — so a regression
+  // dropping the `v` prefix, the em-dash, or the repo name fails the
+  // test for the right reason.
+  let title = header_title("gwm-cli", "/Users/kbrdn1/Projects/Perso/gwm-cli");
+  assert!(title.contains("gwm-cli"), "missing repo name: {}", title);
+  assert!(
+    title.contains("/Users/kbrdn1/Projects/Perso/gwm-cli"),
+    "missing workdir: {}",
+    title
+  );
+  let version_token = format!("v{}", env!("CARGO_PKG_VERSION"));
+  assert!(
+    title.contains(&version_token),
+    "missing running version `{}`: {}",
+    version_token,
+    title
+  );
+  // Pin the exact layout so a refactor moving the version pre/post
+  // would have to update this assertion deliberately.
+  assert_eq!(
+    title,
+    format!(
+      " gwm v{} — gwm-cli (/Users/kbrdn1/Projects/Perso/gwm-cli) ",
+      env!("CARGO_PKG_VERSION")
+    )
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -24,6 +24,7 @@ fn worktree_fixture(name: &str) -> WorktreeInfo {
     is_locked: false,
     is_prunable: false,
     status: BranchStatus::default(),
+    link: gwm::github::BranchLink::empty(),
   }
 }
 
@@ -1523,6 +1524,53 @@ fn yank_selected_path_returns_none_when_nothing_selected() {
   let (_dir, mut app) = make_app();
   app.list_state.select(None);
   assert!(app.yank_selected_path().is_none());
+}
+
+// ---- Issue #73 (PR #74 follow-up): table marker pastille ------------------
+// The marker column (first cell) doubles as the lazygit-style status dot.
+// `★` still wins for main; non-main worktrees that carry a link (issue or
+// PR) get `●` so the row visually signals "this has GitHub context", even
+// when the sidebar is hidden (`<120` cols or `v` collapsed).
+
+#[test]
+fn table_marker_for_main_worktree_is_yellow_star() {
+  use gwm::github::BranchLink;
+  let mut w = worktree_fixture("main");
+  w.is_main = true;
+  w.link = BranchLink::empty();
+  let (label, color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, "★");
+  assert_eq!(color, Color::Yellow);
+}
+
+#[test]
+fn table_marker_for_linked_non_main_is_neutral_dot() {
+  // No fetched state available at the table layer — colour stays neutral
+  // (Cyan) so the dot reads as "has link" without claiming a specific
+  // open/closed status. The coloured dot lives in the sidebar header where
+  // the live fetch state is known.
+  use gwm::github::{BranchLink, LinkSource};
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink {
+    issue: Some(42),
+    pr: None,
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::None,
+  };
+  let (label, color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, "●");
+  assert_eq!(color, Color::Cyan);
+}
+
+#[test]
+fn table_marker_for_unlinked_non_main_is_blank() {
+  use gwm::github::BranchLink;
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink::empty();
+  let (label, _color) = gwm::tui::table_marker(&w);
+  assert_eq!(label, " ", "unlinked non-main rows keep an empty marker cell");
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1882,6 +1882,171 @@ fn recent_commits_line_marks_merge_commit_with_bullseye() {
   );
 }
 
+// ---- Commit graph topology (lazygit port — pipes + connectors) ---------
+
+use gwm::tui::commit_graph::{box_drawing_chars, build_pipe_sets, render_commits, render_pipe_set, test_row, PipeKind};
+
+fn spans_to_text(spans: &[ratatui::text::Span<'static>]) -> String {
+  spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+#[allow(clippy::type_complexity)]
+fn graph_glyph_table_matches_lazygit_truth_table() {
+  // 16-case ground truth ported verbatim from
+  // `lazygit/pkg/gui/presentation/graph/cell.go::getBoxDrawingChars`.
+  // If any of these flip, the entire graph rendering will silently shift.
+  let cases: &[((bool, bool, bool, bool), (char, char))] = &[
+    ((true, true, true, true), ('│', '─')),
+    ((true, true, true, false), ('│', ' ')),
+    ((true, true, false, true), ('│', '─')),
+    ((true, true, false, false), ('│', ' ')),
+    ((true, false, true, true), ('┴', '─')),
+    ((true, false, true, false), ('╯', ' ')),
+    ((true, false, false, true), ('╰', '─')),
+    ((true, false, false, false), ('╵', ' ')),
+    ((false, true, true, true), ('┬', '─')),
+    ((false, true, true, false), ('╮', ' ')),
+    ((false, true, false, true), ('╭', '─')),
+    ((false, true, false, false), ('╷', ' ')),
+    ((false, false, true, true), ('─', '─')),
+    ((false, false, true, false), ('─', ' ')),
+    ((false, false, false, true), ('╶', '─')),
+    ((false, false, false, false), (' ', ' ')),
+  ];
+  for &((u, d, l, r), expected) in cases {
+    assert_eq!(
+      box_drawing_chars(u, d, l, r),
+      expected,
+      "case ({}, {}, {}, {}) — expected {:?}",
+      u,
+      d,
+      l,
+      r,
+      expected
+    );
+  }
+}
+
+#[test]
+fn graph_linear_history_emits_single_column_circles() {
+  // Three commits, each pointing at the next: c (parent b) → b (parent a) → a (no parent).
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  assert_eq!(graphs.len(), 3);
+  // Each row should be a 2-cell render (one column → 2 chars).
+  for (idx, g) in graphs.iter().enumerate() {
+    let text = spans_to_text(g);
+    assert!(
+      text.contains('○'),
+      "linear history row {} must carry a ○ node, got {:?}",
+      idx,
+      text
+    );
+    assert!(
+      !text.contains('◎'),
+      "linear history row {} must NOT carry a ◎ merge node, got {:?}",
+      idx,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_merge_commit_carries_bullseye_and_branch_corners() {
+  // Topology:
+  //   c (merge: parents = a, b)
+  //   b (parent a)         ← side branch
+  //   a (no parent)        ← trunk root
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  // Row 0 = merge commit, must carry ◎.
+  let merge_text = spans_to_text(&graphs[0]);
+  assert!(merge_text.contains('◎'), "merge row must carry ◎, got {:?}", merge_text);
+  // Row 1 (the side branch) must spawn somewhere outside column 0 —
+  // there should be a `╮` corner on row 0 to drop the second parent
+  // into a fresh column.
+  assert!(
+    merge_text.contains('╮') || merge_text.contains('─'),
+    "merge row must carry a corner / horizontal stroke into the new branch column, got {:?}",
+    merge_text
+  );
+}
+
+#[test]
+fn graph_pipe_set_first_commit_seeds_starts_pipe() {
+  // Internal invariant: the first row's pipe set must contain a STARTS
+  // pipe for the first commit, regardless of how many parents it has.
+  let rows = vec![test_row("a", &["b"])];
+  let pipes = build_pipe_sets(&rows);
+  assert_eq!(pipes.len(), 1);
+  assert!(
+    pipes[0]
+      .iter()
+      .any(|p| p.kind == PipeKind::Starts && p.from_hash == "a"),
+    "first row must contain a STARTS pipe whose from_hash is the commit itself, got {:?}",
+    pipes[0]
+  );
+}
+
+#[test]
+fn graph_pipe_set_merge_commit_emits_extra_starts_per_parent() {
+  // A merge with 2 parents should emit 2 STARTS pipes whose from_pos is
+  // the commit's column and to_pos points at distinct columns.
+  let rows = vec![test_row("c", &["a", "b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let pipes = build_pipe_sets(&rows);
+  let row0 = &pipes[0];
+  let starts: Vec<_> = row0.iter().filter(|p| p.kind == PipeKind::Starts).collect();
+  assert_eq!(
+    starts.len(),
+    2,
+    "merge row must emit 2 STARTS pipes (one per parent), got {} ({:?})",
+    starts.len(),
+    starts
+  );
+}
+
+#[test]
+fn graph_render_pipe_set_empty_input_returns_empty() {
+  let graphs = render_commits(&[]);
+  assert!(graphs.is_empty());
+}
+
+#[test]
+fn graph_row_width_is_deterministic_on_commit_list() {
+  // The graph width is `2 * (max_pos + 1)` chars, derived from pipe
+  // topology — it must NOT depend on terminal width or external state.
+  // Snapshot the linear-history width so a regression caught quickly.
+  let rows = vec![test_row("c", &["b"]), test_row("b", &["a"]), test_row("a", &[])];
+  let graphs = render_commits(&rows);
+  for g in &graphs {
+    let text = spans_to_text(g);
+    let chars = text.chars().count();
+    assert!(
+      (1..=8).contains(&chars),
+      "linear-history row must render in ≤ 8 chars, got {} ({:?})",
+      chars,
+      text
+    );
+  }
+}
+
+#[test]
+fn graph_render_pipe_set_handles_single_pipe_starts() {
+  use gwm::tui::commit_graph::Pipe;
+  let pipes = vec![Pipe {
+    from_pos: 0,
+    to_pos: 0,
+    from_hash: "a".into(),
+    to_hash: "b".into(),
+    kind: PipeKind::Starts,
+  }];
+  let spans = render_pipe_set(&pipes);
+  let text = spans_to_text(&spans);
+  // Cell 0: ○ + filler (space, since right has no neighbor)
+  assert!(text.starts_with('○'), "expected ○ glyph at column 0, got {:?}", text);
+}
+
 #[test]
 fn recent_commits_line_marks_normal_commit_with_open_circle() {
   let (dir, _repo) = init_repo();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1249,3 +1249,57 @@ fn refresh_worktrees_resets_fetch_state() {
   app.refresh().unwrap();
   assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
 }
+
+#[test]
+fn refresh_github_status_message_reflects_partial_failure() {
+  // PR #68 Copilot review: when one of the fetches fails the status line
+  // must not claim "refreshed" — the user should see something hinting
+  // the refresh was incomplete.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // Simulate the result of a refresh where the issue fetch failed but
+  // (for the sake of this test) the PR fetch went through. Apply the
+  // failure directly — we can't shell out to `gh` in unit tests.
+  app.apply_issue_fetch_result(Err("gh: connection refused".into()));
+  let pr = gwm::github::PrStatus {
+    number: 1,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: "https://example.test/pr".into(),
+    updated_at: "".into(),
+    checks_passed: 0,
+    checks_total: 0,
+  };
+  app.apply_pr_fetch_result(Ok(pr));
+  // Now call the same status-rendering logic the refresh would have run.
+  app.report_github_refresh_status();
+  assert!(
+    !app.status.contains("refreshed"),
+    "status must not claim 'refreshed' on partial failure: {}",
+    app.status
+  );
+  assert!(
+    app.status.to_lowercase().contains("error") || app.status.to_lowercase().contains("fail"),
+    "status should mention failure: {}",
+    app.status
+  );
+}
+
+#[test]
+fn refresh_github_status_message_celebrates_full_success() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let issue = gwm::github::IssueStatus {
+    number: 42,
+    title: "x".into(),
+    state: gwm::github::IssueState::Open,
+    url: "https://example.test".into(),
+    labels: vec![],
+    updated_at: "".into(),
+  };
+  app.apply_issue_fetch_result(Ok(issue));
+  app.report_github_refresh_status();
+  assert!(
+    app.status.to_lowercase().contains("refreshed") || app.status.to_lowercase().contains("ok"),
+    "all-green refresh should signal success: {}",
+    app.status
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2,8 +2,12 @@ mod common;
 
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
-use gwm::tui::{filled_cells_for_progress, App, ConfirmKeyAction, CountdownTickOutcome, Field, View};
+use gwm::tui::{
+  branch_name_color, filled_cells_for_progress, freshness_color, pr_badge_color, App, ConfirmKeyAction,
+  CountdownTickOutcome, Field, View,
+};
 use gwm::worktree::{BranchStatus, WorktreeInfo};
+use ratatui::style::Color;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -1302,4 +1306,132 @@ fn refresh_github_status_message_celebrates_full_success() {
     "all-green refresh should signal success: {}",
     app.status
   );
+}
+
+// ---- Issue #73: lazygit-style color helpers --------------------------------
+// Three pure functions live in `tui/ui.rs` and are re-exported through
+// `tui/mod.rs` so the table-driven tests below can pin the contract.
+// Visual regressions land here first, before showing up in screenshots.
+
+#[test]
+fn branch_name_color_codes_synced_branch_as_green() {
+  let synced = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&synced), Color::Green);
+}
+
+#[test]
+fn branch_name_color_codes_dirty_branch_as_red() {
+  // Dirty = local working copy has uncommitted work. Lazygit doesn't surface
+  // dirty in its branches view (it has a dedicated files view), but for a
+  // worktree manager the most important signal is "this worktree has work
+  // not yet captured anywhere" — red flags that hard.
+  let dirty = BranchStatus {
+    is_dirty: true,
+    has_upstream: true,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&dirty), Color::Red);
+}
+
+#[test]
+fn branch_name_color_codes_ahead_or_behind_as_yellow() {
+  let ahead = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 3,
+    behind: 0,
+    unknown: false,
+  };
+  let behind = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 2,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&ahead), Color::Yellow);
+  assert_eq!(branch_name_color(&behind), Color::Yellow);
+}
+
+#[test]
+fn branch_name_color_codes_unpublished_branch_as_magenta() {
+  // No upstream + nothing dirty = branch exists locally only. Mirrors
+  // lazygit's "?" magenta marker for RemoteBranchNotStoredLocally —
+  // distinct from "synced" (green) and from "behind" (yellow) so the user
+  // can tell at a glance whether they've pushed yet.
+  let unpublished = BranchStatus {
+    is_dirty: false,
+    has_upstream: false,
+    ahead: 0,
+    behind: 0,
+    unknown: false,
+  };
+  assert_eq!(branch_name_color(&unpublished), Color::Magenta);
+}
+
+#[test]
+fn branch_name_color_codes_unknown_status_as_darkgray() {
+  let unknown = BranchStatus {
+    unknown: true,
+    ..BranchStatus::default()
+  };
+  assert_eq!(branch_name_color(&unknown), Color::DarkGray);
+}
+
+#[test]
+fn freshness_color_picks_green_for_recent_branches() {
+  assert_eq!(freshness_color(Duration::from_secs(0)), Color::Green);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 3)), Color::Green);
+  assert_eq!(
+    freshness_color(Duration::from_secs(86_400 * 6 + 3600 * 23)),
+    Color::Green
+  );
+}
+
+#[test]
+fn freshness_color_picks_yellow_for_one_to_four_week_branches() {
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 7)), Color::Yellow);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 15)), Color::Yellow);
+  assert_eq!(
+    freshness_color(Duration::from_secs(86_400 * 29 + 3600 * 23)),
+    Color::Yellow
+  );
+}
+
+#[test]
+fn freshness_color_picks_darkgray_for_stale_branches() {
+  // Branches older than a month read as "stale" — gwm encourages cleanup
+  // via `gwm doctor`, so the colour reinforces the prompt.
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 30)), Color::DarkGray);
+  assert_eq!(freshness_color(Duration::from_secs(86_400 * 365)), Color::DarkGray);
+}
+
+#[test]
+fn pr_badge_color_maps_each_state_to_its_lazygit_palette() {
+  // Mirrors `pkg/gui/presentation/branches.go::WithPrColor` — open=green,
+  // draft=darkgray, merged=magenta, closed=red. The actual lazygit RGB
+  // shades are slightly off-palette for terminal themes; we use the
+  // 16-color names so the dots respect the user's colour scheme.
+  assert_eq!(pr_badge_color(PrState::Open), Color::Green);
+  assert_eq!(pr_badge_color(PrState::Draft), Color::DarkGray);
+  assert_eq!(pr_badge_color(PrState::Merged), Color::Magenta);
+  assert_eq!(pr_badge_color(PrState::Closed), Color::Red);
+}
+
+// Ensure the IssueState variants stay accessible — once `branch_name_color`
+// and the rest land, the sidebar's badge function will need to fall back to
+// an issue-derived colour when no PR is linked. The compile-time check below
+// catches a stale import without polluting the runtime tests.
+#[test]
+fn issue_state_variants_compile() {
+  let _ = IssueState::Open;
+  let _ = IssueState::Closed;
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -274,11 +274,11 @@ fn next_prev_invalidate_sidebar_cache() {
   // Moving selection must drop any cached sidebar content so the new
   // worktree's preview is recomputed on the next frame.
   let (_dir, mut app) = make_app();
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.next();
   assert!(app.sidebar_cache.is_none(), "next() must invalidate the sidebar cache");
 
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.prev();
   assert!(app.sidebar_cache.is_none(), "prev() must invalidate the sidebar cache");
 }
@@ -286,7 +286,7 @@ fn next_prev_invalidate_sidebar_cache() {
 #[test]
 fn refresh_invalidates_sidebar_cache() {
   let (_dir, mut app) = make_app();
-  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), vec![]));
+  app.sidebar_cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
   app.refresh().unwrap();
   assert!(app.sidebar_cache.is_none());
 }
@@ -1301,5 +1301,145 @@ fn refresh_github_status_message_celebrates_full_success() {
     app.status.to_lowercase().contains("refreshed") || app.status.to_lowercase().contains("ok"),
     "all-green refresh should signal success: {}",
     app.status
+  );
+}
+
+// ---- Sidebar sections (Option C — bordered subsections, no Commands block) ----
+
+use gwm::tui::build_sidebar_sections;
+
+fn detailed_worktree_fixture() -> WorktreeInfo {
+  WorktreeInfo {
+    name: "api-rest".into(),
+    path: PathBuf::from("/Users/test/cc-worktree/api-rest"),
+    branch: Some("feat/#42-api-rest".into()),
+    head: Some("08d1029f1234567890abcdef".into()),
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus {
+      is_dirty: false,
+      has_upstream: true,
+      ahead: 0,
+      behind: 0,
+      unknown: false,
+    },
+  }
+}
+
+fn section_text(lines: &[ratatui::text::Line<'static>]) -> String {
+  lines
+    .iter()
+    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+    .collect::<Vec<_>>()
+    .join("")
+}
+
+#[test]
+fn sidebar_sections_omit_commands_block() {
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let all = format!(
+    "{}\n{}\n{}",
+    section_text(&sections.worktree),
+    section_text(&sections.working_tree),
+    section_text(&sections.recent_commits),
+  );
+  assert!(
+    !all.contains("Commands"),
+    "the Commands cheat-sheet block must be removed (lives in ? help); got: {}",
+    all
+  );
+  assert!(
+    !all.contains("Bootstrap worktree"),
+    "help-overlay phrasing must not leak into the sidebar: {}",
+    all
+  );
+  assert!(
+    !all.contains("Toggle this sidebar"),
+    "help-overlay phrasing must not leak into the sidebar: {}",
+    all
+  );
+}
+
+#[test]
+fn sidebar_sections_omit_inline_section_headers() {
+  // The new layout puts section titles on the Block borders, so the inline
+  // `Basic Settings:` / `Recent commits:` / `Working tree:` headers must
+  // disappear from the content lines.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let all = format!(
+    "{}\n{}\n{}",
+    section_text(&sections.worktree),
+    section_text(&sections.working_tree),
+    section_text(&sections.recent_commits),
+  );
+  assert!(!all.contains("Basic Settings:"), "got: {}", all);
+  assert!(!all.contains("Recent commits:"), "got: {}", all);
+  assert!(!all.contains("Working tree:"), "got: {}", all);
+}
+
+#[test]
+fn sidebar_worktree_section_is_compact_identity() {
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let text = section_text(&sections.worktree);
+
+  assert!(text.contains("api-rest"), "name on top line: {}", text);
+  assert!(text.contains("feat/#42-api-rest"), "branch shown: {}", text);
+  assert!(text.contains("08d1029"), "short head shown: {}", text);
+  assert!(
+    text.contains("synced") || text.contains("✓"),
+    "synced state badge shown: {}",
+    text
+  );
+  assert!(
+    text.contains("main") || text.contains("★"),
+    "main badge shown: {}",
+    text
+  );
+}
+
+#[test]
+fn sidebar_worktree_section_short_enough_for_compact_layout() {
+  // Compact identity block: name, branch · head, badges, path → 4 lines target.
+  // Allow ≤5 to leave headroom for variable badges.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  assert!(
+    sections.worktree.len() <= 5,
+    "compact worktree block must stay ≤5 lines (target 4), got {}: {:?}",
+    sections.worktree.len(),
+    sections.worktree.iter().map(section_text_single).collect::<Vec<_>>()
+  );
+}
+
+fn section_text_single(l: &ratatui::text::Line<'static>) -> String {
+  l.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+fn sidebar_worktree_section_skips_irrelevant_badges() {
+  // A non-main, unlocked, non-prunable worktree should NOT advertise
+  // those flags — only the ones that are true add visual noise.
+  let mut w = detailed_worktree_fixture();
+  w.is_main = false;
+  let sections = build_sidebar_sections(&w);
+  let text = section_text(&sections.worktree);
+  assert!(
+    !text.contains("★ main"),
+    "non-main worktree must not show ★ main: {}",
+    text
+  );
+  assert!(
+    !text.contains("locked"),
+    "unlocked worktree must not show locked badge: {}",
+    text
+  );
+  assert!(
+    !text.contains("prunable"),
+    "non-prunable worktree must not show prunable badge: {}",
+    text
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1443,3 +1443,59 @@ fn sidebar_worktree_section_skips_irrelevant_badges() {
     text
   );
 }
+
+#[test]
+fn sidebar_worktree_badge_uses_divergence_sigil_when_ahead() {
+  // Regression: PR #70 review (Copilot) flagged that a non-dirty/non-unknown
+  // status always rendered `✓ <label>`, which produced misleading badges like
+  // `✓ ↑2` for branches that were *ahead* of upstream. The `✓` is reserved
+  // for synced / clean — divergence must use `↑` / `↓` / `⇅` (or no sigil).
+  let mut w = detailed_worktree_fixture();
+  w.status = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 2,
+    behind: 0,
+    unknown: false,
+  };
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(
+    !badge.contains("✓"),
+    "ahead-only branch must not display the synced/clean ✓ sigil: {}",
+    badge
+  );
+  assert!(badge.contains("↑2"), "ahead label must still be visible: {}", badge);
+}
+
+#[test]
+fn sidebar_worktree_badge_uses_divergence_sigil_when_behind() {
+  let mut w = detailed_worktree_fixture();
+  w.status = BranchStatus {
+    is_dirty: false,
+    has_upstream: true,
+    ahead: 0,
+    behind: 3,
+    unknown: false,
+  };
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(
+    !badge.contains("✓"),
+    "behind-only branch must not display the synced/clean ✓ sigil: {}",
+    badge
+  );
+  assert!(badge.contains("↓3"), "behind label must still be visible: {}", badge);
+}
+
+#[test]
+fn sidebar_worktree_badge_keeps_check_sigil_when_synced() {
+  // Sanity: the fixture has `has_upstream=true, ahead=0, behind=0` so the
+  // synced label *should* still display `✓`. Guards against an over-eager
+  // fix that would drop the sigil everywhere.
+  let w = detailed_worktree_fixture();
+  let sections = build_sidebar_sections(&w);
+  let badge = section_text_single(&sections.worktree[2]);
+  assert!(badge.contains("✓"), "synced branch must keep the ✓ sigil: {}", badge);
+  assert!(badge.contains("synced"), "label must still say synced: {}", badge);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1772,6 +1772,23 @@ fn author_initials_empty_returns_empty() {
 }
 
 #[test]
+fn author_initials_takes_first_unicode_scalar_per_token() {
+  // Documented divergence from lazygit (PR #72 Copilot review): gwm's
+  // `author_initials` uses `str::chars()` and slices on Unicode scalar
+  // values, NOT grapheme clusters. Single-scalar emoji ("🦀") survive
+  // intact, but multi-scalar grapheme clusters like the French flag
+  // "🇫🇷" (two regional indicators) are split — only the first scalar
+  // makes it into the initials. Pinning this so a future contributor
+  // doesn't quietly break it by adopting a grapheme-aware crate.
+  assert_eq!(author_initials("🦀 Crab"), "🦀C");
+  assert_eq!(
+    author_initials("🇫🇷 Bardini"),
+    "🇫B",
+    "two-scalar grapheme cluster (flag) is intentionally split per scalar"
+  );
+}
+
+#[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly
   // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1010,3 +1010,173 @@ fn filled_cells_floors_partial_progress() {
   // 0.5 exact → 5 cells.
   assert_eq!(filled_cells_for_progress(0.5, 10), 5);
 }
+
+// ---- Issue / PR linking (issue #67) -------------------------------------
+
+use gwm::github::{IssueState, IssueStatus, LinkSource, PrState, PrStatus};
+use gwm::tui::{GitHubFetchState, LinkPromptStage, LinkTarget};
+
+fn make_app_on_branch(name: &str) -> (tempfile::TempDir, git2::Repository, App) {
+  let (dir, repo) = init_repo();
+  {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch(name, &head, false).unwrap();
+  }
+  repo.set_head(&format!("refs/heads/{}", name)).unwrap();
+  let app = App::new_at(Some(dir.path())).unwrap();
+  (dir, repo, app)
+}
+
+#[test]
+fn current_link_reflects_branch_name_auto_detect() {
+  let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
+  let link = app.current_link();
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+  assert_eq!(link.pr, None);
+}
+
+#[test]
+fn enter_open_menu_transitions_view() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.enter_open_menu();
+  assert_eq!(app.view, View::OpenMenu);
+}
+
+#[test]
+fn open_menu_choose_issue_returns_url_when_linked_and_slug_available() {
+  let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  app.enter_open_menu();
+  let url = app.open_menu_pick(LinkTarget::Issue).unwrap();
+  assert_eq!(url, "https://github.com/kbrdn1/gwm-cli/issues/42");
+  // After picking, the view is back to the list.
+  assert_eq!(app.view, View::List);
+}
+
+#[test]
+fn open_menu_pick_returns_none_when_no_link() {
+  let (_dir, repo, mut app) = make_app_on_branch("random-branch");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  app.enter_open_menu();
+  let url = app.open_menu_pick(LinkTarget::Pr);
+  assert!(url.is_none());
+  // Status bar should hint why.
+  assert!(
+    app.status.to_lowercase().contains("no pr"),
+    "status should mention missing PR link: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_link_prompt_starts_at_choose_target() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert_eq!(app.view, View::LinkPrompt);
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::ChooseTarget);
+  assert!(app.link_prompt_number_input().is_empty());
+}
+
+#[test]
+fn link_prompt_choose_issue_advances_to_input() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::InputNumber);
+}
+
+#[test]
+fn link_prompt_only_accepts_digits() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  for c in "12a3".chars() {
+    app.link_prompt_push_char(c);
+  }
+  assert_eq!(app.link_prompt_number_input(), "123");
+}
+
+#[test]
+fn link_prompt_submit_writes_branch_config() {
+  let (_dir, repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue);
+  for c in "42".chars() {
+    app.link_prompt_push_char(c);
+  }
+  app.link_prompt_submit().unwrap();
+  // After submit, view returns to list and the link is persisted.
+  assert_eq!(app.view, View::List);
+  let cfg = repo.config().unwrap();
+  let v = cfg.get_string("branch.random-branch.gwm-issue").unwrap();
+  assert_eq!(v, "42");
+}
+
+#[test]
+fn link_prompt_cancel_returns_to_list() {
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.link_prompt_cancel();
+  assert_eq!(app.view, View::List);
+}
+
+#[test]
+fn github_fetch_state_default_is_idle() {
+  let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn apply_fetch_results_loads_issue_and_pr_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let issue = IssueStatus {
+    number: 42,
+    title: "TUI search".into(),
+    state: IssueState::Open,
+    url: "https://example.test".into(),
+    labels: vec!["feature".into()],
+    updated_at: "2026-05-19T00:00:00Z".into(),
+  };
+  let pr = PrStatus {
+    number: 61,
+    title: "feat(tui): search".into(),
+    state: PrState::Draft,
+    url: "https://example.test/pr".into(),
+    updated_at: "2026-05-19T00:00:00Z".into(),
+    checks_passed: 2,
+    checks_total: 3,
+  };
+  app.apply_issue_fetch_result(Ok(issue.clone()));
+  app.apply_pr_fetch_result(Ok(pr.clone()));
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(_) => {}
+    other => panic!("expected Loaded, got {:?}", other),
+  }
+  match app.pr_fetch_state() {
+    GitHubFetchState::Loaded(_) => {}
+    other => panic!("expected Loaded, got {:?}", other),
+  }
+}
+
+#[test]
+fn apply_fetch_error_stores_error_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_issue_fetch_result(Err("gh not found".into()));
+  match app.issue_fetch_state() {
+    GitHubFetchState::Error(msg) => assert!(msg.contains("gh"), "msg = {}", msg),
+    other => panic!("expected Error, got {:?}", other),
+  }
+}
+
+#[test]
+fn refresh_link_invalidates_fetch_state() {
+  // After the user changes selection or the branch link changes, any
+  // previously fetched status no longer applies. The state must reset.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_issue_fetch_result(Err("e".into()));
+  app.refresh_link();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1858,7 +1858,10 @@ fn commit_row_carries_parent_hashes() {
 }
 
 #[test]
-fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+fn recent_commits_line_marks_merge_commit_with_bullseye() {
+  // U+25CE ◎ is named "BULLSEYE" in Unicode — it is what lazygit uses
+  // for `MergeSymbol`. The previous test name said "diamond" which
+  // was geometrically wrong; this name pins the actual glyph.
   let (dir, repo) = init_repo();
   add_merge_commit(&repo);
   let w = worktree_pointing_at_dir(dir.path());
@@ -1874,7 +1877,7 @@ fn recent_commits_line_marks_merge_commit_with_open_diamond() {
   let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
   assert!(
     joined.contains('◎'),
-    "merge row must carry the ◎ marker, got: {}",
+    "merge row must carry the ◎ bullseye marker, got: {}",
     joined
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1648,3 +1648,188 @@ fn issue_summary_line_truncates_error_state_to_budget() {
   let width = line_visible_width(&line);
   assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
 }
+
+// ---- Recent Commits panel: lazygit-style fill + clip (issue #71) ---------
+
+use gwm::tui::{recent_commits_lines, RECENT_COMMITS_LIMIT};
+
+fn add_commits(repo: &git2::Repository, count: usize) {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  for i in 0..count {
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(Some("HEAD"), &sig, &sig, &format!("commit-{}", i), &tree, &[&parent])
+      .unwrap();
+  }
+}
+
+fn worktree_pointing_at_dir(dir: &std::path::Path) -> WorktreeInfo {
+  WorktreeInfo {
+    name: "test".into(),
+    path: dir.to_path_buf(),
+    branch: Some("main".into()),
+    head: None,
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus::default(),
+  }
+}
+
+#[test]
+fn recent_commits_lines_respects_limit_when_repo_has_more() {
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 14); // 15 total commits (1 seed + 14)
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 5);
+  assert_eq!(
+    lines.len(),
+    5,
+    "limit=5 must produce exactly 5 lines, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+fn recent_commits_lines_returns_all_when_under_limit() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 100);
+  assert_eq!(
+    lines.len(),
+    1,
+    "init_repo has 1 commit, asking for 100 should still return 1, got {}",
+    lines.len()
+  );
+}
+
+#[test]
+#[allow(clippy::assertions_on_constants)] // intentional const pin
+fn recent_commits_default_limit_fills_modern_terminal_heights() {
+  // Regression: the previous hardcoded limit of 10 left the bottom of tall
+  // sidebars empty. On a 50-line terminal, the Recent Commits block gets
+  // ~12–18 rows after the small fixed sections take their slice; on a
+  // 100-line terminal it gets ~70+. Keep the default generous so the
+  // block fills the panel without re-shelling git on scroll. A future
+  // contributor that lowers the constant will trip this test.
+  assert!(
+    RECENT_COMMITS_LIMIT >= 50,
+    "RECENT_COMMITS_LIMIT must be ≥ 50 to fill a typical sidebar, got {}",
+    RECENT_COMMITS_LIMIT
+  );
+}
+
+#[test]
+fn build_sidebar_sections_fetches_up_to_default_recent_commits_limit() {
+  // Wire-up smoke: build_sidebar_sections must use RECENT_COMMITS_LIMIT (or
+  // higher) so the cached section is dense enough to fill a tall panel.
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 30); // 31 total commits
+  let w = worktree_pointing_at_dir(dir.path());
+  let sections = build_sidebar_sections(&w);
+  assert_eq!(
+    sections.recent_commits.len(),
+    31,
+    "expected all 31 commits to be cached (default limit ≥ 50 ≥ 31), got {}",
+    sections.recent_commits.len()
+  );
+}
+
+// ---- lazygit-style row format (hash + initials + subject) ----------------
+
+use gwm::tui::{author_initials, COMMIT_HASH_DISPLAY_LEN};
+
+#[test]
+fn author_initials_two_word_name_picks_first_letters_of_each() {
+  assert_eq!(author_initials("Kylian Bardini"), "KB");
+  assert_eq!(author_initials("Jesse Duffield"), "JD");
+}
+
+#[test]
+fn author_initials_single_word_takes_first_two_chars() {
+  assert_eq!(author_initials("Linus"), "Li");
+  assert_eq!(author_initials("kb"), "kb");
+}
+
+#[test]
+fn author_initials_three_or_more_words_only_uses_first_two() {
+  // Lazygit caps the result at 2 chars regardless of token count.
+  assert_eq!(author_initials("Jean-Paul Marie Dupont"), "JM");
+}
+
+#[test]
+fn author_initials_strips_leading_whitespace() {
+  assert_eq!(author_initials("  Kylian Bardini"), "KB");
+}
+
+#[test]
+fn author_initials_empty_returns_empty() {
+  assert_eq!(author_initials(""), "");
+  assert_eq!(author_initials("   "), "");
+}
+
+#[test]
+fn recent_commits_line_starts_with_short_hash() {
+  // The first span of every row must be a hash of exactly
+  // COMMIT_HASH_DISPLAY_LEN hex chars (8 by default, matching lazygit).
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  assert_eq!(lines.len(), 1, "init_repo should produce 1 commit");
+  let head_span = lines[0]
+    .spans
+    .first()
+    .expect("commit row must carry at least the hash span");
+  assert_eq!(
+    head_span.content.chars().count(),
+    COMMIT_HASH_DISPLAY_LEN,
+    "expected hash span of {} chars, got {:?}",
+    COMMIT_HASH_DISPLAY_LEN,
+    head_span.content
+  );
+  // Must be all-hex.
+  assert!(
+    head_span.content.chars().all(|c| c.is_ascii_hexdigit()),
+    "expected hex hash, got {:?}",
+    head_span.content
+  );
+}
+
+#[test]
+fn recent_commits_line_includes_author_initials_after_hash() {
+  // init_repo signs commits as "gwm-test" — a single token → first 2 chars.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  // Initials live as a styled span after the hash + double space.
+  assert!(
+    joined.contains("gw"),
+    "expected 'gw' initials from 'gwm-test', got {:?}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_carries_subject_unclipped() {
+  // The renderer relies on ratatui's view-level clip — `recent_commits_lines`
+  // itself must NOT pre-truncate the subject (otherwise scrollback / wider
+  // sidebars would lose information). Verify the full subject is preserved.
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains("init"),
+    "expected the seed 'init' subject, got {:?}",
+    joined
+  );
+  assert!(
+    !joined.contains('…'),
+    "must not pre-emptively truncate with ellipsis: {:?}",
+    joined
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1788,6 +1788,115 @@ fn author_initials_takes_first_unicode_scalar_per_token() {
   );
 }
 
+// ---- Graph node markers (○ commit, ◎ merge) -----------------------------
+
+fn add_merge_commit(repo: &git2::Repository) -> git2::Oid {
+  use git2::Signature;
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+
+  // Start from current HEAD. Create a sibling branch with one commit, then
+  // merge it back into HEAD with a true 2-parent merge commit.
+  let base = repo.head().unwrap().peel_to_commit().unwrap();
+  let branch_name = "tmp-side";
+  repo.branch(branch_name, &base, false).unwrap();
+  // Side commit.
+  let side_oid = {
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo
+      .commit(
+        Some(&format!("refs/heads/{}", branch_name)),
+        &sig,
+        &sig,
+        "side",
+        &tree,
+        &[&base],
+      )
+      .unwrap()
+  };
+  let side = repo.find_commit(side_oid).unwrap();
+  // Merge commit on HEAD with two parents.
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo
+    .commit(
+      Some("HEAD"),
+      &sig,
+      &sig,
+      "merge: side into trunk",
+      &tree,
+      &[&base, &side],
+    )
+    .unwrap()
+}
+
+#[test]
+fn commit_row_carries_parent_hashes() {
+  // Regression: the renderer needs the parent count to pick ○ vs ◎.
+  // git_log_with_author must surface the parent list, not flatten it.
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo); // adds two extra commits (side + merge)
+  let rows = gwm::worktree::git_log_with_author(dir.path(), 10).unwrap();
+  // First row = merge commit (HEAD), should have 2 parents.
+  assert!(!rows.is_empty(), "expected at least 1 commit");
+  assert_eq!(
+    rows[0].parents.len(),
+    2,
+    "HEAD is a merge commit and must surface both parents, got {:?}",
+    rows[0].parents
+  );
+  // The seed `init` commit has no parent.
+  let seed = rows
+    .iter()
+    .find(|r| r.subject == "init")
+    .expect("seed commit must be in log");
+  assert!(
+    seed.parents.is_empty(),
+    "seed commit has no parents, got {:?}",
+    seed.parents
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_merge_commit_with_open_diamond() {
+  let (dir, repo) = init_repo();
+  add_merge_commit(&repo);
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 10);
+  // Find the merge commit row by subject; assert it carries ◎ somewhere.
+  let merge = lines
+    .iter()
+    .find(|l| {
+      let joined: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+      joined.contains("merge: side into trunk")
+    })
+    .expect("merge row must be present");
+  let joined: String = merge.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('◎'),
+    "merge row must carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
+#[test]
+fn recent_commits_line_marks_normal_commit_with_open_circle() {
+  let (dir, _repo) = init_repo();
+  let w = worktree_pointing_at_dir(dir.path());
+  let lines = recent_commits_lines(&w, 1);
+  let joined: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains('○'),
+    "non-merge row must carry the ○ marker, got: {}",
+    joined
+  );
+  assert!(
+    !joined.contains('◎'),
+    "non-merge row must NOT carry the ◎ marker, got: {}",
+    joined
+  );
+}
+
 #[test]
 fn recent_commits_line_starts_with_short_hash() {
   // The first span of every row must be a hash of exactly

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1499,3 +1499,38 @@ fn sidebar_worktree_badge_keeps_check_sigil_when_synced() {
   assert!(badge.contains("✓"), "synced branch must keep the ✓ sigil: {}", badge);
   assert!(badge.contains("synced"), "label must still say synced: {}", badge);
 }
+
+// ---- tilde_compress path-boundary safety (PR #70 review, Copilot) -------
+
+use gwm::tui::tilde_compress_with_home;
+
+#[test]
+fn tilde_compress_does_not_slice_across_path_boundaries() {
+  // Regression: PR #70 review (Copilot) flagged that string `strip_prefix`
+  // on the rendered home dir would slice into longer directory names that
+  // merely *start with* the same characters — e.g. home `/home/al` would
+  // turn `/home/alice/repo` into `~ice/repo`. The compression must only
+  // fire when the prefix ends at a path separator boundary.
+  let home = std::path::Path::new("/home/al");
+  assert_eq!(
+    tilde_compress_with_home("/home/alice/repo", home),
+    "/home/alice/repo",
+    "must not slice across the `alice` directory name"
+  );
+}
+
+#[test]
+fn tilde_compress_compresses_exact_home_match() {
+  let home = std::path::Path::new("/home/alice");
+  assert_eq!(tilde_compress_with_home("/home/alice", home), "~");
+  assert_eq!(tilde_compress_with_home("/home/alice/repo", home), "~/repo");
+  assert_eq!(tilde_compress_with_home("/home/alice/repo/sub", home), "~/repo/sub");
+}
+
+#[test]
+fn tilde_compress_falls_back_when_path_outside_home() {
+  let home = std::path::Path::new("/home/alice");
+  assert_eq!(tilde_compress_with_home("/var/log/x", home), "/var/log/x");
+  // Sibling directory starting with the same letters → no match.
+  assert_eq!(tilde_compress_with_home("/home/alicent/x", home), "/home/alicent/x");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1284,6 +1284,143 @@ fn refresh_github_status_message_reflects_partial_failure() {
   );
 }
 
+// ---- Configurable launchers (issue #75) --------------------------------
+//
+// The `R` key in the worktree-list view now triggers the [review]
+// launcher; the previous "refresh GitHub status" action moves to `F`.
+// `f` becomes the worktree refresh (previously `r`). These tests pin
+// the new methods that back those keybindings; the actual key
+// dispatch sits in `src/tui/mod.rs` and is exercised by the
+// behaviour we assert here.
+
+#[test]
+fn prepare_review_returns_none_when_no_review_configured() {
+  // Default config has no [review] block ⇒ pressing `R` must surface
+  // a status-bar hint, not spawn anything.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let plan = app.prepare_review();
+  assert!(plan.is_none(), "no [review] config ⇒ no launcher plan");
+  let s = app.status.to_lowercase();
+  assert!(
+    s.contains("review") && (s.contains("not configured") || s.contains("not set") || s.contains("gwm.toml")),
+    "status bar must explain why R was inert: {}",
+    app.status
+  );
+}
+
+#[test]
+fn prepare_review_skips_when_no_changes_and_flag_on() {
+  // skip_when_no_changes defaults to true. A fresh repo has zero
+  // commits past `main` ⇒ R must short-circuit with the documented
+  // "no changes to review" status line.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.review.command = Some("lumen diff {base}..{head}".into());
+  app.config.review.fullscreen = Some(true);
+  // The branch was created from HEAD (main), and we have made no new
+  // commits — count_commits_ahead must be 0.
+  let plan = app.prepare_review();
+  assert!(plan.is_none(), "no commits past base + skip_when_no_changes ⇒ skip");
+  let s = app.status.to_lowercase();
+  assert!(
+    s.contains("no changes"),
+    "status bar must say 'no changes': {}",
+    app.status
+  );
+  assert!(
+    app.status.contains("main") || app.status.contains("dev"),
+    "status should name the resolved base: {}",
+    app.status
+  );
+}
+
+#[test]
+fn prepare_review_returns_plan_when_configured_and_diff_exists() {
+  // The full happy path: [review].command set, head ≠ base (one extra
+  // commit), skip_when_no_changes off so we don't have to bother
+  // creating a diff. The plan must surface the expanded argv with all
+  // placeholders substituted.
+  let (dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.review.command = Some("reviewer --base {base} --head {head}".into());
+  app.config.review.skip_when_no_changes = false;
+  // Force a known base so the test isn't sensitive to the chain order.
+  app.config.review.default_base = Some("main".into());
+  // Drop the upstream / gwm-base config so default_base wins.
+  let mut cfg = repo.config().unwrap();
+  let _ = cfg.remove("branch.feat/#42-tui-search.gwm-base");
+
+  let plan = app.prepare_review().expect("configured + no skip ⇒ plan present");
+  let argv = &plan.expanded.argv;
+  assert_eq!(argv[0], "reviewer");
+  assert_eq!(argv[1], "--base");
+  assert_eq!(argv[2], "main");
+  assert_eq!(argv[3], "--head");
+  assert_eq!(argv[4], "feat/#42-tui-search");
+  // The cwd must be the worktree path so the spawned tool sees the
+  // selected branch's working tree as `.`. Use `paths_equal` so the
+  // macOS `/private/var` ↔ `/var` symlink doesn't flake the assertion.
+  assert!(
+    common::paths_equal(&plan.cwd, dir.path()),
+    "plan.cwd = {} vs dir = {}",
+    plan.cwd.display(),
+    dir.path().display()
+  );
+}
+
+#[test]
+fn prepare_review_respects_default_base_chain() {
+  // `branch.<n>.gwm-base` (set by gwm create) must outrank
+  // `[review].default_base`. Recorded as `main` by the fixture.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // Manually record gwm-base since the test fixture didn't go through
+  // worktree::add. The base chain reads from this key.
+  gwm::launcher::write_gwm_base(&app.repo, "feat/#42-tui-search", "release-3.x").unwrap();
+  app.config.review.command = Some("echo {base}".into());
+  app.config.review.skip_when_no_changes = false;
+  app.config.review.default_base = Some("trunk".into());
+
+  let plan = app.prepare_review().expect("must resolve");
+  assert_eq!(
+    plan.expanded.argv,
+    vec!["echo", "release-3.x"],
+    "gwm-base must win over [review].default_base"
+  );
+}
+
+#[test]
+fn prepare_git_tui_default_uses_lazygit() {
+  // Backwards-compat: no `[git_tui]` block ⇒ `l` still runs
+  // `lazygit -p <path>` fullscreen.
+  let (dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  let plan = app.prepare_git_tui().expect("git_tui has a default");
+  let argv = &plan.expanded.argv;
+  assert_eq!(argv[0], "lazygit");
+  assert_eq!(argv[1], "-p");
+  // The path the launcher injects is the *currently selected* worktree;
+  // make_app_on_branch only creates the main, so the default selection
+  // is the main repo's path. Use `paths_equal` to dodge the macOS
+  // `/private/var` ↔ `/var` mismatch (same trick as elsewhere in the
+  // suite).
+  assert!(
+    common::paths_equal(std::path::Path::new(&argv[2]), dir.path()),
+    "argv[2] = {} vs dir = {}",
+    argv[2],
+    dir.path().display()
+  );
+  assert!(plan.fullscreen, "lazygit defaults to fullscreen");
+}
+
+#[test]
+fn prepare_git_tui_uses_user_command_when_set() {
+  // [git_tui].command override must beat the lazygit default.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.config.git_tui.command = Some("gitui -d {path}".into());
+  app.config.git_tui.fullscreen = Some(false);
+  let plan = app.prepare_git_tui().expect("must resolve");
+  assert_eq!(plan.expanded.argv[0], "gitui");
+  assert_eq!(plan.expanded.argv[1], "-d");
+  assert!(!plan.fullscreen, "user opted out of fullscreen");
+}
+
 #[test]
 fn refresh_github_status_message_celebrates_full_success() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1180,3 +1180,72 @@ fn refresh_link_invalidates_fetch_state() {
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
   assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
 }
+
+#[test]
+fn next_resets_fetch_state_on_selection_change() {
+  // PR #68 Copilot review: selection change must invalidate the cached
+  // GitHub fetch state, otherwise the right-panel Issue/PR block shows
+  // stale data from the previously selected worktree.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.next();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn prev_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_pr_fetch_result(Err("stale".into()));
+  app.prev();
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn first_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(1));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.first();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn last_resets_fetch_state_on_selection_change() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.last();
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn filter_clamping_resets_fetch_state_when_selection_moves() {
+  // When typing into the filter narrows the visible set so much that the
+  // current selection no longer points at the same worktree, the link
+  // cache must invalidate too. Otherwise the right-panel block lies.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("zzz-unique"));
+  app.list_state.select(Some(1));
+  app.apply_issue_fetch_result(Err("stale".into()));
+  app.enter_filter();
+  app.filter_push_char('z'); // only the second fixture matches
+                             // The selection survives but the link cache should still reset because
+                             // the filter operation can drop selection back to index 0 on the
+                             // filtered subset. The contract: any selection-state mutation refreshes.
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+}
+
+#[test]
+fn refresh_worktrees_resets_fetch_state() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.apply_pr_fetch_result(Err("stale".into()));
+  app.refresh().unwrap();
+  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1534,3 +1534,117 @@ fn tilde_compress_falls_back_when_path_outside_home() {
   // Sibling directory starting with the same letters → no match.
   assert_eq!(tilde_compress_with_home("/home/alicent/x", home), "/home/alicent/x");
 }
+
+// ---- Issue / PR summary line width budgeting ----------------------------
+
+use gwm::tui::{issue_summary_line, pr_summary_line};
+
+fn line_visible_width(line: &ratatui::text::Line<'static>) -> usize {
+  line.spans.iter().map(|s| s.content.chars().count()).sum()
+}
+
+#[test]
+fn issue_summary_line_truncates_loaded_state_to_budget() {
+  // Regression: with a 48-column sidebar, a fully-loaded issue line was
+  // `#67 (auto) [open] <40-char title>` ≈ 58 chars, overflowing the
+  // Issue/PR block and forcing ratatui's `Wrap` to push the title onto a
+  // second visual row that the layout's `Constraint::Length` didn't
+  // budget for. The Loaded variant must keep the head + badge prefix
+  // intact and trim the title so the total ≤ max_width.
+  let status = gwm::github::IssueStatus {
+    number: 828,
+    title:
+      "Stats: subscriptions distribution across schools and individual customers (very long title to force truncation)"
+        .into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  };
+  let line = issue_summary_line(
+    828,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    30,
+  );
+  let width = line_visible_width(&line);
+  assert!(
+    width <= 30,
+    "loaded issue line must fit in 30 cols, got {}: {:?}",
+    width,
+    line.spans.iter().map(|s| s.content.as_ref()).collect::<Vec<_>>()
+  );
+  // Ellipsis confirms the title was actually trimmed (not just clipped).
+  let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(joined.ends_with('…'), "expected trailing ellipsis: {}", joined);
+}
+
+#[test]
+fn pr_summary_line_truncates_loaded_state_to_budget() {
+  let status = gwm::github::PrStatus {
+    number: 70,
+    title: "feat(tui): redesign Details sidebar with bordered subsections and four cards".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 3,
+    checks_total: 3,
+    updated_at: String::new(),
+  };
+  let line = pr_summary_line(
+    70,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    35,
+  );
+  let width = line_visible_width(&line);
+  assert!(
+    width <= 35,
+    "loaded PR line must fit in 35 cols, got {}: {:?}",
+    width,
+    line.spans.iter().map(|s| s.content.as_ref()).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn issue_summary_line_keeps_short_title_intact() {
+  // Sanity: budget large enough → no truncation, no spurious ellipsis.
+  let status = gwm::github::IssueStatus {
+    number: 1,
+    title: "short".into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  };
+  let line = issue_summary_line(
+    1,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Loaded(status),
+    80,
+  );
+  let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    joined.contains("short"),
+    "short title must not be truncated: {}",
+    joined
+  );
+  assert!(
+    !joined.contains('…'),
+    "no ellipsis when budget exceeds content: {}",
+    joined
+  );
+}
+
+#[test]
+fn issue_summary_line_truncates_error_state_to_budget() {
+  let line = issue_summary_line(
+    42,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Error(
+      "gh: API rate limit exceeded for user, retry after 60s with exponential backoff please".into(),
+    ),
+    30,
+  );
+  let width = line_visible_width(&line);
+  assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -5,7 +5,10 @@
 mod common;
 
 use common::{init_repo, paths_equal};
+use git2::{Repository, Signature, Time};
 use gwm::worktree;
+use std::path::Path;
+use std::time::Duration;
 use tempfile::TempDir;
 
 #[test]
@@ -195,4 +198,159 @@ fn git_log_oneline_errors_outside_repo() {
   let empty = TempDir::new().unwrap();
   let err = worktree::git_log_oneline(empty.path(), 5);
   assert!(err.is_err(), "expected error outside a git repo, got: {:?}", err);
+}
+
+// Issue #73: relative-duration formatter + branch age. The formatter is a
+// pure function (table-driven tests below); `branch_age` walks the commit
+// graph and needs a real repo with controlled commit timestamps.
+
+#[test]
+fn format_relative_duration_under_one_minute_renders_seconds() {
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(0)), "0s");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(1)), "1s");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(59)), "59s");
+}
+
+#[test]
+fn format_relative_duration_steps_through_units() {
+  // Anchor cases at the lazygit boundary (>= unit threshold → render in that unit).
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(60)), "1m");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(60 * 59)), "59m");
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(3600)), "1h");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(3600 * 23)),
+    "23h"
+  );
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(86_400)), "1d");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 6)),
+    "6d"
+  );
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 7)),
+    "1w"
+  );
+  // 4 weeks is still rendered as weeks; the month cutoff sits at ~30 days.
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(86_400 * 28)),
+    "4w"
+  );
+}
+
+#[test]
+fn format_relative_duration_handles_months_and_years() {
+  // Month uses a 30.25-day approximation (lazygit `pkg/utils/date.go`).
+  let one_month = 30 * 86_400 + 6 * 3600;
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(one_month)), "1M");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(one_month * 11)),
+    "11M"
+  );
+  let one_year = 365 * 86_400 + 6 * 3600;
+  assert_eq!(worktree::format_relative_duration(Duration::from_secs(one_year)), "1y");
+  assert_eq!(
+    worktree::format_relative_duration(Duration::from_secs(one_year * 3 + 86_400 * 10)),
+    "3y"
+  );
+}
+
+#[test]
+fn format_relative_duration_output_stays_under_four_chars_for_realistic_inputs() {
+  // Lazygit's recency column is documented as "always three characters";
+  // gwm cell is slightly more lenient (4) but the lazygit promise must hold
+  // for every value below 100 of any unit.
+  for secs in [
+    0, 1, 59, 60, 3599, 3600, 86_399, 86_400, 604_799, 604_800, 2_595_600, 2_595_601,
+  ] {
+    let out = worktree::format_relative_duration(Duration::from_secs(secs));
+    assert!(
+      out.len() <= 4,
+      "format_relative_duration({}s) = {:?} exceeded 4 chars",
+      secs,
+      out
+    );
+  }
+}
+
+#[test]
+fn branch_age_returns_none_for_main_only_repo() {
+  // Repo with a single branch (`main`) and no divergence has no "branch
+  // creation" date — `branch_age` returns None so the UI can fall back to
+  // a dash.
+  let (dir, _) = init_repo();
+  let repo = Repository::open(dir.path()).unwrap();
+  assert!(worktree::branch_age(&repo, "main").is_none());
+}
+
+#[test]
+fn branch_age_reflects_oldest_branch_commit() {
+  // Build a `feat/age` branch with two commits — `branch_age` must return
+  // the elapsed time since the *oldest* commit on that branch (the one
+  // that pinned the branch creation), not the latest tip commit.
+  let (dir, repo) = init_repo();
+  // Anchor "branch creation" at a known instant — 3 days ago, so the
+  // formatter rendering layer can also be sanity-checked downstream.
+  let three_days_ago = chrono::Utc::now().timestamp() - 3 * 86_400;
+  let one_hour_ago = chrono::Utc::now().timestamp() - 3600;
+
+  let main_oid = repo.head().unwrap().target().unwrap();
+  let main_commit = repo.find_commit(main_oid).unwrap();
+  repo.branch("feat/age", &main_commit, false).unwrap();
+
+  // First commit on the branch — dated 3 days ago.
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/age", "branch-old", three_days_ago);
+  // Second commit on the branch — dated 1 hour ago.
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/age", "branch-recent", one_hour_ago);
+
+  let age = worktree::branch_age(&repo, "feat/age").expect("branch must have an age");
+  let three_days_secs = 3 * 86_400;
+  // Allow a 5-minute wiggle for test execution time.
+  let drift = age.as_secs().abs_diff(three_days_secs);
+  assert!(
+    drift < 300,
+    "expected ~{} seconds, got {} (drift {}s)",
+    three_days_secs,
+    age.as_secs(),
+    drift
+  );
+}
+
+#[test]
+fn branch_age_treats_master_and_dev_as_trunks() {
+  // A `feat/work` branch must still get a non-None age even when the
+  // default trunk is `dev` (not `main`). Verifies the trunk-candidates
+  // list covers the common conventions.
+  let dir = TempDir::new().unwrap();
+  let repo = Repository::init(dir.path()).unwrap();
+  repo.set_head("refs/heads/dev").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  let dev_oid = repo.head().unwrap().target().unwrap();
+  let dev_commit = repo.find_commit(dev_oid).unwrap();
+  repo.branch("feat/work", &dev_commit, false).unwrap();
+
+  let two_days_ago = chrono::Utc::now().timestamp() - 2 * 86_400;
+  commit_with_time(dir.path(), &repo, "refs/heads/feat/work", "branch-commit", two_days_ago);
+
+  let age = worktree::branch_age(&repo, "feat/work").expect("dev-rooted branch must have an age");
+  let drift = age.as_secs().abs_diff(2 * 86_400);
+  assert!(drift < 300, "expected ~2 days, got {}s", age.as_secs());
+}
+
+/// Helper: append a commit (empty tree, configurable timestamp) on top of
+/// the given ref. The committer / author share the same timestamp so
+/// `branch_age` (which reads committer time) is deterministic.
+fn commit_with_time(workdir: &Path, repo: &Repository, ref_name: &str, message: &str, unix_secs: i64) {
+  let _ = workdir; // currently unused but reserved if we later need to touch the index
+  let time = Time::new(unix_secs, 0);
+  let sig = Signature::new("gwm-test", "gwm@test", &time).unwrap();
+  let parent_oid = repo.find_reference(ref_name).unwrap().target().unwrap();
+  let parent = repo.find_commit(parent_oid).unwrap();
+  let tree_id = parent.tree_id();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo
+    .commit(Some(ref_name), &sig, &sig, message, &tree, &[&parent])
+    .unwrap();
 }

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -42,6 +42,26 @@ fn add_creates_branch_and_worktree() {
 }
 
 #[test]
+fn add_records_gwm_base_for_new_branch() {
+  // Issue #75: `branch.<name>.gwm-base` is the second link in the
+  // review base-resolution chain. `gwm create` (via `worktree::add`)
+  // must set it to HEAD's short name so the review launcher can fall
+  // back to the original parent even on branches without an upstream.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-7-launcher");
+  worktree::add(&repo, "feat-7-launcher", &target, "feat/#7-launcher").unwrap();
+
+  let cfg = repo.config().unwrap();
+  let base = cfg.get_string("branch.feat/#7-launcher.gwm-base").unwrap();
+  assert_eq!(
+    base, "main",
+    "worktree::add must record HEAD's short name as gwm-base for the review fallback"
+  );
+}
+
+#[test]
 fn add_refuses_to_clobber_existing_dir() {
   let (dir, _) = init_repo();
   let repo = worktree::discover_repo(Some(dir.path())).unwrap();

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -339,6 +339,30 @@ fn branch_age_treats_master_and_dev_as_trunks() {
   assert!(drift < 300, "expected ~2 days, got {}s", age.as_secs());
 }
 
+#[test]
+fn branch_age_returns_none_when_no_trunk_candidate_exists_locally() {
+  // PR #74 Copilot review: if none of the trunk candidates (main /
+  // master / dev) resolves as a local branch, the revwalk hides nothing
+  // and `branch_age` falls back to the repo's initial commit — turning
+  // every branch into a misleadingly large age (the repo's lifetime).
+  // The intent is "branch age relative to a trunk baseline"; without
+  // a baseline, we must surface `None` so the UI renders `-`.
+  let dir = TempDir::new().unwrap();
+  let repo = Repository::init(dir.path()).unwrap();
+  // Initialise the repo on a branch that's *not* a trunk candidate so
+  // the seed commit lives on `feat/standalone`, not `main`/`master`/`dev`.
+  repo.set_head("refs/heads/feat/standalone").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+
+  assert!(
+    worktree::branch_age(&repo, "feat/standalone").is_none(),
+    "no trunk baseline → branch_age must be None, not the repo's lifetime"
+  );
+}
+
 /// Helper: append a commit (empty tree, configurable timestamp) on top of
 /// the given ref. The committer / author share the same timestamp so
 /// `branch_age` (which reads committer time) is deterministic.


### PR DESCRIPTION
## Description

Promotes the v0.6.0 line on `dev` to `main` for the stable release. Follows the existing release-merge convention used for v0.2.0 (d7ab086 → 3e3ddfc), v0.3.0 (edd8dfc), v0.4.0 (a2a1346), and v0.5.0 (d7ab086).

The full per-PR breakdown of what ships in v0.6.0 lives in [`changelogs/0.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.6.0.md).

## Type of change

- [x] 🔀 Release merge (`dev` → `main`)

## What's new in v0.6.0

### Added

- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [PR #68](https://github.com/kbrdn1/gwm-cli/pull/68)) — `gwm link / unlink / open / status`, auto-detect from `<type>/#<N>-<slug>`, live status in the TUI sidebar via `gh`.
- **TUI Details sidebar redesign** ([#69](https://github.com/kbrdn1/gwm-cli/issues/69) / [PR #70](https://github.com/kbrdn1/gwm-cli/pull/70)) — four independent rounded-border subsections (Worktree / Issue · PR / Working Tree / Recent Commits).
- **TUI Recent Commits panel — lazygit-style layout** ([#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [PR #72](https://github.com/kbrdn1/gwm-cli/pull/72)) — 300-commit buffer, hard-clipped subjects, full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
- **TUI sidebar lazygit-style facelift** ([#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [PR #74](https://github.com/kbrdn1/gwm-cli/pull/74)) — `Created` branch-age column, status-coloured branch names, header status dot, `o`/`y` rebinds, `[tui.open]` dispatch (shell / editor / finder), `y: yank` to clipboard.
- **TUI configurable launchers** ([#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [PR #76](https://github.com/kbrdn1/gwm-cli/pull/76)) — `[git_tui]` and `[review]` sections with `{base} {head} {path} {diff}` placeholders, 5 presets for `[review]` (`lumen` / `claude` / `codex` / `aider` / `gh`), shared launcher pipeline, lazy `{diff}` tempfile materialisation.
- **Docs restructured into `docs/` tree** ([#77](https://github.com/kbrdn1/gwm-cli/issues/77) / [PR #78](https://github.com/kbrdn1/gwm-cli/pull/78)) — Nuxt Content conventions, 7 sections × 30 markdown files, README shrunk from 493 to 77 lines.

### Changed

- **TUI keybind reshuffle** (#75): `f` now refreshes the worktree list (was `r`, kept as alias for muscle memory); `F` refreshes the GitHub issue/PR status (was `R` pre-#75); the freed `R` triggers the new review launcher.
- **Default behaviour of `o:` open** (#73): now spawns `$SHELL` in the worktree by default; opt back into the OS file manager via `[tui.open] mode = "finder"`.
- **`gwm doctor`** now probes the configured `[review]` and `[git_tui]` binaries against `$PATH` (#75). Missing review tool surfaces as Warning (exit `1`), never Failed (`2`) — review is opt-in.

### Fixed

- `src/github.rs::trim_git_suffix` — `https://github.com/owner/repo.git/` previously left `.git` in the parsed slug because the trailing `/` made `strip_suffix(".git")` fail. The fix normalises trailing slashes first (caught by Copilot on PR #68).
- `src/tui/app.rs` selection-change handling — `next` / `prev` / `first` / `last` / filter typing / `refresh` now re-resolve the cached link & slug, so the right-panel Issue/PR block no longer shows stale data from the previously selected worktree.
- `src/tui/app.rs::refresh_github_status` — the status bar no longer claims `"github status refreshed"` when one or both `gh` fetches errored.

### Removed

- **`Commands:` cheat-sheet from the Details sidebar** (#69) — the 15-line keybindings list duplicated the `?` help overlay; press `?` for the full key map.

### Dependencies

- Added `serde_json` for parsing `gh` CLI JSON output.
- Added `shell-words` and `tempfile` (#75) for launcher placeholder tokenisation and lazy `{diff}` materialisation.
- Added `which` (#75) for `$PATH` probing of launcher binaries in `gwm doctor`.

## Tests

- [x] `cargo test` — 433 tests across 15 integration files + colocated unit tests
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `gwm doctor` (advisory) — green on the gwm-cli repo itself

All checks pass on the latest PR (#78). The CI workflow on this release PR will re-run them.

## Checklist

- [x] Release notes archived under `changelogs/0.6.0.md`
- [x] Root `CHANGELOG.md` carries the index entry for v0.6.0 under `## Past releases`
- [x] Docs (`docs/`, `README.md`, `ROADMAP.md`, `skills/SKILL.md`) reflect the v0.6.0 surface — see PR #78
- [x] Homebrew tap auto-update (`homebrew-tap-update` job in `release.yml`) is gated on stable tags only; pre-release filter active
- [x] Branch convention preserved: merge, do not squash, do not delete `dev` after merge

## Linked

- All v0.6.0 PRs: #68, #70, #72, #74, #76, #78
- All v0.6.0 issues: #67, #69, #71, #73, #75, #77
- Per-version release notes: `changelogs/0.6.0.md`
- v0.6.0-rc.1 changelog (carried forward): `changelogs/pre-releases/0.6.0-rc.1.md`

## Notes for reviewers

This PR follows the project convention of merge-from-dev release PRs (see d7ab086, a2a1346, edd8dfc, 3e3ddfc for the four prior examples). After merge, `release.yml` triggers on the `v0.6.0` tag push to publish binaries, update the Homebrew tap, and source release notes from `changelogs/0.6.0.md`.