### PR TITLE
👷 ci(release): reject duplicate rc changelog entries

### DIFF
--- a/.github/scripts/check-rc-changelog-dupes.sh
+++ b/.github/scripts/check-rc-changelog-dupes.sh
@@ -29,12 +29,16 @@ if [ ! -f "$previous_rc" ]; then
   exit 1
 fi
 
-unreleased_bullets="$(mktemp)"
-previous_bullets="$(mktemp)"
-unreleased_refs="$(mktemp)"
-previous_refs="$(mktemp)"
-duplicate_bullets="$(mktemp)"
-duplicate_refs="$(mktemp)"
+temp_file() {
+  mktemp "${TMPDIR:-/tmp}/gwm-rc-dupes.XXXXXX"
+}
+
+unreleased_bullets="$(temp_file)"
+previous_bullets="$(temp_file)"
+unreleased_refs="$(temp_file)"
+previous_refs="$(temp_file)"
+duplicate_bullets="$(temp_file)"
+duplicate_refs="$(temp_file)"
 trap 'rm -f "$unreleased_bullets" "$previous_bullets" "$unreleased_refs" "$previous_refs" "$duplicate_bullets" "$duplicate_refs"' EXIT
 
 awk '

--- a/.github/scripts/check-rc-changelog-dupes.sh
+++ b/.github/scripts/check-rc-changelog-dupes.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+if [ -z "$tag" ]; then
+  echo "::error::usage: check-rc-changelog-dupes.sh <vX.Y.Z-rc.N>" >&2
+  exit 2
+fi
+
+version="${tag#v}"
+case "$version" in
+  *-rc.[0-9]*) ;;
+  *)
+    echo "tag ${tag} is not an rc tag; skipping previous-rc changelog duplicate check"
+    exit 0
+    ;;
+esac
+
+base="${version%-rc.*}"
+rc_number="${version##*-rc.}"
+if [ "$rc_number" -eq 1 ]; then
+  echo "tag ${tag} is rc.1; no previous rc changelog to compare"
+  exit 0
+fi
+
+previous_rc="changelogs/pre-releases/${base}-rc.$((rc_number - 1)).md"
+if [ ! -f "$previous_rc" ]; then
+  echo "::error::Expected previous RC changelog ${previous_rc} to exist for tag ${tag}." >&2
+  exit 1
+fi
+
+unreleased_bullets="$(mktemp)"
+previous_bullets="$(mktemp)"
+unreleased_refs="$(mktemp)"
+previous_refs="$(mktemp)"
+duplicate_bullets="$(mktemp)"
+duplicate_refs="$(mktemp)"
+trap 'rm -f "$unreleased_bullets" "$previous_bullets" "$unreleased_refs" "$previous_refs" "$duplicate_bullets" "$duplicate_refs"' EXIT
+
+awk '
+  /^## \[Unreleased\]/ { in_unreleased = 1; next }
+  in_unreleased && /^## / { in_unreleased = 0 }
+  in_unreleased && /^[[:space:]]*-[[:space:]]+/ {
+    sub(/^[[:space:]]*-[[:space:]]+/, "- ")
+    sub(/[[:space:]]+$/, "")
+    print
+  }
+' CHANGELOG.md | LC_ALL=C sort -u > "$unreleased_bullets"
+
+awk '
+  /^[[:space:]]*-[[:space:]]+/ {
+    sub(/^[[:space:]]*-[[:space:]]+/, "- ")
+    sub(/[[:space:]]+$/, "")
+    print
+  }
+' "$previous_rc" | LC_ALL=C sort -u > "$previous_bullets"
+
+grep -Eo '#[0-9]+' "$unreleased_bullets" | LC_ALL=C sort -u > "$unreleased_refs" || true
+grep -Eo '#[0-9]+' "$previous_bullets" | LC_ALL=C sort -u > "$previous_refs" || true
+
+comm -12 "$unreleased_bullets" "$previous_bullets" > "$duplicate_bullets"
+comm -12 "$unreleased_refs" "$previous_refs" > "$duplicate_refs"
+
+if [ -s "$duplicate_bullets" ] || [ -s "$duplicate_refs" ]; then
+  echo "::error::CHANGELOG.md [Unreleased] repeats entries already present in ${previous_rc}." >&2
+  if [ -s "$duplicate_refs" ]; then
+    echo "Duplicate issue/PR references:" >&2
+    sed 's/^/  /' "$duplicate_refs" >&2
+  fi
+  if [ -s "$duplicate_bullets" ]; then
+    echo "Duplicate changelog bullets:" >&2
+    sed 's/^/  /' "$duplicate_bullets" >&2
+  fi
+  exit 1
+fi
+
+echo "CHANGELOG.md [Unreleased] has no duplicate bullets or issue refs from ${previous_rc}"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -167,6 +167,10 @@ jobs:
           fi
           echo "path=${CHANGELOG_PATH}" >> "$GITHUB_OUTPUT"
 
+      - name: check unreleased changelog against previous rc
+        shell: bash
+        run: ./.github/scripts/check-rc-changelog-dupes.sh "${{ steps.tag.outputs.name }}"
+
       - name: publish pre-release
         uses: softprops/action-gh-release@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pre-release publishing now fails before upload when root `[Unreleased]` repeats bullets or issue references already shipped in the immediately previous RC notes. (#147)
+
 ## Past releases
 
 In reverse chronological order:

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -1,4 +1,6 @@
-use std::fs;
+use std::{fs, path::Path, process::Command};
+
+const CHECK_RC_DUPES: &str = ".github/scripts/check-rc-changelog-dupes.sh";
 
 #[test]
 fn stable_release_workflow_skips_prerelease_tags() {
@@ -33,4 +35,173 @@ fn prerelease_workflow_does_not_match_stable_tags() {
     !workflow.contains("\n      - \"v*.*.*\""),
     "pre-release.yml must not trigger on stable tags"
   );
+}
+
+#[test]
+fn prerelease_workflow_checks_unreleased_against_previous_rc_before_publish() {
+  let workflow = fs::read_to_string(".github/workflows/pre-release.yml").unwrap();
+  let check_pos = workflow
+    .find("check unreleased changelog against previous rc")
+    .expect("pre-release.yml must run the duplicate changelog guard");
+  let publish_pos = workflow
+    .find("publish pre-release")
+    .expect("pre-release.yml must still publish the pre-release");
+
+  assert!(
+    check_pos < publish_pos,
+    "duplicate changelog guard must run before publishing the pre-release"
+  );
+  assert!(
+    workflow.contains("./.github/scripts/check-rc-changelog-dupes.sh \"${{ steps.tag.outputs.name }}\""),
+    "pre-release.yml must call the duplicate changelog guard with the resolved tag"
+  );
+}
+
+#[test]
+fn rc_changelog_dupe_check_fails_on_repeated_bullet() {
+  let tmp = tempfile::tempdir().unwrap();
+  write_release_files(
+    tmp.path(),
+    r#"
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Release workflow publishes with the workflow token. (#146)
+- Fresh post-rc delta. (#147)
+
+## Past releases
+"#,
+    r#"
+# [0.7.0-rc.2] - 2026-05-23
+
+### Fixed
+
+- Release workflow publishes with the workflow token. (#146)
+"#,
+  );
+
+  let output = run_dupe_check(tmp.path(), "v0.7.0-rc.3");
+
+  assert!(!output.status.success(), "duplicate bullet must fail the check");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    stderr.contains("#146"),
+    "failure should name the duplicated issue ref: {stderr}"
+  );
+  assert!(
+    stderr.contains("Release workflow publishes with the workflow token"),
+    "failure should name the duplicated changelog bullet: {stderr}"
+  );
+}
+
+#[test]
+fn rc_changelog_dupe_check_fails_on_repeated_issue_ref() {
+  let tmp = tempfile::tempdir().unwrap();
+  write_release_files(
+    tmp.path(),
+    r#"
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Tighten release workflow token handling. (#146)
+
+## Past releases
+"#,
+    r#"
+# [0.7.0-rc.2] - 2026-05-23
+
+### Fixed
+
+- Release workflow publishes with the workflow token. (#146)
+"#,
+  );
+
+  let output = run_dupe_check(tmp.path(), "v0.7.0-rc.3");
+
+  assert!(!output.status.success(), "repeated issue ref must fail the check");
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    stderr.contains("#146"),
+    "failure should name the duplicated issue ref: {stderr}"
+  );
+}
+
+#[test]
+fn rc_changelog_dupe_check_allows_new_post_rc_delta() {
+  let tmp = tempfile::tempdir().unwrap();
+  write_release_files(
+    tmp.path(),
+    r#"
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Fresh post-rc delta. (#147)
+
+## Past releases
+"#,
+    r#"
+# [0.7.0-rc.2] - 2026-05-23
+
+### Fixed
+
+- Release workflow publishes with the workflow token. (#146)
+"#,
+  );
+
+  let output = run_dupe_check(tmp.path(), "v0.7.0-rc.3");
+
+  assert!(
+    output.status.success(),
+    "new post-rc deltas must pass: {}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+}
+
+#[test]
+fn rc_changelog_dupe_check_skips_first_rc_without_previous_notes() {
+  let tmp = tempfile::tempdir().unwrap();
+  fs::create_dir_all(tmp.path().join("changelogs/pre-releases")).unwrap();
+  fs::write(
+    tmp.path().join("CHANGELOG.md"),
+    r#"
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- First rc entry. (#147)
+
+## Past releases
+"#,
+  )
+  .unwrap();
+
+  let output = run_dupe_check(tmp.path(), "v0.7.0-rc.1");
+
+  assert!(
+    output.status.success(),
+    "rc.1 has no previous rc to compare: {}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+}
+
+fn write_release_files(root: &Path, changelog: &str, previous_rc: &str) {
+  fs::create_dir_all(root.join("changelogs/pre-releases")).unwrap();
+  fs::write(root.join("CHANGELOG.md"), changelog).unwrap();
+  fs::write(root.join("changelogs/pre-releases/0.7.0-rc.2.md"), previous_rc).unwrap();
+}
+
+fn run_dupe_check(root: &Path, tag: &str) -> std::process::Output {
+  let script = std::env::current_dir().unwrap().join(CHECK_RC_DUPES);
+  Command::new(script).arg(tag).current_dir(root).output().unwrap()
 }


### PR DESCRIPTION
## Description

Add a pre-release guard that compares root `CHANGELOG.md` `[Unreleased]` entries with the immediately previous RC notes before publishing.

Closes #147

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

- Added `.github/scripts/check-rc-changelog-dupes.sh` to fail when `[Unreleased]` repeats previous-RC bullets or `#NNN` issue/PR refs.
- Wired the guard into `pre-release.yml` before `publish pre-release`.
- Covered duplicate bullet failure, duplicate issue-ref failure, legitimate post-RC deltas, `rc.1` skip behavior, and workflow ordering.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

N/A

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #147
- Related PR: N/A

## Notes for reviewers

`bash -n .github/scripts/check-rc-changelog-dupes.sh` passes. `shellcheck` is not installed locally. Local gates run: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and targeted red/green `cargo test --test release_workflow_tests`.
