### PR TITLE
✨ feat: add configurable lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `gwm config get/set/unset/list/validate/path/edit` for git-config-style `.gwm.toml` reads and comment-preserving edits.
+- Add lifecycle hooks under `[hooks.*]` for create/bootstrap/remove phases, with placeholders, per-step `on_fail`, `--skip-hooks`, and legacy `[[bootstrap.command]]` compatibility as `post_create`.
 
 ## Past releases
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -1,6 +1,6 @@
 ---
 title: .gwm.toml schema
-description: Every section — worktree, bootstrap.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
+description: Every section — worktree, bootstrap.*, hooks.*, git_tui, review, tui, tui.open, doctor — with defaults and validation rules.
 ---
 
 # `.gwm.toml` schema
@@ -109,7 +109,7 @@ path = "node_modules"
 
 ## `[[bootstrap.command]]`
 
-Shell hooks run after copies / guards / no-symlink.
+Legacy shell hooks. New configs should prefer `[[hooks.post_create]]`. When a config defines both legacy `[[bootstrap.command]]` entries and any `[hooks.*]` entries, gwm prints a deprecation warning and treats the legacy commands as extra `post_create` steps to avoid ordering ambiguity.
 
 ```toml
 [[bootstrap.command]]
@@ -125,6 +125,42 @@ env  = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 | `run`  | string                | shell line to exec (split via `sh -c`)                                |
 | `when` | string                | [`when:` predicate](/configuration/when-predicates) (optional)        |
 | `env`  | table of string→string | extra env vars injected for this command (optional)                  |
+
+## `[[hooks.*]]`
+
+Lifecycle hooks run around worktree creation, bootstrap, and removal. Supported phases:
+
+- `[[hooks.pre_create]]` — before `git worktree add`, with `cwd` at the main repo.
+- `[[hooks.post_create]]` — after the worktree exists, with `cwd` at the worktree.
+- `[[hooks.pre_bootstrap]]` / `[[hooks.post_bootstrap]]` — around the bootstrap core.
+- `[[hooks.pre_remove]]` / `[[hooks.post_remove]]` — before and after `gwm remove`.
+
+```toml
+[[hooks.post_create]]
+name = "install deps"
+run  = "npm ci"
+when = "file_exists:package-lock.json"
+on_fail = "warn" # abort | warn | ignore (default: abort)
+env = { CI = "1" }
+```
+
+| Field     | Type                   | Meaning                                                       |
+|:----------|:-----------------------|:--------------------------------------------------------------|
+| `name`    | string                 | shown in lifecycle reports as `[phase] name`                  |
+| `run`     | string                 | shell line to exec via `sh -c`                                |
+| `when`    | string                 | [`when:` predicate](/configuration/when-predicates) (optional) |
+| `env`     | table of string→string | extra env vars injected for this hook (optional)              |
+| `on_fail` | string                 | `abort`, `warn`, or `ignore`; default is `abort`              |
+
+Hook commands and env values can use placeholders: `{branch}`, `{path}`, `{type}`, `{issue}`, `{desc}`, `{user}`, `{owner}`, `{repo}`.
+
+Emergency bypass:
+
+```bash
+gwm create feat 42 auth --skip-hooks pre_create
+gwm bootstrap auth --skip-hooks pre_bootstrap,post_bootstrap
+gwm remove auth --force # implies --skip-hooks pre_remove,post_remove
+```
 
 ## `[git_tui]` and `[review]`
 

--- a/docs/4.configuration/2.bootstrap.md
+++ b/docs/4.configuration/2.bootstrap.md
@@ -1,6 +1,6 @@
 ---
 title: Bootstrap pipeline
-description: Execution order — file copies → regex guards → fallbacks → no-symlink check → shell commands.
+description: Execution order — lifecycle hooks around file copies, regex guards, fallbacks, and no-symlink checks.
 ---
 
 # Bootstrap pipeline
@@ -9,12 +9,14 @@ The bootstrap pipeline runs **after** `git worktree add` succeeds, on every `gwm
 
 Every entry point is **gated by the [TOFU trust ledger](/configuration/trust-ledger)** — the first time you run `gwm create` / `gwm bootstrap` against a repo's `.gwm.toml`, the gate prompts (CLI) or refuses with a status-bar hint (TUI) before any pipeline stage executes. Subsequent runs against the same `(origin URL, sha256 of .gwm.toml)` pair pass silently; any byte change to `.gwm.toml` re-prompts. CI bypass: `--allow-bootstrap` or `GWM_ALLOW_BOOTSTRAP=1`.
 
-Five stages, in this order:
+Lifecycle hooks wrap the bootstrap core:
 
 ```
 gwm create / gwm bootstrap
        ↓
 trust gate (issue #95)                 prompt / refuse on untrusted (origin, hash)
+       ↓
+pre_bootstrap hooks                     optional [[hooks.pre_bootstrap]]
        ↓
 (1) [[bootstrap.copy]]                  duplicate files from main → worktree
        ↓
@@ -25,12 +27,12 @@ trust gate (issue #95)                 prompt / refuse on untrusted (origin, has
        ↓
 (4) [[bootstrap.no_symlink]]            refuse to inherit listed symlinks
        ↓
-(5) [[bootstrap.command]]               shell hooks gated by when: predicates
+post_bootstrap hooks                    optional [[hooks.post_bootstrap]]
        ↓
 ✓ worktree ready, status bar reports per-step ✓ / ! / ✗
 ```
 
-Stages **1 → 4** are tightly coupled — a guard `seed-from-example` action triggers a fallback (stage 3) inline, and the no-symlink check (stage 4) runs after copies so it can refuse links that the copy step would have followed.
+Stages **1 → 4** are tightly coupled — a guard `seed-from-example` action triggers a fallback (stage 3) inline, and the no-symlink check (stage 4) runs after copies so it can refuse links that the copy step would have followed. Legacy `[[bootstrap.command]]` entries are treated as `post_create` hooks for compatibility; prefer `[[hooks.post_create]]` in new configs.
 
 ## stage reports
 
@@ -67,6 +69,7 @@ The `·` sigil (used by some predicate skips) is a "step did not run" indicator 
 
 ```bash
 gwm create feat 42 user-auth --no-bootstrap     # skip the whole pipeline
+gwm bootstrap auth --skip-hooks pre_bootstrap   # skip one lifecycle hook phase
 ```
 
 Useful when:

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -70,39 +70,52 @@ path = "vendor"
 [[bootstrap.no_symlink]]
 path = "node_modules"
 
-# --- post-copy commands -----------------------------------------------------
+# --- lifecycle hooks --------------------------------------------------------
+# Phases: pre_create, post_create, pre_bootstrap, post_bootstrap, pre_remove,
+# post_remove. Placeholders: {branch} {path} {type} {issue} {desc} {user}
+# {owner} {repo}. Failure handling: on_fail = "abort" (default), "warn",
+# or "ignore". Emergency bypass: --skip-hooks <phase,phase>; `gwm remove
+# --force` implies --skip-hooks pre_remove,post_remove.
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "composer install"
 run = "composer install --no-interaction --prefer-dist"
 when = "file_exists:composer.json"
+on_fail = "warn"
 env = { COMPOSER_IGNORE_PLATFORM_REQ = "ext-imagick" }
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "direnv allow"
 run = "direnv allow ."
 when = "file_exists:.envrc"
+on_fail = "ignore"
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "npm install"
 run = "npm install"
 when = "file_exists:package.json"
+
+# --- legacy post-create commands -------------------------------------------
+# `[[bootstrap.command]]` is still accepted for compatibility. New configs
+# should prefer `[[hooks.post_create]]`; if both legacy commands and any
+# `[hooks.*]` entries are present, gwm warns and runs legacy commands as
+# additional post_create hooks.
 
 # --- composable when predicates --------------------------------------------
 # Atoms: file_exists / cmd_exists / env_set / env_eq / glob_exists
 # Operators: ! (NOT), && (AND), || (OR) — precedence: ! > && > ||
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "install (bun if available)"
 run = "bun install"
 when = "file_exists:package.json && cmd_exists:bun"
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "install (npm fallback)"
 run = "npm ci"
 when = "file_exists:package.json && !cmd_exists:bun"
 
-[[bootstrap.command]]
+[[hooks.post_create]]
 name = "full local build"
 run = "./scripts/full-build.sh"
 when = "glob_exists:src/**/*.rs && !env_set:CI"

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -106,16 +106,29 @@ pub fn run(ctx: &BootstrapCtx<'_>) -> Result<BootstrapReport> {
   let mut report = BootstrapReport { steps: Vec::new() };
   let bs = &ctx.config.bootstrap;
 
+  run_core_steps(ctx, bs, &mut report);
+  run_commands(ctx, bs, &mut report);
+
+  Ok(report)
+}
+
+pub fn run_core(ctx: &BootstrapCtx<'_>) -> Result<BootstrapReport> {
+  let mut report = BootstrapReport { steps: Vec::new() };
+  let bs = &ctx.config.bootstrap;
+
+  run_core_steps(ctx, bs, &mut report);
+
+  Ok(report)
+}
+
+fn run_core_steps(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut BootstrapReport) {
   // Order matters (issue #93): `run_no_symlinks` strips any declared
   // symlinked targets BEFORE `run_copies` opens them for writing.
   // Reversed, an attacker-planted symlink at a copy destination
   // redirects the `fs::copy` write outside the worktree — a write-
   // anywhere primitive triggered by `gwm bootstrap` alone.
-  run_no_symlinks(ctx, bs, &mut report);
-  run_copies(ctx, bs, &mut report);
-  run_commands(ctx, bs, &mut report);
-
-  Ok(report)
+  run_no_symlinks(ctx, bs, report);
+  run_copies(ctx, bs, report);
 }
 
 fn run_copies(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut BootstrapReport) {
@@ -619,7 +632,7 @@ fn exec_shell(step: &CommandStep, cwd: &Path) -> Result<String> {
   Ok(if stdout.is_empty() { stderr } else { stdout })
 }
 
-fn trailing_lines(s: &str, n: usize) -> String {
+pub fn trailing_lines(s: &str, n: usize) -> String {
   let lines: Vec<&str> = s.lines().collect();
   let start = lines.len().saturating_sub(n);
   lines[start..].join("\n")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ use crate::gitmoji;
 use crate::history::{self, OpEntry};
 use crate::hooks;
 use crate::labels::{self, LabelDiff};
+use crate::lifecycle::{self, HookContext, HookPhase, HookSkips};
 use crate::milestones::{self, MilestoneDiff};
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
@@ -100,6 +101,9 @@ pub enum Command {
     /// stale tip so the user can audit it.
     #[arg(long)]
     reuse_branch: bool,
+    /// Skip lifecycle hooks for comma-separated phases (e.g. pre_create,post_create).
+    #[arg(long, value_name = "PHASES")]
+    skip_hooks: Option<String>,
   },
   /// Remove a worktree by fuzzy name match.
   Remove {
@@ -114,6 +118,12 @@ pub enum Command {
     /// resolution failures. Issue #31.
     #[arg(long)]
     dry_run: bool,
+    /// Emergency removal mode: skip pre_remove and post_remove hooks.
+    #[arg(long)]
+    force: bool,
+    /// Skip lifecycle hooks for comma-separated phases.
+    #[arg(long, value_name = "PHASES")]
+    skip_hooks: Option<String>,
   },
   /// Print the on-disk path of a worktree (use `$(gwm path …)` to cd into it).
   ///
@@ -125,6 +135,9 @@ pub enum Command {
   Bootstrap {
     /// Worktree path or name; defaults to CWD.
     target: Option<String>,
+    /// Skip lifecycle hooks for comma-separated phases.
+    #[arg(long, value_name = "PHASES")]
+    skip_hooks: Option<String>,
   },
   /// Prune stale worktree references (admin files without a working dir).
   Prune {
@@ -604,14 +617,17 @@ pub fn run(cli: Cli) -> Result<()> {
       desc,
       no_bootstrap,
       reuse_branch,
-    } => cmd_create(branch_type, issue, desc, no_bootstrap, reuse_branch, mode),
+      skip_hooks,
+    } => cmd_create(branch_type, issue, desc, no_bootstrap, reuse_branch, skip_hooks, mode),
     Command::Remove {
       pattern,
       delete_branch,
       dry_run,
-    } => cmd_remove(pattern, delete_branch, dry_run),
+      force,
+      skip_hooks,
+    } => cmd_remove(pattern, delete_branch, dry_run, force, skip_hooks, mode),
     Command::Path { pattern } => cmd_path(pattern),
-    Command::Bootstrap { target } => cmd_bootstrap(target, mode),
+    Command::Bootstrap { target, skip_hooks } => cmd_bootstrap(target, skip_hooks, mode),
     Command::Prune { dry_run } => cmd_prune(dry_run),
     Command::Doctor => cmd_doctor(),
     Command::Types { gitmoji } => cmd_types(gitmoji),
@@ -741,6 +757,7 @@ fn cmd_create(
   desc: String,
   no_bootstrap: bool,
   reuse_branch: bool,
+  skip_hooks: Option<String>,
   trust_mode: TrustMode,
 ) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
@@ -753,13 +770,21 @@ fn cmd_create(
   let branch = spec.branch_name(&config.worktree, &repo_name)?;
   let dirname = spec.worktree_dirname(&config.worktree, &repo_name)?;
   let target = spec.worktree_path(&config.worktree, &repo_name)?;
+  let skips = HookSkips::parse(skip_hooks.as_deref())?;
 
   // Gate the bootstrap RCE primitive on the TOFU ledger BEFORE
   // creating the worktree — a deny / abort here leaves the user's
   // disk state untouched (no orphaned worktree to clean up).
-  if !no_bootstrap {
+  let create_hooks_present = !config.hooks.pre_create.is_empty()
+    || !config.hooks.post_create.is_empty()
+    || (!no_bootstrap && !config.bootstrap.command.is_empty());
+  if !no_bootstrap || create_hooks_present {
     trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
   }
+
+  let pre_ctx = HookContext::for_create(&repo, &workdir, &workdir, &target, &branch, &spec);
+  let report = lifecycle::run_phase(&config, HookPhase::PreCreate, &pre_ctx, &skips, false)?;
+  print_lifecycle_report(&report);
 
   println!("creating worktree:");
   println!("  branch : {}", branch);
@@ -769,18 +794,31 @@ fn cmd_create(
   let created = worktree::add(&repo, &dirname, &target, &branch, reuse_branch)?;
   println!("✓ worktree created at {}", created.display());
 
+  let post_ctx = pre_ctx.with_cwd(&created);
+
   if no_bootstrap {
     println!("(skipped bootstrap)");
-    return Ok(());
+  } else {
+    let report = lifecycle::run_phase(&config, HookPhase::PreBootstrap, &post_ctx, &skips, false)?;
+    print_lifecycle_report(&report);
+
+    let ctx = BootstrapCtx {
+      main_repo: &workdir,
+      worktree: &created,
+      config: &config,
+    };
+    let report = bootstrap::run_core(&ctx)?;
+    print_report(&report);
+
+    let report = lifecycle::run_phase(&config, HookPhase::PostBootstrap, &post_ctx, &skips, false)?;
+    print_lifecycle_report(&report);
   }
 
-  let ctx = BootstrapCtx {
-    main_repo: &workdir,
-    worktree: &created,
-    config: &config,
-  };
-  let report = bootstrap::run(&ctx)?;
-  print_report(&report);
+  if config.hooks.has_any() && !config.bootstrap.command.is_empty() {
+    eprintln!("warning: [[bootstrap.command]] is deprecated as a post_create hook when [hooks.*] is present");
+  }
+  let report = lifecycle::run_phase(&config, HookPhase::PostCreate, &post_ctx, &skips, !no_bootstrap)?;
+  print_lifecycle_report(&report);
   Ok(())
 }
 
@@ -867,8 +905,16 @@ pub fn format_prune_plan(entries: &[worktree::PrunableEntry]) -> String {
   out
 }
 
-fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()> {
+fn cmd_remove(
+  pattern: String,
+  delete_branch: bool,
+  dry_run: bool,
+  force: bool,
+  skip_hooks: Option<String>,
+  trust_mode: TrustMode,
+) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
   let found = worktree::find_fuzzy(&repo, &pattern)?;
   if dry_run {
     // Issue #31: print the would-remove plan and exit. Resolution
@@ -885,6 +931,18 @@ fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()>
     );
     return Ok(());
   }
+
+  let config = Config::load_for_repo(&workdir)?;
+  let mut skips = HookSkips::parse(skip_hooks.as_deref())?;
+  if force {
+    skips = skips.with(HookPhase::PreRemove).with(HookPhase::PostRemove);
+  }
+  if config.hooks.has_any() {
+    trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
+  }
+  let pre_ctx = HookContext::for_worktree(&repo, &workdir, &found.path, &found.path, found.branch.as_deref());
+  let report = lifecycle::run_phase(&config, HookPhase::PreRemove, &pre_ctx, &skips, false)?;
+  print_lifecycle_report(&report);
 
   // Issue #29: capture the branch OID via libgit2 BEFORE the
   // destructive call so we can resurrect the branch on `gwm undo`.
@@ -930,6 +988,9 @@ fn cmd_remove(pattern: String, delete_branch: bool, dry_run: bool) -> Result<()>
       println!("  branch {} deleted", b);
     }
   }
+  let post_ctx = pre_ctx.with_cwd(&workdir);
+  let report = lifecycle::run_phase(&config, HookPhase::PostRemove, &post_ctx, &skips, false)?;
+  print_lifecycle_report(&report);
   Ok(())
 }
 
@@ -940,32 +1001,48 @@ fn cmd_path(pattern: String) -> Result<()> {
   Ok(())
 }
 
-fn cmd_bootstrap(target: Option<String>, trust_mode: TrustMode) -> Result<()> {
+fn cmd_bootstrap(target: Option<String>, skip_hooks: Option<String>, trust_mode: TrustMode) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
   let config = Config::load_for_repo(&workdir)?;
 
+  let mut worktree_branch: Option<String> = None;
   let worktree_path: PathBuf = match target {
     Some(t) => {
       let p = PathBuf::from(&t);
       if p.is_dir() {
         p
       } else {
-        worktree::find_fuzzy(&repo, &t)?.path
+        let found = worktree::find_fuzzy(&repo, &t)?;
+        worktree_branch = found.branch.clone();
+        found.path
       }
     }
     None => std::env::current_dir()?,
   };
+  let skips = HookSkips::parse(skip_hooks.as_deref())?;
 
   trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
+
+  let hook_ctx = HookContext::for_worktree(
+    &repo,
+    &workdir,
+    &worktree_path,
+    &worktree_path,
+    worktree_branch.as_deref(),
+  );
+  let report = lifecycle::run_phase(&config, HookPhase::PreBootstrap, &hook_ctx, &skips, false)?;
+  print_lifecycle_report(&report);
 
   let ctx = BootstrapCtx {
     main_repo: &workdir,
     worktree: &worktree_path,
     config: &config,
   };
-  let report = bootstrap::run(&ctx)?;
+  let report = bootstrap::run_core(&ctx)?;
   print_report(&report);
+  let report = lifecycle::run_phase(&config, HookPhase::PostBootstrap, &hook_ctx, &skips, false)?;
+  print_lifecycle_report(&report);
   Ok(())
 }
 
@@ -2197,6 +2274,9 @@ function gcd {
 "#;
 
 fn print_report(report: &bootstrap::BootstrapReport) {
+  if report.steps.is_empty() {
+    return;
+  }
   println!();
   println!("bootstrap report:");
   for s in &report.steps {
@@ -2208,6 +2288,13 @@ fn print_report(report: &bootstrap::BootstrapReport) {
       }
     }
   }
+}
+
+fn print_lifecycle_report(report: &bootstrap::BootstrapReport) {
+  if report.steps.is_empty() {
+    return;
+  }
+  lifecycle::print_report(report);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
   #[serde(default)]
   pub bootstrap: BootstrapConfig,
   #[serde(default)]
+  pub hooks: LifecycleHooksConfig,
+  #[serde(default)]
   pub doctor: DoctorConfig,
   #[serde(default)]
   pub tui: TuiConfig,
@@ -236,6 +238,70 @@ pub struct CommandStep {
   pub when: Option<String>,
   #[serde(default)]
   pub env: HashMap<String, String>,
+}
+
+/// `[hooks]` lifecycle automation. Each array uses the same command
+/// shape as `[[bootstrap.command]]`, plus explicit failure handling.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleHooksConfig {
+  #[serde(default)]
+  pub pre_create: Vec<HookStep>,
+  #[serde(default)]
+  pub post_create: Vec<HookStep>,
+  #[serde(default)]
+  pub pre_bootstrap: Vec<HookStep>,
+  #[serde(default)]
+  pub post_bootstrap: Vec<HookStep>,
+  #[serde(default)]
+  pub pre_remove: Vec<HookStep>,
+  #[serde(default)]
+  pub post_remove: Vec<HookStep>,
+}
+
+impl LifecycleHooksConfig {
+  pub fn has_any(&self) -> bool {
+    !self.pre_create.is_empty()
+      || !self.post_create.is_empty()
+      || !self.pre_bootstrap.is_empty()
+      || !self.post_bootstrap.is_empty()
+      || !self.pre_remove.is_empty()
+      || !self.post_remove.is_empty()
+  }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HookStep {
+  pub name: String,
+  pub run: String,
+  #[serde(default)]
+  pub when: Option<String>,
+  #[serde(default)]
+  pub env: HashMap<String, String>,
+  #[serde(default)]
+  pub on_fail: HookOnFail,
+}
+
+impl From<CommandStep> for HookStep {
+  fn from(step: CommandStep) -> Self {
+    Self {
+      name: step.name,
+      run: step.run,
+      when: step.when,
+      env: step.env,
+      on_fail: HookOnFail::Abort,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookOnFail {
+  #[default]
+  Abort,
+  Warn,
+  Ignore,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod history;
 pub mod hooks;
 pub mod labels;
 pub mod launcher;
+pub mod lifecycle;
 pub mod milestones;
 pub mod multiplexer;
 pub mod naming;

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -1,0 +1,298 @@
+use crate::bootstrap::{self, BootstrapReport, StepResult};
+use crate::config::{Config, HookOnFail, HookStep};
+use crate::error::{GwmError, Result};
+use crate::github;
+use crate::naming::BranchSpec;
+use git2::Repository;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HookPhase {
+  PreCreate,
+  PostCreate,
+  PreBootstrap,
+  PostBootstrap,
+  PreRemove,
+  PostRemove,
+}
+
+impl HookPhase {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::PreCreate => "pre_create",
+      Self::PostCreate => "post_create",
+      Self::PreBootstrap => "pre_bootstrap",
+      Self::PostBootstrap => "post_bootstrap",
+      Self::PreRemove => "pre_remove",
+      Self::PostRemove => "post_remove",
+    }
+  }
+
+  fn parse(value: &str) -> Option<Self> {
+    match value {
+      "pre_create" => Some(Self::PreCreate),
+      "post_create" => Some(Self::PostCreate),
+      "pre_bootstrap" => Some(Self::PreBootstrap),
+      "post_bootstrap" => Some(Self::PostBootstrap),
+      "pre_remove" => Some(Self::PreRemove),
+      "post_remove" => Some(Self::PostRemove),
+      _ => None,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HookSkips {
+  phases: HashSet<HookPhase>,
+}
+
+impl HookSkips {
+  pub fn parse(raw: Option<&str>) -> Result<Self> {
+    let mut phases = HashSet::new();
+    let Some(raw) = raw else {
+      return Ok(Self { phases });
+    };
+    for part in raw.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+      let phase = HookPhase::parse(part).ok_or_else(|| {
+        GwmError::Config(format!(
+          "unknown hook phase '{}' in --skip-hooks (expected one of pre_create,post_create,pre_bootstrap,post_bootstrap,pre_remove,post_remove)",
+          part
+        ))
+      })?;
+      phases.insert(phase);
+    }
+    Ok(Self { phases })
+  }
+
+  pub fn with(mut self, phase: HookPhase) -> Self {
+    self.phases.insert(phase);
+    self
+  }
+
+  fn contains(&self, phase: HookPhase) -> bool {
+    self.phases.contains(&phase)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct HookContext {
+  pub main_repo: PathBuf,
+  pub cwd: PathBuf,
+  pub path: PathBuf,
+  pub branch: String,
+  pub branch_type: String,
+  pub issue: String,
+  pub desc: String,
+  pub user: String,
+  pub owner: String,
+  pub repo: String,
+}
+
+impl HookContext {
+  pub fn for_create(
+    repo: &Repository,
+    main_repo: &Path,
+    cwd: &Path,
+    path: &Path,
+    branch: &str,
+    spec: &BranchSpec,
+  ) -> Self {
+    let meta = RepoMeta::from_repo(repo);
+    Self {
+      main_repo: main_repo.to_path_buf(),
+      cwd: cwd.to_path_buf(),
+      path: path.to_path_buf(),
+      branch: branch.to_string(),
+      branch_type: spec.type_.clone(),
+      issue: spec.issue.clone(),
+      desc: spec.desc.clone(),
+      user: git_user(repo),
+      owner: meta.owner,
+      repo: meta.repo,
+    }
+  }
+
+  pub fn for_worktree(repo: &Repository, main_repo: &Path, cwd: &Path, path: &Path, branch: Option<&str>) -> Self {
+    let meta = RepoMeta::from_repo(repo);
+    let parsed = branch.and_then(crate::naming::parse_branch);
+    Self {
+      main_repo: main_repo.to_path_buf(),
+      cwd: cwd.to_path_buf(),
+      path: path.to_path_buf(),
+      branch: branch.unwrap_or_default().to_string(),
+      branch_type: parsed.as_ref().map(|s| s.type_.clone()).unwrap_or_default(),
+      issue: parsed.as_ref().map(|s| s.issue.clone()).unwrap_or_default(),
+      desc: parsed.as_ref().map(|s| s.desc.clone()).unwrap_or_default(),
+      user: git_user(repo),
+      owner: meta.owner,
+      repo: meta.repo,
+    }
+  }
+
+  pub fn with_cwd(&self, cwd: &Path) -> Self {
+    let mut next = self.clone();
+    next.cwd = cwd.to_path_buf();
+    next
+  }
+}
+
+#[derive(Debug)]
+pub struct HookAbort {
+  pub phase: HookPhase,
+  pub step: String,
+  pub detail: String,
+}
+
+pub fn run_phase(
+  config: &Config,
+  phase: HookPhase,
+  ctx: &HookContext,
+  skips: &HookSkips,
+  include_legacy_post_create: bool,
+) -> Result<BootstrapReport> {
+  let mut report = BootstrapReport { steps: Vec::new() };
+  if skips.contains(phase) {
+    report.steps.push(StepResult::skipped(
+      format!("[{}] hooks", phase.as_str()),
+      "skipped by --skip-hooks",
+    ));
+    return Ok(report);
+  }
+
+  let mut steps = steps_for(config, phase);
+  if phase == HookPhase::PostCreate && include_legacy_post_create {
+    steps.extend(config.bootstrap.command.iter().cloned().map(HookStep::from));
+  }
+
+  for step in steps {
+    let label = format!("[{}] {}", phase.as_str(), step.name);
+    if let Some(ref guard) = step.when {
+      if !bootstrap::evaluate_when(guard, &ctx.cwd) {
+        report
+          .steps
+          .push(StepResult::skipped(label, format!("when condition '{}' false", guard)));
+        continue;
+      }
+    }
+
+    match run_step(&step, ctx) {
+      Ok(output) => report
+        .steps
+        .push(StepResult::ok_with_detail(label, bootstrap::trailing_lines(&output, 3))),
+      Err(detail) => match step.on_fail {
+        HookOnFail::Abort => {
+          report.steps.push(StepResult::failed(label, detail.clone()));
+          print_report(&report);
+          return Err(GwmError::CommandFailed(format!(
+            "hook {} '{}' failed: {}",
+            phase.as_str(),
+            step.name,
+            detail
+          )));
+        }
+        HookOnFail::Warn => report.steps.push(StepResult::warning(label, detail)),
+        HookOnFail::Ignore => report
+          .steps
+          .push(StepResult::skipped(label, format!("ignored failure: {}", detail))),
+      },
+    }
+  }
+
+  Ok(report)
+}
+
+pub fn print_report(report: &BootstrapReport) {
+  for s in &report.steps {
+    let sigil = s.status.sigil();
+    println!("  {} {}", sigil, s.label);
+    if !s.detail.is_empty() {
+      for line in s.detail.lines() {
+        println!("      {}", line);
+      }
+    }
+  }
+}
+
+fn steps_for(config: &Config, phase: HookPhase) -> Vec<HookStep> {
+  match phase {
+    HookPhase::PreCreate => config.hooks.pre_create.clone(),
+    HookPhase::PostCreate => config.hooks.post_create.clone(),
+    HookPhase::PreBootstrap => config.hooks.pre_bootstrap.clone(),
+    HookPhase::PostBootstrap => config.hooks.post_bootstrap.clone(),
+    HookPhase::PreRemove => config.hooks.pre_remove.clone(),
+    HookPhase::PostRemove => config.hooks.post_remove.clone(),
+  }
+}
+
+fn run_step(step: &HookStep, ctx: &HookContext) -> std::result::Result<String, String> {
+  let run = expand_placeholders(&step.run, ctx);
+  let env = step
+    .env
+    .iter()
+    .map(|(key, value)| (key.clone(), expand_placeholders(value, ctx)))
+    .collect::<HashMap<_, _>>();
+  let mut cmd = Command::new("sh");
+  cmd.arg("-c").arg(run).current_dir(&ctx.cwd);
+  for (key, value) in env {
+    cmd.env(key, value);
+  }
+  let out = cmd.output().map_err(|e| format!("failed to spawn: {}", e))?;
+  let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+  let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+  let detail = if stdout.is_empty() { stderr } else { stdout };
+  if !out.status.success() {
+    return Err(format!("exited with {}\n{}", out.status, detail).trim().to_string());
+  }
+  Ok(detail)
+}
+
+fn expand_placeholders(template: &str, ctx: &HookContext) -> String {
+  template
+    .replace("{branch}", &ctx.branch)
+    .replace("{path}", &ctx.path.display().to_string())
+    .replace("{type}", &ctx.branch_type)
+    .replace("{issue}", &ctx.issue)
+    .replace("{desc}", &ctx.desc)
+    .replace("{user}", &ctx.user)
+    .replace("{owner}", &ctx.owner)
+    .replace("{repo}", &ctx.repo)
+}
+
+fn git_user(repo: &Repository) -> String {
+  repo
+    .config()
+    .ok()
+    .and_then(|cfg| cfg.get_string("user.name").ok())
+    .filter(|value| !value.trim().is_empty())
+    .or_else(|| std::env::var("USER").ok())
+    .unwrap_or_default()
+}
+
+struct RepoMeta {
+  owner: String,
+  repo: String,
+}
+
+impl RepoMeta {
+  fn from_repo(repo: &Repository) -> Self {
+    let repo_name = crate::worktree::repo_name(repo);
+    let Ok(slug) = github::repo_slug(repo) else {
+      return Self {
+        owner: String::new(),
+        repo: repo_name,
+      };
+    };
+    let Some((owner, name)) = slug.split_once('/') else {
+      return Self {
+        owner: String::new(),
+        repo: repo_name,
+      };
+    };
+    Self {
+      owner: owner.to_string(),
+      repo: name.to_string(),
+    }
+  }
+}

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -166,7 +166,12 @@ pub fn evaluate(workdir: &Path, origin: &str, mode: TrustMode) -> Result<TrustOu
   if let Ok(body_str) = std::str::from_utf8(&bytes) {
     if let Ok(cfg) = toml::from_str::<Config>(body_str) {
       let bs = &cfg.bootstrap;
-      if bs.copy.is_empty() && bs.guard.is_empty() && bs.no_symlink.is_empty() && bs.command.is_empty() {
+      if bs.copy.is_empty()
+        && bs.guard.is_empty()
+        && bs.no_symlink.is_empty()
+        && bs.command.is_empty()
+        && !cfg.hooks.has_any()
+      {
         return Ok(TrustOutcome::Proceed);
       }
     }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1520,6 +1520,276 @@ required = true
 }
 
 #[test]
+fn create_runs_lifecycle_hooks_and_legacy_bootstrap_command_alias() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_create]]
+name = "record pre-create"
+run = "printf pre-{{branch}}-{{issue}}-{{desc}} > pre-create.txt"
+
+[[hooks.post_create]]
+name = "record post-create"
+run = "printf post-{{branch}} > post-create.txt"
+
+[[bootstrap.command]]
+name = "legacy post-create"
+run = "printf legacy > legacy-post-create.txt"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "88", "hooks"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("[pre_create] record pre-create"))
+    .stdout(predicate::str::contains("[post_create] record post-create"))
+    .stdout(predicate::str::contains("[post_create] legacy post-create"));
+
+  let worktree = base.path().join("feat-88-hooks");
+  assert_eq!(
+    std::fs::read_to_string(dir.path().join("pre-create.txt")).unwrap(),
+    "pre-feat/#88-hooks-88-hooks"
+  );
+  assert_eq!(
+    std::fs::read_to_string(worktree.join("post-create.txt")).unwrap(),
+    "post-feat/#88-hooks"
+  );
+  assert_eq!(
+    std::fs::read_to_string(worktree.join("legacy-post-create.txt")).unwrap(),
+    "legacy"
+  );
+}
+
+#[test]
+fn create_pre_create_abort_failure_leaves_no_worktree() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_create]]
+name = "block create"
+run = "false"
+on_fail = "abort"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "88", "blocked"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("hook pre_create 'block create' failed"));
+
+  assert!(
+    !base.path().join("feat-88-blocked").exists(),
+    "pre_create abort must happen before worktree creation"
+  );
+}
+
+#[test]
+fn create_warn_and_ignore_hook_failures_do_not_abort() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_create]]
+name = "warn only"
+run = "false"
+on_fail = "warn"
+
+[[hooks.pre_create]]
+name = "ignore failure"
+run = "false"
+on_fail = "ignore"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "88", "nonfatal"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("! [pre_create] warn only"))
+    .stdout(predicate::str::contains("· [pre_create] ignore failure"));
+
+  assert!(base.path().join("feat-88-nonfatal").exists());
+}
+
+#[test]
+fn create_skip_hooks_bypasses_named_phase() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_create]]
+name = "would block"
+run = "false"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "88", "skip", "--skip-hooks", "pre_create"])
+    .assert()
+    .success();
+
+  assert!(base.path().join("feat-88-skip").exists());
+}
+
+#[test]
+fn bootstrap_runs_pre_and_post_bootstrap_hooks() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_bootstrap]]
+name = "before bootstrap"
+run = "printf pre > pre-bootstrap.txt"
+
+[[bootstrap.copy]]
+from = "seed.txt"
+to = "seed.txt"
+required = true
+
+[[hooks.post_bootstrap]]
+name = "after bootstrap"
+run = "printf post > post-bootstrap.txt"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+  std::fs::write(dir.path().join("seed.txt"), "seed").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "88", "boot-hooks", "--no-bootstrap"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["bootstrap", "feat-88-boot-hooks"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("[pre_bootstrap] before bootstrap"))
+    .stdout(predicate::str::contains("[post_bootstrap] after bootstrap"));
+
+  let worktree = base.path().join("feat-88-boot-hooks");
+  assert_eq!(
+    std::fs::read_to_string(worktree.join("pre-bootstrap.txt")).unwrap(),
+    "pre"
+  );
+  assert_eq!(std::fs::read_to_string(worktree.join("seed.txt")).unwrap(), "seed");
+  assert_eq!(
+    std::fs::read_to_string(worktree.join("post-bootstrap.txt")).unwrap(),
+    "post"
+  );
+}
+
+#[test]
+fn remove_runs_pre_and_post_remove_hooks_and_force_skips_them() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["create", "feat", "88", "remove-hooks", "--no-bootstrap"])
+    .assert()
+    .success();
+
+  let config = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[hooks.pre_remove]]
+name = "block remove"
+run = "false"
+
+[[hooks.post_remove]]
+name = "cleanup"
+run = "printf removed-{{branch}} > post-remove.txt"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), config).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["remove", "remove-hooks"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("hook pre_remove 'block remove' failed"));
+  assert!(base.path().join("feat-88-remove-hooks").exists());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["remove", "remove-hooks", "--force"])
+    .assert()
+    .success();
+  assert!(!base.path().join("feat-88-remove-hooks").exists());
+  assert!(
+    !dir.path().join("post-remove.txt").exists(),
+    "--force must skip pre_remove and post_remove hooks"
+  );
+}
+
+#[test]
 fn create_skips_bootstrap_with_no_bootstrap_flag() {
   // Same scaffolding as the previous test, but `--no-bootstrap` must
   // short-circuit `bootstrap::run` BEFORE the copy step. The worktree


### PR DESCRIPTION
## Summary
- add `[hooks.*]` lifecycle phases for create, bootstrap, and remove flows
- support hook placeholders, per-step `on_fail`, `--skip-hooks`, and `remove --force` hook bypass
- document the new schema and map legacy `[[bootstrap.command]]` to `post_create`

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- ./target/debug/gwm doctor

Closes #88