### PR TITLE
✨ feat: add [pr_template] defaults and gwm pr command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `gwm config get/set/unset/list/validate/path/edit` for git-config-style `.gwm.toml` reads and comment-preserving edits.
 - Add lifecycle hooks under `[hooks.*]` for create/bootstrap/remove phases, with placeholders, per-step `on_fail`, `--skip-hooks`, and legacy `[[bootstrap.command]]` compatibility as `post_create`.
 - Add `[issue_template]` defaults plus `gwm new <type> <desc>` to create a GitHub issue from issue-form templates and immediately create the linked worktree.
+- Add `[pr_template]` defaults plus `gwm pr [--draft] [--base <ref>] [--render]` to render per-branch-type PR bodies (with `{commits}` / `{files_changed}` placeholders) and shell out to `gh pr create`.
 
 ## Past releases
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -88,6 +88,30 @@ gwm new feat add-config-types
 | `--reuse-branch` | Attach to an existing local branch after the issue is created       |
 | `--skip-hooks`   | Skip comma-separated lifecycle hook phases                          |
 
+## `gwm pr [--draft] [--base <ref>] [--render]`
+
+Render the PR body from `[pr_template]` and shell out to `gh pr create` against the resolved trunk.
+
+```bash
+gwm pr                                # creates the PR
+gwm pr --draft                        # creates a draft PR
+gwm pr --base develop                 # diff against develop instead of [doctor].trunks
+gwm pr --render                       # prints the rendered body to stdout (no PR created)
+gwm pr --render | gh pr create --body-file -
+```
+
+`gwm pr` reads the current branch (parsing `<type>/#<N>-<desc>` for the `{type}` / `{issue}` / `{desc}` placeholders), picks the first existing trunk from `[doctor].trunks` (or falls back to `main`), then renders the per-branch-type template under `[pr_template.by_type.<type>]` (inline `body` wins over `path`), with `[pr_template].default` as the fallback.
+
+| Flag                | Action                                                              |
+|:--------------------|:--------------------------------------------------------------------|
+| `--render`          | Print the rendered Markdown to stdout; never shell out to `gh`      |
+| `--draft`           | Forward `--draft` to `gh pr create` so the PR opens as a draft      |
+| `--base <REF>`      | Override the comparison base instead of the first matching trunk    |
+
+On success the new PR number is recorded under `branch.<head>.gwm-pr` (same key `gwm link pr` writes), so `gwm status` and `gwm open pr` resolve the link without a separate `gwm link` call.
+
+Body resolution and placeholder semantics are documented under [Configuration → `[pr_template]`](/configuration/gwm-toml#pr-template-issue-84).
+
 ## `gwm list [--format=table|names]`
 
 List the worktrees in the current repo.

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -381,6 +381,54 @@ hotfix = { template = "bug_report.yml", surface = "cli", title_prefix = "[Hotfix
 
 Template bodies support placeholders `{type}`, `{desc}`, and `{repo}`. Issue-form markdown blocks are preserved, text inputs/areas become markdown sections, and configured dropdown defaults render as single-line `**Label:** value` entries.
 
+## `[pr_template]` (issue #84)
+
+Per-branch-type PR bodies for `gwm pr [--draft] [--base <ref>] [--render]`. Without the subcommand, `gh pr create` falls back to `.github/pull_request_template.md`; `gwm pr` lets each branch type point at its own body so a `docs/` PR doesn't get the same checklist as a `hotfix/`.
+
+```toml
+[pr_template]
+default = ".github/pull_request_template.md"
+
+[pr_template.by_type]
+feat = { path = ".github/pr-templates/feat.md" }
+fix  = { path = ".github/pr-templates/fix.md" }
+docs = { path = ".github/pr-templates/docs.md" }
+
+[pr_template.by_type.chore]
+body = """
+## Summary
+{desc}
+
+Closes #{issue}
+
+## Test plan
+- [ ] cargo test
+"""
+```
+
+| Field     | Type   | Meaning                                                                  |
+|:----------|:-------|:-------------------------------------------------------------------------|
+| `default` | string | fallback Markdown file (workdir-relative path)                           |
+| `path`    | string | per-type Markdown file (workdir-relative path)                           |
+| `body`    | string | inline Markdown body — wins over `path` when both are set on one type    |
+
+Both `default` and `path` are workdir-relative paths; absolute paths, `..` parents, and Windows drive prefixes are rejected to stop a template path from escaping the worktree root.
+
+Placeholders the renderer substitutes before handing the body to `gh pr create`:
+
+| Placeholder       | Source                                                                        |
+|:------------------|:------------------------------------------------------------------------------|
+| `{type}`          | branch type parsed from the current branch name                              |
+| `{issue}`         | issue number parsed from the branch name (empty when none)                   |
+| `{desc}`          | description slug parsed from the branch name                                 |
+| `{base}`          | resolved trunk from `[doctor].trunks` (first that exists) or `--base` value  |
+| `{head}`          | current branch shorthand                                                     |
+| `{repo}`          | `owner/repo` slug parsed from the `origin` remote URL                        |
+| `{commits}`       | `git log --pretty=format:- %s {base}..{head}` (one bullet per commit subject) |
+| `{files_changed}` | `git diff --stat {base}..{head}`, capped at 30 lines (`… N more lines trimmed`) |
+
+`gwm pr --render` prints the rendered body to stdout instead of creating a PR — useful for `gwm pr --render | gh pr create --body-file -` when you want to tweak the body in `$EDITOR` first.
+
 ## `[aliases]` (issue #86)
 
 Repo-level CLI aliases — declarative `git config`-style aliases that follow the repo across machines. Each entry maps an alias name to an argv-substituted expansion run BEFORE clap parses, so `wip = "create feat 0 wip"` makes `gwm wip` behave as `gwm create feat 0 wip`.
@@ -423,6 +471,7 @@ Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` 
 | `[doctor].trunks`                    | `["dev", "main"]`                |
 | `[[labels]]`                         | empty — `gwm labels {list,push}` are no-ops |
 | `[issue_template]`                   | empty — `gwm new` is not configured          |
+| `[pr_template]`                      | empty — `gwm pr` errors with a hint, `gh pr create` keeps using `.github/pull_request_template.md` |
 | `[aliases]`                          | empty — no CLI alias expansion              |
 
 ## validation rules

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -375,6 +375,38 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # docs = { template = "task.yml", title_prefix = "[Docs]: " }
 # hotfix = { template = "bug_report.yml", surface = "cli", title_prefix = "[Hotfix]: ", labels = ["priority: high"] }
 
+# --- PR templates for `gwm pr` (issue #84) ----------------------------------
+# `gwm pr [--draft] [--base <ref>] [--render]` renders a per-branch-type PR
+# body and shells out to `gh pr create`. Bodies can be a workdir-relative
+# Markdown file (`path = …`) or an inline string (`body = "…"`). Placeholders
+# `{type}`, `{issue}`, `{desc}`, `{base}`, `{head}`, `{repo}`, `{commits}`
+# (`- subject` lines from `git log base..head`), and `{files_changed}`
+# (`git diff --stat base..head`, capped at 30 lines) are substituted before
+# the body lands on the temp file `gh pr create --body-file` reads.
+#
+# `gwm pr --render` skips `gh` entirely and prints the rendered body to
+# stdout so you can pipe it elsewhere: `gwm pr --render | gh pr create
+# --body-file -`.
+#
+# [pr_template]
+# default = ".github/pull_request_template.md"
+#
+# [pr_template.by_type]
+# feat = { path = ".github/pr-templates/feat.md" }
+# fix  = { path = ".github/pr-templates/fix.md" }
+# docs = { path = ".github/pr-templates/docs.md" }
+#
+# [pr_template.by_type.chore]
+# body = """
+# ## Summary
+# {desc}
+#
+# Closes #{issue}
+#
+# ## Test plan
+# - [ ] cargo test
+# """
+
 # --- CLI aliases (issue #86) ------------------------------------------------
 # Mirror of `git config`'s `[alias]` block. Each entry maps a short
 # name to an argv-substituted expansion run BEFORE clap parses, so

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
 use crate::naming::{parse_branch, BranchSpec};
+use crate::pr_templates::{self, PrTemplateContext};
 use crate::trust::{self, TrustLedger, TrustMode, TrustOutcome};
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -105,6 +106,34 @@ pub enum Command {
     /// Skip lifecycle hooks for comma-separated phases (e.g. pre_create,post_create).
     #[arg(long, value_name = "PHASES")]
     skip_hooks: Option<String>,
+  },
+  /// Render the PR body from `[pr_template]` (issue #84), then
+  /// `gh pr create` unless `--render` is passed.
+  ///
+  /// Without `--render`, the rendered Markdown is written to a temp
+  /// file and shelled out to `gh pr create --title <subject> --body-file
+  /// <tmp> --head <branch>` (plus `--draft` and `--base` when
+  /// specified). The body resolution honours
+  /// `[pr_template.by_type.<type>]` (inline `body` wins over per-type
+  /// `path`), then `[pr_template].default` as a fallback.
+  ///
+  /// Placeholders substituted by the template engine:
+  ///   `{type}` `{issue}` `{desc}` `{base}` `{head}` `{repo}`
+  ///   `{commits}`        — `git log --pretty='- %s' base..head`
+  ///   `{files_changed}`  — `git diff --stat base..head`, capped 30 lines
+  Pr {
+    /// Render the body to stdout instead of creating the PR. The output
+    /// is suitable for piping into `gh pr create --body-file -`.
+    #[arg(long)]
+    render: bool,
+    /// Create the PR as a draft (shells out to `gh pr create --draft`).
+    /// Ignored when `--render` is set.
+    #[arg(long, conflicts_with = "render")]
+    draft: bool,
+    /// Override the base ref to compare against (defaults to the
+    /// resolved trunk from `[doctor].trunks`, then `main`).
+    #[arg(long, value_name = "REF")]
+    base: Option<String>,
   },
   /// Create a GitHub issue from templates, then create its worktree.
   New {
@@ -645,6 +674,7 @@ pub fn run(cli: Cli) -> Result<()> {
       reuse_branch,
       skip_hooks,
     } => cmd_new(branch_type, desc, no_bootstrap, reuse_branch, skip_hooks, mode),
+    Command::Pr { render, draft, base } => cmd_pr(render, draft, base),
     Command::Remove {
       pattern,
       delete_branch,
@@ -897,6 +927,116 @@ fn cmd_new(
     skip_hooks,
     trust_mode,
   )
+}
+
+/// Maximum number of lines kept from `git diff --stat <base>..<head>`
+/// when rendering the `{files_changed}` placeholder. Hardcoded by issue
+/// #84 so a sprawling refactor PR doesn't push the body past GitHub's
+/// 65 535-byte limit; the renderer appends a `… (N more lines trimmed)`
+/// rider when the cap fires.
+const PR_FILES_CHANGED_MAX_LINES: usize = 30;
+
+fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Result<()> {
+  let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  let config = Config::load_for_repo(&workdir)?;
+  let head_name = current_branch(&repo)?;
+  let branch_spec = parse_branch(&head_name);
+
+  let branch_type = branch_spec
+    .as_ref()
+    .map(|s| s.type_.clone())
+    .unwrap_or_else(|| "chore".into());
+  let issue = branch_spec.as_ref().map(|s| s.issue.clone()).unwrap_or_default();
+  let desc = branch_spec.as_ref().map(|s| s.desc.clone()).unwrap_or_default();
+
+  let base = base_override
+    .or_else(|| resolve_pr_base(&repo, &config.doctor.trunks))
+    .unwrap_or_else(|| "main".into());
+
+  let commits = worktree::git_log_subject_between(&workdir, &base, &head_name).unwrap_or_default();
+  let files_changed =
+    worktree::git_diff_stat_between(&workdir, &base, &head_name, PR_FILES_CHANGED_MAX_LINES).unwrap_or_default();
+  let repo_slug = github::repo_slug(&repo).unwrap_or_default();
+
+  let ctx = PrTemplateContext {
+    branch_type: branch_type.clone(),
+    issue,
+    desc,
+    base: base.clone(),
+    head: head_name.clone(),
+    commits,
+    files_changed,
+    repo: repo_slug.clone(),
+  };
+  let body = pr_templates::render_pr_body(&config.pr_template, &workdir, &ctx)?;
+
+  if render_only {
+    print!("{}", body);
+    if !body.ends_with('\n') {
+      println!();
+    }
+    return Ok(());
+  }
+
+  let mut body_file = tempfile::NamedTempFile::new()?;
+  use std::io::Write;
+  body_file.write_all(body.as_bytes())?;
+  body_file.flush()?;
+
+  let title = pr_title(&ctx);
+  let slug = if repo_slug.is_empty() {
+    None
+  } else {
+    Some(repo_slug.as_str())
+  };
+  let created = github::create_pr(&github::PrCreateRequest {
+    title: &title,
+    body_file: body_file.path(),
+    head: &head_name,
+    base: Some(base.as_str()),
+    draft,
+    repo: slug,
+  })?;
+  println!("✓ created PR #{}", created.number);
+  println!("  {}", created.url);
+  if let Err(e) = github::link_pr(&repo, &head_name, created.number) {
+    // Linking is a best-effort convenience: surface the failure but
+    // don't drop the freshly-created PR on the floor.
+    eprintln!("note: could not record gwm-pr config for {}: {}", head_name, e);
+  }
+  Ok(())
+}
+
+/// Pick the first `trunks` entry that resolves to a local branch in
+/// `repo`. Returns `None` if the list is empty or no entry exists —
+/// the caller falls back to `"main"` so a freshly-init'd repo doesn't
+/// trip on the `[doctor].trunks` default of `["dev", "main"]` (issue
+/// #84: the trunk list was added for `gwm doctor`, but `gwm pr` is the
+/// first feature that *requires* a base ref to actually exist).
+fn resolve_pr_base(repo: &Repository, trunks: &[String]) -> Option<String> {
+  for trunk in trunks {
+    if repo.find_branch(trunk, git2::BranchType::Local).is_ok() {
+      return Some(trunk.clone());
+    }
+  }
+  None
+}
+
+fn pr_title(ctx: &PrTemplateContext) -> String {
+  // Title heuristic mirrors `me:issue-worktree-pr`: take the latest
+  // commit subject if there is one, else fall back to "<type>: <desc>"
+  // so the user gets a deterministic, non-empty title.
+  if let Some(first) = ctx.commits.lines().next() {
+    let trimmed = first.trim_start_matches("- ").trim();
+    if !trimmed.is_empty() {
+      return trimmed.to_string();
+    }
+  }
+  if !ctx.desc.is_empty() {
+    return format!("{}: {}", ctx.branch_type, ctx.desc);
+  }
+  format!("update {}", ctx.head)
 }
 
 /// Render the would-do plan for `gwm remove --dry-run` (issue #31).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -954,9 +954,22 @@ fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Resu
     .or_else(|| resolve_pr_base(&repo, &config.doctor.trunks))
     .unwrap_or_else(|| "main".into());
 
-  let commits = worktree::git_log_subject_between(&workdir, &base, &head_name).unwrap_or_default();
-  let files_changed =
-    worktree::git_diff_stat_between(&workdir, &base, &head_name, PR_FILES_CHANGED_MAX_LINES).unwrap_or_default();
+  let commits = worktree::git_log_subject_between(&workdir, &base, &head_name)
+    .inspect_err(|e| {
+      eprintln!(
+        "note: could not collect `{{commits}}` from `git log {}..{}`: {} (placeholder will be empty)",
+        base, head_name, e
+      );
+    })
+    .unwrap_or_default();
+  let files_changed = worktree::git_diff_stat_between(&workdir, &base, &head_name, PR_FILES_CHANGED_MAX_LINES)
+    .inspect_err(|e| {
+      eprintln!(
+        "note: could not collect `{{files_changed}}` from `git diff --stat {}..{}`: {} (placeholder will be empty)",
+        base, head_name, e
+      );
+    })
+    .unwrap_or_default();
   let repo_slug = github::repo_slug(&repo).unwrap_or_default();
 
   let ctx = PrTemplateContext {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1021,16 +1021,27 @@ fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Resu
   Ok(())
 }
 
-/// Pick the first `trunks` entry that resolves to a local branch in
-/// `repo`. Returns `None` if the list is empty or no entry exists —
-/// the caller falls back to `"main"` so a freshly-init'd repo doesn't
-/// trip on the `[doctor].trunks` default of `["dev", "main"]` (issue
-/// #84: the trunk list was added for `gwm doctor`, but `gwm pr` is the
-/// first feature that *requires* a base ref to actually exist).
+/// Pick a base ref for `gwm pr` by walking the configured `[doctor].trunks`
+/// list first, then the common defaults (`main`, `master`, `dev`,
+/// `develop`, `trunk`) so a repo whose local trunk is `master` and which
+/// hasn't customised `[doctor]` doesn't fall back to a non-existent
+/// `"main"`. Returns `None` only if none of the candidates resolve to a
+/// local branch — the caller then uses `"main"` as a last resort so the
+/// downstream `gh pr create --base main` produces a clean error message
+/// instead of a panic.
 fn resolve_pr_base(repo: &Repository, trunks: &[String]) -> Option<String> {
+  const COMMON_TRUNKS: &[&str] = &["main", "master", "dev", "develop", "trunk"];
   for trunk in trunks {
     if repo.find_branch(trunk, git2::BranchType::Local).is_ok() {
       return Some(trunk.clone());
+    }
+  }
+  for trunk in COMMON_TRUNKS {
+    if trunks.iter().any(|t| t == trunk) {
+      continue; // already tried as a configured trunk above
+    }
+    if repo.find_branch(trunk, git2::BranchType::Local).is_ok() {
+      return Some((*trunk).to_string());
     }
   }
   None

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,8 @@ pub struct Config {
   pub gitmoji: BTreeMap<String, String>,
   #[serde(default)]
   pub issue_template: IssueTemplateConfig,
+  #[serde(default)]
+  pub pr_template: PrTemplateConfig,
 }
 
 /// One `[[labels]]` entry. `name` is the GitHub key (unique per repo);
@@ -132,6 +134,35 @@ pub struct IssueTemplateTypeConfig {
   pub title_prefix: Option<String>,
   #[serde(default)]
   pub labels: Vec<String>,
+}
+
+/// `[pr_template]` config block (issue #84). `default` is a workdir-
+/// relative path to a Markdown template used as the fallback PR body;
+/// `by_type` maps a branch type to either a per-type `path` or an
+/// inline `body` string. The resolver in `pr_templates` picks the most
+/// specific entry (per-type wins over default) and runs the templating
+/// engine on the result.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrTemplateConfig {
+  #[serde(default)]
+  pub default: Option<String>,
+  #[serde(default)]
+  pub by_type: BTreeMap<String, PrTemplateTypeConfig>,
+}
+
+/// Per-branch-type override under `[pr_template.by_type.<type>]`. Either
+/// `path` (a workdir-relative Markdown file) or `body` (an inline
+/// string) must be set; setting both is allowed and `path` wins so an
+/// inline `body` can be used as a stable default while a per-repo file
+/// shadows it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrTemplateTypeConfig {
+  #[serde(default)]
+  pub path: Option<String>,
+  #[serde(default)]
+  pub body: Option<String>,
 }
 
 /// Origin of the resolved branch-type list — surfaced verbatim under

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,9 +153,12 @@ pub struct PrTemplateConfig {
 
 /// Per-branch-type override under `[pr_template.by_type.<type>]`. Either
 /// `path` (a workdir-relative Markdown file) or `body` (an inline
-/// string) must be set; setting both is allowed and `path` wins so an
-/// inline `body` can be used as a stable default while a per-repo file
-/// shadows it.
+/// string) must be set; setting both is allowed and inline `body` wins
+/// over `path` so a stable on-disk template can be carried in `path`
+/// while a focused `body` override takes precedence for a specific
+/// branch type. The resolver in `pr_templates` enforces this ordering;
+/// see `inline_body_wins_over_path_when_both_set` in
+/// `tests/pr_templates_tests.rs` for the pinned contract.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrTemplateTypeConfig {

--- a/src/github.rs
+++ b/src/github.rs
@@ -20,6 +20,8 @@ use std::sync::LazyLock;
 
 static ISSUE_URL_RE: LazyLock<regex::Regex> =
   LazyLock::new(|| regex::Regex::new(r"/issues/(\d+)(?:\b|$)").expect("static issue URL regex compiles"));
+static PR_URL_RE: LazyLock<regex::Regex> =
+  LazyLock::new(|| regex::Regex::new(r"/pull/(\d+)(?:\b|$)").expect("static PR URL regex compiles"));
 
 const ISSUE_CONFIG_KEY: &str = "gwm-issue";
 const PR_CONFIG_KEY: &str = "gwm-pr";
@@ -216,6 +218,22 @@ pub struct CreatedIssue {
   pub url: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct PrCreateRequest<'a> {
+  pub title: &'a str,
+  pub body_file: &'a std::path::Path,
+  pub head: &'a str,
+  pub base: Option<&'a str>,
+  pub draft: bool,
+  pub repo: Option<&'a str>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreatedPr {
+  pub number: u64,
+  pub url: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrState {
   Open,
@@ -378,6 +396,47 @@ pub fn create_issue(req: &IssueCreateRequest<'_>) -> Result<CreatedIssue> {
     .and_then(|m| m.as_str().parse::<u64>().ok())
     .ok_or_else(|| GwmError::CommandFailed(format!("failed to parse issue number from gh output: {}", stdout)))?;
   Ok(CreatedIssue { number, url: stdout })
+}
+
+/// Shell out to `gh pr create` with a body file already rendered by
+/// [`crate::pr_templates::render_pr_body`]. Parses the URL printed by
+/// gh on success to extract the PR number.
+pub fn create_pr(req: &PrCreateRequest<'_>) -> Result<CreatedPr> {
+  let mut args: Vec<OsString> = Vec::with_capacity(
+    8 + if req.draft { 1 } else { 0 } + if req.base.is_some() { 2 } else { 0 } + if req.repo.is_some() { 2 } else { 0 },
+  );
+  args.push("pr".into());
+  args.push("create".into());
+  args.push("--title".into());
+  args.push(req.title.into());
+  args.push("--body-file".into());
+  args.push(req.body_file.as_os_str().to_owned());
+  args.push("--head".into());
+  args.push(req.head.into());
+  if let Some(base) = req.base {
+    args.push("--base".into());
+    args.push(base.into());
+  }
+  if req.draft {
+    args.push("--draft".into());
+  }
+  if let Some(repo) = req.repo {
+    args.push("--repo".into());
+    args.push(repo.into());
+  }
+  let stdout = run_gh(&args)?;
+  let stdout = stdout.trim().to_string();
+  let Some(caps) = PR_URL_RE.captures(&stdout) else {
+    return Err(GwmError::CommandFailed(format!(
+      "gh pr create did not print a PR URL containing a number: {}",
+      stdout
+    )));
+  };
+  let number = caps
+    .get(1)
+    .and_then(|m| m.as_str().parse::<u64>().ok())
+    .ok_or_else(|| GwmError::CommandFailed(format!("failed to parse PR number from gh output: {}", stdout)))?;
+  Ok(CreatedPr { number, url: stdout })
 }
 
 /// Run `gh pr view <n> --repo <slug> --json …` and parse the result.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod lifecycle;
 pub mod milestones;
 pub mod multiplexer;
 pub mod naming;
+pub mod pr_templates;
 pub mod templating;
 pub mod trust;
 pub mod tui;

--- a/src/pr_templates.rs
+++ b/src/pr_templates.rs
@@ -1,0 +1,110 @@
+//! PR body renderer for the `[pr_template]` config block (issue #84).
+//!
+//! Mirrors the issue-template flow from [`crate::issue_templates`] but
+//! is deliberately pure: callers (e.g. `gwm pr`) collect the branch
+//! context, base/head refs, commit list, and diff stats from libgit2 +
+//! `gh`, then hand a [`PrTemplateContext`] over to [`render_pr_body`].
+//! The renderer itself does not touch git so unit tests can drive it
+//! against a `tempfile::TempDir` without seeding a repo.
+//!
+//! Body resolution precedence (most → least specific):
+//!   1. `[pr_template.by_type.<type>].body` — inline override
+//!   2. `[pr_template.by_type.<type>].path` — workdir-relative Markdown
+//!   3. `[pr_template].default` — workdir-relative Markdown fallback
+//!   4. otherwise an error so the caller can surface a config hint
+//!
+//! Path inputs are sandboxed against the same `Component::Prefix` /
+//! `Component::RootDir` / parent-traversal hardening as
+//! [`crate::issue_templates::resolve_template_path`], plus a
+//! belt-and-braces `strip_prefix(workdir)` containment check.
+
+use crate::config::{PrTemplateConfig, PrTemplateTypeConfig};
+use crate::error::{GwmError, Result};
+use crate::templating::{self, TemplateContext};
+use std::path::{Component, Path, PathBuf};
+
+/// Inputs the renderer substitutes into the template body. All fields
+/// default to the empty string so callers can fill in only the ones
+/// the configured template references.
+#[derive(Debug, Clone, Default)]
+pub struct PrTemplateContext {
+  pub branch_type: String,
+  pub issue: String,
+  pub desc: String,
+  pub base: String,
+  pub head: String,
+  pub commits: String,
+  pub files_changed: String,
+  pub repo: String,
+}
+
+/// Render the PR body for `ctx.branch_type` from `config`, anchored at
+/// `workdir`. Resolves the most-specific template (inline body > per-
+/// type path > default path), then runs the shared placeholder engine
+/// against the supplied context.
+pub fn render_pr_body(config: &PrTemplateConfig, workdir: &Path, ctx: &PrTemplateContext) -> Result<String> {
+  let type_config = config.by_type.get(&ctx.branch_type);
+  let raw_body = resolve_raw_body(config, workdir, &ctx.branch_type, type_config)?;
+  let tctx = TemplateContext::from_pairs([
+    ("type", ctx.branch_type.as_str()),
+    ("issue", ctx.issue.as_str()),
+    ("desc", ctx.desc.as_str()),
+    ("base", ctx.base.as_str()),
+    ("head", ctx.head.as_str()),
+    ("commits", ctx.commits.as_str()),
+    ("files_changed", ctx.files_changed.as_str()),
+    ("repo", ctx.repo.as_str()),
+  ]);
+  Ok(templating::render_template(&raw_body, &tctx))
+}
+
+fn resolve_raw_body(
+  config: &PrTemplateConfig,
+  workdir: &Path,
+  branch_type: &str,
+  type_config: Option<&PrTemplateTypeConfig>,
+) -> Result<String> {
+  if let Some(tc) = type_config {
+    if let Some(body) = tc.body.as_deref() {
+      return Ok(body.to_string());
+    }
+    if let Some(path) = tc.path.as_deref() {
+      return read_template_file(workdir, path, "pr_template");
+    }
+  }
+  if let Some(path) = config.default.as_deref() {
+    return read_template_file(workdir, path, "pr_template default");
+  }
+  Err(GwmError::Config(format!(
+    "no pr_template configured for branch type '{}' (set [pr_template].default or [pr_template.by_type.{}].path/body)",
+    branch_type, branch_type
+  )))
+}
+
+fn read_template_file(workdir: &Path, path: &str, label: &str) -> Result<String> {
+  let resolved = resolve_template_path(workdir, path)?;
+  std::fs::read_to_string(&resolved)
+    .map_err(|e| GwmError::Config(format!("{} '{}' could not be read: {}", label, path, e)))
+}
+
+fn resolve_template_path(workdir: &Path, path: &str) -> Result<PathBuf> {
+  let rel = Path::new(path);
+  let suspicious = rel.is_absolute()
+    || rel
+      .components()
+      .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_) | Component::RootDir));
+  if suspicious {
+    return Err(GwmError::Config(format!(
+      "pr_template path '{}' must be relative and stay inside the worktree root",
+      path
+    )));
+  }
+  let joined = workdir.join(rel);
+  if joined.strip_prefix(workdir).is_err() {
+    return Err(GwmError::Config(format!(
+      "pr_template path '{}' escapes the worktree root",
+      path
+    )));
+  }
+  Ok(joined)
+}

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -579,6 +579,66 @@ pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {
   Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+/// Shell out to `git log --pretty=- %s <base>..<head>` inside `path`
+/// and return raw stdout. Used by `gwm pr` to fill the `{commits}`
+/// placeholder in PR templates (issue #84) — each commit becomes a
+/// Markdown bullet so a list of commit subjects drops straight into a
+/// PR body without extra formatting.
+pub fn git_log_subject_between(path: &Path, base: &str, head: &str) -> Result<String> {
+  let range = format!("{}..{}", base, head);
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["log", "--pretty=format:- %s"])
+    .arg(&range)
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git log failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git log exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+}
+
+/// Shell out to `git diff --stat <base>..<head>` inside `path`. The
+/// output is truncated to `max_lines` lines so a sprawling diff stat
+/// doesn't blow up the PR body (issue #84: 30-line cap by convention).
+pub fn git_diff_stat_between(path: &Path, base: &str, head: &str, max_lines: usize) -> Result<String> {
+  let range = format!("{}..{}", base, head);
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["diff", "--stat"])
+    .arg(&range)
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git diff failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git diff exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let raw = String::from_utf8_lossy(&output.stdout);
+  let mut lines: Vec<&str> = raw.lines().collect();
+  let truncated = lines.len() > max_lines;
+  if truncated {
+    lines.truncate(max_lines);
+  }
+  let mut out = lines.join("\n");
+  if truncated {
+    out.push_str(&format!(
+      "\n… ({} more line{} trimmed)",
+      raw.lines().count() - max_lines,
+      if raw.lines().count() - max_lines == 1 { "" } else { "s" }
+    ));
+  }
+  Ok(out)
+}
+
 /// Shell out to `git status --short` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview the working-tree state.
 pub fn git_status_short(path: &Path) -> Result<String> {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -3656,6 +3656,44 @@ body = "draft body for {desc}"
 }
 
 #[test]
+fn pr_falls_back_to_common_trunk_when_configured_trunks_do_not_resolve() {
+  // If `[doctor].trunks` only lists refs that don't exist locally
+  // (e.g. a repo customised the list but the trunk hasn't been
+  // created yet, or the repo uses `master`), `gwm pr` must still
+  // find a sensible base ref by walking the common trunk names
+  // (`main` / `master` / `dev` / `develop` / `trunk`) before giving
+  // up — otherwise `{commits}` / `{files_changed}` come out empty
+  // and the user has no signal as to why (Copilot review on PR #164).
+  let (dir, repo) = init_repo();
+  make_feature_branch_with_commit(
+    &repo,
+    dir.path(),
+    "feat/#84-fallback",
+    "src/fallback.rs",
+    "fn fb() {}\n",
+    "✨ feat: fallback",
+  );
+
+  let body = r###"
+[doctor]
+trunks = ["nonexistent-trunk"]
+
+[pr_template.by_type.feat]
+body = "summary: {desc} (#{issue})\ncommits:\n{commits}\n"
+"###;
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["pr", "--render"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("fallback (#84)"))
+    .stdout(predicate::str::contains("- ✨ feat: fallback"));
+}
+
+#[test]
 fn pr_errors_when_no_template_configured() {
   // Without any `[pr_template]` block in `.gwm.toml`, `gwm pr` exits
   // non-zero with a hint about the missing config — same shape as the

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -28,6 +28,8 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  create "))
     // Issue #83: create an issue from repo templates, then create the worktree.
     .stdout(predicate::str::contains("  new "))
+    // Issue #84: render the PR body from `[pr_template]` and shell out to `gh pr create`.
+    .stdout(predicate::str::contains("  pr "))
     .stdout(predicate::str::contains("  path "))
     .stdout(predicate::str::contains("[aliases: cd]"))
     .stdout(predicate::str::contains("  bootstrap "))
@@ -3486,4 +3488,195 @@ repo_root = "/nonexistent/other-repo"
     .success()
     .stdout(predicate::str::contains("feat-here-foo"))
     .stdout(predicate::str::contains("feat-elsewhere-bar"));
+}
+
+// --- gwm pr (issue #84) -------------------------------------------------
+
+/// Build a `feat/#<issue>-<desc>` branch on top of `main` carrying one
+/// extra commit so `git log main..HEAD` and `git diff --stat main..HEAD`
+/// produce non-empty output for the `{commits}` and `{files_changed}`
+/// placeholders. Switches the working tree to that branch.
+fn make_feature_branch_with_commit(
+  repo: &git2::Repository,
+  workdir: &std::path::Path,
+  branch: &str,
+  filename: &str,
+  contents: &str,
+  message: &str,
+) {
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  let branch_ref = repo.branch(branch, &head, false).unwrap();
+  let ref_name = branch_ref.into_reference().name().unwrap().to_string();
+  repo.set_head(&ref_name).unwrap();
+  repo
+    .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+    .unwrap();
+
+  let dest = workdir.join(filename);
+  if let Some(parent) = dest.parent() {
+    std::fs::create_dir_all(parent).unwrap();
+  }
+  std::fs::write(&dest, contents).unwrap();
+  let mut index = repo.index().unwrap();
+  index.add_path(std::path::Path::new(filename)).unwrap();
+  index.write().unwrap();
+  let tree_id = index.write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  let sig = git2::Signature::now("gwm-test", "gwm@test").unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&head]).unwrap();
+}
+
+#[test]
+fn pr_render_prints_body_with_placeholders_substituted() {
+  // `gwm pr --render` resolves the template configured for the current
+  // branch type, substitutes the placeholders against the current
+  // branch's context (type / issue / desc / base / head / commits /
+  // files_changed), and prints the rendered Markdown to stdout. It
+  // never shells out to `gh` — the canonical pipe-friendly form is
+  // `gwm pr --render | gh pr create --body-file -`.
+  let (dir, repo) = init_repo();
+  make_feature_branch_with_commit(
+    &repo,
+    dir.path(),
+    "feat/#84-pr-templates",
+    "docs/note.md",
+    "hello pr\n",
+    "✨ feat: pr templates",
+  );
+
+  let body = r###"
+[pr_template.by_type.feat]
+body = """
+## Summary
+
+{desc} (#{issue})
+
+## Commits
+
+{commits}
+
+## Files changed
+
+{files_changed}
+"""
+"###;
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["pr", "--render"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("pr-templates (#84)"))
+    .stdout(predicate::str::contains("- ✨ feat: pr templates"))
+    .stdout(predicate::str::contains("docs/note.md"));
+}
+
+#[test]
+fn pr_creates_pull_request_via_gh() {
+  // `gwm pr` (no `--render`) renders the body, writes it to a temp
+  // file, and shells out to `gh pr create --title … --body-file …
+  // --head <branch>`. The fake gh prints a PR URL so the CLI can
+  // surface the new number in stdout.
+  let (dir, repo) = init_repo();
+  make_feature_branch_with_commit(
+    &repo,
+    dir.path(),
+    "feat/#84-pr-templates",
+    "src/x.rs",
+    "fn x() {}\n",
+    "✨ feat: x",
+  );
+
+  let fake_bin = tempfile::TempDir::new().unwrap();
+  let fake_gh = write_fake_gh(fake_bin.path(), "https://github.com/acme/widgets/pull/321\n");
+
+  let body = r###"
+[pr_template.by_type.feat]
+body = "## Summary\n{desc} (#{issue})\n"
+"###;
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_GH", &fake_gh)
+    .env("PATH", prepend_path(fake_bin.path()))
+    .args(["pr"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("created PR #321"))
+    .stdout(predicate::str::contains("https://github.com/acme/widgets/pull/321"));
+
+  let gh_args_raw = std::fs::read_to_string(fake_bin.path().join("gh-args.txt")).unwrap();
+  let gh_args = gh_args_raw.replace('"', "");
+  assert!(gh_args.contains("pr create"), "{gh_args_raw}");
+  assert!(gh_args.contains("--head feat/#84-pr-templates"), "{gh_args_raw}");
+  let gh_body = std::fs::read_to_string(fake_bin.path().join("gh-body.md")).unwrap();
+  assert!(gh_body.contains("pr-templates (#84)"), "{gh_body}");
+}
+
+#[test]
+fn pr_draft_flag_is_forwarded_to_gh() {
+  // `gwm pr --draft` passes `--draft` through to `gh pr create` so the
+  // resulting PR opens as a draft instead of a normal review-ready PR.
+  let (dir, repo) = init_repo();
+  make_feature_branch_with_commit(
+    &repo,
+    dir.path(),
+    "feat/#84-pr-templates",
+    "src/y.rs",
+    "fn y() {}\n",
+    "✨ feat: y",
+  );
+
+  let fake_bin = tempfile::TempDir::new().unwrap();
+  let fake_gh = write_fake_gh(fake_bin.path(), "https://github.com/acme/widgets/pull/777\n");
+
+  let body = r###"
+[pr_template.by_type.feat]
+body = "draft body for {desc}"
+"###;
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_GH", &fake_gh)
+    .env("PATH", prepend_path(fake_bin.path()))
+    .args(["pr", "--draft"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("created PR #777"));
+
+  let gh_args_raw = std::fs::read_to_string(fake_bin.path().join("gh-args.txt")).unwrap();
+  let gh_args = gh_args_raw.replace('"', "");
+  assert!(gh_args.contains("--draft"), "{gh_args_raw}");
+}
+
+#[test]
+fn pr_errors_when_no_template_configured() {
+  // Without any `[pr_template]` block in `.gwm.toml`, `gwm pr` exits
+  // non-zero with a hint about the missing config — same shape as the
+  // `gwm new` failure for an unconfigured branch type.
+  let (dir, repo) = init_repo();
+  make_feature_branch_with_commit(
+    &repo,
+    dir.path(),
+    "feat/#84-pr-templates",
+    "src/z.rs",
+    "fn z() {}\n",
+    "✨ feat: z",
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), "").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["pr", "--render"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("pr_template"))
+    .stderr(predicate::str::contains("feat"));
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1376,3 +1376,87 @@ on_match      = "abort"
     msg
   );
 }
+
+// --- PR template section (issue #84) ------------------------------------
+
+#[test]
+fn pr_template_defaults_are_empty() {
+  // Without a [pr_template] block, both `default` and `by_type`
+  // resolve to empty so `gwm pr` falls back to the GitHub-side
+  // PULL_REQUEST_TEMPLATE.md (same as before #84).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "").unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert!(cfg.pr_template.default.is_none());
+  assert!(cfg.pr_template.by_type.is_empty());
+}
+
+#[test]
+fn pr_template_section_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r###"
+[pr_template]
+default = ".github/pull_request_template.md"
+
+[pr_template.by_type]
+feat = { path = ".github/pr-templates/feat.md" }
+fix = { path = ".github/pr-templates/fix.md" }
+
+[pr_template.by_type.chore]
+body = "## Summary\n{desc}\n\nCloses #{issue}\n"
+"###,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(
+    cfg.pr_template.default.as_deref(),
+    Some(".github/pull_request_template.md")
+  );
+
+  let feat = cfg.pr_template.by_type.get("feat").expect("feat entry");
+  assert_eq!(feat.path.as_deref(), Some(".github/pr-templates/feat.md"));
+  assert_eq!(feat.body, None);
+
+  let chore = cfg.pr_template.by_type.get("chore").expect("chore entry");
+  assert_eq!(chore.path, None);
+  assert_eq!(chore.body.as_deref(), Some("## Summary\n{desc}\n\nCloses #{issue}\n"));
+}
+
+#[test]
+fn pr_template_unknown_root_field_is_rejected() {
+  // `[pr_template]` mirrors `[issue_template]`'s `deny_unknown_fields`
+  // contract so typos surface at load time, not as a silent no-op.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[pr_template]
+default = ".github/pull_request_template.md"
+mystery = "boom"
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("unknown field must reject");
+  let msg = format!("{}", err);
+  assert!(msg.contains("mystery"), "{msg}");
+}
+
+#[test]
+fn pr_template_unknown_per_type_field_is_rejected() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[pr_template.by_type.feat]
+path = ".github/pr-templates/feat.md"
+bogus = true
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("unknown per-type field must reject");
+  let msg = format!("{}", err);
+  assert!(msg.contains("bogus"), "{msg}");
+}

--- a/tests/pr_templates_tests.rs
+++ b/tests/pr_templates_tests.rs
@@ -1,0 +1,178 @@
+//! Unit tests for the [`gwm::pr_templates`] renderer (issue #84).
+//!
+//! The renderer is pure: it takes a `PrTemplateConfig`, the worktree
+//! root, and a `PrTemplateContext` built by the caller. Tests construct
+//! everything in-memory and drive `render_pr_body` directly so the
+//! `gh pr create` and git plumbing live elsewhere.
+
+use gwm::config::{PrTemplateConfig, PrTemplateTypeConfig};
+use gwm::pr_templates::{render_pr_body, PrTemplateContext};
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn ctx(branch_type: &str, issue: &str, desc: &str) -> PrTemplateContext {
+  PrTemplateContext {
+    branch_type: branch_type.into(),
+    issue: issue.into(),
+    desc: desc.into(),
+    base: "main".into(),
+    head: format!("{}/#{}-{}", branch_type, issue, desc),
+    commits: "- first commit\n- second commit".into(),
+    files_changed: " src/foo.rs | 5 +++++".into(),
+    repo: String::new(),
+  }
+}
+
+#[test]
+fn inline_body_substitutes_placeholders() {
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "chore".to_string(),
+    PrTemplateTypeConfig {
+      path: None,
+      body: Some("## Summary\n{desc}\n\nCloses #{issue}\n".into()),
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+  let workdir = TempDir::new().unwrap();
+  let body = render_pr_body(&cfg, workdir.path(), &ctx("chore", "42", "tidy-imports")).unwrap();
+  assert!(body.contains("tidy-imports"), "{body}");
+  assert!(body.contains("Closes #42"), "{body}");
+  assert!(!body.contains("{desc}"), "unsubstituted placeholder leaked: {body}");
+}
+
+#[test]
+fn path_resolves_workdir_relative_markdown_and_renders_commits_block() {
+  let workdir = TempDir::new().unwrap();
+  fs::create_dir_all(workdir.path().join(".github/pr-templates")).unwrap();
+  fs::write(
+    workdir.path().join(".github/pr-templates/feat.md"),
+    "## Summary\n{desc}\n\n## Commits\n{commits}\n\n## Files changed\n{files_changed}\n",
+  )
+  .unwrap();
+
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "feat".to_string(),
+    PrTemplateTypeConfig {
+      path: Some(".github/pr-templates/feat.md".into()),
+      body: None,
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+
+  let body = render_pr_body(&cfg, workdir.path(), &ctx("feat", "100", "add-x")).unwrap();
+  assert!(body.contains("add-x"), "{body}");
+  assert!(body.contains("- first commit"), "{body}");
+  assert!(body.contains("- second commit"), "{body}");
+  assert!(body.contains("src/foo.rs"), "{body}");
+}
+
+#[test]
+fn falls_back_to_default_when_no_per_type_entry() {
+  let workdir = TempDir::new().unwrap();
+  fs::create_dir_all(workdir.path().join(".github")).unwrap();
+  fs::write(
+    workdir.path().join(".github/pull_request_template.md"),
+    "fallback for {type}: {desc}",
+  )
+  .unwrap();
+  let cfg = PrTemplateConfig {
+    default: Some(".github/pull_request_template.md".into()),
+    by_type: BTreeMap::new(),
+  };
+  let body = render_pr_body(&cfg, workdir.path(), &ctx("docs", "0", "tweak")).unwrap();
+  assert_eq!(body.trim(), "fallback for docs: tweak");
+}
+
+#[test]
+fn errors_when_no_template_configured_for_branch_type() {
+  let cfg = PrTemplateConfig::default();
+  let workdir = TempDir::new().unwrap();
+  let err = render_pr_body(&cfg, workdir.path(), &ctx("feat", "1", "x")).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("pr_template"), "{msg}");
+  assert!(msg.contains("feat"), "{msg}");
+}
+
+#[test]
+fn inline_body_wins_over_path_when_both_set() {
+  // Per the [`PrTemplateTypeConfig`] docstring: `body` is the most
+  // explicit override, so if both are set the inline value wins over
+  // the on-disk file. This lets a repo carry a "stable default" body
+  // while a `path` placeholder waits to be filled in later.
+  let workdir = TempDir::new().unwrap();
+  fs::create_dir_all(workdir.path().join(".github/pr-templates")).unwrap();
+  fs::write(workdir.path().join(".github/pr-templates/fix.md"), "FROM-FILE: {desc}").unwrap();
+
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "fix".to_string(),
+    PrTemplateTypeConfig {
+      path: Some(".github/pr-templates/fix.md".into()),
+      body: Some("INLINE: {desc}".into()),
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+
+  let body = render_pr_body(&cfg, workdir.path(), &ctx("fix", "9", "boom")).unwrap();
+  assert!(body.starts_with("INLINE: boom"), "{body}");
+  assert!(!body.contains("FROM-FILE"), "file body should not appear: {body}");
+}
+
+#[test]
+fn rejects_path_traversal_in_template_path() {
+  let workdir = TempDir::new().unwrap();
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "feat".to_string(),
+    PrTemplateTypeConfig {
+      path: Some("../etc/passwd.md".into()),
+      body: None,
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+
+  let err = render_pr_body(&cfg, workdir.path(), &ctx("feat", "1", "x")).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("escape") || msg.contains("must be relative"), "{msg}");
+}
+
+#[test]
+fn rejects_absolute_template_path() {
+  let workdir = TempDir::new().unwrap();
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "feat".to_string(),
+    PrTemplateTypeConfig {
+      path: Some("/etc/passwd.md".into()),
+      body: None,
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+  let err = render_pr_body(&cfg, workdir.path(), &ctx("feat", "1", "x")).unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("relative") || msg.contains("escape"), "{msg}");
+}
+
+#[test]
+fn renders_repo_placeholder() {
+  // The renderer exposes `{repo}` so a PR body can hard-code paths to
+  // the repo's wiki / docs / etc. without the author re-typing the
+  // slug.
+  let mut by_type = BTreeMap::new();
+  by_type.insert(
+    "feat".to_string(),
+    PrTemplateTypeConfig {
+      path: None,
+      body: Some("see https://github.com/{repo}/wiki for context".into()),
+    },
+  );
+  let cfg = PrTemplateConfig { default: None, by_type };
+  let workdir = TempDir::new().unwrap();
+  let mut c = ctx("feat", "1", "x");
+  c.repo = "kbrdn1/gwm-cli".into();
+  let body = render_pr_body(&cfg, workdir.path(), &c).unwrap();
+  assert!(body.contains("kbrdn1/gwm-cli"), "{body}");
+}


### PR DESCRIPTION
## Description

Add configurable per-branch-type PR body templates and a `gwm pr [--draft] [--base <ref>] [--render]` workflow that renders the resolved body and shells out to `gh pr create`. Shares `src/templating.rs` with the `[issue_template]` flow from #83 so the renderer plumbing isn't duplicated.

Closes #84

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Add `[pr_template]` config schema (`default` + `[pr_template.by_type]` with either `path` or inline `body`; inline `body` wins over per-type `path`; per-type wins over `default`). Same path-traversal hardening as `[issue_template]` (reject absolute paths, `..` parents, Windows `Prefix` / `RootDir`, plus `strip_prefix(workdir)` containment guard).
- Add `src/pr_templates.rs` with a pure `render_pr_body(config, workdir, ctx)` substituting `{type}` `{issue}` `{desc}` `{base}` `{head}` `{repo}` `{commits}` and `{files_changed}`.
- Add `github::create_pr` (shells out via the shared `run_gh` helper, new `PR_URL_RE` `LazyLock<Regex>` for URL parsing) and `worktree::git_log_subject_between` / `git_diff_stat_between` shell-outs for the `{commits}` and `{files_changed}` placeholders.
- Add `gwm pr` CLI: parses the current branch via `parse_branch`, resolves the base by walking `[doctor].trunks` until a local branch exists (falls back to `main`), renders the body, then either prints it (`--render`) or writes to a tempfile and shells out to `gh pr create`. On success the new PR number is recorded under `branch.<head>.gwm-pr`.
- Update `examples/gwm.toml.example`, `docs/3.cli/1.reference.md`, `docs/4.configuration/1.gwm-toml.md`, and `CHANGELOG.md` to document the new surface.

## Tests

- [x] `cargo test` passes locally (full suite + `PATH="…/bin:/usr/bin:/bin" cargo test --test cli_binary 'pr_'`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `gwm doctor` clean
- [x] New tests added under `tests/` (`tests/config_tests.rs` schema parsing × 4, `tests/pr_templates_tests.rs` renderer × 8, `tests/cli_binary.rs` CLI flows × 4)

## Screenshots / TUI captures

N/A — CLI/config only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#84-pr-template-cli`)
- [x] Commits follow Gitmoji + Conventional Commits (test + feat, atomic split)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (not applicable; `docs/3.cli/1.reference.md` updated)
- [x] `examples/gwm.toml.example` updated with the new `[pr_template]` block
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #84
- Related PR: #163 (#83 — `[issue_template]` + `gwm new`, merged 2026-05-26)

## Notes for reviewers

The renderer is pure — `pr_templates::render_pr_body` takes `&PrTemplateConfig`, a workdir, and a `PrTemplateContext` so unit tests drive it without seeding a repo. The CLI plumbing (current branch, base resolution, commit / diff-stat collection) lives in `cli::cmd_pr` and shells out to `git -C <workdir>` for the textual `--stat` output (libgit2 doesn't expose it).