### PR TITLE
⚡ perf(tui): cache sidebar recent commits by OID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ⚡ TUI sidebar commit graph pipes now carry `git2::Oid` values instead of heap-allocated hash strings, cutting the 300-row graph render benchmark by about 47% and keeping `Pipe` allocation-free. Closes [#108](https://github.com/kbrdn1/gwm-cli/issues/108).
-- ⚡ Recent Commits in the TUI sidebar now uses a libgit2 revwalk cached by `(head OID, limit)` instead of shelling out to `git log` on repeated sidebar rebuilds, cutting the 300-row sidebar benchmark by about 99%. Closes [#107](https://github.com/kbrdn1/gwm-cli/issues/107).
+- ⚡ Recent Commits in the TUI sidebar now use a libgit2 revwalk cached by `(worktree path, head OID, limit)` instead of shelling out to `git log` on repeated sidebar rebuilds, cutting the 300-row sidebar benchmark by about 99%. Closes [#107](https://github.com/kbrdn1/gwm-cli/issues/107).
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ⚡ TUI sidebar commit graph pipes now carry `git2::Oid` values instead of heap-allocated hash strings, cutting the 300-row graph render benchmark by about 47% and keeping `Pipe` allocation-free. Closes [#108](https://github.com/kbrdn1/gwm-cli/issues/108).
+- ⚡ Recent Commits in the TUI sidebar now uses a libgit2 revwalk cached by `(head OID, limit)` instead of shelling out to `git log` on repeated sidebar rebuilds, cutting the 300-row sidebar benchmark by about 99%. Closes [#107](https://github.com/kbrdn1/gwm-cli/issues/107).
 
 ## Past releases
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ predicates = "3"
 name = "commit_graph"
 harness = false
 
+[[bench]]
+name = "sidebar_recent_commits"
+harness = false
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/benches/sidebar_recent_commits.rs
+++ b/benches/sidebar_recent_commits.rs
@@ -1,0 +1,69 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use git2::{Repository, Signature};
+use gwm::github::BranchLink;
+use gwm::tui::recent_commits_lines;
+use gwm::worktree::{BranchStatus, WorktreeInfo};
+use tempfile::TempDir;
+
+fn fixture_repo(commit_count: usize) -> (TempDir, Repository, WorktreeInfo) {
+  let dir = TempDir::new().unwrap();
+  let repo = Repository::init(dir.path()).unwrap();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+
+  std::fs::write(dir.path().join("file.txt"), "seed").unwrap();
+  repo
+    .index()
+    .unwrap()
+    .add_path(std::path::Path::new("file.txt"))
+    .unwrap();
+  repo.index().unwrap().write().unwrap();
+  {
+    let tree_id = repo.index().unwrap().write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  }
+
+  for i in 0..commit_count {
+    std::fs::write(dir.path().join("file.txt"), format!("commit-{i}")).unwrap();
+    repo
+      .index()
+      .unwrap()
+      .add_path(std::path::Path::new("file.txt"))
+      .unwrap();
+    repo.index().unwrap().write().unwrap();
+    let parent = repo.head().unwrap().peel_to_commit().unwrap();
+    {
+      let tree_id = repo.index().unwrap().write_tree().unwrap();
+      let tree = repo.find_tree(tree_id).unwrap();
+      repo
+        .commit(Some("HEAD"), &sig, &sig, &format!("commit-{i}"), &tree, &[&parent])
+        .unwrap();
+    }
+  }
+
+  let head = repo.head().unwrap().target().unwrap().to_string();
+  let info = WorktreeInfo {
+    name: "bench".into(),
+    path: dir.path().to_path_buf(),
+    branch: Some("main".into()),
+    head: Some(head),
+    is_main: true,
+    is_locked: false,
+    is_prunable: false,
+    status: BranchStatus::default(),
+    link: BranchLink::empty(),
+    age: None,
+  };
+
+  (dir, repo, info)
+}
+
+fn sidebar_recent_commits(c: &mut Criterion) {
+  let (_dir, _repo, info) = fixture_repo(300);
+  c.bench_function("recent_commits_lines_300_rows", |b| {
+    b.iter(|| recent_commits_lines(black_box(&info), black_box(300)));
+  });
+}
+
+criterion_group!(benches, sidebar_recent_commits);
+criterion_main!(benches);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -576,7 +576,7 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// behaviour: one commit per visual line, overflow cut at the right
 /// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
-  match worktree::git_log_with_author(&w.path, limit) {
+  match worktree::recent_commits_cached(w, limit) {
     Ok(rows) if !rows.is_empty() => {
       let graphs = super::commit_graph::render_commits(&rows);
       rows

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -4,7 +4,7 @@ use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePr
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
 /// Trunk branches treated as "merge destinations" when measuring how
@@ -13,7 +13,8 @@ use std::time::Duration;
 /// convention). Hardcoded here because `branch_age` is also reachable
 /// from contexts that don't carry a `Config` (CLI smoke paths).
 const TRUNK_CANDIDATES: &[&str] = &["main", "master", "dev"];
-type RecentCommitCacheKey = (git2::Oid, usize);
+const RECENT_COMMITS_CACHE_MAX_ENTRIES: usize = 64;
+type RecentCommitCacheKey = (PathBuf, git2::Oid, usize);
 
 static RECENT_COMMITS_CACHE: LazyLock<Mutex<HashMap<RecentCommitCacheKey, Vec<CommitRow>>>> =
   LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -413,29 +414,38 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
 /// callers with `head = None` fall back to opening the worktree once.
 pub fn recent_commits_cached(w: &WorktreeInfo, limit: usize) -> Result<Vec<CommitRow>> {
   let tip = worktree_head_oid(w)?;
-  let key = (tip, limit);
-  if let Some(rows) = RECENT_COMMITS_CACHE
-    .lock()
-    .expect("recent commits cache poisoned")
-    .get(&key)
-    .cloned()
-  {
+  let key = (recent_commits_cache_repo_key(&w.path), tip, limit);
+  if let Some(rows) = recent_commits_cache().get(&key).cloned() {
     return Ok(rows);
   }
 
   let repo = Repository::open(&w.path)?;
   let rows = recent_commits_revwalk(&repo, tip, limit)?;
-  RECENT_COMMITS_CACHE
-    .lock()
-    .expect("recent commits cache poisoned")
-    .insert(key, rows.clone());
+  let mut cache = recent_commits_cache();
+  if cache.len() >= RECENT_COMMITS_CACHE_MAX_ENTRIES {
+    if let Some(oldest_key) = cache.keys().next().cloned() {
+      cache.remove(&oldest_key);
+    }
+  }
+  cache.insert(key, rows.clone());
   Ok(rows)
+}
+
+fn recent_commits_cache() -> MutexGuard<'static, HashMap<RecentCommitCacheKey, Vec<CommitRow>>> {
+  match RECENT_COMMITS_CACHE.lock() {
+    Ok(cache) => cache,
+    Err(poisoned) => poisoned.into_inner(),
+  }
+}
+
+fn recent_commits_cache_repo_key(path: &Path) -> PathBuf {
+  std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn worktree_head_oid(w: &WorktreeInfo) -> Result<git2::Oid> {
   if let Some(head) = &w.head {
     return git2::Oid::from_str(head)
-      .map_err(|e| GwmError::CommandFailed(format!("cached worktree head '{}' is not an oid: {}", head, e)));
+      .map_err(|e| GwmError::Other(format!("cached worktree head '{}' is not an oid: {}", head, e)));
   }
 
   let repo = Repository::open(&w.path)?;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1,8 +1,10 @@
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink};
 use git2::{BranchType, Repository, StatusOptions, WorktreeAddOptions, WorktreePruneOptions};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 /// Trunk branches treated as "merge destinations" when measuring how
@@ -11,6 +13,10 @@ use std::time::Duration;
 /// convention). Hardcoded here because `branch_age` is also reachable
 /// from contexts that don't carry a `Config` (CLI smoke paths).
 const TRUNK_CANDIDATES: &[&str] = &["main", "master", "dev"];
+type RecentCommitCacheKey = (git2::Oid, usize);
+
+static RECENT_COMMITS_CACHE: LazyLock<Mutex<HashMap<RecentCommitCacheKey, Vec<CommitRow>>>> =
+  LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
@@ -390,32 +396,75 @@ pub struct CommitRow {
   pub subject: String,
 }
 
-/// Shell out to `git log --format='%H%x00%aN%x00%P%x00%s' -n <n>` inside
-/// `path` and parse the NUL-separated output into [`CommitRow`]s. The TUI
-/// sidebar uses this for the Recent Commits block — the NUL separator
-/// avoids ambiguity when a subject contains the usual ` `, `|`, or tab
-/// characters lazygit also relies on. The `%P` field carries the
-/// space-separated list of parent SHAs (empty for the seed commit, one for
-/// a normal commit, two-plus for a merge).
+/// Return recent commits for the sidebar using libgit2. This is the uncached
+/// compatibility entry point; the TUI should call [`recent_commits_cached`]
+/// so repeated sidebar rebuilds for the same branch tip are a hash lookup.
 pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["log", "--format=%H%x00%aN%x00%P%x00%s", "-n"])
-    .arg(n.to_string())
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git log failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git log exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  let raw = String::from_utf8_lossy(&output.stdout).into_owned();
-  parse_git_log_with_author_output(&raw)
+  let repo = Repository::open(path)?;
+  let tip = repo.head()?.target().ok_or_else(|| GwmError::UnbornHead {
+    reason: "HEAD does not point at a commit".into(),
+  })?;
+  recent_commits_revwalk(&repo, tip, n)
 }
 
+/// Return recent commits for one worktree, memoised by branch-tip OID and
+/// limit. `WorktreeInfo.head` is populated by [`list`], so normal TUI sidebar
+/// refreshes can hit the cache without reopening the repo. Fixtures and older
+/// callers with `head = None` fall back to opening the worktree once.
+pub fn recent_commits_cached(w: &WorktreeInfo, limit: usize) -> Result<Vec<CommitRow>> {
+  let tip = worktree_head_oid(w)?;
+  let key = (tip, limit);
+  if let Some(rows) = RECENT_COMMITS_CACHE
+    .lock()
+    .expect("recent commits cache poisoned")
+    .get(&key)
+    .cloned()
+  {
+    return Ok(rows);
+  }
+
+  let repo = Repository::open(&w.path)?;
+  let rows = recent_commits_revwalk(&repo, tip, limit)?;
+  RECENT_COMMITS_CACHE
+    .lock()
+    .expect("recent commits cache poisoned")
+    .insert(key, rows.clone());
+  Ok(rows)
+}
+
+fn worktree_head_oid(w: &WorktreeInfo) -> Result<git2::Oid> {
+  if let Some(head) = &w.head {
+    return git2::Oid::from_str(head)
+      .map_err(|e| GwmError::CommandFailed(format!("cached worktree head '{}' is not an oid: {}", head, e)));
+  }
+
+  let repo = Repository::open(&w.path)?;
+  let head_ref = repo.head()?;
+  head_ref.target().ok_or_else(|| GwmError::UnbornHead {
+    reason: "HEAD does not point at a commit".into(),
+  })
+}
+
+fn recent_commits_revwalk(repo: &Repository, tip: git2::Oid, limit: usize) -> Result<Vec<CommitRow>> {
+  let mut walker = repo.revwalk()?;
+  walker.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
+  walker.push(tip)?;
+
+  let mut rows = Vec::new();
+  for oid in walker.take(limit) {
+    let oid = oid?;
+    let commit = repo.find_commit(oid)?;
+    rows.push(CommitRow {
+      hash: oid,
+      author: commit.author().name().unwrap_or("").to_string(),
+      parents: commit.parent_ids().collect(),
+      subject: commit.summary().unwrap_or("").to_string(),
+    });
+  }
+  Ok(rows)
+}
+
+#[cfg(test)]
 fn parse_git_log_with_author_output(raw: &str) -> Result<Vec<CommitRow>> {
   let mut rows = Vec::new();
   for line in raw.lines() {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2232,6 +2232,33 @@ fn recent_commits_lines_reuses_cached_rows_for_unchanged_head() {
 }
 
 #[test]
+fn recent_commits_cache_is_scoped_to_worktree_path() {
+  let (dir, repo) = init_repo();
+  let mut cached = worktree_pointing_at_dir(dir.path());
+  cached.head = Some(repo.head().unwrap().target().unwrap().to_string());
+
+  let first = recent_commits_lines(&cached, 1);
+  let first_text: String = first[0].spans.iter().map(|span| span.content.as_ref()).collect();
+
+  let other = tempfile::TempDir::new().unwrap();
+  let mut same_oid_different_path = worktree_pointing_at_dir(other.path());
+  same_oid_different_path.head = cached.head.clone();
+
+  let second = recent_commits_lines(&same_oid_different_path, 1);
+  let second_text: String = second[0].spans.iter().map(|span| span.content.as_ref()).collect();
+
+  assert!(
+    second_text.starts_with("! "),
+    "same OID in a different worktree path must miss the cache, got: {}",
+    second_text
+  );
+  assert_ne!(
+    second_text, first_text,
+    "recent commit cache must not leak rows across repositories that share an OID"
+  );
+}
+
+#[test]
 #[allow(clippy::assertions_on_constants)] // intentional const pin
 fn recent_commits_default_limit_fills_modern_terminal_heights() {
   // Regression: the previous hardcoded limit of 10 left the bottom of tall

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2205,6 +2205,33 @@ fn recent_commits_lines_returns_all_when_under_limit() {
 }
 
 #[test]
+fn recent_commits_lines_reuses_cached_rows_for_unchanged_head() {
+  let (dir, repo) = init_repo();
+  add_commits(&repo, 3);
+  let mut w = worktree_pointing_at_dir(dir.path());
+  w.head = Some(repo.head().unwrap().target().unwrap().to_string());
+
+  let first = recent_commits_lines(&w, 4);
+  let first_text: Vec<String> = first
+    .iter()
+    .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+    .collect();
+  drop(repo);
+
+  std::fs::rename(dir.path().join(".git"), dir.path().join(".git.hidden")).unwrap();
+  let second = recent_commits_lines(&w, 4);
+  let second_text: Vec<String> = second
+    .iter()
+    .map(|line| line.spans.iter().map(|span| span.content.as_ref()).collect())
+    .collect();
+
+  assert_eq!(
+    second_text, first_text,
+    "unchanged head+limit should reuse cached recent commit rows instead of re-reading the repo"
+  );
+}
+
+#[test]
 #[allow(clippy::assertions_on_constants)] // intentional const pin
 fn recent_commits_default_limit_fills_modern_terminal_heights() {
   // Regression: the previous hardcoded limit of 10 left the bottom of tall


### PR DESCRIPTION
## Summary
- replace the TUI Recent Commits path with a libgit2 revwalk instead of spawning `git log`
- add an in-process cache keyed by `(head OID, limit)` so repeated sidebar rebuilds are served from memory
- keep existing fallback behavior for fixtures/older callers when `WorktreeInfo.head` is absent
- add a Criterion benchmark for the full 300-row sidebar Recent Commits renderer

Closes #107.

## TDD
- Red: `cargo test recent_commits_lines_reuses_cached_rows_for_unchanged_head -- --nocapture` failed because the second render attempted `git log` again and errored after `.git` was hidden
- Green: the same test now passes from the `(head OID, limit)` cache

## Benchmarks
Command: `cargo bench --bench sidebar_recent_commits -- --sample-size 20`

- Before: `recent_commits_lines_300_rows` `[12.647 ms 13.467 ms 14.455 ms]`
- After: `recent_commits_lines_300_rows` `[133.75 µs 139.53 µs 147.30 µs]`
- Criterion delta: `[-99.487% -99.428% -99.351%]`, p `< 0.05`

## Tests
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo bench --bench sidebar_recent_commits -- --sample-size 20`