### PR TITLE
♻️ refactor(tui): privatize FilterState.query + drop fuzzy_match_indices re-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ConfirmModal extraction). The single external read site
   (`src/tui/ui.rs` rendering the safety-countdown bar) was migrated;
   no behaviour change. ([#131](https://github.com/kbrdn1/gwm-cli/issues/131))
+- ♻️ **`FilterState.query` is now private; read access goes through `FilterState::query() -> &str`** ([#134](https://github.com/kbrdn1/gwm-cli/issues/134)). Copilot review on PR #134 (the FilterState extraction) flagged the `pub query: String` field as leaking the buffer across the module boundary — every external caller did `.is_empty()`, `.len()`, or `format!("... {}", q)`, all equally well served by a `&str` accessor. Privatising the field also funnels the full write surface through `push_char` / `pop_char` / `set_query` / `clear`, each of which maintains the cache-invalidation contract that the field-write path bypassed. 8 read sites migrated across `src/tui/{mod,ui,app}.rs`; 32 test sites switched to `set_query()` / `query()`. New `query_accessor_reflects_push_char_and_pop_char` test pins the accessor.
+- ♻️ **`tui::fuzzy_match_indices` re-export dropped** ([#134](https://github.com/kbrdn1/gwm-cli/issues/134)). The helper was promoted to `tui::` even though the only in-crate consumer (`tui::app::App`) already imports it via the full `tui::state::filter::fuzzy_match_indices` path. The re-export widened the public surface by one symbol for no return. Trimmed to `pub use state::filter::FilterState;`.
 
 ### Fixed
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -807,16 +807,16 @@ impl App {
   /// match set and returns the cursor to list navigation.
   pub fn exit_filter_keep(&mut self) {
     self.filter.close_keep();
-    self.status = if self.filter.query.is_empty() {
+    self.status = if self.filter.query().is_empty() {
       "press ? for help".into()
     } else {
-      format!("filter sticky: {}", self.filter.query)
+      format!("filter sticky: {}", self.filter.query())
     };
   }
 
   /// Close the filter bar and clear the query: `Esc` returns to the full list.
   pub fn exit_filter_cancel(&mut self) {
-    let had_query = !self.filter.query.is_empty();
+    let had_query = !self.filter.query().is_empty();
     self.filter.close_cancel();
     self.clamp_selection_to_filter();
     self.invalidate_sidebar_cache();
@@ -834,9 +834,9 @@ impl App {
   }
 
   pub fn filter_pop_char(&mut self) {
-    let before = self.filter.query.len();
+    let before = self.filter.query().len();
     self.filter.pop_char();
-    if self.filter.query.len() != before {
+    if self.filter.query().len() != before {
       self.clamp_selection_to_filter();
       self.invalidate_sidebar_cache();
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,7 +181,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           // list is already in its plain state. Avoids the trap where a user
           // hits Esc expecting to clear /-filter and accidentally exits.
           KeyCode::Esc => {
-            if !app.filter.query.is_empty() {
+            if !app.filter.query().is_empty() {
               app.exit_filter_cancel();
             } else {
               break;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 pub use app::{App, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
-pub use state::filter::{fuzzy_match_indices, FilterState};
+pub use state::filter::FilterState;
 pub use state::github_fetch::{FetchAction, FetchKey, GitHubFetch, GitHubFetchState};
 pub use state::link_prompt::LinkPrompt;
 pub use state::sidebar::SidebarState;

--- a/src/tui/state/filter.rs
+++ b/src/tui/state/filter.rs
@@ -66,8 +66,12 @@ pub struct FilterState {
   /// (the close methods describe the sticky-vs-clear contract).
   pub active: bool,
   /// Live query buffer. Empty = no filter active; the visible list is
-  /// the identity over `App.worktrees`.
-  pub query: String,
+  /// the identity over `App.worktrees`. Private so the mutation
+  /// surface stays funnelled through `push_char` / `pop_char` /
+  /// `set_query` / `clear` (each of which maintains the cache-
+  /// invalidation contract); external readers go through
+  /// [`Self::query`].
+  query: String,
   /// Cached matched-indices vec from the last call to
   /// [`Self::filtered_indices`]. `None` = cold cache (must recompute).
   /// Any buffer mutation, explicit [`Self::invalidate`], or worktrees-
@@ -84,6 +88,15 @@ pub struct FilterState {
 impl FilterState {
   pub fn new() -> Self {
     Self::default()
+  }
+
+  /// Read access to the live query buffer. Returned as `&str` so the
+  /// caller can't grow / shrink the underlying `String` and bypass the
+  /// cache-invalidation contract on `push_char` / `pop_char` /
+  /// `set_query` / `clear`. Use `query().len()` if you need the byte
+  /// length and `query().is_empty()` for the "no filter" check.
+  pub fn query(&self) -> &str {
+    &self.query
   }
 
   /// Append a character to the query buffer and invalidate the cache.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -99,7 +99,7 @@ pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
 fn draw_filter_bar(f: &mut Frame, area: Rect, app: &App) {
   let mut spans = vec![
     Span::styled("/", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-    Span::raw(app.filter.query().to_string()),
+    Span::raw(app.filter.query()),
   ];
   if app.filter.active {
     spans.push(Span::styled(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -38,7 +38,7 @@ pub const SIDEBAR_MIN_WIDTH: u16 = 120;
 pub fn draw(f: &mut Frame, app: &mut App) {
   // Filter bar is shown while the user is typing, AND while a sticky filter
   // remains in effect (so they can see what's filtering the list).
-  let filter_visible = app.filter.active || !app.filter.query.is_empty();
+  let filter_visible = app.filter.active || !app.filter.query().is_empty();
 
   let chunks = if filter_visible {
     Layout::default()
@@ -99,7 +99,7 @@ pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
 fn draw_filter_bar(f: &mut Frame, area: Rect, app: &App) {
   let mut spans = vec![
     Span::styled("/", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-    Span::raw(app.filter.query.as_str().to_string()),
+    Span::raw(app.filter.query().to_string()),
   ];
   if app.filter.active {
     spans.push(Span::styled(
@@ -217,7 +217,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let list_has_focus = !(app.sidebar.open && app.sidebar.focused);
   let border_color = if list_has_focus { Color::Cyan } else { Color::DarkGray };
 
-  let title = if app.filter.query.is_empty() {
+  let title = if app.filter.query().is_empty() {
     format!(" worktrees ({}) ", app.worktrees.len())
   } else {
     format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -365,7 +365,7 @@ fn on_navigation_resets_scroll_and_invalidates_sidebar_cache() {
 fn filter_state_defaults_to_inactive_and_empty() {
   let (_dir, app) = make_app();
   assert!(!app.filter.active, "filter must default to inactive");
-  assert!(app.filter.query.is_empty(), "filter query must default to empty");
+  assert!(app.filter.query().is_empty(), "filter query must default to empty");
 }
 
 #[test]
@@ -408,9 +408,9 @@ fn enter_filter_preserves_existing_query() {
   // Hitting `/` on a sticky filter re-opens the bar so the user can refine
   // it; only Esc clears.
   let (_dir, mut app) = make_app();
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
   app.enter_filter();
-  assert_eq!(app.filter.query, "auth");
+  assert_eq!(app.filter.query(), "auth");
   assert!(app.filter.active);
 }
 
@@ -421,16 +421,16 @@ fn filter_push_char_appends_to_query() {
   for c in "tui".chars() {
     app.filter_push_char(c);
   }
-  assert_eq!(app.filter.query, "tui");
+  assert_eq!(app.filter.query(), "tui");
 }
 
 #[test]
 fn filter_pop_char_removes_last_char() {
   let (_dir, mut app) = make_app();
   app.enter_filter();
-  app.filter.query = "tuix".into();
+  app.filter.set_query("tuix".into());
   app.filter_pop_char();
-  assert_eq!(app.filter.query, "tui");
+  assert_eq!(app.filter.query(), "tui");
 }
 
 #[test]
@@ -438,7 +438,7 @@ fn filter_pop_char_on_empty_is_noop() {
   let (_dir, mut app) = make_app();
   app.enter_filter();
   app.filter_pop_char();
-  assert_eq!(app.filter.query, "");
+  assert_eq!(app.filter.query(), "");
   assert!(app.filter.active, "popping an empty query must not exit filter mode");
 }
 
@@ -447,10 +447,10 @@ fn exit_filter_keep_disables_capture_keeps_query() {
   // Enter behaviour: filter sticks, navigation returns to the list.
   let (_dir, mut app) = make_app();
   app.enter_filter();
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
   app.exit_filter_keep();
   assert!(!app.filter.active);
-  assert_eq!(app.filter.query, "auth", "Enter must not wipe the query");
+  assert_eq!(app.filter.query(), "auth", "Enter must not wipe the query");
 }
 
 #[test]
@@ -458,10 +458,10 @@ fn exit_filter_cancel_clears_query() {
   // Esc behaviour: full list back, query gone.
   let (_dir, mut app) = make_app();
   app.enter_filter();
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
   app.exit_filter_cancel();
   assert!(!app.filter.active);
-  assert!(app.filter.query.is_empty(), "Esc must clear the query");
+  assert!(app.filter.query().is_empty(), "Esc must clear the query");
 }
 
 #[test]
@@ -484,7 +484,7 @@ fn filtered_indices_keeps_only_matching_worktrees() {
     worktree_fixture("feat-2-cli-completions"),
     worktree_fixture("fix-3-locked-worktree"),
   ];
-  app.filter.query = "tui".into();
+  app.filter.set_query("tui".into());
 
   let idx: Vec<usize> = app.filtered_indices().to_vec();
   let names: Vec<&str> = idx.iter().map(|&i| app.worktrees[i].name.as_str()).collect();
@@ -508,7 +508,7 @@ fn filtered_indices_supports_subsequence_match() {
     worktree_fixture("a-foo-u-bar-t-baz-h-qux"),
     worktree_fixture("chore-1-bump-deps"),
   ];
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
   // Sanity-guard the precondition: if a future refactor introduces an `auth`
   // substring into the fixture, the test would silently degrade to a
   // substring check again.
@@ -535,7 +535,7 @@ fn filtered_indices_ranks_substring_above_subsequence() {
     // direct substring of "auth"
     worktree_fixture("auth-service"),
   ];
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
 
   let idx: Vec<usize> = app.filtered_indices().to_vec();
   assert!(!idx.is_empty(), "at least the substring candidate must match");
@@ -549,7 +549,7 @@ fn filtered_indices_ranks_substring_above_subsequence() {
 fn filtered_indices_skips_when_no_match() {
   let (_dir, mut app) = make_app();
   app.worktrees = vec![worktree_fixture("alpha"), worktree_fixture("beta")];
-  app.filter.query = "zzzz".into();
+  app.filter.set_query("zzzz".into());
   assert!(app.filtered_indices().is_empty());
 }
 
@@ -563,7 +563,7 @@ fn selected_returns_filtered_worktree() {
     worktree_fixture("authentication"),
     worktree_fixture("beta"),
   ];
-  app.filter.query = "auth".into();
+  app.filter.set_query("auth".into());
   app.list_state.select(Some(0));
 
   let sel = app.selected().expect("filtered selection must resolve");
@@ -574,7 +574,7 @@ fn selected_returns_filtered_worktree() {
 fn selected_returns_none_when_filter_matches_nothing() {
   let (_dir, mut app) = make_app();
   app.worktrees = vec![worktree_fixture("alpha"), worktree_fixture("beta")];
-  app.filter.query = "zzzz".into();
+  app.filter.set_query("zzzz".into());
   app.list_state.select(Some(0));
   assert!(app.selected().is_none());
 }
@@ -587,7 +587,7 @@ fn next_navigates_within_filtered_subset_and_wraps() {
     worktree_fixture("foo-a"),
     worktree_fixture("foo-b"),
   ];
-  app.filter.query = "foo".into();
+  app.filter.set_query("foo".into());
   app.list_state.select(Some(0));
 
   app.next();
@@ -608,7 +608,7 @@ fn prev_navigates_within_filtered_subset_and_wraps() {
     worktree_fixture("foo-a"),
     worktree_fixture("foo-b"),
   ];
-  app.filter.query = "foo".into();
+  app.filter.set_query("foo".into());
   app.list_state.select(Some(0));
 
   app.prev();
@@ -625,7 +625,7 @@ fn first_and_last_jump_inside_filtered_subset() {
     worktree_fixture("foo-2"),
     worktree_fixture("gamma"),
   ];
-  app.filter.query = "foo".into();
+  app.filter.set_query("foo".into());
   app.list_state.select(Some(1));
 
   app.first();
@@ -644,7 +644,7 @@ fn filter_push_clamps_selection_when_subset_shrinks() {
   // selection must clamp instead of dangling past the new end.
   let (_dir, mut app) = make_app();
   app.worktrees = vec![worktree_fixture("foo-bar"), worktree_fixture("foo-baz-xx")];
-  app.filter.query = "foo".into();
+  app.filter.set_query("foo".into());
   app.list_state.select(Some(1));
 
   // Typing more reduces the match set to just "foo-bar".
@@ -670,11 +670,11 @@ fn exit_filter_cancel_restores_full_list_selection() {
     worktree_fixture("foo"),
     worktree_fixture("beta"),
   ];
-  app.filter.query = "foo".into();
+  app.filter.set_query("foo".into());
   app.list_state.select(Some(0));
 
   app.exit_filter_cancel();
-  assert!(app.filter.query.is_empty());
+  assert!(app.filter.query().is_empty());
   assert_eq!(app.filtered_indices(), vec![0, 1, 2]);
   // Selection from the filtered view (index 0) remains a valid index in the
   // full list (index 0). The clamp logic doesn't move it forward, only back.

--- a/tests/tui_state_filter_tests.rs
+++ b/tests/tui_state_filter_tests.rs
@@ -76,6 +76,23 @@ fn pop_char_on_empty_is_noop() {
 }
 
 #[test]
+fn query_accessor_reflects_push_char_and_pop_char() {
+  // Pin the `query()` accessor as the public read path now that the
+  // `query` field is private (refs #134). Two `push_char` calls then a
+  // single `pop_char` must reflect through the accessor without
+  // leaking the underlying `String`.
+  let mut f = FilterState::new();
+  f.push_char('a');
+  f.push_char('b');
+  f.push_char('c');
+  assert_eq!(f.query(), "abc", "accessor must reflect buffered push_char appends");
+
+  f.pop_char();
+  f.pop_char();
+  assert_eq!(f.query(), "a", "accessor must reflect pop_char removals");
+}
+
+#[test]
 fn open_sets_active_preserves_query() {
   let mut f = FilterState::new();
   f.set_query("auth".into());

--- a/tests/tui_state_filter_tests.rs
+++ b/tests/tui_state_filter_tests.rs
@@ -48,7 +48,7 @@ fn wt(name: &str) -> WorktreeInfo {
 fn default_state_is_inactive_empty_buffer() {
   let f = FilterState::new();
   assert!(!f.active);
-  assert!(f.query.is_empty());
+  assert!(f.query().is_empty());
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn push_char_appends_to_buffer() {
   for c in "tui".chars() {
     f.push_char(c);
   }
-  assert_eq!(f.query, "tui");
+  assert_eq!(f.query(), "tui");
 }
 
 #[test]
@@ -65,14 +65,14 @@ fn pop_char_removes_last_character() {
   let mut f = FilterState::new();
   f.set_query("tuix".into());
   f.pop_char();
-  assert_eq!(f.query, "tui");
+  assert_eq!(f.query(), "tui");
 }
 
 #[test]
 fn pop_char_on_empty_is_noop() {
   let mut f = FilterState::new();
   f.pop_char();
-  assert!(f.query.is_empty());
+  assert!(f.query().is_empty());
 }
 
 #[test]
@@ -98,7 +98,11 @@ fn open_sets_active_preserves_query() {
   f.set_query("auth".into());
   f.open();
   assert!(f.active);
-  assert_eq!(f.query, "auth", "open must preserve the existing query for refinement");
+  assert_eq!(
+    f.query(),
+    "auth",
+    "open must preserve the existing query for refinement"
+  );
 }
 
 #[test]
@@ -108,7 +112,7 @@ fn close_keep_disables_active_keeps_query() {
   f.set_query("auth".into());
   f.close_keep();
   assert!(!f.active);
-  assert_eq!(f.query, "auth", "close_keep (Enter) is the sticky-filter path");
+  assert_eq!(f.query(), "auth", "close_keep (Enter) is the sticky-filter path");
 }
 
 #[test]
@@ -118,7 +122,7 @@ fn close_cancel_clears_buffer_and_disables_active() {
   f.set_query("auth".into());
   f.close_cancel();
   assert!(!f.active);
-  assert!(f.query.is_empty(), "close_cancel (Esc) is the clear-everything path");
+  assert!(f.query().is_empty(), "close_cancel (Esc) is the clear-everything path");
 }
 
 #[test]
@@ -128,7 +132,7 @@ fn clear_drops_buffer_and_active() {
   f.set_query("auth".into());
   f.clear();
   assert!(!f.active);
-  assert!(f.query.is_empty());
+  assert!(f.query().is_empty());
 }
 
 // ---- Memoisation contract --------------------------------------------------

--- a/tests/tui_state_filter_tests.rs
+++ b/tests/tui_state_filter_tests.rs
@@ -78,8 +78,8 @@ fn pop_char_on_empty_is_noop() {
 #[test]
 fn query_accessor_reflects_push_char_and_pop_char() {
   // Pin the `query()` accessor as the public read path now that the
-  // `query` field is private (refs #134). Two `push_char` calls then a
-  // single `pop_char` must reflect through the accessor without
+  // `query` field is private (refs #134). Three `push_char` calls then
+  // two `pop_char` calls must reflect through the accessor without
   // leaking the underlying `String`.
   let mut f = FilterState::new();
   f.push_char('a');


### PR DESCRIPTION
## Description

Encapsulation polish from Copilot review on PR #134 (the FilterState extraction). Two changes:

1. **`FilterState.query`** was `pub String` — only-ever read as `&str` (or `.len()` for write-side delta). Replaced with `pub fn query(&self) -> &str` accessor; field is now private.
2. **`tui::fuzzy_match_indices` re-export** dropped — the only consumer (`tui::app::App`) already imports it via the full `tui::state::filter::fuzzy_match_indices` path. Surface area reduced by one symbol.

Closes #134

## Type of change
- [x] ♻️ Refactor (no behaviour change)

## Changes
- `src/tui/state/filter.rs`: `pub query` → private; new `pub fn query(&self) -> &str`.
- `src/tui/mod.rs`: drop `fuzzy_match_indices` from `pub use state::filter::{...}` re-export.
- `src/tui/{app,mod,ui}.rs`: 8 read sites migrated to the accessor.
- Tests updated to the public API.

## Tests
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — full suite green

## Checklist
- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased] > Changed`

## Linked issues / docs
- Issue: #134