### PR TITLE
✨ feat(tui): configurable keymap with chord support (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add lifecycle hooks under `[hooks.*]` for create/bootstrap/remove phases, with placeholders, per-step `on_fail`, `--skip-hooks`, and legacy `[[bootstrap.command]]` compatibility as `post_create`.
 - Add `[issue_template]` defaults plus `gwm new <type> <desc>` to create a GitHub issue from issue-form templates and immediately create the linked worktree.
 - Add `[pr_template]` defaults plus `gwm pr [--draft] [--base <ref>] [--render]` to render per-branch-type PR bodies (with `{commits}` / `{files_changed}` placeholders) and shell out to `gh pr create`.
+- Add `[tui.keys]` block in `.gwm.toml` to rebind every TUI list-view action (`down`, `up`, `top`, `bottom`, `quit`, …) with crossterm-grammar keys, including multi-key chords like `g g`. Overrides are validated at load time (unknown actions, parse errors, chord conflicts, and prefix collisions are hard errors). Adds `gwm tui keys` to print the resolved keymap with per-row source, a `gwm doctor` check for unbound `quit`, and a keymap-driven help overlay (`?`) so the documentation always matches the resolved bindings.
 
 ## Past releases
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -768,14 +768,20 @@ fn cmd_tui(action: TuiAction) -> Result<()> {
 fn cmd_tui_keys() -> Result<()> {
   use crate::tui::keymap::{Keymap, Source};
 
-  // Build the resolved keymap. Outside a repo, fall back to defaults
-  // so the command still works for new users discovering the binary.
+  // Build the resolved keymap. Outside a repo, OR inside a bare
+  // repo (no workdir to read `.gwm.toml` from), fall back to
+  // defaults so the command stays useful for new users discovering
+  // the binary. Same fallback path either way — surfacing
+  // `NotInGitRepo` on a bare repo would be misleading because the
+  // command itself is repo-agnostic.
   let keymap = match worktree::discover_repo(None) {
-    Ok(repo) => {
-      let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-      let cfg = Config::load_for_repo(&workdir)?;
-      cfg.tui.keys.resolved_keymap()?
-    }
+    Ok(repo) => match repo.workdir() {
+      Some(workdir) => {
+        let cfg = Config::load_for_repo(workdir)?;
+        cfg.tui.keys.resolved_keymap()?
+      }
+      None => Keymap::defaults(),
+    },
     Err(_) => Keymap::defaults(),
   };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,6 +447,39 @@ pub enum Command {
     #[arg(long)]
     bootstrap: bool,
   },
+  /// TUI introspection / debugging subcommands (issue #87).
+  ///
+  /// Today exposes a single child — `keys` — which prints the
+  /// resolved keymap (built-in defaults layered with `[tui.keys]`
+  /// overrides from `.gwm.toml`). Reserved as a sub-tree so future
+  /// TUI knobs (`gwm tui themes`, `gwm tui dump-state`, …) have a
+  /// stable home without further crowding the top-level surface.
+  Tui {
+    #[command(subcommand)]
+    action: TuiAction,
+  },
+}
+
+/// Subcommands of `gwm tui` (issue #87).
+#[derive(Debug, Subcommand)]
+pub enum TuiAction {
+  /// Print the resolved TUI keymap (built-in defaults + `[tui.keys]`
+  /// overrides, with the source per row).
+  ///
+  /// Output shape:
+  /// ```text
+  /// action            keys              source
+  /// down              j, Down           default
+  /// up                Ctrl+n            .gwm.toml
+  /// top               g g               default
+  /// …
+  /// ```
+  ///
+  /// The action column lists the slugs accepted in `[tui.keys]`;
+  /// the keys column shows every chord bound to that action
+  /// (comma-separated). Empty keys = action is currently unbound
+  /// (the user explicitly cleared it).
+  Keys,
 }
 
 /// Subcommands of `gwm aliases` (issue #86). Read-only for now —
@@ -713,7 +746,84 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Config { action } => cmd_config(action),
     Command::History { limit, all } => cmd_history(limit, all),
     Command::Undo { bootstrap } => cmd_undo(bootstrap),
+    Command::Tui { action } => cmd_tui(action),
   }
+}
+
+fn cmd_tui(action: TuiAction) -> Result<()> {
+  match action {
+    TuiAction::Keys => cmd_tui_keys(),
+  }
+}
+
+/// Print the resolved TUI keymap as a 3-column table.
+///
+/// Resolves `[tui.keys]` against the current repo's `.gwm.toml`
+/// (falling back to bare defaults if there is no `.gwm.toml` and to
+/// repo-less defaults when invoked outside any repo, so the command
+/// is useful even before a project is set up). The output is the
+/// human-readable side of the keymap surface — `gwm doctor` (issue
+/// #87 part 8) consumes the same `Keymap::list()` API for its
+/// validation pass, so the column contents stay in sync.
+fn cmd_tui_keys() -> Result<()> {
+  use crate::tui::keymap::{Keymap, Source};
+
+  // Build the resolved keymap. Outside a repo, fall back to defaults
+  // so the command still works for new users discovering the binary.
+  let keymap = match worktree::discover_repo(None) {
+    Ok(repo) => {
+      let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+      let cfg = Config::load_for_repo(&workdir)?;
+      cfg.tui.keys.resolved_keymap()?
+    }
+    Err(_) => Keymap::defaults(),
+  };
+
+  let rows = keymap.list();
+  // Column widths sized to the longest content so the table stays
+  // aligned even when a chord runs long (`Ctrl+Alt+Shift+F12`).
+  let action_w = rows
+    .iter()
+    .map(|b| b.action.slug().len())
+    .max()
+    .unwrap_or(0)
+    .max("action".len());
+  let keys_w = rows
+    .iter()
+    .map(|b| {
+      b.chords
+        .iter()
+        .map(|c| c.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(" "))
+        .collect::<Vec<_>>()
+        .join(", ")
+        .len()
+    })
+    .max()
+    .unwrap_or(0)
+    .max("keys".len());
+
+  println!("{:<aw$}  {:<kw$}  source", "action", "keys", aw = action_w, kw = keys_w);
+  for binding in rows {
+    let keys = binding
+      .chords
+      .iter()
+      .map(|c| c.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(" "))
+      .collect::<Vec<_>>()
+      .join(", ");
+    let source = match binding.source {
+      Source::Default => "default",
+      Source::UserConfig => ".gwm.toml",
+    };
+    println!(
+      "{:<aw$}  {:<kw$}  {}",
+      binding.action.slug(),
+      keys,
+      source,
+      aw = action_w,
+      kw = keys_w
+    );
+  }
+  Ok(())
 }
 
 fn cmd_init() -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -426,6 +426,14 @@ pub struct TuiConfig {
   /// kept available under `mode = "finder"`.
   #[serde(default)]
   pub open: TuiOpenConfig,
+
+  /// `[tui.keys]` sub-table (issue #87) — user overrides for the
+  /// remappable keymap. Absent → keymap stays at the built-in
+  /// defaults. Present → every listed action *replaces* its default
+  /// binding set; actions left unmentioned keep their defaults. An
+  /// empty array (`down = []`) unbinds the action entirely.
+  #[serde(default)]
+  pub keys: TuiKeysConfig,
 }
 
 impl Default for TuiConfig {
@@ -433,7 +441,65 @@ impl Default for TuiConfig {
     Self {
       confirm_countdown_secs: default_confirm_countdown_secs(),
       open: TuiOpenConfig::default(),
+      keys: TuiKeysConfig::default(),
     }
+  }
+}
+
+/// `[tui.keys]` — user-facing override table for the TUI keymap.
+/// Stored as `action-slug -> [chord, …]` so the TOML stays declarative
+/// and copy-pastable across machines.
+///
+/// Resolution / validation happens in [`Self::resolved_keymap`], which
+/// is called from `Config::load_for_repo` so a malformed override is
+/// surfaced at load time (action name typos, parse errors, chord
+/// conflicts, prefix collisions) rather than as a silent no-op in the
+/// TUI. The raw map is preserved on `Self` so `gwm tui keys` can show
+/// both the user's source and the resolved bindings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TuiKeysConfig {
+  pub bindings: std::collections::BTreeMap<String, Vec<String>>,
+}
+
+impl TuiKeysConfig {
+  /// Apply this user override layer on top of the built-in defaults.
+  /// Returns a fully-resolved [`crate::tui::keymap::Keymap`] ready to
+  /// hand to the TUI event loop.
+  pub fn resolved_keymap(&self) -> Result<crate::tui::keymap::Keymap> {
+    use crate::tui::keymap::{Action, KeyStroke, Keymap};
+
+    let mut km = Keymap::defaults();
+    for (action_slug, chord_strings) in &self.bindings {
+      let action = Action::from_slug(action_slug).ok_or_else(|| {
+        GwmError::Config(format!(
+          "tui.keys: unknown action {:?} (run `gwm tui keys` for the full list)",
+          action_slug
+        ))
+      })?;
+      let mut parsed = Vec::with_capacity(chord_strings.len());
+      for chord_str in chord_strings {
+        let chord = KeyStroke::parse_chord(chord_str).map_err(|e| {
+          // Re-wrap so the user sees `tui.keys.<action>` as the
+          // coordinate rather than the bare "keymap:" prefix from
+          // the parser.
+          let inner = match e {
+            GwmError::Config(msg) => msg,
+            other => other.to_string(),
+          };
+          GwmError::Config(format!("tui.keys.{}: {}", action_slug, inner))
+        })?;
+        parsed.push(chord);
+      }
+      km.apply_override(action, parsed).map_err(|e| {
+        let inner = match e {
+          GwmError::Config(msg) => msg,
+          other => other.to_string(),
+        };
+        GwmError::Config(format!("tui.keys.{}: {}", action_slug, inner))
+      })?;
+    }
+    Ok(km)
   }
 }
 
@@ -522,7 +588,19 @@ impl Config {
     cfg.validate_bootstrap_guards()?;
     cfg.validate_labels()?;
     cfg.validate_aliases()?;
+    cfg.validate_tui_keys()?;
     Ok(cfg)
+  }
+
+  /// Reject `[tui.keys]` entries that name an unknown action, list a
+  /// chord that does not parse, or create a conflict / prefix
+  /// collision with another binding (issue #87). Delegates to
+  /// [`TuiKeysConfig::resolved_keymap`] which does the full layering +
+  /// validation in one pass — the resolved keymap is discarded here
+  /// (it's rebuilt by the TUI at startup); the call is only kept for
+  /// its error side-effects.
+  pub(crate) fn validate_tui_keys(&self) -> Result<()> {
+    self.tui.keys.resolved_keymap().map(|_| ())
   }
 
   /// Reject `[aliases]` entries that shadow built-in subcommands, are

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -165,12 +165,16 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
     }
   };
 
+  // Snapshot once. The pre-review version called `keymap.list()`
+  // twice — both `quit_has_user_binding` and the success count
+  // cloned the bindings vector. One snapshot reused below.
+  let bindings = keymap.list();
+
   // Quit is special: the only hard-coded escape hatch is `Ctrl+C` in
   // `run_app`. We don't refuse an empty `quit` binding (per the design
   // note in `src/tui/keymap.rs`), but we do flag it so the user knows
   // the discoverable key is gone.
-  let quit_has_user_binding = keymap
-    .list()
+  let quit_has_user_binding = bindings
     .iter()
     .any(|b| b.action == crate::tui::keymap::Action::Quit && !b.chords.is_empty());
   if !quit_has_user_binding {
@@ -181,7 +185,14 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
     .with_hint("add `quit = [\"q\", \"Esc\"]` (or any other key) to `[tui.keys]`");
   }
 
-  Check::ok(name, format!("{} action(s) bound", keymap.list().len()))
+  // Count only actions with at least one chord. The pre-review
+  // version used `bindings.len()` which includes unbound entries
+  // (`action = []` in `[tui.keys]` leaves the action in the list
+  // with an empty chord vec), inflating the count visible in
+  // `gwm doctor` output and misleading the user about how many
+  // actions are actually reachable.
+  let bound_count = bindings.iter().filter(|b| !b.chords.is_empty()).count();
+  Check::ok(name, format!("{} action(s) bound", bound_count))
 }
 
 /// Check #1: `.gwm.toml` parses cleanly. Missing config is fine — defaults

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -132,7 +132,56 @@ pub fn run(ctx: &DoctorCtx<'_>) -> Result<DoctorReport> {
   }
 
   report.checks.push(check_base_dir_writable(ctx));
+  report.checks.push(check_tui_keymap(ctx));
   Ok(report)
+}
+
+/// TUI keymap diagnostic (issue #87). Re-runs the same
+/// [`crate::tui::keymap::Keymap`] resolution path the TUI itself uses
+/// at startup, so any user-facing `[tui.keys]` mistake surfaces here
+/// before the TUI actually fails to dispatch.
+///
+/// Three outcomes:
+///
+/// 1. **Failed** — the keymap fails to resolve (parse error, unknown
+///    action slug, chord conflict, prefix collision). The detail
+///    repeats the underlying [`crate::error::GwmError::Config`]
+///    message verbatim so the user can paste it into a search.
+/// 2. **Warning** — the keymap resolves, but `quit` has been
+///    unbound entirely. The hard-coded `Ctrl+C` branch in `run_app`
+///    keeps the TUI exitable; we warn anyway because losing the
+///    discoverable quit key is a hostile UX choice users usually
+///    don't realise they made.
+/// 3. **Ok** — keymap is valid and `quit` has at least one
+///    user-visible binding.
+fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
+  let name = "[tui.keys] keymap resolves";
+
+  let keymap = match ctx.config.tui.keys.resolved_keymap() {
+    Ok(km) => km,
+    Err(e) => {
+      return Check::failed(name, format!("{}", e))
+        .with_hint("fix the `[tui.keys]` entry called out above; the full list of action slugs is `gwm tui keys`");
+    }
+  };
+
+  // Quit is special: the only hard-coded escape hatch is `Ctrl+C` in
+  // `run_app`. We don't refuse an empty `quit` binding (per the design
+  // note in `src/tui/keymap.rs`), but we do flag it so the user knows
+  // the discoverable key is gone.
+  let quit_has_user_binding = keymap
+    .list()
+    .iter()
+    .any(|b| b.action == crate::tui::keymap::Action::Quit && !b.chords.is_empty());
+  if !quit_has_user_binding {
+    return Check::warning(
+      name,
+      "`quit` has no binding — Ctrl+C still exits the TUI as a hard-coded fallback, but no discoverable key remains",
+    )
+    .with_hint("add `quit = [\"q\", \"Esc\"]` (or any other key) to `[tui.keys]`");
+  }
+
+  Check::ok(name, format!("{} action(s) bound", keymap.list().len()))
 }
 
 /// Check #1: `.gwm.toml` parses cleanly. Missing config is fine — defaults

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,3 +1,4 @@
+use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::CreateForm;
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -12,6 +13,7 @@ use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use crate::launcher::{self, ExpandedCommand, LauncherContext};
 use crate::naming::BranchSpec;
 use crate::worktree::{self, WorktreeInfo};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::Repository;
 use ratatui::widgets::TableState;
 use std::path::{Path, PathBuf};
@@ -124,7 +126,25 @@ pub struct App {
   pub sidebar: SidebarState,
 
   // Vim motion buffer: armed by first `g`, completed by the second.
+  // **Kept for backward compatibility** with pre-#87 tests that read
+  // it directly. Now a *mirror* of [`Self::pending_chord`] —
+  // [`Self::dispatch_key`] keeps the two synchronised via
+  // [`Self::sync_legacy_pending`]. New code should consume
+  // [`Self::pending_chord_is_empty`] instead.
   pub pending_g: bool,
+
+  /// Generic pending-keys buffer for the configurable keymap
+  /// (issue #87). Empty most of the time; populated with the
+  /// strokes seen so far whenever the user is partway through a
+  /// chord that is a prefix of a bound binding (e.g. after the
+  /// first `g` of the default `g g → Top`).
+  pub pending_chord: Vec<KeyStroke>,
+
+  /// Resolved keymap for this TUI session. Built from
+  /// [`Config::tui.keys`] at construction time and never mutated
+  /// thereafter — the user has to relaunch gwm to pick up a config
+  /// change, mirroring how every other knob in `[tui]` behaves.
+  pub keymap: Keymap,
 
   // Inline fuzzy filter on the worktree list (issue #21, extracted per
   // #124 with memoisation closing #104). The sub-struct owns the buffer
@@ -195,6 +215,11 @@ impl App {
     let repo_name = worktree::repo_name(&repo);
     let config = Config::load_for_repo(&workdir)?;
     let branch_types = config.resolved_branch_types().types;
+    // Resolve the keymap once at construction. Config::load_for_repo
+    // already validated the overrides, so this should not surface a
+    // fresh error — but we re-`?` it rather than `.expect()` so a
+    // future hot-reload path could exercise the same call.
+    let keymap = config.tui.keys.resolved_keymap()?;
     let worktrees = worktree::list(&repo)?;
     let mut state = TableState::default();
     if !worktrees.is_empty() {
@@ -215,6 +240,8 @@ impl App {
       report: None,
       sidebar: SidebarState::new(),
       pending_g: false,
+      pending_chord: Vec::new(),
+      keymap,
       filter: FilterState::new(),
       picker_mode: false,
       picker_result: None,
@@ -382,17 +409,97 @@ impl App {
   }
 
   /// Drive the two-keystroke `gg` motion. First press arms it, second jumps to top.
+  ///
+  /// **Compatibility shim** — kept so the existing tests in
+  /// `tests/tui_app_tests.rs::handle_g_motion_tracks_pending_then_jumps_to_first`
+  /// and the not-yet-migrated event-loop branch keep working
+  /// verbatim. The implementation routes through
+  /// [`Self::dispatch_key`] so the legacy and generic paths cannot
+  /// drift on the chord semantics.
   pub fn handle_g(&mut self) {
-    if self.pending_g {
-      self.pending_g = false;
+    let ev = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::empty());
+    if let Some(Action::Top) = self.dispatch_key(ev) {
       self.first();
-    } else {
-      self.pending_g = true;
     }
   }
 
+  /// Drop any in-flight chord prefix. Called by the legacy event-loop
+  /// branch on any non-`g` keystroke (pre-#87 contract). New call
+  /// sites that route through [`Self::dispatch_key`] don't need it —
+  /// `dispatch_key` already clears the buffer on `NoMatch`.
   pub fn cancel_pending_motion(&mut self) {
-    self.pending_g = false;
+    self.pending_chord.clear();
+    self.sync_legacy_pending_flag();
+  }
+
+  /// True iff no chord prefix is currently armed. Surface for tests
+  /// and for the help / status-bar code that may want to show a
+  /// "waiting for next key" hint once chord support is wired up.
+  pub fn pending_chord_is_empty(&self) -> bool {
+    self.pending_chord.is_empty()
+  }
+
+  /// Drive a raw `KeyEvent` through the keymap.
+  ///
+  /// Returns `Some(action)` when the buffer (current pending chord +
+  /// this stroke) matches a binding — caller fires the action and the
+  /// buffer is left cleared. Returns `None` when the buffer is now a
+  /// strict prefix of a longer binding (caller waits for the next
+  /// keystroke) **or** when the stroke matches nothing at all
+  /// (caller drops it).
+  ///
+  /// Vim-style fallback: if appending the stroke to a non-empty
+  /// buffer produces a `NoMatch`, the buffer is cleared and the
+  /// stroke is re-tried on its own. This mirrors the historical
+  /// `g j` behaviour where the stray `g` is forgotten and `j`
+  /// still navigates down.
+  pub fn dispatch_key(&mut self, key: KeyEvent) -> Option<Action> {
+    let stroke = KeyStroke::from_event(&key);
+    let mut tentative = self.pending_chord.clone();
+    tentative.push(stroke.clone());
+
+    let outcome = match self.keymap.lookup(&tentative) {
+      ChordResolution::Matched(action) => {
+        self.pending_chord.clear();
+        Some(action)
+      }
+      ChordResolution::PendingPrefix => {
+        self.pending_chord = tentative;
+        None
+      }
+      ChordResolution::NoMatch if self.pending_chord.is_empty() => {
+        // Single stroke, no binding. Nothing to retry.
+        None
+      }
+      ChordResolution::NoMatch => {
+        // Mismatched continuation. Drop the in-flight prefix and
+        // retry the new stroke on its own so the user's keypress
+        // is not silently swallowed when it has a single-key
+        // binding (the `g j` case).
+        self.pending_chord.clear();
+        let single = vec![stroke];
+        match self.keymap.lookup(&single) {
+          ChordResolution::Matched(action) => Some(action),
+          ChordResolution::PendingPrefix => {
+            self.pending_chord = single;
+            None
+          }
+          ChordResolution::NoMatch => None,
+        }
+      }
+    };
+
+    self.sync_legacy_pending_flag();
+    outcome
+  }
+
+  /// Mirror the new `pending_chord` buffer into the legacy
+  /// `pending_g` boolean so pre-#87 tests that read it as a field
+  /// stay green. Removed when those tests migrate to
+  /// [`Self::pending_chord_is_empty`].
+  fn sync_legacy_pending_flag(&mut self) {
+    let g = KeyStroke::new(KeyCode::Char('g'), KeyModifiers::empty());
+    self.pending_g = self.pending_chord.len() == 1 && self.pending_chord[0] == g;
   }
 
   // ---- Sidebar ------------------------------------------------------------

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -1,0 +1,512 @@
+//! Configurable TUI keymap (issue #87).
+//!
+//! Three layers, in order of authority:
+//!
+//! 1. **Built-in defaults** ([`Keymap::defaults`]) — the bindings the
+//!    binary ships with. Captures the historical hard-coded set
+//!    (`j/k`, `g g`, `Tab`, `o`, `l`, `R`, `y`, `p`, `f/F`, `/`, `?`,
+//!    `q`, …).
+//! 2. **User overrides** ([`Keymap::apply_override`]) — fed from
+//!    `[tui.keys]` in `.gwm.toml`. An override **replaces** the
+//!    default for the targeted action; it does not merge. Passing an
+//!    empty `Vec` unbinds the action entirely.
+//! 3. **Hard-coded escape hatches** — `Ctrl+C` (emergency quit) and
+//!    `Esc` / `Enter` keep their contextual handling in
+//!    `src/tui/mod.rs`. They are deliberately outside the keymap
+//!    because their semantics depend on the active view (filter bar,
+//!    picker mode, sticky filter, etc.) — folding them into the
+//!    keymap would require modal state the configuration language
+//!    has no way to express.
+//!
+//! ## Chord / prefix policy
+//!
+//! Per the design decision recorded on PR #87, binding a chord that
+//! is a strict prefix of another chord (e.g. `g` alone while `g g` is
+//! also bound) is a **hard error at load time**. Resolving the
+//! ambiguity at runtime would require a Vim-style 500 ms timeout in
+//! the event loop, which conflicts with the project's preference for
+//! a pure state-machine TUI. Easier to refuse the config and force
+//! the user to pick.
+//!
+//! ## Quit policy
+//!
+//! `quit` is the only action with a guaranteed escape hatch: the
+//! hard-coded `Ctrl+C` branch in `run_app` runs *before* any keymap
+//! lookup, so even an empty / hostile user keymap can be exited. The
+//! doctor check defined in `crate::doctor` emits a warning when no
+//! non-`Ctrl+C` binding for `quit` survives the override layer.
+
+use crate::error::{GwmError, Result};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Action enum + ACTIONS table
+// ---------------------------------------------------------------------------
+
+/// Declarative macro that defines `Action`, its slug roundtrip, the
+/// `ACTIONS` table, and `Action::all()` from a **single** ordered list
+/// of `(Variant => "slug")` pairs. Adding a new action means editing
+/// one place; the rest stays in sync mechanically.
+macro_rules! define_actions {
+  ($( $variant:ident => $slug:literal ),* $(,)?) => {
+    /// Every user-rebindable verb the TUI exposes.
+    ///
+    /// Variants whose semantics depend on the active view (`Enter`,
+    /// `Esc`, `Ctrl+C`) are deliberately **not** listed — see the
+    /// module-level "Hard-coded escape hatches" note for why.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum Action {
+      $( $variant, )*
+    }
+
+    impl Action {
+      /// Stable string slug used in `[tui.keys]`, `gwm tui keys`, and
+      /// any future docs generator. Lowercase + underscores; never
+      /// renamed in a backwards-incompatible way without a deprecation
+      /// alias.
+      pub fn slug(self) -> &'static str {
+        match self {
+          $( Action::$variant => $slug, )*
+        }
+      }
+
+      /// Inverse of [`Action::slug`]. Used by the config loader to
+      /// translate `.gwm.toml` keys into typed actions.
+      pub fn from_slug(s: &str) -> Option<Self> {
+        match s {
+          $( $slug => Some(Action::$variant), )*
+          _ => None,
+        }
+      }
+
+      /// Iterator over every variant. Order matches the declarative
+      /// macro invocation below, which is also the order surfaced by
+      /// `gwm tui keys`.
+      pub fn all() -> impl Iterator<Item = Self> {
+        [ $( Action::$variant, )* ].into_iter()
+      }
+    }
+
+    /// Static (Action, slug) table — convenience for callers that
+    /// want both at once (the help-overlay renderer, `gwm tui keys`
+    /// printer, `gwm doctor` reporter).
+    pub const ACTIONS: &[(Action, &str)] = &[
+      $( (Action::$variant, $slug), )*
+    ];
+  };
+}
+
+define_actions! {
+  // Navigation
+  Down              => "down",
+  Up                => "up",
+  Top               => "top",
+  Bottom            => "bottom",
+  ToggleSidebar     => "toggle_sidebar",
+  FocusSwap         => "focus_swap",
+  // Filter
+  Filter            => "filter",
+  // Lifecycle / mutating
+  Refresh           => "refresh",
+  Create            => "create",
+  DeleteConfirm     => "delete",
+  Bootstrap         => "bootstrap",
+  ToggleDeleteBranch => "delete_branch",
+  // Hand-offs
+  GitTui            => "git_tui",
+  Review            => "review",
+  Yank              => "yank",
+  Open              => "open",
+  OpenMenu          => "open_menu",
+  LinkPrompt        => "link",
+  FetchGithub       => "fetch_github",
+  // Overlays
+  Help              => "help",
+  Quit              => "quit",
+  // Future surface — bound to ':' by default, picked up by #32.
+  CommandPalette    => "command_palette",
+}
+
+// ---------------------------------------------------------------------------
+// Key-string parser
+// ---------------------------------------------------------------------------
+
+/// One keystroke in a chord. Wraps a crossterm [`KeyCode`] +
+/// [`KeyModifiers`] pair, but only retains the three modifier bits
+/// that are meaningful at the keymap layer (Ctrl / Alt / Shift) —
+/// other crossterm bits (keypad, repeat, …) are filtered in
+/// [`KeyStroke::from_event`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyStroke {
+  pub code: KeyCode,
+  pub modifiers: KeyModifiers,
+}
+
+impl KeyStroke {
+  pub fn new(code: KeyCode, modifiers: KeyModifiers) -> Self {
+    Self {
+      code,
+      modifiers: Self::sanitize(modifiers),
+    }
+  }
+
+  /// Build a stroke from a raw crossterm event, dropping modifier
+  /// bits we never bind against (KEYPAD, REPEAT, SUPER, HYPER, META).
+  pub fn from_event(ev: &KeyEvent) -> Self {
+    Self::new(ev.code, ev.modifiers)
+  }
+
+  fn sanitize(m: KeyModifiers) -> KeyModifiers {
+    m & (KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
+  }
+
+  /// Parse a chord string (`"j"`, `"g g"`, `"Ctrl+x Ctrl+s"`) into
+  /// its sequence of keystrokes. Whitespace separates keystrokes;
+  /// `+` separates modifiers from the key. Use `"Space"` for the
+  /// literal space character.
+  pub fn parse_chord(s: &str) -> Result<Vec<KeyStroke>> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+      return Err(GwmError::Config(format!("keymap: empty key string {:?}", s)));
+    }
+    trimmed.split_whitespace().map(Self::parse_single).collect()
+  }
+
+  fn parse_single(token: &str) -> Result<KeyStroke> {
+    if token.is_empty() {
+      return Err(GwmError::Config("keymap: empty keystroke token".into()));
+    }
+    let parts: Vec<&str> = token.split('+').collect();
+    if parts.iter().any(|p| p.is_empty()) {
+      return Err(GwmError::Config(format!("keymap: dangling '+' in {:?}", token)));
+    }
+    let (key_str, mod_strs) = parts.split_last().expect("token is non-empty, split_last cannot fail");
+
+    let mut modifiers = KeyModifiers::empty();
+    for m in mod_strs {
+      let bit = match *m {
+        "Ctrl" => KeyModifiers::CONTROL,
+        "Alt" => KeyModifiers::ALT,
+        "Shift" => KeyModifiers::SHIFT,
+        other => {
+          return Err(GwmError::Config(format!(
+            "keymap: unknown modifier {:?} in {:?}",
+            other, token
+          )))
+        }
+      };
+      if modifiers.contains(bit) {
+        return Err(GwmError::Config(format!(
+          "keymap: duplicate modifier {:?} in {:?}",
+          m, token
+        )));
+      }
+      modifiers |= bit;
+    }
+
+    let code = parse_keycode(key_str, token)?;
+    Ok(KeyStroke { code, modifiers })
+  }
+}
+
+fn parse_keycode(s: &str, full_token: &str) -> Result<KeyCode> {
+  let code = match s {
+    "Tab" => KeyCode::Tab,
+    "Enter" => KeyCode::Enter,
+    "Esc" => KeyCode::Esc,
+    "Up" => KeyCode::Up,
+    "Down" => KeyCode::Down,
+    "Left" => KeyCode::Left,
+    "Right" => KeyCode::Right,
+    "Backspace" => KeyCode::Backspace,
+    "BackTab" => KeyCode::BackTab,
+    "Home" => KeyCode::Home,
+    "End" => KeyCode::End,
+    "PageUp" => KeyCode::PageUp,
+    "PageDown" => KeyCode::PageDown,
+    "Insert" => KeyCode::Insert,
+    "Delete" => KeyCode::Delete,
+    "Space" => KeyCode::Char(' '),
+    other if other.starts_with('F') && other.len() > 1 => {
+      let n: u8 = other[1..]
+        .parse()
+        .map_err(|_| GwmError::Config(format!("keymap: invalid function key {:?}", other)))?;
+      if !(1..=12).contains(&n) {
+        return Err(GwmError::Config(format!(
+          "keymap: function key out of range {:?} (expected F1..=F12)",
+          other
+        )));
+      }
+      KeyCode::F(n)
+    }
+    other => {
+      let mut chars = other.chars();
+      let (first, second) = (chars.next(), chars.next());
+      match (first, second) {
+        (Some(c), None) => KeyCode::Char(c),
+        _ => {
+          return Err(GwmError::Config(format!(
+            "keymap: unknown key {:?} in {:?}",
+            other, full_token
+          )))
+        }
+      }
+    }
+  };
+  Ok(code)
+}
+
+impl fmt::Display for KeyStroke {
+  /// Canonical rendering used by `gwm tui keys` and the help overlay.
+  /// Modifier order is always `Ctrl+Alt+Shift+<key>` so two bindings
+  /// that compare equal also render identically.
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if self.modifiers.contains(KeyModifiers::CONTROL) {
+      write!(f, "Ctrl+")?;
+    }
+    if self.modifiers.contains(KeyModifiers::ALT) {
+      write!(f, "Alt+")?;
+    }
+    if self.modifiers.contains(KeyModifiers::SHIFT) {
+      write!(f, "Shift+")?;
+    }
+    match self.code {
+      KeyCode::Char(' ') => write!(f, "Space"),
+      KeyCode::Char(c) => write!(f, "{c}"),
+      KeyCode::Tab => write!(f, "Tab"),
+      KeyCode::Enter => write!(f, "Enter"),
+      KeyCode::Esc => write!(f, "Esc"),
+      KeyCode::Up => write!(f, "Up"),
+      KeyCode::Down => write!(f, "Down"),
+      KeyCode::Left => write!(f, "Left"),
+      KeyCode::Right => write!(f, "Right"),
+      KeyCode::Backspace => write!(f, "Backspace"),
+      KeyCode::BackTab => write!(f, "BackTab"),
+      KeyCode::Home => write!(f, "Home"),
+      KeyCode::End => write!(f, "End"),
+      KeyCode::PageUp => write!(f, "PageUp"),
+      KeyCode::PageDown => write!(f, "PageDown"),
+      KeyCode::Insert => write!(f, "Insert"),
+      KeyCode::Delete => write!(f, "Delete"),
+      KeyCode::F(n) => write!(f, "F{n}"),
+      other => write!(f, "{other:?}"),
+    }
+  }
+}
+
+fn format_chord(strokes: &[KeyStroke]) -> String {
+  strokes.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Keymap
+// ---------------------------------------------------------------------------
+
+/// Where a given binding came from. Surfaces in `gwm tui keys` as the
+/// third column so the user can audit what's hers vs. what shipped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+  Default,
+  UserConfig,
+}
+
+/// One entry in the resolved keymap: an action, the list of chords
+/// that fire it (any one match suffices), and the source layer the
+/// binding came from.
+#[derive(Debug, Clone)]
+pub struct Binding {
+  pub action: Action,
+  pub chords: Vec<Vec<KeyStroke>>,
+  pub source: Source,
+}
+
+/// Outcome of [`Keymap::lookup`] for a given pending-keys buffer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChordResolution {
+  /// Buffer exactly matches a bound chord. Caller fires the action
+  /// and clears the buffer.
+  Matched(Action),
+  /// Buffer is the strict prefix of at least one bound chord.
+  /// Caller keeps the buffer armed and waits for the next stroke.
+  PendingPrefix,
+  /// Buffer matches no binding and is not the prefix of any.
+  /// Caller clears the buffer (and may retry the last stroke alone
+  /// — that policy lives in the event loop, not here).
+  NoMatch,
+}
+
+#[derive(Debug, Clone)]
+pub struct Keymap {
+  entries: Vec<Binding>,
+}
+
+impl Keymap {
+  /// Built-in defaults. Mirrors the historical hard-coded set in
+  /// `src/tui/mod.rs` before issue #87. Adding a default binding
+  /// here automatically surfaces it in `gwm tui keys` and the help
+  /// overlay.
+  pub fn defaults() -> Self {
+    let entries = vec![
+      def(Action::Down, &["j", "Down"]),
+      def(Action::Up, &["k", "Up"]),
+      def(Action::Top, &["g g"]),
+      def(Action::Bottom, &["G", "End"]),
+      def(Action::ToggleSidebar, &["v"]),
+      def(Action::FocusSwap, &["Tab"]),
+      def(Action::Filter, &["/"]),
+      def(Action::Refresh, &["f", "r"]),
+      def(Action::Create, &["n"]),
+      def(Action::DeleteConfirm, &["d"]),
+      def(Action::Bootstrap, &["b"]),
+      def(Action::ToggleDeleteBranch, &["p"]),
+      def(Action::GitTui, &["l"]),
+      def(Action::Review, &["R"]),
+      def(Action::Yank, &["y"]),
+      def(Action::Open, &["o"]),
+      def(Action::OpenMenu, &["O"]),
+      def(Action::LinkPrompt, &["L"]),
+      def(Action::FetchGithub, &["F"]),
+      def(Action::Help, &["?"]),
+      def(Action::Quit, &["q"]),
+      def(Action::CommandPalette, &[":"]),
+    ];
+    Self { entries }
+  }
+
+  /// Replace the chords bound to `action` with `chords` and re-validate
+  /// the full keymap. An empty `Vec` unbinds the action. The validation
+  /// pass rejects:
+  ///
+  /// - the same chord wired to two different actions (conflict);
+  /// - a chord that is a strict prefix of another (`g` while `g g`
+  ///   is bound) — see the module-level chord/prefix policy note.
+  ///
+  /// Returns `Err(GwmError::Config(_))` on failure; the keymap is
+  /// left untouched on error so callers can surface the message and
+  /// move on.
+  pub fn apply_override(&mut self, action: Action, chords: Vec<Vec<KeyStroke>>) -> Result<()> {
+    let mut candidate: Vec<(Action, Vec<Vec<KeyStroke>>)> = self
+      .entries
+      .iter()
+      .map(|b| {
+        if b.action == action {
+          (b.action, chords.clone())
+        } else {
+          (b.action, b.chords.clone())
+        }
+      })
+      .collect();
+    if !candidate.iter().any(|(a, _)| *a == action) {
+      candidate.push((action, chords.clone()));
+    }
+    Self::validate(&candidate)?;
+
+    let mut replaced = false;
+    for entry in self.entries.iter_mut() {
+      if entry.action == action {
+        entry.chords = chords.clone();
+        entry.source = Source::UserConfig;
+        replaced = true;
+        break;
+      }
+    }
+    if !replaced {
+      self.entries.push(Binding {
+        action,
+        chords,
+        source: Source::UserConfig,
+      });
+    }
+    Ok(())
+  }
+
+  fn validate(entries: &[(Action, Vec<Vec<KeyStroke>>)]) -> Result<()> {
+    let mut all: Vec<(&[KeyStroke], Action)> = Vec::new();
+    for (action, chords) in entries {
+      for chord in chords {
+        if chord.is_empty() {
+          return Err(GwmError::Config(format!(
+            "keymap: empty chord bound to {:?}",
+            action.slug()
+          )));
+        }
+        all.push((chord.as_slice(), *action));
+      }
+    }
+    for i in 0..all.len() {
+      for j in (i + 1)..all.len() {
+        if all[i].0 == all[j].0 {
+          if all[i].1 != all[j].1 {
+            return Err(GwmError::Config(format!(
+              "keymap: chord {:?} bound to both {:?} and {:?} — conflict",
+              format_chord(all[i].0),
+              all[i].1.slug(),
+              all[j].1.slug()
+            )));
+          }
+          continue;
+        }
+        let (short, long) = if all[i].0.len() < all[j].0.len() {
+          (i, j)
+        } else {
+          (j, i)
+        };
+        if all[short].0.len() < all[long].0.len() && all[long].0.starts_with(all[short].0) {
+          return Err(GwmError::Config(format!(
+            "keymap: chord {:?} (action {:?}) is a prefix of {:?} (action {:?}) — refused at load time so the event loop never has to time out",
+            format_chord(all[short].0),
+            all[short].1.slug(),
+            format_chord(all[long].0),
+            all[long].1.slug()
+          )));
+        }
+      }
+    }
+    Ok(())
+  }
+
+  /// Resolve a pending-keys buffer against the keymap.
+  pub fn lookup(&self, keys: &[KeyStroke]) -> ChordResolution {
+    let mut pending = false;
+    for entry in &self.entries {
+      for chord in &entry.chords {
+        if chord.as_slice() == keys {
+          return ChordResolution::Matched(entry.action);
+        }
+        if chord.len() > keys.len() && chord.starts_with(keys) {
+          pending = true;
+        }
+      }
+    }
+    if pending {
+      ChordResolution::PendingPrefix
+    } else {
+      ChordResolution::NoMatch
+    }
+  }
+
+  /// Snapshot the resolved keymap for `gwm tui keys` / help overlay.
+  /// Order matches the declarative `define_actions!` invocation so the
+  /// rendered table stays stable across runs.
+  pub fn list(&self) -> Vec<Binding> {
+    self.entries.clone()
+  }
+}
+
+/// Build a default `Binding` from a list of chord literals. Panics
+/// if a literal does not parse — that is a programmer error in the
+/// defaults table, never user input.
+fn def(action: Action, chord_literals: &[&str]) -> Binding {
+  let chords = chord_literals
+    .iter()
+    .map(|s| {
+      KeyStroke::parse_chord(s).unwrap_or_else(|e| panic!("default keymap chord {:?} failed to parse: {}", s, e))
+    })
+    .collect();
+  Binding {
+    action,
+    chords,
+    source: Source::Default,
+  }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,10 +6,12 @@ mod app;
 /// actually depend on.
 #[doc(hidden)]
 pub mod commit_graph;
+pub mod keymap;
 pub mod state;
 mod ui;
 
 use crate::error::Result;
+use crate::tui::keymap::Action;
 use crossterm::{
   event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers},
   execute,
@@ -49,8 +51,8 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, branch_name_color, build_sidebar_sections, filled_cells_for_progress, freshness_color, header_title,
-  issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line, recent_commits_lines, table_marker,
-  tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line, recent_commits_lines,
+  table_marker, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {
@@ -171,78 +173,87 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         _ => {}
       },
       View::List => {
-        // Two-keystroke vim motion `gg`: any non-'g' keypress disarms it.
-        if !matches!(key.code, KeyCode::Char('g')) {
+        // Esc and Enter stay hard-coded because their semantics are
+        // *contextual* (filter state, picker mode, sticky filter) —
+        // folding them into the user-rebindable keymap would require
+        // a modal grammar the config language cannot express. Their
+        // pre-#87 behaviour is preserved verbatim; both also drop
+        // any in-flight chord so a stray `g` followed by Esc never
+        // leaks state into the next view.
+        if key.code == KeyCode::Esc {
           app.cancel_pending_motion();
-        }
-        match key.code {
-          KeyCode::Char('q') => break,
-          // Esc on the list clears a sticky filter first, then quits if the
-          // list is already in its plain state. Avoids the trap where a user
-          // hits Esc expecting to clear /-filter and accidentally exits.
-          KeyCode::Esc => {
-            if !app.filter.query().is_empty() {
-              app.exit_filter_cancel();
-            } else {
-              break;
-            }
+          if !app.filter.query().is_empty() {
+            app.exit_filter_cancel();
+          } else {
+            break;
           }
-          KeyCode::Char('?') => app.view = View::Help,
-          KeyCode::Char('j') | KeyCode::Down => app.next(),
-          KeyCode::Char('k') | KeyCode::Up => app.prev(),
-          KeyCode::Char('g') => app.handle_g(),
-          KeyCode::Char('G') => app.last(),
-          KeyCode::Char('v') => app.toggle_sidebar(),
-          KeyCode::Tab => app.toggle_focus(),
-          KeyCode::Char('/') => app.enter_filter(),
-          KeyCode::Char('l') => {
-            // Issue #75: `l` is driven by the configurable `[git_tui]`
-            // launcher pipeline (default `lazygit -p {path}`,
-            // fullscreen=true). Replaces the old hardcoded lazygit call.
-            if let Some(plan) = app.prepare_git_tui() {
-              run_launcher(terminal, plan, &mut app)?;
-            }
+        } else if key.code == KeyCode::Enter {
+          app.cancel_pending_motion();
+          if app.picker_mode {
+            app.picker_confirm();
+          } else {
+            app.copy_path_to_status();
           }
-          // Issue #75 keybinding reshuffle (was `r` → refresh worktree list).
-          // `f` is the new mnemonic; the `r` alias is kept for muscle memory.
-          KeyCode::Char('f') | KeyCode::Char('r') => app.refresh()?,
-          // Mutating actions are inert in picker mode — the issue explicitly
-          // calls for a stripped-down picker that only navigates and selects.
-          KeyCode::Char('n') if !app.picker_mode => app.enter_create(),
-          KeyCode::Char('d') if !app.picker_mode => app.enter_confirm_delete(),
-          KeyCode::Char('b') if !app.picker_mode => app.bootstrap_selected(),
-          KeyCode::Char('p') if !app.picker_mode => app.toggle_delete_branch(),
-          KeyCode::Char('y') => yank_selected_path_to_clipboard(&mut app),
-          KeyCode::Char('o') => match app.resolve_open_target() {
-            None => app.status = "nothing selected".into(),
-            Some(OpenTarget::Finder { .. }) => app.open_selected_in_finder(),
-            Some(OpenTarget::Shell { path, command }) => {
-              run_subshell(terminal, &command, &[], Some(&path), &mut app, "shell")?
+        } else if let Some(action) = app.dispatch_key(key) {
+          // Issue #87: the View::List binding table is driven by the
+          // resolved keymap (`config.tui.keys` overrides on top of
+          // `Keymap::defaults`). The match below maps each Action to
+          // its side-effect; picker-mode-gated rows preserve the
+          // pre-#87 contract that `gwm switch` exposes a stripped-
+          // down picker (navigate + select, no mutations).
+          match action {
+            Action::Quit => break,
+            Action::Down => app.next(),
+            Action::Up => app.prev(),
+            Action::Top => app.first(),
+            Action::Bottom => app.last(),
+            Action::ToggleSidebar => app.toggle_sidebar(),
+            Action::FocusSwap => app.toggle_focus(),
+            Action::Filter => app.enter_filter(),
+            Action::Refresh => app.refresh()?,
+            Action::Help => app.view = View::Help,
+            Action::Yank => yank_selected_path_to_clipboard(&mut app),
+            Action::Open => match app.resolve_open_target() {
+              None => app.status = "nothing selected".into(),
+              Some(OpenTarget::Finder { .. }) => app.open_selected_in_finder(),
+              Some(OpenTarget::Shell { path, command }) => {
+                run_subshell(terminal, &command, &[], Some(&path), &mut app, "shell")?
+              }
+              Some(OpenTarget::Editor { path, command }) => {
+                let path_str = path.display().to_string();
+                run_subshell(terminal, &command, &[&path_str], None, &mut app, "editor")?
+              }
+            },
+            Action::GitTui => {
+              if let Some(plan) = app.prepare_git_tui() {
+                run_launcher(terminal, plan, &mut app)?;
+              }
             }
-            Some(OpenTarget::Editor { path, command }) => {
-              let path_str = path.display().to_string();
-              run_subshell(terminal, &command, &[&path_str], None, &mut app, "editor")?
+            // Mutating actions inert in picker mode.
+            Action::Create if !app.picker_mode => app.enter_create(),
+            Action::DeleteConfirm if !app.picker_mode => app.enter_confirm_delete(),
+            Action::Bootstrap if !app.picker_mode => app.bootstrap_selected(),
+            Action::ToggleDeleteBranch if !app.picker_mode => app.toggle_delete_branch(),
+            Action::OpenMenu if !app.picker_mode => app.enter_open_menu(),
+            Action::LinkPrompt if !app.picker_mode => app.enter_link_prompt(),
+            Action::FetchGithub if !app.picker_mode => app.refresh_github_status(),
+            Action::Review if !app.picker_mode => {
+              if let Some(plan) = app.prepare_review() {
+                run_launcher(terminal, plan, &mut app)?;
+              }
             }
-          },
-          // Issue/PR linking (issue #67).
-          KeyCode::Char('O') if !app.picker_mode => app.enter_open_menu(),
-          KeyCode::Char('L') if !app.picker_mode => app.enter_link_prompt(),
-          // Issue #75 reshuffle: `F` is the new mnemonic for "fetch GitHub
-          // status" (was `R`). `R` now triggers the configured review tool.
-          KeyCode::Char('F') if !app.picker_mode => app.refresh_github_status(),
-          KeyCode::Char('R') if !app.picker_mode => {
-            if let Some(plan) = app.prepare_review() {
-              run_launcher(terminal, plan, &mut app)?;
-            }
+            // Reserved for #32 — bound to `:` by default, currently a
+            // no-op until the command palette overlay lands. Surfacing
+            // it here (rather than dropping it from the keymap) keeps
+            // the `gwm tui keys` output stable across the #87 → #32
+            // boundary.
+            Action::CommandPalette => {}
+            // Picker-mode-gated actions fall through to no-op when
+            // the guard fails (i.e. the user pressed them inside
+            // `gwm switch`). Same fallthrough catches future actions
+            // not yet wired into the List view.
+            _ => {}
           }
-          KeyCode::Enter => {
-            if app.picker_mode {
-              app.picker_confirm();
-            } else {
-              app.copy_path_to_status();
-            }
-          }
-          _ => {}
         }
       }
       View::Help => match key.code {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -845,71 +845,123 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   f.render_widget(Paragraph::new(text).wrap(Wrap { trim: true }), area);
 }
 
-fn draw_help(f: &mut Frame, app: &App) {
-  let area = centered(60, 60, f.area());
-  let title_text = if app.picker_mode {
+/// Pure builder for the help overlay body (issue #87).
+///
+/// Reads every list-view binding from the resolved `Keymap` so user
+/// overrides under `[tui.keys]` show through verbatim — a user who
+/// rebinds `down = ["Ctrl+n"]` sees `Ctrl+n` next to "next" instead
+/// of the historical `j / ↓`. Lines that document non-rebindable
+/// surfaces (Ctrl-C escape hatch, contextual Esc / Enter, create-
+/// form keys, confirm-delete keys) remain hard-coded.
+///
+/// Exposed as `pub` (and re-exported through `tui::help_lines`) so
+/// the state-machine test in `tests/tui_chord_tests.rs` can assert
+/// the doc/binding contract end-to-end without spawning a terminal.
+pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> {
+  use super::keymap::Action;
+
+  // Format every chord bound to `action` as a comma-separated list
+  // (`"j, Down"` or `"g g"` or `""` for unbound). The width 13 is
+  // wide enough for `Ctrl+Shift+Tab` while keeping the help overlay
+  // narrow enough for an 80-column terminal.
+  let keys_for = |action: Action| -> String {
+    km.list()
+      .iter()
+      .find(|b| b.action == action)
+      .map(|b| {
+        b.chords
+          .iter()
+          .map(|c| c.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(" "))
+          .collect::<Vec<_>>()
+          .join(", ")
+      })
+      .unwrap_or_default()
+  };
+  let row = |action: Action, label: &str| -> String {
+    let keys = keys_for(action);
+    let keys = if keys.is_empty() { "(unbound)".to_string() } else { keys };
+    format!("  {:<13} {}", keys, label)
+  };
+
+  let title_text = if picker_mode {
     "gwm switch — keys"
   } else {
     "gwm — keys"
   };
-  let mut lines = vec![
-    Line::from(Span::styled(
-      title_text,
-      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-    )),
-    Line::from(""),
-    Line::from("global"),
-    Line::from("  q / Esc       quit"),
-    Line::from("  Ctrl-C        force quit"),
-    Line::from(""),
-    Line::from("list view"),
-    Line::from("  j / ↓         next (scrolls sidebar when focused)"),
-    Line::from("  k / ↑         prev (scrolls sidebar when focused)"),
-    Line::from("  gg            jump to first worktree"),
-    Line::from("  G             jump to last worktree"),
+
+  let mut lines: Vec<String> = vec![
+    title_text.to_string(),
+    String::new(),
+    "global".to_string(),
+    format!(
+      "  {:<13} quit (Esc also quits when filter is clear)",
+      keys_for(Action::Quit)
+    ),
+    "  Ctrl-C        force quit (hard-coded escape hatch)".to_string(),
+    String::new(),
+    "list view".to_string(),
+    row(Action::Down, "next (scrolls sidebar when focused)"),
+    row(Action::Up, "prev (scrolls sidebar when focused)"),
+    row(Action::Top, "jump to first worktree"),
+    row(Action::Bottom, "jump to last worktree"),
   ];
-  if app.picker_mode {
-    lines.push(Line::from(
-      "  enter         select highlighted worktree (prints path on exit)",
-    ));
+  if picker_mode {
+    lines.push("  enter         select highlighted worktree (prints path on exit)".to_string());
   } else {
-    lines.push(Line::from("  n             new worktree"));
-    lines.push(Line::from("  d             delete selected"));
-    lines.push(Line::from("  b             bootstrap selected"));
+    lines.push(row(Action::Create, "new worktree"));
+    lines.push(row(Action::DeleteConfirm, "delete selected"));
+    lines.push(row(Action::Bootstrap, "bootstrap selected"));
   }
-  lines.extend([
-    Line::from("  o             open per [tui.open] — shell (default) / editor / finder"),
-    Line::from("  y             yank selected path to system clipboard"),
-    Line::from("  l             launch [git_tui] launcher (default lazygit -p, configurable)"),
-    Line::from("  v             toggle git preview sidebar (auto-hidden < 120 cols)"),
-    Line::from("  Tab           swap focus between worktree list and sidebar"),
-    Line::from("  /             open fuzzy filter bar (enter: sticky, esc: clear)"),
-    Line::from("  f             refresh worktree list"),
-    Line::from("  F             refresh GitHub issue/PR status via `gh`"),
-    Line::from("  R             run [review] launcher against the resolved base"),
-  ]);
-  if !app.picker_mode {
-    lines.push(Line::from("  p             toggle 'delete branch on remove'"));
-    lines.push(Line::from("  enter         show path in status bar"));
-    lines.push(Line::from(""));
-    lines.push(Line::from("issue / PR (#67)"));
-    lines.push(Line::from("  O             open menu — i=issue · p=pull request"));
-    lines.push(Line::from("  L             link prompt — i / p then digits"));
+  lines.push(row(Action::Open, "open per [tui.open] — shell / editor / finder"));
+  lines.push(row(Action::Yank, "yank selected path to system clipboard"));
+  lines.push(row(Action::GitTui, "launch [git_tui] launcher (default lazygit -p)"));
+  lines.push(row(Action::ToggleSidebar, "toggle git preview sidebar"));
+  lines.push(row(Action::FocusSwap, "swap focus between worktree list and sidebar"));
+  lines.push(row(Action::Filter, "open fuzzy filter bar (enter: sticky, esc: clear)"));
+  lines.push(row(Action::Refresh, "refresh worktree list"));
+  if !picker_mode {
+    lines.push(row(Action::FetchGithub, "refresh GitHub issue/PR status via `gh`"));
+    lines.push(row(Action::Review, "run [review] launcher against the resolved base"));
+    lines.push(row(Action::ToggleDeleteBranch, "toggle 'delete branch on remove'"));
+    lines.push("  enter         show path in status bar".to_string());
+    lines.push(String::new());
+    lines.push("issue / PR (#67)".to_string());
+    lines.push(row(Action::OpenMenu, "open menu — i=issue · p=pull request"));
+    lines.push(row(Action::LinkPrompt, "link prompt — i / p then digits"));
   }
-  lines.push(Line::from("  ?             this help"));
-  if !app.picker_mode {
+  lines.push(row(Action::Help, "this help"));
+  if !picker_mode {
     lines.extend([
-      Line::from(""),
-      Line::from("create form"),
-      Line::from("  ↑/↓           change branch type"),
-      Line::from("  Tab/Shift-Tab next/prev field"),
-      Line::from("  Enter (desc)  submit"),
-      Line::from("  Esc           cancel"),
-      Line::from(""),
-      Line::from("confirm delete"),
-      Line::from("  y / Enter     confirm"),
-      Line::from("  n / Esc       cancel"),
+      String::new(),
+      "create form".to_string(),
+      "  ↑/↓           change branch type".to_string(),
+      "  Tab/Shift-Tab next/prev field".to_string(),
+      "  Enter (desc)  submit".to_string(),
+      "  Esc           cancel".to_string(),
+      String::new(),
+      "confirm delete".to_string(),
+      "  y / Enter     confirm".to_string(),
+      "  n / Esc       cancel".to_string(),
     ]);
+  }
+  lines
+}
+
+fn draw_help(f: &mut Frame, app: &App) {
+  let area = centered(60, 60, f.area());
+  let strings = help_lines(&app.keymap, app.picker_mode);
+  let mut lines: Vec<Line<'_>> = Vec::with_capacity(strings.len());
+  // First line is the title — render bold cyan like the pre-#87
+  // overlay. Subsequent lines are plain so the resolved bindings
+  // stay legible at low contrast.
+  if let Some((first, rest)) = strings.split_first() {
+    lines.push(Line::from(Span::styled(
+      first.clone(),
+      Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    )));
+    for s in rest {
+      lines.push(Line::from(s.clone()));
+    }
   }
   let block = Block::default()
     .borders(Borders::ALL)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -860,12 +860,18 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
 pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> {
   use super::keymap::Action;
 
+  // Snapshot the keymap once. The pre-#87-review version called
+  // `km.list()` inside `keys_for`, which cloned the entire bindings
+  // vector for every help row — measurable churn for the ~20 rows
+  // the overlay renders. Single clone here, indexed by action below.
+  let bindings = km.list();
+
   // Format every chord bound to `action` as a comma-separated list
   // (`"j, Down"` or `"g g"` or `""` for unbound). The width 13 is
   // wide enough for `Ctrl+Shift+Tab` while keeping the help overlay
   // narrow enough for an 80-column terminal.
   let keys_for = |action: Action| -> String {
-    km.list()
+    bindings
       .iter()
       .find(|b| b.action == action)
       .map(|b| {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -59,7 +59,9 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  hooks "))
     // Issue #29: operation journal + undo + history.
     .stdout(predicate::str::contains("  undo "))
-    .stdout(predicate::str::contains("  history "));
+    .stdout(predicate::str::contains("  history "))
+    // Issue #87: configurable TUI keymap (`gwm tui keys`).
+    .stdout(predicate::str::contains("  tui "));
 }
 
 // --- gitmoji (issue #85) ------------------------------------------------
@@ -3717,4 +3719,77 @@ fn pr_errors_when_no_template_configured() {
     .failure()
     .stderr(predicate::str::contains("pr_template"))
     .stderr(predicate::str::contains("feat"));
+}
+
+// --- gwm tui keys (issue #87) -------------------------------------------
+
+#[test]
+fn tui_keys_lists_default_bindings() {
+  // The bare invocation prints the full resolved keymap as a
+  // human-readable table. Default surface ships with `down → j, Down`,
+  // `top → g g`, `quit → q`, … — assert the canary rows so a regression
+  // in the table layout or the defaults map fails loudly.
+  let (dir, _) = init_repo();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["tui", "keys"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("down"))
+    .stdout(predicate::str::contains("j"))
+    .stdout(predicate::str::contains("top"))
+    .stdout(predicate::str::contains("g g"))
+    .stdout(predicate::str::contains("quit"))
+    .stdout(predicate::str::contains("default"));
+}
+
+#[test]
+fn tui_keys_marks_user_overrides_in_source_column() {
+  // When the user overrides a binding via `[tui.keys]`, the source
+  // column for that row flips from `default` to a non-default marker
+  // (we use `.gwm.toml`). The other rows keep `default`.
+  let (dir, _) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[tui.keys]
+down = ["Ctrl+n"]
+"#,
+  )
+  .unwrap();
+
+  let output = Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["tui", "keys"])
+    .assert()
+    .success()
+    .get_output()
+    .clone();
+
+  let stdout = String::from_utf8(output.stdout).unwrap();
+  // Find the `down` row and assert it carries the user-config marker.
+  let down_line = stdout
+    .lines()
+    .find(|l| l.starts_with("down"))
+    .unwrap_or_else(|| panic!("expected a `down` row in:\n{stdout}"));
+  assert!(
+    down_line.contains("Ctrl+n"),
+    "expected `down` row to show the override, got: {down_line}"
+  );
+  assert!(
+    down_line.contains(".gwm.toml"),
+    "expected `down` row source to be `.gwm.toml`, got: {down_line}"
+  );
+  // `up` was not overridden — must still read as default.
+  let up_line = stdout
+    .lines()
+    .find(|l| l.starts_with("up"))
+    .unwrap_or_else(|| panic!("expected an `up` row in:\n{stdout}"));
+  assert!(
+    up_line.contains("default"),
+    "expected `up` row source to stay `default`, got: {up_line}"
+  );
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1460,3 +1460,151 @@ bogus = true
   let msg = format!("{}", err);
   assert!(msg.contains("bogus"), "{msg}");
 }
+
+// --- [tui.keys] section (issue #87) -------------------------------------
+
+#[test]
+fn tui_keys_default_is_empty_map() {
+  // Absent `[tui.keys]` block resolves to an empty map — the keymap
+  // layer then keeps every built-in default. Mirrors the `labels` /
+  // `milestones` "no override declared" contract.
+  let cfg = Config::default();
+  assert!(cfg.tui.keys.bindings.is_empty());
+}
+
+#[test]
+fn tui_keys_section_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+down = ["j", "Ctrl+n"]
+up   = ["k", "Ctrl+p"]
+top  = ["g g"]
+"#,
+  )
+  .unwrap();
+
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  assert_eq!(
+    cfg.tui.keys.bindings.get("down").map(Vec::as_slice),
+    Some(["j".to_string(), "Ctrl+n".to_string()].as_slice())
+  );
+  assert_eq!(
+    cfg.tui.keys.bindings.get("up").map(Vec::as_slice),
+    Some(["k".to_string(), "Ctrl+p".to_string()].as_slice())
+  );
+  assert_eq!(
+    cfg.tui.keys.bindings.get("top").map(Vec::as_slice),
+    Some(["g g".to_string()].as_slice())
+  );
+}
+
+#[test]
+fn tui_keys_rejects_unknown_action_at_load_time() {
+  // `gallop` is not in `keymap::ACTIONS`. The user almost certainly
+  // typo'd a real action name; surfacing the error here saves a
+  // mystifying "my binding does nothing in the TUI" round trip.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+gallop = ["g"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("unknown action must reject");
+  let msg = format!("{}", err).to_lowercase();
+  assert!(
+    msg.contains("gallop"),
+    "expected message to name the bad action, got: {msg}"
+  );
+  assert!(
+    msg.contains("unknown"),
+    "expected message to flag it as unknown, got: {msg}"
+  );
+}
+
+#[test]
+fn tui_keys_rejects_invalid_key_string() {
+  // `Foobar` is not a named key and is not a single character. The
+  // parser surfaces it as a config error.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+down = ["Foobar"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("invalid key string must reject");
+  let msg = format!("{}", err).to_lowercase();
+  assert!(
+    msg.contains("foobar"),
+    "expected message to name the bad key, got: {msg}"
+  );
+}
+
+#[test]
+fn tui_keys_rejects_chord_that_is_strict_prefix() {
+  // Binding `g` alone while the default `g g` is still in place
+  // creates a chord/prefix ambiguity. Per the design note on PR #87
+  // this is a hard error at load — never a runtime timeout.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+open = ["g"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("prefix collision must reject");
+  let msg = format!("{}", err).to_lowercase();
+  assert!(msg.contains("prefix"), "expected prefix error, got: {msg}");
+}
+
+#[test]
+fn tui_keys_rejects_chord_conflict_across_actions() {
+  // `down` and `up` both rebound to `x` — same chord, two actions,
+  // ambiguous dispatch. Refuse at load time.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+down = ["x"]
+up   = ["x"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_for_repo(dir.path()).expect_err("conflict must reject");
+  let msg = format!("{}", err).to_lowercase();
+  assert!(msg.contains("conflict"), "expected conflict error, got: {msg}");
+}
+
+#[test]
+fn tui_keys_empty_binding_list_unbinds_action() {
+  // `down = []` removes every binding for the `down` action. Useful
+  // for users who prefer to navigate with the arrow keys only.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+down = []
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let km = cfg.tui.keys.resolved_keymap().unwrap();
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  let j = KeyStroke::parse_chord("j").unwrap();
+  assert!(matches!(km.lookup(&j), ChordResolution::NoMatch));
+  // The other defaults survive.
+  let k = KeyStroke::parse_chord("k").unwrap();
+  assert!(matches!(km.lookup(&k), ChordResolution::Matched(Action::Up)));
+}

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -787,3 +787,65 @@ fn orphan_check_ignores_configured_trunks_that_do_not_exist() {
   let c = report.checks.iter().find(|c| c.name.contains("orphan")).unwrap();
   assert_eq!(c.status, CheckStatus::Ok);
 }
+
+// --- TUI keymap check (issue #87) ---------------------------------------
+
+#[test]
+fn doctor_passes_with_default_keymap() {
+  // No `[tui.keys]` overrides → the resolved keymap is the built-in
+  // default. Every required action is bound, so the check is green.
+  let (dir, repo) = init_repo();
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check in the report");
+  assert_eq!(
+    c.status,
+    CheckStatus::Ok,
+    "default keymap must pass cleanly, got: {} — {}",
+    match c.status {
+      CheckStatus::Ok => "ok",
+      CheckStatus::Warning => "warning",
+      CheckStatus::Failed => "failed",
+    },
+    c.detail
+  );
+}
+
+#[test]
+fn doctor_warns_when_user_unbinds_quit() {
+  // `quit` is the only action with a hard-coded escape hatch
+  // (`Ctrl+C` in `run_app`). Even so, leaving it without any other
+  // binding is hostile UX: warn the user so they can either restore
+  // a binding or acknowledge the choice.
+  let (dir, repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[tui.keys]
+quit = []
+"#,
+  )
+  .unwrap();
+  let config = Config::load_for_repo(dir.path()).unwrap();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check in the report");
+  assert_eq!(c.status, CheckStatus::Warning);
+  assert!(
+    c.detail.to_lowercase().contains("quit"),
+    "expected message to name the missing action, got: {}",
+    c.detail
+  );
+  assert!(
+    c.detail.to_lowercase().contains("ctrl"),
+    "expected message to mention the Ctrl+C fallback, got: {}",
+    c.detail
+  );
+}

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -1,0 +1,269 @@
+//! Tests for the configurable TUI keymap (issue #87).
+//!
+//! Covers in this file:
+//!   - `Action` enum + `ACTIONS` table invariants (slug uniqueness,
+//!     kebab-case, every variant present);
+//!   - key-string parser (`parse_chord` — single keys, named keys,
+//!     modifiers, multi-key chords, every reject path);
+//!   - `Keymap` layering (defaults, override replaces single action,
+//!     conflict detection at load time, chord/prefix collision is a
+//!     hard error per the design decision recorded on PR #87).
+//!
+//! The chord-buffer integration (`App::dispatch_key`) lives in
+//! `tests/tui_chord_tests.rs` so that file stays focused on the event
+//! loop side of the contract.
+
+use gwm::tui::keymap::{Action, ChordResolution, KeyStroke, Keymap, Source, ACTIONS};
+
+// ---------------------------------------------------------------------------
+// Action enum + ACTIONS table
+// ---------------------------------------------------------------------------
+
+#[test]
+fn actions_table_covers_every_variant() {
+  // Every variant of `Action` MUST appear exactly once in `ACTIONS`. The
+  // table is the single source of truth consumed by `gwm tui keys`, the
+  // help overlay, and `gwm doctor` — a missing entry would silently
+  // drop an action from all three.
+  let table_variants: Vec<Action> = ACTIONS.iter().map(|(action, _)| *action).collect();
+  let unique: std::collections::HashSet<_> = table_variants.iter().collect();
+  assert_eq!(unique.len(), table_variants.len(), "ACTIONS has duplicate variants");
+
+  for variant in Action::all() {
+    assert!(
+      table_variants.contains(&variant),
+      "Action::{:?} is missing from ACTIONS",
+      variant
+    );
+  }
+}
+
+#[test]
+fn action_slugs_are_unique_and_kebab_case() {
+  let mut seen = std::collections::HashSet::new();
+  for (action, slug) in ACTIONS.iter() {
+    assert!(seen.insert(*slug), "duplicate slug {:?} for {:?}", slug, action);
+    assert!(
+      slug.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+      "slug {:?} for {:?} is not snake_case ascii",
+      slug,
+      action
+    );
+    assert!(!slug.is_empty(), "empty slug for {:?}", action);
+  }
+}
+
+#[test]
+fn action_from_slug_roundtrips() {
+  for (action, slug) in ACTIONS.iter() {
+    assert_eq!(
+      Action::from_slug(slug),
+      Some(*action),
+      "Action::from_slug({:?}) did not roundtrip to {:?}",
+      slug,
+      action
+    );
+    assert_eq!(action.slug(), *slug);
+  }
+  assert_eq!(Action::from_slug("does-not-exist"), None);
+}
+
+// ---------------------------------------------------------------------------
+// Key-string parser
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_single_char() {
+  let chord = KeyStroke::parse_chord("j").unwrap();
+  assert_eq!(chord.len(), 1);
+  assert_eq!(chord[0].to_string(), "j");
+}
+
+#[test]
+fn parse_named_key() {
+  let chord = KeyStroke::parse_chord("Tab").unwrap();
+  assert_eq!(chord.len(), 1);
+  assert_eq!(chord[0].to_string(), "Tab");
+
+  // Esc / Enter / Up / Down / Backspace / Home / End / PageUp / PageDown / F1.
+  for name in [
+    "Esc",
+    "Enter",
+    "Up",
+    "Down",
+    "Left",
+    "Right",
+    "Backspace",
+    "BackTab",
+    "Home",
+    "End",
+    "PageUp",
+    "PageDown",
+    "F1",
+    "F12",
+    "Space",
+  ] {
+    let parsed = KeyStroke::parse_chord(name).unwrap();
+    assert_eq!(parsed.len(), 1, "{name} did not parse to a single key");
+    assert_eq!(parsed[0].to_string(), name);
+  }
+}
+
+#[test]
+fn parse_modifier_combinations() {
+  let chord = KeyStroke::parse_chord("Ctrl+c").unwrap();
+  assert_eq!(chord.len(), 1);
+  assert_eq!(chord[0].to_string(), "Ctrl+c");
+
+  // Modifier order in the source string does not affect equality.
+  let a = KeyStroke::parse_chord("Ctrl+Alt+a").unwrap();
+  let b = KeyStroke::parse_chord("Alt+Ctrl+a").unwrap();
+  assert_eq!(a, b);
+}
+
+#[test]
+fn parse_chord_sequence() {
+  let chord = KeyStroke::parse_chord("g g").unwrap();
+  assert_eq!(chord.len(), 2);
+  assert_eq!(chord[0].to_string(), "g");
+  assert_eq!(chord[1].to_string(), "g");
+
+  let chord = KeyStroke::parse_chord("Ctrl+x Ctrl+s").unwrap();
+  assert_eq!(chord.len(), 2);
+}
+
+#[test]
+fn parse_rejects_empty_string() {
+  assert!(KeyStroke::parse_chord("").is_err());
+  assert!(KeyStroke::parse_chord("   ").is_err());
+}
+
+#[test]
+fn parse_rejects_unknown_named_key() {
+  assert!(KeyStroke::parse_chord("Foo").is_err());
+  assert!(KeyStroke::parse_chord("ControlEnter").is_err());
+}
+
+#[test]
+fn parse_rejects_dangling_modifier() {
+  assert!(KeyStroke::parse_chord("Ctrl+").is_err());
+  assert!(KeyStroke::parse_chord("Ctrl").is_err());
+}
+
+#[test]
+fn parse_rejects_duplicate_modifier() {
+  assert!(KeyStroke::parse_chord("Ctrl+Ctrl+c").is_err());
+}
+
+#[test]
+fn parse_rejects_unknown_modifier() {
+  assert!(KeyStroke::parse_chord("Meta+c").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Keymap layering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_keymap_resolves_core_navigation() {
+  let km = Keymap::defaults();
+
+  let down = KeyStroke::parse_chord("j").unwrap();
+  assert!(matches!(km.lookup(&down), ChordResolution::Matched(Action::Down)));
+
+  let up = KeyStroke::parse_chord("k").unwrap();
+  assert!(matches!(km.lookup(&up), ChordResolution::Matched(Action::Up)));
+
+  let top = KeyStroke::parse_chord("g g").unwrap();
+  assert!(matches!(km.lookup(&top), ChordResolution::Matched(Action::Top)));
+
+  // `g` alone is a pending prefix of `g g`, not a match.
+  let g_prefix = vec![top[0].clone()];
+  assert!(matches!(km.lookup(&g_prefix), ChordResolution::PendingPrefix));
+}
+
+#[test]
+fn keymap_lookup_returns_no_match_for_unbound_key() {
+  let km = Keymap::defaults();
+  let zzz = KeyStroke::parse_chord("Ctrl+Alt+z").unwrap();
+  assert!(matches!(km.lookup(&zzz), ChordResolution::NoMatch));
+}
+
+#[test]
+fn user_override_replaces_default_for_one_action() {
+  let mut km = Keymap::defaults();
+  km.apply_override(Action::Down, vec![KeyStroke::parse_chord("Ctrl+n").unwrap()])
+    .unwrap();
+
+  // New binding wins.
+  let ctrl_n = KeyStroke::parse_chord("Ctrl+n").unwrap();
+  assert!(matches!(km.lookup(&ctrl_n), ChordResolution::Matched(Action::Down)));
+
+  // The default `j` is gone — overriding replaces, never merges.
+  let j = KeyStroke::parse_chord("j").unwrap();
+  assert!(matches!(km.lookup(&j), ChordResolution::NoMatch));
+
+  // Other defaults untouched.
+  let k = KeyStroke::parse_chord("k").unwrap();
+  assert!(matches!(km.lookup(&k), ChordResolution::Matched(Action::Up)));
+}
+
+#[test]
+fn user_override_can_unbind_an_action() {
+  let mut km = Keymap::defaults();
+  km.apply_override(Action::Down, vec![]).unwrap();
+
+  let j = KeyStroke::parse_chord("j").unwrap();
+  assert!(matches!(km.lookup(&j), ChordResolution::NoMatch));
+}
+
+#[test]
+fn conflicting_user_bindings_are_rejected() {
+  let mut km = Keymap::defaults();
+  // Bind `Down` to `x`, then try to bind `Up` to `x` too. Hard error.
+  km.apply_override(Action::Down, vec![KeyStroke::parse_chord("x").unwrap()])
+    .unwrap();
+  let err = km
+    .apply_override(Action::Up, vec![KeyStroke::parse_chord("x").unwrap()])
+    .unwrap_err();
+  assert!(
+    err.to_string().to_lowercase().contains("conflict"),
+    "expected conflict error, got: {err}"
+  );
+}
+
+#[test]
+fn chord_that_is_strict_prefix_of_existing_binding_is_rejected() {
+  // Per the design decision on PR #87: refusing this at load time is
+  // preferable to running a Vim-style 500ms timer in the event loop.
+  let mut km = Keymap::defaults();
+  // Default `g g` is bound to Top. Trying to bind `g` alone to anything
+  // else creates a prefix collision and MUST fail.
+  let err = km
+    .apply_override(Action::Open, vec![KeyStroke::parse_chord("g").unwrap()])
+    .unwrap_err();
+  assert!(
+    err.to_string().to_lowercase().contains("prefix"),
+    "expected prefix-collision error, got: {err}"
+  );
+}
+
+#[test]
+fn list_returns_entries_with_source() {
+  let mut km = Keymap::defaults();
+  km.apply_override(Action::Down, vec![KeyStroke::parse_chord("J").unwrap()])
+    .unwrap();
+  let listed = km.list();
+
+  let down_entry = listed
+    .iter()
+    .find(|entry| entry.action == Action::Down)
+    .expect("Down should appear in list()");
+  assert_eq!(down_entry.source, Source::UserConfig);
+
+  let up_entry = listed
+    .iter()
+    .find(|entry| entry.action == Action::Up)
+    .expect("Up should appear in list()");
+  assert_eq!(up_entry.source, Source::Default);
+}

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Covers in this file:
 //!   - `Action` enum + `ACTIONS` table invariants (slug uniqueness,
-//!     kebab-case, every variant present);
+//!     snake_case, every variant present);
 //!   - key-string parser (`parse_chord` — single keys, named keys,
 //!     modifiers, multi-key chords, every reject path);
 //!   - `Keymap` layering (defaults, override replaces single action,
@@ -39,7 +39,7 @@ fn actions_table_covers_every_variant() {
 }
 
 #[test]
-fn action_slugs_are_unique_and_kebab_case() {
+fn action_slugs_are_unique_and_snake_case() {
   let mut seen = std::collections::HashSet::new();
   for (action, slug) in ACTIONS.iter() {
     assert!(seen.insert(*slug), "duplicate slug {:?} for {:?}", slug, action);

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -1,0 +1,169 @@
+//! Tests for the generic chord buffer in `App` (issue #87).
+//!
+//! Drives `App::dispatch_key` end-to-end: feed it crossterm
+//! `KeyEvent`s, observe the returned `Option<Action>` and the
+//! internal pending-keys buffer state. The dispatcher is the bridge
+//! between raw terminal events and the rebindable keymap — it owns
+//! the "is this the first half of a chord?" decision the old hard-
+//! coded `gg` handler used to make in `App::handle_g`.
+//!
+//! These tests deliberately stay below the event-loop layer: they do
+//! not touch ratatui or crossterm's terminal handle. The harness
+//! mirrors the one in `tests/tui_app_tests.rs` (an `App` built on a
+//! tempdir-backed repo).
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use gwm::tui::keymap::Action;
+use gwm::tui::App;
+
+mod common;
+use common::init_repo;
+
+fn make_app() -> (tempfile::TempDir, App) {
+  let (dir, _) = init_repo();
+  let app = App::new_at(Some(dir.path())).unwrap();
+  (dir, app)
+}
+
+fn press(c: char) -> KeyEvent {
+  KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty())
+}
+
+fn press_named(code: KeyCode) -> KeyEvent {
+  KeyEvent::new(code, KeyModifiers::empty())
+}
+
+#[test]
+fn single_key_dispatches_action_immediately() {
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('j')), Some(Action::Down));
+  assert!(app.pending_chord_is_empty(), "buffer must clear after a matched action");
+}
+
+#[test]
+fn first_g_arms_pending_buffer() {
+  // `g` alone is the strict prefix of the default `g g` (Top). The
+  // dispatcher must keep the buffer armed and return None so the
+  // event loop can render a status hint.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('g')), None);
+  assert!(
+    !app.pending_chord_is_empty(),
+    "first g must leave the chord buffer armed"
+  );
+}
+
+#[test]
+fn second_g_completes_chord() {
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('g')), None);
+  assert_eq!(app.dispatch_key(press('g')), Some(Action::Top));
+  assert!(
+    app.pending_chord_is_empty(),
+    "buffer must clear after the chord matches"
+  );
+}
+
+#[test]
+fn mismatched_second_key_falls_back_to_single_key_dispatch() {
+  // Vim's classic recovery: `g j` is not a bound chord, but `j` alone
+  // is bound to Down. The dispatcher must clear the buffer AND retry
+  // the new stroke alone so the user's `j` still navigates down.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('g')), None);
+  assert_eq!(app.dispatch_key(press('j')), Some(Action::Down));
+  assert!(app.pending_chord_is_empty());
+}
+
+#[test]
+fn mismatched_second_key_with_no_fallback_clears_buffer() {
+  // `g` then `z` — neither a chord match nor a single-key binding.
+  // Returns None and clears the buffer; the event loop ignores it.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('g')), None);
+  assert_eq!(app.dispatch_key(press('z')), None);
+  assert!(app.pending_chord_is_empty());
+}
+
+#[test]
+fn unbound_key_returns_none_without_arming_buffer() {
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('z')), None);
+  assert!(app.pending_chord_is_empty());
+}
+
+#[test]
+fn named_key_dispatch() {
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press_named(KeyCode::Down)), Some(Action::Down));
+  assert_eq!(app.dispatch_key(press_named(KeyCode::Tab)), Some(Action::FocusSwap));
+}
+
+#[test]
+fn shifted_uppercase_g_dispatches_bottom() {
+  // The default `Bottom` binding is `G` (uppercase char, no modifier),
+  // not `Shift+g`. Most terminals deliver Shift+G as `KeyCode::Char('G')`
+  // sans modifier, which is what `KeyStroke::from_event` consumes.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('G')), Some(Action::Bottom));
+}
+
+#[test]
+fn help_overlay_reflects_user_keymap_override() {
+  // The help overlay must read from the resolved keymap rather than
+  // hard-coded strings, so a user who rebinds `down = ["Ctrl+n"]`
+  // sees `Ctrl+n` next to "next" in `?`. Otherwise the discoverable
+  // documentation drifts from the actual bindings — the worst kind
+  // of doc bug for a TUI.
+  use gwm::tui::help_lines;
+  use gwm::tui::keymap::Keymap;
+
+  let mut km = Keymap::defaults();
+  km.apply_override(
+    gwm::tui::keymap::Action::Down,
+    vec![gwm::tui::keymap::KeyStroke::parse_chord("Ctrl+n").unwrap()],
+  )
+  .unwrap();
+
+  let lines = help_lines(&km, false);
+  let next_line = lines
+    .iter()
+    .find(|l| l.contains("next"))
+    .unwrap_or_else(|| panic!("expected a `next` line in:\n{}", lines.join("\n")));
+  assert!(
+    next_line.contains("Ctrl+n"),
+    "expected the override to appear next to `next`, got: {next_line}"
+  );
+  assert!(
+    !next_line.contains("j"),
+    "the default `j` binding must NOT appear after the override, got: {next_line}"
+  );
+}
+
+#[test]
+fn user_keymap_override_dispatches_through_app() {
+  // End-to-end: writing `[tui.keys] down = ["Ctrl+n"]` in `.gwm.toml`
+  // must change which keystroke fires `Action::Down` in the TUI. This
+  // is the contract the whole #87 stack exists to deliver — surface
+  // it as one concrete test so a regression in any layer
+  // (Config::load → Keymap → App::keymap → dispatch_key) lights up
+  // here with an unambiguous message.
+  let (dir, _) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[tui.keys]
+down = ["Ctrl+n"]
+"#,
+  )
+  .unwrap();
+
+  let mut app = App::new_at(Some(dir.path())).unwrap();
+
+  // The default `j` no longer fires Down — the override replaces.
+  assert_eq!(app.dispatch_key(press('j')), None);
+
+  // `Ctrl+n` does.
+  let ctrl_n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL);
+  assert_eq!(app.dispatch_key(ctrl_n), Some(Action::Down));
+}


### PR DESCRIPTION
## Description

Implements issue #87 — fully configurable TUI keymap with multi-key
chord support, surfaced as a `[tui.keys]` block in `.gwm.toml`, a
`gwm tui keys` introspection subcommand, and a `gwm doctor` check.

Closes #87

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- New `src/tui/keymap.rs` module: `Action` enum + `ACTIONS` slug table (single source of truth for docs / `gwm tui keys` / `gwm doctor`), `KeyStroke` with a crossterm-grammar parser (`parse_chord` — named keys, `Ctrl/Alt/Shift+`, whitespace-separated chords), and `Keymap` with default + user-override layering returning a `Matched / PendingPrefix / NoMatch` resolution.
- `[tui.keys]` validation wired through `Config::load_for_repo` so unknown action slugs, parse errors, chord conflicts, and prefix collisions surface as `GwmError::Config` at load time — never as silent no-ops in the TUI.
- New `App::dispatch_key(KeyEvent)` event-loop entry: maintains a generic `pending_chord` buffer, implements Vim's `g j` fallback (mismatched second stroke retries the new key alone so the user isn't punished for an aborted chord). Legacy `pending_g` / `handle_g` / `cancel_pending_motion` are kept as thin shims over the new buffer so pre-#87 tests stay green.
- `View::List` in `src/tui/mod.rs` rewired through `dispatch_key`; picker-mode guards preserved. `Esc` / `Enter` / `Ctrl+C` stay hard-coded because their semantics depend on the active view (filter state, picker mode) and can't be expressed in the config language.
- Help overlay (`?`) now driven by the pure `ui::help_lines(&keymap, picker_mode)` function — user rebinds appear next to the corresponding verbs.
- New `gwm tui keys` subcommand: 3-column table (action / keys / source) so users can audit resolved bindings.
- New `gwm doctor` check (`check_tui_keymap`): warns when `quit` has no discoverable binding (Ctrl+C still works as hard-coded fallback).

## Tests

- [x] `cargo test` passes locally (1000+ tests across 40 binaries, 0 failed)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)
- [x] CI-like minimal-PATH run passes (`PATH=\$(dirname \"\$(command -v cargo)\"):/usr/bin:/bin cargo test`)

New test files / additions:
- `tests/keymap_tests.rs` (NEW, 19 tests) — Action / slug invariants, parser happy + every reject path, Keymap layering, conflict + prefix-collision detection.
- `tests/tui_chord_tests.rs` (NEW, 10 tests) — `dispatch_key` state machine + end-to-end override through `Config::load`.
- `tests/config_tests.rs::tui_keys_*` — 7 tests: round-trip, unknown action, invalid key, prefix collision, conflict, unbind via empty list.
- `tests/cli_binary.rs::tui_keys_*` — 2 tests: default listing + override source column.
- `tests/doctor_tests.rs::doctor_*_keymap*` — 2 tests: default keymap passes, unbound quit warns.
- `tests/cli_binary.rs::help_prints_subcommands` updated to include the `tui` canary row.

## Screenshots / TUI captures

\`\`\`text
\$ gwm tui keys
action              keys              source
down                j, Down           default
up                  k, Up             default
top                 g g               default
bottom              G, End            default
toggle_sidebar      v                 default
focus_swap          Tab               default
filter              /                 default
refresh             f, r              default
create              n                 default
delete              d                 default
bootstrap           b                 default
delete_branch       p                 default
git_tui             l                 default
review              R                 default
yank                y                 default
open                o                 default
open_menu           O                 default
link                L                 default
fetch_github        F                 default
help                ?                 default
quit                q                 default
command_palette     :                 default
\`\`\`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (N/A — README does not enumerate subcommands; `gwm --help` is canonical)
- [ ] `examples/gwm.toml.example` updated if config schema changed (TODO in a follow-up — keeping this PR focused on the engine)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only — new prints are in `cmd_tui_keys` CLI path)

## Linked issues / docs

- Issue: #87
- Related: #32 (command palette — `Action::CommandPalette` is wired and bound to `:` by default, reserved as a no-op until #32 lands), #33 (themes), #34 (sidebar stashes view)

## Notes for reviewers

- **Chord / prefix policy decision**: binding a chord that is a strict prefix of another (`g` while `g g` is bound) is refused at load time rather than resolved at runtime with a Vim-style 500ms timeout. Rationale documented in `src/tui/keymap.rs` module docs. Happy to revisit if reviewers feel the Vim timeout model fits better.
- **Quit policy**: `quit` can be unbound (`quit = []`), but `Ctrl+C` is kept as a hard-coded escape hatch in `run_app`. `gwm doctor` warns when no discoverable binding survives.
- **What stays hard-coded**: `Esc` (filter clear vs. quit), `Enter` (picker confirm vs. copy_path), `Ctrl+C` — all view-contextual, not expressible in the config language. Modal sub-views (`View::Create`, `View::Confirm`, `View::Help`, …) keep their hand-coded micro-grammars.
- **Forward-compatibility with #32 / #33**: `Action::CommandPalette` is in `ACTIONS` and the keymap, bound to `:` by default, currently dispatched as a no-op. When #32 lands, only the match arm in `src/tui/mod.rs` needs to change. Adding new actions is a single edit in the `define_actions!` macro at the top of `src/tui/keymap.rs`.
- **Merge strategy**: per CLAUDE.md, regular merge commit (not squash) — atomic commit history matters here (3 commits: foundation, surfaces, changelog).