### PR TITLE
🔧 chore(config): align own worktree base with Zed's ../worktrees default

### DIFF
--- a/.gwm.toml
+++ b/.gwm.toml
@@ -2,11 +2,14 @@
 #
 # Placeholders supported in paths/patterns: {repo} {home} {repo_path}
 # {repo_parent} {type} {issue} {desc}. {repo_parent} = the dir containing the
-# repo, so `base = "{repo_parent}/worktrees"` mirrors a `../worktrees` layout.
+# repo. `base = "{repo_parent}/worktrees/{repo}"` mirrors Zed's default
+# git.worktree_directory = "../worktrees": Zed resolves it relative to the repo
+# then appends the repo dir name (zed-industries/zed#53673), so both land
+# worktrees in <repo_parent>/worktrees/<repo>/… — same on-disk location.
 # Docs: https://github.com/kbrdn1/gwm-cli
 
 [worktree]
-base           = "{home}/cc-worktree/{repo}"
+base           = "{repo_parent}/worktrees/{repo}"
 path_pattern   = "{type}-{issue}-{desc}"
 branch_pattern = "{type}/#{issue}-{desc}"
 


### PR DESCRIPTION
## Description

Dogfoods the `{repo_parent}` placeholder (#176) in gwm-cli's own `.gwm.toml`: `[worktree].base` `{home}/cc-worktree/{repo}` → `{repo_parent}/worktrees/{repo}`, mirroring Zed's default `git.worktree_directory = "../worktrees"`. Zed resolves the dir relative to the repo then appends the repo dir name (zed-industries/zed#53673), so gwm and Zed's native worktree picker share `<repo_parent>/worktrees/<repo>/…`.

Closes #177

## Type of change

- [x] 🔧 Configuration (repo's own `.gwm.toml`, no CLI/behaviour change)

## Changes

- `.gwm.toml`: `[worktree].base` → `{repo_parent}/worktrees/{repo}` + comment refresh.

## Tests

- `gwm doctor` resolves the new base to `~/Projects/Perso/worktrees/gwm-cli` (parent writable).
- No code change → no CHANGELOG entry (feature itself shipped in #176).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] No code change (config only) — CHANGELOG/README n/a