### PR TITLE
⚡ perf(tui): store commit graph hashes as OIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_(no in-progress entries — last published: [`0.7.0-rc.3`](changelogs/pre-releases/0.7.0-rc.3.md))_
+- ⚡ TUI sidebar commit graph pipes now carry `git2::Oid` values instead of heap-allocated hash strings, cutting the 300-row graph render benchmark by about 47% and keeping `Pipe` allocation-free. Closes [#108](https://github.com/kbrdn1/gwm-cli/issues/108).
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +234,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -318,6 +357,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +443,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -702,6 +808,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "criterion",
  "crossterm",
  "dirs",
  "git2",
@@ -720,6 +827,17 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "which",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -753,6 +871,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -934,10 +1058,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1231,6 +1375,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1532,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,7 +1689,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -1563,13 +1741,33 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1654,6 +1852,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2026,6 +2233,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,7 +2311,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2175,6 +2392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2281,6 +2508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2613,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2578,6 +2824,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,12 @@ libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
+criterion = "0.5"
 predicates = "3"
+
+[[bench]]
+name = "commit_graph"
+harness = false
 
 [profile.release]
 opt-level = 3

--- a/benches/commit_graph.rs
+++ b/benches/commit_graph.rs
@@ -1,0 +1,29 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gwm::tui::commit_graph::{render_commits, test_row};
+
+fn graph_rows(count: usize) -> Vec<gwm::worktree::CommitRow> {
+  let hashes: Vec<String> = (0..count).map(|i| format!("{:040x}", i + 1)).collect();
+
+  (0..count)
+    .map(|i| {
+      let mut parents = Vec::new();
+      if i + 1 < count {
+        parents.push(hashes[i + 1].as_str());
+      }
+      if i % 17 == 0 && i + 7 < count {
+        parents.push(hashes[i + 7].as_str());
+      }
+      test_row(hashes[i].as_str(), &parents)
+    })
+    .collect()
+}
+
+fn render_commit_graph(c: &mut Criterion) {
+  let rows = graph_rows(300);
+  c.bench_function("render_commits_300_rows", |b| {
+    b.iter(|| render_commits(black_box(&rows)));
+  });
+}
+
+criterion_group!(benches, render_commit_graph);
+criterion_main!(benches);

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -27,16 +27,17 @@
 //! - **No selected-commit override** — lazygit highlights the pipes
 //!   originating from the cursor; our sidebar's selection lives on the
 //!   *worktree* list, not on a specific commit.
-//! - **No empty-tree sentinel** — lazygit targets a synthetic
+//! - **Zero OID empty-tree sentinel** — lazygit targets a synthetic
 //!   `EmptyTreeCommitHash` from the first commit's `Starts` pipe so
-//!   `○` doesn't look orphaned. gwm uses an empty string for the
-//!   first parent of a root commit; the rendered cell is still a
+//!   `○` doesn't look orphaned. gwm uses `0000000000000000000000000000000000000000`
+//!   for the first parent of a root commit; the rendered cell is still a
 //!   plain `○` because the seeded sentinel pipe from row 0 terminates
 //!   on it. The trivial commit-on-commit `Terminates` (where
 //!   `from_pos == to_pos == commit_pos`) is skipped in
 //!   [`render_pipe_set`] so it doesn't overwrite the node glyph.
 
 use crate::worktree::CommitRow;
+use git2::Oid;
 use ratatui::{
   style::{Color, Modifier, Style},
   text::Span,
@@ -60,8 +61,8 @@ pub enum PipeKind {
 pub struct Pipe {
   pub from_pos: i16,
   pub to_pos: i16,
-  pub from_hash: String,
-  pub to_hash: String,
+  pub from_hash: Oid,
+  pub to_hash: Oid,
   pub kind: PipeKind,
 }
 
@@ -147,10 +148,12 @@ pub fn box_drawing_chars(up: bool, down: bool, left: bool, right: bool) -> (char
   }
 }
 
-/// Seed sentinel hash used by lazygit for the pipe that ends on the
-/// very first commit (`graph.go:36`). The actual value is opaque — it
-/// just must never equal any real SHA-1.
-const START_HASH: &str = "__GWM_GRAPH_START__";
+/// Seed sentinel hash used for the pipe that ends on the very first
+/// commit. Zero OID is outside normal `git log` output and keeps pipe
+/// comparisons allocation-free.
+fn start_hash() -> Oid {
+  Oid::zero()
+}
 
 /// Walk `commits` once, producing the per-row pipe sets. This is the
 /// Rust translation of lazygit's `GetPipeSets` (`graph.go:60-69`).
@@ -161,8 +164,8 @@ pub fn build_pipe_sets(commits: &[CommitRow]) -> Vec<Vec<Pipe>> {
   let mut pipes = vec![Pipe {
     from_pos: 0,
     to_pos: 0,
-    from_hash: START_HASH.to_string(),
-    to_hash: commits[0].hash.clone(),
+    from_hash: start_hash(),
+    to_hash: commits[0].hash,
     kind: PipeKind::Starts,
   }];
   let mut out = Vec::with_capacity(commits.len());
@@ -196,11 +199,11 @@ fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
 
   // Emit the STARTS pipe for the *first* parent (or empty-tree sentinel
   // when this is the root commit).
-  let first_parent = commit.parents.first().cloned().unwrap_or_else(|| String::from(""));
+  let first_parent = commit.parents.first().copied().unwrap_or_else(start_hash);
   new_pipes.push(Pipe {
     from_pos: pos,
     to_pos: pos,
-    from_hash: commit.hash.clone(),
+    from_hash: commit.hash,
     to_hash: first_parent,
     kind: PipeKind::Starts,
   });
@@ -249,8 +252,8 @@ fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
       new_pipes.push(Pipe {
         from_pos: pipe.to_pos,
         to_pos: pos,
-        from_hash: pipe.from_hash.clone(),
-        to_hash: pipe.to_hash.clone(),
+        from_hash: pipe.from_hash,
+        to_hash: pipe.to_hash,
         kind: PipeKind::Terminates,
       });
       traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, pos);
@@ -260,8 +263,8 @@ fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
       new_pipes.push(Pipe {
         from_pos: pipe.to_pos,
         to_pos: avail,
-        from_hash: pipe.from_hash.clone(),
-        to_hash: pipe.to_hash.clone(),
+        from_hash: pipe.from_hash,
+        to_hash: pipe.to_hash,
         kind: PipeKind::Continues,
       });
       traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, avail);
@@ -275,8 +278,8 @@ fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
       new_pipes.push(Pipe {
         from_pos: pos,
         to_pos: avail,
-        from_hash: commit.hash.clone(),
-        to_hash: parent.clone(),
+        from_hash: commit.hash,
+        to_hash: *parent,
         kind: PipeKind::Starts,
       });
       taken_spots.insert(avail);
@@ -299,8 +302,8 @@ fn get_next_pipes(prev_pipes: &[Pipe], commit: &CommitRow) -> Vec<Pipe> {
       new_pipes.push(Pipe {
         from_pos: pipe.to_pos,
         to_pos: last,
-        from_hash: pipe.from_hash.clone(),
-        to_hash: pipe.to_hash.clone(),
+        from_hash: pipe.from_hash,
+        to_hash: pipe.to_hash,
         kind: PipeKind::Continues,
       });
       traverse(&mut taken_spots, &mut traversed_spots, pipe.to_pos, last);
@@ -436,10 +439,18 @@ pub fn render_commits(commits: &[CommitRow]) -> Vec<Vec<Span<'static>>> {
 /// minimum data the graph algorithm needs.
 #[doc(hidden)]
 pub fn test_row(hash: &str, parents: &[&str]) -> CommitRow {
+  fn oid(label: &str) -> Oid {
+    if label.len() == 40 {
+      return Oid::from_str(label).expect("test hash must be valid hex");
+    }
+    let padded = format!("{:0>40}", label);
+    Oid::from_str(&padded).expect("test hash label must be valid hex")
+  }
+
   CommitRow {
-    hash: hash.into(),
+    hash: oid(hash),
     author: String::new(),
-    parents: parents.iter().map(|s| s.to_string()).collect(),
+    parents: parents.iter().map(|s| oid(s)).collect(),
     subject: String::new(),
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -597,7 +597,8 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
 }
 
 fn commit_row_line(row: worktree::CommitRow, graph: Vec<Span<'static>>) -> Line<'static> {
-  let short_hash: String = row.hash.to_string().chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
+  let mut short_hash = row.hash.to_string();
+  short_hash.truncate(COMMIT_HASH_DISPLAY_LEN);
   let initials = author_initials(&row.author);
   let mut spans: Vec<Span<'static>> = Vec::with_capacity(5 + graph.len());
   spans.push(Span::styled(short_hash, Style::default().fg(Color::Yellow)));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -597,7 +597,7 @@ pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>
 }
 
 fn commit_row_line(row: worktree::CommitRow, graph: Vec<Span<'static>>) -> Line<'static> {
-  let short_hash: String = row.hash.chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
+  let short_hash: String = row.hash.to_string().chars().take(COMMIT_HASH_DISPLAY_LEN).collect();
   let initials = author_initials(&row.author);
   let mut spans: Vec<Span<'static>> = Vec::with_capacity(5 + graph.len());
   spans.push(Span::styled(short_hash, Style::default().fg(Color::Yellow)));

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -34,6 +34,36 @@ pub struct WorktreeInfo {
   pub age: Option<Duration>,
 }
 
+#[cfg(test)]
+mod tests {
+  use super::parse_git_log_with_author_output;
+
+  #[test]
+  fn parse_git_log_error_includes_invalid_commit_oid_text() {
+    let err = parse_git_log_with_author_output("not-an-oid\u{0}Ada\u{0}\u{0}subject\n").unwrap_err();
+    let rendered = err.to_string();
+
+    assert!(
+      rendered.contains("not-an-oid"),
+      "invalid commit oid should be included in the error, got: {}",
+      rendered
+    );
+  }
+
+  #[test]
+  fn parse_git_log_error_includes_invalid_parent_oid_text() {
+    let raw = "0123456789abcdef0123456789abcdef01234567\u{0}Ada\u{0}bad-parent\u{0}subject\n";
+    let err = parse_git_log_with_author_output(raw).unwrap_err();
+    let rendered = err.to_string();
+
+    assert!(
+      rendered.contains("bad-parent"),
+      "invalid parent oid should be included in the error, got: {}",
+      rendered
+    );
+  }
+}
+
 /// Cheap snapshot of "where are we vs. clean / upstream".
 #[derive(Debug, Clone, Default)]
 pub struct BranchStatus {
@@ -383,6 +413,10 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
     )));
   }
   let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+  parse_git_log_with_author_output(&raw)
+}
+
+fn parse_git_log_with_author_output(raw: &str) -> Result<Vec<CommitRow>> {
   let mut rows = Vec::new();
   for line in raw.lines() {
     let mut parts = line.splitn(4, '\u{0}');
@@ -394,12 +428,12 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
       continue;
     }
     let hash = git2::Oid::from_str(hash)
-      .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid commit oid: {}", e)))?;
+      .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid commit oid '{}': {}", hash, e)))?;
     let parents: Vec<git2::Oid> = parents_field
       .split_whitespace()
       .map(|s| {
         git2::Oid::from_str(s)
-          .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid parent oid: {}", e)))
+          .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid parent oid '{}': {}", s, e)))
       })
       .collect::<Result<Vec<_>>>()?;
     rows.push(CommitRow {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -345,18 +345,18 @@ pub fn prune(repo: &Repository) -> Result<usize> {
 
 /// A commit row pulled from `git log` for the Recent Commits sidebar block.
 /// Mirrors lazygit's columnar layout (hash + author + subject) so the
-/// renderer can lay out one commit per visual line. Hashes are full
-/// 40-char SHAs; the renderer trims them on display to a fixed length
-/// (the `COMMIT_HASH_DISPLAY_LEN` constant in `src/tui/ui.rs`, currently
-/// 8 chars, matching lazygit's `Gui.CommitHashLength` default). Not
+/// renderer can lay out one commit per visual line. Hashes are parsed
+/// into binary OIDs once, then formatted on display to a fixed length (the
+/// `COMMIT_HASH_DISPLAY_LEN` constant in `src/tui/ui.rs`, currently 8
+/// chars, matching lazygit's `Gui.CommitHashLength` default). Not
 /// user-configurable today — change the constant to retune.
 /// `parents.len() >= 2` flags a merge commit, which the renderer marks
 /// with `◎` instead of `○`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommitRow {
-  pub hash: String,
+  pub hash: git2::Oid,
   pub author: String,
-  pub parents: Vec<String>,
+  pub parents: Vec<git2::Oid>,
   pub subject: String,
 }
 
@@ -386,14 +386,22 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   let mut rows = Vec::new();
   for line in raw.lines() {
     let mut parts = line.splitn(4, '\u{0}');
-    let hash = parts.next().unwrap_or("").to_string();
+    let hash = parts.next().unwrap_or("");
     let author = parts.next().unwrap_or("").to_string();
     let parents_field = parts.next().unwrap_or("");
     let subject = parts.next().unwrap_or("").to_string();
     if hash.is_empty() {
       continue;
     }
-    let parents: Vec<String> = parents_field.split_whitespace().map(|s| s.to_string()).collect();
+    let hash = git2::Oid::from_str(hash)
+      .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid commit oid: {}", e)))?;
+    let parents: Vec<git2::Oid> = parents_field
+      .split_whitespace()
+      .map(|s| {
+        git2::Oid::from_str(s)
+          .map_err(|e| GwmError::CommandFailed(format!("git log returned invalid parent oid: {}", e)))
+      })
+      .collect::<Result<Vec<_>>>()?;
     rows.push(CommitRow {
       hash,
       author,

--- a/tests/commit_graph_perf_tests.rs
+++ b/tests/commit_graph_perf_tests.rs
@@ -1,0 +1,9 @@
+use gwm::tui::commit_graph::Pipe;
+
+#[test]
+fn commit_graph_pipe_hashes_do_not_own_heap_allocations() {
+  assert!(
+    !std::mem::needs_drop::<Pipe>(),
+    "Pipe must stay allocation-free; use git2::Oid instead of owned String hashes"
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2481,7 +2481,7 @@ fn graph_pipe_set_first_commit_seeds_starts_pipe() {
   assert!(
     pipes[0]
       .iter()
-      .any(|p| p.kind == PipeKind::Starts && p.from_hash == "a"),
+      .any(|p| p.kind == PipeKind::Starts && p.from_hash == test_row("a", &[]).hash),
     "first row must contain a STARTS pipe whose from_hash is the commit itself, got {:?}",
     pipes[0]
   );
@@ -2532,11 +2532,13 @@ fn graph_row_width_is_deterministic_on_commit_list() {
 #[test]
 fn graph_render_pipe_set_handles_single_pipe_starts() {
   use gwm::tui::commit_graph::Pipe;
+  let from = test_row("a", &[]);
+  let to = test_row("b", &[]);
   let pipes = vec![Pipe {
     from_pos: 0,
     to_pos: 0,
-    from_hash: "a".into(),
-    to_hash: "b".into(),
+    from_hash: from.hash,
+    to_hash: to.hash,
     kind: PipeKind::Starts,
   }];
   let spans = render_pipe_set(&pipes);


### PR DESCRIPTION
## Summary
- parse recent commit hashes and parent hashes into `git2::Oid` once in `git_log_with_author`
- store `Pipe.from_hash` / `Pipe.to_hash` as copyable OIDs instead of heap-owned `String`s
- add a Criterion benchmark for 300-row commit graph rendering and an allocation guard asserting `Pipe` does not need `Drop`

Closes #108.

## TDD
- Red: `cargo test commit_graph_pipe_hashes_do_not_own_heap_allocations` failed before the refactor because `Pipe` still owned `String` hashes
- Green: same test passes after the OID refactor

## Benchmarks
Command: `cargo bench --bench commit_graph -- --sample-size 20`

- Before: `render_commits_300_rows` `[135.03 µs 138.93 µs 144.77 µs]`
- After: `render_commits_300_rows` `[68.550 µs 71.824 µs 77.187 µs]`
- Criterion delta: `[-50.806% -47.084% -42.906%]`, p `< 0.05`

## Tests
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo bench --bench commit_graph -- --sample-size 20`