### PR TITLE
✨ feat(cli): gwm undo + gwm history + operation journal (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gwm undo` + `gwm history` + operation journal**
+  ([#29](https://github.com/kbrdn1/gwm-cli/issues/29)). Recover from
+  a misfired `gwm remove` without `git reflog` archaeology.
+  - **Operation journal**: every destructive op (`gwm remove`,
+    with or without `--delete-branch`) appends an entry to
+    `$XDG_DATA_HOME/gwm/history.toml` (override via
+    `$GWM_HISTORY_FILE`; macOS fallback under `Application
+    Support`, Windows under `%LOCALAPPDATA%`). Each entry
+    captures the timestamp, worktree name, branch name,
+    branch OID at deletion time, on-disk path, the
+    `--delete-branch` flag, and the canonicalised
+    `repo_root` so per-repo separation works across symlink
+    chains.
+  - **Rotation cap**: 100 entries max across the whole
+    journal; oldest-by-timestamp dropped on overflow.
+  - **`gwm undo [--bootstrap]`**: pops the most recent op for
+    the current repo, recreates `refs/heads/<branch>` at the
+    saved OID via `Repository::reference`, re-adds the
+    worktree at the saved path with `reuse_branch: true`. The
+    `--bootstrap` flag opts into re-running the per-worktree
+    bootstrap (off by default to keep undo cheap). The
+    journal entry is consumed only after a successful
+    resurrection — a mid-flight failure keeps the recovery
+    anchor intact.
+  - **`gwm history [--limit N] [--all]`**: lists the recent
+    ops newest-first. Default `--limit` is 20. By default
+    filters to the current repo's canonicalised workdir;
+    `--all` surfaces every entry across every repo for
+    forensic / multi-repo grep. Empty result prints `no
+    operations recorded` as a stable scripted signal.
+  - `gwm remove --dry-run` does NOT write to the journal —
+    previewing a destruction must never allow "undoing"
+    something that never happened.
+  - Journal IO failures are logged to stderr but never block
+    the destructive op: failing a remove because we couldn't
+    write `~/.local/share/gwm/history.toml` (disk full,
+    read-only FS, sandboxed CI runner) would be more
+    surprising than losing recoverability.
 - **`--dry-run` flag on `gwm remove` and `gwm prune`**
   ([#31](https://github.com/kbrdn1/gwm-cli/issues/31)). Preview
   destructive operations before running them.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -834,7 +834,9 @@ fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()>
     // already happened above — an ambiguous pattern surfaced via
     // `find_fuzzy` returns the same `Other(... ambiguous ...)` error
     // the destructive form raises, satisfying the spec's "same error
-    // contract" requirement.
+    // contract" requirement. The journal hook MUST NOT fire here —
+    // a preview that wrote to the journal would let the user "undo"
+    // something that never happened.
     worktree::remove_dry_run(&repo, &found.name)?;
     print!(
       "{}",
@@ -842,6 +844,44 @@ fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()>
     );
     return Ok(());
   }
+
+  // Issue #29: capture the branch OID via libgit2 BEFORE the
+  // destructive call so we can resurrect the branch on `gwm undo`.
+  // We swallow any journal IO failure with a stderr warning rather
+  // than blocking a destruction the user explicitly asked for —
+  // losing recoverability is unfortunate, but failing the remove
+  // because we can't write to `~/.local/share/gwm/history.toml` would
+  // be far more surprising. (Disk full, read-only FS, sandboxed
+  // CI runner without home dir, …)
+  let branch_oid = found.branch.as_deref().and_then(|b| {
+    repo
+      .find_branch(b, git2::BranchType::Local)
+      .ok()
+      .and_then(|br| br.into_reference().target())
+      .map(|o| o.to_string())
+  });
+  let repo_root = repo
+    .workdir()
+    .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf()))
+    .unwrap_or_default();
+  let entry = OpEntry {
+    ts: chrono::Utc::now(),
+    kind: crate::history::OpKind::Remove,
+    worktree: found.name.clone(),
+    branch: found.branch.clone(),
+    branch_oid,
+    path: found.path.clone(),
+    deleted_branch: delete_branch,
+    repo_root,
+    undone: false,
+  };
+  if let Err(e) = history::record(entry) {
+    eprintln!(
+      "warning: failed to record undo journal entry: {} (continuing with the remove anyway)",
+      e
+    );
+  }
+
   worktree::remove(&repo, &found.name, delete_branch)?;
   println!("✓ removed {} ({})", found.name, found.path.display());
   if delete_branch {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use crate::doctor::{self, CheckStatus, DoctorCtx};
 use crate::error::{GwmError, LinkKind, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use crate::gitmoji;
+use crate::history::{self, OpEntry};
 use crate::hooks;
 use crate::labels::{self, LabelDiff};
 use crate::milestones::{self, MilestoneDiff};
@@ -348,6 +349,37 @@ pub enum Command {
     #[command(subcommand)]
     action: AliasesAction,
   },
+  /// List the recent destructive operations recorded by `gwm`
+  /// (issue #29). One line per op, newest first, with timestamp,
+  /// kind, and worktree name.
+  ///
+  /// Defaults to the current repo only — pass `--all` to list ops
+  /// across every repo in the journal. The journal file lives at
+  /// `$GWM_HISTORY_FILE` if set, otherwise
+  /// `$XDG_DATA_HOME/gwm/history.toml`.
+  History {
+    /// Maximum number of entries to print (newest first). Default 20.
+    #[arg(long, default_value_t = 20)]
+    limit: usize,
+    /// Show ops across every repo, not just the current one. Useful
+    /// for power users grepping the journal for forensic purposes.
+    #[arg(long)]
+    all: bool,
+  },
+  /// Undo the most recent destructive operation recorded for the
+  /// current repo (issue #29). Recreates the branch at the saved
+  /// OID, re-adds the worktree at the saved path, then drops the
+  /// entry from the journal.
+  ///
+  /// Pass `--bootstrap` to re-run the per-worktree bootstrap after
+  /// the resurrection (off by default — bootstrap can be expensive
+  /// and the user often just wants the directory back).
+  Undo {
+    /// Re-run bootstrap after the worktree is re-added. Off by
+    /// default to keep undo cheap.
+    #[arg(long)]
+    bootstrap: bool,
+  },
 }
 
 /// Subcommands of `gwm aliases` (issue #86). Read-only for now —
@@ -566,6 +598,8 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Milestones { action } => cmd_milestones(action),
     Command::Trust { action } => cmd_trust(action),
     Command::Aliases { action } => cmd_aliases(action),
+    Command::History { limit, all } => cmd_history(limit, all),
+    Command::Undo { bootstrap } => cmd_undo(bootstrap),
   }
 }
 
@@ -2081,4 +2115,140 @@ fn print_report(report: &bootstrap::BootstrapReport) {
       }
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #29 — `gwm history` + `gwm undo`
+// ---------------------------------------------------------------------------
+
+/// Resolve the canonicalised main repo workdir for journal lookups.
+/// `gwm undo` / `gwm history` filter on this path verbatim, so the
+/// canonicalisation step matters: `/var` vs `/private/var` on macOS
+/// would otherwise cross-pollute repos that happen to live on
+/// different symlink chains.
+fn current_repo_root() -> Result<PathBuf> {
+  let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  Ok(std::fs::canonicalize(&workdir).unwrap_or(workdir))
+}
+
+/// Render one journal entry as a single line for `gwm history`. Shape:
+/// `<ago>  <kind>  <worktree>  [(undone)]`. Extracted as a pure
+/// function so the formatter is unit-testable without spinning up a
+/// real journal (see `cli_format_tests.rs`).
+pub fn format_history_row(entry: &OpEntry, now: chrono::DateTime<chrono::Utc>) -> String {
+  let delta = (now - entry.ts).to_std().unwrap_or(std::time::Duration::from_secs(0));
+  let ago = worktree::format_relative_duration(delta);
+  let suffix = if entry.undone { "  (undone)" } else { "" };
+  format!("{:<5}  {:<7}  {}{}", ago, entry.kind.as_str(), entry.worktree, suffix)
+}
+
+fn cmd_history(limit: usize, all: bool) -> Result<()> {
+  let path = history::default_journal_path()?;
+  let journal = history::Journal::load(&path)?;
+
+  // Build the filtered+sorted view. With `--all`, surface every entry
+  // regardless of `repo_root`. Without it, restrict to the current
+  // repo's canonicalised workdir. Resolving the root outside the
+  // `if` so its lifetime spans the whole function — the `else` arm
+  // returns an iterator that borrows from it.
+  let root: Option<PathBuf> = if all { None } else { Some(current_repo_root()?) };
+  let mut rows: Vec<&OpEntry> = match &root {
+    Some(r) => journal.entries_for_repo(r).collect(),
+    None => journal.entries().iter().collect(),
+  };
+
+  // Newest first — the user just ran an op, they expect it on top.
+  rows.sort_by(|a, b| b.ts.cmp(&a.ts));
+  rows.truncate(limit);
+
+  if rows.is_empty() {
+    println!("no operations recorded");
+    return Ok(());
+  }
+
+  let now = chrono::Utc::now();
+  for entry in rows {
+    println!("{}", format_history_row(entry, now));
+  }
+  Ok(())
+}
+
+fn cmd_undo(run_bootstrap: bool) -> Result<()> {
+  let path = history::default_journal_path()?;
+  let mut journal = history::Journal::load(&path)?;
+  let root = current_repo_root()?;
+
+  let Some(entry) = journal.pop_last_for_repo(&root) else {
+    return Err(GwmError::Other(format!(
+      "nothing to undo for {} — the journal is empty for this repo",
+      root.display()
+    )));
+  };
+
+  let repo = worktree::discover_repo(None)?;
+
+  // (1) Resurrect the branch at the saved OID — only if a branch was
+  //     recorded AND the user opted into deletion (or the branch is
+  //     missing for any other reason). Skipping the branch create
+  //     when the ref already exists keeps `gwm undo` idempotent
+  //     against partial recoveries.
+  if let (Some(branch_name), Some(oid_hex)) = (&entry.branch, &entry.branch_oid) {
+    let oid = git2::Oid::from_str(oid_hex)
+      .map_err(|e| GwmError::Other(format!("journal entry has invalid branch_oid '{}': {}", oid_hex, e)))?;
+    if repo.find_branch(branch_name, git2::BranchType::Local).is_err() {
+      repo
+        .reference(
+          &format!("refs/heads/{}", branch_name),
+          oid,
+          false,
+          "gwm undo: resurrect branch",
+        )
+        .map_err(|e| {
+          GwmError::Other(format!(
+            "failed to recreate branch {} at {}: {}",
+            branch_name, oid_hex, e
+          ))
+        })?;
+      println!(
+        "✓ recreated branch {} at {}",
+        branch_name,
+        &oid_hex[..oid_hex.len().min(8)]
+      );
+    } else {
+      println!("· branch {} already exists — skipping resurrection", branch_name);
+    }
+  }
+
+  // (2) Re-add the worktree at the saved path. `worktree::add` refuses
+  //     to clobber an existing directory, so a leftover dir from a
+  //     half-failed remove will surface as an error here — the user
+  //     can clean up manually before retrying undo.
+  let branch_name = entry.branch.as_deref().unwrap_or("HEAD");
+  // `reuse_branch: true` because the branch already exists (we just
+  // created it above, or it was never deleted).
+  worktree::add(&repo, &entry.worktree, &entry.path, branch_name, true)?;
+  println!("✓ re-added worktree at {}", entry.path.display());
+
+  // (3) Persist the journal AFTER the resurrection succeeds — if we
+  //     dropped the entry first and then the resurrection failed, the
+  //     user would lose the recovery anchor entirely.
+  journal.save(&path)?;
+
+  // (4) Optionally re-run bootstrap.
+  if run_bootstrap {
+    let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+    let config = Config::load_for_repo(&workdir)?;
+    let ctx = BootstrapCtx {
+      main_repo: &workdir,
+      worktree: &entry.path,
+      config: &config,
+    };
+    let report = bootstrap::run(&ctx)?;
+    print_report(&report);
+  } else {
+    println!("(skipped re-bootstrap; pass --bootstrap to run it)");
+  }
+
+  Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2198,14 +2198,21 @@ fn cmd_history(limit: usize, all: bool) -> Result<()> {
     None => journal.entries().iter().collect(),
   };
 
-  // Newest first — the user just ran an op, they expect it on top.
-  rows.sort_by_key(|e| std::cmp::Reverse(e.ts));
-  rows.truncate(limit);
-
+  // Distinguish "the journal is empty for this view" from "the user
+  // asked for zero rows" — `--limit 0` is an explicit no-op that
+  // should print nothing and exit 0, not falsely claim the journal
+  // is empty (PR #155 Copilot review).
   if rows.is_empty() {
     println!("no operations recorded");
     return Ok(());
   }
+  if limit == 0 {
+    return Ok(());
+  }
+
+  // Newest first — the user just ran an op, they expect it on top.
+  rows.sort_by_key(|e| std::cmp::Reverse(e.ts));
+  rows.truncate(limit);
 
   let now = chrono::Utc::now();
   for entry in rows {
@@ -2264,7 +2271,23 @@ fn cmd_undo(run_bootstrap: bool) -> Result<()> {
   //     to clobber an existing directory, so a leftover dir from a
   //     half-failed remove will surface as an error here — the user
   //     can clean up manually before retrying undo.
-  let branch_name = entry.branch.as_deref().unwrap_or("HEAD");
+  //
+  //     `OpEntry.branch == None` flags a worktree that was checked out
+  //     in detached-HEAD state. We don't support resurrecting those
+  //     yet — the original sin is that `worktree::add` only knows how
+  //     to attach a worktree to a named branch. Falling back to a
+  //     literal `"HEAD"` (the pre-fix behaviour) would either fail at
+  //     the libgit2 level (invalid refname) or create a real branch
+  //     named "HEAD" which is a disaster all of its own. Surface a
+  //     clear error so the user knows what's happening and can file
+  //     a follow-up issue if detached-HEAD support matters to them
+  //     (PR #155 Copilot review).
+  let branch_name = entry.branch.as_deref().ok_or_else(|| {
+    GwmError::Other(format!(
+      "cannot undo remove of detached-HEAD worktree {} — only branch-attached worktrees are supported today",
+      entry.worktree
+    ))
+  })?;
   // `reuse_branch: true` because the branch already exists (we just
   // created it above, or it was never deleted).
   worktree::add(&repo, &entry.worktree, &entry.path, branch_name, true)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2199,7 +2199,7 @@ fn cmd_history(limit: usize, all: bool) -> Result<()> {
   };
 
   // Newest first — the user just ran an op, they expect it on top.
-  rows.sort_by(|a, b| b.ts.cmp(&a.ts));
+  rows.sort_by_key(|e| std::cmp::Reverse(e.ts));
   rows.truncate(limit);
 
   if rows.is_empty() {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,248 @@
+//! Operation journal backing `gwm undo` + `gwm history` (issue #29).
+//!
+//! Records destructive operations (today: `gwm remove`) to a single
+//! per-user TOML file so the user can recover from a stray keystroke
+//! without `git reflog` archaeology. Each entry carries enough state
+//! to recreate the branch (its OID at deletion time) and re-add the
+//! worktree (its path + name) — the inverse of [`worktree::remove`].
+//!
+//! ## File location
+//!
+//! Resolution order (matches the `trust::default_ledger_path` shape
+//! so the two user-facing files live in symmetrical places):
+//!
+//!   1. `$GWM_HISTORY_FILE` if set and non-empty. The testability hook
+//!      and power-user override.
+//!   2. `$XDG_DATA_HOME/gwm/history.toml` if `$XDG_DATA_HOME` is set.
+//!   3. `dirs::data_dir()/gwm/history.toml` (XDG on Linux,
+//!      `Application Support` on macOS, `%LOCALAPPDATA%` on Windows).
+//!
+//! ## Cap + rotation
+//!
+//! Hard-cap at [`MAX_ENTRIES`] (currently 100). On [`Journal::append`]
+//! we drop the OLDEST entry by timestamp when we'd overflow. Keeping
+//! the cap global (not per-repo) means a power user juggling 30 repos
+//! still has a bounded ledger; the per-repo separation is enforced at
+//! READ time via [`Journal::entries_for_repo`], not at write time.
+//!
+//! ## Per-repo separation
+//!
+//! Every entry records its `repo_root` (the canonicalised main workdir
+//! of the repo the op happened in). [`Journal::last_for_repo`] and
+//! [`Journal::pop_last_for_repo`] filter on this so `gwm undo` in repo
+//! A cannot resurrect a worktree from repo B.
+
+use crate::error::{GwmError, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::Builder;
+
+/// Maximum number of entries kept across the whole journal. Append
+/// past this cap drops the oldest entry — keeps the file bounded over
+/// the lifetime of a heavy gwm user without per-repo bookkeeping.
+pub const MAX_ENTRIES: usize = 100;
+
+/// Discriminator for the kind of operation recorded. Today only
+/// `Remove` is wired up — `Create` is reserved for a future extension
+/// that hooks `gwm create` into the journal so `gwm undo` can also
+/// roll back accidental worktree creations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OpKind {
+  /// `gwm remove` (with or without `--delete-branch`).
+  Remove,
+  /// Reserved for `gwm create` instrumentation — not wired today.
+  Create,
+}
+
+impl OpKind {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      OpKind::Remove => "remove",
+      OpKind::Create => "create",
+    }
+  }
+}
+
+/// One recorded destructive operation.
+///
+/// `branch_oid` is the SHA the branch ref pointed at *at deletion
+/// time* — that is the resurrection anchor for `gwm undo`. `git`'s
+/// object DB keeps the commit alive until `git gc` runs (defaults to
+/// at least 30 days for unreachable objects), so the OID stays
+/// resolvable for the whole window where undo makes sense.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpEntry {
+  /// RFC3339 timestamp of when the op happened. Used to sort entries
+  /// newest-first when surfacing to the user.
+  pub ts: DateTime<Utc>,
+  pub kind: OpKind,
+  /// Name of the worktree (the `<dirname>` portion, not the full path).
+  pub worktree: String,
+  /// Branch name. `None` for detached-HEAD worktrees.
+  pub branch: Option<String>,
+  /// OID the branch ref pointed at when the op started. Used by
+  /// `gwm undo` to recreate `refs/heads/<branch>` at the exact tip
+  /// that was deleted.
+  pub branch_oid: Option<String>,
+  /// Worktree directory on disk (the `path` field of `WorktreeInfo`).
+  pub path: PathBuf,
+  /// Whether the destructive call also deleted the branch
+  /// (`--delete-branch`). Drives whether `gwm undo` has to recreate
+  /// the branch or just re-add the worktree.
+  pub deleted_branch: bool,
+  /// Canonicalised path of the main repo workdir this op happened in.
+  /// Filters `last_for_repo` / `entries_for_repo` so a global journal
+  /// doesn't cross-pollute repos.
+  pub repo_root: PathBuf,
+  /// Set to `true` after `gwm undo` consumed this entry — but `undo`
+  /// removes the entry on success, so a `true` here means the user
+  /// manually edited the journal. Surfaced in `gwm history` for
+  /// completeness.
+  #[serde(default)]
+  pub undone: bool,
+}
+
+/// The on-disk journal. Plain TOML so users can `cat`/`less` it and
+/// audit what their previous gwm sessions did.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Journal {
+  #[serde(default, rename = "op")]
+  entries: Vec<OpEntry>,
+}
+
+impl Journal {
+  /// Load the journal from `path`. A missing file is NOT an error —
+  /// treated as an empty journal. Matches the trust-ledger contract
+  /// in `src/trust.rs`.
+  pub fn load(path: &Path) -> Result<Self> {
+    match fs::read_to_string(path) {
+      Ok(raw) => {
+        let journal: Journal = toml::from_str(&raw)?;
+        Ok(journal)
+      }
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+      Err(e) => Err(e.into()),
+    }
+  }
+
+  /// Append `entry` to the journal, enforcing the [`MAX_ENTRIES`] cap.
+  /// When the cap is exceeded, the OLDEST entry (by timestamp) is
+  /// dropped — the rotation policy.
+  pub fn append(&mut self, entry: OpEntry) {
+    self.entries.push(entry);
+    if self.entries.len() > MAX_ENTRIES {
+      // Drop the entry with the smallest timestamp. We scan rather
+      // than maintain sorted order on push so the file remains in
+      // insertion order on disk (easier to diff manually).
+      let oldest_idx = self
+        .entries
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, e)| e.ts)
+        .map(|(i, _)| i);
+      if let Some(i) = oldest_idx {
+        self.entries.remove(i);
+      }
+    }
+  }
+
+  /// Persist the journal atomically (same primitive as the trust
+  /// ledger): write a randomised tmp file in the same dir, then
+  /// rename(2). Parent dirs are created on demand.
+  pub fn save(&self, path: &Path) -> Result<()> {
+    let parent = match path.parent() {
+      Some(p) if !p.as_os_str().is_empty() => {
+        fs::create_dir_all(p)?;
+        p.to_path_buf()
+      }
+      _ => PathBuf::from("."),
+    };
+    let body = toml::to_string_pretty(self)?;
+    let mut tmp = Builder::new()
+      .prefix("gwm-history-")
+      .suffix(".tmp")
+      .tempfile_in(&parent)?;
+    tmp.write_all(body.as_bytes())?;
+    tmp.persist(path).map_err(|e| GwmError::Io(e.error))?;
+    Ok(())
+  }
+
+  /// Read-only view of all entries (insertion order).
+  pub fn entries(&self) -> &[OpEntry] {
+    &self.entries
+  }
+
+  /// Iterator over entries whose `repo_root` matches `repo_root`
+  /// verbatim. Used by `gwm history` (which filters by the current
+  /// repo) and `gwm undo` (via [`Self::last_for_repo`]).
+  pub fn entries_for_repo<'a>(&'a self, repo_root: &'a Path) -> impl Iterator<Item = &'a OpEntry> + 'a {
+    self.entries.iter().filter(move |e| e.repo_root == repo_root)
+  }
+
+  /// Most-recent entry (by timestamp) for `repo_root`, or `None` if
+  /// no op has been recorded for that repo.
+  pub fn last_for_repo<'a>(&'a self, repo_root: &'a Path) -> Option<&'a OpEntry> {
+    self.entries_for_repo(repo_root).max_by_key(|e| e.ts)
+  }
+
+  /// Remove and return the most-recent entry for `repo_root`. Used
+  /// by `gwm undo` to consume the op it's about to replay. The
+  /// caller is responsible for persisting the journal after a
+  /// successful undo.
+  pub fn pop_last_for_repo(&mut self, repo_root: &Path) -> Option<OpEntry> {
+    let target = self
+      .entries
+      .iter()
+      .enumerate()
+      .filter(|(_, e)| e.repo_root == repo_root)
+      .max_by_key(|(_, e)| e.ts)
+      .map(|(i, _)| i)?;
+    Some(self.entries.remove(target))
+  }
+}
+
+/// Resolve the active journal path.
+///
+/// Resolution order:
+///   1. `$GWM_HISTORY_FILE` if set and non-empty.
+///   2. `$XDG_DATA_HOME/gwm/history.toml` if `$XDG_DATA_HOME` is set.
+///   3. `dirs::data_dir()/gwm/history.toml`.
+///
+/// The fallback maps to platform-native data dirs (Linux:
+/// `~/.local/share`, macOS: `~/Library/Application Support`, Windows:
+/// `%LOCALAPPDATA%`).
+pub fn default_journal_path() -> Result<PathBuf> {
+  if let Ok(p) = std::env::var("GWM_HISTORY_FILE") {
+    if !p.is_empty() {
+      return Ok(PathBuf::from(p));
+    }
+  }
+  if let Ok(p) = std::env::var("XDG_DATA_HOME") {
+    if !p.is_empty() {
+      return Ok(PathBuf::from(p).join("gwm").join("history.toml"));
+    }
+  }
+  let base = dirs::data_dir().ok_or_else(|| {
+    GwmError::Other("could not resolve user data directory — set GWM_HISTORY_FILE to override".into())
+  })?;
+  Ok(base.join("gwm").join("history.toml"))
+}
+
+/// Convenience: append `entry` to the journal at
+/// [`default_journal_path`], creating parent dirs as needed. On IO
+/// failure, returns the error WITHOUT modifying the on-disk file —
+/// the caller (usually `worktree::remove` plumbing) decides whether
+/// to fail the destructive op or log + continue. The recommended
+/// pattern is "log + continue": never block a destruction the user
+/// explicitly asked for because the journal couldn't be written.
+pub fn record(entry: OpEntry) -> Result<()> {
+  let path = default_journal_path()?;
+  let mut journal = Journal::load(&path)?;
+  journal.append(entry);
+  journal.save(&path)?;
+  Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod doctor;
 pub mod error;
 pub mod github;
 pub mod gitmoji;
+pub mod history;
 pub mod hooks;
 pub mod labels;
 pub mod launcher;

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -49,7 +49,10 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  aliases "))
     // Issue #85: gitmoji commit-prefix + commit-msg hook installer.
     .stdout(predicate::str::contains("  commit-prefix "))
-    .stdout(predicate::str::contains("  hooks "));
+    .stdout(predicate::str::contains("  hooks "))
+    // Issue #29: operation journal + undo + history.
+    .stdout(predicate::str::contains("  undo "))
+    .stdout(predicate::str::contains("  history "));
 }
 
 // --- gitmoji (issue #85) ------------------------------------------------
@@ -2579,4 +2582,174 @@ fn binary_tolerates_non_utf8_argv() {
     "binary panicked instead of gracefully handling non-UTF-8 argv: {}",
     stderr
   );
+}
+
+// --- Issue #29: gwm history + gwm undo --------------------------------------
+
+/// Seed a journal file at `path` with a single recorded `remove` op
+/// rooted at `repo_root` (canonical form). The OID is a synthetic 40-
+/// char hex string the journal accepts verbatim — `gwm history` is a
+/// read-only listing so it never resolves the OID against the object
+/// DB, which means we don't need to seed a matching commit.
+fn write_seed_history(path: &Path, repo_root: &Path, worktree: &str, branch: &str) {
+  let body = format!(
+    r#"[[op]]
+ts = "2026-05-19T08:42:11Z"
+kind = "remove"
+worktree = "{worktree}"
+branch = "{branch}"
+branch_oid = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+path = "/tmp/cc-worktree/{worktree}"
+deleted_branch = false
+repo_root = "{repo_root}"
+"#,
+    repo_root = repo_root.display(),
+  );
+  if let Some(parent) = path.parent() {
+    std::fs::create_dir_all(parent).unwrap();
+  }
+  std::fs::write(path, body).unwrap();
+}
+
+#[test]
+fn history_empty_journal_reports_no_ops() {
+  // Empty case: a fresh repo with no recorded operations must print
+  // a clear "no operations recorded" line and exit 0. Scripted callers
+  // (e.g. `gwm history | head -n1`) need a stable signal — silent
+  // stdout would force them to also check `$?` to disambiguate.
+  let (dir, _) = init_repo();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("history")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no operations recorded"));
+}
+
+#[test]
+fn history_lists_recorded_remove_op() {
+  // Happy path: a seeded journal with one `remove` op produces a
+  // single-row listing carrying the worktree name. The exact
+  // column shape is intentionally flexible — we pin only the
+  // load-bearing tokens (kind = `remove`, worktree name) so the
+  // formatter can evolve without test churn.
+  let (dir, _) = init_repo();
+  let repo_root = dir.path().canonicalize().unwrap();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+  write_seed_history(&history_file, &repo_root, "feat-29-foo", "feat/#29-foo");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("history")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("remove"))
+    .stdout(predicate::str::contains("feat-29-foo"));
+}
+
+#[test]
+fn history_filters_to_current_repo_by_default() {
+  // Two ops recorded against two different repos. From inside
+  // repo A, `gwm history` must surface ONLY the entry whose
+  // `repo_root` matches the current repo — the per-repo
+  // separation contract.
+  let (dir, _) = init_repo();
+  let repo_root = dir.path().canonicalize().unwrap();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+
+  // Seed two ops: one for the current repo, one for a fake "other-repo"
+  // path. Only the first should surface in the default listing.
+  let body = format!(
+    r#"[[op]]
+ts = "2026-05-19T08:42:11Z"
+kind = "remove"
+worktree = "feat-here-foo"
+branch = "feat/#1-here"
+branch_oid = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+path = "/tmp/cc-worktree/feat-here-foo"
+deleted_branch = false
+repo_root = "{repo_root}"
+
+[[op]]
+ts = "2026-05-19T09:00:00Z"
+kind = "remove"
+worktree = "feat-elsewhere-bar"
+branch = "feat/#2-elsewhere"
+branch_oid = "b2c3d4e5f60718293a4b5c6d7e8f9012345678a1"
+path = "/tmp/cc-worktree/feat-elsewhere-bar"
+deleted_branch = false
+repo_root = "/nonexistent/other-repo"
+"#,
+    repo_root = repo_root.display(),
+  );
+  if let Some(parent) = history_file.parent() {
+    std::fs::create_dir_all(parent).unwrap();
+  }
+  std::fs::write(&history_file, body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("history")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat-here-foo"))
+    .stdout(predicate::str::contains("feat-elsewhere-bar").not());
+}
+
+#[test]
+fn history_all_flag_surfaces_every_repo() {
+  // `--all` opt-out from the per-repo filter: useful for power users
+  // grepping the journal for forensic purposes. Both entries must
+  // appear in the listing.
+  let (dir, _) = init_repo();
+  let repo_root = dir.path().canonicalize().unwrap();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+
+  let body = format!(
+    r#"[[op]]
+ts = "2026-05-19T08:42:11Z"
+kind = "remove"
+worktree = "feat-here-foo"
+branch = "feat/#1-here"
+branch_oid = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+path = "/tmp/cc-worktree/feat-here-foo"
+deleted_branch = false
+repo_root = "{repo_root}"
+
+[[op]]
+ts = "2026-05-19T09:00:00Z"
+kind = "remove"
+worktree = "feat-elsewhere-bar"
+branch = "feat/#2-elsewhere"
+branch_oid = "b2c3d4e5f60718293a4b5c6d7e8f9012345678a1"
+path = "/tmp/cc-worktree/feat-elsewhere-bar"
+deleted_branch = false
+repo_root = "/nonexistent/other-repo"
+"#,
+    repo_root = repo_root.display(),
+  );
+  std::fs::create_dir_all(history_file.parent().unwrap()).unwrap();
+  std::fs::write(&history_file, body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["history", "--all"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat-here-foo"))
+    .stdout(predicate::str::contains("feat-elsewhere-bar"));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2708,6 +2708,126 @@ repo_root = "/nonexistent/other-repo"
 }
 
 #[test]
+fn remove_records_journal_entry_before_destruction() {
+  // Issue #29: `gwm remove <name>` must write a journal entry naming
+  // the doomed worktree + branch + OID BEFORE the destructive call
+  // runs. Without this hook `gwm undo` has nothing to replay. The
+  // assertion is intentionally loose on the exact TOML shape — we
+  // pin only that the journal file exists, is non-empty, and
+  // contains the worktree name we asked to remove.
+  let (dir, _) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let history_dir = tempfile::TempDir::new().unwrap();
+  let history_file = history_dir.path().join("history.toml");
+
+  // Seed a worktree the test will then remove.
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["create", "feat", "29", "doomed", "--no-bootstrap"])
+    .assert()
+    .success();
+
+  // No journal entry should exist yet — `gwm create` does NOT hook
+  // the journal (only destructive ops do).
+  assert!(
+    !history_file.exists() || std::fs::read_to_string(&history_file).unwrap().trim().is_empty(),
+    "create must not record a journal entry"
+  );
+
+  // Now remove it — the journal must capture the op.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["remove", "feat-29-doomed"])
+    .assert()
+    .success();
+
+  assert!(
+    history_file.exists(),
+    "remove must create the journal file at {}",
+    history_file.display()
+  );
+  let body = std::fs::read_to_string(&history_file).unwrap();
+  assert!(
+    body.contains("feat-29-doomed"),
+    "journal must record the removed worktree name; got:\n{}",
+    body
+  );
+  assert!(
+    body.contains("kind = \"remove\""),
+    "journal must record kind = remove; got:\n{}",
+    body
+  );
+  assert!(
+    body.contains("feat/#29-doomed"),
+    "journal must record the branch name; got:\n{}",
+    body
+  );
+}
+
+#[test]
+fn remove_dry_run_does_not_record_journal_entry() {
+  // The dry-run flag (issue #31) gives the user a preview without
+  // touching state. The journal hook MUST gate on the destructive
+  // path only — a `--dry-run` invocation that wrote to the journal
+  // would let the user "undo" something that never happened.
+  let (dir, _) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let history_dir = tempfile::TempDir::new().unwrap();
+  let history_file = history_dir.path().join("history.toml");
+
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["create", "feat", "31", "preview", "--no-bootstrap"])
+    .assert()
+    .success();
+
+  // dry-run must not write to the journal.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["remove", "feat-31-preview", "--dry-run"])
+    .assert()
+    .success();
+
+  assert!(
+    !history_file.exists() || std::fs::read_to_string(&history_file).unwrap().trim().is_empty(),
+    "remove --dry-run must NOT write to the journal; got: {:?}",
+    std::fs::read_to_string(&history_file).ok()
+  );
+}
+
+#[test]
 fn history_all_flag_surfaces_every_repo() {
   // `--all` opt-out from the per-repo filter: useful for power users
   // grepping the journal for forensic purposes. Both entries must

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2591,6 +2591,11 @@ fn binary_tolerates_non_utf8_argv() {
 /// char hex string the journal accepts verbatim — `gwm history` is a
 /// read-only listing so it never resolves the OID against the object
 /// DB, which means we don't need to seed a matching commit.
+///
+/// `repo_root` is escaped via `toml_basic_string` because Windows
+/// paths (`\\?\C:\...`) contain backslashes that TOML treats as
+/// escape sequences; without the escape the parser fails with
+/// "missing escaped value, expected b, e, f, n, r, \\, …".
 fn write_seed_history(path: &Path, repo_root: &Path, worktree: &str, branch: &str) {
   let body = format!(
     r#"[[op]]
@@ -2603,7 +2608,7 @@ path = "/tmp/cc-worktree/{worktree}"
 deleted_branch = false
 repo_root = "{repo_root}"
 "#,
-    repo_root = repo_root.display(),
+    repo_root = toml_basic_string(repo_root),
   );
   if let Some(parent) = path.parent() {
     std::fs::create_dir_all(parent).unwrap();
@@ -2668,6 +2673,8 @@ fn history_filters_to_current_repo_by_default() {
 
   // Seed two ops: one for the current repo, one for a fake "other-repo"
   // path. Only the first should surface in the default listing.
+  // `toml_basic_string` escapes the repo path for TOML — Windows
+  // canonical paths (`\\?\C:\…`) would otherwise break the parser.
   let body = format!(
     r#"[[op]]
 ts = "2026-05-19T08:42:11Z"
@@ -2689,7 +2696,7 @@ path = "/tmp/cc-worktree/feat-elsewhere-bar"
 deleted_branch = false
 repo_root = "/nonexistent/other-repo"
 "#,
-    repo_root = repo_root.display(),
+    repo_root = toml_basic_string(&repo_root),
   );
   if let Some(parent) = history_file.parent() {
     std::fs::create_dir_all(parent).unwrap();
@@ -2938,6 +2945,8 @@ fn history_all_flag_surfaces_every_repo() {
   let tmp = tempfile::TempDir::new().unwrap();
   let history_file = tmp.path().join("history.toml");
 
+  // `toml_basic_string` escapes the repo path for TOML so this seed
+  // parses on Windows (canonical paths there start with `\\?\C:\…`).
   let body = format!(
     r#"[[op]]
 ts = "2026-05-19T08:42:11Z"
@@ -2959,7 +2968,7 @@ path = "/tmp/cc-worktree/feat-elsewhere-bar"
 deleted_branch = false
 repo_root = "/nonexistent/other-repo"
 "#,
-    repo_root = repo_root.display(),
+    repo_root = toml_basic_string(&repo_root),
   );
   std::fs::create_dir_all(history_file.parent().unwrap()).unwrap();
   std::fs::write(&history_file, body).unwrap();

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2828,6 +2828,107 @@ branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
 }
 
 #[test]
+fn undo_recreates_branch_and_worktree_after_remove() {
+  // The full round-trip contract: create → remove → undo. After
+  // `gwm undo`, the worktree dir must exist again AND the local
+  // branch must resolve. The journal entry must be consumed.
+  let (dir, _) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let history_dir = tempfile::TempDir::new().unwrap();
+  let history_file = history_dir.path().join("history.toml");
+
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  // 1. Create.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["create", "feat", "29", "undo-rt", "--no-bootstrap"])
+    .assert()
+    .success();
+  let wt_path = base.path().join("feat-29-undo-rt");
+  assert!(wt_path.exists(), "create must produce the worktree dir");
+
+  // 2. Remove (with --delete-branch so we exercise the harder
+  //    resurrection path).
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["remove", "feat-29-undo-rt", "--delete-branch"])
+    .assert()
+    .success();
+  assert!(!wt_path.exists(), "remove must drop the worktree dir");
+
+  let repo = git2::Repository::open(dir.path()).unwrap();
+  assert!(
+    repo.find_branch("feat/#29-undo-rt", git2::BranchType::Local).is_err(),
+    "remove --delete-branch must drop the local branch"
+  );
+
+  // 3. Undo. The branch must come back at the same OID, and the
+  //    worktree dir must reappear.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("undo")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("recreated branch"))
+    .stdout(predicate::str::contains("re-added worktree"));
+
+  assert!(wt_path.exists(), "undo must restore the worktree dir");
+  let repo = git2::Repository::open(dir.path()).unwrap();
+  assert!(
+    repo.find_branch("feat/#29-undo-rt", git2::BranchType::Local).is_ok(),
+    "undo must recreate the local branch"
+  );
+
+  // 4. The journal entry is consumed — a second undo errors with
+  //    "nothing to undo".
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("undo")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("nothing to undo"));
+}
+
+#[test]
+fn undo_with_empty_journal_errors_clearly() {
+  // A clean install with no recorded operations: `gwm undo` must
+  // exit non-zero with a clear "nothing to undo" message — silent
+  // success would mislead users into thinking the previous op was
+  // already undone.
+  let (dir, _) = init_repo();
+  let history_dir = tempfile::TempDir::new().unwrap();
+  let history_file = history_dir.path().join("history.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("undo")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("nothing to undo"));
+}
+
+#[test]
 fn history_all_flag_surfaces_every_repo() {
   // `--all` opt-out from the per-repo filter: useful for power users
   // grepping the journal for forensic purposes. Both entries must

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -2916,6 +2916,78 @@ branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
 }
 
 #[test]
+fn undo_refuses_detached_head_entry_with_clear_error() {
+  // PR #155 Copilot review: a journal entry with `branch = ""` (the
+  // serialised form of `branch: None`) flags a worktree that was
+  // removed while on a detached HEAD. The pre-fix code fell back to
+  // `branch_name = "HEAD"` and called `worktree::add`, which either
+  // failed at the libgit2 level (invalid refname) or created a real
+  // branch named "HEAD" — a foot-gun. The fix surfaces a clear
+  // error message so the user knows the limitation and can file a
+  // follow-up if it matters.
+  //
+  // We seed the journal directly with a `branch = ""` entry rather
+  // than going through `gwm create / gwm remove` because the create
+  // path always attaches a branch — there's no shortcut to a
+  // detached-HEAD worktree from the CLI. The fixture matches what
+  // serde produces for `Option<String>::None` once round-tripped
+  // through TOML.
+  let (dir, _) = init_repo();
+  let repo_root = dir.path().canonicalize().unwrap();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+
+  // Direct TOML seed without a `branch` key — serde will deserialise
+  // it as `Option::None`, which is the detached-HEAD discriminator.
+  let body = format!(
+    r#"[[op]]
+ts = "2026-05-19T08:42:11Z"
+kind = "remove"
+worktree = "feat-detached-foo"
+branch_oid = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+path = "/tmp/cc-worktree/feat-detached-foo"
+deleted_branch = false
+repo_root = "{repo_root}"
+"#,
+    repo_root = toml_basic_string(&repo_root),
+  );
+  std::fs::write(&history_file, body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("undo")
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("detached-HEAD"));
+}
+
+#[test]
+fn history_with_zero_limit_prints_nothing_but_does_not_lie() {
+  // PR #155 Copilot review: `--limit 0` used to truncate the row list
+  // to empty, which then triggered the "no operations recorded"
+  // branch — factually wrong when ops exist, and breaks the scripted
+  // signal callers rely on. The fix prints nothing and exits 0,
+  // leaving the "no operations recorded" sentinel reserved for the
+  // truly-empty case.
+  let (dir, _) = init_repo();
+  let repo_root = dir.path().canonicalize().unwrap();
+  let tmp = tempfile::TempDir::new().unwrap();
+  let history_file = tmp.path().join("history.toml");
+  write_seed_history(&history_file, &repo_root, "feat-zero-foo", "feat/#1-zero");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["history", "--limit", "0"])
+    .assert()
+    .success()
+    .stdout(predicate::eq(""));
+}
+
+#[test]
 fn undo_with_empty_journal_errors_clearly() {
   // A clean install with no recorded operations: `gwm undo` must
   // exit non-zero with a clear "nothing to undo" message — silent

--- a/tests/history_tests.rs
+++ b/tests/history_tests.rs
@@ -18,7 +18,21 @@
 use chrono::{Duration, Utc};
 use gwm::history::{self, OpEntry, OpKind};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
+
+/// Process-global lock guarding every test that mutates `std::env`.
+/// Rust 1.86+ marks `set_var` / `remove_var` as `unsafe` because the
+/// underlying libc calls aren't thread-safe; without this lock, two
+/// env-mutating tests running in parallel under `cargo test`'s
+/// default thread pool can race and trigger UB. Mirrors the same
+/// helper in `tests/trust_tests.rs` — the two test files use distinct
+/// locks because they live in distinct cargo-test binaries, so a
+/// shared helper module would buy nothing.
+fn env_lock() -> &'static Mutex<()> {
+  static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+  LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Build a synthetic [`OpEntry`] for the given suffix. Timestamps
 /// default to `now()`; callers that need ordering override after the
@@ -214,33 +228,52 @@ fn default_path_resolution_order() {
   // home dir lookup and isn't safe to override mid-test — we trust the
   // `dirs` crate for that one.
 
+  // Hold the process-wide env lock for the whole test body so a
+  // parallel env-mutating test cannot interleave `set_var` /
+  // `remove_var` calls with ours. Rust 1.86+ marks both as `unsafe`
+  // specifically because libc's env table isn't thread-safe.
+  // Poisoning is fine to ignore: a panic in another env test is
+  // unrelated to our state, and we're going to overwrite the
+  // variable anyway.
+  let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
   // Snapshot whatever the runner's env looked like so we restore it
   // verbatim afterwards (CI runners can have either, neither, or both
   // set; PR #43 hit a CI flake from a similar oversight in trust tests).
   let prev_history = std::env::var("GWM_HISTORY_FILE").ok();
   let prev_xdg = std::env::var("XDG_DATA_HOME").ok();
 
-  // (1) `GWM_HISTORY_FILE` wins when set and non-empty.
-  std::env::set_var("GWM_HISTORY_FILE", "/tmp/explicit-gwm-history.toml");
+  // SAFETY: env mutation is guarded by `env_lock()` above, so no
+  // other test in this binary is mutating env concurrently. We
+  // restore the prior values before dropping the lock to keep the
+  // harness consistent for any later test.
+  unsafe {
+    // (1) `GWM_HISTORY_FILE` wins when set and non-empty.
+    std::env::set_var("GWM_HISTORY_FILE", "/tmp/explicit-gwm-history.toml");
+  }
   let path = history::default_journal_path().unwrap();
   assert_eq!(path, PathBuf::from("/tmp/explicit-gwm-history.toml"));
 
   // (2) Falls back to `$XDG_DATA_HOME/gwm/history.toml` when the override
   // is unset.
   let tmp = TempDir::new().unwrap();
-  std::env::remove_var("GWM_HISTORY_FILE");
-  std::env::set_var("XDG_DATA_HOME", tmp.path());
+  unsafe {
+    std::env::remove_var("GWM_HISTORY_FILE");
+    std::env::set_var("XDG_DATA_HOME", tmp.path());
+  }
   let path = history::default_journal_path().unwrap();
   assert_eq!(path, tmp.path().join("gwm").join("history.toml"));
 
-  // Restore the original env so unrelated tests in the same process
-  // aren't affected.
-  match prev_history {
-    Some(v) => std::env::set_var("GWM_HISTORY_FILE", v),
-    None => std::env::remove_var("GWM_HISTORY_FILE"),
-  }
-  match prev_xdg {
-    Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-    None => std::env::remove_var("XDG_DATA_HOME"),
+  // SAFETY: restoration step paired with the set/remove_var above,
+  // still under the env_lock guard.
+  unsafe {
+    match prev_history {
+      Some(v) => std::env::set_var("GWM_HISTORY_FILE", v),
+      None => std::env::remove_var("GWM_HISTORY_FILE"),
+    }
+    match prev_xdg {
+      Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+      None => std::env::remove_var("XDG_DATA_HOME"),
+    }
   }
 }

--- a/tests/history_tests.rs
+++ b/tests/history_tests.rs
@@ -17,13 +17,13 @@
 
 use chrono::{Duration, Utc};
 use gwm::history::{self, OpEntry, OpKind};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 /// Build a synthetic [`OpEntry`] for the given suffix. Timestamps
 /// default to `now()`; callers that need ordering override after the
 /// fact.
-fn entry(suffix: &str, repo_root: &PathBuf) -> OpEntry {
+fn entry(suffix: &str, repo_root: &Path) -> OpEntry {
   OpEntry {
     ts: Utc::now(),
     kind: OpKind::Remove,
@@ -32,7 +32,7 @@ fn entry(suffix: &str, repo_root: &PathBuf) -> OpEntry {
     branch_oid: Some("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678".into()),
     path: PathBuf::from(format!("/tmp/cc-worktree/feat-{}-foo", suffix)),
     deleted_branch: false,
-    repo_root: repo_root.clone(),
+    repo_root: repo_root.to_path_buf(),
     undone: false,
   }
 }
@@ -198,26 +198,49 @@ fn pop_last_for_repo_removes_and_returns_entry() {
 }
 
 #[test]
-fn default_path_honours_gwm_history_file_env() {
-  // The override env var `GWM_HISTORY_FILE` mirrors `GWM_TRUST_LEDGER`
-  // in shape: when set and non-empty, it takes precedence over the
-  // XDG fallback. Pin it so tests can isolate from the user's home.
+fn default_path_resolution_order() {
+  // Combined into one test because `std::env::set_var` is process-global
+  // and parallel tests would race. Cargo runs each `#[test]` on a
+  // separate thread but in the same process, so two env-mutating tests
+  // would flake without serialisation. Folding the two cases into one
+  // sequential test makes the resolution-order contract testable without
+  // pulling in `serial_test` for one assertion.
+  //
+  // Resolution order under test:
+  //   1. `GWM_HISTORY_FILE` (testability hook + power-user override).
+  //   2. `XDG_DATA_HOME/gwm/history.toml`.
+  //
+  // The third fallback (`dirs::data_dir()`) depends on the platform
+  // home dir lookup and isn't safe to override mid-test — we trust the
+  // `dirs` crate for that one.
+
+  // Snapshot whatever the runner's env looked like so we restore it
+  // verbatim afterwards (CI runners can have either, neither, or both
+  // set; PR #43 hit a CI flake from a similar oversight in trust tests).
+  let prev_history = std::env::var("GWM_HISTORY_FILE").ok();
+  let prev_xdg = std::env::var("XDG_DATA_HOME").ok();
+
+  // (1) `GWM_HISTORY_FILE` wins when set and non-empty.
   std::env::set_var("GWM_HISTORY_FILE", "/tmp/explicit-gwm-history.toml");
   let path = history::default_journal_path().unwrap();
   assert_eq!(path, PathBuf::from("/tmp/explicit-gwm-history.toml"));
-  std::env::remove_var("GWM_HISTORY_FILE");
-}
 
-#[test]
-fn default_path_falls_back_to_xdg_data_home() {
-  // Without the override, the journal lives under
-  // `$XDG_DATA_HOME/gwm/history.toml`. We isolate via a per-test
-  // tempdir so this doesn't depend on the actual user's
-  // `$XDG_DATA_HOME` value.
+  // (2) Falls back to `$XDG_DATA_HOME/gwm/history.toml` when the override
+  // is unset.
   let tmp = TempDir::new().unwrap();
   std::env::remove_var("GWM_HISTORY_FILE");
   std::env::set_var("XDG_DATA_HOME", tmp.path());
   let path = history::default_journal_path().unwrap();
   assert_eq!(path, tmp.path().join("gwm").join("history.toml"));
-  std::env::remove_var("XDG_DATA_HOME");
+
+  // Restore the original env so unrelated tests in the same process
+  // aren't affected.
+  match prev_history {
+    Some(v) => std::env::set_var("GWM_HISTORY_FILE", v),
+    None => std::env::remove_var("GWM_HISTORY_FILE"),
+  }
+  match prev_xdg {
+    Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+    None => std::env::remove_var("XDG_DATA_HOME"),
+  }
 }

--- a/tests/history_tests.rs
+++ b/tests/history_tests.rs
@@ -1,0 +1,223 @@
+//! Tests for the operation journal (`src/history.rs`). Issue #29.
+//!
+//! The journal records destructive operations (`gwm remove`) so they
+//! can be undone via `gwm undo`. The contract is intentionally narrow:
+//!
+//! - Append a new entry to `$XDG_DATA_HOME/gwm/history.toml` (or
+//!   `~/.local/share/gwm/history.toml` fallback). Override via
+//!   `GWM_HISTORY_FILE` env var (the testability hook).
+//! - Read the most-recent-N entries.
+//! - Rotate at a cap of 100 entries — drop the oldest on append.
+//! - Per-repo filtering: each entry records the `repo_root` of the
+//!   worktree it operated on, so `gwm undo` only resurfaces the
+//!   current repo's history.
+//!
+//! These tests pin the IO contract before any production code lands —
+//! TDD-strict per CLAUDE.md.
+
+use chrono::{Duration, Utc};
+use gwm::history::{self, OpEntry, OpKind};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Build a synthetic [`OpEntry`] for the given suffix. Timestamps
+/// default to `now()`; callers that need ordering override after the
+/// fact.
+fn entry(suffix: &str, repo_root: &PathBuf) -> OpEntry {
+  OpEntry {
+    ts: Utc::now(),
+    kind: OpKind::Remove,
+    worktree: format!("feat-{}-foo", suffix),
+    branch: Some(format!("feat/#{}-foo", suffix)),
+    branch_oid: Some("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678".into()),
+    path: PathBuf::from(format!("/tmp/cc-worktree/feat-{}-foo", suffix)),
+    deleted_branch: false,
+    repo_root: repo_root.clone(),
+    undone: false,
+  }
+}
+
+#[test]
+fn load_returns_empty_on_missing_file() {
+  // Fresh install — no `~/.local/share/gwm/history.toml` exists.
+  // `load` must return an empty journal, NOT propagate a NotFound
+  // error: the first ever invocation of `gwm history` must succeed
+  // cleanly with "0 ops recorded".
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let journal = history::Journal::load(&path).unwrap();
+  assert!(journal.entries().is_empty());
+}
+
+#[test]
+fn append_then_load_roundtrips_entry() {
+  // Append an entry, persist to disk, reload. The reloaded journal
+  // must contain the exact same entry — TOML round-trip is the IO
+  // backbone of the whole feature.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo = tmp.path().join("repo");
+
+  let mut journal = history::Journal::load(&path).unwrap();
+  let original = entry("99", &repo);
+  journal.append(original.clone());
+  journal.save(&path).unwrap();
+
+  let reloaded = history::Journal::load(&path).unwrap();
+  let entries = reloaded.entries();
+  assert_eq!(entries.len(), 1);
+  assert_eq!(entries[0].worktree, original.worktree);
+  assert_eq!(entries[0].branch, original.branch);
+  assert_eq!(entries[0].branch_oid, original.branch_oid);
+  assert_eq!(entries[0].path, original.path);
+  assert_eq!(entries[0].deleted_branch, original.deleted_branch);
+  assert_eq!(entries[0].repo_root, original.repo_root);
+}
+
+#[test]
+fn rotation_caps_at_one_hundred_entries() {
+  // Cap is 100 entries TOTAL across all repos. On append #101, drop
+  // the oldest. This pins the rotation contract — the journal must
+  // not grow unbounded.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo = tmp.path().join("repo");
+
+  let mut journal = history::Journal::default();
+  // Seed 101 entries with monotonic timestamps (oldest first).
+  let base = Utc::now() - Duration::days(200);
+  for i in 0..101 {
+    let mut e = entry(&format!("{}", i), &repo);
+    e.ts = base + Duration::minutes(i as i64);
+    journal.append(e);
+  }
+  journal.save(&path).unwrap();
+
+  let reloaded = history::Journal::load(&path).unwrap();
+  let entries = reloaded.entries();
+  assert_eq!(entries.len(), 100, "journal must cap at 100 entries");
+  // The dropped entry is the oldest one (worktree feat-0-foo).
+  assert!(
+    !entries.iter().any(|e| e.worktree == "feat-0-foo"),
+    "oldest entry must be dropped on rotation"
+  );
+  // The newest entry survives.
+  assert!(entries.iter().any(|e| e.worktree == "feat-100-foo"));
+}
+
+#[test]
+fn entries_for_repo_filters_by_repo_root() {
+  // The journal is global (one file across all repos). `entries_for_repo`
+  // must return only the ops whose `repo_root` matches verbatim — that
+  // is the per-repo separation `gwm undo` and `gwm history` rely on so
+  // an `undo` in repo A cannot resurrect a worktree from repo B.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo_a = tmp.path().join("repo-a");
+  let repo_b = tmp.path().join("repo-b");
+
+  let mut journal = history::Journal::default();
+  journal.append(entry("1", &repo_a));
+  journal.append(entry("2", &repo_b));
+  journal.append(entry("3", &repo_a));
+  journal.save(&path).unwrap();
+
+  let reloaded = history::Journal::load(&path).unwrap();
+  let only_a: Vec<&OpEntry> = reloaded.entries_for_repo(&repo_a).collect();
+  assert_eq!(only_a.len(), 2);
+  assert!(only_a.iter().all(|e| e.repo_root == repo_a));
+
+  let only_b: Vec<&OpEntry> = reloaded.entries_for_repo(&repo_b).collect();
+  assert_eq!(only_b.len(), 1);
+  assert_eq!(only_b[0].repo_root, repo_b);
+}
+
+#[test]
+fn last_for_repo_returns_most_recent_entry() {
+  // `gwm undo` pulls the *most recent* op for the current repo. Pin
+  // the ordering contract: entries are listed newest-first via
+  // `last_for_repo` regardless of insertion order.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo = tmp.path().join("repo");
+
+  let mut journal = history::Journal::default();
+  let base = Utc::now();
+  let mut e1 = entry("old", &repo);
+  e1.ts = base - Duration::hours(2);
+  let mut e2 = entry("new", &repo);
+  e2.ts = base - Duration::minutes(1);
+  // Insert in non-monotonic order to make sure the lookup is
+  // timestamp-driven, not insertion-driven.
+  journal.append(e2.clone());
+  journal.append(e1);
+  journal.save(&path).unwrap();
+
+  let reloaded = history::Journal::load(&path).unwrap();
+  let last = reloaded.last_for_repo(&repo).expect("must find latest op");
+  assert_eq!(last.worktree, "feat-new-foo");
+}
+
+#[test]
+fn last_for_repo_returns_none_for_unknown_repo() {
+  // If no ops have been recorded for the current repo, `last_for_repo`
+  // returns `None` — `gwm undo` then prints "nothing to undo" rather
+  // than crashing.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo_a = tmp.path().join("repo-a");
+  let repo_b = tmp.path().join("repo-b");
+
+  let mut journal = history::Journal::default();
+  journal.append(entry("1", &repo_a));
+  journal.save(&path).unwrap();
+
+  let reloaded = history::Journal::load(&path).unwrap();
+  assert!(reloaded.last_for_repo(&repo_b).is_none());
+}
+
+#[test]
+fn pop_last_for_repo_removes_and_returns_entry() {
+  // After a successful undo, `gwm undo` needs to drop the entry so a
+  // second `undo` resurfaces the previous op instead of replaying the
+  // same one. `pop_last_for_repo` must atomically return-and-remove
+  // the newest entry for the repo.
+  let tmp = TempDir::new().unwrap();
+  let path = tmp.path().join("history.toml");
+  let repo = tmp.path().join("repo");
+
+  let mut journal = history::Journal::default();
+  journal.append(entry("1", &repo));
+  journal.append(entry("2", &repo));
+  journal.save(&path).unwrap();
+
+  let mut reloaded = history::Journal::load(&path).unwrap();
+  let popped = reloaded.pop_last_for_repo(&repo).expect("must pop");
+  assert_eq!(popped.worktree, "feat-2-foo");
+  assert_eq!(reloaded.entries_for_repo(&repo).count(), 1);
+}
+
+#[test]
+fn default_path_honours_gwm_history_file_env() {
+  // The override env var `GWM_HISTORY_FILE` mirrors `GWM_TRUST_LEDGER`
+  // in shape: when set and non-empty, it takes precedence over the
+  // XDG fallback. Pin it so tests can isolate from the user's home.
+  std::env::set_var("GWM_HISTORY_FILE", "/tmp/explicit-gwm-history.toml");
+  let path = history::default_journal_path().unwrap();
+  assert_eq!(path, PathBuf::from("/tmp/explicit-gwm-history.toml"));
+  std::env::remove_var("GWM_HISTORY_FILE");
+}
+
+#[test]
+fn default_path_falls_back_to_xdg_data_home() {
+  // Without the override, the journal lives under
+  // `$XDG_DATA_HOME/gwm/history.toml`. We isolate via a per-test
+  // tempdir so this doesn't depend on the actual user's
+  // `$XDG_DATA_HOME` value.
+  let tmp = TempDir::new().unwrap();
+  std::env::remove_var("GWM_HISTORY_FILE");
+  std::env::set_var("XDG_DATA_HOME", tmp.path());
+  let path = history::default_journal_path().unwrap();
+  assert_eq!(path, tmp.path().join("gwm").join("history.toml"));
+  std::env::remove_var("XDG_DATA_HOME");
+}


### PR DESCRIPTION
## Description

Implements [issue #29](https://github.com/kbrdn1/gwm-cli/issues/29):
a tiny operation journal that lets `gwm undo` recover from a stray
`gwm remove` (with or without `--delete-branch`) without `git
reflog` archaeology, plus `gwm history` for inspection.

Closes #29

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- New `src/history.rs` module: `Journal` (load / append / save /
  rotate at 100 entries) + `OpEntry` + `default_journal_path()`
  (resolution order: `$GWM_HISTORY_FILE` → `$XDG_DATA_HOME/gwm/
  history.toml` → `dirs::data_dir()/gwm/...`). Atomic save via
  the same tempfile-rename primitive `trust::TrustLedger::save`
  uses.
- New `gwm history [--limit N] [--all]` subcommand. Default
  `--limit` is 20; filters to the current repo's canonicalised
  workdir by default, `--all` opts out for forensic /
  multi-repo grep. Empty result prints `no operations
  recorded` (stable scripted signal). Newest-first sort.
- New `gwm undo [--bootstrap]` subcommand. Pops the most
  recent op for the current repo, recreates `refs/heads/
  <branch>` at the saved OID via `Repository::reference`,
  re-adds the worktree at the saved path with `reuse_branch:
  true`. The `--bootstrap` flag opts into re-running the
  per-worktree bootstrap (off by default — undo stays
  cheap). The journal entry is consumed only AFTER a
  successful resurrection so a mid-flight failure keeps the
  recovery anchor intact.
- Hook in `cmd_remove`: captures `branch_oid` via libgit2
  BEFORE the destructive call, writes the journal entry,
  then runs the destruction. Fires only on the destructive
  path — `--dry-run` short-circuits before reaching the
  hook so a preview cannot pollute the journal. Journal IO
  failures are logged to stderr but NEVER block the remove.
- `help_prints_subcommands` updated to assert both new
  subcommands appear in `gwm --help` (the canary contract
  per `CLAUDE.md`).
- `CHANGELOG.md` entry under `[Unreleased] / Added`.

## Tests

- [x] `cargo test` passes locally (838 passed, 0 failed)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`:
  - `tests/history_tests.rs`: 8 unit tests pinning the
    journal IO contract (round-trip, rotation cap, per-repo
    filter, last/pop helpers, env-based path resolution).
  - `tests/cli_binary.rs`: 8 new E2E tests pinning the
    `gwm history`, `gwm undo`, and `gwm remove`-hook
    contracts (empty journal, single-op listing, per-repo
    filter, `--all` opt-out, undo round-trip, undo on empty
    journal, hook on destructive remove, no-hook on
    dry-run).
- Pre-validated under a stripped PATH (`PATH=\"\$(dirname \$(command -v cargo)\):/usr/bin:/bin\"`)
  per `CLAUDE.md` — every env-sensitive test isolates via
  `GWM_HISTORY_FILE` and a `tempfile::TempDir`.

## Design decisions

- **Rotation is global, not per-repo.** Keeps the
  bookkeeping trivial (one cap to enforce on every
  append). A heavy user juggling 30 repos still gets a
  bounded ledger; the per-repo separation is enforced at
  READ time via `entries_for_repo`, not at write time.
- **Hook only on `remove` today.** The `OpKind` enum
  reserves a `Create` variant for a future extension that
  would let `gwm undo` also roll back accidental worktree
  creations, but wiring it in this PR would mean two more
  destructive surfaces to design (does undo of \`create\`
  delete the dir? what about uncommitted work?). Out of
  scope for #29; can land as a follow-up if real usage
  justifies it.
- **`--bootstrap` opt-in on undo.** Per the issue's design
  notes: bootstrap can be expensive and the user often
  just wants the directory back. The opt-in keeps the
  default path fast and predictable.
- **Atomic resurrect-then-persist.** `Journal::save` runs
  only after both branch + worktree are back. A mid-flight
  failure leaves the entry intact so the user can retry
  (idempotent against the "branch already exists" path).
- **`eprintln!` on journal IO failure, never block.** The
  destruction is what the user typed; losing recoverability
  is unfortunate, blocking the remove because we couldn't
  write `~/.local/share/gwm/history.toml` (disk full,
  read-only FS, sandboxed CI runner) would be far more
  surprising.

## Smoke verification

```bash
$ gwm history
no operations recorded

$ gwm undo
error: nothing to undo for /Users/kbrdn1/Projects/Perso/gwm-cli — the journal is empty for this repo

$ gwm --help
...
  history        List the recent destructive operations recorded by `gwm` (issue #29)...
  undo           Undo the most recent destructive operation recorded for the current repo...
```

Full create → remove → undo round-trip is covered by
`undo_recreates_branch_and_worktree_after_remove` in
`tests/cli_binary.rs`.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths (only in test
      helpers / genuinely-infallible call sites)
- [x] No `println!` in TUI render code (journal writes
      happen at the CLI layer; `worktree::remove` is
      untouched and the warning goes through `eprintln!`
      at the CLI side)

## Linked issues / docs

- Issue: #29
- Related: #31 (`--dry-run` flag whose gate this PR honours)

## Notes for reviewers

- The TDD pair pattern is strict: every commit alternates
  RED (test pinning behaviour, builds-but-fails) and
  GREEN (minimal production code to flip the test green).
  The 8 commits are atomic and reversible.
- Per-repo separation is enforced via canonicalised
  `repo_root` paths — important on macOS where `/var` and
  `/private/var` are the same inode but compare unequal as
  strings.
- Follow-up ideas (filed only if reviewers see real
  scope): hooking `gwm create` into the journal so undo
  can also roll back accidental creations; recording a
  `bootstrap_fingerprint` so `--bootstrap` knows whether
  the prior bootstrap report would still apply.