### PR TITLE
📝 docs: complete TOFU trust ledger coverage (#114)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thanks for your interest in `gwm` — a Rust CLI / TUI for managing git worktree
 `gwm` is a single-binary Rust crate (`bin` + reusable `lib`):
 
 - **bin** `gwm` — entry point: dispatches to subcommands (CLI) or opens the TUI.
-- **lib** `gwm` — modules (`config`, `naming`, `worktree`, `bootstrap`, `cli`, `tui`, `error`) exposed publicly so integration tests in `tests/` can drive them directly.
+- **lib** `gwm` — modules (`config`, `naming`, `worktree`, `bootstrap`, `cli`, `tui`, `error`, `trust`, `doctor`, `github`, `labels`, `milestones`, `launcher`, `multiplexer`) exposed publicly so integration tests in `tests/` can drive them directly.
 
 It uses [`git2`](https://docs.rs/git2) (vendored libgit2) for worktree operations and [`ratatui`](https://docs.rs/ratatui) for the TUI.
 
@@ -43,6 +43,13 @@ gwm-cli/
 │   ├── naming.rs         # branch / path conventions
 │   ├── worktree.rs       # libgit2 worktree ops
 │   ├── bootstrap.rs      # copies / guards / shell hooks
+│   ├── trust.rs          # TOFU ledger gating bootstrap (issue #95)
+│   ├── doctor.rs         # 7 health checks for `gwm doctor`
+│   ├── github.rs         # gh shell-out + issue / PR linking
+│   ├── labels.rs         # declarative GitHub label set (issue #81)
+│   ├── milestones.rs     # declarative GitHub milestone set (issue #82)
+│   ├── launcher.rs       # `l` / `R` TUI launcher resolution (issue #75)
+│   ├── multiplexer.rs    # tmux / zellij window+split helpers
 │   ├── cli.rs            # clap subcommands
 │   └── tui/
 │       ├── mod.rs        # event loop
@@ -53,6 +60,7 @@ gwm-cli/
     ├── config_tests.rs
     ├── naming_tests.rs
     ├── bootstrap_tests.rs
+    ├── trust_tests.rs    # ledger load/save/lookup/record/revoke (issue #95)
     ├── worktree_integration.rs
     ├── tui_app_tests.rs
     └── cli_binary.rs     # assert_cmd end-to-end

--- a/docs/1.getting-started/2.first-worktree.md
+++ b/docs/1.getting-started/2.first-worktree.md
@@ -37,6 +37,26 @@ Available placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`. Tilde
 
 The `{desc}` slot is **kebab-case normalised** by gwm — `"User Authentication"`, `"user authentication"`, and `"User_Authentication"` all become `user-authentication` on disk and in the branch name. This keeps shell completion and fuzzy lookup deterministic.
 
+## the trust prompt (first run only)
+
+If the repo has a `.gwm.toml` declaring a bootstrap surface (copies, guards, no-symlinks, or commands), the **first** `gwm create` on that repo opens a one-shot trust prompt before touching anything:
+
+```
+gwm: this repo's .gwm.toml has not been trusted yet.
+     path   : /path/to/repo/.gwm.toml
+     origin : git@github.com:foo/bar.git
+     hash   : 3a4f9c2bdeadbeef...
+     bootstrap surface:
+       - copy   .env.testing → .env.testing
+       - run    composer install (composer install --no-interaction)
+
+Trust this .gwm.toml? [y/N/show]:
+```
+
+`y` records the approval in `~/.config/gwm/trust.toml` and proceeds, `N` aborts (the worktree is **not** created — no orphaned state), `show` re-prints the raw `.gwm.toml` for inspection. Subsequent runs on the same repo pass silently until `.gwm.toml` changes (any byte edit re-prompts).
+
+For CI runners and other non-interactive contexts, bypass with `--allow-bootstrap` or `GWM_ALLOW_BOOTSTRAP=1`. The bypass does not record an entry, so an interactive run on the same machine later still prompts. See [Configuration → TOFU trust ledger](/configuration/trust-ledger) for the full threat model and ledger management commands (`gwm trust list / revoke / show`).
+
 ## the bootstrap pipeline
 
 If a `.gwm.toml` is present at the repo root, `gwm create` runs its bootstrap pipeline immediately after the `git worktree add`:

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -15,9 +15,9 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `↓` / `j`   | next worktree (scrolls the sidebar when it has focus)                                             |
 | `gg`        | jump to the first worktree                                                                        |
 | `G`         | jump to the last worktree                                                                         |
-| `n`         | new worktree (form: type → issue → description)                                                   |
+| `n`         | new worktree (form: type → issue → description) · gated by the [TOFU trust ledger](/configuration/trust-ledger) — refuses with a status-bar hint on untrusted `.gwm.toml` |
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see [confirm-overlay](/tui/confirm-countdown)) |
-| `b`         | re-run bootstrap on the selected worktree                                                         |
+| `b`         | re-run bootstrap on the selected worktree · same [trust gate](/configuration/trust-ledger) as `n` |
 | `o`         | open the worktree per [`[tui.open]`](/tui/open-dispatch) — `shell` (default) / `editor` / `finder` |
 | `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
 | `l`         | launch the configured [`[git_tui]`](/tui/launchers) command (default `lazygit -p {path}`, fullscreen) |
@@ -49,8 +49,10 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 |:--------------------------|:--------------------------------------------------------|
 | `Tab` / `↓`               | next field                                              |
 | `Shift+Tab` / `↑`         | previous field                                          |
-| `Enter` (on last field)   | submit and bootstrap                                    |
+| `Enter` (on last field)   | submit and bootstrap (subject to the [TOFU trust gate](/configuration/trust-ledger)) |
 | `Esc`                     | cancel                                                  |
+
+If the repo's `.gwm.toml` isn't trusted, `Enter` lands the form's status bar on a refuse message instead of running the bootstrap — the worktree directory is **not** created in that case, so you can fix the trust state in another terminal (`gwm bootstrap` from CLI, or set `GWM_ALLOW_BOOTSTRAP=1` and relaunch) and retry. See [Configuration → TOFU trust ledger](/configuration/trust-ledger#tui-behaviour) for the exact wording and full decision tree.
 
 ## issue / PR link prompt (`L`)
 

--- a/docs/2.tui/index.md
+++ b/docs/2.tui/index.md
@@ -16,4 +16,4 @@ Bare `gwm` (no arguments) opens the ratatui interface on the current repo. From 
 - **[Configurable launchers](/tui/launchers)** — `[git_tui]` (`l`) and `[review]` (`R`), with `{base} {head} {path} {diff}` placeholders.
 - **[Open dispatch](/tui/open-dispatch)** — `[tui.open]` controls what `o` does (`shell` / `editor` / `finder`).
 
-The picker variant (`gwm switch`, alias `gwm s`) reuses the same TUI but disables create / delete / bootstrap, then prints the chosen worktree's path on stdout — meant to be `eval`d by the `gcd` shell wrapper.
+`n` (new worktree) and `b` (re-bootstrap) are gated by the [TOFU trust ledger](/configuration/trust-ledger) — an untrusted `.gwm.toml` lands a refuse message in the status bar rather than running bootstrap. The picker variant (`gwm switch`, alias `gwm s`) reuses the same TUI but disables create / delete / bootstrap, then prints the chosen worktree's path on stdout — meant to be `eval`d by the `gcd` shell wrapper.

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -7,10 +7,14 @@ description: Execution order — file copies → regex guards → fallbacks → 
 
 The bootstrap pipeline runs **after** `git worktree add` succeeds, on every `gwm create` (unless `--no-bootstrap` is set) and on every `gwm bootstrap`. It is also re-runnable from inside the TUI via the `b` key.
 
+Every entry point is **gated by the [TOFU trust ledger](/configuration/trust-ledger)** — the first time you run `gwm create` / `gwm bootstrap` against a repo's `.gwm.toml`, the gate prompts (CLI) or refuses with a status-bar hint (TUI) before any pipeline stage executes. Subsequent runs against the same `(origin URL, sha256 of .gwm.toml)` pair pass silently; any byte change to `.gwm.toml` re-prompts. CI bypass: `--allow-bootstrap` or `GWM_ALLOW_BOOTSTRAP=1`.
+
 Five stages, in this order:
 
 ```
 gwm create / gwm bootstrap
+       ↓
+trust gate (issue #95)                 prompt / refuse on untrusted (origin, hash)
        ↓
 (1) [[bootstrap.copy]]                  duplicate files from main → worktree
        ↓

--- a/docs/4.configuration/5.trust-ledger.md
+++ b/docs/4.configuration/5.trust-ledger.md
@@ -1,0 +1,133 @@
+---
+title: TOFU trust ledger
+description: Threat model, gate behaviour, CLI surface, and ledger format for the trust-on-first-use protection on `.gwm.toml` bootstrap.
+---
+
+# TOFU trust ledger
+
+`gwm` runs the `[[bootstrap.*]]` pipeline from `.gwm.toml` under your user — copies, regex guards, no-symlink checks, and arbitrary shell commands. Cloning a repository and running `gwm create` (or any command that triggers bootstrap) is therefore equivalent to `curl … | sh` against whoever authored the `.gwm.toml`. The trust ledger ([#95](https://github.com/kbrdn1/gwm-cli/issues/95)) establishes an explicit trust boundary between "I cloned this remote" and "this remote can execute commands as me".
+
+## threat model
+
+The gate exists to defend against three concrete attack patterns:
+
+- **Hostile fork / clone** — a user clones a malicious mirror of a legitimate project and runs `gwm create` against it. Pre-gate, `[[bootstrap.command]]` lines from the malicious `.gwm.toml` would execute on the first invocation without any user-visible prompt.
+- **PR-fork contamination** — a contributor pulls down a teammate's PR fork to review and runs `gwm create` to set up their review worktree. The fork's `.gwm.toml` runs as them.
+- **Shared monorepo commit-access compromise** — anyone with commit access to `.gwm.toml` in a shared repo can ship a bootstrap line that runs as every co-worker on the next pull-and-create.
+
+**Whitespace matters.** The ledger hashes the raw bytes of `.gwm.toml`, not the parsed TOML. `rm -rf /tmp/` and `rm -rf /tmp /` are one byte apart and behave catastrophically differently, so a sub-byte edit re-triggers the prompt.
+
+**SSH ≠ HTTPS.** The ledger keys on the verbatim `origin` URL. `git@github.com:foo/bar.git` and `https://github.com/foo/bar` record as distinct trust paths — they ARE distinct (different auth, different intercept failure modes), so trusting one doesn't transitively trust the other. Run `gwm trust list` to audit which form you've approved.
+
+## gate behaviour
+
+The gate fires at the top of every `bootstrap::run` call site:
+
+- `gwm create` — before `git worktree add`, so a refusal leaves disk state untouched.
+- `gwm bootstrap` — before the pipeline runs.
+- TUI `n` (new worktree) — same ordering as `gwm create`.
+- TUI `b` (re-bootstrap selected) — same ordering as `gwm bootstrap`.
+
+Decision tree on each invocation:
+
+```
+.gwm.toml at workdir?
+├── no   → proceed silently (nothing to execute)
+└── yes  → mode == Deny ?
+          ├── yes → refuse with hash in the error
+          └── no  → bootstrap surface empty?
+                   ├── yes → proceed silently
+                   └── no  → mode == Allow ?
+                            ├── yes → proceed without recording
+                            └── no  → ledger entry exists for (origin, hash)?
+                                     ├── yes → proceed silently
+                                     └── no  → CLI: prompt y/N/show · TUI: refuse with hint
+```
+
+The **empty-surface short-circuit** is deliberate UX: a `.gwm.toml` with only `[worktree]` carries no RCE risk, so prompting for it would just train the user to mash `y`. The **Allow-before-load short-circuit** is the CI contract: a malformed `~/.config/gwm/trust.toml` on a runner host must not break the `--allow-bootstrap` bypass.
+
+## CLI surface
+
+### `gwm trust {list|revoke|show}`
+
+Manage the ledger from a shell. See [CLI reference → `gwm trust`](/cli/reference#gwm-trust-listrevokeshow) for the full per-subcommand contract.
+
+```bash
+gwm trust list                                # audit every approved (origin, hash) pair
+gwm trust revoke git@github.com:foo/bar.git   # drop entries for an origin (verbatim match)
+gwm trust show                                # print the ledger path + raw TOML
+```
+
+### global flags + env
+
+| Surface | Effect |
+|:--------|:-------|
+| `--allow-bootstrap` | Skip the prompt without recording. Use in non-interactive contexts. |
+| `--deny-bootstrap` | Refuse to run bootstrap even when trusted. Forensic mode. |
+| `GWM_ALLOW_BOOTSTRAP=1` | Env equivalent of `--allow-bootstrap` — for CI runners where you can't always inject extra args. |
+| `GWM_TRUST_LEDGER=…` | Override the ledger path (default `~/.config/gwm/trust.toml`). Used by `gwm trust *` tests and power users with non-XDG dotfiles. |
+
+`--allow-bootstrap` and `--deny-bootstrap` are `clap` global flags — they work on every subcommand that runs bootstrap (`gwm create`, `gwm bootstrap`, bare `gwm` for the TUI). The clap `conflicts_with` constraint rejects passing both at once.
+
+## TUI behaviour
+
+The alternate-screen mode can't host an inline stdin prompt without a dedicated modal view (deferred follow-up). So in the TUI, an untrusted `.gwm.toml` lands as a **refusal in the status bar** rather than a prompt:
+
+```
+.gwm.toml at /path/to/repo/.gwm.toml not in trust ledger (hash 3a4f9c2b…) — run `gwm bootstrap` from a CLI in another terminal to approve, or relaunch with GWM_ALLOW_BOOTSTRAP=1 / --allow-bootstrap
+```
+
+The keys affected are `n` (new worktree) and `b` (re-run bootstrap on the selected worktree). Both leave the TUI alive — you can fix the trust state from another terminal and retry without restarting `gwm`.
+
+In `submit_create` the gate fires **before** `worktree::add`, so a refusal leaves zero on-disk side-effects (no orphaned worktree directory to clean up). Mirrors the `cmd_create` ordering on the CLI side.
+
+## ledger location and format
+
+Default location: `~/.config/gwm/trust.toml` (resolved via `dirs::config_dir()` — XDG on Linux, `Application Support` on macOS, `%APPDATA%` on Windows).
+
+Override with `GWM_TRUST_LEDGER=/absolute/path/to/trust.toml`. Empty value falls back to the default.
+
+Format:
+
+```toml
+[[entries]]
+origin = "git@github.com:kbrdn1/gwm-cli.git"
+config_sha = "3a4f9c2bdeadbeefbabe..."         # lowercase hex sha256
+trusted_at = "2026-05-22T10:00:00Z"
+trusted_by = "kylian@laptop"
+```
+
+`trusted_by` is a best-effort `user@host` audit string captured at record time (`gethostname(3)` on Unix, `%COMPUTERNAME%` fallback on Windows). Not security-relevant — never used for trust decisions, purely an audit hint for multi-machine users sharing the ledger via dotfiles.
+
+**Writes are atomic.** `gwm` serialises to a uniquely-named sibling file (`gwm-trust-<random>.tmp`) and renames it onto the target — two concurrent `gwm` processes never clobber each other's writes. The temp file is consumed by the rename; a successful save leaves no `.tmp` sidecar.
+
+**Malformed ledgers are an error, not silently empty.** A corrupted `trust.toml` is suspicious (potential tampering) — refusing to load it loudly is better than silently treating it as fresh, which would re-prompt every previously trusted repo and habituate the user to `y`. The exception is `--allow-bootstrap`, which short-circuits before the load specifically so a broken ledger doesn't break the CI bypass.
+
+## migration notes
+
+The trust ledger is a **soft breaking change** introduced in `[Unreleased]`. Existing users on the first run after upgrade get a one-shot prompt per repo:
+
+```
+gwm: this repo's .gwm.toml has not been trusted yet.
+     path   : /path/to/repo/.gwm.toml
+     origin : git@github.com:foo/bar.git
+     hash   : 3a4f9c2bdeadbeef...
+     bootstrap surface:
+       - copy   .env.testing → .env.testing
+       - guard  no-aws-rds (on_match=seed-from-example, deny=1 pattern(s))
+       - run    composer install (composer install --no-interaction)
+
+Trust this .gwm.toml? [y/N/show]:
+```
+
+`y` records and proceeds, `N` (or EOF / unrecognised answer) aborts, `show` re-prints the raw `.gwm.toml`. Subsequent runs are silent until the file changes.
+
+For CI runners, set `GWM_ALLOW_BOOTSTRAP=1` (or pass `--allow-bootstrap`) in the workflow env. The bypass does NOT record an entry — CI bypasses must not pollute the local ledger of whoever ends up running an interactive `gwm` from the same machine later.
+
+## related
+
+- [CLI reference → `gwm trust`](/cli/reference#gwm-trust-listrevokeshow) — per-subcommand contract.
+- [Bootstrap pipeline](/configuration/bootstrap) — the RCE primitive the gate protects.
+- [TUI keybindings](/tui/keybindings) — `n` and `b` annotations re: trust gate.
+- Source: [`src/trust.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/trust.rs) — module-level comment carries the canonical threat model.
+- Issue: [#95](https://github.com/kbrdn1/gwm-cli/issues/95).

--- a/docs/4.configuration/index.md
+++ b/docs/4.configuration/index.md
@@ -13,5 +13,6 @@ gwm reads `.gwm.toml` from the repo root. Without a config, it falls back to sen
 - **[Bootstrap pipeline](/configuration/bootstrap)** — execution order: copies → guards → fallbacks → no-symlink check → commands.
 - **[Regex guards](/configuration/guards)** — deny-list patterns on copied files (the original "no AWS RDS in `.env`" incident).
 - **[`when` predicates](/configuration/when-predicates)** — `file_exists:`, `cmd_exists:`, `env_set:`, `env_eq:`, `glob_exists:`, with `!`, `&&`, `||` composition.
+- **[TOFU trust ledger](/configuration/trust-ledger)** — the gate that fires before the bootstrap pipeline (issue #95). Threat model, CLI surface (`gwm trust list / revoke / show`), TUI behaviour, ledger format, CI bypass.
 
 Run `gwm init` in a fresh repo to write a default `.gwm.toml`. For the full annotated example with every field commented, see [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) in the repo.

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -127,8 +127,14 @@ Checks that the configured `[worktree].base` exists and is writable, or — if i
 ```yaml
 # .github/workflows/ci.yml
 - name: gwm health
+  env:
+    GWM_ALLOW_BOOTSTRAP: "1"          # if the job also runs `gwm create` / `gwm bootstrap`
   run: gwm doctor                    # exits 1 on Warning, 2 on Failure
 ```
+
+`gwm doctor` itself doesn't go through the [TOFU trust gate](/configuration/trust-ledger) (the doctor never invokes `bootstrap::run` — it only reads config), so `GWM_ALLOW_BOOTSTRAP=1` is harmless here. Set it for jobs that also create worktrees in the same workflow run.
+
+> **What doctor does NOT audit (yet)**: the trust ledger contents themselves. A job that wants to assert "this CI host has trusted exactly the configs the workflow expects" would have to parse `~/.config/gwm/trust.toml` (or `$GWM_TRUST_LEDGER`) manually. Auditing the ledger from `gwm doctor` is on the post-#95 follow-up list.
 
 Or as a pre-commit hook:
 

--- a/docs/5.integrations/index.md
+++ b/docs/5.integrations/index.md
@@ -13,4 +13,6 @@ gwm is small on purpose — it shells out to the tools you already use rather th
 - **[`gwm doctor`](/integrations/doctor)** — the 7 health checks, exit-code semantics (`0 / 1 / 2`), and the v0.6 update that now probes the configured launcher binaries.
 - **[Homebrew & Nix](/integrations/homebrew-nix)** — the packaging surface: how releases flow into the Homebrew tap and the Nix flake.
 
+For CI runners that spin up worktrees via `gwm create`, set `GWM_ALLOW_BOOTSTRAP=1` (or pass `--allow-bootstrap` on the gwm invocation) so the [TOFU trust gate](/configuration/trust-ledger) bypasses the interactive prompt — required since the gate's default-deny policy aborts on non-tty stdin to prevent silent execution of attacker-controlled bootstrap lines.
+
 The TUI-side integrations (the configurable launchers for `l` and `R`, the `[tui.open]` dispatch) live under [TUI → Configurable launchers](/tui/launchers) and [TUI → Open dispatch](/tui/open-dispatch).

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -19,6 +19,15 @@ For reference — what made it into the current stable line:
 
 The full v0.6.0 release notes (with the Changed / Fixed / Removed sections, Dependencies, and PR-by-PR breakdown) live at [`changelogs/0.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.6.0.md).
 
+## merged on dev since v0.6.0
+
+Surface that has landed but not yet been promoted to a stable tag:
+
+- **TOFU trust ledger on `.gwm.toml`** ([#95](https://github.com/kbrdn1/gwm-cli/issues/95) / [#113](https://github.com/kbrdn1/gwm-cli/pull/113)) — `gwm trust list / revoke / show` subcommand family, `--allow-bootstrap` / `--deny-bootstrap` global flags, `GWM_ALLOW_BOOTSTRAP=1` env bypass. Closes the arbitrary-RCE primitive against hostile clones — see [TOFU trust ledger](/configuration/trust-ledger) for the threat model and full surface.
+- **`bootstrap` symlink + path-traversal hardening** ([#93](https://github.com/kbrdn1/gwm-cli/issues/93) / [#94](https://github.com/kbrdn1/gwm-cli/issues/94)) — `O_NOFOLLOW`-based write primitives, canonicalize + prefix-check on every resolved bootstrap path, reorder of `run_no_symlinks` before `run_copies`. Closes a write-anywhere primitive on attacker-controlled checkouts.
+
+Track the full unreleased surface in [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) under `[Unreleased]`.
+
 ## what's next
 
 Post-v0.6.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects.
 - Branch convention `<type>/#<issue>-<description>` by default; overridable per repo.
 - Configurable launchers for the `l` (git TUI) and `R` (review) keybindings.
 - First-class GitHub issue / PR linking — branches matching the naming convention auto-link to their issue.
+- [TOFU trust ledger](/configuration/trust-ledger) on `.gwm.toml` — first `gwm create` / `gwm bootstrap` on a repo prompts before executing any `[[bootstrap.command]]` line. `--allow-bootstrap` / `GWM_ALLOW_BOOTSTRAP=1` for CI bypass.
 
 ## documentation map
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -1,5 +1,17 @@
 # gwm config — copy this to your repo root as `.gwm.toml`
 # placeholders supported in paths/patterns: {repo} {home} {type} {issue} {desc}
+#
+# === TOFU trust gate (issue #95) ===========================================
+# The first `gwm create` / `gwm bootstrap` against this file opens a
+# one-shot trust prompt that summarises the bootstrap surface (copies,
+# guards, no-symlinks, commands) and records the (origin URL, sha256)
+# pair in `~/.config/gwm/trust.toml` on approval. Any byte change to this
+# file re-prompts (whitespace matters — `rm -rf /tmp/` and
+# `rm -rf /tmp /` differ by one byte and behave catastrophically
+# differently). CI runners bypass the prompt with `--allow-bootstrap` or
+# `GWM_ALLOW_BOOTSTRAP=1`. Forensic mode: `--deny-bootstrap` refuses
+# even when trusted. Manage entries with `gwm trust list / revoke / show`.
+# Full threat model: https://github.com/kbrdn1/gwm-cli/blob/main/src/trust.rs
 
 [worktree]
 base = "{home}/cc-worktree/{repo}"


### PR DESCRIPTION
## Description

PR #113 shipped the [TOFU trust ledger](https://github.com/kbrdn1/gwm-cli/blob/main/src/trust.rs) feature but the doc surface lagged — only `CHANGELOG.md`, `README.md`, and `docs/3.cli/1.reference.md` covered the new behaviour. A user landing on the getting-started flow or the TUI keybindings page would hit a one-shot trust prompt with no documented warning. This PR catches the docs up.

Closes #114
refs #95

## Type of change

- [x] 📝 Docs

## Changes

- **New** `docs/4.configuration/5.trust-ledger.md` — full dedicated page (threat model, gate behaviour decision tree, CLI surface, TUI behaviour, ledger format, migration notes).
- **Updated** `docs/index.md`, `docs/1.getting-started/2.first-worktree.md`, `docs/2.tui/1.keybindings.md`, `docs/2.tui/index.md`, `docs/4.configuration/2.bootstrap.md`, `docs/4.configuration/index.md`, `docs/5.integrations/index.md`, `docs/5.integrations/2.doctor.md`, `docs/7.roadmap.md`.
- **Updated** `examples/gwm.toml.example` — header comment block explains the trust gate inline (ships via `include_str!` in `gwm init`).
- **Updated** `CONTRIBUTING.md` — stale module list refreshed (added `trust`, `doctor`, `github`, `labels`, `milestones`, `launcher`, `multiplexer`); project-layout tree now mirrors the actual `src/` and `tests/` shape.

No behaviour change, no schema change.

## Tests

- [x] `cargo test` passes locally (169 unit + 27 trust + 93 cli_binary + all others — same totals as #113 head, no regressions)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `gwm doctor` reports all ✓
- [x] New tests added — N/A (docs-only)

## Screenshots / TUI captures

N/A — docs-only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` → `docs/#114-trust-ledger-docs`
- [x] Commits follow Gitmoji + Conventional Commits (`📝 docs: …`)
- [x] CHANGELOG.md updated under `## [Unreleased]` — **not required** for this PR (the feature itself was already chronicled in #113's CHANGELOG entry; this is a doc-only follow-up that just catches the prose up. Recording the docs-catchup again would duplicate the entry.)
- [x] README updated if CLI surface changed → N/A (README already touched in #113)
- [x] `examples/gwm.toml.example` updated if config schema changed → header comment touched (no schema change)
- [x] No `unwrap()` on user-facing paths → N/A
- [x] No `println!` in TUI render code → N/A

## Linked issues / docs

- Issue: #114
- Parent feature: #95 (TOFU ledger) / #113 (implementation PR)

## Notes for reviewers

- Render-test on Nuxt Content not run locally (the docs site lives outside this repo). Frontmatter `title` / `description` follow the existing convention.
- All cross-links use the `/section/page#anchor` form per the convention documented in `docs/README.md`. Spot-checked: every `/configuration/trust-ledger` link points at the new page.
- Tone matches the project's existing prose style — terse, prefers links over inlined explanations, single-sentence bullets where possible.