### PR TITLE
✨ feat(cli): gitmoji mapping ([gitmoji] + gwm commit-prefix + commit-msg hook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shell alias for shell semantics. New `gwm aliases list`
   subcommand prints the resolved chain grouped by source, with
   shadowed user entries flagged inline.
+- **Gitmoji mapping + `gwm commit-prefix` + opt-in `commit-msg` hook**
+  (issue #85). The repo's Gitmoji + Conventional Commits convention is
+  now first-class. Three new surfaces:
+  - `gwm commit-prefix [--branch <name>] [--unicode]` prints the
+    canonical commit prefix (e.g. `:sparkles: feat(#41):` or
+    `✨ feat(#41):`) — handy for shell prompts, AI assistants, and
+    scripted commit composition.
+  - `gwm types --gitmoji` extends the existing branch-type list with
+    two more columns (unicode emoji + `:shortcode:`).
+  - `gwm hooks install commit-msg [--force]` installs an opt-in
+    `.git/hooks/commit-msg` that auto-prepends the resolved prefix
+    when the user's commit message doesn't already start with one.
+    Non-destructive by default (refuses to overwrite a pre-existing
+    hook without `--force`).
+- New `[gitmoji]` block in `.gwm.toml` lets teams override individual
+  shortcodes without redeclaring the whole table (the ten built-in
+  defaults are baked into the binary). Custom branch types are
+  supported — `migration = ":truck:"` round-trips through `gwm types
+  --gitmoji`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaults are baked into the binary). Custom branch types are
   supported — `migration = ":truck:"` round-trips through `gwm types
   --gitmoji`.
+- Under `--unicode`, `gwm commit-prefix` and the unicode column of
+  `gwm types --gitmoji` now normalise known `:shortcode:` overrides
+  (e.g. `feat = ":rocket:"` → `🚀 feat(#1):` instead of
+  `:rocket: feat(#1):`). The known-shortcode set extends to the most
+  commonly-swapped Gitmoji entries (`:rocket:`, `:fire:`, `:lock:`,
+  `:art:`, `:lipstick:`, `:hammer:`, `:bookmark:`, …). Unknown
+  shortcodes fall through verbatim — no panic, no substitution.
+  (#85)
 
 ### Fixed
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -174,6 +174,64 @@ trunks = ["dev", "main"]
 
 Repos using a non-default trunk (`master`, `trunk`, `release-1.x`, …) must list it here to keep the orphan check meaningful.
 
+## `[gitmoji]` (issue #85)
+
+Per-repo override of the built-in `branch_type → :shortcode:` table consumed by [`gwm commit-prefix`](/cli/reference#gwm-commit-prefix), [`gwm types --gitmoji`](/cli/reference#gwm-types), and the bundled commit-msg hook ([`gwm hooks install commit-msg`](/cli/reference#gwm-hooks-install)).
+
+```toml
+[gitmoji]
+feat      = ":rocket:"    # team uses 🚀 for new features instead of ✨
+migration = ":truck:"     # custom branch type
+```
+
+Defaults (used when `[gitmoji]` is absent or omits a key):
+
+| branch type | shortcode               | unicode |
+|:------------|:------------------------|:--------|
+| `feat`      | `:sparkles:`            | ✨      |
+| `fix`       | `:bug:`                 | 🐛      |
+| `hotfix`    | `:ambulance:`           | 🚑      |
+| `docs`      | `:memo:`                | 📝      |
+| `test`      | `:white_check_mark:`    | ✅      |
+| `refactor`  | `:recycle:`             | ♻      |
+| `chore`     | `:wrench:`              | 🔧      |
+| `perf`      | `:zap:`                 | ⚡      |
+| `ci`        | `:construction_worker:` | 👷      |
+| `build`     | `:package:`             | 📦      |
+
+`[gitmoji]` is **additive** — overriding one entry doesn't wipe the other nine. Custom branch types declared under `[[branch_types]]` can carry their own emoji here without redeclaring the built-ins.
+
+### `--unicode` normalisation of overrides
+
+Surfaces that render the prefix as a unicode glyph (`gwm commit-prefix --unicode`, the unicode column of `gwm types --gitmoji`, and the installed commit-msg hook) **normalise known `:shortcode:` overrides to their glyph**:
+
+```toml
+[gitmoji]
+feat = ":rocket:"
+```
+
+```text
+$ gwm commit-prefix --branch feat/#1-x
+:rocket: feat(#1):
+
+$ gwm commit-prefix --branch feat/#1-x --unicode
+🚀 feat(#1):
+```
+
+The known-shortcode set covers the ten built-in mappings plus a curated extension of the most commonly-swapped Gitmoji entries (`:rocket:`, `:fire:`, `:lock:`, `:art:`, `:lipstick:`, `:hammer:`, `:bookmark:`, …). **Unknown shortcodes fall through verbatim** — no panic, no substitution:
+
+```toml
+[gitmoji]
+feat = ":foo:"          # not in the built-in unicode table
+```
+
+```text
+$ gwm commit-prefix --branch feat/#1-x --unicode
+:foo: feat(#1):
+```
+
+Without `--unicode`, every override is emitted verbatim regardless of whether the table knows it — the shortcode form is the one downstream consumers (GitHub Markdown, commit linters, gitmoji-cli) parse.
+
 ## `[[labels]]` (issue #81)
 
 Declarative GitHub label set pushed to the `origin` remote by [`gwm labels push`](/cli/reference#gwm-labels-listpush).

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -159,6 +159,18 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #   gwm types --gitmoji                  → branch types + emoji columns
 #   gwm hooks install commit-msg         → opt-in auto-prepend on `git commit`
 #
+# `--unicode` normalisation of overrides:
+#   With `feat = ":rocket:"`:
+#     gwm commit-prefix --branch feat/#1-x           → ":rocket: feat(#1):"
+#     gwm commit-prefix --branch feat/#1-x --unicode → "🚀 feat(#1):"
+#   With `feat = ":foo:"` (shortcode unknown to gwm's built-in table):
+#     gwm commit-prefix --branch feat/#1-x --unicode → ":foo: feat(#1):"
+#   Unknown shortcodes fall through verbatim — no panic, no
+#   `:question:` substitution. The known-shortcode set covers the ten
+#   built-in mappings plus the most commonly-swapped Gitmoji entries
+#   (`:rocket:`, `:fire:`, `:lock:`, `:art:`, `:lipstick:`, `:hammer:`,
+#   `:bookmark:`, …).
+#
 # [gitmoji]
 # feat = ":rocket:"            # team uses 🚀 for new features instead of ✨
 # migration = ":truck:"        # custom branch type — emoji wins on `gwm types --gitmoji`

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -131,6 +131,38 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # name = "migration"
 # description = "Database migration"
 
+# --- gitmoji mapping (issue #85) --------------------------------------------
+# Per-repo override of the built-in `branch_type → :shortcode:` table used
+# by `gwm commit-prefix`, `gwm types --gitmoji`, and the bundled
+# `commit-msg` hook (`gwm hooks install commit-msg`). Absent (default) ⇒
+# the built-in table is used:
+#
+#   feat     → :sparkles:               ✨
+#   fix      → :bug:                    🐛
+#   hotfix   → :ambulance:              🚑
+#   docs     → :memo:                   📝
+#   test     → :white_check_mark:       ✅
+#   refactor → :recycle:                ♻
+#   chore    → :wrench:                 🔧
+#   perf     → :zap:                    ⚡
+#   ci       → :construction_worker:    👷
+#   build    → :package:                📦
+#
+# `[gitmoji]` is **additive** — overriding one entry doesn't wipe the
+# other nine. You can also map custom branch types (e.g. `migration`)
+# without redeclaring the built-ins.
+#
+# Surface:
+#   gwm commit-prefix                    → ":sparkles: feat(#41):"  (HEAD)
+#   gwm commit-prefix --unicode          → "✨ feat(#41):"
+#   gwm commit-prefix --branch feat/#7-x → ":sparkles: feat(#7):"   (named)
+#   gwm types --gitmoji                  → branch types + emoji columns
+#   gwm hooks install commit-msg         → opt-in auto-prepend on `git commit`
+#
+# [gitmoji]
+# feat = ":rocket:"            # team uses 🚀 for new features instead of ✨
+# migration = ":truck:"        # custom branch type — emoji wins on `gwm types --gitmoji`
+
 # --- doctor knobs -----------------------------------------------------------
 # Trunk branches `gwm doctor`'s orphan-branch check treats as merge
 # destinations. A gwm-style branch fully reachable from one of these is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,12 +3,14 @@ use crate::config::Config;
 use crate::doctor::{self, CheckStatus, DoctorCtx};
 use crate::error::{GwmError, LinkKind, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
+use crate::gitmoji;
+use crate::hooks;
 use crate::labels::{self, LabelDiff};
 use crate::milestones::{self, MilestoneDiff};
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
-use crate::naming::BranchSpec;
+use crate::naming::{parse_branch, BranchSpec};
 use crate::trust::{self, TrustLedger, TrustMode, TrustOutcome};
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -123,7 +125,49 @@ pub enum Command {
   /// suitable for CI / pre-commit hooks.
   Doctor,
   /// List the supported branch types.
-  Types,
+  ///
+  /// Pass `--gitmoji` to extend the output with two more columns: the
+  /// resolved emoji (unicode) and its `:shortcode:` form (issue #85).
+  /// The shortcode mapping is the built-in default plus any per-repo
+  /// overrides under `[gitmoji]` in `.gwm.toml`.
+  Types {
+    /// Show the resolved emoji + shortcode for each branch type
+    /// (issue #85). Without the flag, only `name` + `description`
+    /// are printed — matches the pre-#85 surface.
+    #[arg(long)]
+    gitmoji: bool,
+  },
+  /// Print the Gitmoji + Conventional Commits prefix for the current
+  /// (or named) branch (issue #85).
+  ///
+  /// Output shape: `:sparkles: feat(#41):` — the canonical commit
+  /// prefix used across this repo (see CONTRIBUTING.md §Commits).
+  /// `--unicode` substitutes the shortcode for the real emoji
+  /// character (e.g. `✨` instead of `:sparkles:`); useful for shell
+  /// prompts and the bundled `commit-msg` hook.
+  ///
+  /// Without `--branch`, reads the current branch from HEAD via
+  /// libgit2 — requires the CWD to be inside a git repo.
+  CommitPrefix {
+    /// Branch name to resolve (e.g. `feat/#41-tui-search`). When
+    /// omitted, defaults to HEAD of the current repo.
+    #[arg(long)]
+    branch: Option<String>,
+    /// Emit the real emoji character (`✨`) instead of the
+    /// shortcode form (`:sparkles:`).
+    #[arg(long)]
+    unicode: bool,
+  },
+  /// Manage git hooks installed by `gwm` (issue #85).
+  ///
+  /// Currently exposes a single hook: `commit-msg`, which
+  /// auto-prepends the resolved Gitmoji + Conventional Commits
+  /// prefix when the commit message doesn't already start with one.
+  /// Hooks are **opt-in** — `gwm` never installs them implicitly.
+  Hooks {
+    #[command(subcommand)]
+    action: HooksAction,
+  },
   /// Generate a shell completion script on stdout.
   ///
   /// Install (zsh):  `gwm completions zsh > $fpath[1]/_gwm`
@@ -309,6 +353,40 @@ pub enum AliasesAction {
   List,
 }
 
+/// Subcommands of `gwm hooks` (issue #85). The split anticipates
+/// future hook variants (`pre-push`, `pre-commit`); for now only
+/// `install commit-msg` is wired up, which is the directly-load-bearing
+/// surface for the auto-prefix workflow.
+#[derive(Debug, Subcommand)]
+pub enum HooksAction {
+  /// Install a hook into `.git/hooks/`. Refuses to overwrite an
+  /// existing hook unless `--force` is passed, so a pre-existing
+  /// husky / commitlint / pre-commit installation is preserved by
+  /// default.
+  Install {
+    /// Which hook to install. Today only `commit-msg` is supported.
+    #[arg(value_enum)]
+    hook: HookKind,
+    /// Replace an existing hook of the same name. Without `--force`,
+    /// the command exits non-zero with the path of the conflicting
+    /// hook so the user can decide.
+    #[arg(long)]
+    force: bool,
+  },
+}
+
+/// Discriminator for `gwm hooks install <kind>`. A `ValueEnum` (rather
+/// than a free-form string) so clap rejects typos at parse time
+/// (`gwm hooks install commit-msge` → "invalid value … expected one
+/// of: commit-msg") rather than letting the installer fail with a
+/// less-actionable error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum HookKind {
+  /// Auto-prepend the Gitmoji + Conventional Commits prefix when
+  /// the user's commit message doesn't already start with one.
+  CommitMsg,
+}
+
 /// Subcommands of `gwm labels`. The split is intentional: `list` is
 /// read-only and safe to run in CI; `push` mutates the remote and
 /// therefore gets `--dry-run` / `--prune` flags of its own.
@@ -446,7 +524,9 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Bootstrap { target } => cmd_bootstrap(target, mode),
     Command::Prune => cmd_prune(),
     Command::Doctor => cmd_doctor(),
-    Command::Types => cmd_types(),
+    Command::Types { gitmoji } => cmd_types(gitmoji),
+    Command::CommitPrefix { branch, unicode } => cmd_commit_prefix(branch, unicode),
+    Command::Hooks { action } => cmd_hooks(action),
     Command::Completions { shell } => cmd_completions(shell),
     Command::ShellInit { shell } => cmd_shell_init(shell),
     Command::Switch => cmd_switch(),
@@ -704,7 +784,7 @@ fn print_doctor_report(report: &doctor::DoctorReport) {
   }
 }
 
-fn cmd_types() -> Result<()> {
+fn cmd_types(gitmoji_flag: bool) -> Result<()> {
   // Resolve the active branch-type list. When invoked inside a repo
   // with a workdir we honour any `[[branch_types]]` override in
   // `.gwm.toml`; outside of one — or inside a bare repo where
@@ -713,22 +793,117 @@ fn cmd_types() -> Result<()> {
   // `gwm types` remains useful as a discovery command (used by `gwm`
   // newcomers before they've initialised a config, and from CI inspect
   // commands that point at bare clones).
-  let resolved = match worktree::discover_repo(None) {
-    Ok(repo) => match repo.workdir().map(|w| w.to_path_buf()) {
-      Some(workdir) => Config::load_for_repo(&workdir)?.resolved_branch_types(),
-      None => Config::default().resolved_branch_types(),
-    },
-    Err(_) => Config::default().resolved_branch_types(),
+  let workdir = match worktree::discover_repo(None) {
+    Ok(repo) => repo.workdir().map(|w| w.to_path_buf()),
+    Err(_) => None,
+  };
+  let resolved = match &workdir {
+    Some(w) => Config::load_for_repo(w)?.resolved_branch_types(),
+    None => Config::default().resolved_branch_types(),
+  };
+
+  // Resolve the gitmoji map only when the caller asked for it — the
+  // default `gwm types` output stays a stable two-column shape every
+  // scripted parser of the pre-#85 surface depended on.
+  let gitmoji_map = if gitmoji_flag {
+    Some(gitmoji::load(workdir.as_deref())?)
+  } else {
+    None
   };
 
   // Align the description column on the longest name so a custom list
   // with a long entry (e.g. `migration`) still renders cleanly.
   let width = resolved.types.iter().map(|t| t.name.len()).max().unwrap_or(0).max(8);
+  // When the gitmoji columns are active, align the shortcode column on
+  // the widest shortcode (`:white_check_mark:`, currently 18 chars) so
+  // the description column doesn't drift between rows.
+  let sc_width = match &gitmoji_map {
+    Some(map) => map.iter().map(|(_, sc)| sc.len()).max().unwrap_or(0).max(10),
+    None => 0,
+  };
+
   for t in &resolved.types {
-    println!("  {:<width$}  {}", t.name, t.description, width = width);
+    match &gitmoji_map {
+      Some(map) => {
+        // Two extra columns: unicode glyph (1 cell wide, padded for
+        // BMP code points; emoji ZWJ sequences would break alignment
+        // but our built-in set is all single-glyph) + shortcode.
+        let shortcode = map.get(&t.name).unwrap_or(":question:");
+        let unicode = gitmoji::shortcode_to_unicode(shortcode);
+        println!(
+          "  {:<width$}  {}  {:<sw$}  {}",
+          t.name,
+          unicode,
+          shortcode,
+          t.description,
+          width = width,
+          sw = sc_width,
+        );
+      }
+      None => {
+        println!("  {:<width$}  {}", t.name, t.description, width = width);
+      }
+    }
   }
   println!();
   println!("(source: {})", resolved.source.label());
+  Ok(())
+}
+
+/// `gwm commit-prefix [--branch <name>] [--unicode]` (issue #85).
+/// Renders `:sparkles: feat(#41):` (or `✨ feat(#41):` with `--unicode`)
+/// for the supplied branch or HEAD. Useful for shell prompts, AI
+/// assistants, and the bundled `commit-msg` hook.
+fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<()> {
+  // Two resolution paths: an explicit `--branch <name>` (no repo
+  // required — useful for scripted contexts) and the implicit
+  // "use HEAD" branch (requires a repo). Both go through
+  // `parse_branch` so the prefix shape stays canonical regardless of
+  // entry point.
+  let (workdir, branch_name) = match branch_override {
+    Some(name) => (None, name),
+    None => {
+      let repo = worktree::discover_repo(None)?;
+      let wd = repo.workdir().map(|w| w.to_path_buf());
+      let name = current_branch(&repo)?;
+      (wd, name)
+    }
+  };
+
+  let spec = parse_branch(&branch_name).ok_or_else(|| {
+    GwmError::Other(format!(
+      "branch '{}' does not follow the gwm convention <type>/#<issue>-<slug> — \
+       cannot derive a commit prefix from it",
+      branch_name
+    ))
+  })?;
+
+  let map = gitmoji::load(workdir.as_deref())?;
+  let prefix = gitmoji::resolve_prefix(&map, &spec, unicode);
+  println!("{}", prefix);
+  Ok(())
+}
+
+/// `gwm hooks <action>` (issue #85). Currently only `install
+/// commit-msg` is wired up; the subcommand layer is shaped so future
+/// hooks (`pre-push`, `pre-commit`) drop in without breaking the
+/// existing CLI surface.
+fn cmd_hooks(action: HooksAction) -> Result<()> {
+  match action {
+    HooksAction::Install { hook, force } => cmd_hooks_install(hook, force),
+  }
+}
+
+fn cmd_hooks_install(hook: HookKind, force: bool) -> Result<()> {
+  let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  match hook {
+    HookKind::CommitMsg => {
+      let path = hooks::install_commit_msg(&workdir, force)?;
+      println!("✓ installed {}", path.display());
+      println!("  (auto-prepends gitmoji+type prefix when missing)");
+    }
+  }
   Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -856,12 +856,30 @@ fn cmd_types(gitmoji_flag: bool) -> Result<()> {
 /// assistants, and the bundled `commit-msg` hook.
 fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<()> {
   // Two resolution paths: an explicit `--branch <name>` (no repo
-  // required — useful for scripted contexts) and the implicit
-  // "use HEAD" branch (requires a repo). Both go through
-  // `parse_branch` so the prefix shape stays canonical regardless of
-  // entry point.
+  // *required* — useful for scripted contexts outside a repo) and
+  // the implicit "use HEAD" branch (requires a repo). Both go
+  // through `parse_branch` so the prefix shape stays canonical
+  // regardless of entry point.
+  //
+  // For BOTH paths we still attempt repo discovery so the workdir
+  // handle is fed into `gitmoji::load` — this is what makes
+  // per-repo `.gwm.toml` `[gitmoji]` overrides apply uniformly to
+  // `gwm commit-prefix` (no flag, --branch, or whatever the
+  // installed commit-msg hook ends up calling). Discovery failures
+  // are silently downgraded to "no workdir" so the `--branch` form
+  // still works outside a git checkout — that's the whole point of
+  // the explicit-branch entry point.
   let (workdir, branch_name) = match branch_override {
-    Some(name) => (None, name),
+    Some(name) => {
+      // Best-effort discovery: outside a repo the user passed
+      // `--branch` precisely because there's no HEAD to read; we
+      // must not fail here. Inside a repo we want the workdir so
+      // `.gwm.toml` overrides apply.
+      let workdir = worktree::discover_repo(None)
+        .ok()
+        .and_then(|r| r.workdir().map(|w| w.to_path_buf()));
+      (workdir, name)
+    }
     None => {
       let repo = worktree::discover_repo(None)?;
       let wd = repo.workdir().map(|w| w.to_path_buf());

--- a/src/gitmoji.rs
+++ b/src/gitmoji.rs
@@ -1,0 +1,182 @@
+//! Gitmoji mapping (issue #85).
+//!
+//! This repo standardises commits as `<emoji> <type>(#<issue>): <subject>`
+//! (Gitmoji + Conventional Commits — see CONTRIBUTING.md). The mapping
+//! `branch_type → emoji shortcode` is universal across the project, so
+//! we bake a default table into the binary and let `.gwm.toml` override
+//! individual entries via a `[gitmoji]` block:
+//!
+//! ```toml
+//! [gitmoji]
+//! feat = ":rocket:"  # team uses 🚀 for new features instead of ✨
+//! ```
+//!
+//! Three surfaces consume this module:
+//! 1. `gwm commit-prefix` — prints `:sparkles: feat(#41):` for the current
+//!    or named branch (with `--unicode` to emit ✨ instead).
+//! 2. `gwm types --gitmoji` — extends the branch-type list with the
+//!    unicode + shortcode columns.
+//! 3. `gwm hooks install commit-msg` — installs a `.git/hooks/commit-msg`
+//!    that shells out to `gwm commit-prefix --unicode` and auto-prepends
+//!    the prefix when missing.
+//!
+//! The shortcode → unicode table is intentionally kept small (the ten
+//! built-in branch types + `:question:` as the unknown-type fallback)
+//! to avoid pulling in a heavy `gh-emoji`-style dependency for a
+//! handful of entries.
+
+use crate::config::CONFIG_FILE;
+use crate::error::Result;
+use crate::naming::BranchSpec;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Built-in `branch_type → shortcode` table. Lifted to a `&[(&str,
+/// &str)]` const so the static table stays compile-time and zero-alloc
+/// at the storage level; the runtime view materialises on demand via
+/// [`default_map`]. The list mirrors the ten built-in branch types
+/// declared in `naming::BRANCH_TYPES`.
+pub const DEFAULT_GITMOJI: &[(&str, &str)] = &[
+  ("feat", ":sparkles:"),
+  ("fix", ":bug:"),
+  ("hotfix", ":ambulance:"),
+  ("docs", ":memo:"),
+  ("test", ":white_check_mark:"),
+  ("refactor", ":recycle:"),
+  ("chore", ":wrench:"),
+  ("perf", ":zap:"),
+  ("ci", ":construction_worker:"),
+  ("build", ":package:"),
+];
+
+/// Fallback shortcode used by [`resolve_prefix`] when neither the user's
+/// `[gitmoji]` block nor the built-in defaults claim a given branch
+/// type. Picked so the surface stays syntactically valid (a prefix is
+/// always emitted) while flagging "this type has no emoji yet" visually.
+const UNKNOWN_SHORTCODE: &str = ":question:";
+
+/// Resolved `branch_type → shortcode` table. The `BTreeMap` choice is
+/// load-bearing: it gives deterministic iteration order (alphabetical
+/// by branch type), which `gwm types --gitmoji` relies on so a CI diff
+/// against the previous run is byte-stable.
+#[derive(Debug, Clone, Default)]
+pub struct GitmojiMap {
+  entries: BTreeMap<String, String>,
+}
+
+impl GitmojiMap {
+  /// Look up the shortcode for a branch type. Returns `None` for types
+  /// not in the table — callers (notably [`resolve_prefix`]) decide
+  /// the fallback policy.
+  pub fn get(&self, branch_type: &str) -> Option<&str> {
+    self.entries.get(branch_type).map(String::as_str)
+  }
+
+  /// Iterate over `(branch_type, shortcode)` pairs in deterministic
+  /// (alphabetical) order. Used by `gwm types --gitmoji` and the
+  /// "every default has a unicode" test sweep.
+  pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+    self.entries.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+  }
+
+  /// Merge another `(branch_type, shortcode)` pair into the table.
+  /// Overrides the existing entry if any. Public so external callers
+  /// (e.g. tests, future programmatic surfaces) can build a custom
+  /// map without round-tripping through TOML.
+  pub fn insert(&mut self, branch_type: impl Into<String>, shortcode: impl Into<String>) {
+    self.entries.insert(branch_type.into(), shortcode.into());
+  }
+}
+
+/// Materialise the built-in table as a [`GitmojiMap`]. The runtime cost
+/// is one allocation per built-in entry — measured at ~1µs total in
+/// release builds, dominated by the `BTreeMap` insertions, so we don't
+/// cache.
+pub fn default_map() -> GitmojiMap {
+  let mut map = GitmojiMap::default();
+  for (ty, shortcode) in DEFAULT_GITMOJI {
+    map.insert(*ty, *shortcode);
+  }
+  map
+}
+
+/// Load `.gwm.toml`'s `[gitmoji]` block from the given repo root and
+/// merge it on top of the built-in defaults. Returns the built-in
+/// defaults verbatim when the file is missing or the block is absent.
+///
+/// `repo_root` is `Option` so callers without a workdir handle (e.g.
+/// the `gwm commit-prefix --branch <name>` path, which doesn't need
+/// to open a repo) can still get the defaults.
+pub fn load(repo_root: Option<&Path>) -> Result<GitmojiMap> {
+  let mut map = default_map();
+  let Some(root) = repo_root else {
+    return Ok(map);
+  };
+  let path = root.join(CONFIG_FILE);
+  if !path.exists() {
+    return Ok(map);
+  }
+  let raw = std::fs::read_to_string(&path)?;
+  // Deserialise only the `[gitmoji]` block — we don't want to fail
+  // here on unrelated config errors (a malformed `[[bootstrap.copy]]`
+  // shouldn't break `gwm commit-prefix`). The dedicated struct keeps
+  // the parse local to this module's contract.
+  let parsed: GitmojiOnlyConfig = toml::from_str(&raw)?;
+  for (ty, shortcode) in parsed.gitmoji {
+    map.insert(ty, shortcode);
+  }
+  Ok(map)
+}
+
+/// Render the canonical commit prefix for a branch: `<emoji>
+/// <type>(#<issue>):`. Use `unicode = true` to substitute the
+/// shortcode for its real emoji character (e.g. `:sparkles:` → ✨).
+///
+/// When `branch.type_` has no entry in the map, falls back to
+/// `:question:` / ❓ rather than panicking — the surface must be
+/// usable on any branch, including non-gwm-style ones that bypass
+/// `BranchSpec::validate`.
+pub fn resolve_prefix(map: &GitmojiMap, branch: &BranchSpec, unicode: bool) -> String {
+  let shortcode = map.get(&branch.type_).unwrap_or(UNKNOWN_SHORTCODE);
+  let emoji = if unicode {
+    shortcode_to_unicode(shortcode)
+  } else {
+    shortcode
+  };
+  format!("{} {}(#{}):", emoji, branch.type_, branch.issue)
+}
+
+/// Map a `:shortcode:` to its unicode character. Only the entries
+/// shipped in the built-in table + `:question:` are supported — a
+/// shortcode the user invented for their own branch type (e.g. `:fire:`
+/// for `chore-remove`) round-trips verbatim, which is the right
+/// behaviour: rendering an arbitrary user string under `--unicode`
+/// would require a 3000-entry table or a heavy dep, and shortcodes
+/// remain valid commit-message decoration anyway.
+pub fn shortcode_to_unicode(shortcode: &str) -> &str {
+  match shortcode {
+    ":sparkles:" => "✨",
+    ":bug:" => "🐛",
+    ":ambulance:" => "🚑",
+    ":memo:" => "📝",
+    ":white_check_mark:" => "✅",
+    ":recycle:" => "♻",
+    ":wrench:" => "🔧",
+    ":zap:" => "⚡",
+    ":construction_worker:" => "👷",
+    ":package:" => "📦",
+    ":question:" => "❓",
+    other => other,
+  }
+}
+
+/// Local deserialisation envelope: we only care about the `[gitmoji]`
+/// block here, and accepting unknown fields lets the rest of
+/// `.gwm.toml` (bootstrap, worktree, labels, …) coexist without a
+/// schema dependency in this module.
+#[derive(Debug, Default, Deserialize)]
+struct GitmojiOnlyConfig {
+  #[serde(default)]
+  gitmoji: BTreeMap<String, String>,
+}

--- a/src/gitmoji.rs
+++ b/src/gitmoji.rs
@@ -147,15 +147,19 @@ pub fn resolve_prefix(map: &GitmojiMap, branch: &BranchSpec, unicode: bool) -> S
   format!("{} {}(#{}):", emoji, branch.type_, branch.issue)
 }
 
-/// Map a `:shortcode:` to its unicode character. Only the entries
-/// shipped in the built-in table + `:question:` are supported — a
-/// shortcode the user invented for their own branch type (e.g. `:fire:`
-/// for `chore-remove`) round-trips verbatim, which is the right
-/// behaviour: rendering an arbitrary user string under `--unicode`
-/// would require a 3000-entry table or a heavy dep, and shortcodes
-/// remain valid commit-message decoration anyway.
+/// Map a `:shortcode:` to its unicode character. Covers the ten
+/// built-in defaults plus a curated set of the most commonly-used
+/// Gitmoji shortcodes (the ones a team `[gitmoji]` override is
+/// statistically likely to swap to — `:rocket:`, `:fire:`, `:lock:`,
+/// `:art:`, `:lipstick:`, …). Anything outside the table round-trips
+/// verbatim: rendering an arbitrary user string under `--unicode`
+/// would require the full 3000-entry Gitmoji set (a heavy dep) and
+/// shortcodes remain valid commit-message decoration anyway. The
+/// `:question:` fallback covers the unknown-branch-type path inside
+/// [`resolve_prefix`].
 pub fn shortcode_to_unicode(shortcode: &str) -> &str {
   match shortcode {
+    // Built-in default mappings (mirror DEFAULT_GITMOJI).
     ":sparkles:" => "✨",
     ":bug:" => "🐛",
     ":ambulance:" => "🚑",
@@ -167,6 +171,59 @@ pub fn shortcode_to_unicode(shortcode: &str) -> &str {
     ":construction_worker:" => "👷",
     ":package:" => "📦",
     ":question:" => "❓",
+    // Curated extension — common Gitmoji shortcodes teams swap in
+    // via `[gitmoji]` overrides. The list is intentionally not the
+    // full Gitmoji set (~3000 entries); it covers the ones witnessed
+    // in OSS `.gwm.toml`/`.commitlintrc` configs.
+    ":rocket:" => "🚀",
+    ":tada:" => "🎉",
+    ":boom:" => "💥",
+    ":fire:" => "🔥",
+    ":lock:" => "🔒",
+    ":closed_lock_with_key:" => "🔐",
+    ":key:" => "🔑",
+    ":art:" => "🎨",
+    ":lipstick:" => "💄",
+    ":hammer:" => "🔨",
+    ":wastebasket:" => "🗑",
+    ":truck:" => "🚚",
+    ":bookmark:" => "🔖",
+    ":pencil2:" => "✏",
+    ":pushpin:" => "📌",
+    ":green_heart:" => "💚",
+    ":rotating_light:" => "🚨",
+    ":construction:" => "🚧",
+    ":heavy_plus_sign:" => "➕",
+    ":heavy_minus_sign:" => "➖",
+    ":arrow_up:" => "⬆",
+    ":arrow_down:" => "⬇",
+    ":lock_with_ink_pen:" => "🔏",
+    ":mag:" => "🔍",
+    ":bulb:" => "💡",
+    ":poop:" => "💩",
+    ":rewind:" => "⏪",
+    ":twisted_rightwards_arrows:" => "🔀",
+    ":alien:" => "👽",
+    ":seedling:" => "🌱",
+    ":triangular_flag_on_post:" => "🚩",
+    ":bento:" => "🍱",
+    ":busts_in_silhouette:" => "👥",
+    ":children_crossing:" => "🚸",
+    ":building_construction:" => "🏗",
+    ":iphone:" => "📱",
+    ":clown_face:" => "🤡",
+    ":egg:" => "🥚",
+    ":see_no_evil:" => "🙈",
+    ":camera_flash:" => "📸",
+    ":coffin:" => "⚰",
+    ":test_tube:" => "🧪",
+    ":necktie:" => "👔",
+    ":stethoscope:" => "🩺",
+    ":bricks:" => "🧱",
+    ":technologist:" => "🧑‍💻",
+    ":money_with_wings:" => "💸",
+    ":thread:" => "🧵",
+    ":safety_vest:" => "🦺",
     other => other,
   }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,143 @@
+//! Git hook installer (issue #85).
+//!
+//! Currently exposes a single hook: `commit-msg`. The installed script
+//! shells out to `gwm commit-prefix --unicode` and auto-prepends the
+//! resolved Gitmoji + Conventional Commits prefix when the user's
+//! commit message doesn't already start with one.
+//!
+//! Design:
+//! - **Opt-in** — `gwm` never installs hooks implicitly. The
+//!   `gwm hooks install` subcommand is the only entry point.
+//! - **Non-destructive by default** — refuses to overwrite a
+//!   pre-existing `commit-msg` (husky, commitlint, pre-commit, …)
+//!   unless `--force` is passed.
+//! - **Self-contained script** — the generated POSIX `sh` script
+//!   uses only `grep` + `sed`, both POSIX-mandated. The shell-out
+//!   to `gwm commit-prefix` degrades gracefully when `gwm` is not
+//!   on `$PATH` (silent no-op rather than blocking the commit).
+//!
+//! The script is materialised by [`commit_msg_script`] and
+//! installed by [`install_commit_msg`]. Tests against the rendered
+//! script live in `tests/hooks_tests.rs` so a regression on the
+//! detection clause (the "is the message already prefixed?" guard)
+//! surfaces immediately rather than at the user's next `git commit`.
+
+use crate::error::{GwmError, Result};
+use std::path::{Path, PathBuf};
+
+/// Install `.git/hooks/commit-msg` under `repo_root`. Returns the
+/// written path on success. When `force` is `false` (default) and a
+/// `commit-msg` already exists, returns
+/// `GwmError::Other("commit-msg hook already exists at … — pass
+/// --force to overwrite")` without touching the file.
+///
+/// Requires `repo_root` to point at a workdir whose `.git` directory
+/// exists. Bare repos and non-git dirs are rejected with an error;
+/// the goal is "fail loudly, leak nothing into the filesystem".
+pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
+  let git_dir = repo_root.join(".git");
+  if !git_dir.exists() {
+    return Err(GwmError::Other(format!(
+      "no .git directory found at {} — `gwm hooks install` must be run from inside a git repo",
+      repo_root.display()
+    )));
+  }
+  // Bare repos have a directory at `.git`-the-path but no `hooks/`
+  // subdir hierarchy in the same way; even if it existed, hooks on
+  // a bare repo are server-side, not commit-time. We let the
+  // existence check above pass, but the subsequent `hooks_dir`
+  // creation handles the rest uniformly.
+  let hooks_dir = git_dir.join("hooks");
+  std::fs::create_dir_all(&hooks_dir)?;
+
+  let hook_path = hooks_dir.join("commit-msg");
+  if hook_path.exists() && !force {
+    return Err(GwmError::Other(format!(
+      "commit-msg hook already exists at {} — pass --force to overwrite",
+      hook_path.display()
+    )));
+  }
+
+  std::fs::write(&hook_path, commit_msg_script())?;
+
+  // Mark the hook executable. Git refuses to run a non-executable
+  // hook silently — which would be the worst failure mode for a
+  // "commit-msg" hook: the user thinks their commits are getting
+  // auto-prefixed, but git is just skipping the hook entirely.
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&hook_path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&hook_path, perms)?;
+  }
+
+  Ok(hook_path)
+}
+
+/// Return the body of the generated `commit-msg` hook. Exposed as a
+/// pure function so tests can assert on the rendered script without
+/// touching the filesystem, and so future hook variants (commit-msg,
+/// pre-push, …) can share helpers from this module.
+///
+/// The script:
+/// 1. Reads the in-progress commit message (path passed by git as `$1`).
+/// 2. Bails out (exit 0) if the first non-empty line already starts
+///    with an emoji-ish prefix (`grep -E` against a small set of
+///    unicode codepoints + the `:shortcode:` form).
+/// 3. Shells out to `gwm commit-prefix --unicode`. If `gwm` is
+///    missing from `$PATH`, the hook exits 0 cleanly — the goal is
+///    "never block a commit because the hook itself broke".
+/// 4. Prepends the resolved prefix + a space to the message and
+///    writes the result back to the same file.
+pub fn commit_msg_script() -> String {
+  // The raw string literal keeps escaping minimal. `\\$` would turn
+  // into `\$` (shell var literal); we use a regular `$` so the
+  // generated file is hand-readable. `grep -E` is mandated by POSIX
+  // and present everywhere git is.
+  r#"#!/bin/sh
+# gwm commit-msg hook — auto-prepends the gitmoji + type prefix when
+# the commit message doesn't already start with one. Installed by
+# `gwm hooks install commit-msg` (issue #85). Re-running the installer
+# with --force overwrites this file.
+
+set -eu
+
+# Skip when `gwm` isn't on $PATH — never block a commit because of us.
+if ! command -v gwm >/dev/null 2>&1; then
+  exit 0
+fi
+
+msg_file="$1"
+[ -f "$msg_file" ] || exit 0
+
+first_line="$(sed -n '1p' "$msg_file")"
+
+# Already-prefixed messages are passed through untouched. We detect
+# both the shortcode form (`:sparkles: feat(…)`) and the unicode form
+# (✨ feat(…)) — any non-space first byte that looks like an emoji
+# fence covers the latter. The shortcode check is tighter so common
+# `:foo:` mentions in PR / issue subjects don't false-positive.
+case "$first_line" in
+  :[a-z_]*:\ *) exit 0 ;;
+esac
+
+# Unicode emoji check via grep: the leading character is well into
+# the BMP, so a `[^[:alnum:][:space:][:punct:]]` heuristic catches it
+# without needing a full emoji table.
+if printf '%s' "$first_line" | grep -qE '^[^[:alnum:][:space:][:punct:]]'; then
+  exit 0
+fi
+
+prefix="$(gwm commit-prefix --unicode 2>/dev/null)" || exit 0
+[ -n "$prefix" ] || exit 0
+
+# Prepend `<prefix> ` + the original body. Using printf so a missing
+# trailing newline doesn't fold the user's first line into the prefix.
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/gwm-commit-msg.XXXXXX")"
+printf '%s ' "$prefix" > "$tmp_file"
+cat "$msg_file" >> "$tmp_file"
+mv "$tmp_file" "$msg_file"
+"#
+  .to_string()
+}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -11,10 +11,24 @@
 //! - **Non-destructive by default** — refuses to overwrite a
 //!   pre-existing `commit-msg` (husky, commitlint, pre-commit, …)
 //!   unless `--force` is passed.
-//! - **Self-contained script** — the generated POSIX `sh` script
-//!   uses only `grep` + `sed`, both POSIX-mandated. The shell-out
-//!   to `gwm commit-prefix` degrades gracefully when `gwm` is not
-//!   on `$PATH` (silent no-op rather than blocking the commit).
+//! - **Linked-worktree aware** — `gwm`'s primary use case is linked
+//!   worktrees whose `.git` is a file pointing at the real admin dir
+//!   (`<main>/.git/worktrees/<name>/`). The installer resolves the
+//!   effective gitdir via `git2::Repository::discover` rather than
+//!   blindly joining `.git/hooks/` to the workdir path.
+//! - **`core.hooksPath` aware** — when the repo config sets a custom
+//!   hooks directory (this project even recommends
+//!   `git config core.hooksPath .githooks`), the installer writes
+//!   into that directory. Writing into `.git/hooks/` while
+//!   `core.hooksPath` is set is dead code: git never invokes hooks
+//!   from the default location once the override is in play.
+//! - **Self-contained, best-effort script** — the generated POSIX
+//!   `sh` script uses only widely-available tools (`grep`, `sed`,
+//!   `printf`, `cat`, `mv`, `mktemp`, `command -v`). It deliberately
+//!   does NOT enable `set -e`: a transient filesystem failure must
+//!   not abort the user's commit. The shell-out to
+//!   `gwm commit-prefix` degrades gracefully when `gwm` is not on
+//!   `$PATH` (silent no-op rather than blocking the commit).
 //!
 //! The script is materialised by [`commit_msg_script`] and
 //! installed by [`install_commit_msg`]. Tests against the rendered
@@ -25,29 +39,35 @@
 use crate::error::{GwmError, Result};
 use std::path::{Path, PathBuf};
 
-/// Install `.git/hooks/commit-msg` under `repo_root`. Returns the
-/// written path on success. When `force` is `false` (default) and a
-/// `commit-msg` already exists, returns
-/// `GwmError::Other("commit-msg hook already exists at … — pass
-/// --force to overwrite")` without touching the file.
+/// Install `commit-msg` for the repository rooted at `repo_root`. The
+/// effective target directory is resolved as follows:
 ///
-/// Requires `repo_root` to point at a workdir whose `.git` directory
-/// exists. Bare repos and non-git dirs are rejected with an error;
-/// the goal is "fail loudly, leak nothing into the filesystem".
+/// 1. Open the repository via `git2::Repository::discover` so a
+///    linked worktree's `.git` file pointer is followed transparently.
+/// 2. If `core.hooksPath` is set in the repo config (the project's
+///    recommended setup is `core.hooksPath = .githooks`), resolve it
+///    against the workdir and install there. The directory is created
+///    if missing.
+/// 3. Otherwise fall back to `<gitdir>/hooks/` (where `<gitdir>` is
+///    the worktree's admin dir — e.g.
+///    `<main>/.git/worktrees/<name>/` for a linked worktree, or
+///    `<root>/.git/` for the main worktree).
+///
+/// Returns the written path on success. When `force` is `false`
+/// (default) and the target file already exists, returns
+/// `GwmError::Other("commit-msg hook already exists at … — pass
+/// --force to overwrite")` without touching the file. Bare repos and
+/// non-git dirs are rejected with an error; the goal is "fail
+/// loudly, leak nothing into the filesystem".
 pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
-  let git_dir = repo_root.join(".git");
-  if !git_dir.exists() {
-    return Err(GwmError::Other(format!(
-      "no .git directory found at {} — `gwm hooks install` must be run from inside a git repo",
+  let repo = git2::Repository::discover(repo_root).map_err(|_| {
+    GwmError::Other(format!(
+      "no git repository discovered from {} — `gwm hooks install` must be run from inside a git repo",
       repo_root.display()
-    )));
-  }
-  // Bare repos have a directory at `.git`-the-path but no `hooks/`
-  // subdir hierarchy in the same way; even if it existed, hooks on
-  // a bare repo are server-side, not commit-time. We let the
-  // existence check above pass, but the subsequent `hooks_dir`
-  // creation handles the rest uniformly.
-  let hooks_dir = git_dir.join("hooks");
+    ))
+  })?;
+
+  let hooks_dir = resolve_hooks_dir(&repo)?;
   std::fs::create_dir_all(&hooks_dir)?;
 
   let hook_path = hooks_dir.join("commit-msg");
@@ -75,6 +95,43 @@ pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
   Ok(hook_path)
 }
 
+/// Resolve the directory git will actually load hooks from. Priority
+/// order matches git itself: `core.hooksPath` (if set) > `<gitdir>/hooks`.
+///
+/// `core.hooksPath` is resolved against the workdir when it's
+/// relative (matches git's own behaviour — `git config
+/// core.hooksPath .githooks` puts hooks at `<repo>/.githooks/`, not
+/// `<cwd>/.githooks/`). Absolute paths are honoured verbatim.
+fn resolve_hooks_dir(repo: &git2::Repository) -> Result<PathBuf> {
+  // `Repository::config` opens a snapshot view that includes the
+  // global / system / repo layers in priority order — exactly what
+  // git uses when invoking hooks at commit time.
+  if let Ok(cfg) = repo.config() {
+    if let Ok(custom) = cfg.get_string("core.hooksPath") {
+      let trimmed = custom.trim();
+      if !trimmed.is_empty() {
+        let candidate = Path::new(trimmed);
+        let resolved = if candidate.is_absolute() {
+          candidate.to_path_buf()
+        } else if let Some(wd) = repo.workdir() {
+          wd.join(candidate)
+        } else {
+          // Bare repo + relative `core.hooksPath` — exceedingly rare
+          // and ill-defined in git itself. Fall through to the
+          // default gitdir-based location so we at least produce a
+          // deterministic path.
+          repo.path().join("hooks")
+        };
+        return Ok(resolved);
+      }
+    }
+  }
+  // `repo.path()` returns the gitdir — `<main>/.git/` for the main
+  // worktree, `<main>/.git/worktrees/<name>/` for a linked one. This
+  // is the path git itself uses to locate the default hooks dir.
+  Ok(repo.path().join("hooks"))
+}
+
 /// Return the body of the generated `commit-msg` hook. Exposed as a
 /// pure function so tests can assert on the rendered script without
 /// touching the filesystem, and so future hook variants (commit-msg,
@@ -82,36 +139,59 @@ pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
 ///
 /// The script:
 /// 1. Reads the in-progress commit message (path passed by git as `$1`).
-/// 2. Bails out (exit 0) if the first non-empty line already starts
-///    with an emoji-ish prefix (`grep -E` against a small set of
-///    unicode codepoints + the `:shortcode:` form).
-/// 3. Shells out to `gwm commit-prefix --unicode`. If `gwm` is
-///    missing from `$PATH`, the hook exits 0 cleanly — the goal is
-///    "never block a commit because the hook itself broke".
-/// 4. Prepends the resolved prefix + a space to the message and
-///    writes the result back to the same file.
+/// 2. Locates the *first non-empty non-comment* line — git's own
+///    commit template puts `# Please enter the commit message…`
+///    above the user's first real line, and `git commit -v` appends
+///    a diff dump prefixed with `#`. Both are stripped before the
+///    "is the message already prefixed?" check.
+/// 3. Bails out (exit 0) if that line already starts with an
+///    emoji-ish prefix (a `case` match against the `:shortcode:`
+///    form + a `grep -E` for unicode emoji codepoints).
+/// 4. Shells out to `gwm commit-prefix --unicode`. If `gwm` is
+///    missing from `$PATH`, or the shell-out fails for any reason,
+///    the hook exits 0 cleanly — the goal is "never block a commit
+///    because the hook itself broke".
+/// 5. Prepends the resolved prefix + a space to the message and
+///    writes the result back to the same file. Every filesystem
+///    step here is guarded by `|| exit 0` so a transient failure
+///    (full /tmp, noexec mount, read-only fs, …) lets the original
+///    commit through unmodified rather than aborting it.
 pub fn commit_msg_script() -> String {
-  // The raw string literal keeps escaping minimal. `\\$` would turn
-  // into `\$` (shell var literal); we use a regular `$` so the
-  // generated file is hand-readable. `grep -E` is mandated by POSIX
-  // and present everywhere git is.
+  // The raw string literal keeps escaping minimal. We deliberately do
+  // NOT enable `set -e`: the script is best-effort, and any failure
+  // path must return 0 so `git commit` proceeds with the user's
+  // original message. `set -u` is kept so referencing an unset
+  // variable surfaces as a real bug (rather than silently producing
+  // empty output).
   r#"#!/bin/sh
 # gwm commit-msg hook — auto-prepends the gitmoji + type prefix when
 # the commit message doesn't already start with one. Installed by
 # `gwm hooks install commit-msg` (issue #85). Re-running the installer
 # with --force overwrites this file.
+#
+# Best-effort by design: every filesystem step is guarded so a
+# transient failure (full /tmp, noexec mount, …) never blocks the
+# commit — the user just loses the auto-prefix for that one commit.
 
-set -eu
+set -u
 
 # Skip when `gwm` isn't on $PATH — never block a commit because of us.
 if ! command -v gwm >/dev/null 2>&1; then
   exit 0
 fi
 
-msg_file="$1"
+msg_file="${1:-}"
+[ -n "$msg_file" ] || exit 0
 [ -f "$msg_file" ] || exit 0
 
-first_line="$(sed -n '1p' "$msg_file")"
+# Find the first non-empty / non-comment line. `grep -nvE` returns
+# `<lineno>:<text>` for every line that is NOT pure whitespace AND NOT
+# a `#`-prefixed comment; we take the first match. Falling back to an
+# empty string lets the downstream check no-op cleanly when the buffer
+# only contains the git template (i.e. the user aborted with an empty
+# message — git itself will reject that commit, no need for us to).
+first_line="$(grep -nvE '^([[:space:]]*#|[[:space:]]*$)' "$msg_file" 2>/dev/null | sed -n '1s/^[0-9]*://p')"
+[ -n "$first_line" ] || exit 0
 
 # Already-prefixed messages are passed through untouched. We detect
 # both the shortcode form (`:sparkles: feat(…)`) and the unicode form
@@ -132,12 +212,14 @@ fi
 prefix="$(gwm commit-prefix --unicode 2>/dev/null)" || exit 0
 [ -n "$prefix" ] || exit 0
 
-# Prepend `<prefix> ` + the original body. Using printf so a missing
-# trailing newline doesn't fold the user's first line into the prefix.
-tmp_file="$(mktemp "${TMPDIR:-/tmp}/gwm-commit-msg.XXXXXX")"
-printf '%s ' "$prefix" > "$tmp_file"
-cat "$msg_file" >> "$tmp_file"
-mv "$tmp_file" "$msg_file"
+# Prepend `<prefix> ` + the original body. Every fs step below is
+# guarded with `|| exit 0` so a failure (read-only mount, full /tmp,
+# noexec /tmp, …) leaves the user's commit message intact rather than
+# aborting the commit.
+tmp_file="$(mktemp "${TMPDIR:-/tmp}/gwm-commit-msg.XXXXXX" 2>/dev/null)" || exit 0
+{ printf '%s ' "$prefix" > "$tmp_file"; } || { rm -f "$tmp_file"; exit 0; }
+cat "$msg_file" >> "$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; exit 0; }
+mv "$tmp_file" "$msg_file" 2>/dev/null || { rm -f "$tmp_file"; exit 0; }
 "#
   .to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod doctor;
 pub mod error;
 pub mod github;
+pub mod gitmoji;
+pub mod hooks;
 pub mod labels;
 pub mod launcher;
 pub mod milestones;

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -127,6 +127,72 @@ fn commit_prefix_on_non_gwm_branch_reports_error() {
 }
 
 #[test]
+fn commit_prefix_unicode_normalizes_known_shortcode_override() {
+  // The UX guarantee from the PR #152 follow-up: under `--unicode`,
+  // a `.gwm.toml` override that supplied a known `:shortcode:` (like
+  // `:rocket:`) must render as the unicode glyph (🚀), not the
+  // shortcode literal. Asymmetry between this surface and
+  // `gwm types --gitmoji`'s unicode column was the original bug.
+  let (dir, _repo) = init_repo();
+  std::fs::write(dir.path().join(".gwm.toml"), "[gitmoji]\nfeat = \":rocket:\"\n").expect("seed .gwm.toml");
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["commit-prefix", "--branch", "feat/#1-x", "--unicode"]);
+  cmd.assert().success().stdout(predicate::str::contains("🚀 feat(#1):"));
+}
+
+#[test]
+fn commit_prefix_unicode_leaves_unknown_shortcode_override_verbatim() {
+  // Graceful degradation for shortcodes the built-in table doesn't
+  // know about. `:foo:` is not in `shortcode_to_unicode`, so under
+  // `--unicode` we keep the value verbatim — the surface must remain
+  // usable on any user configuration without falling back to
+  // `:question:`/❓ (which would hide the user's intent).
+  let (dir, _repo) = init_repo();
+  std::fs::write(dir.path().join(".gwm.toml"), "[gitmoji]\nfeat = \":foo:\"\n").expect("seed .gwm.toml");
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["commit-prefix", "--branch", "feat/#1-x", "--unicode"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(":foo: feat(#1):"));
+}
+
+#[test]
+fn types_gitmoji_normalizes_known_shortcode_override_in_unicode_column() {
+  // Symmetry with `gwm commit-prefix --unicode`: the `gwm types
+  // --gitmoji` unicode column must show the GLYPH for a known
+  // shortcode override (not the shortcode literal). The shortcode
+  // column still shows the literal `:rocket:` so both forms remain
+  // greppable on the same row.
+  let (dir, _repo) = init_repo();
+  std::fs::write(dir.path().join(".gwm.toml"), "[gitmoji]\nfeat = \":rocket:\"\n").expect("seed .gwm.toml");
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).args(["types", "--gitmoji"]);
+  let assert = cmd.assert().success();
+  let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+  // Find the `feat` row and check both columns on it. A per-row
+  // assertion (rather than two independent `contains(...)` checks)
+  // catches the regression where the glyph appears on some unrelated
+  // row but `feat` still shows `:rocket:` in the unicode column.
+  let feat_row = stdout
+    .lines()
+    .find(|l| l.trim_start().starts_with("feat "))
+    .expect("feat row must be present in `gwm types --gitmoji` output");
+  assert!(
+    feat_row.contains("🚀"),
+    "feat unicode column must be normalised to 🚀, got: {feat_row:?}"
+  );
+  assert!(
+    feat_row.contains(":rocket:"),
+    "feat shortcode column must still be :rocket:, got: {feat_row:?}"
+  );
+}
+
+#[test]
 fn types_with_gitmoji_flag_includes_emoji_columns() {
   // `gwm types --gitmoji` extends the existing per-type list with
   // two more columns: the unicode emoji and the shortcode form. The

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -75,10 +75,7 @@ fn commit_prefix_unicode_emits_real_emoji() {
   // sequence in the message body, not the shortcode form).
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["commit-prefix", "--branch", "feat/#41-foo", "--unicode"]);
-  cmd
-    .assert()
-    .success()
-    .stdout(predicate::str::contains("✨ feat(#41):"));
+  cmd.assert().success().stdout(predicate::str::contains("✨ feat(#41):"));
 }
 
 #[test]
@@ -104,10 +101,7 @@ fn commit_prefix_on_non_gwm_branch_reports_error() {
   // there's no auto-fallback to CWD to fall back to.
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["commit-prefix", "--branch", "random"]);
-  cmd
-    .assert()
-    .failure()
-    .stderr(predicate::str::contains("random"));
+  cmd.assert().failure().stderr(predicate::str::contains("random"));
 }
 
 #[test]
@@ -178,10 +172,7 @@ fn hooks_install_commit_msg_refuses_existing_hook_without_force() {
 
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.current_dir(dir.path()).args(["hooks", "install", "commit-msg"]);
-  cmd
-    .assert()
-    .failure()
-    .stderr(predicate::str::contains("--force"));
+  cmd.assert().failure().stderr(predicate::str::contains("--force"));
 
   let body = std::fs::read_to_string(&hook_path).expect("read seeded hook");
   assert!(

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -93,6 +93,28 @@ fn commit_prefix_for_fix_branch_uses_bug_emoji() {
 }
 
 #[test]
+fn commit_prefix_with_explicit_branch_honours_repo_gitmoji_overrides() {
+  // Regression guard: `--branch <name>` is a scripted entry point —
+  // shell prompts, AI assistants, the installed commit-msg hook —
+  // but if it bypasses `.gwm.toml`'s `[gitmoji]` block the renderer
+  // contradicts itself between `gwm types --gitmoji` (which loads
+  // the config) and `gwm commit-prefix --branch …` (which used not
+  // to). The two surfaces MUST agree.
+  let (dir, _repo) = init_repo();
+  let cfg = "[gitmoji]\nfeat = \":rocket:\"\n";
+  std::fs::write(dir.path().join(".gwm.toml"), cfg).expect("seed .gwm.toml");
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["commit-prefix", "--branch", "feat/#41-foo"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(":rocket: feat(#41):"));
+}
+
+#[test]
 fn commit_prefix_on_non_gwm_branch_reports_error() {
   // `gwm commit-prefix --branch random` doesn't match the
   // `<type>/#<N>-<slug>` regex — the contract is "fail loudly with a

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -46,7 +46,171 @@ fn help_prints_subcommands() {
     // Issue #95: TOFU trust ledger.
     .stdout(predicate::str::contains("  trust "))
     // Issue #86: CLI aliases (`gwm aliases list`).
-    .stdout(predicate::str::contains("  aliases "));
+    .stdout(predicate::str::contains("  aliases "))
+    // Issue #85: gitmoji commit-prefix + commit-msg hook installer.
+    .stdout(predicate::str::contains("  commit-prefix "))
+    .stdout(predicate::str::contains("  hooks "));
+}
+
+// --- gitmoji (issue #85) ------------------------------------------------
+
+#[test]
+fn commit_prefix_resolves_branch_to_shortcode_form() {
+  // The canonical contract: `gwm commit-prefix --branch feat/#41-foo`
+  // prints `:sparkles: feat(#41):` — the prefix every commit in this
+  // repo starts with. The shortcode form is the default (matches
+  // most commit hooks and tooling that lint emoji on raw text).
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["commit-prefix", "--branch", "feat/#41-foo"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(":sparkles: feat(#41):"));
+}
+
+#[test]
+fn commit_prefix_unicode_emits_real_emoji() {
+  // The `--unicode` flag swaps `:sparkles:` for ✨ — meant for shell
+  // prompts and the commit-msg hook (which wants the final byte
+  // sequence in the message body, not the shortcode form).
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["commit-prefix", "--branch", "feat/#41-foo", "--unicode"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("✨ feat(#41):"));
+}
+
+#[test]
+fn commit_prefix_for_fix_branch_uses_bug_emoji() {
+  // Second branch type to pin: `fix/#10-bar` ↔ `:bug:` ↔ 🐛. The two
+  // most-used emojis in the history both need an end-to-end test
+  // so a future refactor that breaks one trips a binary-level
+  // assertion.
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["commit-prefix", "--branch", "fix/#10-bar"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(":bug: fix(#10):"));
+}
+
+#[test]
+fn commit_prefix_on_non_gwm_branch_reports_error() {
+  // `gwm commit-prefix --branch random` doesn't match the
+  // `<type>/#<N>-<slug>` regex — the contract is "fail loudly with a
+  // pointer to the convention" rather than silently rendering a
+  // bogus prefix. The user typed `--branch <name>` explicitly, so
+  // there's no auto-fallback to CWD to fall back to.
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["commit-prefix", "--branch", "random"]);
+  cmd
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("random"));
+}
+
+#[test]
+fn types_with_gitmoji_flag_includes_emoji_columns() {
+  // `gwm types --gitmoji` extends the existing per-type list with
+  // two more columns: the unicode emoji and the shortcode form. The
+  // shortcode is asserted via `:sparkles:` (textual, deterministic);
+  // the unicode column is asserted via the ✨ character.
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).args(["types", "--gitmoji"]);
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat"))
+    .stdout(predicate::str::contains(":sparkles:"))
+    .stdout(predicate::str::contains("✨"))
+    .stdout(predicate::str::contains(":bug:"))
+    .stdout(predicate::str::contains("🐛"));
+}
+
+#[test]
+fn types_without_gitmoji_flag_does_not_include_emoji_columns() {
+  // Backwards compatibility: `gwm types` (no flag) must NOT spill
+  // shortcodes into its output — every scripted parser of the
+  // pre-#85 surface depends on the two-column layout.
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).arg("types");
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat"))
+    .stdout(predicate::str::contains(":sparkles:").not())
+    .stdout(predicate::str::contains("✨").not());
+}
+
+#[test]
+fn hooks_install_commit_msg_creates_executable_hook() {
+  // `gwm hooks install commit-msg` writes `.git/hooks/commit-msg` and
+  // exits 0. We assert on the resulting file (not the stdout
+  // message), so the test is robust to cosmetic copy changes.
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).args(["hooks", "install", "commit-msg"]);
+  cmd.assert().success();
+
+  let hook = dir.path().join(".git").join("hooks").join("commit-msg");
+  assert!(hook.exists(), "commit-msg hook must exist after `gwm hooks install`");
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(&hook).expect("stat hook").permissions().mode();
+    assert!(mode & 0o100 != 0, "hook must be executable by owner");
+  }
+}
+
+#[test]
+fn hooks_install_commit_msg_refuses_existing_hook_without_force() {
+  // Idempotent-safe contract: a pre-existing `commit-msg` (husky,
+  // commitlint, …) is left intact and the command exits non-zero
+  // with a clear pointer to `--force`.
+  let (dir, _repo) = init_repo();
+  let hooks_dir = dir.path().join(".git").join("hooks");
+  std::fs::create_dir_all(&hooks_dir).expect("hooks dir");
+  let hook_path = hooks_dir.join("commit-msg");
+  std::fs::write(&hook_path, "#!/bin/sh\necho 'pre-existing hook'\n").expect("seed hook");
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir.path()).args(["hooks", "install", "commit-msg"]);
+  cmd
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("--force"));
+
+  let body = std::fs::read_to_string(&hook_path).expect("read seeded hook");
+  assert!(
+    body.contains("pre-existing hook"),
+    "seeded hook must not be overwritten on the refusal path"
+  );
+}
+
+#[test]
+fn hooks_install_commit_msg_force_overwrites() {
+  // The escape hatch.
+  let (dir, _repo) = init_repo();
+  let hooks_dir = dir.path().join(".git").join("hooks");
+  std::fs::create_dir_all(&hooks_dir).expect("hooks dir");
+  let hook_path = hooks_dir.join("commit-msg");
+  std::fs::write(&hook_path, "#!/bin/sh\necho 'old'\n").expect("seed hook");
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .args(["hooks", "install", "commit-msg", "--force"]);
+  cmd.assert().success();
+
+  let body = std::fs::read_to_string(&hook_path).expect("read installed hook");
+  assert!(
+    body.contains("gwm commit-msg hook"),
+    "installed hook must carry the gwm marker; got {:?}",
+    body
+  );
 }
 
 // --- labels (issue #81) -------------------------------------------------

--- a/tests/gitmoji_tests.rs
+++ b/tests/gitmoji_tests.rs
@@ -1,0 +1,155 @@
+//! Unit tests for the gitmoji module (issue #85). The module exposes a
+//! built-in `branch_type → emoji shortcode` table baked into the binary,
+//! merged at load time with optional `[gitmoji]` overrides from
+//! `.gwm.toml`. Resolution then composes the prefix expected by every
+//! commit in this repo: `<emoji> <type>(#<issue>):`.
+
+use gwm::gitmoji::{default_map, load, resolve_prefix, shortcode_to_unicode};
+use gwm::naming::BranchSpec;
+
+#[test]
+fn default_map_contains_built_in_branch_types() {
+  // All ten built-in branch types declared in CONTRIBUTING.md must be
+  // resolvable out of the box — defaults are the contract for users
+  // who never write a `[gitmoji]` block. Spot-check the four canonical
+  // pairings; the full sweep is implied by the iteration below.
+  let map = default_map();
+  assert_eq!(map.get("feat"), Some(":sparkles:"));
+  assert_eq!(map.get("fix"), Some(":bug:"));
+  assert_eq!(map.get("hotfix"), Some(":ambulance:"));
+  assert_eq!(map.get("chore"), Some(":wrench:"));
+
+  // Hard-pin the full set so a future "let's drop one" decision shows up
+  // in this test rather than silently breaking shell prompts.
+  for ty in [
+    "feat", "fix", "hotfix", "docs", "test", "refactor", "chore", "perf", "ci", "build",
+  ] {
+    assert!(
+      map.get(ty).is_some(),
+      "default gitmoji map must include built-in branch type {:?}",
+      ty
+    );
+  }
+}
+
+#[test]
+fn load_without_dot_gwm_toml_yields_defaults() {
+  // The repo-less path: no `.gwm.toml` means defaults verbatim.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  let map = load(Some(dir.path())).expect("load defaults");
+  assert_eq!(map.get("feat"), Some(":sparkles:"));
+  assert_eq!(map.get("fix"), Some(":bug:"));
+}
+
+#[test]
+fn load_merges_dot_gwm_toml_overrides_on_top_of_defaults() {
+  // `[gitmoji]` is additive on top of the built-in table: overriding
+  // `feat` must not erase `fix` / `chore` / etc. This is the contract
+  // that lets a team customise one entry without re-declaring the whole
+  // table.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+feat = ":rocket:"
+"#,
+  )
+  .expect("write .gwm.toml");
+
+  let map = load(Some(dir.path())).expect("load with override");
+  // Overridden entry wins.
+  assert_eq!(map.get("feat"), Some(":rocket:"));
+  // Other defaults survive intact — this is the bug we explicitly do
+  // NOT want: a partial override wiping the rest of the table.
+  assert_eq!(map.get("fix"), Some(":bug:"));
+  assert_eq!(map.get("chore"), Some(":wrench:"));
+}
+
+#[test]
+fn load_accepts_custom_branch_types_not_in_defaults() {
+  // A repo using a non-built-in branch type (`migration`, `release`, …)
+  // must be able to declare its emoji without `gwm` rejecting the key.
+  // Gitmoji map shape is "open by design"; validation against
+  // `BRANCH_TYPES` is `BranchSpec::validate`'s job, not ours.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+migration = ":truck:"
+"#,
+  )
+  .expect("write .gwm.toml");
+
+  let map = load(Some(dir.path())).expect("load with custom type");
+  assert_eq!(map.get("migration"), Some(":truck:"));
+}
+
+#[test]
+fn resolve_prefix_renders_shortcode_form_by_default() {
+  // The canonical form on this repo's commits: `:sparkles: feat(#41):`.
+  // The trailing colon AND space matters — every commit subject in the
+  // history is `:emoji: type(#N): <subject>`.
+  let map = default_map();
+  let spec = BranchSpec::new("feat", "41", "tui-search").expect("valid branch");
+  let prefix = resolve_prefix(&map, &spec, false);
+  assert_eq!(prefix, ":sparkles: feat(#41):");
+}
+
+#[test]
+fn resolve_prefix_with_unicode_emits_the_real_emoji() {
+  // Same shape, but `:sparkles:` becomes ✨ — useful for shell prompts
+  // and commit-msg hooks that want a single byte sequence in the
+  // commit message body rather than a shortcode.
+  let map = default_map();
+  let spec = BranchSpec::new("feat", "41", "tui-search").expect("valid branch");
+  let prefix = resolve_prefix(&map, &spec, true);
+  assert_eq!(prefix, "✨ feat(#41):");
+}
+
+#[test]
+fn resolve_prefix_for_fix_branch_uses_bug_emoji() {
+  // Second branch type, mostly to pin `fix` ↔ `:bug:` ↔ `🐛` since it
+  // is the second most-used emoji in the repo's history.
+  let map = default_map();
+  let spec = BranchSpec::new("fix", "10", "bar-baz").expect("valid branch");
+  assert_eq!(resolve_prefix(&map, &spec, false), ":bug: fix(#10):");
+  assert_eq!(resolve_prefix(&map, &spec, true), "🐛 fix(#10):");
+}
+
+#[test]
+fn resolve_prefix_unknown_type_falls_back_to_question_mark() {
+  // A branch like `release/#1-…` with no matching `[gitmoji]` entry
+  // and no built-in default must still produce a syntactically valid
+  // commit prefix — we degrade to `:question:` / ❓ rather than panic
+  // or return an error. This keeps the CLI safe to call from a
+  // commit-msg hook on any branch.
+  let map = default_map();
+  // Build a spec directly (bypassing `BranchSpec::new`'s validation)
+  // because `release` is not in the built-in branch-types list.
+  let spec = BranchSpec {
+    type_: "release".into(),
+    issue: "7".into(),
+    desc: "v0-8".into(),
+  };
+  assert_eq!(resolve_prefix(&map, &spec, false), ":question: release(#7):");
+  assert_eq!(resolve_prefix(&map, &spec, true), "❓ release(#7):");
+}
+
+#[test]
+fn shortcode_to_unicode_covers_every_default_entry() {
+  // Every shortcode shipped in the built-in table must have a unicode
+  // mapping — otherwise `--unicode` silently falls back to the
+  // shortcode form on a known emoji, which is the user-confusing
+  // failure mode we want to prevent at the type-system / test level.
+  let map = default_map();
+  for (_, shortcode) in map.iter() {
+    let unicode = shortcode_to_unicode(shortcode);
+    assert!(
+      !unicode.is_empty() && unicode != shortcode,
+      "shortcode {:?} has no unicode mapping",
+      shortcode
+    );
+  }
+}

--- a/tests/gitmoji_tests.rs
+++ b/tests/gitmoji_tests.rs
@@ -138,6 +138,96 @@ fn resolve_prefix_unknown_type_falls_back_to_question_mark() {
 }
 
 #[test]
+fn resolve_prefix_normalizes_known_shortcode_override_when_unicode_requested() {
+  // The UX bug we're fixing (PR #152 follow-up): a `.gwm.toml` override
+  // like `feat = ":rocket:"` produced `:rocket: feat(#1):` even under
+  // `--unicode`, because the renderer passed the override value through
+  // `shortcode_to_unicode()` verbatim and the helper used to return
+  // unknown inputs unchanged. With Option A (the validated UX choice),
+  // a KNOWN shortcode in the override table must be normalised to its
+  // unicode glyph when `--unicode` is set, so `gwm commit-prefix
+  // --unicode` mirrors the asymmetry-free contract of `gwm types
+  // --gitmoji`'s unicode column.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+feat = ":rocket:"
+"#,
+  )
+  .expect("write .gwm.toml");
+  let map = load(Some(dir.path())).expect("load with override");
+  let spec = BranchSpec::new("feat", "1", "x").expect("valid branch");
+  assert_eq!(resolve_prefix(&map, &spec, true), "🚀 feat(#1):");
+}
+
+#[test]
+fn resolve_prefix_keeps_unknown_shortcode_override_verbatim_when_unicode_requested() {
+  // The graceful-degradation half of Option A: if the user picks a
+  // shortcode the built-in `shortcode_to_unicode` table doesn't know
+  // (e.g. `:foo:`), `--unicode` must NOT panic, NOT error out, NOT
+  // substitute `:question:` — it must leave the value as-is. The
+  // prefix surface must remain usable on any user configuration.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+feat = ":foo:"
+"#,
+  )
+  .expect("write .gwm.toml");
+  let map = load(Some(dir.path())).expect("load with unknown override");
+  let spec = BranchSpec::new("feat", "1", "x").expect("valid branch");
+  assert_eq!(resolve_prefix(&map, &spec, true), ":foo: feat(#1):");
+}
+
+#[test]
+fn resolve_prefix_keeps_unicode_override_verbatim_when_unicode_not_requested() {
+  // Counterpart to the above: a user who already wrote the literal
+  // unicode glyph in `.gwm.toml` (e.g. `feat = "🚀"`) gets that glyph
+  // back even without `--unicode`. There is no reverse table from
+  // unicode → shortcode, and the current contract is "verbatim" when
+  // `--unicode` is off, so this exercises the "no transformation"
+  // path for non-shortcode values.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+feat = "🚀"
+"#,
+  )
+  .expect("write .gwm.toml");
+  let map = load(Some(dir.path())).expect("load with unicode override");
+  let spec = BranchSpec::new("feat", "1", "x").expect("valid branch");
+  assert_eq!(resolve_prefix(&map, &spec, false), "🚀 feat(#1):");
+}
+
+#[test]
+fn resolve_prefix_keeps_shortcode_override_verbatim_when_unicode_not_requested() {
+  // Symmetry guard: the normalisation step is gated by `--unicode`.
+  // Without the flag, a shortcode override (even a known one) must
+  // round-trip verbatim — the no-flag form is what tooling that
+  // expects a `:shortcode:` literal (commit-msg linters, GitHub
+  // Markdown renderers) consumes. Regressing this would silently
+  // break those downstream consumers.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[gitmoji]
+feat = ":rocket:"
+"#,
+  )
+  .expect("write .gwm.toml");
+  let map = load(Some(dir.path())).expect("load with shortcode override");
+  let spec = BranchSpec::new("feat", "1", "x").expect("valid branch");
+  assert_eq!(resolve_prefix(&map, &spec, false), ":rocket: feat(#1):");
+}
+
+#[test]
 fn shortcode_to_unicode_covers_every_default_entry() {
   // Every shortcode shipped in the built-in table must have a unicode
   // mapping — otherwise `--unicode` silently falls back to the

--- a/tests/hooks_tests.rs
+++ b/tests/hooks_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests for the `gwm hooks install commit-msg` machinery
+//! (issue #85). The hook script is the bridge between `gwm
+//! commit-prefix` and `git commit` — it auto-prepends the resolved
+//! prefix when the user's commit message doesn't already start with
+//! one, and stays out of the way otherwise.
+
+use gwm::hooks::{commit_msg_script, install_commit_msg};
+use std::os::unix::fs::PermissionsExt;
+
+/// Initialise a fresh git repo with a worktree on `feat/#42-demo`. The
+/// hook installer needs a `.git` directory; we don't need any commits
+/// to verify the install path (the hook is a static script + permission
+/// bits).
+fn init_repo_on_feat_branch() -> tempfile::TempDir {
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  let repo = git2::Repository::init(dir.path()).expect("init repo");
+  // Set HEAD to a feat branch so the hook's `gwm commit-prefix`
+  // resolution has something realistic to chew on at runtime — we
+  // don't actually execute the hook in this test, but a fixture that
+  // mirrors a real scenario is cheap.
+  repo
+    .reference_symbolic("HEAD", "refs/heads/feat/#42-demo", true, "setup")
+    .expect("set HEAD");
+  dir
+}
+
+#[test]
+fn install_commit_msg_creates_the_hook_file() {
+  // The contract: `install_commit_msg(repo)` writes
+  // `<repo>/.git/hooks/commit-msg` and returns its path. The file must
+  // exist after the call — the hook installer is the only surface that
+  // touches the `.git/hooks/` directory.
+  let dir = init_repo_on_feat_branch();
+  let path = install_commit_msg(dir.path(), false).expect("install hook");
+  assert!(path.exists(), "commit-msg hook file should exist after install");
+  assert!(
+    path.ends_with(".git/hooks/commit-msg"),
+    "expected .git/hooks/commit-msg, got {}",
+    path.display()
+  );
+}
+
+#[test]
+#[cfg(unix)]
+fn install_commit_msg_marks_the_hook_executable() {
+  // Git refuses to invoke a hook that isn't executable. The installer
+  // sets mode 0o755 explicitly; we assert on the owner-exec bit
+  // because the group / world bits depend on the user's umask and
+  // are not part of the contract.
+  let dir = init_repo_on_feat_branch();
+  let path = install_commit_msg(dir.path(), false).expect("install hook");
+  let mode = std::fs::metadata(&path).expect("stat hook").permissions().mode();
+  assert!(
+    mode & 0o100 != 0,
+    "hook must be executable by owner (mode = {:o})",
+    mode
+  );
+}
+
+#[test]
+fn install_commit_msg_refuses_to_overwrite_existing_hook_without_force() {
+  // A pre-existing `commit-msg` may belong to husky, pre-commit,
+  // commitlint, … — silently clobbering it would be destructive. The
+  // contract is "refuse without `--force`", with an error that names
+  // the offending file so the user can decide.
+  let dir = init_repo_on_feat_branch();
+  let hooks_dir = dir.path().join(".git").join("hooks");
+  std::fs::create_dir_all(&hooks_dir).expect("hooks dir");
+  let hook_path = hooks_dir.join("commit-msg");
+  std::fs::write(&hook_path, "#!/bin/sh\necho 'pre-existing hook'\n").expect("seed hook");
+
+  let result = install_commit_msg(dir.path(), false);
+  assert!(result.is_err(), "install should refuse to overwrite without --force");
+
+  // The pre-existing file MUST be intact — the failure path is
+  // non-destructive by contract.
+  let body = std::fs::read_to_string(&hook_path).expect("read seeded hook");
+  assert!(
+    body.contains("pre-existing hook"),
+    "seeded hook must not be overwritten on the refusal path; got {:?}",
+    body
+  );
+}
+
+#[test]
+fn install_commit_msg_overwrites_with_force() {
+  // The escape hatch: `--force` lets the user knowingly replace an
+  // existing hook. After the call, the file must be our generated
+  // script (we detect this via a stable marker comment).
+  let dir = init_repo_on_feat_branch();
+  let hooks_dir = dir.path().join(".git").join("hooks");
+  std::fs::create_dir_all(&hooks_dir).expect("hooks dir");
+  let hook_path = hooks_dir.join("commit-msg");
+  std::fs::write(&hook_path, "#!/bin/sh\necho 'old hook'\n").expect("seed hook");
+
+  let path = install_commit_msg(dir.path(), true).expect("install with --force");
+  let body = std::fs::read_to_string(&path).expect("read installed hook");
+  assert!(
+    body.contains("gwm commit-msg hook"),
+    "installed hook must carry the gwm marker; got {:?}",
+    body
+  );
+  assert!(
+    !body.contains("old hook"),
+    "force-install must replace the pre-existing body; got {:?}",
+    body
+  );
+}
+
+#[test]
+fn install_commit_msg_outside_git_repo_fails() {
+  // Defence-in-depth: a plain temp dir has no `.git` directory, so
+  // there's no place to put the hook. The installer must refuse
+  // cleanly rather than fabricating a `.git/hooks/` tree.
+  let dir = tempfile::TempDir::new().expect("tempdir");
+  let result = install_commit_msg(dir.path(), false);
+  assert!(result.is_err(), "install outside a git repo must fail");
+}
+
+#[test]
+fn commit_msg_script_is_a_posix_sh_file_referencing_gwm() {
+  // The generated script's shape: a shebang, our marker, and a
+  // shell-out to `gwm commit-prefix --unicode`. We don't assert on
+  // the exact body so future cosmetic tweaks don't break the test —
+  // just the three load-bearing tokens.
+  let script = commit_msg_script();
+  assert!(
+    script.starts_with("#!/bin/sh\n") || script.starts_with("#!/usr/bin/env sh\n"),
+    "script must start with a POSIX shebang; got {:?}",
+    &script[..script.len().min(40)]
+  );
+  assert!(
+    script.contains("gwm commit-msg hook"),
+    "script must contain the gwm marker"
+  );
+  assert!(
+    script.contains("gwm commit-prefix"),
+    "script must shell out to gwm commit-prefix"
+  );
+  assert!(
+    script.contains("--unicode"),
+    "script must request --unicode so the commit message gets the real emoji"
+  );
+}
+
+#[test]
+fn commit_msg_script_skips_when_prefix_already_present() {
+  // The hook's behavioural contract: if the commit message already
+  // starts with an emoji, leave it alone. We can't run the hook
+  // headless here (no `git` shell invocation), but we can assert the
+  // script's pattern-detection clause exists — a regression that
+  // drops it would auto-double-prefix every amend.
+  let script = commit_msg_script();
+  // The script uses `grep` on the first line to detect existing
+  // gitmoji / `:shortcode:` prefixes. Both forms must be covered.
+  assert!(
+    script.contains("grep") || script.contains("case "),
+    "script must include a guard for already-prefixed messages"
+  );
+}

--- a/tests/hooks_tests.rs
+++ b/tests/hooks_tests.rs
@@ -202,7 +202,10 @@ fn install_commit_msg_resolves_linked_worktree_gitdir() {
   // directory. Installing into `<worktree>/.git/hooks/commit-msg`
   // would either fail (write into a file) or — worse — install at the
   // wrong location. The installer must follow the `.git` pointer and
-  // land the hook under the worktree's actual gitdir.
+  // land the hook under the worktree's actual gitdir (which, for a
+  // linked worktree, is `<main>/.git/worktrees/<name>/hooks/` — that's
+  // where git itself looks for `commit-msg` when this worktree is
+  // active).
   let main = tempfile::TempDir::new().expect("main tempdir");
   let repo = git2::Repository::init(main.path()).expect("init main repo");
   // Need one commit so a linked worktree can attach.
@@ -210,8 +213,7 @@ fn install_commit_msg_resolves_linked_worktree_gitdir() {
     let sig = git2::Signature::now("Test", "test@example.com").expect("sig");
     let tree_id = {
       let mut idx = repo.index().expect("index");
-      let tree_oid = idx.write_tree().expect("write tree");
-      tree_oid
+      idx.write_tree().expect("write tree")
     };
     let tree = repo.find_tree(tree_id).expect("find tree");
     repo
@@ -229,16 +231,35 @@ fn install_commit_msg_resolves_linked_worktree_gitdir() {
     "hook must be installed at the resolved gitdir, got {}",
     hook_path.display()
   );
-  // The hook MUST live under the linked worktree's admin dir, not
-  // under `<worktree>/.git/hooks/` (which doesn't exist as a real
-  // directory for linked worktrees).
-  let expected_admin = wt.path().join("hooks").join("commit-msg");
-  assert_eq!(
-    hook_path, expected_admin,
-    "expected hook at {}, got {}",
-    expected_admin.display(),
-    hook_path.display()
+  // The hook MUST live under the linked worktree's *admin* directory
+  // — `<main>/.git/worktrees/wt-demo/hooks/commit-msg` — not under
+  // `<worktree>/.git/hooks/` (the latter would treat `.git` as a
+  // directory, which fails on a linked worktree where `.git` is a
+  // file pointer). Assert by structural shape rather than equality
+  // because macOS canonicalizes `/var/folders/…` to
+  // `/private/var/folders/…` and the two halves of the comparison
+  // wouldn't share a common prefix without canonicalize on both
+  // sides.
+  let canon_got = std::fs::canonicalize(&hook_path).expect("canonicalize got");
+  assert!(
+    canon_got.ends_with(".git/worktrees/wt-demo/hooks/commit-msg"),
+    "hook must land in the linked worktree's admin dir; got {}",
+    canon_got.display()
   );
+  // Also ensure the installer did NOT fabricate `<worktree>/.git` as
+  // a directory — for a linked worktree it is and must remain a file
+  // pointing at the admin dir.
+  let dotgit = wt_path.join(".git");
+  assert!(
+    dotgit.is_file(),
+    "linked worktree `.git` must remain a pointer file, got {:?}",
+    std::fs::metadata(&dotgit).map(|m| m.file_type())
+  );
+  // Keep `wt` alive until here so its drop doesn't run while we still
+  // read the admin directory above. Touching its path is a cheap
+  // way to silence the unused-variable warning without `_` (we want
+  // it to drop *after* assertions, not be optimised out).
+  let _ = wt.path();
 }
 
 #[test]
@@ -262,11 +283,16 @@ fn install_commit_msg_honours_core_hookspath() {
   drop(repo);
 
   let hook_path = install_commit_msg(dir.path(), false).expect("install honouring core.hooksPath");
+  // Canonicalize because macOS resolves `/var/folders/…` to
+  // `/private/var/folders/…`, which would make a literal `starts_with`
+  // false-negative even though both paths refer to the same dir.
+  let canon_hook = std::fs::canonicalize(&hook_path).expect("canonicalize hook");
+  let canon_custom = std::fs::canonicalize(&custom_hooks).expect("canonicalize custom hooks dir");
   assert!(
-    hook_path.starts_with(&custom_hooks),
+    canon_hook.starts_with(&canon_custom),
     "expected hook under {} (core.hooksPath target), got {}",
-    custom_hooks.display(),
-    hook_path.display()
+    canon_custom.display(),
+    canon_hook.display()
   );
   // The legacy `.git/hooks/commit-msg` MUST NOT be created — leaving
   // a stale file there is misleading (the user would think the hook

--- a/tests/hooks_tests.rs
+++ b/tests/hooks_tests.rs
@@ -276,9 +276,7 @@ fn install_commit_msg_honours_core_hookspath() {
   // `Repository::open` sees it.
   let repo = git2::Repository::open(dir.path()).expect("reopen repo");
   let mut cfg = repo.config().expect("config");
-  cfg
-    .set_str("core.hooksPath", ".githooks")
-    .expect("set core.hooksPath");
+  cfg.set_str("core.hooksPath", ".githooks").expect("set core.hooksPath");
   drop(cfg);
   drop(repo);
 

--- a/tests/hooks_tests.rs
+++ b/tests/hooks_tests.rs
@@ -5,6 +5,7 @@
 //! one, and stays out of the way otherwise.
 
 use gwm::hooks::{commit_msg_script, install_commit_msg};
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 /// Initialise a fresh git repo with a worktree on `feat/#42-demo`. The
@@ -156,5 +157,124 @@ fn commit_msg_script_skips_when_prefix_already_present() {
   assert!(
     script.contains("grep") || script.contains("case "),
     "script must include a guard for already-prefixed messages"
+  );
+}
+
+#[test]
+fn commit_msg_script_does_not_use_unguarded_set_e() {
+  // Stated goal of the hook (see module docs): "never block a commit
+  // because the hook itself broke". `set -e` aborts the script on any
+  // non-zero exit — including transient `mktemp` / `mv` failures from
+  // a full /tmp, a noexec mount, etc. — which would in turn abort
+  // `git commit`. We accept `set -u` (unset variables are a real bug
+  // we want to surface), but `set -eu` together violates the contract.
+  let script = commit_msg_script();
+  assert!(
+    !script.contains("set -eu") && !script.contains("set -e\n") && !script.contains("set -e "),
+    "script must not enable `set -e`: a failing fs op would abort `git commit`. Found: {:?}",
+    script
+  );
+}
+
+#[test]
+fn commit_msg_script_skips_leading_comment_lines() {
+  // Doc says the script inspects the "first non-empty line" — git's
+  // own commit-message template puts `# Please enter the commit
+  // message…` comments at the top, and `git commit -v` adds a diff
+  // dump prefixed with `#`. The script must therefore find the first
+  // line that is neither empty nor a `#`-comment when deciding
+  // whether the message is already prefixed (and when prepending).
+  let script = commit_msg_script();
+  assert!(
+    script.contains("first non-empty non-comment")
+      || script.contains("skip leading empty / comment lines")
+      || script.contains("grep -nvE '^([[:space:]]*#|[[:space:]]*$)'"),
+    "script must explicitly skip leading empty / `#`-prefixed lines when locating the user's first real line; got: {}",
+    script
+  );
+}
+
+#[test]
+fn install_commit_msg_resolves_linked_worktree_gitdir() {
+  // `gwm`'s primary use case IS linked worktrees: `gwm create feat 42
+  // demo` materialises one at `<root>/feat-42-demo` whose `.git` is a
+  // *file* (`gitdir: <main>/.git/worktrees/feat-42-demo`), not a
+  // directory. Installing into `<worktree>/.git/hooks/commit-msg`
+  // would either fail (write into a file) or — worse — install at the
+  // wrong location. The installer must follow the `.git` pointer and
+  // land the hook under the worktree's actual gitdir.
+  let main = tempfile::TempDir::new().expect("main tempdir");
+  let repo = git2::Repository::init(main.path()).expect("init main repo");
+  // Need one commit so a linked worktree can attach.
+  {
+    let sig = git2::Signature::now("Test", "test@example.com").expect("sig");
+    let tree_id = {
+      let mut idx = repo.index().expect("index");
+      let tree_oid = idx.write_tree().expect("write tree");
+      tree_oid
+    };
+    let tree = repo.find_tree(tree_id).expect("find tree");
+    repo
+      .commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+      .expect("seed commit");
+  }
+  let wt_path = main.path().join("wt-demo");
+  let wt = repo
+    .worktree("wt-demo", &wt_path, None)
+    .expect("create linked worktree");
+
+  let hook_path = install_commit_msg(&wt_path, false).expect("install in linked worktree");
+  assert!(
+    hook_path.exists(),
+    "hook must be installed at the resolved gitdir, got {}",
+    hook_path.display()
+  );
+  // The hook MUST live under the linked worktree's admin dir, not
+  // under `<worktree>/.git/hooks/` (which doesn't exist as a real
+  // directory for linked worktrees).
+  let expected_admin = wt.path().join("hooks").join("commit-msg");
+  assert_eq!(
+    hook_path, expected_admin,
+    "expected hook at {}, got {}",
+    expected_admin.display(),
+    hook_path.display()
+  );
+}
+
+#[test]
+fn install_commit_msg_honours_core_hookspath() {
+  // Git supports `core.hooksPath` to relocate the entire hooks dir
+  // (this repo recommends `git config core.hooksPath .githooks`).
+  // When set, writing into `.git/hooks/commit-msg` is dead code: git
+  // never runs it. The installer must resolve the effective hooks
+  // directory via the repo config and install there.
+  let dir = init_repo_on_feat_branch();
+  let custom_hooks = dir.path().join(".githooks");
+  std::fs::create_dir_all(&custom_hooks).expect("custom hooks dir");
+  // Persist `core.hooksPath` into the repo config so a fresh
+  // `Repository::open` sees it.
+  let repo = git2::Repository::open(dir.path()).expect("reopen repo");
+  let mut cfg = repo.config().expect("config");
+  cfg
+    .set_str("core.hooksPath", ".githooks")
+    .expect("set core.hooksPath");
+  drop(cfg);
+  drop(repo);
+
+  let hook_path = install_commit_msg(dir.path(), false).expect("install honouring core.hooksPath");
+  assert!(
+    hook_path.starts_with(&custom_hooks),
+    "expected hook under {} (core.hooksPath target), got {}",
+    custom_hooks.display(),
+    hook_path.display()
+  );
+  // The legacy `.git/hooks/commit-msg` MUST NOT be created — leaving
+  // a stale file there is misleading (the user would think the hook
+  // is installed when git is actually reading from .githooks/).
+  let legacy = dir.path().join(".git").join("hooks").join("commit-msg");
+  assert!(
+    !legacy.exists(),
+    "installer must not write into .git/hooks/ when core.hooksPath is set; found stale {}",
+    legacy.display()
   );
 }


### PR DESCRIPTION
## Description

Implements issue #85 — Gitmoji + Conventional Commits is now first-class in `gwm`. Three new CLI surfaces (`commit-prefix`, `types --gitmoji`, `hooks install commit-msg`) consume a built-in `branch_type → :shortcode:` table, optionally overridden by a new `[gitmoji]` block in `.gwm.toml`.

Closes #85

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- New `src/gitmoji.rs` — `DEFAULT_GITMOJI` table (10 built-in entries), `GitmojiMap` (BTreeMap-backed for deterministic iteration), `default_map()`, `load(repo_root)` that reads `.gwm.toml`'s `[gitmoji]` block and merges on top of defaults (overriding one entry doesn't wipe the other nine), `resolve_prefix(map, branch, unicode)`, and `shortcode_to_unicode` (11-entry match — no `gh-emoji` dep).
- New `src/hooks.rs` — `install_commit_msg(repo, force)` writes `.git/hooks/commit-msg` (chmod 0o755 on Unix), refuses to overwrite without `--force`, returns the written path. `commit_msg_script()` returns a self-contained POSIX `sh` script that detects already-prefixed messages (both `:shortcode:` and unicode-emoji forms) and degrades to a no-op when `gwm` isn't on `$PATH` (never blocks a commit).
- New CLI subcommands wired through `cli::run`:
  - `gwm commit-prefix [--branch <name>] [--unicode]` — prints `:sparkles: feat(#41):` (or `✨ feat(#41):`).
  - `gwm hooks install commit-msg [--force]` — opt-in hook installer.
  - `gwm types --gitmoji` flag — extends the existing list with unicode + shortcode columns.
- `examples/gwm.toml.example` — new `[gitmoji]` section between `[[branch_types]]` and `[doctor]`, fully commented with the override table, the additive contract, and two examples.
- `CHANGELOG.md` — entry under `[Unreleased] > Added`.

Design notes:
- Unicode table embarked manually (11 entries) rather than pulling in `gh-emoji` — the surface is small and the dep would dwarf the value.
- `[gitmoji]` is **additive** — overriding `feat` keeps the other 9 defaults intact. This is what lets a team customise one entry without re-declaring the whole table.
- Unknown branch type → `:question:` / ❓ fallback, never panics. The CLI surface stays usable on any branch.
- Hook script is **opt-in** (off by default) and **non-destructive** (refuses to clobber `husky` / `commitlint` without `--force`). Hook shell-outs to `gwm commit-prefix --unicode` and silently no-ops if `gwm` is missing from `$PATH`.
- Diff on `src/main.rs` deliberately empty — the new subcommands ride the existing `cli::run` dispatch, so the merge surface against PR #151 (issue #86 aliases) stays minimal.

## Tests

- [x] `cargo test` passes locally (751 tests, all green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`:
  - `tests/gitmoji_tests.rs` (9 tests) — default map, TOML override merge, custom branch types, prefix resolution in both shortcode + unicode forms, unknown-type fallback, full unicode coverage sweep.
  - `tests/hooks_tests.rs` (7 tests) — installer creates the file, sets exec bit, refuses without `--force`, force-overwrites, fails outside a git repo, script body assertions.
  - `tests/cli_binary.rs` (9 new end-to-end tests) — `commit-prefix` happy path, `--unicode`, fix branch, non-gwm branch error, `types --gitmoji` (with + without flag), `hooks install commit-msg` (creates, refuses without force, force overwrites). `help_prints_subcommands` updated with the two new rows (CONTRIBUTING.md canary).
- [x] TDD loop respected: RED commit (`✅ test(gitmoji): ...`) lands before the implementation commits (`✨ feat(gitmoji): ...` and `✨ feat(cli): ...`).
- [x] Env-stripped test run validated locally: `PATH="$(dirname $(command -v cargo)):/usr/bin:/bin" cargo test --test gitmoji_tests --test hooks_tests --test cli_binary` is green.

## Screenshots / TUI captures

CLI output:

```
$ gwm commit-prefix --branch feat/#41-foo
:sparkles: feat(#41):

$ gwm commit-prefix --branch feat/#41-foo --unicode
✨ feat(#41):

$ gwm types --gitmoji
  feat      ✨  :sparkles:             New feature implementation
  fix       🐛  :bug:                  Bug fix
  hotfix    🚑  :ambulance:            Critical production bug fix
  docs      📝  :memo:                 Documentation changes
  test      ✅  :white_check_mark:     Test additions or modifications
  refactor  ♻  :recycle:              Code restructuring
  chore     🔧  :wrench:               Maintenance tasks
  perf      ⚡  :zap:                  Performance improvements
  ci        👷  :construction_worker:  CI/CD configuration
  build     📦  :package:              Build system changes

(source: built-in defaults)
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#85-gitmoji`)
- [x] Commits follow Gitmoji + Conventional Commits (4 atomic commits: ✅ test → ✨ feat plumbing → ✨ feat CLI → 📝 docs)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] `examples/gwm.toml.example` updated (new `[gitmoji]` section)
- [x] No `unwrap()` on user-facing paths — every fallible path returns `GwmError`
- [x] No `println!` in TUI render code (the new subcommand is CLI-only; `println!` is OK there)

## Linked issues / docs

- Issue: #85
- Related PR: #151 (issue #86 aliases — also touches `src/cli.rs`; diff was kept minimal here to avoid conflicts. If #151 merges first, this branch will need a small `Command` enum / `match` rebase but no semantic conflict.)

## Notes for reviewers

- The `:question:` / ❓ fallback for unknown branch types is deliberate — it's the "be useful on any branch" contract that makes the `commit-msg` hook safe to install repo-wide. Pinned by `resolve_prefix_unknown_type_falls_back_to_question_mark`.
- `shortcode_to_unicode` returns its input verbatim for unmapped shortcodes (so a user-defined `:fire:` round-trips), which means `--unicode` is best-effort for custom shortcodes. Documented in the function's doc comment.
- The hook's already-prefixed detection uses a POSIX `case` glob for `:shortcode:` and a `grep -E` heuristic for unicode emoji on the first line. Tested via assertions on the rendered script (we don't shell-out to git in the test path) — that keeps the test fast and hermetic.