### PR TITLE
♻️ refactor(tui): privatize ConfirmModal.started_at + add is_armed() accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`tui::state::confirm`** — `ConfirmModal.started_at` is now private;
+  callers read armed-state through the new `is_armed() -> bool`
+  accessor instead of poking at the raw `Option<Instant>`.
+  Encapsulation polish from a Copilot review on PR #131 (the original
+  ConfirmModal extraction). The single external read site
+  (`src/tui/ui.rs` rendering the safety-countdown bar) was migrated;
+  no behaviour change. ([#131](https://github.com/kbrdn1/gwm-cli/issues/131))
+
 ### Fixed
 
 - 🐛 **`GitHubFetch` cache keyed by issue/PR number + drops late results after `invalidate()`** ([#138](https://github.com/kbrdn1/gwm-cli/issues/138)). Closes two correctness bugs flagged by Copilot review on #137 (the #128 extraction PR), both in the new `GitHubFetch` sub-struct:

--- a/src/tui/state/confirm.rs
+++ b/src/tui/state/confirm.rs
@@ -45,7 +45,14 @@ pub struct ConfirmModal {
   /// renders a progress bar and [`ConfirmModal::tick`] decrements it
   /// before returning `ReadyToFire`. `None` = modal closed, classic mode,
   /// or armed-but-just-disarmed by a second `y` press.
-  pub started_at: Option<Instant>,
+  ///
+  /// Private since #131 (encapsulation polish — Copilot review on PR
+  /// #131 flagged the prior `pub` exposure as leaking internal timer
+  /// state). External callers should use [`ConfirmModal::is_armed`] to
+  /// check whether the countdown is running and the
+  /// [`ConfirmModal::progress`] / [`ConfirmModal::remaining_secs`]
+  /// helpers for rendering.
+  started_at: Option<Instant>,
 }
 
 impl ConfirmModal {
@@ -57,6 +64,16 @@ impl ConfirmModal {
   /// Called by the orchestrator when the modal opens or dismisses.
   pub fn reset(&mut self) {
     self.started_at = None;
+  }
+
+  /// `true` when the safety countdown is currently running (between
+  /// [`ConfirmModal::press_y`] arming it and either a second `press_y`,
+  /// a [`ConfirmModal::dismiss`], or the [`ConfirmModal::tick`] that
+  /// crosses `total`). Replaces the prior `pub started_at.is_some()`
+  /// pattern so callers never reach for the raw `Option<Instant>`
+  /// (#131).
+  pub fn is_armed(&self) -> bool {
+    self.started_at.is_some()
   }
 
   /// Handle a `y` / Enter press. `total` is the configured countdown

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1038,7 +1038,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
       if app.confirm_is_countdown_mode() {
         let now = Instant::now();
         let total_secs = app.confirm_countdown_total().as_secs();
-        if app.confirm.started_at.is_some() {
+        if app.confirm.is_armed() {
           lines.push(Line::from(countdown_bar(
             app.confirm_countdown_progress(now),
             app.confirm_countdown_remaining_secs(now),

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -920,10 +920,7 @@ fn confirm_press_y_in_classic_mode_fires_immediately() {
   // delete_branch OFF → classic flow
   let action = app.confirm_press_y(Instant::now());
   assert_eq!(action, ConfirmKeyAction::FireNow);
-  assert!(
-    app.confirm.started_at.is_none(),
-    "classic mode must never set the timer"
-  );
+  assert!(!app.confirm.is_armed(), "classic mode must never set the timer");
 }
 
 #[test]
@@ -933,7 +930,11 @@ fn confirm_press_y_in_countdown_mode_arms_the_timer() {
   let now = Instant::now();
   let action = app.confirm_press_y(now);
   assert_eq!(action, ConfirmKeyAction::Armed);
-  assert_eq!(app.confirm.started_at, Some(now));
+  assert!(app.confirm.is_armed());
+  // Anchor is exactly `now`: zero elapsed means progress is 0.0. This
+  // pins the anchor through the public API instead of reading the
+  // (now private since #131) raw `started_at` field.
+  assert_eq!(app.confirm.progress(now, app.confirm_countdown_total()), 0.0);
 }
 
 #[test]
@@ -945,7 +946,7 @@ fn confirm_press_y_a_second_time_disarms_the_timer() {
   let t1 = t0 + Duration::from_millis(500);
   let action = app.confirm_press_y(t1);
   assert_eq!(action, ConfirmKeyAction::Disarmed);
-  assert!(app.confirm.started_at.is_none());
+  assert!(!app.confirm.is_armed());
 }
 
 #[test]
@@ -954,13 +955,10 @@ fn confirm_dismiss_resets_timer_and_returns_to_list() {
   app.toggle_delete_branch();
   app.view = View::Confirm;
   app.confirm_press_y(Instant::now());
-  assert!(app.confirm.started_at.is_some());
+  assert!(app.confirm.is_armed());
   app.confirm_dismiss();
   assert_eq!(app.view, View::List);
-  assert!(
-    app.confirm.started_at.is_none(),
-    "Esc/n must always disarm the countdown"
-  );
+  assert!(!app.confirm.is_armed(), "Esc/n must always disarm the countdown");
 }
 
 #[test]
@@ -978,10 +976,7 @@ fn tick_before_duration_is_pending() {
   app.confirm_press_y(t0);
   let outcome = app.tick_confirm_countdown(t0 + Duration::from_millis(1500));
   assert_eq!(outcome, CountdownTickOutcome::Pending);
-  assert!(
-    app.confirm.started_at.is_some(),
-    "pending tick must not clear the timer"
-  );
+  assert!(app.confirm.is_armed(), "pending tick must not clear the timer");
 }
 
 #[test]

--- a/tests/tui_state_confirm_tests.rs
+++ b/tests/tui_state_confirm_tests.rs
@@ -19,10 +19,7 @@ fn classic_mode_fires_immediately_on_first_y() {
   let mut modal = ConfirmModal::new();
   let action = modal.press_y(Instant::now(), Duration::ZERO);
   assert_eq!(action, ConfirmKeyAction::FireNow);
-  assert!(
-    modal.started_at.is_none(),
-    "classic mode must never arm the countdown timer"
-  );
+  assert!(!modal.is_armed(), "classic mode must never arm the countdown timer");
 }
 
 #[test]
@@ -34,13 +31,17 @@ fn countdown_mode_arms_on_first_y_and_disarms_on_second() {
   let t0 = Instant::now();
   let action = modal.press_y(t0, total);
   assert_eq!(action, ConfirmKeyAction::Armed);
-  assert_eq!(modal.started_at, Some(t0));
+  assert!(modal.is_armed());
+  // Anchor is exactly t0 → progress at t0 is 0.0 (zero elapsed since
+  // arming). This pins the anchor through the public API rather than
+  // reading the private `started_at` field directly.
+  assert_eq!(modal.progress(t0, total), 0.0);
 
   // Second press 1s later disarms.
   let t1 = t0 + Duration::from_secs(1);
   let action = modal.press_y(t1, total);
   assert_eq!(action, ConfirmKeyAction::Disarmed);
-  assert!(modal.started_at.is_none());
+  assert!(!modal.is_armed());
 }
 
 #[test]
@@ -48,9 +49,9 @@ fn dismiss_clears_armed_countdown() {
   let mut modal = ConfirmModal::new();
   let total = Duration::from_secs(3);
   modal.press_y(Instant::now(), total);
-  assert!(modal.started_at.is_some());
+  assert!(modal.is_armed());
   modal.dismiss();
-  assert!(modal.started_at.is_none(), "dismiss must reset the timer");
+  assert!(!modal.is_armed(), "dismiss must reset the timer");
 }
 
 #[test]
@@ -79,7 +80,7 @@ fn tick_returns_ready_to_fire_at_or_after_total() {
   let outcome = modal.tick(t0 + Duration::from_secs(3), total);
   assert_eq!(outcome, CountdownTickOutcome::ReadyToFire);
   assert!(
-    modal.started_at.is_none(),
+    !modal.is_armed(),
     "tick that reached the deadline must clear the timer so a re-entrant tick returns NotArmed"
   );
 }
@@ -93,11 +94,11 @@ fn tick_with_zero_total_resets_and_returns_not_armed() {
   let total = Duration::from_secs(3);
   let t0 = Instant::now();
   modal.press_y(t0, total);
-  assert!(modal.started_at.is_some());
+  assert!(modal.is_armed());
 
   let outcome = modal.tick(t0 + Duration::from_millis(100), Duration::ZERO);
   assert_eq!(outcome, CountdownTickOutcome::NotArmed);
-  assert!(modal.started_at.is_none());
+  assert!(!modal.is_armed());
 }
 
 #[test]
@@ -128,10 +129,7 @@ fn is_armed_returns_true_after_first_press_y_and_false_after_second() {
   // peek at the `Option<Instant>` directly.
   let mut modal = ConfirmModal::new();
   let total = Duration::from_secs(3);
-  assert!(
-    !modal.is_armed(),
-    "freshly constructed modal must not be armed"
-  );
+  assert!(!modal.is_armed(), "freshly constructed modal must not be armed");
 
   let t0 = Instant::now();
   let action = modal.press_y(t0, total);

--- a/tests/tui_state_confirm_tests.rs
+++ b/tests/tui_state_confirm_tests.rs
@@ -120,6 +120,37 @@ fn progress_caps_at_one_after_total() {
 }
 
 #[test]
+fn is_armed_returns_true_after_first_press_y_and_false_after_second() {
+  // Pins the public `is_armed()` accessor (encapsulation polish on top
+  // of #125 — Copilot review on PR #131 flagged `pub started_at` as
+  // leaking internal timer state). Exercises the armed → disarmed
+  // transition through the public surface so callers never need to
+  // peek at the `Option<Instant>` directly.
+  let mut modal = ConfirmModal::new();
+  let total = Duration::from_secs(3);
+  assert!(
+    !modal.is_armed(),
+    "freshly constructed modal must not be armed"
+  );
+
+  let t0 = Instant::now();
+  let action = modal.press_y(t0, total);
+  assert_eq!(action, ConfirmKeyAction::Armed);
+  assert!(
+    modal.is_armed(),
+    "is_armed() must return true after the first press_y in countdown mode"
+  );
+
+  let t1 = t0 + Duration::from_millis(500);
+  let action = modal.press_y(t1, total);
+  assert_eq!(action, ConfirmKeyAction::Disarmed);
+  assert!(
+    !modal.is_armed(),
+    "is_armed() must return false after the second press_y disarms the countdown"
+  );
+}
+
+#[test]
 fn remaining_secs_rounds_up_to_next_whole_second() {
   // The UI label reads remaining_secs as the countdown number; rounding
   // up matches the visual contract "still seeing 2s on the label means


### PR DESCRIPTION
## Description

Encapsulation polish from Copilot review on PR #131 (the ConfirmModal extraction). The `started_at: Option<Instant>` field was `pub` — Copilot correctly flagged this as leaking internal timer state. Only one external read site existed (`ui.rs:1041` did `.is_some()`), so we replace `pub started_at` with a private field + `is_armed()` accessor.

Closes #131

## Type of change
- [x] ♻️ Refactor (no behaviour change)

## Changes
- `src/tui/state/confirm.rs`: `pub started_at` → private; new `pub fn is_armed(&self) -> bool`.
- `src/tui/ui.rs`: read site uses `app.confirm.is_armed()` instead of `app.confirm.started_at.is_some()`.
- Tests migrated to public API where possible.

## Tests
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — full suite green, no behaviour change

## Checklist
- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased] > Changed`

## Linked issues / docs
- Issue: #131
- Original review: PR #131 Copilot suggestion