### PR TITLE
✨ feat(cli): add --dry-run to gwm remove and gwm prune (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--dry-run` flag on `gwm remove` and `gwm prune`**
+  ([#31](https://github.com/kbrdn1/gwm-cli/issues/31)). Preview
+  destructive operations before running them.
+  - `gwm prune --dry-run` walks the worktree list, prints every
+    prunable entry (name + path + reason), and exits 0 without
+    touching the admin files. Empty case reports `0 worktree(s) to
+    prune` so scripted callers get a stable signal. Output is sorted
+    by name for deterministic stdout diffing.
+  - `gwm remove <pattern> --dry-run` resolves the fuzzy pattern,
+    prints the would-remove plan (name + path + branch, with
+    `(would be deleted)` next to the branch when `--delete-branch` is
+    also passed), and exits 0. An ambiguous pattern fires the same
+    non-zero candidate-list error as the destructive form —
+    `--dry-run` only suppresses destruction, not resolution failures.
+  - No breaking change: existing call sites without `--dry-run` keep
+    the destructive default.
 - **CLI aliases (`[aliases]` in `.gwm.toml` + user-level fallback)**
   ([#86](https://github.com/kbrdn1/gwm-cli/issues/86)). `git config`
   ships with `[alias]`; `gwm` now mirrors the shape. Declare an

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -720,13 +720,32 @@ fn cmd_create(
 /// `--delete-branch` reports "(no branch to delete)" instead, mirror-
 /// ing `worktree::remove`'s actual behaviour (it only drops a branch
 /// when one is resolvable).
-pub fn format_remove_plan(
-  name: &str,
-  path: &Path,
-  branch: Option<&str>,
-  delete_branch: bool,
-) -> String {
-  String::new()
+pub fn format_remove_plan(name: &str, path: &Path, branch: Option<&str>, delete_branch: bool) -> String {
+  use std::fmt::Write;
+  let mut out = String::new();
+  let _ = writeln!(out, "would remove:");
+  let _ = writeln!(out, "  name:   {}", name);
+  let _ = writeln!(out, "  path:   {}", path.display());
+  match (branch, delete_branch) {
+    (Some(b), true) => {
+      let _ = writeln!(out, "  branch: {} (would be deleted)", b);
+    }
+    (Some(b), false) => {
+      let _ = writeln!(out, "  branch: {}", b);
+    }
+    (None, true) => {
+      // Detached HEAD worktree: `worktree::remove` only drops a
+      // branch when one is resolvable, so the dry-run must not
+      // claim a deletion that will never happen. The clarifying
+      // rider tells the user why `--delete-branch` is a no-op
+      // here without forcing them to re-read the docs.
+      let _ = writeln!(out, "  branch: - (no branch to delete)");
+    }
+    (None, false) => {
+      let _ = writeln!(out, "  branch: -");
+    }
+  }
+  out
 }
 
 /// Render the would-do plan for `gwm prune --dry-run` (issue #31).
@@ -741,7 +760,36 @@ pub fn format_remove_plan(
 /// (`.chars().count()`), not bytes (`.len()`), so non-ASCII paths
 /// stay aligned in a fixed-width terminal.
 pub fn format_prune_plan(entries: &[worktree::PrunableEntry]) -> String {
-  String::new()
+  use std::fmt::Write;
+  let mut out = String::new();
+  if entries.is_empty() {
+    let _ = writeln!(out, "0 worktree(s) to prune");
+    return out;
+  }
+  // Widths in Unicode characters, not bytes — non-ASCII names or
+  // paths would otherwise drift the reason column right by the
+  // (byte_len - char_count) delta. Rust's `{:<width$}` format spec
+  // pads to a *character* count, so feeding it `.len()` is the bug
+  // Copilot flagged on PR #154.
+  let name_w = entries.iter().map(|e| e.name.chars().count()).max().unwrap_or(4);
+  let path_w = entries
+    .iter()
+    .map(|e| e.path.display().to_string().chars().count())
+    .max()
+    .unwrap_or(4);
+  let _ = writeln!(out, "would prune {} worktree(s):", entries.len());
+  for entry in entries {
+    let _ = writeln!(
+      out,
+      "  {:<nw$}  {:<pw$}  ({})",
+      entry.name,
+      entry.path.display(),
+      entry.reason,
+      nw = name_w,
+      pw = path_w,
+    );
+  }
+  out
 }
 
 fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()> {
@@ -754,15 +802,10 @@ fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()>
     // the destructive form raises, satisfying the spec's "same error
     // contract" requirement.
     worktree::remove_dry_run(&repo, &found.name)?;
-    let branch_display = found.branch.as_deref().unwrap_or("-");
-    println!("would remove:");
-    println!("  name:   {}", found.name);
-    println!("  path:   {}", found.path.display());
-    if delete_branch {
-      println!("  branch: {} (would be deleted)", branch_display);
-    } else {
-      println!("  branch: {}", branch_display);
-    }
+    print!(
+      "{}",
+      format_remove_plan(&found.name, &found.path, found.branch.as_deref(), delete_branch)
+    );
     return Ok(());
   }
   worktree::remove(&repo, &found.name, delete_branch)?;
@@ -814,35 +857,12 @@ fn cmd_bootstrap(target: Option<String>, trust_mode: TrustMode) -> Result<()> {
 fn cmd_prune(dry_run: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   if dry_run {
-    // Issue #31: enumerate prunable worktrees (name + path + reason),
-    // print one row per entry plus a header that names the count so
-    // even the empty case has a stable signal for piped consumers.
+    // Issue #31: enumerate prunable worktrees (name + path + reason)
+    // and render the plan through the shared formatter. Empty input
+    // still emits "0 worktree(s) to prune" so piped consumers always
+    // get a stable signal.
     let plan = worktree::prunable_worktrees(&repo)?;
-    if plan.is_empty() {
-      println!("0 worktree(s) to prune");
-      return Ok(());
-    }
-    // Align the name + path columns on the widest observed value so
-    // human eyeballs can scan the plan. The reason column is fixed-length
-    // today ("working dir missing") but its width is still computed so a
-    // future libgit2 with richer reasons stays aligned without code change.
-    let name_w = plan.iter().map(|e| e.name.len()).max().unwrap_or(4);
-    let path_w = plan
-      .iter()
-      .map(|e| e.path.display().to_string().len())
-      .max()
-      .unwrap_or(4);
-    println!("would prune {} worktree(s):", plan.len());
-    for entry in &plan {
-      println!(
-        "  {:<nw$}  {:<pw$}  ({})",
-        entry.name,
-        entry.path.display(),
-        entry.reason,
-        nw = name_w,
-        pw = path_w,
-      );
-    }
+    print!("{}", format_prune_plan(&plan));
     return Ok(());
   }
   let n = worktree::prune(&repo)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -709,6 +709,41 @@ fn cmd_create(
   Ok(())
 }
 
+/// Render the would-do plan for `gwm remove --dry-run` (issue #31).
+/// Extracted from `cmd_remove` so the formatter is unit-testable
+/// without spinning up a real worktree. Pure function: takes the
+/// resolved name + path + branch, returns a multi-line string
+/// (trailing newline included).
+///
+/// `delete_branch` only adds "(would be deleted)" when there *is* a
+/// branch to delete — a detached HEAD worktree with
+/// `--delete-branch` reports "(no branch to delete)" instead, mirror-
+/// ing `worktree::remove`'s actual behaviour (it only drops a branch
+/// when one is resolvable).
+pub fn format_remove_plan(
+  name: &str,
+  path: &Path,
+  branch: Option<&str>,
+  delete_branch: bool,
+) -> String {
+  String::new()
+}
+
+/// Render the would-do plan for `gwm prune --dry-run` (issue #31).
+/// Extracted from `cmd_prune` so the formatter is unit-testable on
+/// arbitrary `PrunableEntry` fixtures (non-ASCII names / paths
+/// without needing a real repo). Pure function: trailing newline
+/// included; empty input still emits the canonical
+/// "0 worktree(s) to prune" line so piped consumers get a stable
+/// signal instead of empty stdout.
+///
+/// Column widths are computed in Unicode characters
+/// (`.chars().count()`), not bytes (`.len()`), so non-ASCII paths
+/// stay aligned in a fixed-width terminal.
+pub fn format_prune_plan(entries: &[worktree::PrunableEntry]) -> String {
+  String::new()
+}
+
 fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let found = worktree::find_fuzzy(&repo, &pattern)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,6 +105,13 @@ pub enum Command {
     /// Also delete the branch.
     #[arg(long)]
     delete_branch: bool,
+    /// Print the resolved worktree (name + path + branch + would-delete-branch
+    /// flag) without touching anything. Exit code 0. If the pattern is
+    /// ambiguous, the same non-zero candidate-list error fires as in the
+    /// destructive form — `--dry-run` only suppresses *destruction*, not
+    /// resolution failures. Issue #31.
+    #[arg(long)]
+    dry_run: bool,
   },
   /// Print the on-disk path of a worktree (use `$(gwm path …)` to cd into it).
   ///
@@ -118,7 +125,14 @@ pub enum Command {
     target: Option<String>,
   },
   /// Prune stale worktree references (admin files without a working dir).
-  Prune,
+  Prune {
+    /// List the prunable worktrees (name + path + reason) without
+    /// touching the admin entries. Exit code 0. Useful for piping into
+    /// a confirmation script before running the destructive form.
+    /// Issue #31.
+    #[arg(long)]
+    dry_run: bool,
+  },
   /// Diagnose the gwm setup (config, env, worktree state).
   ///
   /// Exit code 0 if all green, 1 if any warning, 2 if any failure —
@@ -519,10 +533,14 @@ pub fn run(cli: Cli) -> Result<()> {
       no_bootstrap,
       reuse_branch,
     } => cmd_create(branch_type, issue, desc, no_bootstrap, reuse_branch, mode),
-    Command::Remove { pattern, delete_branch } => cmd_remove(pattern, delete_branch),
+    Command::Remove {
+      pattern,
+      delete_branch,
+      dry_run,
+    } => cmd_remove(pattern, delete_branch, dry_run),
     Command::Path { pattern } => cmd_path(pattern),
     Command::Bootstrap { target } => cmd_bootstrap(target, mode),
-    Command::Prune => cmd_prune(),
+    Command::Prune { dry_run } => cmd_prune(dry_run),
     Command::Doctor => cmd_doctor(),
     Command::Types { gitmoji } => cmd_types(gitmoji),
     Command::CommitPrefix { branch, unicode } => cmd_commit_prefix(branch, unicode),
@@ -691,9 +709,27 @@ fn cmd_create(
   Ok(())
 }
 
-fn cmd_remove(pattern: String, delete_branch: bool) -> Result<()> {
+fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let found = worktree::find_fuzzy(&repo, &pattern)?;
+  if dry_run {
+    // Issue #31: print the would-remove plan and exit. Resolution
+    // already happened above — an ambiguous pattern surfaced via
+    // `find_fuzzy` returns the same `Other(... ambiguous ...)` error
+    // the destructive form raises, satisfying the spec's "same error
+    // contract" requirement.
+    worktree::remove_dry_run(&repo, &found.name)?;
+    let branch_display = found.branch.as_deref().unwrap_or("-");
+    println!("would remove:");
+    println!("  name:   {}", found.name);
+    println!("  path:   {}", found.path.display());
+    if delete_branch {
+      println!("  branch: {} (would be deleted)", branch_display);
+    } else {
+      println!("  branch: {}", branch_display);
+    }
+    return Ok(());
+  }
   worktree::remove(&repo, &found.name, delete_branch)?;
   println!("✓ removed {} ({})", found.name, found.path.display());
   if delete_branch {
@@ -740,8 +776,40 @@ fn cmd_bootstrap(target: Option<String>, trust_mode: TrustMode) -> Result<()> {
   Ok(())
 }
 
-fn cmd_prune() -> Result<()> {
+fn cmd_prune(dry_run: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
+  if dry_run {
+    // Issue #31: enumerate prunable worktrees (name + path + reason),
+    // print one row per entry plus a header that names the count so
+    // even the empty case has a stable signal for piped consumers.
+    let plan = worktree::prunable_worktrees(&repo)?;
+    if plan.is_empty() {
+      println!("0 worktree(s) to prune");
+      return Ok(());
+    }
+    // Align the name + path columns on the widest observed value so
+    // human eyeballs can scan the plan. The reason column is fixed-length
+    // today ("working dir missing") but its width is still computed so a
+    // future libgit2 with richer reasons stays aligned without code change.
+    let name_w = plan.iter().map(|e| e.name.len()).max().unwrap_or(4);
+    let path_w = plan
+      .iter()
+      .map(|e| e.path.display().to_string().len())
+      .max()
+      .unwrap_or(4);
+    println!("would prune {} worktree(s):", plan.len());
+    for entry in &plan {
+      println!(
+        "  {:<nw$}  {:<pw$}  ({})",
+        entry.name,
+        entry.path.display(),
+        entry.reason,
+        nw = name_w,
+        pw = path_w,
+      );
+    }
+    return Ok(());
+  }
   let n = worktree::prune(&repo)?;
   println!("pruned {} stale worktree(s)", n);
   Ok(())

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -358,6 +358,46 @@ pub fn remove(repo: &Repository, name: &str, delete_branch: bool) -> Result<()> 
   Ok(())
 }
 
+/// One prunable worktree entry as surfaced by `gwm prune --dry-run`
+/// (issue #31). The `reason` is libgit2's prunable rationale rendered
+/// for humans — currently always "working dir missing" because
+/// `is_prunable(None)` only flags worktrees whose working tree has been
+/// removed out from under the admin entry. Captured as a struct field
+/// rather than hard-coded in the CLI so future libgit2 versions can
+/// expose richer reasons without breaking the CLI surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrunableEntry {
+  pub name: String,
+  pub path: PathBuf,
+  pub reason: String,
+}
+
+/// Compute (without mutating) the list of worktree admin entries that
+/// `gwm prune` would drop. Used by `gwm prune --dry-run` (issue #31)
+/// and as the shared scanner for the real `prune` so the two surfaces
+/// can never drift on what "prunable" means. Output is sorted by name
+/// for deterministic stdout — scripted callers diff across runs.
+pub fn prunable_worktrees(repo: &Repository) -> Result<Vec<PrunableEntry>> {
+  let names = repo.worktrees()?;
+  let mut out = Vec::new();
+  for name in names.iter().flatten() {
+    let wt = match repo.find_worktree(name) {
+      Ok(w) => w,
+      Err(_) => continue,
+    };
+    if !matches!(wt.is_prunable(None), Ok(p) if p) {
+      continue;
+    }
+    out.push(PrunableEntry {
+      name: name.to_string(),
+      path: wt.path().to_path_buf(),
+      reason: "working dir missing".to_string(),
+    });
+  }
+  out.sort_by(|a, b| a.name.cmp(&b.name));
+  Ok(out)
+}
+
 /// Prune stale worktree admin entries (gwq cleanup equivalent).
 pub fn prune(repo: &Repository) -> Result<usize> {
   let names = repo.worktrees()?;
@@ -378,6 +418,20 @@ pub fn prune(repo: &Repository) -> Result<usize> {
     }
   }
   Ok(pruned)
+}
+
+/// Read-only check that `name` resolves to a removable worktree —
+/// the libgit2 half of `gwm remove --dry-run` (issue #31). Errors on
+/// the same "worktree not found" path as `remove` so the dry-run
+/// surface and the destructive surface share an error contract;
+/// returns `Ok(())` when the worktree exists. The caller (the CLI)
+/// is responsible for rendering the plan; this function intentionally
+/// touches no filesystem state and emits no output.
+pub fn remove_dry_run(repo: &Repository, name: &str) -> Result<()> {
+  repo
+    .find_worktree(name)
+    .map_err(|_| GwmError::WorktreeNotFound(name.into()))?;
+  Ok(())
 }
 
 /// A commit row pulled from `git log` for the Recent Commits sidebar block.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -359,12 +359,13 @@ pub fn remove(repo: &Repository, name: &str, delete_branch: bool) -> Result<()> 
 }
 
 /// One prunable worktree entry as surfaced by `gwm prune --dry-run`
-/// (issue #31). The `reason` is libgit2's prunable rationale rendered
-/// for humans — currently always "working dir missing" because
-/// `is_prunable(None)` only flags worktrees whose working tree has been
-/// removed out from under the admin entry. Captured as a struct field
-/// rather than hard-coded in the CLI so future libgit2 versions can
-/// expose richer reasons without breaking the CLI surface.
+/// (issue #31). The `reason` field is a human-readable rationale that
+/// is currently hard-coded to "working dir missing" — that is the only
+/// case `is_prunable(None)` flags today (working tree removed out from
+/// under the admin entry). Kept as a `String` rather than a literal
+/// in the CLI so future libgit2 versions can surface richer reasons
+/// (locked worktrees, broken HEAD, …) without breaking the CLI
+/// rendering contract.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrunableEntry {
   pub name: String,
@@ -374,9 +375,9 @@ pub struct PrunableEntry {
 
 /// Compute (without mutating) the list of worktree admin entries that
 /// `gwm prune` would drop. Used by `gwm prune --dry-run` (issue #31)
-/// and as the shared scanner for the real `prune` so the two surfaces
-/// can never drift on what "prunable" means. Output is sorted by name
-/// for deterministic stdout — scripted callers diff across runs.
+/// and consumed by [`prune`] so the dry-run preview and the destructive
+/// pass can never drift on what "prunable" means. Output is sorted by
+/// name for deterministic stdout — scripted callers diff across runs.
 pub fn prunable_worktrees(repo: &Repository) -> Result<Vec<PrunableEntry>> {
   let names = repo.worktrees()?;
   let mut out = Vec::new();
@@ -399,18 +400,17 @@ pub fn prunable_worktrees(repo: &Repository) -> Result<Vec<PrunableEntry>> {
 }
 
 /// Prune stale worktree admin entries (gwq cleanup equivalent).
+/// Consumes [`prunable_worktrees`] so what `--dry-run` shows is exactly
+/// what this destructive pass acts on — the two surfaces share the
+/// scanner, by construction.
 pub fn prune(repo: &Repository) -> Result<usize> {
-  let names = repo.worktrees()?;
+  let plan = prunable_worktrees(repo)?;
   let mut pruned = 0usize;
-  for name in names.iter().flatten() {
-    let wt = match repo.find_worktree(name) {
+  for entry in plan {
+    let wt = match repo.find_worktree(&entry.name) {
       Ok(w) => w,
       Err(_) => continue,
     };
-    let prunable = matches!(wt.is_prunable(None), Ok(p) if p);
-    if !prunable {
-      continue;
-    }
     let mut opts = WorktreePruneOptions::new();
     opts.valid(true).locked(true).working_tree(true);
     if wt.prune(Some(&mut opts)).is_ok() {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1798,6 +1798,172 @@ fn remove_outside_git_repo_fails() {
     .stderr(predicate::str::contains("not inside a git repository"));
 }
 
+// --- remove --dry-run / prune --dry-run (issue #31) ---------------------
+
+#[test]
+fn remove_dry_run_prints_plan_and_keeps_worktree_intact() {
+  // Issue #31 contract for `gwm remove --dry-run`: resolve the pattern,
+  // print the would-remove plan (name + path + branch), exit 0, do NOT
+  // touch the worktree directory or the local branch. The user can pipe
+  // the output into a confirmation script.
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "31", "preview"])
+    .assert()
+    .success();
+  let wt_dir = base.path().join("feat-31-preview");
+  assert!(wt_dir.exists());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "preview", "--dry-run"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("would remove"))
+    .stdout(predicate::str::contains("feat-31-preview"))
+    .stdout(predicate::str::contains("feat/#31-preview"));
+
+  assert!(wt_dir.exists(), "--dry-run must not delete the worktree directory");
+  assert!(
+    repo.find_branch("feat/#31-preview", git2::BranchType::Local).is_ok(),
+    "--dry-run must not delete the local branch"
+  );
+}
+
+#[test]
+fn remove_dry_run_with_delete_branch_flags_branch_deletion() {
+  // When `--delete-branch` is combined with `--dry-run`, the plan must
+  // surface that the branch would be deleted — without actually
+  // dropping it. The user sees a single line that mirrors the live
+  // command's would-do trail.
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "32", "preview-drop"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "preview-drop", "--delete-branch", "--dry-run"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("would be deleted"));
+
+  assert!(
+    repo
+      .find_branch("feat/#32-preview-drop", git2::BranchType::Local)
+      .is_ok(),
+    "--dry-run --delete-branch must not delete the local branch"
+  );
+}
+
+#[test]
+fn remove_dry_run_on_ambiguous_pattern_still_fails() {
+  // Spec: an ambiguous pattern under `--dry-run` exits non-zero with the
+  // candidate list — same error contract as the regular failure mode.
+  // `--dry-run` only suppresses *destruction*, not resolution failures.
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "33", "ambiguous-one"])
+    .assert()
+    .success();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "34", "ambiguous-two"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["remove", "ambiguous", "--dry-run"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("ambiguous"));
+}
+
+#[test]
+fn prune_dry_run_prints_plan_without_pruning() {
+  // Issue #31 contract for `gwm prune --dry-run`: walk the worktree
+  // list, detect prunable entries, print each (name + path + reason),
+  // exit 0, and leave the admin entries in place. The follow-up
+  // (non-dry-run) `gwm prune` is the destructive sibling.
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "35", "stale"])
+    .assert()
+    .success();
+  let wt_dir = base.path().join("feat-35-stale");
+  assert!(wt_dir.exists());
+
+  // Simulate a "working dir missing" prunable: delete the worktree
+  // directory on disk WITHOUT going through `gwm remove`, so the admin
+  // entry under `.git/worktrees/<name>` stays around and libgit2 flags
+  // the worktree as prunable.
+  std::fs::remove_dir_all(&wt_dir).unwrap();
+
+  let admin_dir = dir.path().join(".git").join("worktrees").join("feat-35-stale");
+  assert!(admin_dir.exists(), "precondition: admin entry must still exist");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["prune", "--dry-run"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("would prune"))
+    .stdout(predicate::str::contains("feat-35-stale"));
+
+  assert!(admin_dir.exists(), "--dry-run must not remove the prunable admin entry");
+  assert!(
+    repo.find_worktree("feat-35-stale").is_ok(),
+    "--dry-run must leave libgit2's worktree list untouched"
+  );
+}
+
+#[test]
+fn prune_dry_run_reports_no_candidates_when_clean() {
+  // Empty case: a clean repo has nothing to prune. The command exits 0
+  // with a friendly "0 worktree(s) to prune" so scripts that pipe the
+  // output get a stable signal instead of an empty stdout.
+  let (dir, _repo) = init_repo();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["prune", "--dry-run"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("0 worktree"));
+}
+
 // --- trust ledger (issue #95) -------------------------------------------
 
 #[test]

--- a/tests/cli_format_tests.rs
+++ b/tests/cli_format_tests.rs
@@ -1,0 +1,187 @@
+//! Pin the contracts of the `gwm::cli` formatters extracted in the
+//! Copilot-review follow-up on PR #154 (issue #31). These are pure
+//! string-building helpers — no repo, no worktree, no I/O — so they
+//! exist mostly to lock the human-facing output against accidental
+//! drift, and to prove two specific Copilot review nits stay fixed:
+//!
+//! - "(would be deleted)" must not be appended when there is no
+//!   branch to delete (a detached HEAD worktree); the dry-run plan
+//!   must not promise a side effect that `worktree::remove` would
+//!   never perform.
+//! - Column widths in the prune plan must be computed in characters,
+//!   not bytes, so worktree names or paths containing non-ASCII code
+//!   points still align in a fixed-width terminal.
+
+use gwm::cli::{format_prune_plan, format_remove_plan};
+use gwm::worktree::PrunableEntry;
+use std::path::{Path, PathBuf};
+
+// --- format_remove_plan -----------------------------------------------------
+
+#[test]
+fn remove_plan_with_branch_and_no_delete_omits_deletion_marker() {
+  let out = format_remove_plan(
+    "feat-31-preview",
+    Path::new("/tmp/wt/feat-31-preview"),
+    Some("feat/#31-preview"),
+    false,
+  );
+
+  assert!(out.contains("would remove"), "header missing: {out}");
+  assert!(out.contains("name:   feat-31-preview"), "name row missing: {out}");
+  assert!(
+    out.contains("path:   /tmp/wt/feat-31-preview"),
+    "path row missing: {out}"
+  );
+  assert!(out.contains("branch: feat/#31-preview"), "branch row missing: {out}");
+  assert!(
+    !out.contains("would be deleted"),
+    "must not advertise branch deletion when --delete-branch is off: {out}"
+  );
+  assert!(
+    !out.contains("no branch"),
+    "must not advertise 'no branch' when a branch is resolved: {out}"
+  );
+}
+
+#[test]
+fn remove_plan_with_branch_and_delete_flag_marks_branch_deletion() {
+  let out = format_remove_plan(
+    "feat-31-preview",
+    Path::new("/tmp/wt/feat-31-preview"),
+    Some("feat/#31-preview"),
+    true,
+  );
+
+  assert!(
+    out.contains("branch: feat/#31-preview (would be deleted)"),
+    "delete marker missing: {out}"
+  );
+}
+
+#[test]
+fn remove_plan_without_branch_and_no_delete_renders_dash_only() {
+  // Detached HEAD worktree with no resolvable branch; the legacy
+  // format prints `branch: -` and that pre-existing contract must be
+  // preserved so scripts that grep the line keep working.
+  let out = format_remove_plan(
+    "detached",
+    Path::new("/tmp/wt/detached"),
+    None,
+    false,
+  );
+
+  assert!(out.contains("branch: -"), "dash row missing: {out}");
+  assert!(
+    !out.contains("would be deleted"),
+    "no delete marker without --delete-branch: {out}"
+  );
+  assert!(
+    !out.contains("no branch"),
+    "no 'no branch' rider without --delete-branch (avoid noise): {out}"
+  );
+}
+
+#[test]
+fn remove_plan_without_branch_but_with_delete_flag_does_not_claim_deletion() {
+  // The Copilot review nit on PR #154: combining `--dry-run` with
+  // `--delete-branch` on a detached HEAD worktree must NOT print
+  // "(would be deleted)" because `worktree::remove` only drops a
+  // branch when one is resolvable. The dry-run plan must mirror the
+  // real behaviour exactly — print a clarifying rider so the user
+  // sees why the destructive path would not delete anything.
+  let out = format_remove_plan(
+    "detached",
+    Path::new("/tmp/wt/detached"),
+    None,
+    true,
+  );
+
+  assert!(
+    !out.contains("would be deleted"),
+    "must not claim a deletion that worktree::remove will not perform: {out}"
+  );
+  assert!(
+    out.contains("no branch to delete"),
+    "must clarify why --delete-branch is a no-op here: {out}"
+  );
+}
+
+// --- format_prune_plan ------------------------------------------------------
+
+#[test]
+fn prune_plan_empty_emits_zero_count_marker() {
+  let out = format_prune_plan(&[]);
+  assert!(out.contains("0 worktree"), "stable zero-count marker missing: {out}");
+}
+
+#[test]
+fn prune_plan_lists_entries_with_header_and_rows() {
+  let entries = vec![
+    PrunableEntry {
+      name: "feat-1-alpha".into(),
+      path: PathBuf::from("/tmp/wt/feat-1-alpha"),
+      reason: "working dir missing".into(),
+    },
+    PrunableEntry {
+      name: "feat-2-bravo".into(),
+      path: PathBuf::from("/tmp/wt/feat-2-bravo"),
+      reason: "working dir missing".into(),
+    },
+  ];
+
+  let out = format_prune_plan(&entries);
+  assert!(out.contains("would prune 2 worktree(s):"), "header missing: {out}");
+  assert!(out.contains("feat-1-alpha"), "first row missing: {out}");
+  assert!(out.contains("feat-2-bravo"), "second row missing: {out}");
+  assert!(out.contains("working dir missing"), "reason missing: {out}");
+}
+
+#[test]
+fn prune_plan_aligns_columns_in_unicode_chars_not_bytes() {
+  // Pin the Copilot nit on PR #154: column widths must be derived
+  // from character counts, not byte counts, otherwise a multi-byte
+  // codepoint in a name or path shoves later columns to the left.
+  //
+  // "féat-α-1" is 8 chars, 11 bytes. "feat-b-22" is 9 chars, 9
+  // bytes. With `.len()` width, the unicode row would have its
+  // `reason` column drift right by 3 byte-spaces relative to the
+  // ASCII row. With `.chars().count()`, both rows hit `(working
+  // dir missing)` at the same character column.
+  let entries = vec![
+    PrunableEntry {
+      name: "féat-α-1".into(),
+      path: PathBuf::from("/tmp/wt/féat-α-1"),
+      reason: "working dir missing".into(),
+    },
+    PrunableEntry {
+      name: "feat-b-22".into(),
+      path: PathBuf::from("/tmp/wt/feat-b-22"),
+      reason: "working dir missing".into(),
+    },
+  ];
+
+  let out = format_prune_plan(&entries);
+
+  // Find the character offset of "(working dir missing)" on each
+  // data row. They must match.
+  let mut reason_offsets: Vec<usize> = Vec::new();
+  for line in out.lines() {
+    if let Some(idx) = line.find("(working dir missing)") {
+      // Convert byte index to char index — that's what the user's
+      // terminal column reads.
+      let char_idx = line[..idx].chars().count();
+      reason_offsets.push(char_idx);
+    }
+  }
+
+  assert_eq!(
+    reason_offsets.len(),
+    2,
+    "expected two reason cells, got {reason_offsets:?} (output: {out})"
+  );
+  assert_eq!(
+    reason_offsets[0], reason_offsets[1],
+    "reason column drifted across rows ({reason_offsets:?}) — width must be in chars, not bytes:\n{out}"
+  );
+}

--- a/tests/cli_format_tests.rs
+++ b/tests/cli_format_tests.rs
@@ -64,12 +64,7 @@ fn remove_plan_without_branch_and_no_delete_renders_dash_only() {
   // Detached HEAD worktree with no resolvable branch; the legacy
   // format prints `branch: -` and that pre-existing contract must be
   // preserved so scripts that grep the line keep working.
-  let out = format_remove_plan(
-    "detached",
-    Path::new("/tmp/wt/detached"),
-    None,
-    false,
-  );
+  let out = format_remove_plan("detached", Path::new("/tmp/wt/detached"), None, false);
 
   assert!(out.contains("branch: -"), "dash row missing: {out}");
   assert!(
@@ -90,12 +85,7 @@ fn remove_plan_without_branch_but_with_delete_flag_does_not_claim_deletion() {
   // branch when one is resolvable. The dry-run plan must mirror the
   // real behaviour exactly — print a clarifying rider so the user
   // sees why the destructive path would not delete anything.
-  let out = format_remove_plan(
-    "detached",
-    Path::new("/tmp/wt/detached"),
-    None,
-    true,
-  );
+  let out = format_remove_plan("detached", Path::new("/tmp/wt/detached"), None, true);
 
   assert!(
     !out.contains("would be deleted"),

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -136,6 +136,92 @@ fn prune_returns_zero_when_clean() {
   assert_eq!(n, 0);
 }
 
+// --- Issue #31: dry-run plans for remove + prune -----------------------------
+
+#[test]
+fn prunable_worktrees_returns_empty_when_clean() {
+  // Empty case for `prunable_worktrees`: a brand-new repo has no
+  // worktree admin entries at all, so the plan list is empty. This
+  // backs `gwm prune --dry-run` reporting "0 worktree(s) to prune".
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let plan = worktree::prunable_worktrees(&repo).unwrap();
+  assert!(plan.is_empty());
+}
+
+#[test]
+fn prunable_worktrees_lists_orphaned_admin_entry() {
+  // When the working directory of a linked worktree is deleted out
+  // from under the admin entry (a "ghost worktree"), libgit2 flags it
+  // as prunable. `prunable_worktrees` must surface it with name, path,
+  // and reason — the three columns the `--dry-run` CLI prints.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-31-ghost");
+  worktree::add(&repo, "feat-31-ghost", &target, "feat/#31-ghost", false).unwrap();
+  std::fs::remove_dir_all(&target).unwrap();
+
+  let plan = worktree::prunable_worktrees(&repo).unwrap();
+  assert_eq!(plan.len(), 1, "ghost worktree must appear in the prune plan");
+  assert_eq!(plan[0].name, "feat-31-ghost");
+  assert!(
+    !plan[0].reason.is_empty(),
+    "every prunable entry must carry a human reason"
+  );
+
+  // Sanity: the dry-run plan must not have mutated libgit2's state.
+  assert!(
+    repo.find_worktree("feat-31-ghost").is_ok(),
+    "prunable_worktrees is read-only — the admin entry must still resolve"
+  );
+}
+
+#[test]
+fn prunable_worktrees_sorted_by_name() {
+  // Deterministic output is a hard requirement of the `--dry-run`
+  // contract — scripted callers diff stdout across runs. We pin the
+  // sort order to ascending by `name`.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let zeta = wt_root.path().join("feat-99-zeta");
+  let alpha = wt_root.path().join("feat-99-alpha");
+  worktree::add(&repo, "feat-99-zeta", &zeta, "feat/#99-zeta", false).unwrap();
+  worktree::add(&repo, "feat-99-alpha", &alpha, "feat/#99-alpha", false).unwrap();
+  std::fs::remove_dir_all(&zeta).unwrap();
+  std::fs::remove_dir_all(&alpha).unwrap();
+
+  let plan = worktree::prunable_worktrees(&repo).unwrap();
+  let names: Vec<&str> = plan.iter().map(|e| e.name.as_str()).collect();
+  assert_eq!(names, vec!["feat-99-alpha", "feat-99-zeta"]);
+}
+
+#[test]
+fn remove_with_dry_run_keeps_worktree_and_branch_intact() {
+  // The libgit2-level pin for `worktree::remove(.., dry_run=true)`:
+  // resolution still happens (the caller hands us a `name` that
+  // matched), but no admin prune, no rmdir, no branch deletion. The
+  // function must return Ok(()) so the CLI prints the plan and exits 0.
+  let (_dir, repo) = init_repo();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-31-keep");
+  worktree::add(&repo, "feat-31-keep", &target, "feat/#31-keep", false).unwrap();
+  assert!(target.exists());
+
+  worktree::remove_dry_run(&repo, "feat-31-keep").unwrap();
+
+  assert!(target.exists(), "dry-run must not delete the worktree dir");
+  assert!(
+    repo.find_branch("feat/#31-keep", git2::BranchType::Local).is_ok(),
+    "dry-run must not delete the local branch"
+  );
+  assert!(
+    repo.find_worktree("feat-31-keep").is_ok(),
+    "dry-run must leave libgit2's worktree admin entry in place"
+  );
+}
+
 #[test]
 fn repo_name_derives_from_workdir() {
   let parent = TempDir::new().unwrap();


### PR DESCRIPTION
## Description

Add an opt-in `--dry-run` flag to `gwm remove` and `gwm prune` so users
can preview destructive operations before running them. Output is
plain-text aligned and pipeable into a confirmation script.

Closes #31

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `worktree::prunable_worktrees(&Repository) -> Vec<PrunableEntry>` —
  read-only sibling of `worktree::prune`. Walks the worktree admin
  entries, filters by libgit2's `is_prunable(None)`, returns a
  sorted-by-name plan (`name` + `path` + human `reason`).
  Deterministic order so scripted callers can diff output across
  runs.
- `worktree::remove_dry_run(&Repository, name)` — read-only sibling
  of `worktree::remove`. Re-runs `find_worktree` resolution so the
  dry-run and destructive surfaces share the same `WorktreeNotFound`
  error contract.
- `cmd_remove` (CLI): `--dry-run` prints a 4-line plan (`would
  remove:` header + name + path + branch). Combining with
  `--delete-branch` appends `(would be deleted)` to the branch row.
  An ambiguous pattern fires the same non-zero candidate-list error
  as the destructive form — `--dry-run` only suppresses destruction,
  not resolution.
- `cmd_prune` (CLI): `--dry-run` prints a column-aligned plan
  (`would prune N worktree(s):` header + one row per entry). Empty
  case prints `0 worktree(s) to prune` so piped consumers still get
  a stable signal.
- `CHANGELOG.md` `[Unreleased]` → `### Added` documents the new flag
  with both subcommand variants.

## Design notes

- No new error variants — dry-run paths share the existing
  `WorktreeNotFound` / fuzzy-ambiguity surface with the destructive
  forms.
- `PrunableEntry.reason` is a `String` field rather than a hard-
  coded literal in the CLI, so future libgit2 versions can expose
  richer prunable reasons (locked, expired, …) without forcing a CLI
  rewrite.
- No `println!` inside `src/worktree.rs` — helpers return data
  structures and the CLI renders them, preserving the layering
  invariant.
- No breaking change. Existing call sites without `--dry-run` keep
  the destructive default.

## Tests

- [x] `cargo test` passes locally (815 tests, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour
  without tests is sent back)

Test breakdown (red commit landed BEFORE green commit):

- `tests/cli_binary.rs` (5 new tests):
  - `remove_dry_run_prints_plan_and_keeps_worktree_intact`
  - `remove_dry_run_with_delete_branch_flags_branch_deletion`
  - `remove_dry_run_on_ambiguous_pattern_still_fails`
  - `prune_dry_run_prints_plan_without_pruning`
  - `prune_dry_run_reports_no_candidates_when_clean`
- `tests/worktree_integration.rs` (4 new tests):
  - `prunable_worktrees_returns_empty_when_clean`
  - `prunable_worktrees_lists_orphaned_admin_entry`
  - `prunable_worktrees_sorted_by_name`
  - `remove_with_dry_run_keeps_worktree_and_branch_intact`

Manual smoke (release binary):

```
$ gwm prune --dry-run
0 worktree(s) to prune

$ gwm remove dry-run-remove-prune --dry-run
would remove:
  name:   feat-31-dry-run-remove-prune
  path:   /Users/kbrdn1/cc-worktree/gwm-cli/feat-31-dry-run-remove-prune
  branch: feat/#31-dry-run-remove-prune

$ gwm remove dry-run-remove-prune --delete-branch --dry-run
would remove:
  name:   feat-31-dry-run-remove-prune
  path:   /Users/kbrdn1/cc-worktree/gwm-cli/feat-31-dry-run-remove-prune
  branch: feat/#31-dry-run-remove-prune (would be deleted)
```

Pre-validated with minimal `PATH` (`$(dirname $(command -v cargo)):/usr/bin:/bin`)
— no env-dependent failures expected on CI.

## Screenshots / TUI captures

N/A — CLI-only change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see
  CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — no README mention of
  remove/prune flags; the new help output is self-documenting.
- [ ] `examples/gwm.toml.example` updated if config schema changed
  — no config schema change.
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only) — TUI is
  untouched.

## Linked issues / docs

- Issue: #31
- Related PR: —

## Notes for reviewers

- The TDD split is preserved in the commit history: the first commit
  (`🧪 test(cli): pin --dry-run contract …`) introduces the failing
  tests; the second (`✨ feat(cli): add --dry-run …`) turns them
  green. Reviewing in order makes the contract explicit.
- Output format is deliberately conservative — header + indented
  rows, two-space padding, lower-case verbs. Matches the existing
  `gwm list` / `gwm labels push --dry-run` aesthetic.
- The `worktree::PrunableEntry` struct is new public API. If you
  prefer it stays crate-private for now (e.g. unsure about the
  contract), the next polish PR can demote it — it's surfaced
  through the CLI today, so leaving it public felt right.