### PR TITLE
🏗️ build: cut v0.8.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,109 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **`gwm undo` + `gwm history` + operation journal**
-  ([#29](https://github.com/kbrdn1/gwm-cli/issues/29)). Recover from
-  a misfired `gwm remove` without `git reflog` archaeology.
-  - **Operation journal**: every destructive op (`gwm remove`,
-    with or without `--delete-branch`) appends an entry to
-    `$XDG_DATA_HOME/gwm/history.toml` (override via
-    `$GWM_HISTORY_FILE`; macOS fallback under `Application
-    Support`, Windows under `%LOCALAPPDATA%`). Each entry
-    captures the timestamp, worktree name, branch name,
-    branch OID at deletion time, on-disk path, the
-    `--delete-branch` flag, and the canonicalised
-    `repo_root` so per-repo separation works across symlink
-    chains.
-  - **Rotation cap**: 100 entries max across the whole
-    journal; oldest-by-timestamp dropped on overflow.
-  - **`gwm undo [--bootstrap]`**: pops the most recent op for
-    the current repo, recreates `refs/heads/<branch>` at the
-    saved OID via `Repository::reference`, re-adds the
-    worktree at the saved path with `reuse_branch: true`. The
-    `--bootstrap` flag opts into re-running the per-worktree
-    bootstrap (off by default to keep undo cheap). The
-    journal entry is consumed only after a successful
-    resurrection — a mid-flight failure keeps the recovery
-    anchor intact.
-  - **`gwm history [--limit N] [--all]`**: lists the recent
-    ops newest-first. Default `--limit` is 20. By default
-    filters to the current repo's canonicalised workdir;
-    `--all` surfaces every entry across every repo for
-    forensic / multi-repo grep. Empty result prints `no
-    operations recorded` as a stable scripted signal.
-  - `gwm remove --dry-run` does NOT write to the journal —
-    previewing a destruction must never allow "undoing"
-    something that never happened.
-  - Journal IO failures are logged to stderr but never block
-    the destructive op: failing a remove because we couldn't
-    write `~/.local/share/gwm/history.toml` (disk full,
-    read-only FS, sandboxed CI runner) would be more
-    surprising than losing recoverability.
-- **`--dry-run` flag on `gwm remove` and `gwm prune`**
-  ([#31](https://github.com/kbrdn1/gwm-cli/issues/31)). Preview
-  destructive operations before running them.
-  - `gwm prune --dry-run` walks the worktree list, prints every
-    prunable entry (name + path + reason), and exits 0 without
-    touching the admin files. Empty case reports `0 worktree(s) to
-    prune` so scripted callers get a stable signal. Output is sorted
-    by name for deterministic stdout diffing.
-  - `gwm remove <pattern> --dry-run` resolves the fuzzy pattern,
-    prints the would-remove plan (name + path + branch, with
-    `(would be deleted)` next to the branch when `--delete-branch` is
-    also passed), and exits 0. An ambiguous pattern fires the same
-    non-zero candidate-list error as the destructive form —
-    `--dry-run` only suppresses destruction, not resolution failures.
-  - No breaking change: existing call sites without `--dry-run` keep
-    the destructive default.
-- **CLI aliases (`[aliases]` in `.gwm.toml` + user-level fallback)**
-  ([#86](https://github.com/kbrdn1/gwm-cli/issues/86)). `git config`
-  ships with `[alias]`; `gwm` now mirrors the shape. Declare an
-  alias under `[aliases]` in `.gwm.toml` (repo-level, follows the
-  repo across machines) or in `~/.config/gwm/aliases.toml`
-  (user-level fallback). `gwm <alias>` is expanded to argv tokens
-  BEFORE clap parses, so `wip = "create feat 0 wip"` makes `gwm
-  wip` behave as `gwm create feat 0 wip`. Resolution order:
-  built-in subcommands always win (`gwm list` can never be
-  shadowed), then repo, then user. Shell pipelines (`&&`, `|`,
-  `;`, backticks) in alias values are refused at load time — use a
-  shell alias for shell semantics. New `gwm aliases list`
-  subcommand prints the resolved chain grouped by source, with
-  shadowed user entries flagged inline.
-- **Gitmoji mapping + `gwm commit-prefix` + opt-in `commit-msg` hook**
-  (issue #85). The repo's Gitmoji + Conventional Commits convention is
-  now first-class. Three new surfaces:
-  - `gwm commit-prefix [--branch <name>] [--unicode]` prints the
-    canonical commit prefix (e.g. `:sparkles: feat(#41):` or
-    `✨ feat(#41):`) — handy for shell prompts, AI assistants, and
-    scripted commit composition.
-  - `gwm types --gitmoji` extends the existing branch-type list with
-    two more columns (unicode emoji + `:shortcode:`).
-  - `gwm hooks install commit-msg [--force]` installs an opt-in
-    `.git/hooks/commit-msg` that auto-prepends the resolved prefix
-    when the user's commit message doesn't already start with one.
-    Non-destructive by default (refuses to overwrite a pre-existing
-    hook without `--force`).
-- New `[gitmoji]` block in `.gwm.toml` lets teams override individual
-  shortcodes without redeclaring the whole table (the ten built-in
-  defaults are baked into the binary). Custom branch types are
-  supported — `migration = ":truck:"` round-trips through `gwm types
-  --gitmoji`.
-- Under `--unicode`, `gwm commit-prefix` and the unicode column of
-  `gwm types --gitmoji` now normalise known `:shortcode:` overrides
-  (e.g. `feat = ":rocket:"` → `🚀 feat(#1):` instead of
-  `:rocket: feat(#1):`). The known-shortcode set extends to the most
-  commonly-swapped Gitmoji entries (`:rocket:`, `:fire:`, `:lock:`,
-  `:art:`, `:lipstick:`, `:hammer:`, `:bookmark:`, …). Unknown
-  shortcodes fall through verbatim — no panic, no substitution.
-  (#85)
-
-### Fixed
-
-- Pre-release publishing now fails before upload when root `[Unreleased]` repeats bullets or issue references already shipped in the immediately previous RC notes. (#147)
-- Stable GitHub Releases now publish through the GitHub CLI with the workflow token and clobberable asset uploads, avoiding the `softprops/action-gh-release` bad-credentials failure seen on v0.7.0. (#146)
-- CI now runs the main cargo build/test matrix on `windows-latest`, exercising Windows-only path validation coverage. (#112)
+_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
 
 ## Past releases
 
@@ -130,6 +28,7 @@ In reverse chronological order:
 
 Per-RC notes covering only the delta against the previous RC (or against the previous stable, for `rc.1`):
 
+- [`0.8.0-rc.2`](changelogs/pre-releases/0.8.0-rc.2.md) — 2026-05-23
 - [`0.8.0-rc.1`](changelogs/pre-releases/0.8.0-rc.1.md) — 2026-05-23
 - [`0.7.0-rc.3`](changelogs/pre-releases/0.7.0-rc.3.md) — 2026-05-23
 - [`0.7.0-rc.2`](changelogs/pre-releases/0.7.0-rc.2.md) — 2026-05-23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwm"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,9 @@ For reference (each linked to its closing PR):
 | [#138](https://github.com/kbrdn1/gwm-cli/issues/138) | v0.7.0-rc.3 | `GitHubFetch` cache keyed by issue/PR number; late results dropped after `invalidate()` |
 | [#131](https://github.com/kbrdn1/gwm-cli/pull/131) / [#134](https://github.com/kbrdn1/gwm-cli/pull/134) | v0.7.0-rc.3 | TUI state encapsulation polish for `ConfirmModal` and `FilterState` |
 | [#107](https://github.com/kbrdn1/gwm-cli/issues/107) / [#108](https://github.com/kbrdn1/gwm-cli/issues/108) | v0.7.0 | Measured P3 TUI sidebar perf: cached libgit2 Recent Commits and `Oid` commit graph pipes |
+| [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) | v0.8.0-rc.1 | Release hardening: `gh`-CLI publish + workflow token, pre-release `[Unreleased]` dupe guard, Windows in the test matrix |
+| [#86](https://github.com/kbrdn1/gwm-cli/issues/86) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) | v0.8.0-rc.1 | CLI aliases (`[aliases]` in `.gwm.toml` + user fallback, pre-clap expansion), gitmoji mapping + `gwm commit-prefix` + opt-in `commit-msg` hook |
+| [#31](https://github.com/kbrdn1/gwm-cli/issues/31) / [#29](https://github.com/kbrdn1/gwm-cli/issues/29) | v0.8.0-rc.2 | Safety daily: `--dry-run` on `gwm remove` / `gwm prune`, `gwm undo` + `gwm history` operation journal at `$XDG_DATA_HOME/gwm/history.toml` |
 
 If an issue still shows `open` on GitHub even though its work shipped, it's a tracking issue waiting for a follow-up audit — check the CHANGELOG and the linked PR before reopening scope work on it.
 
@@ -73,24 +76,10 @@ Small, well-scoped items with high daily-usage payoff. Likely picks for the next
 
 - [#24](https://github.com/kbrdn1/gwm-cli/issues/24) — **`gwm sync`** — fetch + rebase (or merge) the selected worktree's branch against its upstream, with conflict detection.
 - [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive instead of compiling from source.
-- [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — **`--dry-run` on `gwm remove` and `gwm prune`** — show the resolved target / planned actions, no side effects. Pairs nicely with the safety stance of [#29](https://github.com/kbrdn1/gwm-cli/issues/29) below.
-- [#86](https://github.com/kbrdn1/gwm-cli/issues/86) — **`[aliases]` in `.gwm.toml`** — git-config-style aliases (`wip = "create feat 0 wip"`, `ll = "list --format names"`), plus a user-level `~/.config/gwm/aliases.toml` fallback. Lowest-cost item on the configurability axis (pre-clap argv expansion).
-
-## Release hardening
-
-The stable v0.7.0 release was successful, but three gaps should be closed before the next tag — two release-process gaps and one CI-coverage blind spot.
-
-- [#146](https://github.com/kbrdn1/gwm-cli/issues/146) — **Make `release.yml` publish reliably**. Replace or fix the failing `softprops/action-gh-release@v3` publish step so stable releases do not need manual recovery.
-- [#147](https://github.com/kbrdn1/gwm-cli/issues/147) — **Guard pre-release changelog hygiene**. Compare root `[Unreleased]` against the previous RC changelog and fail on duplicate issue/PR references or repeated bullets.
-- [#112](https://github.com/kbrdn1/gwm-cli/issues/112) — **Add Windows CI coverage**. This closes a platform-specific blind spot in the path traversal hardening tests.
 
 ## Configurability
 
 A coherent batch of items that move hardcoded conventions and one-off shell scripts into `.gwm.toml`. Theme: every team-portable convention should live in the config that's already checked in, not in tribal knowledge.
-
-### Repo conventions
-
-- [#85](https://github.com/kbrdn1/gwm-cli/issues/85) — **`[gitmoji]` mapping** — `branch_type → emoji` table with sensible defaults; new `gwm commit-prefix` subcommand prints the resolved prefix for the current branch; opt-in `commit-msg` hook auto-prepends it. Pairs naturally with `[[branch_types]]`.
 
 ### GitHub publish (declarative repo state)
 
@@ -102,12 +91,6 @@ A coherent batch of items that move hardcoded conventions and one-off shell scri
 - [#88](https://github.com/kbrdn1/gwm-cli/issues/88) — **`[hooks.*]` lifecycle hooks** — six phases (`pre_create`, `post_create`, `pre_bootstrap`, `post_bootstrap`, `pre_remove`, `post_remove`) with `on_fail = "abort" | "warn" | "ignore"`. Existing `[[bootstrap.command]]` aliased to `[[hooks.post_create]]` for compat.
 - [#89](https://github.com/kbrdn1/gwm-cli/issues/89) — **`gwm config get/set/list/validate/path/edit`** — git-config-style CLI over `.gwm.toml` with `toml_edit` for comment-preserving round-tripping. Includes dot-path notation (`worktree.base`) and array-table indexing (`labels[+].name = "bug"`).
 - [#87](https://github.com/kbrdn1/gwm-cli/issues/87) — **`[tui.keys]` keymap** — remap any TUI action through `.gwm.toml`, chord support (`g g`), with `gwm tui keys` introspection. Sits alongside themes (#33) and command palette (#32) as the "TUI personalisation" trio.
-
-## Safety & UX
-
-Defensive features for a tool that performs destructive operations.
-
-- [#29](https://github.com/kbrdn1/gwm-cli/issues/29) — **`gwm undo` + `gwm history`** — operation journal at `$XDG_DATA_HOME/gwm/history.toml` with branch-OID recovery so a fat-finger `gwm remove --delete-branch` is recoverable beyond `git reflog`.
 
 ## TUI polish
 

--- a/changelogs/pre-releases/0.8.0-rc.2.md
+++ b/changelogs/pre-releases/0.8.0-rc.2.md
@@ -1,0 +1,33 @@
+# [0.8.0-rc.2] - 2026-05-23
+
+Delta against v0.8.0-rc.1. Merged PRs: #153, #154, #155.
+
+Second RC of the 0.8.0 series. Ships the **Safety daily** tranche — preview before you destroy, then `gwm undo` if you destroy anyway — plus the codified v0.7.0 retrospective in `CLAUDE.md` and a sibling `AGENTS.md` mirror.
+
+### Added
+
+- **`--dry-run` flag on `gwm remove` and `gwm prune`** ([#31](https://github.com/kbrdn1/gwm-cli/issues/31) / [#154](https://github.com/kbrdn1/gwm-cli/pull/154)). Preview destructive operations before running them.
+  - `gwm prune --dry-run` walks the worktree list, prints every prunable entry (name + path + reason), and exits 0 without touching the admin files. Empty case reports `0 worktree(s) to prune` so scripted callers get a stable signal. Output is sorted by name for deterministic stdout diffing.
+  - `gwm remove <pattern> --dry-run` resolves the fuzzy pattern, prints the would-remove plan (name + path + branch, with `(would be deleted)` next to the branch when `--delete-branch` is also passed), and exits 0. An ambiguous pattern fires the same non-zero candidate-list error as the destructive form — `--dry-run` only suppresses destruction, not resolution failures.
+  - Detached HEAD worktree edge case: combining `--dry-run --delete-branch` on a worktree with no resolvable branch now prints `branch: - (no branch to delete)` instead of the misleading `(would be deleted)` rider, mirroring `worktree::remove`'s actual behaviour (it only drops a branch when one is resolvable).
+  - Column widths in the prune plan are computed in Unicode characters (`.chars().count()`), not bytes, so non-ASCII worktree names or paths stay aligned in a fixed-width terminal.
+  - `worktree::prune` now consumes `worktree::prunable_worktrees` (the same scanner that backs `--dry-run`), so the preview and the destructive pass can never drift on what "prunable" means.
+  - No breaking change: existing call sites without `--dry-run` keep the destructive default.
+- **`gwm undo` + `gwm history` + operation journal** ([#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#155](https://github.com/kbrdn1/gwm-cli/pull/155)). Recover from a misfired `gwm remove` without `git reflog` archaeology.
+  - **Operation journal**: every destructive op (`gwm remove`, with or without `--delete-branch`) appends an entry to `$XDG_DATA_HOME/gwm/history.toml` (override via `$GWM_HISTORY_FILE`; macOS fallback under `Application Support`, Windows under `%LOCALAPPDATA%`). Each entry captures the timestamp, worktree name, branch name, branch OID at deletion time, on-disk path, the `--delete-branch` flag, and the canonicalised `repo_root` so per-repo separation works across symlink chains.
+  - **Rotation cap**: 100 entries max across the whole journal; oldest-by-timestamp dropped on overflow.
+  - **`gwm undo [--bootstrap]`**: pops the most recent op for the current repo, recreates `refs/heads/<branch>` at the saved OID via `Repository::reference`, re-adds the worktree at the saved path with `reuse_branch: true`. The `--bootstrap` flag opts into re-running the per-worktree bootstrap (off by default to keep undo cheap). The journal entry is consumed only after a successful resurrection — a mid-flight failure keeps the recovery anchor intact. Detached-HEAD entries are refused with an explicit error rather than silently doing nothing.
+  - **`gwm history [--limit N] [--all]`**: lists the recent ops newest-first. Default `--limit` is 20. By default filters to the current repo's canonicalised workdir; `--all` surfaces every entry across every repo for forensic / multi-repo grep. Empty result prints `no operations recorded` as a stable scripted signal. `--limit 0` keeps the count line distinct from an empty journal so scripts can tell "I asked for nothing" from "there is nothing".
+  - `gwm remove --dry-run` does NOT write to the journal — previewing a destruction must never allow "undoing" something that never happened.
+  - Journal IO failures are logged to stderr but never block the destructive op: failing a remove because we couldn't write `~/.local/share/gwm/history.toml` (disk full, read-only FS, sandboxed CI runner) would be more surprising than losing recoverability.
+
+### Docs
+
+- **Codify v0.7.0 retrospective rules + AGENTS.md mirror** ([#153](https://github.com/kbrdn1/gwm-cli/pull/153)). Seven recurring patterns from the v0.7.0 post-mortems land in `CLAUDE.md`: stack depth (max 2-3 PRs), encapsulation-nit batching after a stack merges, parallel-agent ownership rule (only when file ownership is disjoint), follow-up issues beating scope creep, MSRV verification against the whole codebase, root CHANGELOG hygiene against rc duplicates, and the release-workflow credentials proof. `AGENTS.md` is added as a sibling mirror so the same house rules apply whether Claude Code or Codex is driving. `ROADMAP.md` Current state bumps to v0.7.0, and `.gitignore` picks up `.claude/` and `.serena/`.
+
+### Tests
+
+- ✅ 7 new unit tests in `tests/cli_format_tests.rs` pinning the `format_remove_plan` / `format_prune_plan` helpers extracted in the Copilot follow-up on #154 (detached-HEAD safety, unicode column alignment).
+- ✅ 9 new E2E tests in `tests/cli_binary.rs` and 4 in `tests/worktree_integration.rs` covering `--dry-run` for both `remove` and `prune` (#154).
+- ✅ 10 new E2E tests in `tests/cli_binary.rs` and 8 new unit tests in `tests/history_tests.rs` covering the journal IO contract, `gwm history`, `gwm undo`, the `remove` journal hook, and detached-HEAD refusal (#155).
+- **840 tests total**, all green on `ubuntu-latest`, `macos-latest`, and `windows-latest`.

--- a/changelogs/pre-releases/0.8.0-rc.2.md
+++ b/changelogs/pre-releases/0.8.0-rc.2.md
@@ -30,4 +30,4 @@ Second RC of the 0.8.0 series. Ships the **Safety daily** tranche — preview be
 - ✅ 7 new unit tests in `tests/cli_format_tests.rs` pinning the `format_remove_plan` / `format_prune_plan` helpers extracted in the Copilot follow-up on #154 (detached-HEAD safety, unicode column alignment).
 - ✅ 9 new E2E tests in `tests/cli_binary.rs` and 4 in `tests/worktree_integration.rs` covering `--dry-run` for both `remove` and `prune` (#154).
 - ✅ 10 new E2E tests in `tests/cli_binary.rs` and 8 new unit tests in `tests/history_tests.rs` covering the journal IO contract, `gwm history`, `gwm undo`, the `remove` journal hook, and detached-HEAD refusal (#155).
-- **840 tests total**, all green on `ubuntu-latest`, `macos-latest`, and `windows-latest`.
+- **840 tests total** across the `cargo test` matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`) wired in `ci.yml`. Each merge into `dev` is gated on the matrix turning green; pre-release artifacts are built from the same commit by `pre-release.yml`.


### PR DESCRIPTION
## Summary

Second RC of the 0.8.0 series. Bundles the **Safety daily** tranche on top of rc.1:

- `--dry-run` on `gwm remove` / `gwm prune` (#31, PR #154)
- `gwm undo` + `gwm history` operation journal (#29, PR #155)
- Codified v0.7.0 retrospective + `AGENTS.md` mirror (PR #153)

## Changes

- `Cargo.toml`: 0.8.0-rc.1 → 0.8.0-rc.2.
- `changelogs/pre-releases/0.8.0-rc.2.md`: new per-RC delta against rc.1 (Added / Docs / Tests). The publish workflow sources its release body from this file, never from the index.
- `CHANGELOG.md`: purge `[Unreleased]` of bullets already shipped in rc.1 (#86, #85, #146, #147, #112). Merging those PRs into dev had re-introduced them via their per-PR `[Unreleased]` blocks — the exact dupe pattern the guard from #147 was built to catch. `[Unreleased]` is reset to the placeholder so the next cycle starts empty. Index gets `0.8.0-rc.2` above `0.8.0-rc.1`.
- `ROADMAP.md`: add rc.1 + rc.2 rows to the "Shipped highlights" table; remove the now-shipped items from Quick wins (#31, #86), Release hardening (#146, #147, #112), Configurability (#85), and Safety & UX (#29).

## Reconciliation

`gh pr list --state open` → `[]`. Nothing queued for inclusion or deferral.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets -- -W clippy::incompatible_msrv` (no violation against the rust-version=1.82 floor declared in Cargo.toml)
- [x] `./.github/scripts/check-rc-changelog-dupes.sh v0.8.0-rc.2` → "CHANGELOG.md [Unreleased] has no duplicate bullets or issue refs from changelogs/pre-releases/0.8.0-rc.1.md"
- [x] `cargo test` (840 tests, all green)
- [ ] CI green on `ubuntu-latest`, `macos-latest`, `windows-latest` (auto-runs on push)

## Post-merge

Once merged into \`dev\`:

1. Tag \`v0.8.0-rc.2\` on the merge commit, push the tag.
2. \`pre-release.yml\` builds the 5-target matrix and publishes a GitHub Pre-release with \`changelogs/pre-releases/0.8.0-rc.2.md\` as the body.