### PR TITLE
👷 ci(release): publish stable releases with gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,18 +142,37 @@ jobs:
           echo "path=${CHANGELOG_PATH}" >> "$GITHUB_OUTPUT"
 
       - name: publish release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          body_path: ${{ steps.changelog.outputs.path }}
-          files: |
-            dist/*.tar.gz
-            dist/*.tar.gz.sha256
-            dist/*.zip
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --notes-file "${{ steps.changelog.outputs.path }}" \
+              --draft=false \
+              --prerelease=false
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --notes-file "${{ steps.changelog.outputs.path }}" \
+              --verify-tag \
+              --draft=false \
+              --prerelease=false
+          fi
+
+          gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            dist/*.tar.gz \
+            dist/*.tar.gz.sha256 \
+            dist/*.zip \
             dist/*.zip.sha256
-          draft: false
-          prerelease: false
 
   homebrew-tap-update:
     name: update homebrew tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stable GitHub Releases now publish through the GitHub CLI with the workflow token and clobberable asset uploads, avoiding the `softprops/action-gh-release` bad-credentials failure seen on v0.7.0. (#146)
+
 ## Past releases
 
 In reverse chronological order:

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -16,25 +16,30 @@ fn stable_release_workflow_skips_prerelease_tags() {
 #[test]
 fn stable_release_publish_uses_github_cli_with_workflow_token() {
   let workflow = fs::read_to_string(".github/workflows/release.yml").unwrap();
+  let publish_step = workflow
+    .split("      - name: publish release")
+    .nth(1)
+    .and_then(|tail| tail.split("\n  homebrew-tap-update:").next())
+    .expect("release.yml must contain a publish release step before homebrew-tap-update");
 
   assert!(
     !workflow.contains("uses: softprops/action-gh-release"),
     "release.yml must not use softprops/action-gh-release for the stable GitHub Release publish step"
   );
   assert!(
-    workflow.contains("GH_TOKEN: ${{ github.token }}"),
-    "release.yml must pass the workflow token to gh via GH_TOKEN"
+    publish_step.contains("GH_TOKEN: ${{ github.token }}"),
+    "release.yml must pass the workflow token to gh via GH_TOKEN in the publish release step"
   );
   assert!(
-    workflow.contains("gh release create \"$TAG\""),
+    publish_step.contains("gh release create \"$TAG\""),
     "release.yml must create the stable GitHub Release with gh release create"
   );
   assert!(
-    workflow.contains("--notes-file \"${{ steps.changelog.outputs.path }}\""),
+    publish_step.contains("--notes-file \"${{ steps.changelog.outputs.path }}\""),
     "stable release notes must still come from changelogs/<version>.md"
   );
   assert!(
-    workflow.contains("gh release upload \"$TAG\"") && workflow.contains("--clobber"),
+    publish_step.contains("gh release upload \"$TAG\"") && publish_step.contains("--clobber"),
     "release.yml must upload artifacts with gh release upload --clobber so recovery reruns can replace assets"
   );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -14,6 +14,32 @@ fn stable_release_workflow_skips_prerelease_tags() {
 }
 
 #[test]
+fn stable_release_publish_uses_github_cli_with_workflow_token() {
+  let workflow = fs::read_to_string(".github/workflows/release.yml").unwrap();
+
+  assert!(
+    !workflow.contains("uses: softprops/action-gh-release"),
+    "release.yml must not use softprops/action-gh-release for the stable GitHub Release publish step"
+  );
+  assert!(
+    workflow.contains("GH_TOKEN: ${{ github.token }}"),
+    "release.yml must pass the workflow token to gh via GH_TOKEN"
+  );
+  assert!(
+    workflow.contains("gh release create \"$TAG\""),
+    "release.yml must create the stable GitHub Release with gh release create"
+  );
+  assert!(
+    workflow.contains("--notes-file \"${{ steps.changelog.outputs.path }}\""),
+    "stable release notes must still come from changelogs/<version>.md"
+  );
+  assert!(
+    workflow.contains("gh release upload \"$TAG\"") && workflow.contains("--clobber"),
+    "release.yml must upload artifacts with gh release upload --clobber so recovery reruns can replace assets"
+  );
+}
+
+#[test]
 fn prerelease_workflow_does_not_match_stable_tags() {
   let workflow = fs::read_to_string(".github/workflows/pre-release.yml").unwrap();
 


### PR DESCRIPTION
## Description

Replace the stable GitHub Release publish step with explicit `gh release create/edit` and `gh release upload --clobber` using the workflow token.

Closes #146

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

- Stable release publishing now uses `GH_TOKEN: ${{ github.token }}` with GitHub CLI commands instead of `softprops/action-gh-release`.
- Re-runs can update existing release notes and replace uploaded assets via `gh release upload --clobber`.
- Added a workflow regression test pinning the token, GitHub CLI publish path, changelog notes file, and clobberable uploads.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

N/A

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #146
- Related PR: N/A

## Notes for reviewers

`actionlint` is not installed locally, so workflow syntax validation is left to CI/GitHub. Local gates run: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and targeted red/green `cargo test --test release_workflow_tests`.
