### PR TITLE
✅ test(cli,worktree): E2E coverage for init / create / remove (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Requires `gh` on `$PATH` (already a soft dependency of `gwm status`).
 - ✨ `[[branch_types]]` block in `.gwm.toml` overrides the built-in allowed branch types. Absent or empty block ⇒ historical defaults (`feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`); present ⇒ only the listed types are accepted by `gwm create`, the TUI create picker and `BranchSpec::validate()`. `gwm types` prints the resolved list with a `(source: built-in defaults | .gwm.toml)` footer and aligns columns on the longest name. Invalid-type errors now enumerate the repo-local allowed list verbatim instead of leaking the hardcoded set. Entries are validated at load time: `name` must be non-empty, match `^[a-z]+$`, and be unique. (#80)
 
+### Tests
+
+- ✅ E2E coverage for the mutating subcommands (#101). `tests/cli_binary.rs` now exercises `gwm init` (default body shape, idempotency refusal on existing `.gwm.toml`, repo-bound contract), `gwm create` (worktree dir + branch creation at HEAD, `branch.<name>.gwm-base` recorded for the launcher fallback chain, `[[bootstrap.copy]]` runs by default but is skipped under `--no-bootstrap`, validation rejects unknown branch types and non-digit issue numbers), and `gwm remove` (deletes the worktree dir, `--delete-branch` drops the local branch, unknown patterns fail loudly). All worktree-creating tests pin `[worktree].base` to a `tempfile::TempDir` so the CI runner never writes under `~/cc-worktree/...`.
+- ✅ Characterization tests in `tests/worktree_integration.rs` for issues [#98](https://github.com/kbrdn1/gwm-cli/issues/98) and [#99](https://github.com/kbrdn1/gwm-cli/issues/99). `add_silently_attaches_to_pre_existing_stale_branch` pins the current (buggy) reuse behaviour of `worktree::add` when the target branch already exists — a fix for #99 will turn this test red and force the reviewer to confirm the contract change. `remove_prunes_admin_files_on_happy_path` pins the post-condition that `.git/worktrees/<name>` is gone after a successful `worktree::remove` — the post-condition that #98's reorder fix must preserve.
+
 ## Past releases
 
 In reverse chronological order:

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -6,6 +6,7 @@ mod common;
 use assert_cmd::Command;
 use common::init_repo;
 use predicates::prelude::*;
+use std::path::Path;
 
 #[test]
 fn help_prints_subcommands() {
@@ -925,4 +926,399 @@ fn status_on_branch_with_no_link_reports_no_link() {
     .assert()
     .success()
     .stdout(predicate::str::contains("no link"));
+}
+
+// --------------------------------------------------------------------------
+// Issue #101 — E2E tests for the mutating subcommands (init / create / remove)
+// --------------------------------------------------------------------------
+//
+// `cli_binary.rs` historically asserted only `--help` output and a handful
+// of read-only error paths. The three subcommands that mutate state on
+// disk (`init`, `create`, `remove`) had no end-to-end coverage, which let
+// orchestration-layer regressions (e.g. issues #98 and #99) slip through
+// unit-test review. The block below is the canonical CI signal for the
+// CLI surface of those subcommands.
+//
+// Worktree-creating tests pin `[worktree].base` to a `tempfile::TempDir`
+// so the test runner never writes under `~/cc-worktree/...`. The branch
+// pattern is left at its default (`{type}/#{issue}-{desc}`) to exercise
+// the production naming pipeline.
+
+// --- init ---------------------------------------------------------------
+
+#[test]
+fn init_writes_gwm_toml_with_expected_sections() {
+  // The default `.gwm.toml` shipped by `gwm init` is sourced from
+  // `examples/gwm.toml.example`. Asserting on the exact contents would
+  // couple the test to the example file character-for-character; we pin
+  // the structural markers a user (and the rest of the codebase) relies
+  // on: a `[worktree]` block with the documented placeholders, a
+  // `[[bootstrap.copy]]` entry, and a `[[bootstrap.guard]]` entry. The
+  // stdout line names the written path so users discover where it landed.
+  let (dir, _repo) = init_repo();
+  let cfg_path = dir.path().join(".gwm.toml");
+  assert!(!cfg_path.exists(), "precondition: no .gwm.toml in fresh repo");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .arg("init")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(".gwm.toml"));
+
+  assert!(cfg_path.exists(), "gwm init must write .gwm.toml on disk");
+  let body = std::fs::read_to_string(&cfg_path).unwrap();
+  assert!(body.contains("[worktree]"), "missing [worktree] section");
+  assert!(
+    body.contains("base = ") && body.contains("{home}") && body.contains("{repo}"),
+    "missing documented placeholders in [worktree].base"
+  );
+  assert!(
+    body.contains("[[bootstrap.copy]]"),
+    "missing [[bootstrap.copy]] template"
+  );
+  assert!(
+    body.contains("[[bootstrap.guard]]"),
+    "missing [[bootstrap.guard]] template"
+  );
+}
+
+#[test]
+fn init_refuses_to_overwrite_existing_gwm_toml() {
+  // Idempotency contract: a second `gwm init` on a repo that already
+  // carries a `.gwm.toml` must bail out instead of silently clobbering
+  // user edits. The error must name the file so the user knows what to
+  // remove if they truly want to start over.
+  let (dir, _repo) = init_repo();
+  let cfg_path = dir.path().join(".gwm.toml");
+  std::fs::write(&cfg_path, "# user edits\n[worktree]\nbase = \"/custom\"\n").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .arg("init")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains(".gwm.toml"));
+
+  // Original contents must survive the failed init.
+  let body = std::fs::read_to_string(&cfg_path).unwrap();
+  assert!(
+    body.contains("# user edits"),
+    "failed gwm init must not modify the existing .gwm.toml"
+  );
+}
+
+#[test]
+fn init_outside_git_repo_fails() {
+  // `cmd_init` calls `discover_repo` first — the standard `NotInGitRepo`
+  // error wins so the user is steered to `git init` before configuring.
+  let dir = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .arg("init")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+// --- create -------------------------------------------------------------
+
+/// Write a `.gwm.toml` that redirects `[worktree].base` into the test's
+/// own `TempDir`. Returns the resolved base path so the test can assert
+/// on the created worktree directory directly. Bootstrap is left empty
+/// by default so `gwm create` runs in its minimal shape; tests that
+/// need bootstrap behaviour layer a second `.gwm.toml` write on top.
+fn write_test_config(repo_root: &Path, base: &Path) {
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+"#,
+    base = base.display(),
+  );
+  std::fs::write(repo_root.join(".gwm.toml"), body).unwrap();
+}
+
+#[test]
+fn create_adds_worktree_dir_and_branch_at_head() {
+  // The full happy path through `cmd_create`:
+  //   1. The dirname rendered from `[worktree].path_pattern` lands on disk
+  //      under the configured `[worktree].base`.
+  //   2. The branch rendered from `[worktree].branch_pattern` is created
+  //      as a local ref pointing at the seed commit (`init_repo`'s HEAD).
+  //   3. `branch.<name>.gwm-base` is recorded as the parent's short name
+  //      (the launcher fallback chain depends on it — issue #75).
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+  let head_oid = repo.head().unwrap().target().unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "42", "tui-search"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat/#42-tui-search"))
+    .stdout(predicate::str::contains("worktree created"));
+
+  let wt_dir = base.path().join("feat-42-tui-search");
+  assert!(wt_dir.exists(), "worktree dir must exist on disk");
+  assert!(wt_dir.join(".git").exists(), "worktree must carry a .git pointer");
+
+  let branch = repo
+    .find_branch("feat/#42-tui-search", git2::BranchType::Local)
+    .expect("branch must be created");
+  let branch_oid = branch.into_reference().target().unwrap();
+  assert_eq!(branch_oid, head_oid, "fresh branch must point at the main HEAD commit");
+
+  let cfg = repo.config().unwrap();
+  let recorded_base = cfg.get_string("branch.feat/#42-tui-search.gwm-base").unwrap();
+  assert_eq!(
+    recorded_base, "main",
+    "gwm create must record the parent ref for the launcher fallback chain"
+  );
+}
+
+#[test]
+fn create_runs_bootstrap_by_default() {
+  // A `[[bootstrap.copy]]` step lands its destination file inside the
+  // freshly-created worktree iff bootstrap actually ran. The source file
+  // lives in the main repo's workdir; we pin a unique marker string so a
+  // false positive (e.g. a cargo lock file collision) can't pass the
+  // assertion by accident.
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let marker = "GWM_E2E_BOOTSTRAP_MARKER_v1";
+  std::fs::write(dir.path().join("seed.env"), marker).unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[bootstrap.copy]]
+from = "seed.env"
+to = "seed.env"
+required = true
+"#,
+    base = base.path().display(),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "7", "bootstrap-on"])
+    .assert()
+    .success();
+
+  let copied = base.path().join("feat-7-bootstrap-on").join("seed.env");
+  assert!(copied.exists(), "bootstrap copy step did not run");
+  let body = std::fs::read_to_string(&copied).unwrap();
+  assert!(
+    body.contains(marker),
+    "bootstrap copy must duplicate the source file content"
+  );
+}
+
+#[test]
+fn create_skips_bootstrap_with_no_bootstrap_flag() {
+  // Same scaffolding as the previous test, but `--no-bootstrap` must
+  // short-circuit `bootstrap::run` BEFORE the copy step. The worktree
+  // directory still appears (the branch + worktree are created first),
+  // but `seed.env` is absent inside it. The stdout breadcrumb that
+  // `cmd_create` prints when it skips makes the intent observable.
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  std::fs::write(dir.path().join("seed.env"), "marker").unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[bootstrap.copy]]
+from = "seed.env"
+to = "seed.env"
+required = true
+"#,
+    base = base.path().display(),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "8", "bootstrap-off", "--no-bootstrap"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("skipped bootstrap"));
+
+  let wt_dir = base.path().join("feat-8-bootstrap-off");
+  assert!(wt_dir.exists(), "worktree dir must still be created");
+  assert!(
+    !wt_dir.join("seed.env").exists(),
+    "--no-bootstrap must prevent the copy step from running"
+  );
+}
+
+#[test]
+fn create_rejects_unknown_branch_type() {
+  // `BranchSpec::validate` rejects branch types outside the built-in /
+  // configured allow-list before any filesystem operation. We must see
+  // the failure surface on stderr with the offending value so the user
+  // can grep their command history without re-running.
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "blarg", "9", "nope"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("blarg"));
+
+  assert!(
+    !base.path().join("blarg-9-nope").exists(),
+    "no worktree dir may be created when branch-type validation fails"
+  );
+}
+
+#[test]
+fn create_rejects_non_digit_issue() {
+  // Issue must be digits-only — `abc` is rejected by `BranchSpec::new`.
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "abc", "thing"])
+    .assert()
+    .failure();
+}
+
+#[test]
+fn create_subcommand_outside_git_repo_fails() {
+  // The repo-bound contract: outside any git repo the standard
+  // `NotInGitRepo` error wins, no worktree is touched. Named with the
+  // `_subcommand_` infix to avoid colliding with the historical
+  // `create_outside_git_repo_fails` test (line ~327) that — despite the
+  // name — actually exercises `gwm list`.
+  let dir = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "1", "x"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+// --- remove -------------------------------------------------------------
+
+#[test]
+fn remove_deletes_worktree_dir_and_keeps_branch_by_default() {
+  // Without `--delete-branch`, `gwm remove` is the inverse of `gwm
+  // create` for the on-disk directory only: the worktree dir disappears
+  // (and so does its admin entry under `.git/worktrees/`), but the
+  // local branch survives so the user can re-create the worktree from
+  // it later. Stdout names the dir for visual confirmation.
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "10", "remove-me"])
+    .assert()
+    .success();
+  let wt_dir = base.path().join("feat-10-remove-me");
+  assert!(wt_dir.exists());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "remove-me"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("removed"));
+
+  assert!(!wt_dir.exists(), "remove must delete the worktree directory");
+  assert!(
+    repo.find_branch("feat/#10-remove-me", git2::BranchType::Local).is_ok(),
+    "remove without --delete-branch must keep the local branch"
+  );
+}
+
+#[test]
+fn remove_with_delete_branch_drops_branch() {
+  // The `--delete-branch` flag drops the local branch in the same
+  // command. The stdout breadcrumb names both the worktree dir and the
+  // branch so two destructive operations are surfaced explicitly.
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "11", "drop-branch"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "drop-branch", "--delete-branch"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("branch"))
+    .stdout(predicate::str::contains("deleted"));
+
+  assert!(
+    repo
+      .find_branch("feat/#11-drop-branch", git2::BranchType::Local)
+      .is_err(),
+    "--delete-branch must remove the local branch ref"
+  );
+}
+
+#[test]
+fn remove_unknown_pattern_fails() {
+  // Fuzzy lookup must error loudly when nothing matches — silently
+  // doing nothing would mask a user typo and leave them wondering why
+  // their worktree is still around.
+  let (dir, _repo) = init_repo();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "ghost"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn remove_outside_git_repo_fails() {
+  let dir = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "anything"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -988,8 +988,11 @@ fn init_writes_gwm_toml_with_expected_sections() {
 fn init_refuses_to_overwrite_existing_gwm_toml() {
   // Idempotency contract: a second `gwm init` on a repo that already
   // carries a `.gwm.toml` must bail out instead of silently clobbering
-  // user edits. The error must name the file so the user knows what to
-  // remove if they truly want to start over.
+  // user edits. The error must name the file *and* explain why so the
+  // user knows what to remove if they truly want to start over. Pin
+  // the exact "already exists" wording from `Config::write_default`
+  // (src/config.rs) — a looser `.gwm.toml` contains-check would also
+  // pass on a success run since the success path prints the same path.
   let (dir, _repo) = init_repo();
   let cfg_path = dir.path().join(".gwm.toml");
   std::fs::write(&cfg_path, "# user edits\n[worktree]\nbase = \"/custom\"\n").unwrap();
@@ -1000,7 +1003,8 @@ fn init_refuses_to_overwrite_existing_gwm_toml() {
     .arg("init")
     .assert()
     .failure()
-    .stderr(predicate::str::contains(".gwm.toml"));
+    .stderr(predicate::str::contains(".gwm.toml"))
+    .stderr(predicate::str::contains("already exists"));
 
   // Original contents must survive the failed init.
   let body = std::fs::read_to_string(&cfg_path).unwrap();
@@ -1197,7 +1201,13 @@ fn create_rejects_unknown_branch_type() {
 
 #[test]
 fn create_rejects_non_digit_issue() {
-  // Issue must be digits-only — `abc` is rejected by `BranchSpec::new`.
+  // Issue must be digits-only — `abc` is rejected by `BranchSpec::new`
+  // before any filesystem op. As with the unknown-branch-type test,
+  // assert the no-side-effect invariant explicitly: the worktree dir
+  // that *would* have been written (`<base>/feat-abc-thing`) must not
+  // appear on disk. Otherwise a regression where validation runs
+  // post-`worktree::add` could still satisfy a bare `.failure()` check
+  // while leaving stray dirs behind.
   let (dir, _repo) = init_repo();
   let base = tempfile::TempDir::new().unwrap();
   write_test_config(dir.path(), base.path());
@@ -1208,6 +1218,11 @@ fn create_rejects_non_digit_issue() {
     .args(["create", "feat", "abc", "thing"])
     .assert()
     .failure();
+
+  assert!(
+    !base.path().join("feat-abc-thing").exists(),
+    "no worktree dir may be created when issue-number validation fails"
+  );
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1027,8 +1027,9 @@ fn init_outside_git_repo_fails() {
 // --- create -------------------------------------------------------------
 
 /// Write a `.gwm.toml` that redirects `[worktree].base` into the test's
-/// own `TempDir`. Returns the resolved base path so the test can assert
-/// on the created worktree directory directly. Bootstrap is left empty
+/// own `TempDir`. The caller already owns the `base` path (it's the
+/// `TempDir` they passed in), so the test asserts on `base.join(...)`
+/// directly — this helper has no return value. Bootstrap is left empty
 /// by default so `gwm create` runs in its minimal shape; tests that
 /// need bootstrap behaviour layer a second `.gwm.toml` write on top.
 fn write_test_config(repo_root: &Path, base: &Path) {

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -422,8 +422,9 @@ fn add_silently_attaches_to_pre_existing_stale_branch() {
   let (_dir, repo) = init_repo();
   let sig = Signature::now("gwm-test", "gwm@test").unwrap();
 
-  // Create a "stale" branch ahead of main, then move HEAD forward so the
-  // branch and HEAD point at different commits.
+  // Pin a "stale" branch at the current main commit, then advance main
+  // by one commit so the branch ends up BEHIND HEAD. The point is just
+  // to make HEAD and the branch tip resolve to different OIDs.
   let main_oid = repo.head().unwrap().target().unwrap();
   let main_commit = repo.find_commit(main_oid).unwrap();
   let stale_branch = repo.branch("feat/#99-stale", &main_commit, false).unwrap();

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -398,3 +398,91 @@ fn commit_with_time(workdir: &Path, repo: &Repository, ref_name: &str, message: 
     .commit(Some(ref_name), &sig, &sig, message, &tree, &[&parent])
     .unwrap();
 }
+
+// --------------------------------------------------------------------------
+// Issue #101 — characterization tests for the mutating worktree primitives.
+// --------------------------------------------------------------------------
+//
+// These complement the CLI-level E2E tests in `tests/cli_binary.rs` by
+// pinning the libgit2-level contract of `worktree::add` / `worktree::remove`.
+// The first test below intentionally documents the *current* behaviour that
+// powers bug #99 — when issue #99 is fixed the contract changes and the
+// assertion must be updated. Pinning the buggy contract now means the fix
+// can't land silently: the test goes red and forces the reviewer to confirm
+// the new behaviour intentionally.
+
+#[test]
+fn add_silently_attaches_to_pre_existing_stale_branch() {
+  // Characterization test for #99. `worktree::add(repo, name, path, branch)`
+  // currently *reuses* a local branch of the same name when one already
+  // exists, attaching the new worktree to its existing tip rather than
+  // refusing the operation or moving the branch to HEAD. This is the
+  // observable contract today; a fix for #99 will introduce a `--reuse`
+  // flag (or similar) and turn this test red on purpose.
+  let (_dir, repo) = init_repo();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+
+  // Create a "stale" branch ahead of main, then move HEAD forward so the
+  // branch and HEAD point at different commits.
+  let main_oid = repo.head().unwrap().target().unwrap();
+  let main_commit = repo.find_commit(main_oid).unwrap();
+  let stale_branch = repo.branch("feat/#99-stale", &main_commit, false).unwrap();
+  let stale_oid = stale_branch.into_reference().target().unwrap();
+
+  // Advance main by one commit so HEAD != stale branch tip.
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  let new_head = repo
+    .commit(Some("HEAD"), &sig, &sig, "advance main", &tree, &[&main_commit])
+    .unwrap();
+  assert_ne!(new_head, stale_oid, "precondition: HEAD must diverge from stale branch");
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-99-stale");
+  worktree::add(&repo, "feat-99-stale", &target, "feat/#99-stale").unwrap();
+
+  // Documented buggy behaviour: the branch tip is unchanged (still at
+  // the stale commit), NOT moved to HEAD.
+  let resolved = repo
+    .find_branch("feat/#99-stale", git2::BranchType::Local)
+    .unwrap()
+    .into_reference()
+    .target()
+    .unwrap();
+  assert_eq!(
+    resolved, stale_oid,
+    "characterization for #99: stale branch tip is reused as-is; \
+     when #99 lands, update this assertion to reflect the fix"
+  );
+  assert!(target.exists(), "worktree dir must still appear on disk");
+}
+
+#[test]
+fn remove_prunes_admin_files_on_happy_path() {
+  // Companion characterization for #98 — the happy path. After `remove`
+  // succeeds, the admin directory under `.git/worktrees/<name>` must be
+  // gone so `find_worktree` can no longer resolve a phantom entry. This
+  // pins the post-condition that #98's fix must preserve (the fix
+  // reorders prune-before-rmdir; the post-condition itself doesn't
+  // change).
+  let (dir, _repo) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-98-prune");
+  worktree::add(&repo, "feat-98-prune", &target, "feat/#98-prune").unwrap();
+
+  let admin_dir = dir.path().join(".git").join("worktrees").join("feat-98-prune");
+  assert!(admin_dir.exists(), "precondition: admin entry exists after add");
+
+  worktree::remove(&repo, "feat-98-prune", false).unwrap();
+
+  assert!(!target.exists(), "remove must delete the worktree dir");
+  assert!(
+    !admin_dir.exists(),
+    "remove must also prune the admin entry under .git/worktrees/"
+  );
+  assert!(
+    repo.find_worktree("feat-98-prune").is_err(),
+    "libgit2 must no longer resolve the pruned worktree by name"
+  );
+}


### PR DESCRIPTION
## Description

Adds end-to-end test coverage for the mutating subcommands (`gwm init`, `gwm create`, `gwm remove`) plus two libgit2-level characterization tests that pin the current contracts of `worktree::add` / `worktree::remove`. Until now `tests/cli_binary.rs` exercised only `--help` output and a handful of read-only error paths — the orchestration layer of the mutating commands had no CI signal.

Closes #101

## Type of change

- [x] ✅ Tests

## Changes

- **`tests/cli_binary.rs`** — 13 new E2E tests against the compiled binary via `assert_cmd`:
  - `gwm init`: default body shape (`[worktree]` placeholders, `[[bootstrap.copy]]`, `[[bootstrap.guard]]`), idempotency refusal on an existing `.gwm.toml` (preserves user edits), `NotInGitRepo` outside any repo.
  - `gwm create`: worktree dir + branch created at HEAD, `branch.<name>.gwm-base` recorded for the launcher fallback chain (#75), `[[bootstrap.copy]]` runs by default but is skipped under `--no-bootstrap`, validation rejects unknown branch types and non-digit issue numbers, `NotInGitRepo` outside any repo.
  - `gwm remove`: worktree dir deleted, branch kept by default, `--delete-branch` drops it, unknown pattern fails loudly with `not found`, `NotInGitRepo` outside any repo.
  - All worktree-creating tests pin `[worktree].base` to a `tempfile::TempDir` so CI runners never write under `~/cc-worktree/...`.
- **`tests/worktree_integration.rs`** — 2 characterization tests:
  - `add_silently_attaches_to_pre_existing_stale_branch` documents the **current** buggy behaviour for issue #99 (stale branch reused as-is). A fix for #99 will turn this test red on purpose and force the reviewer to confirm the new contract.
  - `remove_prunes_admin_files_on_happy_path` pins the post-condition that `.git/worktrees/<name>` is gone after a successful `worktree::remove`. The post-condition #98's reorder fix must preserve.
- **`CHANGELOG.md`** — entries under `[Unreleased] > Tests` describing both blocks.

## Tests

- [x] `cargo test` passes locally (full suite green; new CLI block: 13 tests added, total `cli_binary` now 74; new worktree block: 2 tests added, total `worktree_integration` now 27)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Re-ran the suite under a minimal `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin"` to validate behaviour in a CI-like stripped environment (per `CLAUDE.md` rule on env-dependent tests). No regressions.
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

N/A — no TUI / CLI surface change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`test/#101-e2e-mutating-subcommands`)
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md) — 3 atomic commits grouped by concern (`test(cli)` / `test(worktree)` / `docs(changelog)`)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — N/A (no surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed — N/A (no schema change)
- [x] No `unwrap()` on user-facing paths — N/A (tests-only PR; `.unwrap()` inside tests is intentional)
- [x] No `println!` in TUI render code — N/A (tests-only PR)

## Linked issues / docs

- Issue: #101
- Sibling bug issues pinned by the characterization tests: #98 (remove prune ordering), #99 (create stale-branch reuse)

## Notes for reviewers

- The two characterization tests in `tests/worktree_integration.rs` are intentionally locked to the **current buggy behaviour** for #98 / #99. When those bugs are fixed, the tests will go red — that is the design: the fix can't land silently because the reviewer is forced to confirm the new contract in the same PR. The tests are also commented to make that intent explicit.
- The `gwm create` E2E test for the bootstrap path uses a `[[bootstrap.copy]]` of a small marker file written into the seed repo; the marker string (`GWM_E2E_BOOTSTRAP_MARKER_v1`) is deliberately unique so a false positive can't pass the assertion by accident.
- I noticed `tests/cli_binary.rs:327` already has a test named `create_outside_git_repo_fails` that — despite the name — actually exercises `gwm list`. I left it as-is and named the new test `create_subcommand_outside_git_repo_fails` to avoid colliding. Happy to rename the legacy one in a follow-up if reviewers prefer.