### PR TITLE
✨ feat(config): configurable branch types via [[branch_types]] in .gwm.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — next entries land here once a new feature / fix / chore is merged into `dev`._
+### Added
+
+- ✨ `[[branch_types]]` block in `.gwm.toml` overrides the built-in allowed branch types. Absent or empty block ⇒ historical defaults (`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`); present ⇒ only the listed types are accepted by `gwm create`, the TUI create picker and `BranchSpec::validate()`. `gwm types` prints the resolved list with a `(source: built-in defaults | .gwm.toml)` footer and aligns columns on the longest name. Invalid-type errors now enumerate the repo-local allowed list verbatim instead of leaking the hardcoded set. (#80)
 
 ## Past releases
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -95,6 +95,30 @@ name = "full local build"
 run = "./scripts/full-build.sh"
 when = "glob_exists:src/**/*.rs && !env_set:CI"
 
+# --- branch types (issue #80) -----------------------------------------------
+# Per-repo override of the allowed branch types. Absent (default) ⇒ the
+# built-in list is used: feat, fix, hotfix, docs, test, refactor, chore,
+# perf, ci, build. Present ⇒ only the listed types are accepted by
+# `gwm create` / TUI create / `BranchSpec::validate()`. `gwm types`
+# prints the resolved set with a footer noting the source
+# (`(source: built-in defaults)` vs `(source: .gwm.toml)`).
+#
+# An empty array (`branch_types = []`) is treated as absent — the
+# built-in list is restored so an accidental wipe doesn't lock you out
+# of `gwm create`.
+#
+# [[branch_types]]
+# name = "feat"
+# description = "New feature implementation"
+#
+# [[branch_types]]
+# name = "fix"
+# description = "Bug fix"
+#
+# [[branch_types]]
+# name = "migration"
+# description = "Database migration"
+
 # --- doctor knobs -----------------------------------------------------------
 # Trunk branches `gwm doctor`'s orphan-branch check treats as merge
 # destinations. A gwm-style branch fully reachable from one of these is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -478,16 +478,19 @@ fn print_doctor_report(report: &doctor::DoctorReport) {
 }
 
 fn cmd_types() -> Result<()> {
-  // Resolve the active branch-type list. When invoked inside a repo we
-  // honour any `[[branch_types]]` override in `.gwm.toml`; outside of
-  // one we silently fall back to the built-in defaults so `gwm types`
-  // remains useful as a discovery command (used by `gwm` newcomers
-  // before they've initialised a config).
+  // Resolve the active branch-type list. When invoked inside a repo
+  // with a workdir we honour any `[[branch_types]]` override in
+  // `.gwm.toml`; outside of one — or inside a bare repo where
+  // `repo.workdir()` is `None` and there's no place to look for
+  // `.gwm.toml` — we silently fall back to the built-in defaults so
+  // `gwm types` remains useful as a discovery command (used by `gwm`
+  // newcomers before they've initialised a config, and from CI inspect
+  // commands that point at bare clones).
   let resolved = match worktree::discover_repo(None) {
-    Ok(repo) => {
-      let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-      Config::load_for_repo(&workdir)?.resolved_branch_types()
-    }
+    Ok(repo) => match repo.workdir().map(|w| w.to_path_buf()) {
+      Some(workdir) => Config::load_for_repo(&workdir)?.resolved_branch_types(),
+      None => Config::default().resolved_branch_types(),
+    },
     Err(_) => Config::default().resolved_branch_types(),
   };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrSta
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
-use crate::naming::{BranchSpec, BRANCH_TYPES};
+use crate::naming::BranchSpec;
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
@@ -357,7 +357,8 @@ fn cmd_create(branch_type: String, issue: String, desc: String, no_bootstrap: bo
   let repo_name = worktree::repo_name(&repo);
 
   let config = Config::load_for_repo(&workdir)?;
-  let spec = BranchSpec::new(branch_type, issue, desc)?;
+  let resolved_types = config.resolved_branch_types();
+  let spec = BranchSpec::new_with_types(branch_type, issue, desc, &resolved_types.types)?;
   let branch = spec.branch_name(&config.worktree, &repo_name)?;
   let dirname = spec.worktree_dirname(&config.worktree, &repo_name)?;
   let target = spec.worktree_path(&config.worktree, &repo_name)?;
@@ -477,9 +478,27 @@ fn print_doctor_report(report: &doctor::DoctorReport) {
 }
 
 fn cmd_types() -> Result<()> {
-  for (t, d) in BRANCH_TYPES {
-    println!("  {:<10} {}", t, d);
+  // Resolve the active branch-type list. When invoked inside a repo we
+  // honour any `[[branch_types]]` override in `.gwm.toml`; outside of
+  // one we silently fall back to the built-in defaults so `gwm types`
+  // remains useful as a discovery command (used by `gwm` newcomers
+  // before they've initialised a config).
+  let resolved = match worktree::discover_repo(None) {
+    Ok(repo) => {
+      let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+      Config::load_for_repo(&workdir)?.resolved_branch_types()
+    }
+    Err(_) => Config::default().resolved_branch_types(),
+  };
+
+  // Align the description column on the longest name so a custom list
+  // with a long entry (e.g. `migration`) still renders cleanly.
+  let width = resolved.types.iter().map(|t| t.name.len()).max().unwrap_or(0).max(8);
+  for t in &resolved.types {
+    println!("  {:<width$}  {}", t.name, t.description, width = width);
   }
+  println!();
+  println!("(source: {})", resolved.source.label());
   Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,54 @@ pub struct Config {
   pub git_tui: GitTuiConfig,
   #[serde(default)]
   pub review: ReviewConfig,
+  /// `[[branch_types]]` — per-repo override of the allowed branch types.
+  /// Empty (the default) means the built-in list from `naming::BRANCH_TYPES`
+  /// is used, keeping zero-friction for existing repos. See
+  /// [`Config::resolved_branch_types`] for the single lookup site shared
+  /// by `BranchSpec::validate`, `gwm types` and the TUI create picker.
+  #[serde(rename = "branch_types", default)]
+  pub branch_types: Vec<BranchType>,
+}
+
+/// One entry of the `[[branch_types]]` table in `.gwm.toml`. The struct
+/// is also produced by [`crate::naming::default_branch_types`] when the
+/// config block is absent, so both the configured and built-in flavours
+/// share the same shape downstream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchType {
+  pub name: String,
+  pub description: String,
+}
+
+/// Origin of the resolved branch-type list — surfaced verbatim under
+/// `gwm types` so users can tell at a glance whether they're looking at
+/// their `.gwm.toml` override or the built-in defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchTypesSource {
+  /// No `[[branch_types]]` block in `.gwm.toml` (or it's empty) — the
+  /// built-in list from `naming::BRANCH_TYPES` is in effect.
+  Default,
+  /// At least one `[[branch_types]]` entry was loaded from `.gwm.toml`.
+  Config,
+}
+
+impl BranchTypesSource {
+  /// Human-readable label rendered as the footer of `gwm types`.
+  pub fn label(self) -> &'static str {
+    match self {
+      Self::Default => "built-in defaults",
+      Self::Config => ".gwm.toml",
+    }
+  }
+}
+
+/// Pair returned by [`Config::resolved_branch_types`] — the list to feed
+/// into validation / display, plus the [`BranchTypesSource`] that
+/// produced it.
+#[derive(Debug, Clone)]
+pub struct ResolvedBranchTypes {
+  pub types: Vec<BranchType>,
+  pub source: BranchTypesSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -266,6 +314,26 @@ impl Config {
 
   pub fn guard_by_name(&self, name: &str) -> Option<&Guard> {
     self.bootstrap.guard.iter().find(|g| g.name == name)
+  }
+
+  /// Single lookup site for the allowed branch types. Returns the
+  /// `[[branch_types]]` block from `.gwm.toml` when present, falling
+  /// back to [`crate::naming::default_branch_types`] otherwise. Used
+  /// by `BranchSpec::validate`, `gwm types`, the TUI create picker
+  /// (and, future-pending, the pre-commit hook) so the list stays
+  /// consistent across surfaces.
+  pub fn resolved_branch_types(&self) -> ResolvedBranchTypes {
+    if self.branch_types.is_empty() {
+      ResolvedBranchTypes {
+        types: crate::naming::default_branch_types(),
+        source: BranchTypesSource::Default,
+      }
+    } else {
+      ResolvedBranchTypes {
+        types: self.branch_types.clone(),
+        source: BranchTypesSource::Config,
+      }
+    }
   }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,7 +298,43 @@ impl Config {
     }
     let raw = std::fs::read_to_string(&path)?;
     let cfg: Config = toml::from_str(&raw)?;
+    cfg.validate_branch_types()?;
     Ok(cfg)
+  }
+
+  /// Validate `[[branch_types]]` entries on load so a malformed config
+  /// surfaces a clear error at startup instead of failing downstream in
+  /// `parse_branch` / git itself with a cryptic message. Rules:
+  ///   - `name` must be non-empty
+  ///   - `name` must match `^[a-z]+$` (the regex `parse_branch` uses
+  ///     for the type segment of a gwm-style branch name)
+  ///   - `name`s must be unique across the table — duplicates would
+  ///     silently override each other under `serde`'s `Vec` decoding
+  ///     and make the resolved list non-deterministic
+  fn validate_branch_types(&self) -> Result<()> {
+    let name_re = regex::Regex::new(r"^[a-z]+$").expect("static regex compiles");
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for entry in &self.branch_types {
+      if entry.name.is_empty() {
+        return Err(GwmError::Config(
+          "branch_types: entry has empty `name`; use a lowercase ASCII alpha token (e.g. \"feat\")".into(),
+        ));
+      }
+      if !name_re.is_match(&entry.name) {
+        return Err(GwmError::Config(format!(
+          "branch_types: invalid `name = \"{}\"`; must match ^[a-z]+$ to be a valid branch-prefix \
+           (lowercase letters only, no digits, no dashes — git refs and `parse_branch` rely on this)",
+          entry.name
+        )));
+      }
+      if !seen.insert(entry.name.as_str()) {
+        return Err(GwmError::Config(format!(
+          "branch_types: duplicate entry for `name = \"{}\"` — each branch type must be declared at most once",
+          entry.name
+        )));
+      }
+    }
+    Ok(())
   }
 
   /// Write a default config to the given repo root.

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,8 @@ pub enum GwmError {
   #[error("shell expand error: {0}")]
   ShellExpand(#[from] shellexpand::LookupError<std::env::VarError>),
 
-  #[error("invalid branch type '{0}' (allowed: feat, fix, hotfix, docs, test, refactor, chore, perf, ci, build)")]
-  InvalidBranchType(String),
+  #[error("invalid branch type '{got}' (allowed: {allowed})")]
+  InvalidBranchType { got: String, allowed: String },
 
   #[error("invalid issue number '{0}' (digits only)")]
   InvalidIssue(String),

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1,7 +1,11 @@
-use crate::config::{expand_placeholders, WorktreeConfig};
+use crate::config::{expand_placeholders, BranchType, WorktreeConfig};
 use crate::error::{GwmError, Result};
 use regex::Regex;
 
+/// Built-in branch types — the fallback when `.gwm.toml` carries no
+/// `[[branch_types]]` block. Kept as a `&[(&str, &str)]` const so the
+/// static string table stays compile-time and zero-alloc; the runtime
+/// view is materialised on demand via [`default_branch_types`].
 pub const BRANCH_TYPES: &[(&str, &str)] = &[
   ("feat", "New feature implementation"),
   ("fix", "Bug fix"),
@@ -15,6 +19,20 @@ pub const BRANCH_TYPES: &[(&str, &str)] = &[
   ("build", "Build system changes"),
 ];
 
+/// Runtime view of [`BRANCH_TYPES`] as a `Vec<BranchType>`. Used by
+/// [`crate::config::Config::resolved_branch_types`] when no override
+/// is configured, and by [`BranchSpec::validate`] / [`BranchSpec::new`]
+/// to keep the legacy "no config = built-in defaults" contract.
+pub fn default_branch_types() -> Vec<BranchType> {
+  BRANCH_TYPES
+    .iter()
+    .map(|(name, desc)| BranchType {
+      name: (*name).into(),
+      description: (*desc).into(),
+    })
+    .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct BranchSpec {
   pub type_: String,
@@ -23,19 +41,50 @@ pub struct BranchSpec {
 }
 
 impl BranchSpec {
+  /// Construct a [`BranchSpec`] validated against the built-in branch
+  /// types. Kept for callers (tests, internal helpers) that don't have
+  /// a [`crate::config::Config`] in scope; production code paths
+  /// (`gwm create`, TUI create) should use [`Self::new_with_types`]
+  /// with the resolved list so per-repo overrides are honoured.
   pub fn new(type_: impl Into<String>, issue: impl Into<String>, desc: impl Into<String>) -> Result<Self> {
+    Self::new_with_types(type_, issue, desc, &default_branch_types())
+  }
+
+  /// Construct a [`BranchSpec`] validated against the supplied list of
+  /// allowed branch types — typically the output of
+  /// [`crate::config::Config::resolved_branch_types`].
+  pub fn new_with_types(
+    type_: impl Into<String>,
+    issue: impl Into<String>,
+    desc: impl Into<String>,
+    allowed: &[BranchType],
+  ) -> Result<Self> {
     let s = Self {
       type_: type_.into(),
       issue: issue.into(),
       desc: kebab(&desc.into()),
     };
-    s.validate()?;
+    s.validate_against(allowed)?;
     Ok(s)
   }
 
+  /// Validate against the built-in branch types. Convenience wrapper
+  /// around [`Self::validate_against`] for legacy call sites.
   pub fn validate(&self) -> Result<()> {
-    if !BRANCH_TYPES.iter().any(|(t, _)| *t == self.type_) {
-      return Err(GwmError::InvalidBranchType(self.type_.clone()));
+    self.validate_against(&default_branch_types())
+  }
+
+  /// Validate against the supplied list of allowed branch types. The
+  /// error message produced when the type is rejected enumerates the
+  /// allowed names so the TUI status bar / CLI stderr always shows the
+  /// repo-local truth (built-in or `.gwm.toml`-driven).
+  pub fn validate_against(&self, allowed: &[BranchType]) -> Result<()> {
+    if !allowed.iter().any(|t| t.name == self.type_) {
+      let names = allowed.iter().map(|t| t.name.as_str()).collect::<Vec<_>>().join(", ");
+      return Err(GwmError::InvalidBranchType {
+        got: self.type_.clone(),
+        allowed: names,
+      });
     }
     if !Regex::new(r"^\d+$").unwrap().is_match(&self.issue) {
       return Err(GwmError::InvalidIssue(self.issue.clone()));

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,9 +1,10 @@
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
+use crate::config::BranchType;
 use crate::config::{Config, TuiOpenConfig, TuiOpenMode};
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::launcher::{self, ExpandedCommand, LauncherContext};
-use crate::naming::{BranchSpec, BRANCH_TYPES};
+use crate::naming::BranchSpec;
 use crate::worktree::{self, WorktreeInfo};
 use git2::Repository;
 use nucleo_matcher::{
@@ -138,6 +139,11 @@ pub struct App {
   pub create_type_index: usize,
   pub create_issue: String,
   pub create_desc: String,
+  /// Branch types displayed in the create-form picker. Resolved once at
+  /// startup from [`Config::resolved_branch_types`] so the picker
+  /// honours any `[[branch_types]]` override in `.gwm.toml` without
+  /// re-reading the file on every key event.
+  pub branch_types: Vec<BranchType>,
 
   // Bootstrap report
   pub report: Option<BootstrapReport>,
@@ -214,6 +220,7 @@ impl App {
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
     let repo_name = worktree::repo_name(&repo);
     let config = Config::load_for_repo(&workdir)?;
+    let branch_types = config.resolved_branch_types().types;
     let worktrees = worktree::list(&repo)?;
     let mut state = TableState::default();
     if !worktrees.is_empty() {
@@ -233,6 +240,7 @@ impl App {
       create_type_index: 0,
       create_issue: String::new(),
       create_desc: String::new(),
+      branch_types,
       report: None,
       sidebar_open: true,
       sidebar_focused: false,
@@ -611,12 +619,18 @@ impl App {
   }
 
   pub fn create_next_type(&mut self) {
-    self.create_type_index = (self.create_type_index + 1) % BRANCH_TYPES.len();
+    if self.branch_types.is_empty() {
+      return;
+    }
+    self.create_type_index = (self.create_type_index + 1) % self.branch_types.len();
   }
 
   pub fn create_prev_type(&mut self) {
+    if self.branch_types.is_empty() {
+      return;
+    }
     if self.create_type_index == 0 {
-      self.create_type_index = BRANCH_TYPES.len() - 1;
+      self.create_type_index = self.branch_types.len() - 1;
     } else {
       self.create_type_index -= 1;
     }
@@ -643,8 +657,17 @@ impl App {
   }
 
   pub fn submit_create(&mut self) -> Result<()> {
-    let type_ = BRANCH_TYPES[self.create_type_index].0.to_string();
-    let spec = BranchSpec::new(type_, self.create_issue.clone(), self.create_desc.clone())?;
+    let type_ = self
+      .branch_types
+      .get(self.create_type_index)
+      .map(|t| t.name.clone())
+      .unwrap_or_default();
+    let spec = BranchSpec::new_with_types(
+      type_,
+      self.create_issue.clone(),
+      self.create_desc.clone(),
+      &self.branch_types,
+    )?;
     let branch = spec.branch_name(&self.config.worktree, &self.repo_name)?;
     let dirname = spec.worktree_dirname(&self.config.worktree, &self.repo_name)?;
     let target = spec.worktree_path(&self.config.worktree, &self.repo_name)?;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,7 +1,6 @@
 use super::app::{App, Field, GitHubFetchState, LinkPromptStage, View};
 use crate::bootstrap::StepStatus;
 use crate::github::{IssueState, LinkSource, PrState};
-use crate::naming::BRANCH_TYPES;
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
   layout::{Constraint, Direction, Layout, Rect},
@@ -941,8 +940,11 @@ fn draw_create(f: &mut Frame, app: &App) {
     ])
     .split(area);
 
-  let type_str = BRANCH_TYPES[app.create_type_index].0;
-  let type_desc = BRANCH_TYPES[app.create_type_index].1;
+  let (type_str, type_desc) = app
+    .branch_types
+    .get(app.create_type_index)
+    .map(|t| (t.name.as_str(), t.description.as_str()))
+    .unwrap_or(("", "(no branch types configured)"));
 
   f.render_widget(
     field_input(

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -210,6 +210,26 @@ description = "Database migration"
 }
 
 #[test]
+fn types_inside_bare_repo_falls_back_to_built_in_defaults() {
+  // Bare repos have no `workdir()`, so there's no place to look for a
+  // `.gwm.toml`. Regression: previously `cmd_types` would propagate a
+  // misleading `NotInGitRepo` error here even though `discover_repo`
+  // succeeded. The fallback is identical to the "outside any repo"
+  // branch — the built-in defaults with a `(source: built-in
+  // defaults)` footer.
+  let dir = tempfile::TempDir::new().unwrap();
+  git2::Repository::init_bare(dir.path()).expect("init bare repo");
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).arg("types");
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat"))
+    .stdout(predicate::str::contains("hotfix"))
+    .stdout(predicate::str::contains("(source: built-in defaults)"));
+}
+
+#[test]
 fn create_outside_git_repo_fails() {
   let dir = tempfile::TempDir::new().unwrap();
   let mut cmd = Command::cargo_bin("gwm").unwrap();

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -159,15 +159,54 @@ fn version_flag() {
 
 #[test]
 fn types_lists_branch_types() {
+  // Outside any repo (the temp cwd of `assert_cmd` is typically not a
+  // git repo on CI runners) `gwm types` must still list the built-in
+  // defaults and surface the `built-in defaults` footer so users can
+  // tell they're not looking at a `.gwm.toml` override.
+  let dir = tempfile::TempDir::new().unwrap();
   let mut cmd = Command::cargo_bin("gwm").unwrap();
-  cmd.arg("types");
+  cmd.current_dir(dir.path()).arg("types");
   cmd
     .assert()
     .success()
     .stdout(predicate::str::contains("feat"))
     .stdout(predicate::str::contains("fix"))
     .stdout(predicate::str::contains("hotfix"))
-    .stdout(predicate::str::contains("chore"));
+    .stdout(predicate::str::contains("chore"))
+    .stdout(predicate::str::contains("(source: built-in defaults)"));
+}
+
+#[test]
+fn types_lists_configured_branch_types_from_dot_gwm_toml() {
+  // When `.gwm.toml` carries a `[[branch_types]]` block, `gwm types`
+  // must reflect the override verbatim and update its source footer.
+  // The legacy entries that aren't in the override must NOT bleed
+  // through (e.g. `hotfix` is part of the built-in defaults but is
+  // intentionally absent from this repo's list).
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[[branch_types]]
+name = "feat"
+description = "Feature"
+
+[[branch_types]]
+name = "migration"
+description = "Database migration"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).arg("types");
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat"))
+    .stdout(predicate::str::contains("migration"))
+    .stdout(predicate::str::contains("Database migration"))
+    .stdout(predicate::str::contains("(source: .gwm.toml)"))
+    .stdout(predicate::str::contains("hotfix").not());
 }
 
 #[test]

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -660,3 +660,107 @@ fn branch_types_source_label_is_user_facing() {
   assert_eq!(BranchTypesSource::Default.label(), "built-in defaults");
   assert_eq!(BranchTypesSource::Config.label(), ".gwm.toml");
 }
+
+#[test]
+fn branch_types_empty_name_is_rejected_at_load() {
+  // An empty `name = ""` would silently produce a worktree on a branch
+  // called `/#123-foo` (no prefix) which git rejects with a cryptic
+  // error several layers down. Surface it as a config error early.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[[branch_types]]
+name = ""
+description = "Whoops"
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("branch_types"), "{msg}");
+  assert!(msg.contains("empty"), "{msg}");
+}
+
+#[test]
+fn branch_types_invalid_name_format_is_rejected_at_load() {
+  // `parse_branch` (the reverse mapping used by `gwm switch`, the TUI
+  // list, and every helper that recovers a `BranchSpec` from a free-
+  // form branch name) requires `^[a-z]+/#…$`. Anything that doesn't
+  // match the type segment regex must be rejected at load so the user
+  // sees one config-time error instead of a tangle of runtime
+  // failures across surfaces.
+  for bad in ["Feat", "feat-1", "wip task", "fix!", "1fix", ""].iter() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+      dir.path().join(CONFIG_FILE),
+      format!(
+        r#"
+[[branch_types]]
+name = "{}"
+description = "x"
+"#,
+        bad
+      ),
+    )
+    .unwrap();
+    assert!(
+      Config::load_for_repo(dir.path()).is_err(),
+      "name = {:?} must be rejected at load",
+      bad
+    );
+  }
+}
+
+#[test]
+fn branch_types_duplicate_name_is_rejected_at_load() {
+  // Two entries with the same name would non-deterministically
+  // override each other downstream (and the `gwm types` listing would
+  // confusingly print the same row twice). Fail fast at load.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[[branch_types]]
+name = "feat"
+description = "Feature"
+
+[[branch_types]]
+name = "feat"
+description = "Different description for the same name"
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("duplicate"), "{msg}");
+  assert!(msg.contains("feat"), "{msg}");
+}
+
+#[test]
+fn branch_types_valid_names_load_successfully() {
+  // Sanity: the validator must accept the canonical built-in names
+  // and a few realistic custom additions, otherwise it's too tight
+  // and the loosening of the rule would have to happen in a follow-up.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[[branch_types]]
+name = "feat"
+description = "Feature"
+
+[[branch_types]]
+name = "migration"
+description = "Database migration"
+
+[[branch_types]]
+name = "wip"
+description = "Work in progress"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).expect("valid config must load");
+  let names: Vec<_> = cfg.branch_types.iter().map(|t| t.name.as_str()).collect();
+  assert_eq!(names, vec!["feat", "migration", "wip"]);
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,6 @@
-use gwm::config::{expand_placeholders, review_tool_preset, Config, TuiOpenMode, WorktreeConfig, CONFIG_FILE};
+use gwm::config::{
+  expand_placeholders, review_tool_preset, BranchTypesSource, Config, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -577,4 +579,84 @@ mode = "neovim"
   )
   .unwrap();
   assert!(Config::load_for_repo(dir.path()).is_err());
+}
+
+// ---- [[branch_types]] (issue #80) ------------------------------------------
+
+#[test]
+fn branch_types_absent_falls_back_to_built_in_defaults() {
+  // The zero-friction contract: a repo without `[[branch_types]]` in
+  // its `.gwm.toml` (or with no config at all) keeps the historical
+  // built-in list. The source must report `Default` so `gwm types` can
+  // surface a truthful footer.
+  let cfg = Config::default();
+  let resolved = cfg.resolved_branch_types();
+  assert_eq!(resolved.source, BranchTypesSource::Default);
+  assert!(
+    resolved.types.iter().any(|t| t.name == "feat"),
+    "default list must include the legacy `feat` entry"
+  );
+  assert!(
+    resolved.types.iter().any(|t| t.name == "hotfix"),
+    "default list must include `hotfix` (regression guard against partial defaults)"
+  );
+}
+
+#[test]
+fn branch_types_parsed_from_toml_replaces_defaults() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[[branch_types]]
+name = "feat"
+description = "New feature implementation"
+
+[[branch_types]]
+name = "fix"
+description = "Bug fix"
+
+[[branch_types]]
+name = "migration"
+description = "Database migration"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let resolved = cfg.resolved_branch_types();
+  assert_eq!(resolved.source, BranchTypesSource::Config);
+  let names: Vec<_> = resolved.types.iter().map(|t| t.name.as_str()).collect();
+  assert_eq!(names, vec!["feat", "fix", "migration"]);
+  // Built-in entries that aren't in the config are dropped — the user's
+  // list is authoritative once they opt in.
+  assert!(!names.contains(&"hotfix"));
+  assert!(!names.contains(&"chore"));
+}
+
+#[test]
+fn branch_types_empty_block_treated_as_absent() {
+  // An empty TOML array (`branch_types = []`) is observationally
+  // identical to omitting the section — neither should replace the
+  // built-in defaults with an empty list (which would lock the user
+  // out of `gwm create`).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+branch_types = []
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let resolved = cfg.resolved_branch_types();
+  assert_eq!(resolved.source, BranchTypesSource::Default);
+  assert!(!resolved.types.is_empty());
+}
+
+#[test]
+fn branch_types_source_label_is_user_facing() {
+  // Footer strings rendered by `gwm types` — pin them so a label tweak
+  // shows up in code review instead of slipping through.
+  assert_eq!(BranchTypesSource::Default.label(), "built-in defaults");
+  assert_eq!(BranchTypesSource::Config.label(), ".gwm.toml");
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -1,5 +1,5 @@
-use gwm::config::WorktreeConfig;
-use gwm::naming::{kebab, parse_branch, BranchSpec, BRANCH_TYPES};
+use gwm::config::{BranchType, WorktreeConfig};
+use gwm::naming::{default_branch_types, kebab, parse_branch, BranchSpec, BRANCH_TYPES};
 
 #[test]
 fn kebab_normalizes() {
@@ -70,6 +70,63 @@ fn renders_paths() {
   assert_eq!(spec.worktree_dirname(&cfg, "myrepo").unwrap(), "feat-10-x");
   let p = spec.worktree_path(&cfg, "myrepo").unwrap();
   assert!(p.to_string_lossy().ends_with("/cc-worktree/myrepo/feat-10-x"));
+}
+
+#[test]
+fn default_branch_types_matches_const_table() {
+  let runtime = default_branch_types();
+  assert_eq!(runtime.len(), BRANCH_TYPES.len());
+  for ((cname, cdesc), bt) in BRANCH_TYPES.iter().zip(runtime.iter()) {
+    assert_eq!(*cname, bt.name);
+    assert_eq!(*cdesc, bt.description);
+  }
+}
+
+#[test]
+fn new_with_custom_types_rejects_default_built_in() {
+  let custom = vec![BranchType {
+    name: "migration".into(),
+    description: "Database migration".into(),
+  }];
+  // `feat` is a built-in default but is NOT in the custom override.
+  let err = BranchSpec::new_with_types("feat", "1", "x", &custom).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("invalid branch type 'feat'"), "got: {msg}");
+  assert!(
+    msg.contains("migration"),
+    "error must list the allowed types — got: {msg}"
+  );
+  assert!(
+    !msg.contains("feat, fix"),
+    "error must not leak the built-in default list — got: {msg}"
+  );
+}
+
+#[test]
+fn new_with_custom_types_accepts_listed_name() {
+  let custom = vec![
+    BranchType {
+      name: "feat".into(),
+      description: "Feature".into(),
+    },
+    BranchType {
+      name: "migration".into(),
+      description: "Database migration".into(),
+    },
+  ];
+  let spec = BranchSpec::new_with_types("migration", "42", "users-table", &custom).expect("ok");
+  assert_eq!(spec.type_, "migration");
+}
+
+#[test]
+fn invalid_type_error_lists_allowed_names_from_defaults() {
+  let err = BranchSpec::new("nope", "1", "x").unwrap_err();
+  let msg = format!("{}", err);
+  // Every built-in name must be enumerated so the user knows what's
+  // accepted in this repo without having to re-read the docs.
+  for (name, _) in BRANCH_TYPES {
+    assert!(msg.contains(name), "expected {name} in error message, got: {msg}");
+  }
 }
 
 #[test]


### PR DESCRIPTION
## Description

Promote `BRANCH_TYPES` from a hardcoded const in `src/naming.rs` to a
configurable `[[branch_types]]` table in `.gwm.toml`. Absent or empty
block ⇒ the historical built-in defaults stay in effect (zero friction
for existing repos); present ⇒ the listed types are the only ones
accepted by `gwm create`, the TUI create picker and
`BranchSpec::validate()`. `gwm types` prints the resolved list with a
`(source: built-in defaults | .gwm.toml)` footer.

Closes #80

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `Config` gains a `branch_types: Vec<BranchType>` field plus a
  `resolved_branch_types() -> ResolvedBranchTypes` single lookup site;
  `BranchTypesSource::{Default, Config}` makes the origin observable.
- `BranchSpec::new_with_types` / `validate_against(&[BranchType])` feed
  the validator a per-repo allowed list; legacy `new` / `validate`
  delegate to the built-in defaults via `default_branch_types()` so no
  external behaviour changes for unconfigured repos.
- `GwmError::InvalidBranchType` is now `{ got, allowed }` so the error
  message enumerates the *actual* allowed names instead of leaking the
  hardcoded set.
- `gwm create`, `gwm types` and the TUI create picker all resolve the
  list once at startup / invocation and use it consistently.
- `examples/gwm.toml.example` carries a commented `[[branch_types]]`
  block with the "empty array = restore defaults" footgun-fix called
  out, so a user can't accidentally lock themselves out of `gwm create`.

## Tests

- [x] `cargo test` passes locally (all 17 binaries, including
      `cargo test` under a stripped `PATH` to mirror the CI environment)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`:
  - `tests/config_tests.rs` — `branch_types_absent_falls_back_to_built_in_defaults`,
    `branch_types_parsed_from_toml_replaces_defaults`,
    `branch_types_empty_block_treated_as_absent`,
    `branch_types_source_label_is_user_facing`
  - `tests/naming_tests.rs` — `default_branch_types_matches_const_table`,
    `new_with_custom_types_rejects_default_built_in`,
    `new_with_custom_types_accepts_listed_name`,
    `invalid_type_error_lists_allowed_names_from_defaults`
  - `tests/cli_binary.rs` — `types_lists_configured_branch_types_from_dot_gwm_toml`;
    `types_lists_branch_types` updated to assert the new
    `(source: built-in defaults)` footer

## Screenshots / TUI captures

```
$ gwm types                            # no [[branch_types]] in .gwm.toml
  feat      New feature implementation
  fix       Bug fix
  hotfix    Critical production bug fix
  …
  build     Build system changes

(source: built-in defaults)
```

```
$ gwm types                            # with [[branch_types]] block
  feat       Feature
  migration  Database migration

(source: .gwm.toml)
```

```
$ gwm create wip 42 some-thing         # error message now lists the resolved list
error: invalid branch type 'wip' (allowed: feat, migration)
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#80-config-branch-types`)
- [x] Commits follow Gitmoji + Conventional Commits (refactor → 2× feat → docs)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (footer is documented in
      `examples/gwm.toml.example`; the README points there)
- [x] `examples/gwm.toml.example` updated (new `[[branch_types]]` block)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #80
- Related PR: —

## Notes for reviewers

The cleanest review path is:
1. `src/config.rs` — `BranchType`, `BranchTypesSource`, `ResolvedBranchTypes`, `Config::resolved_branch_types`
2. `src/naming.rs` + `src/error.rs` — validation surface change
3. `src/cli.rs` + `src/tui/{app,ui}.rs` — wiring
4. `examples/gwm.toml.example` + `CHANGELOG.md` — docs

The aliases knob (`aliases = ["feature"]`) called out in #80 is
intentionally **not** implemented in this PR — kept YAGNI for a future
iteration so the validator contract stays minimal here. Serde silently
tolerates extra fields, so a config with `aliases` won't error out today
(the alias just isn't honoured).