### PR TITLE
✨ feat(cli): CLI aliases ([aliases] in .gwm.toml + user fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI aliases (`[aliases]` in `.gwm.toml` + user-level fallback)**
+  ([#86](https://github.com/kbrdn1/gwm-cli/issues/86)). `git config`
+  ships with `[alias]`; `gwm` now mirrors the shape. Declare an
+  alias under `[aliases]` in `.gwm.toml` (repo-level, follows the
+  repo across machines) or in `~/.config/gwm/aliases.toml`
+  (user-level fallback). `gwm <alias>` is expanded to argv tokens
+  BEFORE clap parses, so `wip = "create feat 0 wip"` makes `gwm
+  wip` behave as `gwm create feat 0 wip`. Resolution order:
+  built-in subcommands always win (`gwm list` can never be
+  shadowed), then repo, then user. Shell pipelines (`&&`, `|`,
+  `;`, backticks) in alias values are refused at load time — use a
+  shell alias for shell semantics. New `gwm aliases list`
+  subcommand prints the resolved chain grouped by source, with
+  shadowed user entries flagged inline.
+
 ## Past releases
 
 In reverse chronological order:

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -264,6 +264,38 @@ Two **global** flags interact with the ledger on every subcommand that runs boot
 
 Threat model and full rationale: see the module-level comment in [`src/trust.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/trust.rs).
 
+## `gwm aliases list` (issue #86)
+
+Print the resolved CLI alias chain — every alias reachable from `gwm <name>`, grouped by source. Read-only; declarative editing happens directly in `.gwm.toml` (repo-level) and `~/.config/gwm/aliases.toml` (user-level).
+
+```bash
+gwm aliases list
+```
+
+Sample output:
+
+```text
+built-in:
+  cd → path
+  s  → switch
+repo (.gwm.toml):
+  ll  → list --format names
+  wip → create feat 0 wip
+user (~/.config/gwm/aliases.toml):
+  copy → path  (shadowed by repo)
+```
+
+Resolution order (highest precedence first):
+
+1. **Built-in subcommands** (`gwm list`, `gwm switch`, …) — never shadowable.
+2. **Built-in visible aliases** (`s → switch`, `cd → path`) — also never shadowable.
+3. **Repo (`.gwm.toml` `[aliases]`)** — follows the repo across machines.
+4. **User (`~/.config/gwm/aliases.toml` `[aliases]`)** — survives machine reinstalls; invisible to teammates.
+
+Aliases are **argv substitution only** — `wip = "create feat 0 wip"` makes `gwm wip` behave as `gwm create feat 0 wip`. The expansion happens BEFORE clap parses argv. Shell pipelines (`&&`, `||`, `|`, `;`, backticks) in values are refused at load time — use a shell alias instead.
+
+Names that shadow a built-in subcommand or visible alias are a hard config error surfaced by `Config::load_for_repo` (e.g. you can't define `list = "..."`). Single-pass expansion — chained aliases don't recurse.
+
 ## exit codes
 
 | Code | Meaning                                                                |

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -251,6 +251,32 @@ Workflow:
 
 Without a `[[milestones]]` block, `gwm milestones {list|push}` are no-ops (`0 milestones declared, nothing to push`) and never shell out to `gh`. Requires `gh` on `$PATH` once milestones are declared (the same soft dependency as `gwm labels` / `gwm status`).
 
+## `[aliases]` (issue #86)
+
+Repo-level CLI aliases — declarative `git config`-style aliases that follow the repo across machines. Each entry maps an alias name to an argv-substituted expansion run BEFORE clap parses, so `wip = "create feat 0 wip"` makes `gwm wip` behave as `gwm create feat 0 wip`.
+
+```toml
+[aliases]
+wip    = "create feat 0 wip"
+ll     = "list --format names"
+sync   = "bootstrap"
+```
+
+A user-level fallback lives at `~/.config/gwm/aliases.toml` (path honours `$XDG_CONFIG_HOME` first, then `dirs::config_dir()`); same `[aliases]` block shape. Repo aliases win over user aliases on name collision.
+
+Surface the resolved chain with `gwm aliases list` — see [CLI → `gwm aliases list`](/cli/reference#gwm-aliases-list-issue-86) for the rendered output and the per-source flagging.
+
+**Rules enforced at load time** (`Config::load_for_repo` returns `GwmError::Config` on violation):
+
+| Rule                                                                                 | Reason                                                                              |
+|:-------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| Alias name MUST NOT shadow a built-in subcommand (`list`, `switch`, …)               | Built-in subcommands are the strongest binding — silent shadowing is a bug factory. |
+| Alias name MUST NOT shadow a built-in visible alias (`s`, `cd`)                      | Same reasoning — `gwm s` should always reach `switch`.                              |
+| Alias value MUST NOT be empty                                                        | Nothing to expand to.                                                               |
+| Alias value MUST NOT contain shell metachars (`&&`, `\|\|`, `\|`, `;`, backticks)    | Aliases are argv substitution only — use a shell alias for shell semantics.         |
+
+Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` expands ONCE and then dispatches; the second hop is not resolved.
+
 ## defaults without `.gwm.toml`
 
 | Setting                              | Default                          |
@@ -266,6 +292,7 @@ Without a `[[milestones]]` block, `gwm milestones {list|push}` are no-ops (`0 mi
 | `[tui.open].mode`                    | `shell` (v0.6 — was `finder`)    |
 | `[doctor].trunks`                    | `["dev", "main"]`                |
 | `[[labels]]`                         | empty — `gwm labels {list,push}` are no-ops |
+| `[aliases]`                          | empty — no CLI alias expansion              |
 
 ## validation rules
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -303,3 +303,39 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # [[milestones]]
 # title = "v0.6.0"
 # state = "closed"
+
+# --- CLI aliases (issue #86) ------------------------------------------------
+# Mirror of `git config`'s `[alias]` block. Each entry maps a short
+# name to an argv-substituted expansion run BEFORE clap parses, so
+# `gwm wip` becomes `gwm create feat 0 wip` for the dispatcher.
+#
+# Resolution order (highest precedence first):
+#   1. Built-in subcommands (`gwm list`, `gwm switch`, …) — never
+#      shadowable.
+#   2. `visible_alias` set on built-in subcommands (`s → switch`,
+#      `cd → path`) — also never shadowable.
+#   3. This `[aliases]` block (repo-level, follows the repo).
+#   4. `~/.config/gwm/aliases.toml` (user-level, lowest precedence).
+#
+# Rules:
+#   - Aliases are argv substitution only — `gwm <alias> <extra>` becomes
+#     `gwm <expansion> <extra>`. NO shell pipelines: values containing
+#     `&&`, `||`, `|`, `;`, or backticks are refused at load time. Use a
+#     shell alias if you need shell semantics (`alias gwmwip='gwm wip &&
+#     lazygit'`).
+#   - Names that shadow a built-in subcommand or visible alias are a
+#     hard config error surfaced at `Config::load_for_repo` time.
+#   - Single-pass expansion — `wip = "ll"` followed by `ll = "list
+#     --format names"` expands ONCE and then dispatches.
+#
+# Surface the resolved chain (built-in + repo + user, with shadowing
+# flagged inline) via:
+#
+#   gwm aliases list
+#
+# Example:
+#
+# [aliases]
+# wip    = "create feat 0 wip"
+# ll     = "list --format names"
+# sync   = "bootstrap"

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -1,0 +1,361 @@
+//! CLI aliases — `[aliases]` in `.gwm.toml` plus a user-level fallback
+//! at `~/.config/gwm/aliases.toml` (issue #86).
+//!
+//! `git config` ships with `[alias]`; `gwm` mirrors the shape. Aliases
+//! are string-substitution: `gwm <alias>` is expanded to argv tokens
+//! before clap parses the command. Three resolution levels coexist:
+//!
+//!   1. **Built-in** — every `visible_alias` declared on a clap
+//!      subcommand (`cd → path` from issue #67, `s → switch` from
+//!      issue #43). Always wins, can never be shadowed by user config.
+//!   2. **Repo (`.gwm.toml`)** — declared under `[aliases]`. Follows
+//!      the repo across machines.
+//!   3. **User (`~/.config/gwm/aliases.toml`)** — same `[aliases]`
+//!      block; survives a machine reinstall but is invisible to the
+//!      rest of the team. Repo aliases win on name collision.
+//!
+//! ## Why expansion happens before clap parses
+//!
+//! Aliases must turn into argv tokens BEFORE clap reaches the
+//! subcommand slot — otherwise clap rejects an unknown subcommand
+//! before we get a chance to substitute it. The flow is:
+//!
+//! ```text
+//!   main() → aliases::load() → aliases::expand_argv() → Cli::parse(expanded)
+//! ```
+//!
+//! This shape mirrors what `git` does with `[alias]` — the dispatcher
+//! sees the expanded form, never the alias name.
+//!
+//! ## What aliases CAN'T do
+//!
+//! - **No shell pipelines** — `wip = "create feat 0 wip && lazygit"`
+//!   is rejected at load. Shell metachars (`&&`, `||`, `|`, `;`,
+//!   backticks) cannot be honoured by an argv-substitution path that
+//!   hands off to clap. Use a shell alias if that's what you need.
+//! - **No recursion** — `wip = "ll"` followed by `ll = "list --
+//!   format names"` expands once, then dispatches. Matches git's
+//!   behaviour and keeps the resolution loop linear.
+//! - **No shadowing of built-in subcommands** — `[aliases] list =
+//!   "create feat 0 wip"` is a hard config error. The check uses the
+//!   compile-time clap CommandFactory, so adding a new subcommand
+//!   automatically extends the shadow gate.
+
+use crate::error::{GwmError, Result};
+use clap::CommandFactory;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// One entry in the built-in alias snapshot. `name` is the clap
+/// `visible_alias` (e.g. `cd`); `expansion` is the canonical
+/// subcommand it points at (e.g. `path`). Static `&'static str` so the
+/// snapshot lives in `BUILT_IN_ALIASES` as a `const` slice (no heap
+/// allocation, no lazy init).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AliasEntry {
+  pub name: &'static str,
+  pub expansion: &'static str,
+}
+
+/// Built-in aliases — every `#[command(visible_alias = "…")]` declared
+/// on the clap `Command` enum. Must stay in lockstep with `src/cli.rs`;
+/// a regression test in `tests/aliases_tests.rs` pins the contract.
+///
+/// The list is short by design — clap visible aliases are the only
+/// "built-ins" gwm exposes. They are reachable as bare argv tokens
+/// (`gwm cd foo`, `gwm s`) so the shadow check has to know about them
+/// to refuse user aliases of the same name.
+pub const BUILT_IN_ALIASES: &[AliasEntry] = &[
+  AliasEntry {
+    name: "cd",
+    expansion: "path",
+  },
+  AliasEntry {
+    name: "s",
+    expansion: "switch",
+  },
+];
+
+/// Resolved alias chain — built-in + repo + user, in lookup-priority
+/// order. Built by [`load`] and consumed by [`expand_argv`] (for the
+/// pre-clap expansion) and by `gwm aliases list` (for the user-facing
+/// summary).
+#[derive(Debug, Clone)]
+pub struct ResolvedAliases {
+  /// Built-in clap `visible_alias` set — always wins over user
+  /// declarations. Static slice cloned into a `Vec` so callers can
+  /// extend it cheaply (e.g. for tests).
+  pub built_in: Vec<AliasEntry>,
+  /// Repo-level aliases from `.gwm.toml`. Wins over `user` on name
+  /// collision. `BTreeMap` so iteration order is deterministic
+  /// (alphabetical), matching the output of `gwm aliases list`.
+  pub repo: BTreeMap<String, String>,
+  /// User-level aliases from `~/.config/gwm/aliases.toml`. Lowest
+  /// precedence — overridden by both `built_in` and `repo`.
+  pub user: BTreeMap<String, String>,
+}
+
+impl ResolvedAliases {
+  /// Look up `name` honouring the resolution chain: built-in first,
+  /// then repo, then user. Returns the raw expansion string (to be
+  /// tokenised by `shell_words::split` at call time).
+  ///
+  /// Built-in entries are checked first because they must be
+  /// impossible to shadow — even if a malformed `ResolvedAliases` is
+  /// constructed by hand (tests, future APIs) with a `list` entry in
+  /// `user`, `expand_argv` MUST treat `list` as the built-in
+  /// subcommand and skip the substitution.
+  fn lookup(&self, name: &str) -> Option<String> {
+    if BUILT_IN_SUBCOMMANDS.contains(&name) {
+      // Built-in subcommand names ARE the strongest binding — never
+      // expand them, regardless of what `repo`/`user` say. This is
+      // the defence-in-depth complement to the shadow check in
+      // `load`.
+      return None;
+    }
+    if let Some(e) = self.built_in.iter().find(|e| e.name == name) {
+      return Some(e.expansion.to_string());
+    }
+    if let Some(v) = self.repo.get(name) {
+      return Some(v.clone());
+    }
+    if let Some(v) = self.user.get(name) {
+      return Some(v.clone());
+    }
+    None
+  }
+}
+
+/// Load and validate the alias chain. `repo_root` is the repo root
+/// (where `.gwm.toml` lives) — `None` skips the repo step entirely
+/// (used by `aliases load` outside a git repo). `user_path` is the
+/// user-level file path — `None` falls back to the default
+/// `~/.config/gwm/aliases.toml`; an explicit path is honoured even if
+/// it doesn't exist (returns empty user map).
+///
+/// Errors:
+///   - `GwmError::Config` when a TOML parse fails, an alias shadows a
+///     built-in subcommand, an alias value contains shell pipeline
+///     metachars (`&&`, `||`, `|`, `;`, backticks), or an alias value
+///     is empty.
+///   - `GwmError::Io` if the file exists but can't be read.
+///   - `GwmError::TomlParse` propagates the underlying serde error.
+pub fn load(repo_root: Option<&Path>, user_path: Option<&Path>) -> Result<ResolvedAliases> {
+  let built_in = BUILT_IN_ALIASES.to_vec();
+
+  // Repo: read `.gwm.toml`'s `[aliases]` block via `Config::load_for_repo`,
+  // which already validates the same shadow / shell-pipeline rules via
+  // its dedicated `validate_aliases` method (called below).
+  let repo = match repo_root {
+    Some(root) => {
+      let cfg = crate::config::Config::load_for_repo(root)?;
+      cfg.aliases
+    }
+    None => BTreeMap::new(),
+  };
+
+  // User: same shape, validated through the standalone helper so the
+  // file path appears in the error message.
+  let resolved_user_path = user_path.map(PathBuf::from).or_else(default_user_path);
+  let user = match resolved_user_path {
+    Some(path) if path.exists() => {
+      let raw = std::fs::read_to_string(&path)?;
+      let file: AliasesFile = toml::from_str(&raw)?;
+      let map = file.aliases;
+      validate_aliases(&map, &format!("{} `[aliases]`", path.display()))?;
+      map
+    }
+    _ => BTreeMap::new(),
+  };
+
+  Ok(ResolvedAliases { built_in, repo, user })
+}
+
+/// Expand `argv` in place: replace the first non-flag token in
+/// `argv[1..]` with its alias expansion (if any). Single-pass — never
+/// recurses, never expands a token that maps to a built-in subcommand
+/// (defence-in-depth on top of `load`'s shadow check).
+///
+/// `argv[0]` (the binary name) is preserved unchanged. Trailing
+/// arguments after the alias slot are appended after the expansion —
+/// `gwm wip --no-bootstrap` with `wip = "create feat 0 wip"` becomes
+/// `gwm create feat 0 wip --no-bootstrap`.
+///
+/// Tokenisation uses `shell_words::split` (POSIX shell quoting). A
+/// malformed value (unbalanced quotes) returns the original argv
+/// unchanged — the load-time validation should already have caught
+/// shell metachars, so reaching this branch means the user
+/// hand-edited the config to something pathological. We refuse to
+/// dispatch a partial substitution and let clap report the unknown
+/// subcommand verbatim.
+pub fn expand_argv(argv: Vec<String>, aliases: &ResolvedAliases) -> Vec<String> {
+  if argv.len() < 2 {
+    return argv;
+  }
+  // Find the first non-flag token starting at index 1. Anything
+  // starting with `-` is a global flag (clap parses `--allow-bootstrap`
+  // anywhere); we look past it to land on the subcommand slot.
+  let Some(alias_idx) = argv
+    .iter()
+    .enumerate()
+    .skip(1)
+    .find_map(|(i, tok)| if tok.starts_with('-') { None } else { Some(i) })
+  else {
+    return argv;
+  };
+
+  let alias_name = &argv[alias_idx];
+  let Some(expansion) = aliases.lookup(alias_name) else {
+    return argv;
+  };
+
+  let Ok(expanded_tokens) = shell_words::split(&expansion) else {
+    // Pathological case: load() should have rejected this. Refuse
+    // partial substitution and let clap surface the unknown subcommand
+    // verbatim — the user sees "error: unrecognized subcommand" with
+    // the original alias name, not a half-expanded mess.
+    return argv;
+  };
+
+  let mut out = Vec::with_capacity(argv.len() + expanded_tokens.len());
+  out.extend_from_slice(&argv[..alias_idx]);
+  out.extend(expanded_tokens);
+  out.extend_from_slice(&argv[alias_idx + 1..]);
+  out
+}
+
+/// Default location of the user-level alias file. Mirrors the
+/// trust-ledger pattern (`~/.config/gwm/trust.toml`): honour
+/// `$XDG_CONFIG_HOME` first, fall back to `dirs::config_dir()` —
+/// returns `None` on systems where neither resolves (sandboxed CI,
+/// containers without `$HOME`).
+fn default_user_path() -> Option<PathBuf> {
+  if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+    if !xdg.is_empty() {
+      return Some(PathBuf::from(xdg).join("gwm").join("aliases.toml"));
+    }
+  }
+  dirs::config_dir().map(|p| p.join("gwm").join("aliases.toml"))
+}
+
+/// Internal shape of the user-level alias file. Mirrors the
+/// `[aliases]` block in `.gwm.toml` so the user can copy-paste
+/// between the two without remembering whether the key prefix
+/// differs.
+#[derive(Debug, Default, serde::Deserialize)]
+struct AliasesFile {
+  #[serde(default)]
+  aliases: BTreeMap<String, String>,
+}
+
+/// Built-in subcommand names. Resolved from the clap `Command` factory
+/// at call time — adding a new subcommand to `cli::Command` extends
+/// this set automatically. Memoised inside `validate_aliases` per
+/// call; the slice form here is just for the const-time lookup in
+/// `ResolvedAliases::lookup` (subcommands hard-coded so the lookup
+/// path doesn't need to allocate). Adding a new subcommand requires
+/// adding its name here AND `tests/aliases_tests.rs` will catch a
+/// miss via the canary test.
+const BUILT_IN_SUBCOMMANDS: &[&str] = &[
+  "init",
+  "list",
+  "create",
+  "remove",
+  "path",
+  "bootstrap",
+  "prune",
+  "doctor",
+  "types",
+  "completions",
+  "shell-init",
+  "switch",
+  "tmux",
+  "zellij",
+  "link",
+  "unlink",
+  "open",
+  "status",
+  "labels",
+  "milestones",
+  "trust",
+  "aliases",
+  "help",
+];
+
+/// Validate a user-supplied alias map. Used by both
+/// [`crate::config::Config::validate_aliases`] (repo-level) and the
+/// user-level loader, so the rules stay symmetric.
+///
+/// `source_label` is woven into the error message ("`.gwm.toml`
+/// `[aliases]`" vs `"/home/x/.config/gwm/aliases.toml [aliases]"`)
+/// so the user knows which file to edit.
+///
+/// Rules enforced (matching the issue contract):
+///
+///   1. Alias name must NOT shadow a built-in subcommand or a
+///      built-in visible alias. The check uses the runtime clap
+///      `CommandFactory` so it's always in sync with `src/cli.rs`.
+///   2. Alias value must NOT be empty after trimming.
+///   3. Alias value must NOT contain shell pipeline metachars:
+///      `&&`, `||`, `|`, `;`, backticks. These would silently lose
+///      semantics under argv substitution — the user must reach for
+///      a shell alias instead.
+pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> Result<()> {
+  // Pull the built-in subcommand + alias names directly from clap so
+  // adding a new subcommand to `cli::Command` automatically extends
+  // the shadow check.
+  let cmd = crate::cli::Cli::command();
+  let mut built_ins: std::collections::HashSet<String> = std::collections::HashSet::new();
+  for sub in cmd.get_subcommands() {
+    built_ins.insert(sub.get_name().to_string());
+    for alias in sub.get_visible_aliases() {
+      built_ins.insert(alias.to_string());
+    }
+    for alias in sub.get_all_aliases() {
+      built_ins.insert(alias.to_string());
+    }
+  }
+  // Always include the canonical subcommand list — keeps the gate
+  // honest when `validate_aliases` is called before `Cli::command()`
+  // has registered new subcommands (e.g. from a test that mutates
+  // the command tree).
+  for name in BUILT_IN_SUBCOMMANDS {
+    built_ins.insert((*name).to_string());
+  }
+
+  for (name, value) in map {
+    if built_ins.contains(name) {
+      return Err(GwmError::Config(format!(
+        "{}: alias '{}' would shadow a built-in subcommand or alias — pick a different name",
+        source_label, name
+      )));
+    }
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+      return Err(GwmError::Config(format!(
+        "{}: alias '{}' has an empty value — provide a subcommand to expand to",
+        source_label, name
+      )));
+    }
+    // Shell pipeline metachar gate. The list is conservative — we
+    // refuse anything that LOOKS like a pipeline so the failure
+    // mode is "user reads the error" rather than "user sees a
+    // half-honoured alias do mysterious things".
+    for pat in SHELL_METACHARS {
+      if trimmed.contains(pat) {
+        return Err(GwmError::Config(format!(
+          "{}: alias '{}' = {:?} contains shell metachar {:?} — \
+           gwm aliases are argv substitution only (no pipelines); use a shell alias instead",
+          source_label, name, value, pat
+        )));
+      }
+    }
+  }
+  Ok(())
+}
+
+/// Forbidden shell metachars in alias values. The list intentionally
+/// stays short — anything that even hints at "shell pipeline" gets
+/// rejected. A user trying to do `path | pbcopy` hits the gate and
+/// reads the error pointing at shell aliases as the right tool.
+const SHELL_METACHARS: &[&str] = &["&&", "||", "|", ";", "`"];

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -224,6 +224,82 @@ pub fn expand_argv(argv: Vec<String>, aliases: &ResolvedAliases) -> Vec<String> 
   out
 }
 
+/// `OsString` counterpart of [`expand_argv`] — accepts the raw
+/// `std::env::args_os()` slice without forcing a UTF-8 round-trip on
+/// every token.
+///
+/// Why this matters: `std::env::args()` panics on the first non-UTF-8
+/// argv entry (Linux/macOS allow arbitrary bytes in argv). Clap parses
+/// `OsString` natively via `args_os`, and the panic in `main` was a
+/// regression vs. that default. We mirror the `expand_argv` logic on
+/// `OsString` and only attempt UTF-8 conversion on the alias-slot
+/// token — if it is not valid UTF-8 it cannot match an alias name
+/// (alias keys are `String` by construction in `ResolvedAliases`), so
+/// the argv is returned unchanged and clap surfaces the unknown
+/// subcommand verbatim.
+///
+/// Flag detection is byte-level: a leading `b'-'` is unambiguous in
+/// every valid argv encoding (the byte is ASCII, so it cannot appear
+/// mid-UTF-8-sequence), which means we can scan past flags without
+/// decoding them.
+pub fn expand_argv_os(argv: Vec<std::ffi::OsString>, aliases: &ResolvedAliases) -> Vec<std::ffi::OsString> {
+  if argv.len() < 2 {
+    return argv;
+  }
+  // First non-flag token from index 1. Use the underlying bytes for
+  // the leading-dash check so we don't reject argv with a non-UTF-8
+  // tail; on Unix this is `as_bytes`, on Windows the encoded form is
+  // WTF-8 and the same ASCII-byte invariant holds for the leading
+  // dash check we do here.
+  let alias_idx = argv.iter().enumerate().skip(1).find_map(|(i, tok)| {
+    let is_flag = first_byte_is_dash(tok);
+    if is_flag {
+      None
+    } else {
+      Some(i)
+    }
+  });
+  let Some(alias_idx) = alias_idx else {
+    return argv;
+  };
+
+  // Only valid UTF-8 can match an alias key. Non-UTF-8 tokens cannot
+  // be alias names (the key type is `String`), so we return the argv
+  // unchanged and let clap surface the unknown subcommand verbatim.
+  let Some(alias_name) = argv[alias_idx].to_str() else {
+    return argv;
+  };
+
+  let Some(expansion) = aliases.lookup(alias_name) else {
+    return argv;
+  };
+
+  let Ok(expanded_tokens) = shell_words::split(&expansion) else {
+    // Pathological case: load() should have rejected this. See
+    // `expand_argv` for the rationale — refuse partial substitution.
+    return argv;
+  };
+
+  let mut out = Vec::with_capacity(argv.len() + expanded_tokens.len());
+  out.extend_from_slice(&argv[..alias_idx]);
+  out.extend(expanded_tokens.into_iter().map(std::ffi::OsString::from));
+  out.extend_from_slice(&argv[alias_idx + 1..]);
+  out
+}
+
+/// Inspect the first byte of an `OsStr` to decide whether the token
+/// is a flag (leading `-`). The byte is examined in the platform's
+/// native argv encoding — ASCII bytes survive both UTF-8 (Unix) and
+/// WTF-8 (Windows) round-trips intact, so a simple `as_encoded_bytes`
+/// check is correct on both targets.
+fn first_byte_is_dash(token: &std::ffi::OsStr) -> bool {
+  // `OsStr::as_encoded_bytes` is stable since 1.74 and exposes the
+  // platform-native encoding. We only check the first byte against
+  // ASCII `-` which is identical in UTF-8 and WTF-8, so this is safe
+  // without ever decoding the rest of the token.
+  token.as_encoded_bytes().first() == Some(&b'-')
+}
+
 /// Default location of the user-level alias file. Mirrors the
 /// trust-ledger pattern (`~/.config/gwm/trust.toml`): honour
 /// `$XDG_CONFIG_HOME` first, fall back to `dirs::config_dir()` —

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -278,6 +278,35 @@ pub enum Command {
     #[command(subcommand)]
     action: TrustAction,
   },
+  /// List the resolved CLI aliases (built-in + repo + user). Issue #86.
+  ///
+  /// `gwm aliases list` surfaces every alias reachable from `gwm
+  /// <name>`, grouped by source: `built-in` (clap `visible_alias`
+  /// set), `repo (.gwm.toml)`, `user (~/.config/gwm/aliases.toml)`.
+  /// The resolution chain favours repo aliases over user aliases when
+  /// both declare the same name, but both rows are still printed so
+  /// the user can see what's being shadowed.
+  Aliases {
+    #[command(subcommand)]
+    action: AliasesAction,
+  },
+}
+
+/// Subcommands of `gwm aliases` (issue #86). Read-only for now —
+/// declarative editing of the alias set stays in TOML files where
+/// users can grep / diff / version-control them. A future `add` /
+/// `remove` could land if real usage justifies it.
+#[derive(Debug, Subcommand)]
+pub enum AliasesAction {
+  /// Print the resolved alias chain (built-in / repo / user).
+  ///
+  /// Reads `.gwm.toml`'s `[aliases]` block (if any) and the
+  /// user-level fallback `~/.config/gwm/aliases.toml` (path resolved
+  /// via `$XDG_CONFIG_HOME` first, then `dirs::config_dir()`). The
+  /// output is grouped by source so users can audit which file
+  /// declares which mapping and where they need to edit to change
+  /// it.
+  List,
 }
 
 /// Subcommands of `gwm labels`. The split is intentional: `list` is
@@ -438,6 +467,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Labels { action } => cmd_labels(action),
     Command::Milestones { action } => cmd_milestones(action),
     Command::Trust { action } => cmd_trust(action),
+    Command::Aliases { action } => cmd_aliases(action),
   }
 }
 
@@ -1557,6 +1587,89 @@ fn print_bootstrap_summary(cfg: &Config) {
   for c in &bs.command {
     println!("       - run    {} ({})", c.name, c.run);
   }
+}
+
+// ---- Aliases commands (issue #86) ---------------------------------------
+
+fn cmd_aliases(action: AliasesAction) -> Result<()> {
+  match action {
+    AliasesAction::List => cmd_aliases_list(),
+  }
+}
+
+/// `gwm aliases list` — print the resolved alias chain. Reads
+/// `.gwm.toml` from the current repo workdir when available (gracefully
+/// degrades to "no repo" when invoked outside a git repo) and the
+/// user-level fallback `~/.config/gwm/aliases.toml`.
+///
+/// Output shape (matches the issue example verbatim):
+///
+/// ```text
+/// built-in:
+///   s    → switch
+///   cd   → path
+/// repo (.gwm.toml):
+///   wip    → create feat 0 wip
+///   ll     → list --format names
+/// user (~/.config/gwm/aliases.toml):
+///   copy   → path
+/// ```
+fn cmd_aliases_list() -> Result<()> {
+  // Discover the repo workdir if any — outside a repo this is `None`
+  // and the repo section degrades to "(no .gwm.toml — not inside a
+  // git repository)". `aliases list` is intentionally tolerant of
+  // running outside a repo so power users can audit their user-level
+  // file without cd'ing first.
+  let repo_workdir: Option<PathBuf> = crate::worktree::discover_repo(None)
+    .ok()
+    .and_then(|r| r.workdir().map(|w| w.to_path_buf()));
+
+  let resolved = crate::aliases::load(repo_workdir.as_deref(), None)?;
+
+  // built-in section ---------------------------------------------------
+  println!("built-in:");
+  if resolved.built_in.is_empty() {
+    println!("  (none)");
+  } else {
+    let width = resolved.built_in.iter().map(|e| e.name.len()).max().unwrap_or(2).max(2);
+    for e in &resolved.built_in {
+      println!("  {:<width$} → {}", e.name, e.expansion, width = width);
+    }
+  }
+
+  // repo section -------------------------------------------------------
+  println!("repo (.gwm.toml):");
+  if repo_workdir.is_none() {
+    println!("  (not inside a git repository — repo aliases are read from <repo>/.gwm.toml)");
+  } else if resolved.repo.is_empty() {
+    println!("  (none declared)");
+  } else {
+    let width = resolved.repo.keys().map(|k| k.len()).max().unwrap_or(2).max(2);
+    for (name, expansion) in &resolved.repo {
+      println!("  {:<width$} → {}", name, expansion, width = width);
+    }
+  }
+
+  // user section -------------------------------------------------------
+  // The display path mirrors the issue example. We don't call into
+  // `default_user_path()` for the label because that function is
+  // private to the `aliases` module; the rendered string is purely
+  // informational here.
+  println!("user (~/.config/gwm/aliases.toml):");
+  if resolved.user.is_empty() {
+    println!("  (none declared)");
+  } else {
+    let width = resolved.user.keys().map(|k| k.len()).max().unwrap_or(2).max(2);
+    for (name, expansion) in &resolved.user {
+      // Mark entries shadowed by a repo declaration so the user can
+      // see why a `gwm <name>` does not pick up the user expansion.
+      let shadowed = resolved.repo.contains_key(name);
+      let suffix = if shadowed { "  (shadowed by repo)" } else { "" };
+      println!("  {:<width$} → {}{}", name, expansion, suffix, width = width);
+    }
+  }
+
+  Ok(())
 }
 
 pub fn shell_init_script(shell: InitShell) -> &'static str {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::error::{GwmError, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 pub const CONFIG_FILE: &str = ".gwm.toml";
@@ -41,6 +41,18 @@ pub struct Config {
   /// by `BranchSpec::validate`, `gwm types` and the TUI create picker.
   #[serde(rename = "branch_types", default)]
   pub branch_types: Vec<BranchType>,
+  /// `[aliases]` table — repo-level CLI aliases expanded BEFORE clap
+  /// parses argv (issue #86). Maps alias name to argv-shell-tokenised
+  /// expansion (e.g. `wip = "create feat 0 wip"`). `BTreeMap` so the
+  /// ordering surfaced by `gwm aliases list` is deterministic.
+  ///
+  /// Absent block resolves to an empty map — aliasing disabled, no
+  /// behaviour change for repos that never opt in. Shadowing a
+  /// built-in subcommand or visible alias is a config error surfaced
+  /// at load time by [`crate::aliases::validate_aliases`]; same for
+  /// values containing shell pipeline metachars.
+  #[serde(default)]
+  pub aliases: BTreeMap<String, String>,
 }
 
 /// One `[[labels]]` entry. `name` is the GitHub key (unique per repo);
@@ -352,7 +364,16 @@ impl Config {
     cfg.validate_bootstrap_paths()?;
     cfg.validate_bootstrap_guards()?;
     cfg.validate_labels()?;
+    cfg.validate_aliases()?;
     Ok(cfg)
+  }
+
+  /// Reject `[aliases]` entries that shadow built-in subcommands, are
+  /// empty, or contain shell pipeline metachars (issue #86). Delegates
+  /// to [`crate::aliases::validate_aliases`] so the same rules apply
+  /// symmetrically to the user-level `~/.config/gwm/aliases.toml`.
+  fn validate_aliases(&self) -> Result<()> {
+    crate::aliases::validate_aliases(&self.aliases, ".gwm.toml `[aliases]`")
   }
 
   /// Reject `[[labels]]` entries whose `name` would be parsed as a flag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Used both by the `gwm` binary (`src/main.rs`) and by integration tests
 //! under `tests/`. Module surface is intentionally `pub` for testability.
 
+pub mod aliases;
 pub mod bootstrap;
 pub mod cli;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use gwm::{aliases, cli};
+use std::ffi::OsString;
 
 fn main() {
   // Issue #86: expand CLI aliases BEFORE clap parses argv. We need
@@ -14,7 +15,15 @@ fn main() {
   // by `Config::load_for_repo` in `cmd_doctor` (`.unwrap_or_default()`),
   // and it matches the issue's "no breaking change" promise:
   // absence of `[aliases]` ⇒ aliasing disabled, full stop.
-  let argv: Vec<String> = std::env::args().collect();
+  //
+  // argv is read as `OsString` via `std::env::args_os()` — `args()`
+  // panics on any non-UTF-8 argv entry, which is a regression vs.
+  // clap's default `args_os` handling and could abort the binary on
+  // a perfectly valid OS argv. The alias expansion path only attempts
+  // UTF-8 decoding on the alias-slot token (alias keys are `String`
+  // by construction); non-UTF-8 tokens flow through untouched and
+  // clap reports the unknown subcommand verbatim.
+  let argv: Vec<OsString> = std::env::args_os().collect();
   let expanded = match expand_aliases(argv.clone()) {
     Ok(v) => v,
     Err(e) => {
@@ -44,10 +53,10 @@ fn main() {
 /// every other repo-bound subcommand. Outside a repo we still load
 /// the user-level file so `gwm wip` works even when the user is
 /// not in a git tree (matching git's own `[alias]` behaviour).
-fn expand_aliases(argv: Vec<String>) -> Result<Vec<String>, gwm::error::GwmError> {
+fn expand_aliases(argv: Vec<OsString>) -> Result<Vec<OsString>, gwm::error::GwmError> {
   let repo_workdir = gwm::worktree::discover_repo(None)
     .ok()
     .and_then(|r| r.workdir().map(|w| w.to_path_buf()));
   let resolved = aliases::load(repo_workdir.as_deref(), None)?;
-  Ok(aliases::expand_argv(argv, &resolved))
+  Ok(aliases::expand_argv_os(argv, &resolved))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,53 @@
 use clap::Parser;
-use gwm::cli;
+use gwm::{aliases, cli};
 
 fn main() {
-  let args = cli::Cli::parse();
+  // Issue #86: expand CLI aliases BEFORE clap parses argv. We need
+  // the repo workdir to read `.gwm.toml`'s `[aliases]` block, so the
+  // discovery happens here in `main` rather than inside `cli::run` —
+  // by the time `run()` is reached, clap has already rejected an
+  // unknown subcommand and the expansion is moot.
+  //
+  // Graceful degradation: any error reading the alias config is
+  // surfaced on stderr but does not abort the process — we fall
+  // back to the raw argv. This is the same conservative shape used
+  // by `Config::load_for_repo` in `cmd_doctor` (`.unwrap_or_default()`),
+  // and it matches the issue's "no breaking change" promise:
+  // absence of `[aliases]` ⇒ aliasing disabled, full stop.
+  let argv: Vec<String> = std::env::args().collect();
+  let expanded = match expand_aliases(argv.clone()) {
+    Ok(v) => v,
+    Err(e) => {
+      // Print the error but keep going with the original argv so a
+      // typo in `[aliases]` doesn't lock the user out of `gwm doctor`
+      // or `gwm aliases list` (which would otherwise be the only
+      // way to surface the typo). The dispatcher will re-surface
+      // the error if the user runs a subcommand that touches
+      // config.
+      eprintln!("warning: failed to load aliases — using raw argv: {}", e);
+      argv
+    }
+  };
+
+  let args = cli::Cli::parse_from(expanded);
   if let Err(e) = cli::run(args) {
     eprintln!("error: {}", e);
     std::process::exit(1);
   }
+}
+
+/// Resolve the alias chain (built-in + repo + user) and run the
+/// single-pass expansion on `argv`. Returns `Ok(argv)` unchanged when
+/// the first non-flag token doesn't match an alias.
+///
+/// Repo discovery uses the current working directory — same gate as
+/// every other repo-bound subcommand. Outside a repo we still load
+/// the user-level file so `gwm wip` works even when the user is
+/// not in a git tree (matching git's own `[alias]` behaviour).
+fn expand_aliases(argv: Vec<String>) -> Result<Vec<String>, gwm::error::GwmError> {
+  let repo_workdir = gwm::worktree::discover_repo(None)
+    .ok()
+    .and_then(|r| r.workdir().map(|w| w.to_path_buf()));
+  let resolved = aliases::load(repo_workdir.as_deref(), None)?;
+  Ok(aliases::expand_argv(argv, &resolved))
 }

--- a/tests/aliases_tests.rs
+++ b/tests/aliases_tests.rs
@@ -451,6 +451,74 @@ wip = "create feat 0 wip"
   );
 }
 
+// ---- expand_argv_os (OsString surface) ----------------------------------
+
+#[test]
+fn expand_argv_os_matches_expand_argv_for_utf8_inputs() {
+  // The `OsString` surface MUST behave identically to the `String`
+  // surface on valid UTF-8 argv — the only divergence is in how
+  // non-UTF-8 tokens flow through (see the test below). Pin a repo
+  // alias + global-flag scenario so a refactor of the OsString path
+  // does not silently change the contract for the common case.
+  use std::ffi::OsString;
+  let repo_dir = tempfile::TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let argv: Vec<OsString> = vec!["gwm".into(), "--allow-bootstrap".into(), "wip".into()];
+  let expected: Vec<OsString> = vec![
+    "gwm".into(),
+    "--allow-bootstrap".into(),
+    "create".into(),
+    "feat".into(),
+    "0".into(),
+    "wip".into(),
+  ];
+  assert_eq!(aliases::expand_argv_os(argv, &resolved), expected);
+}
+
+#[cfg(unix)]
+#[test]
+fn expand_argv_os_passes_non_utf8_token_through_unchanged() {
+  // Non-UTF-8 argv must NOT panic the expander and must NOT be coerced
+  // into a UTF-8 round-trip. Alias keys are `String`, so a non-UTF-8
+  // token cannot match — the contract is "return argv unchanged and
+  // let clap surface the unknown subcommand verbatim".
+  use std::ffi::OsString;
+  use std::os::unix::ffi::OsStringExt;
+  let resolved = aliases::load(None, None).unwrap();
+  let bad: OsString = OsString::from_vec(vec![0xff, 0xfe, 0x80]);
+  let argv: Vec<OsString> = vec!["gwm".into(), bad.clone()];
+  let out = aliases::expand_argv_os(argv.clone(), &resolved);
+  assert_eq!(out, argv, "non-UTF-8 token must flow through unchanged");
+}
+
+#[cfg(unix)]
+#[test]
+fn expand_argv_os_expands_alias_after_non_utf8_flag_value() {
+  // A non-UTF-8 token in a flag-VALUE position (i.e. before the
+  // alias slot, but introduced by a flag like `--config <path>`)
+  // should NOT prevent the alias from being expanded. The expander
+  // only skips tokens that *start* with `-`, which means flag
+  // values are currently treated as the alias slot — so this test
+  // pins the conservative behaviour: a non-UTF-8 token in slot 1
+  // is treated as the alias slot, can't match (alias keys are
+  // String), and argv flows through unchanged.
+  use std::ffi::OsString;
+  use std::os::unix::ffi::OsStringExt;
+  let resolved = aliases::load(None, None).unwrap();
+  let bad: OsString = OsString::from_vec(vec![0xff]);
+  let argv: Vec<OsString> = vec!["gwm".into(), "--verbose".into(), bad.clone()];
+  let out = aliases::expand_argv_os(argv.clone(), &resolved);
+  assert_eq!(out, argv);
+}
+
 // ---- Built-in alias snapshot --------------------------------------------
 
 #[test]

--- a/tests/aliases_tests.rs
+++ b/tests/aliases_tests.rs
@@ -1,0 +1,468 @@
+//! Unit tests for the `aliases` module (issue #86).
+//!
+//! TDD canary for the alias resolution chain. The matrix verifies:
+//!   - Parsing the `[aliases]` block from `.gwm.toml` and from
+//!     `~/.config/gwm/aliases.toml` (user-level fallback).
+//!   - Resolution order: built-in subcommands always win, then repo
+//!     `.gwm.toml`, then user `aliases.toml` (last fallback).
+//!   - Argv expansion is string-only — `gwm wip` becomes a token
+//!     sequence, not a shell command.
+//!   - Shell pipelines (`&&`, `|`, `;`, backticks) in alias values are
+//!     rejected at load time so `wip = "create … && lazygit"` never
+//!     silently passes through to the dispatcher.
+//!   - A repo alias whose name collides with a built-in subcommand is
+//!     a hard config error surfaced by `Config::load_for_repo`.
+
+use gwm::aliases::{self, BUILT_IN_ALIASES};
+use gwm::config::{Config, CONFIG_FILE};
+use gwm::error::GwmError;
+use tempfile::TempDir;
+
+// ---- Parsing ------------------------------------------------------------
+
+#[test]
+fn config_aliases_default_is_empty() {
+  // Absent `[aliases]` block must resolve to an empty map — never `None`
+  // or a placeholder set. This is the "aliasing disabled" no-op contract
+  // from the issue: zero churn for repos that never opt in.
+  let cfg = Config::default();
+  assert!(cfg.aliases.is_empty());
+}
+
+#[test]
+fn config_aliases_round_trip_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+ll = "list --format names"
+"#,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(cfg.aliases.len(), 2);
+  assert_eq!(cfg.aliases.get("wip").map(String::as_str), Some("create feat 0 wip"));
+  assert_eq!(cfg.aliases.get("ll").map(String::as_str), Some("list --format names"));
+}
+
+#[test]
+fn config_aliases_rejects_shadow_of_built_in_subcommand() {
+  // `list` is a built-in subcommand; aliasing it would silently shadow
+  // the built-in (or, worse, infinite-loop the expansion). Refuse at
+  // load time so the user finds out before reaching for the alias.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+list = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+
+  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  match err {
+    GwmError::Config(msg) => {
+      assert!(msg.contains("list"), "error must name the offending alias: {msg}");
+      assert!(msg.contains("built-in"), "error must mention built-in shadowing: {msg}");
+    }
+    other => panic!("expected GwmError::Config, got {other:?}"),
+  }
+}
+
+#[test]
+fn config_aliases_rejects_shadow_of_visible_built_in_alias() {
+  // `s` is a visible alias of `switch` (issue #43); `cd` is a visible
+  // alias of `path`. Both are reachable as `gwm s` / `gwm cd`, so an
+  // alias declaration that would shadow them must fail at load time —
+  // otherwise `gwm s` resolves to the user's alias and the built-in
+  // becomes unreachable without anyone noticing.
+  for shadow in ["s", "cd"] {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+      dir.path().join(CONFIG_FILE),
+      format!(
+        r#"
+[aliases]
+{shadow} = "create feat 0 wip"
+"#
+      ),
+    )
+    .unwrap();
+    let err = Config::load_for_repo(dir.path()).unwrap_err();
+    match err {
+      GwmError::Config(msg) => {
+        assert!(msg.contains(shadow), "error must name '{shadow}': {msg}");
+      }
+      other => panic!("expected GwmError::Config for '{shadow}', got {other:?}"),
+    }
+  }
+}
+
+#[test]
+fn config_aliases_rejects_shell_pipeline_in_value() {
+  // `&&`, `||`, `|`, `;` and backticks are shell metachars — they
+  // cannot be honoured by a string-substitution expansion that hands
+  // argv to clap. Refuse at load so users notice the limit (and reach
+  // for a shell alias instead) rather than silently dropping the
+  // suffix.
+  for bad_value in [
+    "create feat 0 wip && lazygit",
+    "path | pbcopy",
+    "list ; remove x",
+    "echo `whoami`",
+  ] {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+      dir.path().join(CONFIG_FILE),
+      format!(
+        r#"
+[aliases]
+copy = "{bad_value}"
+"#
+      ),
+    )
+    .unwrap();
+    let err = Config::load_for_repo(dir.path()).unwrap_err();
+    match err {
+      GwmError::Config(msg) => {
+        assert!(
+          msg.contains("copy"),
+          "error must name the offending alias 'copy': {msg}"
+        );
+      }
+      other => panic!("expected GwmError::Config for {bad_value:?}, got {other:?}"),
+    }
+  }
+}
+
+#[test]
+fn config_aliases_rejects_empty_value() {
+  // `wip = ""` is meaningless — there's no command to expand to.
+  // Refuse at load time so the user notices the typo.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = ""
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  match err {
+    GwmError::Config(msg) => assert!(msg.contains("wip"), "{msg}"),
+    other => panic!("expected GwmError::Config, got {other:?}"),
+  }
+}
+
+// ---- ResolvedAliases -----------------------------------------------------
+
+#[test]
+fn resolved_aliases_contains_built_in_set() {
+  // The built-in row must be observable from `gwm aliases list` so
+  // users can answer "why does `gwm s` work without being declared?".
+  // Empty repo + no user config still surfaces every visible-alias
+  // entry from clap.
+  let dir = TempDir::new().unwrap();
+  let resolved = aliases::load(Some(dir.path()), None).unwrap();
+  assert!(!resolved.built_in.is_empty());
+  // Sanity: `s → switch` is the canonical example from issue #43;
+  // it MUST live in the built-in list for the chain to be honest.
+  let s_entry = resolved
+    .built_in
+    .iter()
+    .find(|e| e.name == "s")
+    .expect("built-in 's' alias must be present");
+  assert_eq!(s_entry.expansion, "switch");
+}
+
+#[test]
+fn resolved_aliases_repo_overrides_user_for_same_name() {
+  // Repo-level beats user-level: a user with `copy = "path foo"` in
+  // `~/.config/gwm/aliases.toml` and a repo `.gwm.toml` declaring
+  // `copy = "path bar"` must see the repo expansion when `gwm copy`
+  // is invoked inside that repo. The order matters because repo
+  // aliases follow the repo across machines while user aliases don't.
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+copy = "path bar"
+"#,
+  )
+  .unwrap();
+
+  let user_dir = TempDir::new().unwrap();
+  std::fs::write(
+    user_dir.path().join("aliases.toml"),
+    r#"
+[aliases]
+copy = "path foo"
+ll = "list --format names"
+"#,
+  )
+  .unwrap();
+  let user_path = user_dir.path().join("aliases.toml");
+
+  let resolved = aliases::load(Some(repo_dir.path()), Some(&user_path)).unwrap();
+
+  // Repo entry present and wins for "copy".
+  assert_eq!(resolved.repo.get("copy").map(String::as_str), Some("path bar"));
+  assert_eq!(resolved.user.get("copy").map(String::as_str), Some("path foo"));
+
+  // The effective lookup must return the repo expansion.
+  let argv = aliases::expand_argv(vec!["gwm".into(), "copy".into()], &resolved);
+  assert_eq!(argv, vec!["gwm", "path", "bar"]);
+}
+
+#[test]
+fn resolved_aliases_user_only_when_no_repo_block() {
+  // Without a repo `[aliases]` block, the user-level file still
+  // surfaces — that's the whole point of the user fallback.
+  let repo_dir = TempDir::new().unwrap();
+  let user_dir = TempDir::new().unwrap();
+  std::fs::write(
+    user_dir.path().join("aliases.toml"),
+    r#"
+[aliases]
+ll = "list --format names"
+"#,
+  )
+  .unwrap();
+  let user_path = user_dir.path().join("aliases.toml");
+
+  let resolved = aliases::load(Some(repo_dir.path()), Some(&user_path)).unwrap();
+  assert!(resolved.repo.is_empty());
+  assert_eq!(resolved.user.get("ll").map(String::as_str), Some("list --format names"));
+}
+
+#[test]
+fn resolved_aliases_user_missing_file_is_no_op() {
+  // An absent user file is the common case (fresh install). It must
+  // not fail load, it must resolve to an empty user map.
+  let repo_dir = TempDir::new().unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), Some(std::path::Path::new("/nope/aliases.toml"))).unwrap();
+  assert!(resolved.repo.is_empty());
+  assert!(resolved.user.is_empty());
+}
+
+#[test]
+fn resolved_aliases_user_rejects_shell_pipeline() {
+  // Same validation as repo-level — a user-level alias with `&&` is
+  // rejected at load time. The error names the file and the alias so
+  // the user knows which file to fix.
+  let user_dir = TempDir::new().unwrap();
+  std::fs::write(
+    user_dir.path().join("aliases.toml"),
+    r#"
+[aliases]
+copy = "path | pbcopy"
+"#,
+  )
+  .unwrap();
+  let user_path = user_dir.path().join("aliases.toml");
+  let err = aliases::load(None, Some(&user_path)).unwrap_err();
+  match err {
+    GwmError::Config(msg) => {
+      assert!(msg.contains("copy"), "{msg}");
+    }
+    other => panic!("expected GwmError::Config, got {other:?}"),
+  }
+}
+
+#[test]
+fn resolved_aliases_user_rejects_shadow_of_built_in() {
+  // The shadow rule applies symmetrically to the user file.
+  let user_dir = TempDir::new().unwrap();
+  std::fs::write(
+    user_dir.path().join("aliases.toml"),
+    r#"
+[aliases]
+list = "list --format names"
+"#,
+  )
+  .unwrap();
+  let user_path = user_dir.path().join("aliases.toml");
+  let err = aliases::load(None, Some(&user_path)).unwrap_err();
+  match err {
+    GwmError::Config(msg) => assert!(msg.contains("list"), "{msg}"),
+    other => panic!("expected GwmError::Config, got {other:?}"),
+  }
+}
+
+// ---- expand_argv --------------------------------------------------------
+
+#[test]
+fn expand_argv_no_match_passes_through_unchanged() {
+  // Argv that doesn't start with an alias is returned verbatim. The
+  // dispatcher (clap) still sees what the user typed.
+  let resolved = aliases::load(None, None).unwrap();
+  let argv = vec!["gwm".into(), "list".into(), "--format".into(), "names".into()];
+  assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
+}
+
+#[test]
+fn expand_argv_expands_repo_alias() {
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let argv = vec!["gwm".into(), "wip".into()];
+  assert_eq!(
+    aliases::expand_argv(argv, &resolved),
+    vec!["gwm", "create", "feat", "0", "wip"]
+  );
+}
+
+#[test]
+fn expand_argv_built_in_subcommand_always_wins() {
+  // Even if the user-level file somehow declares `list = "create
+  // feat 0 wip"` (which `load` should reject — but bypass via direct
+  // ResolvedAliases construction is possible for tests), the
+  // expansion path itself MUST treat `list` as a built-in token and
+  // pass it through unchanged. This is the second line of defence on
+  // top of the load-time shadow check.
+  use gwm::aliases::{AliasEntry, ResolvedAliases};
+  use std::collections::BTreeMap;
+
+  let mut user = BTreeMap::new();
+  user.insert("list".to_string(), "create feat 0 wip".to_string());
+  let resolved = ResolvedAliases {
+    built_in: vec![AliasEntry {
+      name: "s",
+      expansion: "switch",
+    }],
+    repo: BTreeMap::new(),
+    user,
+  };
+  let argv = vec!["gwm".into(), "list".into()];
+  assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
+}
+
+#[test]
+fn expand_argv_appends_user_trailing_arguments() {
+  // `gwm wip --foo bar` with `wip = "create feat 0 wip"` expands to
+  // `gwm create feat 0 wip --foo bar` — the user-supplied trailing
+  // args are appended after the substitution, matching git's
+  // `[alias]` behaviour.
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let argv = vec!["gwm".into(), "wip".into(), "--no-bootstrap".into()];
+  assert_eq!(
+    aliases::expand_argv(argv, &resolved),
+    vec!["gwm", "create", "feat", "0", "wip", "--no-bootstrap"]
+  );
+}
+
+#[test]
+fn expand_argv_only_first_position_is_substituted() {
+  // `gwm create feat 86 wip` must NOT expand the `wip` token (it's a
+  // positional, not the subcommand slot). Only argv[1] is a
+  // candidate.
+  let user_dir = TempDir::new().unwrap();
+  std::fs::write(
+    user_dir.path().join("aliases.toml"),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let user_path = user_dir.path().join("aliases.toml");
+  let resolved = aliases::load(None, Some(&user_path)).unwrap();
+  let argv = vec!["gwm".into(), "create".into(), "feat".into(), "86".into(), "wip".into()];
+  assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
+}
+
+#[test]
+fn expand_argv_no_recursion_alias_pointing_at_alias() {
+  // `wip = "ll"` followed by `ll = "list --format names"` must NOT
+  // double-expand — `gwm wip` becomes `gwm ll`, which then errors at
+  // clap parse time (ll isn't a subcommand) UNLESS we also expand a
+  // second time. We pick "no recursion" to mirror git's behaviour
+  // (one substitution, then dispatch). This is the simplest contract
+  // and the easiest to reason about.
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = "ll"
+ll = "list --format names"
+"#,
+  )
+  .unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let argv = vec!["gwm".into(), "wip".into()];
+  // After ONE expansion, argv[1] is `ll` — recursion would substitute
+  // it again, but we explicitly don't.
+  assert_eq!(aliases::expand_argv(argv, &resolved), vec!["gwm", "ll"]);
+}
+
+#[test]
+fn expand_argv_empty_argv_passes_through() {
+  // `gwm` (no args, opens the TUI) must not be touched.
+  let resolved = aliases::load(None, None).unwrap();
+  let argv = vec!["gwm".into()];
+  assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
+}
+
+#[test]
+fn expand_argv_global_flags_before_alias_are_preserved() {
+  // `gwm --allow-bootstrap wip` (global flag BEFORE the alias) is the
+  // tricky case. clap parses global flags anywhere, so the alias slot
+  // is technically argv[1] OR argv[2] depending on the user. We
+  // pick the simple rule: expansion looks at the first non-flag
+  // token in argv[1..]. Anything starting with `-` (short or long
+  // flag) is skipped over.
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(
+    repo_dir.path().join(CONFIG_FILE),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let argv = vec!["gwm".into(), "--allow-bootstrap".into(), "wip".into()];
+  assert_eq!(
+    aliases::expand_argv(argv, &resolved),
+    vec!["gwm", "--allow-bootstrap", "create", "feat", "0", "wip"]
+  );
+}
+
+// ---- Built-in alias snapshot --------------------------------------------
+
+#[test]
+fn built_in_aliases_constant_matches_clap_visible_aliases() {
+  // BUILT_IN_ALIASES is the snapshot used by `aliases list` and the
+  // shadow check. It MUST stay in lockstep with the `visible_alias`
+  // attributes on the clap subcommands — otherwise a `gwm cd` that
+  // works through clap would not appear under `aliases list` and
+  // would not be protected from being shadowed by user config.
+  //
+  // Current set: `cd → path` (issue #67), `s → switch` (issue #43).
+  let names: Vec<&str> = BUILT_IN_ALIASES.iter().map(|e| e.name).collect();
+  assert!(names.contains(&"cd"), "expected 'cd' in BUILT_IN_ALIASES: {names:?}");
+  assert!(names.contains(&"s"), "expected 's' in BUILT_IN_ALIASES: {names:?}");
+}

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1907,12 +1907,14 @@ fn aliases_list_prints_built_in_section_outside_repo() {
     .args(["aliases", "list"])
     .assert()
     .success()
-    .stdout(predicate::str::contains("built-in"))
-    // Canonical built-in entries from `BUILT_IN_ALIASES`.
-    .stdout(predicate::str::contains("s"))
-    .stdout(predicate::str::contains("switch"))
-    .stdout(predicate::str::contains("cd"))
-    .stdout(predicate::str::contains("path"));
+    .stdout(predicate::str::contains("built-in:"))
+    // Canonical built-in entries from `BUILT_IN_ALIASES`. Assert the full
+    // formatted row (`  <name>  → <expansion>` with width-2 padding) rather
+    // than a loose `contains("s")` — the latter matched incidental letters
+    // in unrelated words (`aliases`, `built-ins`, …) and let the test pass
+    // even when the `s → switch` row was missing or malformed.
+    .stdout(predicate::str::contains("  s  → switch"))
+    .stdout(predicate::str::contains("  cd → path"));
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -44,7 +44,9 @@ fn help_prints_subcommands() {
     // Issue #82: declarative GitHub milestones.
     .stdout(predicate::str::contains("  milestones "))
     // Issue #95: TOFU trust ledger.
-    .stdout(predicate::str::contains("  trust "));
+    .stdout(predicate::str::contains("  trust "))
+    // Issue #86: CLI aliases (`gwm aliases list`).
+    .stdout(predicate::str::contains("  aliases "));
 }
 
 // --- labels (issue #81) -------------------------------------------------
@@ -1878,4 +1880,231 @@ fn deny_bootstrap_aborts_even_when_trusted() {
     .assert()
     .failure()
     .stderr(predicate::str::contains("--deny-bootstrap"));
+}
+
+// --- aliases (issue #86) ------------------------------------------------
+
+#[test]
+fn aliases_help_lists_list() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["aliases", "--help"]);
+  cmd.assert().success().stdout(predicate::str::contains("list"));
+}
+
+#[test]
+fn aliases_list_prints_built_in_section_outside_repo() {
+  // `aliases list` is read-only and must work outside a git repo —
+  // built-in clap aliases are static and independent of any repo
+  // config. The user fallback (`~/.config/gwm/aliases.toml`) is
+  // silently empty when missing.
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    // Isolate the test from the developer's real `~/.config/gwm/aliases.toml`.
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["aliases", "list"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("built-in"))
+    // Canonical built-in entries from `BUILT_IN_ALIASES`.
+    .stdout(predicate::str::contains("s"))
+    .stdout(predicate::str::contains("switch"))
+    .stdout(predicate::str::contains("cd"))
+    .stdout(predicate::str::contains("path"));
+}
+
+#[test]
+fn aliases_list_prints_repo_aliases_with_source() {
+  // `.gwm.toml` with `[aliases]` ⇒ `aliases list` surfaces them under
+  // the `repo (.gwm.toml):` section.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+wip = "create feat 0 wip"
+ll = "list --format names"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["aliases", "list"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("repo (.gwm.toml)"))
+    .stdout(predicate::str::contains("wip"))
+    .stdout(predicate::str::contains("create feat 0 wip"))
+    .stdout(predicate::str::contains("ll"))
+    .stdout(predicate::str::contains("list --format names"));
+}
+
+#[test]
+fn aliases_list_prints_user_aliases_with_source() {
+  // `~/.config/gwm/aliases.toml` (XDG resolved via `$XDG_CONFIG_HOME`)
+  // surfaces under the user section.
+  let dir = tempfile::TempDir::new().unwrap();
+  let user_cfg = dir.path().join("gwm");
+  std::fs::create_dir_all(&user_cfg).unwrap();
+  std::fs::write(
+    user_cfg.join("aliases.toml"),
+    r#"
+[aliases]
+copy = "path"
+"#,
+  )
+  .unwrap();
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["aliases", "list"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("user"))
+    .stdout(predicate::str::contains("aliases.toml"))
+    .stdout(predicate::str::contains("copy"))
+    .stdout(predicate::str::contains("path"));
+}
+
+#[test]
+fn aliases_list_repo_overrides_user_for_same_name() {
+  // When repo and user both declare the same alias, the repo entry
+  // takes precedence at expansion time. `aliases list` still prints
+  // BOTH sections so the user can see what's being shadowed.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+copy = "path bar"
+"#,
+  )
+  .unwrap();
+  let user_cfg = dir.path().join("gwm");
+  std::fs::create_dir_all(&user_cfg).unwrap();
+  std::fs::write(
+    user_cfg.join("aliases.toml"),
+    r#"
+[aliases]
+copy = "path foo"
+"#,
+  )
+  .unwrap();
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["aliases", "list"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("path bar"))
+    .stdout(predicate::str::contains("path foo"));
+}
+
+#[test]
+fn aliases_list_surfaces_shadow_error_with_alias_name() {
+  // An invalid alias in `.gwm.toml` must fail `aliases list` with a
+  // message naming the offending entry.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+list = "create feat 0 wip"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["aliases", "list"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("list").and(predicate::str::contains("built-in")));
+}
+
+#[test]
+fn alias_expansion_runs_built_in_subcommand() {
+  // End-to-end expansion: declare `lst = "list --format names"`,
+  // invoke `gwm lst` — must behave as `gwm list --format names`.
+  // The repo has no worktrees yet so the names output is just empty.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+lst = "list --format names"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .arg("lst")
+    .assert()
+    .success();
+}
+
+#[test]
+fn alias_expansion_preserves_trailing_user_args() {
+  // `gwm typ` with `typ = "types"` plus a trailing `--help` must
+  // surface clap's `types` help (or success), proving the trailing
+  // arg made it through the expansion.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+typ = "types"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["typ", "--help"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("branch types"));
+}
+
+#[test]
+fn alias_does_not_shadow_built_in_subcommand_at_runtime() {
+  // Even if a hostile `.gwm.toml` somehow tries to alias `types`,
+  // the load gate refuses — `gwm types` always reaches the
+  // built-in. This is the "defence in depth" pillar of the design.
+  let (dir, _repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[aliases]
+types = "list"
+"#,
+  )
+  .unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .args(["types"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("types"));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2110,3 +2110,52 @@ types = "list"
     .failure()
     .stderr(predicate::str::contains("types"));
 }
+
+// --- argv robustness (issue #86 — Copilot follow-up) --------------------
+
+#[cfg(unix)]
+#[test]
+fn binary_tolerates_non_utf8_argv() {
+  // `std::env::args()` panics if any argv entry is non-UTF-8, which is
+  // a regression vs. clap's default `args_os` handling. The binary
+  // must NOT abort the process on a perfectly valid OS argv just
+  // because someone passed bytes that don't decode as UTF-8.
+  //
+  // We don't care about the exit code per se — the contract is "no
+  // panic, no SIGABRT". clap may legitimately reject the unknown
+  // subcommand and exit non-zero (UsageError = 2), which is fine.
+  // What we forbid is the process aborting before clap even sees
+  // the args.
+  use std::ffi::OsString;
+  use std::os::unix::ffi::OsStringExt;
+
+  let dir = tempfile::TempDir::new().unwrap();
+  let invalid_utf8: OsString = OsString::from_vec(vec![0xff, 0xfe, 0x80]);
+
+  let output = Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", dir.path())
+    .env("HOME", dir.path())
+    .arg(&invalid_utf8)
+    .output()
+    .expect("binary must launch");
+
+  // Reject SIGABRT / SIGSEGV / SIGILL — anything that indicates the
+  // process died on a signal rather than exited normally. On Unix,
+  // signal deaths surface as `status.code() == None` from `assert_cmd`.
+  assert!(
+    output.status.code().is_some(),
+    "binary died on a signal (likely a panic abort) when given non-UTF-8 argv; stderr={:?}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+
+  // Belt-and-suspenders: the stderr should not contain the libstd panic
+  // banner for invalid UTF-8 in argv.
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  assert!(
+    !stderr.contains("invalid utf-8") && !stderr.contains("panicked at"),
+    "binary panicked instead of gracefully handling non-UTF-8 argv: {}",
+    stderr
+  );
+}


### PR DESCRIPTION
## Description

Mirror of `git config`'s `[alias]` block for `gwm`. Declare aliases under `[aliases]` in `.gwm.toml` (repo-level, follows the repo across machines) or in `~/.config/gwm/aliases.toml` (user-level fallback). `gwm <alias>` is expanded to argv tokens BEFORE clap parses, so `wip = "create feat 0 wip"` makes `gwm wip` behave as `gwm create feat 0 wip`.

Closes #86

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- New `src/aliases.rs` module: `ResolvedAliases { built_in, repo, user }`, `load()`, `expand_argv()`, `validate_aliases()`. Static `BUILT_IN_ALIASES` slice mirrors every clap `visible_alias` (`cd → path`, `s → switch`) so the shadow gate stays in lockstep with `src/cli.rs`.
- `src/config.rs`: new `Config.aliases: BTreeMap<String, String>` field, validated at `Config::load_for_repo` time via the shared `validate_aliases` helper.
- `src/main.rs`: argv is expanded via `aliases::load()` + `aliases::expand_argv()` BEFORE `Cli::parse_from(...)`. Failure to load the alias chain prints a warning and falls back to the raw argv, so a typo in `[aliases]` doesn't lock the user out of `gwm doctor` or `gwm aliases list`.
- `src/cli.rs`: new `Aliases { action: AliasesAction::List }` subcommand. Prints three grouped sections (`built-in`, `repo (.gwm.toml)`, `user (~/.config/gwm/aliases.toml)`); user entries shadowed by a repo declaration are flagged inline `(shadowed by repo)`.
- Validation rules enforced at load time (`GwmError::Config` on violation):
  - Alias name MUST NOT shadow a built-in subcommand or visible alias.
  - Alias value MUST NOT be empty.
  - Alias value MUST NOT contain shell metachars (`&&`, `||`, `|`, `;`, backticks) — aliases are argv substitution only, use a shell alias for shell semantics.
- Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` expands ONCE and then dispatches (matches git's behaviour).
- Docs: `CHANGELOG.md` Unreleased entry, `examples/gwm.toml.example` commented-out template, `docs/4.configuration/1.gwm-toml.md` full schema section with validation table, `docs/3.cli/1.reference.md` `gwm aliases list` subcommand reference with sample output.

## Tests

- [x] `cargo test` passes locally (all 27 suites green, including 21 new tests in `tests/aliases_tests.rs` and 9 new end-to-end tests in `tests/cli_binary.rs`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: tests landed before production code in the first commit's diff)
- [x] Env-stripped pre-validation: `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test` — all green (per CONTRIBUTING.md lesson from PR #43)
- [x] `gwm doctor` clean on the project repo

### TDD trace per the CLAUDE.md rule

| Test file                  | New tests | Pinned behaviour                                                                                           |
|:---------------------------|:---------:|:-----------------------------------------------------------------------------------------------------------|
| `tests/aliases_tests.rs`   |    21     | TOML round-trip, refusal of shadow + shell metachars + empty value, repo>user precedence, single-pass expansion, global-flag pass-through, defence-in-depth lookup |
| `tests/cli_binary.rs`      |     9     | `aliases list` end-to-end (built-in / repo / user sections), `help_prints_subcommands` canary updated, expansion runs through to `gwm list`, trailing args preserved, shadow refusal at runtime |

## Screenshots / TUI captures

N/A — CLI surface only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` — `feat/#86-aliases`
- [x] Commits follow Gitmoji + Conventional Commits (3 atomic commits — module + tests, CLI wiring + e2e tests, docs)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README usage section — no change (the public CLI is documented under `docs/3.cli/1.reference.md`, which was updated)
- [x] `examples/gwm.toml.example` updated (config schema changed — new `[aliases]` block)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only) — N/A, no TUI changes

## Linked issues / docs

- Issue: #86
- Schema doc: [docs/4.configuration/1.gwm-toml.md → `[aliases]`](https://github.com/kbrdn1/gwm-cli/blob/feat/%2386-aliases/docs/4.configuration/1.gwm-toml.md)
- CLI doc: [docs/3.cli/1.reference.md → `gwm aliases list`](https://github.com/kbrdn1/gwm-cli/blob/feat/%2386-aliases/docs/3.cli/1.reference.md)

## Notes for reviewers

- **Why expansion lives in `main.rs`**: clap rejects unknown subcommands before `cli::run` is reached, so substitution must happen before `Cli::parse_from(...)`. Same shape as `git`'s `[alias]` handling.
- **Defence in depth for shadowing**: `validate_aliases` rejects shadow at load time AND `ResolvedAliases::lookup` skips substitution if the alias name matches a built-in. The second gate handles future APIs that may bypass the loader (tests, programmatic constructors).
- **Why `BTreeMap` over `HashMap`**: deterministic iteration order for `gwm aliases list` output — sorting at print time would also work but the cost is negligible and the data is small.
- **Why no recursion**: matches git's `[alias]` behaviour. Reasoning further captured in the module-level docstring and the `expand_argv_no_recursion_alias_pointing_at_alias` test.
- **Why the warning-on-load-failure path**: a user with a malformed `[aliases]` block should still be able to run `gwm aliases list` (to see what's broken) and `gwm doctor` (to triage). The warning surfaces the error on stderr without aborting the process.