### PR TITLE
✨ feat(config): {repo_path} and {repo_parent} placeholders for repo-relative worktree bases

### DIFF
--- a/.gwm.toml
+++ b/.gwm.toml
@@ -1,6 +1,8 @@
 # gwm — worktree bootstrap for gwm-cli (Rust)
 #
-# Placeholders supported in paths/patterns: {repo} {home} {type} {issue} {desc}
+# Placeholders supported in paths/patterns: {repo} {home} {repo_path}
+# {repo_parent} {type} {issue} {desc}. {repo_parent} = the dir containing the
+# repo, so `base = "{repo_parent}/worktrees"` mirrors a `../worktrees` layout.
 # Docs: https://github.com/kbrdn1/gwm-cli
 
 [worktree]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Added
+
+- `{repo_path}` and `{repo_parent}` placeholders for `.gwm.toml` paths/patterns. `{repo_path}` expands to the main repo's absolute working directory and `{repo_parent}` to its parent, so a base can be expressed relative to the repo on disk — e.g. `base = "{repo_parent}/worktrees"` puts worktrees in a sibling `worktrees/` dir, matching an editor's `../worktrees` convention (Zed's `git.worktree_directory`) without a per-project editor config. Purely additive; existing `{home}`/`{repo}` bases are unchanged. (#175)
 
 ## Past releases
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -1,5 +1,11 @@
 # gwm config — copy this to your repo root as `.gwm.toml`
-# placeholders supported in paths/patterns: {repo} {home} {type} {issue} {desc}
+# placeholders supported in paths/patterns:
+#   {repo}        repo name              {home}    your home directory
+#   {repo_path}   repo's absolute dir    {repo_parent}  the dir *containing* the repo
+#   {type} {issue} {desc}
+# `{repo_parent}` lets the base sit next to the repo — e.g.
+#   base = "{repo_parent}/worktrees"  → a sibling `worktrees/` dir,
+# matching an editor's `../worktrees` convention (Zed git.worktree_directory).
 #
 # === TOFU trust gate (issue #95) ===========================================
 # The first `gwm create` / `gwm bootstrap` against this file opens a
@@ -15,6 +21,8 @@
 
 [worktree]
 base = "{home}/cc-worktree/{repo}"
+# Repo-relative alternative (sibling `worktrees/`, à la Zed `../worktrees`):
+#   base = "{repo_parent}/worktrees"
 path_pattern = "{type}-{issue}-{desc}"
 branch_pattern = "{type}/#{issue}-{desc}"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1062,7 +1062,7 @@ fn cmd_create(
   let spec = BranchSpec::new_with_types(branch_type, issue, desc, &resolved_types.types)?;
   let branch = spec.branch_name(&config.worktree, &repo_name)?;
   let dirname = spec.worktree_dirname(&config.worktree, &repo_name)?;
-  let target = spec.worktree_path(&config.worktree, &repo_name)?;
+  let target = spec.worktree_path(&config.worktree, &repo_name, &workdir)?;
   let skips = HookSkips::parse(skip_hooks.as_deref())?;
 
   // Gate the bootstrap RCE primitive on the TOFU ledger BEFORE

--- a/src/config.rs
+++ b/src/config.rs
@@ -1066,6 +1066,7 @@ pub fn expand_placeholders(
   type_: Option<&str>,
   issue: Option<&str>,
   desc: Option<&str>,
+  _repo_path: Option<&Path>,
 ) -> Result<String> {
   let home = dirs::home_dir()
     .ok_or_else(|| GwmError::Config("cannot resolve $HOME".into()))?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1059,14 +1059,22 @@ pub struct ResolvedLauncher {
   pub fullscreen: bool,
 }
 
-/// Expand `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}` in a template string.
+/// Expand `{home}`, `{repo}`, `{repo_path}`, `{repo_parent}`, `{type}`,
+/// `{issue}`, `{desc}` in a template string.
+///
+/// `{repo}` is the repo **name**; `{repo_path}` is the main repo's
+/// absolute working directory and `{repo_parent}` its parent directory —
+/// both resolved from `repo_path`. These two let a `base` be expressed
+/// relative to the repo on disk (e.g. `{repo_parent}/worktrees`, matching
+/// an editor's `../worktrees` convention). When `repo_path` is `None` the
+/// disk-path tokens are left untouched rather than collapsed to empty.
 pub fn expand_placeholders(
   template: &str,
   repo: &str,
   type_: Option<&str>,
   issue: Option<&str>,
   desc: Option<&str>,
-  _repo_path: Option<&Path>,
+  repo_path: Option<&Path>,
 ) -> Result<String> {
   let home = dirs::home_dir()
     .ok_or_else(|| GwmError::Config("cannot resolve $HOME".into()))?
@@ -1081,6 +1089,12 @@ pub fn expand_placeholders(
   }
   if let Some(d) = desc {
     out = out.replace("{desc}", d);
+  }
+  if let Some(p) = repo_path {
+    out = out.replace("{repo_path}", &p.to_string_lossy());
+    if let Some(parent) = p.parent() {
+      out = out.replace("{repo_parent}", &parent.to_string_lossy());
+    }
   }
   // Tilde expansion in case the template starts with ~/...
   let expanded = shellexpand::tilde(&out).to_string();

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -422,7 +422,8 @@ fn check_binaries_on_path(ctx: &DoctorCtx<'_>) -> Check {
 fn check_base_dir_writable(ctx: &DoctorCtx<'_>) -> Check {
   let name = "base directory writable";
   let repo_name = worktree::repo_name(ctx.repo);
-  let base_expanded = match expand_placeholders(&ctx.config.worktree.base, &repo_name, None, None, None) {
+  let repo_path = ctx.repo.workdir();
+  let base_expanded = match expand_placeholders(&ctx.config.worktree.base, &repo_name, None, None, None, repo_path) {
     Ok(s) => s,
     Err(e) => return Check::failed(name, format!("could not expand base placeholders: {}", e)),
   };

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -122,6 +122,7 @@ impl BranchSpec {
       Some(&self.type_),
       Some(&self.issue),
       Some(&self.desc),
+      None,
     )
   }
 
@@ -132,11 +133,29 @@ impl BranchSpec {
       Some(&self.type_),
       Some(&self.issue),
       Some(&self.desc),
+      None,
     )
   }
 
-  pub fn worktree_path(&self, cfg: &WorktreeConfig, repo: &str) -> Result<std::path::PathBuf> {
-    let base = expand_placeholders(&cfg.base, repo, Some(&self.type_), Some(&self.issue), Some(&self.desc))?;
+  /// Resolve the absolute worktree path for this spec. `repo_path` is the
+  /// main repo's working directory on disk — it feeds the `{repo_path}` /
+  /// `{repo_parent}` placeholders so a `base` like `{repo_parent}/worktrees`
+  /// can be expressed relative to the repo (matching, e.g., an editor's
+  /// `../worktrees` convention).
+  pub fn worktree_path(
+    &self,
+    cfg: &WorktreeConfig,
+    repo: &str,
+    repo_path: &std::path::Path,
+  ) -> Result<std::path::PathBuf> {
+    let base = expand_placeholders(
+      &cfg.base,
+      repo,
+      Some(&self.type_),
+      Some(&self.issue),
+      Some(&self.desc),
+      Some(repo_path),
+    )?;
     let dir = self.worktree_dirname(cfg, repo)?;
     Ok(std::path::PathBuf::from(base).join(dir))
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -873,7 +873,7 @@ impl App {
     )?;
     let branch = spec.branch_name(&self.config.worktree, &self.repo_name)?;
     let dirname = spec.worktree_dirname(&self.config.worktree, &self.repo_name)?;
-    let target = spec.worktree_path(&self.config.worktree, &self.repo_name)?;
+    let target = spec.worktree_path(&self.config.worktree, &self.repo_name, &self.workdir)?;
 
     // Gate the bootstrap RCE primitive on the TOFU ledger BEFORE
     // creating the worktree on disk (issue #95). A refusal here

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -328,6 +328,7 @@ fn placeholders_expand() {
     Some("feat"),
     Some("123"),
     Some("foo"),
+    None,
   )
   .unwrap();
   assert!(out.ends_with("/cc-worktree/my-repo/feat-123-foo"));
@@ -337,8 +338,36 @@ fn placeholders_expand() {
 
 #[test]
 fn placeholders_no_optional_args_leave_repo_only() {
-  let out = expand_placeholders("{home}/{repo}", "x", None, None, None).unwrap();
+  let out = expand_placeholders("{home}/{repo}", "x", None, None, None, None).unwrap();
   assert!(out.ends_with("/x"));
+}
+
+#[test]
+fn placeholders_expand_repo_path_and_parent() {
+  let repo_path = std::path::Path::new("/Users/me/Projects/Perso/gwm-cli");
+  let out = expand_placeholders(
+    "{repo_parent}/worktrees/{repo}-{type}-{issue}",
+    "gwm-cli",
+    Some("feat"),
+    Some("42"),
+    None,
+    Some(repo_path),
+  )
+  .unwrap();
+  assert_eq!(out, "/Users/me/Projects/Perso/worktrees/gwm-cli-feat-42");
+  assert!(!out.contains("{repo_parent}"));
+
+  let full = expand_placeholders("{repo_path}/.worktrees", "gwm-cli", None, None, None, Some(repo_path)).unwrap();
+  assert_eq!(full, "/Users/me/Projects/Perso/gwm-cli/.worktrees");
+  assert!(!full.contains("{repo_path}"));
+}
+
+#[test]
+fn placeholders_repo_path_tokens_left_literal_without_path() {
+  // When no repo path is supplied the disk-path tokens are passed
+  // through untouched rather than collapsing to an empty string.
+  let out = expand_placeholders("{repo_parent}/x", "r", None, None, None, None).unwrap();
+  assert_eq!(out, "{repo_parent}/x");
 }
 
 #[test]

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -345,6 +345,12 @@ fn placeholders_no_optional_args_leave_repo_only() {
 #[test]
 fn placeholders_expand_repo_path_and_parent() {
   let repo_path = std::path::Path::new("/Users/me/Projects/Perso/gwm-cli");
+  // Derive the expected prefixes from `repo_path` itself rather than
+  // duplicating the literal parent string — the contract under test is
+  // "{repo_parent} → the repo's parent dir, {repo_path} → the repo dir".
+  let parent = repo_path.parent().unwrap().to_string_lossy();
+  let full_dir = repo_path.to_string_lossy();
+
   let out = expand_placeholders(
     "{repo_parent}/worktrees/{repo}-{type}-{issue}",
     "gwm-cli",
@@ -354,11 +360,11 @@ fn placeholders_expand_repo_path_and_parent() {
     Some(repo_path),
   )
   .unwrap();
-  assert_eq!(out, "/Users/me/Projects/Perso/worktrees/gwm-cli-feat-42");
+  assert_eq!(out, format!("{parent}/worktrees/gwm-cli-feat-42"));
   assert!(!out.contains("{repo_parent}"));
 
   let full = expand_placeholders("{repo_path}/.worktrees", "gwm-cli", None, None, None, Some(repo_path)).unwrap();
-  assert_eq!(full, "/Users/me/Projects/Perso/gwm-cli/.worktrees");
+  assert_eq!(full, format!("{full_dir}/.worktrees"));
   assert!(!full.contains("{repo_path}"));
 }
 

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -82,7 +82,9 @@ fn renders_paths() {
   let spec = BranchSpec::new("feat", "10", "x").unwrap();
   assert_eq!(spec.branch_name(&cfg, "myrepo").unwrap(), "feat/#10-x");
   assert_eq!(spec.worktree_dirname(&cfg, "myrepo").unwrap(), "feat-10-x");
-  let p = spec.worktree_path(&cfg, "myrepo").unwrap();
+  let p = spec
+    .worktree_path(&cfg, "myrepo", std::path::Path::new("/repos/myrepo"))
+    .unwrap();
   assert!(p.ends_with(std::path::Path::new("cc-worktree").join("myrepo").join("feat-10-x")));
 }
 
@@ -153,6 +155,24 @@ fn renders_with_custom_patterns() {
   let spec = BranchSpec::new("fix", "7", "foo-bar").unwrap();
   assert_eq!(spec.branch_name(&cfg, "r").unwrap(), "release/fix-7");
   assert_eq!(spec.worktree_dirname(&cfg, "r").unwrap(), "fix_7_foo-bar");
-  let p = spec.worktree_path(&cfg, "r").unwrap();
+  let p = spec.worktree_path(&cfg, "r", std::path::Path::new("/repos/r")).unwrap();
   assert_eq!(p, std::path::Path::new("/tmp/r").join("fix_7_foo-bar"));
+}
+
+#[test]
+fn worktree_path_resolves_repo_parent_base() {
+  // `{repo_parent}/worktrees` must land in the repo's sibling directory,
+  // matching an editor's `../worktrees` convention (Zed git.worktree_directory).
+  let cfg = WorktreeConfig {
+    base: "{repo_parent}/worktrees".into(),
+    path_pattern: "{type}-{issue}-{desc}".into(),
+    branch_pattern: "{type}/#{issue}-{desc}".into(),
+  };
+  let spec = BranchSpec::new("feat", "175", "repo-path").unwrap();
+  let repo_path = std::path::Path::new("/Users/me/Projects/Perso/gwm-cli");
+  let p = spec.worktree_path(&cfg, "gwm-cli", repo_path).unwrap();
+  assert_eq!(
+    p,
+    std::path::Path::new("/Users/me/Projects/Perso/worktrees/feat-175-repo-path")
+  );
 }


### PR DESCRIPTION
## Description

Adds two additive `.gwm.toml` placeholders — `{repo_path}` (the main repo's absolute working directory) and `{repo_parent}` (its parent dir) — so a worktree `base` can be expressed **relative to the repo on disk**. This lets a single global config align natively with editors that place worktrees beside the repo: e.g. `base = "{repo_parent}/worktrees"` mirrors Zed's default `git.worktree_directory = "../worktrees"`, with no per-project `.zed/settings.json` needed.

Background: gwm's placeholders were limited to `{home} {repo} {type} {issue} {desc}`, where `{repo}` is the repo *name*, not a disk path — there was no way to reference the repo's own directory or its parent. Zed has no placeholder system and a global config, so it can't reproduce gwm's per-repo absolute scheme; giving gwm the repo-relative expressiveness is the lower-friction side to move.

Closes #175

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `expand_placeholders` gains a `repo_path: Option<&Path>` argument and resolves `{repo_path}` / `{repo_parent}` from it (left literal when `None`; `{repo}` name token unaffected — no substring collision).
- `BranchSpec::worktree_path` threads the repo workdir through; call sites in `cmd_create`, the TUI create path, and the `gwm doctor` base-dir check pass it.
- Docs: `examples/gwm.toml.example` + `.gwm.toml` placeholder legend with a commented `{repo_parent}/worktrees` alternative; `CHANGELOG.md` Unreleased > Added.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD red→green: `tests/config_tests.rs::placeholders_expand_repo_path_and_parent` + `placeholders_repo_path_tokens_left_literal_without_path`, `tests/naming_tests.rs::worktree_path_resolves_repo_parent_base`)

TDD trail is visible in the history: `✅ test` commit lands the failing contract (seam + red tests), `✨ feat` commit wires the body green.

## Screenshots / TUI captures

n/a — no TUI render change (the create path is exercised by the existing state-machine tests).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a — config schema only, no README placeholder section exists)
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

Also ran `gwm doctor` locally (CLAUDE.md rule for `.gwm.toml` changes) — all checks green, config parses cleanly.

## Linked issues / docs

- Issue: #175
- Related PR: —

## Notes for reviewers

- The new placeholders only do something useful inside `base` (resolved by `worktree_path`); `branch_name` / `worktree_dirname` intentionally pass `None` since disk paths don't belong in branch names or dir leaf names.
- `{repo_parent}` is left literal when the repo sits at the filesystem root (no parent) — an intentional, visible no-op rather than an empty string.