### PR TITLE
🏗️ build: cut v0.8.0-rc.4 (gwm sync #24 + cargo-binstall #27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,12 @@ exception; codify the manual test as an integration test.
   edit is the limiting factor.
 - **Keep root `CHANGELOG.md` as in-progress only.** PRs may add entries
   under `[Unreleased]`, but must not reintroduce bullets already moved
-  into the latest `changelogs/pre-releases/<previous-rc>.md`. Until the
-  guard in #147 exists, manually compare before cutting an RC.
+  into the latest `changelogs/pre-releases/<previous-rc>.md`. The guard
+  from #147 now ships as `.github/scripts/check-rc-changelog-dupes.sh`
+  and runs in CI on every pre-release tag (`pre-release.yml`). Run it
+  locally before cutting an RC — `./.github/scripts/check-rc-changelog-dupes.sh <tag>`
+  (e.g. `v0.8.0-rc.4`) — so a duplicated bullet is caught before the tag,
+  not by a red CI job after it.
 - **Release workflow edits must prove publishing credentials.** The
   v0.7.0 stable tag built all five release artifacts, then the GitHub
   Release publish step failed with `Bad credentials` and required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **`gwm sync [<pattern>] [--merge]`** ([#24](https://github.com/kbrdn1/gwm-cli/issues/24)). Fetch a worktree's upstream and rebase its branch onto it — or merge with `--merge`. Resolves the target worktree by fuzzy pattern (defaults to the CWD worktree). Refuses a dirty working tree and a branch with no upstream; a conflicting rebase/merge is aborted so the worktree stays usable, with an actionable error. Read-side inspection uses libgit2; the fetch/rebase/merge steps shell out to `git` so the user's configured credentials are honoured.
-- **`cargo-binstall` support** ([#27](https://github.com/kbrdn1/gwm-cli/issues/27)). `[package.metadata.binstall]` in `Cargo.toml` lets `cargo binstall gwm` pull the prebuilt archive (`gwm-v{version}-{target}.tar.gz`, `.zip` on Windows) straight from the GitHub Release — no Rust toolchain or libgit2 compile at install time. Pinned against artefact-naming drift by `tests/binstall_metadata_tests.rs`.
+_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
 
 ## Past releases
 
@@ -31,6 +28,7 @@ In reverse chronological order:
 
 Per-RC notes covering only the delta against the previous RC (or against the previous stable, for `rc.1`):
 
+- [`0.8.0-rc.4`](changelogs/pre-releases/0.8.0-rc.4.md) — 2026-05-29
 - [`0.8.0-rc.3`](changelogs/pre-releases/0.8.0-rc.3.md) — 2026-05-29
 - [`0.8.0-rc.2`](changelogs/pre-releases/0.8.0-rc.2.md) — 2026-05-23
 - [`0.8.0-rc.1`](changelogs/pre-releases/0.8.0-rc.1.md) — 2026-05-23

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,12 @@ exception; codify the manual test as an integration test.
   edit is the limiting factor.
 - **Keep root `CHANGELOG.md` as in-progress only.** PRs may add entries
   under `[Unreleased]`, but must not reintroduce bullets already moved
-  into the latest `changelogs/pre-releases/<previous-rc>.md`. Until the
-  guard in #147 exists, manually compare before cutting an RC.
+  into the latest `changelogs/pre-releases/<previous-rc>.md`. The guard
+  from #147 now ships as `.github/scripts/check-rc-changelog-dupes.sh`
+  and runs in CI on every pre-release tag (`pre-release.yml`). Run it
+  locally before cutting an RC — `./.github/scripts/check-rc-changelog-dupes.sh <tag>`
+  (e.g. `v0.8.0-rc.4`) — so a duplicated bullet is caught before the tag,
+  not by a red CI job after it.
 - **Release workflow edits must prove publishing credentials.** The
   v0.7.0 stable tag built all five release artifacts, then the GitHub
   Release publish step failed with `Bad credentials` and required

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gwm"
-version = "0.8.0-rc.3"
+version = "0.8.0-rc.4"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,15 +70,9 @@ For reference (each linked to its closing PR):
 | [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#88](https://github.com/kbrdn1/gwm-cli/issues/88) | v0.8.0-rc.3 | Config CLI (`gwm config get/set/unset/list/validate/path/edit`, comment-preserving `toml_edit`) + `[hooks.*]` lifecycle hooks (six phases, `on_fail`, `[[bootstrap.command]]` compat) |
 | [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) | v0.8.0-rc.3 | GitHub templates: `[issue_template]` + `gwm new`, `[pr_template]` + `gwm pr` with `{commits}` / `{files_changed}` placeholders |
 | [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34) | v0.8.0-rc.3 | TUI personalisation: `[tui.keys]` remappable keymap with chords + `gwm tui keys`, command palette (`:`), `[theme]` role-based presets, sidebar stashes mode (`s`) |
+| [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27) | v0.8.0-rc.4 | Quick wins: `gwm sync [<pattern>] [--merge]` (fetch + rebase/merge onto upstream, conflict-safe) and `cargo-binstall` support via `[package.metadata.binstall]` |
 
 If an issue still shows `open` on GitHub even though its work shipped, it's a tracking issue waiting for a follow-up audit — check the CHANGELOG and the linked PR before reopening scope work on it.
-
-## Quick wins
-
-Small, well-scoped items with high daily-usage payoff. Likely picks for the next minor.
-
-- [#24](https://github.com/kbrdn1/gwm-cli/issues/24) — **`gwm sync`** — fetch + rebase (or merge) the selected worktree's branch against its upstream, with conflict detection.
-- [#27](https://github.com/kbrdn1/gwm-cli/issues/27) — **`cargo-binstall` support** via `[package.metadata.binstall]` so `cargo binstall gwm` pulls the prebuilt archive instead of compiling from source.
 
 ## Ambitious
 

--- a/changelogs/pre-releases/0.8.0-rc.4.md
+++ b/changelogs/pre-releases/0.8.0-rc.4.md
@@ -1,0 +1,23 @@
+# [0.8.0-rc.4] - 2026-05-29
+
+Delta against v0.8.0-rc.3. Merged PRs: #172, #173.
+
+Fourth and final RC of the 0.8.0 series. A short delta: the two
+remaining **Quick wins** that landed after rc.3 — `gwm sync` (#24) and
+`cargo-binstall` support (#27). Cut as a dedicated RC rather than folded
+into the stable so the "stable == last soaked RC" discipline holds. The
+`git2` 0.21 bump stays deferred to [#169](https://github.com/kbrdn1/gwm-cli/issues/169) (Dependabot #157 left open).
+
+### Added
+
+- **`gwm sync [<pattern>] [--merge]`** ([#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#172](https://github.com/kbrdn1/gwm-cli/pull/172)). Fetch a worktree's upstream and rebase its branch onto it — or merge with `--merge`. Resolves the target worktree by fuzzy pattern (defaults to the CWD worktree). Refuses a dirty working tree and a branch with no upstream; a conflicting rebase/merge is aborted so the worktree stays usable, with an actionable error. Read-side inspection uses libgit2; the fetch/rebase/merge steps shell out to `git` so the user's configured credentials are honoured.
+- **`cargo-binstall` support** ([#27](https://github.com/kbrdn1/gwm-cli/issues/27) / [#173](https://github.com/kbrdn1/gwm-cli/pull/173)). `[package.metadata.binstall]` in `Cargo.toml` lets `cargo binstall gwm` pull the prebuilt archive (`gwm-v{version}-{target}.tar.gz`, `.zip` on Windows) straight from the GitHub Release — no Rust toolchain or libgit2 compile at install time. Pinned against artefact-naming drift by `tests/binstall_metadata_tests.rs`.
+
+### Deferred
+
+- `git2` 0.20 → 0.21 ([#157](https://github.com/kbrdn1/gwm-cli/pull/157)) remains a breaking accessor-API migration (several `Option`-returning accessors now return `Result`, `Oid::zero` deprecated) and does not build as-is. Tracked as a dedicated source migration in [#169](https://github.com/kbrdn1/gwm-cli/issues/169); the Dependabot PR stays open until that lands.
+
+### Tests
+
+- TDD throughout: `gwm sync` shipped with `format_sync_report` contract tests in `tests/cli_format_tests.rs` plus E2E coverage; `cargo-binstall` metadata pinned by `tests/binstall_metadata_tests.rs` against artefact-naming drift.
+- **989 tests total** green locally and on the `ubuntu-latest` / `macos-latest` / `windows-latest` matrix.

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,36 +1,37 @@
 ---
 title: Roadmap
-description: What ships next — post-v0.6.0 priorities and the link to the issue tracker.
+description: What ships next — post-v0.7.0 priorities and the link to the issue tracker.
 ---
 
 # Roadmap
 
 The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
 
-## shipped in v0.6.0
+## shipped in v0.7.0
 
 For reference — what made it into the current stable line:
 
-- **Issue / PR linking** ([#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://github.com/kbrdn1/gwm-cli/pull/68)) — `gwm link / unlink / open / status`, auto-detect from `<type>/#<N>-<slug>`, live status in the TUI sidebar via `gh`. See [GitHub linking](/integrations/github-linking).
-- **TUI Details sidebar redesign** ([#69](https://github.com/kbrdn1/gwm-cli/issues/69) / [#70](https://github.com/kbrdn1/gwm-cli/pull/70)) — four independent rounded-border subsections (Worktree / Issue · PR / Working Tree / Recent Commits). See [Sidebar](/tui/sidebar).
-- **TUI Recent Commits panel — lazygit-style layout** ([#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72)) — 300-commit buffer, hard-clipped subjects, full topology renderer (`○ ◎ │ ╮ ╭ ╯ ╰ ┴ ┬ ─`).
-- **TUI sidebar lazygit-style facelift** ([#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74)) — `Created` branch-age column, status-coloured branch names, header status dot, `o`/`y` rebinds, `[tui.open]` dispatch.
-- **TUI configurable launchers** ([#75](https://github.com/kbrdn1/gwm-cli/issues/75) / [#76](https://github.com/kbrdn1/gwm-cli/pull/76)) — `[git_tui]` and `[review]` sections with `{base} {head} {path} {diff}` placeholders. See [Configurable launchers](/tui/launchers).
+- **Configurable branch types, declarative GitHub labels & milestones** ([#80](https://github.com/kbrdn1/gwm-cli/issues/80) / [#81](https://github.com/kbrdn1/gwm-cli/issues/81) / [#82](https://github.com/kbrdn1/gwm-cli/issues/82)) — drive `gwm`'s branch taxonomy and GitHub label/milestone set from `.gwm.toml`.
+- **Bootstrap hardening + TOFU trust ledger** ([#93](https://github.com/kbrdn1/gwm-cli/issues/93) / [#94](https://github.com/kbrdn1/gwm-cli/issues/94) / [#95](https://github.com/kbrdn1/gwm-cli/issues/95) / [#96](https://github.com/kbrdn1/gwm-cli/issues/96)) — `O_NOFOLLOW` write primitives, canonicalize + prefix-check on every resolved bootstrap path, and a `gwm trust list / revoke / show` ledger that closes the arbitrary-RCE primitive against hostile clones. See [TOFU trust ledger](/configuration/trust-ledger).
+- **TUI internals: `App` decomposed into focused `tui/state/` sub-structs** ([#102](https://github.com/kbrdn1/gwm-cli/issues/102) and the #123–#128 follow-ups) plus typed error variants and shared render helpers ([#105](https://github.com/kbrdn1/gwm-cli/issues/105) / [#106](https://github.com/kbrdn1/gwm-cli/issues/106)).
+- **Measured TUI sidebar performance** ([#107](https://github.com/kbrdn1/gwm-cli/issues/107) / [#108](https://github.com/kbrdn1/gwm-cli/issues/108)) — Recent Commits via a libgit2 revwalk cached by `(worktree path, head OID, limit)` (~99% off the 300-row benchmark) and a commit graph that carries `git2::Oid` values instead of heap-allocated hash strings (~47% off the graph render benchmark).
 
-The full v0.6.0 release notes (with the Changed / Fixed / Removed sections, Dependencies, and PR-by-PR breakdown) live at [`changelogs/0.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.6.0.md).
+The full v0.7.0 release notes (consolidating rc.1 → rc.3 plus the stable-only delta) live at [`changelogs/0.7.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.7.0.md). MSRV is **1.82**.
 
-## merged on dev since v0.6.0
+## merged on dev since v0.7.0 (the 0.8.0 RC series)
 
-Surface that has landed but not yet been promoted to a stable tag:
+Surface that has landed and soaked through the `0.8.0` release candidates but not yet been promoted to a stable tag. Per-RC notes live under [`changelogs/pre-releases/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs/pre-releases):
 
-- **TOFU trust ledger on `.gwm.toml`** ([#95](https://github.com/kbrdn1/gwm-cli/issues/95) / [#113](https://github.com/kbrdn1/gwm-cli/pull/113)) — `gwm trust list / revoke / show` subcommand family, `--allow-bootstrap` / `--deny-bootstrap` global flags, `GWM_ALLOW_BOOTSTRAP=1` env bypass. Closes the arbitrary-RCE primitive against hostile clones — see [TOFU trust ledger](/configuration/trust-ledger) for the threat model and full surface.
-- **`bootstrap` symlink + path-traversal hardening** ([#93](https://github.com/kbrdn1/gwm-cli/issues/93) / [#94](https://github.com/kbrdn1/gwm-cli/issues/94)) — `O_NOFOLLOW`-based write primitives, canonicalize + prefix-check on every resolved bootstrap path, reorder of `run_no_symlinks` before `run_copies`. Closes a write-anywhere primitive on attacker-controlled checkouts.
+- **Release hardening + CLI aliases + gitmoji** (`v0.8.0-rc.1`, [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) / [#86](https://github.com/kbrdn1/gwm-cli/issues/86)) — `gh`-CLI publish + workflow token, the `[Unreleased]` dupe guard, Windows in the test matrix, `[aliases]` in `.gwm.toml`, and gitmoji mapping with `gwm commit-prefix` + an opt-in `commit-msg` hook.
+- **Safety daily** (`v0.8.0-rc.2`, [#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#31](https://github.com/kbrdn1/gwm-cli/issues/31)) — `--dry-run` on `gwm remove` / `gwm prune`, plus `gwm undo` + `gwm history` backed by an operation journal at `$XDG_DATA_HOME/gwm/history.toml`.
+- **Configurability + GitHub templates + TUI personalisation** (`v0.8.0-rc.3`, [#88](https://github.com/kbrdn1/gwm-cli/issues/88) / [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) / [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34)) — `gwm config get/set/unset/list/validate/path/edit`, `[hooks.*]` lifecycle hooks, `[issue_template]` + `gwm new`, `[pr_template]` + `gwm pr`, a remappable `[tui.keys]` keymap with chords, a `:` command palette, role-based `[theme]` presets, and a sidebar stashes mode (`s`).
+- **Quick wins** (`v0.8.0-rc.4`, [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27)) — `gwm sync [<pattern>] [--merge]` (fetch + rebase/merge onto upstream, conflict-safe) and `cargo-binstall` support via `[package.metadata.binstall]`. See [`gwm sync` in the CLI reference](/cli/reference) and the [install guide](/getting-started/install).
 
-Track the full unreleased surface in [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) under `[Unreleased]`.
+The `git2` 0.20 → 0.21 bump is deferred — it is a breaking accessor-API migration tracked in [#169](https://github.com/kbrdn1/gwm-cli/issues/169). Track the full not-yet-shipped surface in [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) under `[Unreleased]` and the per-RC files.
 
 ## what's next
 
-Post-v0.6.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:
+Post-v0.7.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:
 
 - [Open issues — `enhancement`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aenhancement)
 - [Open issues — `good first issue`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22)

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0`.
+Source: https://github.com/kbrdn1/gwm-cli — current version: `0.7.0`.
 
 ## When to use this skill
 
@@ -29,7 +29,7 @@ Source: https://github.com/kbrdn1/gwm-cli — current version: `0.6.0`.
 
 ```bash
 command -v gwm           # required — installed by `cargo install --path .` from the gwm-cli repo
-command -v cargo         # required at install time (1.80+ recommended)
+command -v cargo         # required at install time (1.82+ — the crate MSRV)
 command -v git           # required at runtime
 command -v gh            # OPTIONAL — needed for live `gwm status` / TUI GitHub state / `R: review` preset
 command -v tmux          # OPTIONAL — needed by `gwm tmux`


### PR DESCRIPTION
## Summary

Fourth and final RC of the 0.8.0 series — a **short delta cut** so the two Quick wins that landed after rc.3 soak through a real RC instead of riding straight into the stable. House rule: *stable == last soaked RC*.

Delta against `v0.8.0-rc.3`:
- **`gwm sync [<pattern>] [--merge]`** ([#24](https://github.com/kbrdn1/gwm-cli/issues/24) / #172) — fetch + rebase (or merge) a worktree's branch onto its upstream, conflict-safe.
- **`cargo-binstall` support** ([#27](https://github.com/kbrdn1/gwm-cli/issues/27) / #173) — `[package.metadata.binstall]` pulls the prebuilt archive, no compile at install time.

## Changes in this PR

- `Cargo.toml` / `Cargo.lock`: `0.8.0-rc.3` → `0.8.0-rc.4`.
- `changelogs/pre-releases/0.8.0-rc.4.md`: new per-RC delta file.
- `CHANGELOG.md`: reset `[Unreleased]` to the placeholder + add rc.4 to the index.
- `ROADMAP.md`: shipped row for #24/#27; drop the now-empty Quick wins section.
- **Docs/skill final pass** (drifted two release cycles, frozen at v0.6.0):
  - `docs/7.roadmap.md`: refreshed to the v0.7.0 stable line + the full 0.8.0 RC surface.
  - `skills/SKILL.md`: current version `0.6.0` → `0.7.0`; cargo MSRV note `1.80+` → `1.82+`.
- **Convention doc**: CLAUDE.md + AGENTS.md note the #147 changelog-dupe guard now ships and runs in CI.

## Housekeeping (done outside this diff)

- Closed [#29](https://github.com/kbrdn1/gwm-cli/issues/29) and [#31](https://github.com/kbrdn1/gwm-cli/issues/31) — shipped in rc.2, issues had stayed open.

## Reconciliation

Open PRs accounted for: only #157 (git2 0.21) remains open, intentionally deferred to [#169](https://github.com/kbrdn1/gwm-cli/issues/169).

## Tests

Local guards green:

```
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo clippy --all-targets -- -W clippy::incompatible_msrv
./.github/scripts/check-rc-changelog-dupes.sh v0.8.0-rc.4
cargo test   # 989 passed, 0 failed
```

No new behaviour in this PR (it's a release cut); `gwm sync` / `cargo-binstall` shipped with their own tests in #172 / #173.