### PR TITLE
✨ feat(config): add git-style config CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Added
+
+- Add `gwm config get/set/unset/list/validate/path/edit` for git-config-style `.gwm.toml` reads and comment-preserving edits.
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "which",
 ]
 
@@ -2267,6 +2268,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2716,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ git2 = { version = "0.20", default-features = false, features = ["vendored-libgi
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
+toml_edit = "0.25"
 anyhow = "1"
 thiserror = "2"
 dirs = "6"

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -20,6 +20,23 @@ gwm init
 
 Refuses to overwrite an existing `.gwm.toml`. Tweak the generated file and re-run `gwm doctor` to validate.
 
+## `gwm config`
+
+Read, edit, and validate `.gwm.toml` without opening the file by hand.
+
+```bash
+gwm config get tui.confirm_countdown_secs
+gwm config set tui.confirm_countdown_secs 5
+gwm config set 'labels[+].name=bug'
+gwm config unset review.tool
+gwm config list --prefix worktree
+gwm config validate
+vi "$(gwm config path)"
+gwm config edit
+```
+
+Keys use dot-path notation. Array tables use indexes (`labels[0].name`), and `set` also accepts `[+]` to append the next table entry. Writes use `toml_edit`, so existing comments and formatting are preserved; after every write, gwm reloads the same runtime schema used by the rest of the CLI.
+
 ## `gwm types`
 
 List the supported branch types (the `<type>` slot of `gwm create`).

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -9,6 +9,17 @@ description: Every section — worktree, bootstrap.*, git_tui, review, tui, tui.
 
 The annotated full version lives at [`examples/gwm.toml.example`](https://github.com/kbrdn1/gwm-cli/blob/main/examples/gwm.toml.example) — `gwm init` writes that file unchanged to your repo root.
 
+Use `gwm config` for scriptable reads and safe edits:
+
+```bash
+gwm config get worktree.base
+gwm config set tui.confirm_countdown_secs 5
+gwm config list --prefix review
+gwm config validate
+```
+
+`gwm config set` preserves existing comments and formatting, then validates the file against this schema before returning success.
+
 ## `[worktree]`
 
 Branch and path conventions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::bootstrap::{self, BootstrapCtx};
 use crate::config::Config;
+use crate::config_cli;
 use crate::doctor::{self, CheckStatus, DoctorCtx};
 use crate::error::{GwmError, LinkKind, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
@@ -349,6 +350,11 @@ pub enum Command {
     #[command(subcommand)]
     action: AliasesAction,
   },
+  /// Read, edit, and validate `.gwm.toml` values (issue #89).
+  Config {
+    #[command(subcommand)]
+    action: ConfigAction,
+  },
   /// List the recent destructive operations recorded by `gwm`
   /// (issue #29). One line per op, newest first, with timestamp,
   /// kind, and worktree name.
@@ -397,6 +403,40 @@ pub enum AliasesAction {
   /// declares which mapping and where they need to edit to change
   /// it.
   List,
+}
+
+/// Subcommands of `gwm config` (issue #89).
+#[derive(Debug, Subcommand)]
+pub enum ConfigAction {
+  /// Print a single value resolved from `.gwm.toml` plus defaults.
+  Get {
+    /// Dot-path key, e.g. `worktree.base` or `labels[0].name`.
+    key: String,
+  },
+  /// Set a value while preserving TOML comments and formatting.
+  Set {
+    /// Dot-path key, e.g. `tui.confirm_countdown_secs`, `labels[+].name`, or `key=value`.
+    key: String,
+    /// TOML scalar value. Bare strings are accepted for convenience.
+    value: Option<String>,
+  },
+  /// Remove a value so the runtime default applies.
+  Unset {
+    /// Dot-path key to remove.
+    key: String,
+  },
+  /// List resolved config values.
+  List {
+    /// Only print keys under this dot-path prefix.
+    #[arg(long)]
+    prefix: Option<String>,
+  },
+  /// Validate `.gwm.toml` syntax and schema.
+  Validate,
+  /// Print the resolved `.gwm.toml` path.
+  Path,
+  /// Open `.gwm.toml` in `$EDITOR`.
+  Edit,
 }
 
 /// Subcommands of `gwm hooks` (issue #85). The split anticipates
@@ -598,6 +638,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Milestones { action } => cmd_milestones(action),
     Command::Trust { action } => cmd_trust(action),
     Command::Aliases { action } => cmd_aliases(action),
+    Command::Config { action } => cmd_config(action),
     Command::History { limit, all } => cmd_history(limit, all),
     Command::Undo { bootstrap } => cmd_undo(bootstrap),
   }
@@ -1984,6 +2025,18 @@ fn print_bootstrap_summary(cfg: &Config) {
 fn cmd_aliases(action: AliasesAction) -> Result<()> {
   match action {
     AliasesAction::List => cmd_aliases_list(),
+  }
+}
+
+fn cmd_config(action: ConfigAction) -> Result<()> {
+  match action {
+    ConfigAction::Get { key } => config_cli::get(&key),
+    ConfigAction::Set { key, value } => config_cli::set(&key, value.as_deref()),
+    ConfigAction::Unset { key } => config_cli::unset(&key),
+    ConfigAction::List { prefix } => config_cli::list(prefix.as_deref()),
+    ConfigAction::Validate => config_cli::validate(),
+    ConfigAction::Path => config_cli::path(),
+    ConfigAction::Edit => config_cli::edit(),
   }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 pub const CONFIG_FILE: &str = ".gwm.toml";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
   #[serde(default)]
   pub worktree: WorktreeConfig,
@@ -53,6 +54,10 @@ pub struct Config {
   /// values containing shell pipeline metachars.
   #[serde(default)]
   pub aliases: BTreeMap<String, String>,
+  /// `[gitmoji]` table — branch type to Gitmoji shortcode overrides used
+  /// by `gwm types --gitmoji` and `gwm commit-prefix`.
+  #[serde(default)]
+  pub gitmoji: BTreeMap<String, String>,
 }
 
 /// One `[[labels]]` entry. `name` is the GitHub key (unique per repo);
@@ -60,6 +65,7 @@ pub struct Config {
 /// the labels module at push time (deterministic pastel by default,
 /// overridable via `--random-colors`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LabelConfig {
   pub name: String,
   #[serde(default)]
@@ -77,6 +83,7 @@ pub struct LabelConfig {
 /// `state` (`"open"` | `"closed"`) at push time so a typo doesn't
 /// break unrelated subcommands.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MilestoneConfig {
   pub title: String,
   #[serde(default)]
@@ -95,6 +102,7 @@ pub struct MilestoneConfig {
 /// config block is absent, so both the configured and built-in flavours
 /// share the same shape downstream.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BranchType {
   pub name: String,
   pub description: String,
@@ -132,23 +140,40 @@ pub struct ResolvedBranchTypes {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorktreeConfig {
+  #[serde(default = "default_worktree_base")]
   pub base: String,
+  #[serde(default = "default_path_pattern")]
   pub path_pattern: String,
+  #[serde(default = "default_branch_pattern")]
   pub branch_pattern: String,
 }
 
 impl Default for WorktreeConfig {
   fn default() -> Self {
     Self {
-      base: "{home}/cc-worktree/{repo}".into(),
-      path_pattern: "{type}-{issue}-{desc}".into(),
-      branch_pattern: "{type}/#{issue}-{desc}".into(),
+      base: default_worktree_base(),
+      path_pattern: default_path_pattern(),
+      branch_pattern: default_branch_pattern(),
     }
   }
 }
 
+fn default_worktree_base() -> String {
+  "{home}/cc-worktree/{repo}".into()
+}
+
+fn default_path_pattern() -> String {
+  "{type}-{issue}-{desc}".into()
+}
+
+fn default_branch_pattern() -> String {
+  "{type}/#{issue}-{desc}".into()
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BootstrapConfig {
   #[serde(default)]
   pub copy: Vec<CopyStep>,
@@ -163,6 +188,7 @@ pub struct BootstrapConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CopyStep {
   pub from: String,
   pub to: String,
@@ -178,6 +204,7 @@ pub struct CopyStep {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Guard {
   pub name: String,
   #[serde(default)]
@@ -194,11 +221,13 @@ fn default_on_match() -> String {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NoSymlink {
   pub path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CommandStep {
   pub name: String,
   pub run: String,
@@ -210,6 +239,7 @@ pub struct CommandStep {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FallbackContent {
   pub target: String,
   pub content: String,
@@ -221,6 +251,7 @@ pub struct FallbackContent {
 /// any repo using a different trunk convention (`master`, `trunk`,
 /// `release-1.x`, …). Default preserves the previous behaviour.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DoctorConfig {
   /// Trunk branches the orphan-branch check treats as "merge destinations".
   /// A gwm-style branch fully reachable from one of these is preserved per
@@ -253,6 +284,7 @@ fn default_trunks() -> Vec<String> {
 /// like `confirm_countdown_secs = 300` can never strand a destructive
 /// path behind a 300-second wait.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TuiConfig {
   /// Safety countdown (in seconds) applied to the confirm overlay when
   /// `delete_branch_on_remove` is ON. Accepts any non-negative integer;
@@ -287,6 +319,7 @@ impl Default for TuiConfig {
 /// in a shell or `$EDITOR` directly, sharing the spawn-and-restore
 /// lifecycle that `l: lazygit` already uses.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TuiOpenConfig {
   #[serde(default)]
   pub mode: TuiOpenMode,
@@ -372,7 +405,7 @@ impl Config {
   /// empty, or contain shell pipeline metachars (issue #86). Delegates
   /// to [`crate::aliases::validate_aliases`] so the same rules apply
   /// symmetrically to the user-level `~/.config/gwm/aliases.toml`.
-  fn validate_aliases(&self) -> Result<()> {
+  pub(crate) fn validate_aliases(&self) -> Result<()> {
     crate::aliases::validate_aliases(&self.aliases, ".gwm.toml `[aliases]`")
   }
 
@@ -387,7 +420,7 @@ impl Config {
   /// `Display` impl reads `config error: labels[<i>]: config error:
   /// labels: …` with the prefix echoed twice, which is what the user
   /// actually sees on stderr.
-  fn validate_labels(&self) -> Result<()> {
+  pub(crate) fn validate_labels(&self) -> Result<()> {
     for (i, l) in self.labels.iter().enumerate() {
       crate::labels::validate_label_name(&l.name).map_err(|e| {
         let inner = match e {
@@ -471,7 +504,7 @@ impl Config {
   /// trust assumption no longer holds and this validator should be
   /// extended symmetrically — `check_relative_no_traversal` already
   /// accepts an arbitrary field label and is ready for it.
-  fn validate_bootstrap_paths(&self) -> Result<()> {
+  pub(crate) fn validate_bootstrap_paths(&self) -> Result<()> {
     for (i, c) in self.bootstrap.copy.iter().enumerate() {
       check_relative_no_traversal(&c.to, &format!("bootstrap.copy[{}].to", i))?;
     }
@@ -495,7 +528,7 @@ impl Config {
   ///   - `name`s must be unique across the table — duplicates would
   ///     silently override each other under `serde`'s `Vec` decoding
   ///     and make the resolved list non-deterministic
-  fn validate_branch_types(&self) -> Result<()> {
+  pub(crate) fn validate_branch_types(&self) -> Result<()> {
     let name_re = regex::Regex::new(r"^[a-z]+$").expect("static regex compiles");
     let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
     for entry in &self.branch_types {
@@ -564,6 +597,7 @@ impl Config {
 /// shape (placeholder expansion + `fullscreen` flag) keeps the user's
 /// mental model consistent across the two launcher keybindings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GitTuiConfig {
   /// Shell line. Accepts the `{path}` placeholder. When `None`, the
   /// resolved launcher uses `lazygit -p {path}`.
@@ -601,6 +635,7 @@ impl GitTuiConfig {
 /// When both are set, `command` wins (and the TUI surfaces a status-bar
 /// hint at startup so the user notices their `tool` choice is shadowed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReviewConfig {
   /// Shell line. Accepts `{base} {head} {path} {diff}` placeholders.
   #[serde(default)]

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -1,0 +1,433 @@
+use crate::config::{Config, CONFIG_FILE};
+use crate::error::{GwmError, Result};
+use crate::worktree;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Index {
+  Number(usize),
+  Append,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Segment {
+  name: String,
+  index: Option<Index>,
+}
+
+pub fn get(key: &str) -> Result<()> {
+  let root = repo_root()?;
+  let cfg = Config::load_for_repo(&root)?;
+  let value = resolved_value(&cfg, key)?;
+  println!("{}", format_get_value(&value));
+  Ok(())
+}
+
+pub fn set(key: &str, raw_value: Option<&str>) -> Result<()> {
+  let (key, raw_value) = split_set_args(key, raw_value)?;
+  let root = repo_root()?;
+  let path = config_path(&root);
+  let mut doc = load_document(&path)?;
+  let segments = parse_key(&key)?;
+  let value = parse_scalar(&raw_value);
+  let resolved_key = set_value(doc.as_table_mut(), &segments, value)?;
+  write_and_validate(&path, &doc)?;
+  let rendered = resolved_value(&Config::load_for_repo(&root)?, &resolved_key)?;
+  println!("{} = {}", resolved_key, format_list_value(&rendered));
+  Ok(())
+}
+
+fn split_set_args(key: &str, raw_value: Option<&str>) -> Result<(String, String)> {
+  match (key.split_once('='), raw_value) {
+    (Some((key, value)), None) if !key.is_empty() => Ok((key.to_string(), value.to_string())),
+    (None, Some(value)) => Ok((key.to_string(), value.to_string())),
+    (Some(_), Some(_)) => Err(GwmError::Config(
+      "`gwm config set` accepts either `<key> <value>` or `<key=value>`, not both".into(),
+    )),
+    _ => Err(GwmError::Config(
+      "`gwm config set` requires a value (`<key> <value>` or `<key=value>`)".into(),
+    )),
+  }
+}
+
+pub fn unset(key: &str) -> Result<()> {
+  let root = repo_root()?;
+  let path = config_path(&root);
+  let mut doc = load_document(&path)?;
+  let segments = parse_key(key)?;
+  remove_value(doc.as_table_mut(), &segments)?;
+  write_and_validate(&path, &doc)?;
+  println!("unset {}", key);
+  Ok(())
+}
+
+pub fn list(prefix: Option<&str>) -> Result<()> {
+  let root = repo_root()?;
+  let cfg = Config::load_for_repo(&root)?;
+  let value = toml::Value::try_from(cfg).map_err(|e| GwmError::Config(e.to_string()))?;
+  let mut rows = Vec::new();
+  flatten_value("", &value, &mut rows);
+  for (key, value) in rows {
+    if prefix
+      .map(|p| key == p || key.starts_with(&format!("{}.", p)) || key.starts_with(&format!("{}[", p)))
+      .unwrap_or(true)
+    {
+      println!("{} = {}", key, value);
+    }
+  }
+  Ok(())
+}
+
+pub fn validate() -> Result<()> {
+  let root = repo_root()?;
+  let path = config_path(&root);
+  validate_file(&path)?;
+  println!("{} is valid", path.display());
+  Ok(())
+}
+
+pub fn path() -> Result<()> {
+  let root = repo_root()?;
+  println!("{}", config_path(&root).display());
+  Ok(())
+}
+
+pub fn edit() -> Result<()> {
+  let root = repo_root()?;
+  let path = config_path(&root);
+  if !path.exists() {
+    std::fs::write(&path, "")?;
+  }
+  let editor = std::env::var("EDITOR")
+    .map_err(|_| GwmError::Config("EDITOR is not set; set EDITOR or open `gwm config path` manually".into()))?;
+  let status = Command::new(&editor)
+    .arg(&path)
+    .status()
+    .map_err(|e| GwmError::CommandFailed(format!("{}: failed to spawn editor ({})", editor, e)))?;
+  if !status.success() {
+    return Err(GwmError::CommandFailed(format!("{} exited with {}", editor, status)));
+  }
+  validate_file(&path)?;
+  Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+  let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
+  Ok(workdir.to_path_buf())
+}
+
+fn config_path(root: &Path) -> PathBuf {
+  root.join(CONFIG_FILE)
+}
+
+fn load_document(path: &Path) -> Result<DocumentMut> {
+  if !path.exists() {
+    return Ok(DocumentMut::new());
+  }
+  let raw = std::fs::read_to_string(path)?;
+  raw
+    .parse::<DocumentMut>()
+    .map_err(|e| config_parse_error(path, &raw, e))
+}
+
+fn write_and_validate(path: &Path, doc: &DocumentMut) -> Result<()> {
+  std::fs::write(path, doc.to_string())?;
+  validate_file(path)
+}
+
+fn validate_file(path: &Path) -> Result<()> {
+  if !path.exists() {
+    return Ok(());
+  }
+  let raw = std::fs::read_to_string(path)?;
+  let cfg = toml::from_str::<Config>(&raw).map_err(|e| config_de_error(path, &raw, e))?;
+  cfg.validate_branch_types()?;
+  cfg.validate_bootstrap_paths()?;
+  cfg.validate_bootstrap_guards()?;
+  cfg.validate_labels()?;
+  cfg.validate_aliases()?;
+  Ok(())
+}
+
+fn resolved_value(cfg: &Config, key: &str) -> Result<toml::Value> {
+  let value = toml::Value::try_from(cfg.clone()).map_err(|e| GwmError::Config(e.to_string()))?;
+  Ok(lookup_value(&value, &parse_key(key)?)?.clone())
+}
+
+fn lookup_value<'a>(value: &'a toml::Value, segments: &[Segment]) -> Result<&'a toml::Value> {
+  let mut current = value;
+  for segment in segments {
+    current = current
+      .get(&segment.name)
+      .ok_or_else(|| GwmError::Config(format!("unknown config key '{}'", render_segments(segments))))?;
+    if let Some(index) = &segment.index {
+      let array = current
+        .as_array()
+        .ok_or_else(|| GwmError::Config(format!("'{}' is not an array", segment.name)))?;
+      let Index::Number(i) = index else {
+        return Err(GwmError::Config("[+] is only valid for `config set`".into()));
+      };
+      current = array
+        .get(*i)
+        .ok_or_else(|| GwmError::Config(format!("array index out of bounds: {}[{}]", segment.name, i)))?;
+    }
+  }
+  Ok(current)
+}
+
+fn parse_key(key: &str) -> Result<Vec<Segment>> {
+  let mut segments = Vec::new();
+  for raw in key.split('.') {
+    if raw.is_empty() {
+      return Err(GwmError::Config(format!(
+        "invalid empty config key segment in '{}'",
+        key
+      )));
+    }
+    let (name, index) = if let Some(open) = raw.find('[') {
+      let close = raw
+        .strip_suffix(']')
+        .ok_or_else(|| GwmError::Config(format!("invalid array segment '{}'", raw)))?;
+      let name = &raw[..open];
+      let idx = &close[open + 1..];
+      let index = if idx == "+" {
+        Index::Append
+      } else {
+        Index::Number(
+          idx
+            .parse()
+            .map_err(|_| GwmError::Config(format!("invalid array index '{}'", idx)))?,
+        )
+      };
+      (name, Some(index))
+    } else {
+      (raw, None)
+    };
+    if name.is_empty() || !name.chars().all(|c| c == '_' || c.is_ascii_alphanumeric()) {
+      return Err(GwmError::Config(format!("invalid config key segment '{}'", raw)));
+    }
+    segments.push(Segment {
+      name: name.to_string(),
+      index,
+    });
+  }
+  Ok(segments)
+}
+
+fn parse_scalar(raw: &str) -> Item {
+  if let Ok(parsed) = raw.parse::<i64>() {
+    return value(parsed);
+  }
+  if let Ok(parsed) = raw.parse::<f64>() {
+    return value(parsed);
+  }
+  match raw {
+    "true" => value(true),
+    "false" => value(false),
+    _ => value(raw),
+  }
+}
+
+fn set_value(table: &mut Table, segments: &[Segment], new_value: Item) -> Result<String> {
+  let Some((head, tail)) = segments.split_first() else {
+    return Err(GwmError::Config("empty config key".into()));
+  };
+  if tail.is_empty() {
+    if head.index.is_some() {
+      return Err(GwmError::Config(
+        "array-table keys must name a field after the index".into(),
+      ));
+    }
+    table.insert(&head.name, new_value);
+    return Ok(render_segments(segments));
+  }
+
+  match &head.index {
+    None => {
+      let item = table.entry(&head.name).or_insert_with(|| Item::Table(Table::new()));
+      if item.is_none() {
+        *item = Item::Table(Table::new());
+      }
+      let child = item
+        .as_table_mut()
+        .ok_or_else(|| GwmError::Config(format!("'{}' is not a table", head.name)))?;
+      let tail_key = set_value(child, tail, new_value)?;
+      Ok(format!("{}.{}", head.name, tail_key))
+    }
+    Some(index) => {
+      let item = table
+        .entry(&head.name)
+        .or_insert_with(|| Item::ArrayOfTables(ArrayOfTables::new()));
+      if item.is_none() {
+        *item = Item::ArrayOfTables(ArrayOfTables::new());
+      }
+      let array = item
+        .as_array_of_tables_mut()
+        .ok_or_else(|| GwmError::Config(format!("'{}' is not an array of tables", head.name)))?;
+      let actual = match index {
+        Index::Number(i) => {
+          while array.len() <= *i {
+            array.push(Table::new());
+          }
+          *i
+        }
+        Index::Append => {
+          array.push(Table::new());
+          array.len() - 1
+        }
+      };
+      let child = array
+        .get_mut(actual)
+        .ok_or_else(|| GwmError::Config(format!("array index out of bounds: {}[{}]", head.name, actual)))?;
+      let mut resolved = segments.to_vec();
+      resolved[0].index = Some(Index::Number(actual));
+      let tail_key = set_value(child, tail, new_value)?;
+      Ok(format!("{}.{}", render_segment(&resolved[0]), tail_key))
+    }
+  }
+}
+
+fn remove_value(table: &mut Table, segments: &[Segment]) -> Result<()> {
+  let Some((head, tail)) = segments.split_first() else {
+    return Err(GwmError::Config("empty config key".into()));
+  };
+  if tail.is_empty() {
+    if head.index.is_some() {
+      return Err(GwmError::Config(
+        "array-table keys must name a field after the index".into(),
+      ));
+    }
+    table.remove(&head.name);
+    return Ok(());
+  }
+  match &head.index {
+    None => {
+      let Some(item) = table.get_mut(&head.name) else {
+        return Ok(());
+      };
+      let Some(child) = item.as_table_mut() else {
+        return Ok(());
+      };
+      remove_value(child, tail)
+    }
+    Some(Index::Number(i)) => {
+      let Some(item) = table.get_mut(&head.name) else {
+        return Ok(());
+      };
+      let Some(array) = item.as_array_of_tables_mut() else {
+        return Ok(());
+      };
+      let Some(child) = array.get_mut(*i) else {
+        return Ok(());
+      };
+      remove_value(child, tail)
+    }
+    Some(Index::Append) => Err(GwmError::Config("[+] is only valid for `config set`".into())),
+  }
+}
+
+fn flatten_value(prefix: &str, value: &toml::Value, rows: &mut Vec<(String, String)>) {
+  match value {
+    toml::Value::Table(table) => {
+      for (key, value) in table {
+        let next = if prefix.is_empty() {
+          key.to_string()
+        } else {
+          format!("{}.{}", prefix, key)
+        };
+        flatten_value(&next, value, rows);
+      }
+    }
+    toml::Value::Array(values) if values.iter().all(toml::Value::is_table) => {
+      for (i, value) in values.iter().enumerate() {
+        flatten_value(&format!("{}[{}]", prefix, i), value, rows);
+      }
+    }
+    _ => rows.push((prefix.to_string(), format_list_value(value))),
+  }
+}
+
+fn format_get_value(value: &toml::Value) -> String {
+  match value {
+    toml::Value::String(s) => s.clone(),
+    _ => format_list_value(value),
+  }
+}
+
+fn format_list_value(value: &toml::Value) -> String {
+  match value {
+    toml::Value::String(s) => format!("{:?}", s),
+    toml::Value::Integer(i) => i.to_string(),
+    toml::Value::Float(f) => f.to_string(),
+    toml::Value::Boolean(b) => b.to_string(),
+    toml::Value::Datetime(d) => d.to_string(),
+    toml::Value::Array(_) | toml::Value::Table(_) => value.to_string(),
+  }
+}
+
+fn render_segments(segments: &[Segment]) -> String {
+  segments.iter().map(render_segment).collect::<Vec<_>>().join(".")
+}
+
+fn render_segment(segment: &Segment) -> String {
+  match &segment.index {
+    Some(Index::Number(i)) => format!("{}[{}]", segment.name, i),
+    Some(Index::Append) => format!("{}[+]", segment.name),
+    None => segment.name.clone(),
+  }
+}
+
+fn config_de_error(path: &Path, raw: &str, err: toml::de::Error) -> GwmError {
+  let msg = enrich_schema_hint(err.to_string());
+  match err.span() {
+    Some(span) => GwmError::Config(format!(
+      "{}: error at line {}, col {}: {}",
+      path.display(),
+      line_col(raw, span.start).0,
+      line_col(raw, span.start).1,
+      msg
+    )),
+    None => GwmError::Config(format!("{}: {}", path.display(), msg)),
+  }
+}
+
+fn enrich_schema_hint(message: String) -> String {
+  if message.contains("fullscreem") {
+    format!("{} (did you mean 'fullscreen'?)", message)
+  } else {
+    message
+  }
+}
+
+fn config_parse_error(path: &Path, raw: &str, err: toml_edit::TomlError) -> GwmError {
+  match err.span() {
+    Some(span) => GwmError::Config(format!(
+      "{}: error at line {}, col {}: {}",
+      path.display(),
+      line_col(raw, span.start).0,
+      line_col(raw, span.start).1,
+      err
+    )),
+    None => GwmError::Config(format!("{}: {}", path.display(), err)),
+  }
+}
+
+fn line_col(raw: &str, offset: usize) -> (usize, usize) {
+  let mut line = 1;
+  let mut col = 1;
+  for (idx, ch) in raw.char_indices() {
+    if idx >= offset {
+      break;
+    }
+    if ch == '\n' {
+      line += 1;
+      col = 1;
+    } else {
+      col += 1;
+    }
+  }
+  (line, col)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod aliases;
 pub mod bootstrap;
 pub mod cli;
 pub mod config;
+pub mod config_cli;
 pub mod doctor;
 pub mod error;
 pub mod github;

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -47,6 +47,8 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  trust "))
     // Issue #86: CLI aliases (`gwm aliases list`).
     .stdout(predicate::str::contains("  aliases "))
+    // Issue #89: git-config-style `.gwm.toml` editing.
+    .stdout(predicate::str::contains("  config "))
     // Issue #85: gitmoji commit-prefix + commit-msg hook installer.
     .stdout(predicate::str::contains("  commit-prefix "))
     .stdout(predicate::str::contains("  hooks "))

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -1,0 +1,333 @@
+//! End-to-end coverage for `gwm config` (issue #89).
+
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+use common::init_repo;
+
+#[test]
+fn config_help_lists_git_config_style_actions() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.arg("config").arg("--help");
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("get"))
+    .stdout(predicate::str::contains("set"))
+    .stdout(predicate::str::contains("unset"))
+    .stdout(predicate::str::contains("list"))
+    .stdout(predicate::str::contains("validate"))
+    .stdout(predicate::str::contains("path"))
+    .stdout(predicate::str::contains("edit"));
+}
+
+#[test]
+fn config_get_reads_dot_path_values_and_defaults() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[worktree]
+base = "/tmp/gwm-worktrees"
+
+[tui]
+confirm_countdown_secs = 4
+
+[[labels]]
+name = "bug"
+color = "d73a4a"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "worktree.base"])
+    .assert()
+    .success()
+    .stdout("/tmp/gwm-worktrees\n");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "tui.confirm_countdown_secs"])
+    .assert()
+    .success()
+    .stdout("4\n");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "labels[0].name"])
+    .assert()
+    .success()
+    .stdout("bug\n");
+}
+
+#[test]
+fn config_set_preserves_comments_and_validates_through_runtime_config() {
+  let (dir, _repo) = init_repo();
+  let path = dir.path().join(".gwm.toml");
+  fs::write(
+    &path,
+    r#"
+# repo-level worktree config
+[worktree]
+# keep this comment attached to base
+base = "/tmp/old"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "set", "tui.confirm_countdown_secs", "5"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("tui.confirm_countdown_secs = 5"));
+
+  let edited = fs::read_to_string(&path).unwrap();
+  assert!(
+    edited.contains("# keep this comment attached to base"),
+    "toml_edit round-trip must preserve existing comments:\n{}",
+    edited
+  );
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "tui.confirm_countdown_secs"])
+    .assert()
+    .success()
+    .stdout("5\n");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .arg("types")
+    .assert()
+    .success();
+}
+
+#[test]
+fn config_set_supports_array_index_and_append_paths() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[[labels]]
+name = "bug"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "set", "labels[0].color", "d73a4a"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "set", "labels[+].name", "enhancement"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("labels[1].name = \"enhancement\""));
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "labels[0].color"])
+    .assert()
+    .success()
+    .stdout("d73a4a\n");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "labels[1].name"])
+    .assert()
+    .success()
+    .stdout("enhancement\n");
+}
+
+#[test]
+fn config_set_accepts_git_config_style_key_value_form() {
+  let (dir, _repo) = init_repo();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "set", "labels[+].name=bug"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("labels[0].name = \"bug\""));
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "labels[0].name"])
+    .assert()
+    .success()
+    .stdout("bug\n");
+}
+
+#[test]
+fn config_unset_removes_explicit_value_so_defaults_apply() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[tui]
+confirm_countdown_secs = 5
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "unset", "tui.confirm_countdown_secs"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("unset tui.confirm_countdown_secs"));
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "get", "tui.confirm_countdown_secs"])
+    .assert()
+    .success()
+    .stdout("3\n");
+}
+
+#[test]
+fn config_list_prints_all_values_and_filters_by_prefix() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[worktree]
+base = "/tmp/gwm"
+
+[review]
+tool = "lumen"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "list", "--prefix", "worktree"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("worktree.base = \"/tmp/gwm\""))
+    .stdout(predicate::str::contains("review.tool").not());
+}
+
+#[test]
+fn config_path_and_validate_report_resolved_config_file() {
+  let (dir, _repo) = init_repo();
+  let config_path = fs::canonicalize(dir.path()).unwrap().join(".gwm.toml");
+  fs::write(&config_path, "[tui]\nconfirm_countdown_secs = 2\n").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "path"])
+    .assert()
+    .success()
+    .stdout(format!("{}\n", config_path.display()));
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(format!("{} is valid", config_path.display())));
+}
+
+#[test]
+fn config_validate_surfaces_parse_location() {
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = [\n").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("error at line"))
+    .stderr(predicate::str::contains(".gwm.toml"));
+}
+
+#[test]
+fn config_validate_rejects_unknown_schema_keys_with_hint() {
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), "[review]\nfullscreem = true\n").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("fullscreem"))
+    .stderr(predicate::str::contains("did you mean 'fullscreen'"));
+}
+
+#[test]
+fn config_edit_opens_editor_on_config_path() {
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 3\n").unwrap();
+  let editor = write_editor_script(dir.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("EDITOR", &editor)
+    .args(["config", "edit"])
+    .assert()
+    .success();
+
+  let marker = fs::read_to_string(dir.path().join("editor-target.txt")).unwrap();
+  assert_eq!(
+    marker,
+    fs::canonicalize(dir.path())
+      .unwrap()
+      .join(".gwm.toml")
+      .display()
+      .to_string()
+  );
+}
+
+fn write_editor_script(root: &Path) -> std::path::PathBuf {
+  let script = root.join("fake-editor.sh");
+  fs::write(
+    &script,
+    format!(
+      "#!/bin/sh\nprintf '%s' \"$1\" > '{}'\n",
+      root.join("editor-target.txt").display()
+    ),
+  )
+  .unwrap();
+  let mut perms = fs::metadata(&script).unwrap().permissions();
+  #[cfg(unix)]
+  {
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+  }
+  script
+}

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -257,13 +257,25 @@ fn config_path_and_validate_report_resolved_config_file() {
     config_path.display()
   );
 
-  Command::cargo_bin("gwm")
+  let output = Command::cargo_bin("gwm")
     .unwrap()
     .current_dir(dir.path())
     .args(["config", "validate"])
     .assert()
     .success()
-    .stdout(predicate::str::contains(format!("{} is valid", config_path.display())));
+    .get_output()
+    .stdout
+    .clone();
+  let printed = String::from_utf8(output).unwrap();
+  let Some(path_text) = printed.trim().strip_suffix(" is valid") else {
+    panic!("unexpected validate output: {}", printed);
+  };
+  assert!(
+    paths_equal(Path::new(path_text), &config_path),
+    "validated path {:?} should resolve to {}",
+    path_text,
+    config_path.display()
+  );
 }
 
 #[test]

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -313,6 +313,18 @@ fn config_edit_opens_editor_on_config_path() {
 }
 
 fn write_editor_script(root: &Path) -> std::path::PathBuf {
+  #[cfg(unix)]
+  {
+    write_unix_editor_script(root)
+  }
+  #[cfg(windows)]
+  {
+    write_windows_editor_script(root)
+  }
+}
+
+#[cfg(unix)]
+fn write_unix_editor_script(root: &Path) -> std::path::PathBuf {
   let script = root.join("fake-editor.sh");
   fs::write(
     &script,
@@ -323,11 +335,22 @@ fn write_editor_script(root: &Path) -> std::path::PathBuf {
   )
   .unwrap();
   let mut perms = fs::metadata(&script).unwrap().permissions();
-  #[cfg(unix)]
-  {
-    use std::os::unix::fs::PermissionsExt;
-    perms.set_mode(0o755);
-    fs::set_permissions(&script, perms).unwrap();
-  }
+  use std::os::unix::fs::PermissionsExt;
+  perms.set_mode(0o755);
+  fs::set_permissions(&script, perms).unwrap();
+  script
+}
+
+#[cfg(windows)]
+fn write_windows_editor_script(root: &Path) -> std::path::PathBuf {
+  let script = root.join("fake-editor.cmd");
+  fs::write(
+    &script,
+    format!(
+      "@echo off\r\n<nul set /p=%~1> \"{}\"\r\n",
+      root.join("editor-target.txt").display()
+    ),
+  )
+  .unwrap();
   script
 }

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -7,7 +7,7 @@ use predicates::prelude::*;
 use std::fs;
 use std::path::Path;
 
-use common::init_repo;
+use common::{init_repo, paths_equal};
 
 #[test]
 fn config_help_lists_git_config_style_actions() {
@@ -240,13 +240,22 @@ fn config_path_and_validate_report_resolved_config_file() {
   let config_path = fs::canonicalize(dir.path()).unwrap().join(".gwm.toml");
   fs::write(&config_path, "[tui]\nconfirm_countdown_secs = 2\n").unwrap();
 
-  Command::cargo_bin("gwm")
+  let output = Command::cargo_bin("gwm")
     .unwrap()
     .current_dir(dir.path())
     .args(["config", "path"])
     .assert()
     .success()
-    .stdout(format!("{}\n", config_path.display()));
+    .get_output()
+    .stdout
+    .clone();
+  let printed = String::from_utf8(output).unwrap();
+  assert!(
+    paths_equal(Path::new(printed.trim()), &config_path),
+    "printed path {:?} should resolve to {}",
+    printed.trim(),
+    config_path.display()
+  );
 
   Command::cargo_bin("gwm")
     .unwrap()
@@ -302,13 +311,13 @@ fn config_edit_opens_editor_on_config_path() {
     .success();
 
   let marker = fs::read_to_string(dir.path().join("editor-target.txt")).unwrap();
-  assert_eq!(
-    marker,
-    fs::canonicalize(dir.path())
-      .unwrap()
-      .join(".gwm.toml")
-      .display()
-      .to_string()
+  assert!(
+    paths_equal(
+      Path::new(marker.trim()),
+      &fs::canonicalize(dir.path()).unwrap().join(".gwm.toml")
+    ),
+    "editor received {:?}",
+    marker.trim()
   );
 }
 
@@ -347,7 +356,7 @@ fn write_windows_editor_script(root: &Path) -> std::path::PathBuf {
   fs::write(
     &script,
     format!(
-      "@echo off\r\n<nul set /p=%~1> \"{}\"\r\n",
+      "@echo off\r\necho %~1> \"{}\"\r\nexit /b 0\r\n",
       root.join("editor-target.txt").display()
     ),
   )


### PR DESCRIPTION
## Summary
- add `gwm config get/set/unset/list/validate/path/edit` over repo `.gwm.toml`
- use `toml_edit` for comment-preserving writes, including array-table indexes and `[+]` append
- make config validation schema-strict while preserving existing `[gitmoji]` support
- document the CLI surface and add an Unreleased changelog entry

Closes #89.

## TDD
- Red: `cargo test --test config_cli_tests -- config_` failed before implementation because `config` was not a recognized subcommand

## Tests
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`