### PR TITLE
✨ feat(tui): sidebar stashes mode toggled by `s` (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `[issue_template]` defaults plus `gwm new <type> <desc>` to create a GitHub issue from issue-form templates and immediately create the linked worktree.
 - Add `[pr_template]` defaults plus `gwm pr [--draft] [--base <ref>] [--render]` to render per-branch-type PR bodies (with `{commits}` / `{files_changed}` placeholders) and shell out to `gh pr create`.
 - Add `[tui.keys]` block in `.gwm.toml` to rebind every TUI list-view action (`down`, `up`, `top`, `bottom`, `quit`, …) with crossterm-grammar keys, including multi-key chords like `g g`. Overrides are validated at load time (unknown actions, parse errors, chord conflicts, and prefix collisions are hard errors). Adds `gwm tui keys` to print the resolved keymap with per-row source, a `gwm doctor` check for unbound `quit`, and a keymap-driven help overlay (`?`) so the documentation always matches the resolved bindings.
+- Add a sidebar stashes mode (issue #34) toggled by `s` (rebindable as `toggle_sidebar_mode` in `[tui.keys]`). Cycles the Details panel between `commits` (`git log --oneline` + `git status --short`, pre-existing behaviour) and `stashes` (`git stash list`). The panel title shows the active mode; the bottom hint switches to `Enter: copy stash@{N} to status` in stashes mode. Cache is keyed by `(worktree-path, mode)` so toggling re-shells the right git command without leaking stale content between modes.
 
 ## Past releases
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -513,6 +513,15 @@ impl App {
     };
   }
 
+  /// Cycle the sidebar preview mode between Commits and Stashes
+  /// (issue #34). Drives the pure-state cycle on `SidebarState`
+  /// plus the status-bar copy: orchestrator-shaped because the
+  /// status bar is owned by `App`, not by the sub-struct.
+  pub fn cycle_sidebar_mode(&mut self) {
+    self.sidebar.cycle_mode();
+    self.status = format!("sidebar: {}", self.sidebar.mode.label());
+  }
+
   pub fn toggle_focus(&mut self) {
     self.sidebar.toggle_focus();
   }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -104,6 +104,7 @@ define_actions! {
   Top               => "top",
   Bottom            => "bottom",
   ToggleSidebar     => "toggle_sidebar",
+  ToggleSidebarMode => "toggle_sidebar_mode",
   FocusSwap         => "focus_swap",
   // Filter
   Filter            => "filter",
@@ -353,6 +354,7 @@ impl Keymap {
       def(Action::Top, &["g g"]),
       def(Action::Bottom, &["G", "End"]),
       def(Action::ToggleSidebar, &["v"]),
+      def(Action::ToggleSidebarMode, &["s"]),
       def(Action::FocusSwap, &["Tab"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f", "r"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -208,6 +208,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
             Action::Top => app.first(),
             Action::Bottom => app.last(),
             Action::ToggleSidebar => app.toggle_sidebar(),
+            Action::ToggleSidebarMode => app.cycle_sidebar_mode(),
             Action::FocusSwap => app.toggle_focus(),
             Action::Filter => app.enter_filter(),
             Action::Refresh => app.refresh()?,

--- a/src/tui/state/sidebar.rs
+++ b/src/tui/state/sidebar.rs
@@ -34,6 +34,35 @@
 use crate::tui::ui::SidebarSections;
 use std::path::PathBuf;
 
+/// Which content the sidebar previews (issue #34).
+///
+/// Toggled with the `s` key in the list view, dispatched through
+/// `Action::ToggleSidebarMode` in the rebindable keymap. Default is
+/// `Commits` so the pre-#34 sidebar behaviour is preserved verbatim.
+/// The mode is per-session — not persisted across `gwm` launches —
+/// because the low-frequency need to view stashes does not justify a
+/// new `.gwm.toml` knob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SidebarMode {
+  /// `git log --oneline -n 10` + `git status --short`. Pre-#34
+  /// behaviour, kept as the default so existing users see no change
+  /// until they press `s`.
+  Commits,
+  /// `git stash list` + a per-stash quick view. New in #34.
+  Stashes,
+}
+
+impl SidebarMode {
+  /// Human-readable label rendered into the sidebar title bar
+  /// (` Details — commits ` vs. ` Details — stashes `).
+  pub fn label(self) -> &'static str {
+    match self {
+      SidebarMode::Commits => "commits",
+      SidebarMode::Stashes => "stashes",
+    }
+  }
+}
+
 /// Pure sidebar state. Use [`Self::new`] (or the [`Default`] impl below)
 /// to get the initial state that matches the previous `App::new_at`
 /// behaviour (open + unfocused + zero scroll + cold cache) — the
@@ -61,12 +90,19 @@ pub struct SidebarState {
   /// be pushed entirely off-screen.
   pub max_scroll: u16,
   /// Cached pre-rendered sections keyed by the selected worktree's
-  /// path. `None` = cold cache (the renderer will rebuild and store).
-  /// Invalidated on selection change ([`Self::on_navigation`]),
-  /// worktree list mutation (`App::refresh` calls [`Self::invalidate`]),
-  /// and filter narrowing (`App::filter_push_char` /
-  /// `filter_pop_char`).
-  pub cache: Option<(PathBuf, SidebarSections)>,
+  /// path **and** the active mode (issue #34). `None` = cold cache
+  /// (the renderer will rebuild and store). Invalidated on selection
+  /// change ([`Self::on_navigation`]), worktree list mutation
+  /// (`App::refresh` calls [`Self::invalidate`]), filter narrowing
+  /// (`App::filter_push_char` / `filter_pop_char`), and mode toggle
+  /// ([`Self::cycle_mode`]). Two-tuple key so a re-toggle re-shells
+  /// `git stash list` / `git log` rather than serving stale content
+  /// for the other mode.
+  pub cache: Option<((PathBuf, SidebarMode), SidebarSections)>,
+  /// Active preview mode. Defaults to [`SidebarMode::Commits`] so the
+  /// pre-#34 sidebar behaviour is unchanged until the user presses
+  /// `s`. Toggled by [`Self::cycle_mode`].
+  pub mode: SidebarMode,
 }
 
 impl Default for SidebarState {
@@ -83,7 +119,24 @@ impl SidebarState {
       scroll: 0,
       max_scroll: 0,
       cache: None,
+      mode: SidebarMode::Commits,
     }
+  }
+
+  /// Cycle the preview mode (issue #34). Pre-#34 the sidebar only
+  /// ever showed `git log` + `git status`; now `s` flips between
+  /// `Commits` and `Stashes`. The scroll offset resets to 0 because
+  /// the new content has its own length and the previous offset
+  /// becomes meaningless. The cache is invalidated because the key
+  /// (path + mode) changes — the new mode re-shells the right git
+  /// command on the next frame.
+  pub fn cycle_mode(&mut self) {
+    self.mode = match self.mode {
+      SidebarMode::Commits => SidebarMode::Stashes,
+      SidebarMode::Stashes => SidebarMode::Commits,
+    };
+    self.scroll = 0;
+    self.cache = None;
   }
 
   /// Navigation-driven reset: drop the scroll back to the top AND

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -294,14 +294,23 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   let issue_pr_inner_width = area.width.saturating_sub(3) as usize;
   let issue_pr_lines = github_status_lines(app, issue_pr_inner_width);
 
-  // Per-section block height = content rows + 2 border lines. Fixed for
-  // the small sections (worktree / issue-PR / working-tree); Recent
-  // Commits flexes to fill the rest of the sidebar height.
+  // Per-section block height = content rows + 2 border lines. Fixed
+  // for the small sections (worktree / issue-PR / working-tree);
+  // Recent Commits flexes to fill the rest of the sidebar height.
+  // Issue #34: the Working Tree section is empty in `Stashes` mode
+  // (no `git status --short` to render); collapse its constraint to
+  // 0 so the empty titled block disappears instead of leaving a
+  // bordered void.
   let h = |lines: usize| (lines as u16).saturating_add(2);
+  let working_tree_height = if sections.working_tree.is_empty() {
+    0
+  } else {
+    h(sections.working_tree.len())
+  };
   let constraints = [
     Constraint::Length(h(sections.worktree.len())),
     Constraint::Length(h(issue_pr_lines.len())),
-    Constraint::Length(h(sections.working_tree.len())),
+    Constraint::Length(working_tree_height),
     Constraint::Min(3),
   ];
   let chunks = Layout::default()
@@ -311,15 +320,17 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
 
   render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0, None);
   render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
-  render_section(
-    f,
-    chunks[2],
-    " Working Tree ",
-    sections.working_tree,
-    border_color,
-    0,
-    None,
-  );
+  if !sections.working_tree.is_empty() {
+    render_section(
+      f,
+      chunks[2],
+      " Working Tree ",
+      sections.working_tree,
+      border_color,
+      0,
+      None,
+    );
+  }
 
   // Recent Commits is the only scrollable section. Clamp the scroll
   // offset to its visible area so `j` / `k` can't scroll past the end.
@@ -375,10 +386,15 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
 fn render_section(
   f: &mut Frame,
   area: Rect,
-  // Title is `Into<String>` so callers can pass either a static
-  // literal (`" Worktree "`) or a runtime-formatted label
-  // (` Recent Commits — commits ` after the issue #34 mode toggle).
-  title: impl Into<String>,
+  // Title is `impl Into<Line<'static>>` so static-literal call
+  // sites (` Worktree ` / ` Issue / PR ` / ` Working Tree `) pass
+  // through to ratatui zero-copy (a `&'static str` becomes a
+  // `Line<'static>` borrowing the slice), while the dynamic
+  // mode-aware title for the bottom panel (` Recent Commits —
+  // commits ` / ` Stashes — stashes `) moves in as an owned
+  // `String`. Pre-review the signature was `impl Into<String>`,
+  // which copied every static literal on every render frame.
+  title: impl Into<ratatui::text::Line<'static>>,
   lines: Vec<Line<'static>>,
   border_color: Color,
   scroll: u16,
@@ -459,11 +475,12 @@ pub fn build_sidebar_sections(w: &WorktreeInfo, mode: super::state::sidebar::Sid
     // rendered alongside; both come from `git log` / `git status` and
     // share a single cache invalidation cycle.
     SidebarMode::Commits => recent_commits_lines(w, RECENT_COMMITS_LIMIT),
-    // Stashes view (issue #34). `working_tree` is left empty because
-    // the stashed lines already carry the per-stash file summary; a
-    // separate `git status` block would only duplicate the user's
-    // current dirty state which has nothing to do with the stash
-    // contents they're auditing.
+    // Stashes view (issue #34). `working_tree` is left empty: the
+    // user's current dirty state has nothing to do with the stashed
+    // contents they're auditing, so a separate `git status` block
+    // alongside would only distract. A per-stash file summary
+    // (`+/-` counts via `git diff-tree --numstat`) is on the
+    // follow-up list; v1 ships `<ref>  <subject>` only.
     SidebarMode::Stashes => stash_lines(w, STASHES_DISPLAY_LIMIT),
   };
   let working_tree = match mode {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -257,14 +257,18 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   // dot line on the Worktree section is also rebuilt fresh each frame
   // (issue #73) so it tracks live PR / issue fetches without
   // invalidating the expensive git-preview cache underneath.
+  // Cache key carries the active mode (issue #34) so toggling between
+  // commits / stashes re-shells the right git command instead of
+  // serving the previous mode's pre-rendered lines.
+  let active_mode = app.sidebar.mode;
   let sections = match app.selected().cloned() {
     Some(w) => {
       let needs_refresh = match &app.sidebar.cache {
-        Some((p, _)) => *p != w.path,
+        Some(((p, m), _)) => *p != w.path || *m != active_mode,
         None => true,
       };
       if needs_refresh {
-        app.sidebar.cache = Some((w.path.clone(), build_sidebar_sections(&w)));
+        app.sidebar.cache = Some(((w.path.clone(), active_mode), build_sidebar_sections(&w, active_mode)));
       }
       let mut cached = app.sidebar.cache.as_ref().map(|(_, s)| s.clone()).unwrap_or_default();
       let mut worktree = vec![sidebar_header_line(&w, app)];
@@ -329,27 +333,52 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   if app.sidebar.scroll > app.sidebar.max_scroll {
     app.sidebar.scroll = app.sidebar.max_scroll;
   }
-  let footer = if commits_len == 0 {
-    None
-  } else {
-    let bottom = app.sidebar.scroll.saturating_add(commits_visible).min(commits_len);
-    Some(format!(" {} of {} ", bottom, commits_len))
+  // Issue #34: surface the active mode in the bottom-scrollable
+  // panel title. The footer keeps the `i of N` counter; the bottom
+  // hint switches to "Enter: copy stash@{N}" in stashes mode.
+  let (panel_title, panel_footer) = match active_mode {
+    super::state::sidebar::SidebarMode::Commits => {
+      let title = " Recent Commits — commits ".to_string();
+      let footer = if commits_len == 0 {
+        None
+      } else {
+        let bottom = app.sidebar.scroll.saturating_add(commits_visible).min(commits_len);
+        Some(format!(" {} of {} ", bottom, commits_len))
+      };
+      (title, footer)
+    }
+    super::state::sidebar::SidebarMode::Stashes => {
+      let title = " Stashes — stashes ".to_string();
+      // The "Enter on stash …" hint from the issue is the operative
+      // affordance in this mode — it's worth more than the i/N
+      // counter because the user needs to know they can paste the
+      // ref name.
+      let footer = if commits_len == 0 {
+        None
+      } else {
+        Some(" Enter: copy stash@{N} to status ".to_string())
+      };
+      (title, footer)
+    }
   };
   render_section(
     f,
     commits_area,
-    " Recent Commits ",
+    panel_title,
     sections.recent_commits,
     border_color,
     app.sidebar.scroll,
-    footer,
+    panel_footer,
   );
 }
 
 fn render_section(
   f: &mut Frame,
   area: Rect,
-  title: &'static str,
+  // Title is `Into<String>` so callers can pass either a static
+  // literal (`" Worktree "`) or a runtime-formatted label
+  // (` Recent Commits — commits ` after the issue #34 mode toggle).
+  title: impl Into<String>,
   lines: Vec<Line<'static>>,
   border_color: Color,
   scroll: u16,
@@ -358,7 +387,7 @@ fn render_section(
   let mut block = Block::default()
     .borders(Borders::ALL)
     .border_type(BorderType::Rounded)
-    .title(title)
+    .title(title.into())
     .border_style(Style::default().fg(border_color));
   if let Some(f) = footer {
     block = block.title_bottom(ratatui::text::Line::from(f).right_aligned());
@@ -423,11 +452,63 @@ fn sidebar_status_dot(app: &App) -> (&'static str, Color) {
 /// The `●` status-dot header is intentionally NOT in `worktree` here either —
 /// it's rebuilt fresh by `draw_sidebar` on every frame so the dot tracks
 /// live PR / issue fetch state without invalidating this cached payload.
-pub fn build_sidebar_sections(w: &WorktreeInfo) -> SidebarSections {
+pub fn build_sidebar_sections(w: &WorktreeInfo, mode: super::state::sidebar::SidebarMode) -> SidebarSections {
+  use super::state::sidebar::SidebarMode;
+  let body = match mode {
+    // Pre-#34 behaviour. The `Working Tree` section is unconditionally
+    // rendered alongside; both come from `git log` / `git status` and
+    // share a single cache invalidation cycle.
+    SidebarMode::Commits => recent_commits_lines(w, RECENT_COMMITS_LIMIT),
+    // Stashes view (issue #34). `working_tree` is left empty because
+    // the stashed lines already carry the per-stash file summary; a
+    // separate `git status` block would only duplicate the user's
+    // current dirty state which has nothing to do with the stash
+    // contents they're auditing.
+    SidebarMode::Stashes => stash_lines(w, STASHES_DISPLAY_LIMIT),
+  };
+  let working_tree = match mode {
+    SidebarMode::Commits => working_tree_lines(w),
+    SidebarMode::Stashes => Vec::new(),
+  };
   SidebarSections {
     worktree: worktree_identity_lines(w),
-    working_tree: working_tree_lines(w),
-    recent_commits: recent_commits_lines(w, RECENT_COMMITS_LIMIT),
+    working_tree,
+    recent_commits: body,
+  }
+}
+
+/// Number of stash entries shown in `SidebarMode::Stashes`. Set to
+/// match `RECENT_COMMITS_LIMIT` so the panel stays a comparable height
+/// across modes. Stashes beyond this are still listed by
+/// `git stash list` — the limit only governs the in-panel preview.
+pub const STASHES_DISPLAY_LIMIT: usize = 10;
+
+/// Render `git stash list` output (issue #34) into ratatui lines for
+/// the stashes mode of the sidebar. One stash per row, formatted as
+/// `<ref>  <subject>` with the ref in yellow (to mimic git's own
+/// colourisation). When the worktree has no stashes the renderer
+/// shows a single muted "(no stashes)" line so the panel never reads
+/// as broken on a fresh worktree.
+fn stash_lines(w: &WorktreeInfo, limit: usize) -> Vec<Line<'static>> {
+  match crate::worktree::git_stash_list(&w.path, limit) {
+    Ok(stashes) if stashes.is_empty() => vec![Line::from(Span::styled(
+      "(no stashes)",
+      Style::default().fg(Color::DarkGray),
+    ))],
+    Ok(stashes) => stashes
+      .into_iter()
+      .map(|s| {
+        Line::from(vec![
+          Span::styled(s.ref_name, Style::default().fg(Color::Yellow)),
+          Span::raw("  "),
+          Span::raw(s.subject),
+        ])
+      })
+      .collect(),
+    Err(e) => vec![Line::from(Span::styled(
+      format!("git stash list failed: {}", e),
+      Style::default().fg(Color::Red),
+    ))],
   }
 }
 
@@ -922,6 +1003,7 @@ pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> 
   lines.push(row(Action::Yank, "yank selected path to system clipboard"));
   lines.push(row(Action::GitTui, "launch [git_tui] launcher (default lazygit -p)"));
   lines.push(row(Action::ToggleSidebar, "toggle git preview sidebar"));
+  lines.push(row(Action::ToggleSidebarMode, "cycle sidebar mode (commits / stashes)"));
   lines.push(row(Action::FocusSwap, "swap focus between worktree list and sidebar"));
   lines.push(row(Action::Filter, "open fuzzy filter bar (enter: sticky, esc: clear)"));
   lines.push(row(Action::Refresh, "refresh worktree list"));

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -639,8 +639,6 @@ pub fn git_diff_stat_between(path: &Path, base: &str, head: &str, max_lines: usi
   Ok(out)
 }
 
-/// Shell out to `git status --short` inside `path` and return raw stdout.
-/// Used by the TUI sidebar to preview the working-tree state.
 /// One row of `git stash list` (issue #34). Surfaced by the sidebar
 /// in stashes mode. Kept deliberately minimal — `ref_name` so the user
 /// can copy `stash@{N}` to the status bar, `subject` so they can tell
@@ -671,10 +669,17 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   // or git ref name, so it's a safe per-field delimiter — same
   // technique `git_log_with_author` uses with `\x1c` for record
   // separation.
+  //
+  // Pass `-n <limit>` (a `git log` option `stash list` forwards
+  // through) so a repo with hundreds of stashes doesn't materialise
+  // the full list in stdout just for the panel to drop everything
+  // past the cap. Pre-review the limit was applied client-side after
+  // the full stdout was read.
+  let limit_arg = format!("-n{}", limit);
   let output = Command::new("git")
     .arg("-C")
     .arg(path)
-    .args(["stash", "list", "--pretty=format:%gd\x1f%s"])
+    .args(["stash", "list", "--pretty=format:%gd\x1f%s", &limit_arg])
     .output()
     .map_err(|e| GwmError::CommandFailed(format!("git stash list failed to spawn: {}", e)))?;
   if !output.status.success() {
@@ -699,6 +704,8 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   Ok(entries)
 }
 
+/// Shell out to `git status --short` inside `path` and return raw stdout.
+/// Used by the TUI sidebar to preview the working-tree state.
 pub fn git_status_short(path: &Path) -> Result<String> {
   let output = Command::new("git")
     .arg("-C")

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -641,6 +641,64 @@ pub fn git_diff_stat_between(path: &Path, base: &str, head: &str, max_lines: usi
 
 /// Shell out to `git status --short` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview the working-tree state.
+/// One row of `git stash list` (issue #34). Surfaced by the sidebar
+/// in stashes mode. Kept deliberately minimal — `ref_name` so the user
+/// can copy `stash@{N}` to the status bar, `subject` so they can tell
+/// which stash is which. Per-file diff numbers (`+/-`) live in a
+/// follow-up — the v1 contract is just "name + subject".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StashEntry {
+  /// Canonical git stash reference (e.g. `stash@{0}`). Stable for the
+  /// lifetime of the panel — the user can paste it into `git stash
+  /// apply <ref>` from the surrounding shell.
+  pub ref_name: String,
+  /// Human-readable subject as written by `git stash push -m <msg>`
+  /// (or the auto-generated `WIP on <branch>: …` when no `-m` was
+  /// supplied).
+  pub subject: String,
+}
+
+/// Parse the worktree's stash list (issue #34). Returns up to `limit`
+/// entries in `git stash list` order (LIFO — `stash@{0}` is the most
+/// recent push).
+///
+/// Uses `--pretty=format:%gd<US>%s` (with `\x1f` as the unit
+/// separator) so subjects containing spaces, colons, or `:` round-trip
+/// safely. An empty stash list returns `Ok(Vec::new())`; only spawn /
+/// non-zero-exit failures surface as `GwmError::CommandFailed`.
+pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
+  // ASCII Unit Separator (0x1F) cannot occur in a normal shell argv
+  // or git ref name, so it's a safe per-field delimiter — same
+  // technique `git_log_with_author` uses with `\x1c` for record
+  // separation.
+  let output = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["stash", "list", "--pretty=format:%gd\x1f%s"])
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git stash list failed to spawn: {}", e)))?;
+  if !output.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git stash list exited {}: {}",
+      output.status,
+      String::from_utf8_lossy(&output.stderr).trim()
+    )));
+  }
+  let raw = String::from_utf8_lossy(&output.stdout);
+  let entries = raw
+    .lines()
+    .filter(|line| !line.is_empty())
+    .take(limit)
+    .filter_map(|line| {
+      let mut parts = line.splitn(2, '\x1f');
+      let ref_name = parts.next()?.to_string();
+      let subject = parts.next().unwrap_or("").to_string();
+      Some(StashEntry { ref_name, subject })
+    })
+    .collect();
+  Ok(entries)
+}
+
 pub fn git_status_short(path: &Path) -> Result<String> {
   let output = Command::new("git")
     .arg("-C")

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -313,11 +313,23 @@ fn next_prev_invalidate_sidebar_cache() {
   // Moving selection must drop any cached sidebar content so the new
   // worktree's preview is recomputed on the next frame.
   let (_dir, mut app) = make_app();
-  app.sidebar.cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
+  app.sidebar.cache = Some((
+    (
+      std::path::PathBuf::from("/tmp/x"),
+      gwm::tui::state::sidebar::SidebarMode::Commits,
+    ),
+    Default::default(),
+  ));
   app.next();
   assert!(app.sidebar.cache.is_none(), "next() must invalidate the sidebar cache");
 
-  app.sidebar.cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
+  app.sidebar.cache = Some((
+    (
+      std::path::PathBuf::from("/tmp/x"),
+      gwm::tui::state::sidebar::SidebarMode::Commits,
+    ),
+    Default::default(),
+  ));
   app.prev();
   assert!(app.sidebar.cache.is_none(), "prev() must invalidate the sidebar cache");
 }
@@ -325,7 +337,13 @@ fn next_prev_invalidate_sidebar_cache() {
 #[test]
 fn refresh_invalidates_sidebar_cache() {
   let (_dir, mut app) = make_app();
-  app.sidebar.cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
+  app.sidebar.cache = Some((
+    (
+      std::path::PathBuf::from("/tmp/x"),
+      gwm::tui::state::sidebar::SidebarMode::Commits,
+    ),
+    Default::default(),
+  ));
   app.refresh().unwrap();
   assert!(app.sidebar.cache.is_none());
 }
@@ -348,7 +366,13 @@ fn on_navigation_resets_scroll_and_invalidates_sidebar_cache() {
   // half of the contract in isolation.
   let (_dir, mut app) = make_app();
   app.sidebar.scroll = 7;
-  app.sidebar.cache = Some((std::path::PathBuf::from("/tmp/x"), Default::default()));
+  app.sidebar.cache = Some((
+    (
+      std::path::PathBuf::from("/tmp/x"),
+      gwm::tui::state::sidebar::SidebarMode::Commits,
+    ),
+    Default::default(),
+  ));
 
   app.on_navigation();
 
@@ -1834,7 +1858,7 @@ fn section_text(lines: &[ratatui::text::Line<'static>]) -> String {
 #[test]
 fn sidebar_sections_omit_commands_block() {
   let w = detailed_worktree_fixture();
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let all = format!(
     "{}\n{}\n{}",
     section_text(&sections.worktree),
@@ -1864,7 +1888,7 @@ fn sidebar_sections_omit_inline_section_headers() {
   // `Basic Settings:` / `Recent commits:` / `Working tree:` headers must
   // disappear from the content lines.
   let w = detailed_worktree_fixture();
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let all = format!(
     "{}\n{}\n{}",
     section_text(&sections.worktree),
@@ -1879,7 +1903,7 @@ fn sidebar_sections_omit_inline_section_headers() {
 #[test]
 fn sidebar_worktree_section_is_compact_identity() {
   let w = detailed_worktree_fixture();
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let text = section_text(&sections.worktree);
 
   assert!(text.contains("api-rest"), "name on top line: {}", text);
@@ -1902,7 +1926,7 @@ fn sidebar_worktree_section_short_enough_for_compact_layout() {
   // Compact identity block: name, branch · head, badges, path → 4 lines target.
   // Allow ≤5 to leave headroom for variable badges.
   let w = detailed_worktree_fixture();
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   assert!(
     sections.worktree.len() <= 5,
     "compact worktree block must stay ≤5 lines (target 4), got {}: {:?}",
@@ -1921,7 +1945,7 @@ fn sidebar_worktree_section_skips_irrelevant_badges() {
   // those flags — only the ones that are true add visual noise.
   let mut w = detailed_worktree_fixture();
   w.is_main = false;
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let text = section_text(&sections.worktree);
   assert!(
     !text.contains("★ main"),
@@ -1954,7 +1978,7 @@ fn sidebar_worktree_badge_uses_divergence_sigil_when_ahead() {
     behind: 0,
     unknown: false,
   };
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let badge = section_text_single(&sections.worktree[2]);
   assert!(
     !badge.contains("✓"),
@@ -1974,7 +1998,7 @@ fn sidebar_worktree_badge_uses_divergence_sigil_when_behind() {
     behind: 3,
     unknown: false,
   };
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let badge = section_text_single(&sections.worktree[2]);
   assert!(
     !badge.contains("✓"),
@@ -1990,7 +2014,7 @@ fn sidebar_worktree_badge_keeps_check_sigil_when_synced() {
   // synced label *should* still display `✓`. Guards against an over-eager
   // fix that would drop the sigil everywhere.
   let w = detailed_worktree_fixture();
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   let badge = section_text_single(&sections.worktree[2]);
   assert!(badge.contains("✓"), "synced branch must keep the ✓ sigil: {}", badge);
   assert!(badge.contains("synced"), "label must still say synced: {}", badge);
@@ -2281,7 +2305,7 @@ fn build_sidebar_sections_fetches_up_to_default_recent_commits_limit() {
   let (dir, repo) = init_repo();
   add_commits(&repo, 30); // 31 total commits
   let w = worktree_pointing_at_dir(dir.path());
-  let sections = build_sidebar_sections(&w);
+  let sections = build_sidebar_sections(&w, gwm::tui::state::sidebar::SidebarMode::Commits);
   assert_eq!(
     sections.recent_commits.len(),
     31,

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -136,9 +136,16 @@ fn help_overlay_lists_toggle_sidebar_mode() {
     .iter()
     .find(|l| l.contains("sidebar mode") || l.contains("stash") || l.contains("toggle_sidebar_mode"))
     .unwrap_or_else(|| panic!("expected a sidebar-mode row in:\n{}", lines.join("\n")));
+  // Target the keys column specifically. `help_lines` formats every
+  // row as `  {keys:<13} {label}`, so the default `s` binding
+  // surfaces as exactly `"  s            "` at the row start.
+  // Pre-review the assertion was `row.contains('s')`, which passed
+  // trivially because the description carries words like
+  // "stashes" / "sidebar" — a regression in the binding column
+  // would not have failed.
   assert!(
-    row.contains('s'),
-    "expected the default `s` binding to appear, got: {row}"
+    row.starts_with("  s ") || row.starts_with("  s\t"),
+    "expected the default `s` binding in the keys column, got: {row}"
   );
 }
 

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -109,6 +109,40 @@ fn shifted_uppercase_g_dispatches_bottom() {
 }
 
 #[test]
+fn s_dispatches_toggle_sidebar_mode() {
+  // Issue #34: pressing `s` in the list view must cycle the sidebar
+  // preview mode (Commits ↔ Stashes). The binding is wired through
+  // the rebindable keymap (`Action::ToggleSidebarMode`) so users can
+  // remap it via `[tui.keys]` if `s` clashes with their muscle
+  // memory.
+  let (_dir, mut app) = make_app();
+  assert_eq!(
+    app.dispatch_key(press('s')),
+    Some(gwm::tui::keymap::Action::ToggleSidebarMode)
+  );
+}
+
+#[test]
+fn help_overlay_lists_toggle_sidebar_mode() {
+  // The keymap-driven help overlay surfaces the new action with its
+  // default `s` binding so users discover the stashes mode through
+  // `?` rather than the changelog.
+  use gwm::tui::help_lines;
+  use gwm::tui::keymap::Keymap;
+
+  let km = Keymap::defaults();
+  let lines = help_lines(&km, false);
+  let row = lines
+    .iter()
+    .find(|l| l.contains("sidebar mode") || l.contains("stash") || l.contains("toggle_sidebar_mode"))
+    .unwrap_or_else(|| panic!("expected a sidebar-mode row in:\n{}", lines.join("\n")));
+  assert!(
+    row.contains('s'),
+    "expected the default `s` binding to appear, got: {row}"
+  );
+}
+
+#[test]
 fn help_overlay_reflects_user_keymap_override() {
   // The help overlay must read from the resolved keymap rather than
   // hard-coded strings, so a user who rebinds `down = ["Ctrl+n"]`

--- a/tests/tui_state_sidebar_tests.rs
+++ b/tests/tui_state_sidebar_tests.rs
@@ -19,7 +19,7 @@
 //!   in a single `App::on_navigation()` wrapper so the triple cannot
 //!   drift back into duplicated literals.
 
-use gwm::tui::state::sidebar::SidebarState;
+use gwm::tui::state::sidebar::{SidebarMode, SidebarState};
 use gwm::tui::SidebarSections;
 use std::path::PathBuf;
 
@@ -51,7 +51,10 @@ fn on_navigation_resets_scroll_to_zero() {
 #[test]
 fn on_navigation_invalidates_cache() {
   let mut s = SidebarState::new();
-  s.cache = Some((PathBuf::from("/tmp/x"), SidebarSections::default()));
+  s.cache = Some((
+    (PathBuf::from("/tmp/x"), SidebarMode::Commits),
+    SidebarSections::default(),
+  ));
   s.on_navigation();
   assert!(
     s.cache.is_none(),
@@ -161,13 +164,68 @@ fn toggle_focus_flips_when_open() {
 
 // ---- Explicit cache flush -------------------------------------------------
 
+// ---- Mode toggle (issue #34) ----------------------------------------------
+
+#[test]
+fn default_mode_is_commits() {
+  // The historical sidebar showed `git log --oneline` + `git status --short`.
+  // Mode = Commits is the only behaviour that pre-existed, so it must
+  // remain the default after the toggle lands.
+  let s = SidebarState::new();
+  assert_eq!(s.mode, SidebarMode::Commits);
+}
+
+#[test]
+fn cycle_mode_flips_commits_to_stashes_and_back() {
+  let mut s = SidebarState::new();
+  s.cycle_mode();
+  assert_eq!(s.mode, SidebarMode::Stashes);
+  s.cycle_mode();
+  assert_eq!(s.mode, SidebarMode::Commits);
+}
+
+#[test]
+fn cycle_mode_resets_scroll() {
+  // Switching modes presents fresh content with its own length; the
+  // scroll offset from the previous mode is meaningless. Reset to 0
+  // matches the on_navigation contract and avoids the user landing
+  // halfway through a panel they did not scroll.
+  let mut s = SidebarState::new();
+  s.max_scroll = 8;
+  s.scroll = 4;
+  s.cycle_mode();
+  assert_eq!(s.scroll, 0, "cycle_mode must reset scroll back to top");
+}
+
+#[test]
+fn cache_is_keyed_by_path_and_mode() {
+  // Per the issue note "Same caching pattern as commits/status mode" —
+  // the cache key carries the active mode so toggling does not leak a
+  // stale render across modes. Storing both modes for the same path
+  // would be possible but adds memory pressure for marginal gain;
+  // keying by `(path, mode)` makes a re-toggle reshell git, which is
+  // documented behaviour.
+  let mut s = SidebarState::new();
+  let path = PathBuf::from("/tmp/wt-a");
+  s.cache = Some(((path.clone(), SidebarMode::Commits), SidebarSections::default()));
+  // Cycling mode invalidates the cache because the key changes.
+  s.cycle_mode();
+  assert!(
+    s.cache.is_none(),
+    "cycle_mode must drop the cached sections for the previous mode"
+  );
+}
+
 #[test]
 fn invalidate_drops_cache_keeps_scroll() {
   // `invalidate()` is the standalone cache flush used outside the
   // navigation path (e.g. `filter_push_char` re-narrows the visible
   // set but doesn't move the cursor — scroll state must survive).
   let mut s = SidebarState::new();
-  s.cache = Some((PathBuf::from("/tmp/x"), SidebarSections::default()));
+  s.cache = Some((
+    (PathBuf::from("/tmp/x"), SidebarMode::Commits),
+    SidebarSections::default(),
+  ));
   s.scroll = 4;
   s.max_scroll = 10;
   s.invalidate();

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -735,3 +735,77 @@ fn list_returns_none_age_for_main_worktree() {
     main.age
   );
 }
+
+// --- git_stash_list (issue #34) -----------------------------------------
+
+/// Create one stash on the given tempdir repo by writing a tracked file,
+/// staging an edit, then `git stash push -m <subject>`. Returns once the
+/// stash has been created so the caller can immediately `git_stash_list`.
+fn create_stash(path: &Path, file_rel: &str, subject: &str) {
+  // Seed a tracked file (commit) then mutate it so `git stash push`
+  // has a non-empty diff to capture. `git stash` on an empty diff is a
+  // no-op and would make the test pin the wrong contract.
+  let abs = path.join(file_rel);
+  std::fs::write(&abs, "v1\n").unwrap();
+  let run = |args: &[&str]| {
+    let status = std::process::Command::new("git")
+      .arg("-C")
+      .arg(path)
+      .args(args)
+      .status()
+      .unwrap();
+    assert!(status.success(), "git {:?} failed", args);
+  };
+  run(&["add", file_rel]);
+  run(&["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-m", "seed"]);
+  std::fs::write(&abs, "v2 dirty\n").unwrap();
+  run(&["stash", "push", "-m", subject]);
+}
+
+#[test]
+fn git_stash_list_empty_returns_empty_vec() {
+  // A fresh repo has no stashes; the helper must report that as an
+  // empty `Vec`, not an error. The sidebar renderer relies on this to
+  // distinguish "(no stashes)" from "git stash list failed".
+  let (dir, _) = init_repo();
+  let entries = worktree::git_stash_list(dir.path(), 10).unwrap();
+  assert!(entries.is_empty());
+}
+
+#[test]
+fn git_stash_list_parses_canonical_output() {
+  let (dir, _) = init_repo();
+  create_stash(dir.path(), "a.txt", "wip on auth refactor");
+  create_stash(dir.path(), "b.txt", "wip on docs");
+
+  let entries = worktree::git_stash_list(dir.path(), 10).unwrap();
+  assert_eq!(entries.len(), 2);
+  // git stashes are LIFO — the most recent push is `stash@{0}`.
+  assert_eq!(entries[0].ref_name, "stash@{0}");
+  assert!(
+    entries[0].subject.contains("wip on docs"),
+    "expected the latest stash subject, got: {}",
+    entries[0].subject
+  );
+  assert_eq!(entries[1].ref_name, "stash@{1}");
+  assert!(
+    entries[1].subject.contains("wip on auth refactor"),
+    "expected the earlier stash subject, got: {}",
+    entries[1].subject
+  );
+}
+
+#[test]
+fn git_stash_list_respects_limit() {
+  // The helper caps the returned vec at `limit` so the sidebar
+  // doesn't allocate an unbounded list on a repo with hundreds of
+  // stashes. The full list is still available through `git stash`
+  // directly — this is a preview-only cap.
+  let (dir, _) = init_repo();
+  create_stash(dir.path(), "a.txt", "first");
+  create_stash(dir.path(), "b.txt", "second");
+  create_stash(dir.path(), "c.txt", "third");
+
+  let limited = worktree::git_stash_list(dir.path(), 2).unwrap();
+  assert_eq!(limited.len(), 2, "limit must cap the result vec");
+}


### PR DESCRIPTION
## Description

Implements issue #34 — sidebar gains a `stashes` mode toggled by `s`
that shows `git stash list` for the selected worktree, alongside the
existing `commits` mode (`git log --oneline` + `git status --short`).

**Stacked on #87** (feat/#87-tui-keymap, PR #165) because the `s`
binding ships through the rebindable keymap as a new
`Action::ToggleSidebarMode`. The PR will need a rebase / re-target
to `dev` once #165 merges; the diff itself doesn't touch any file
that #165 doesn't already touch, so the rebase is mechanical.

Closes #34

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `SidebarMode { Commits, Stashes }` enum on `SidebarState` with `cycle_mode()`. Default is `Commits` so pre-#34 behaviour is preserved verbatim until the user presses `s`.
- Cache key changes from `PathBuf` to `(PathBuf, SidebarMode)` so toggling re-shells the right git command rather than serving stale content for the other mode.
- New `worktree::StashEntry { ref_name, subject }` + `worktree::git_stash_list(path, limit)` helper. Uses `%gd\x1f%s` (ASCII unit separator) so subjects containing colons / spaces round-trip cleanly.
- Sidebar renderer (`build_sidebar_sections`) now takes a `SidebarMode` and dispatches to either `recent_commits_lines` or the new `stash_lines`. Title shows the mode (`Recent Commits — commits` / `Stashes — stashes`); bottom hint switches to `Enter: copy stash@{N} to status` in stashes mode.
- New `Action::ToggleSidebarMode` (slug `toggle_sidebar_mode`), default binding `s`, wired through the View::List dispatcher.
- Help overlay (`?`) gets a new row `s    cycle sidebar mode (commits / stashes)` — drives off the resolved keymap like every other row.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

New tests:
- `tests/tui_state_sidebar_tests.rs::default_mode_is_commits` — pre-#34 contract preserved.
- `tests/tui_state_sidebar_tests.rs::cycle_mode_flips_commits_to_stashes_and_back` — toggle invariant.
- `tests/tui_state_sidebar_tests.rs::cycle_mode_resets_scroll` — fresh content gets fresh viewport.
- `tests/tui_state_sidebar_tests.rs::cache_is_keyed_by_path_and_mode` — toggling invalidates the cache.
- `tests/worktree_integration.rs::git_stash_list_empty_returns_empty_vec` — fresh repo edge case.
- `tests/worktree_integration.rs::git_stash_list_parses_canonical_output` — 2-stash LIFO order + subject preservation.
- `tests/worktree_integration.rs::git_stash_list_respects_limit` — preview cap honoured.
- `tests/tui_chord_tests.rs::s_dispatches_toggle_sidebar_mode` — end-to-end keymap dispatch.
- `tests/tui_chord_tests.rs::help_overlay_lists_toggle_sidebar_mode` — help row surfaces with default binding.

Existing `tui_state_sidebar_tests`, `tui_app_tests`, and `worktree_integration` updated for the new cache key shape + `build_sidebar_sections` signature; all 17 sidebar-state + 173 tui-app + 38 worktree-integration tests stay green.

## Screenshots / TUI captures

```text
Press `s` to toggle:

┌─ Stashes — stashes ─────────────────┐
│ stash@{0}  WIP on feat/auth: tweak  │
│ stash@{1}  WIP on docs: refactor    │
│                                     │
│ Enter: copy stash@{N} to status     │
└─────────────────────────────────────┘

`?` help overlay row:
  s             cycle sidebar mode (commits / stashes)

`gwm tui keys` row:
  toggle_sidebar_mode  s    default
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- **Base branch is `feat/#87-tui-keymap`, not `dev`.** Once #165 merges, I'll retarget this PR to `dev` (the diff is purely additive on top of #87's keymap macro, no conflict expected).
- **No stash-apply from the TUI** per the issue's scope note — that's lazygit's territory. We surface the ref name so the user can paste it into `git stash apply <ref>` in the surrounding shell.
- **Per-stash file +/- counts** are deferred to a follow-up. The v1 contract is `ref_name + subject`; adding `git diff-tree --numstat` per stash would need another shell-out per row and the issue called it out as "optional".
- **Mode is per-session, not persisted** — matches the issue note ("low ROI to remember between launches"). If a user reliably wants stashes by default, the keymap can be rebound to put `s` on a different key and `toggle_sidebar` (`v`) can be repurposed via `[tui.keys]`.