### PR TITLE
✨ feat(tui): colourise working-tree file names git-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `{repo_path}` and `{repo_parent}` placeholders for `.gwm.toml` paths/patterns. `{repo_path}` expands to the main repo's absolute working directory and `{repo_parent}` to its parent, so a base can be expressed relative to the repo on disk — e.g. `base = "{repo_parent}/worktrees"` puts worktrees in a sibling `worktrees/` dir, matching an editor's `../worktrees` convention (Zed's `git.worktree_directory`) without a per-project editor config. Purely additive; existing `{home}`/`{repo}` bases are unchanged. (#175)
-- Git-style colourisation of the **Working Tree** sidebar block in the TUI: the staged (X) status column renders green, the unstaged (Y) column red, untracked `??` entries red, and each file name takes the dominant status colour (red when it carries unstaged/untracked changes, green when staged-only). The displayed text is unchanged — only colour is added — so it stays a faithful `git status -s` view at a glance. (#179)
+- Colourisation of the **Working Tree** sidebar block in the TUI, with three distinct status colours so modified and created files stay visually apart: the staged (X) status column renders cyan, a worktree modification (Y) yellow, and untracked `??` entries green. Each file name takes its dominant status colour (green when untracked, yellow when modified, cyan when staged-only). The displayed text is unchanged — only colour is added — so each entry still shows the exact `git status --short` codes. (#179)
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `{repo_path}` and `{repo_parent}` placeholders for `.gwm.toml` paths/patterns. `{repo_path}` expands to the main repo's absolute working directory and `{repo_parent}` to its parent, so a base can be expressed relative to the repo on disk — e.g. `base = "{repo_parent}/worktrees"` puts worktrees in a sibling `worktrees/` dir, matching an editor's `../worktrees` convention (Zed's `git.worktree_directory`) without a per-project editor config. Purely additive; existing `{home}`/`{repo}` bases are unchanged. (#175)
+- Git-style colourisation of the **Working Tree** sidebar block in the TUI: the staged (X) status column renders green, the unstaged (Y) column red, untracked `??` entries red, and each file name takes the dominant status colour (red when it carries unstaged/untracked changes, green when staged-only). The displayed text is unchanged — only colour is added — so it stays a faithful `git status -s` view at a glance. (#179)
 
 ## Past releases
 

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -61,9 +61,21 @@ The block is auto-rebuilt every selection change, so it never shows stale data f
 The `git status --short` output for the selected worktree:
 
 ```
-M  src/tui/app.rs
+A  src/tui/theme.rs
+ M src/tui/app.rs
 ?? docs/
 ```
+
+Each entry is colour-coded so modified and created files stay visually apart
+(added by [#179](https://github.com/kbrdn1/gwm-cli/issues/179)):
+
+- staged change (`X` column) → **cyan**
+- worktree modification (`Y` column) → **yellow**
+- untracked / created (`??`) → **green**
+
+The file name takes its dominant status colour — green when untracked, yellow
+when modified, cyan when only the index side carries a change. Only colour is
+added: the text still shows the exact `git status --short` codes.
 
 Empty checkout renders as `✓ clean`.
 

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -66,8 +66,7 @@ A  src/tui/theme.rs
 ?? docs/
 ```
 
-Each entry is colour-coded so modified and created files stay visually apart
-(added by [#179](https://github.com/kbrdn1/gwm-cli/issues/179)):
+Each entry is colour-coded so modified and created files stay visually apart:
 
 - staged change (`X` column) → **cyan**
 - worktree modification (`Y` column) → **yellow**

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,7 +54,8 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 pub use ui::{
   author_initials, branch_name_color, build_sidebar_sections, filled_cells_for_progress, freshness_color, header_title,
   help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line, recent_commits_lines,
-  table_marker, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  table_marker, tilde_compress_with_home, working_tree_status_line, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
+  RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -53,9 +53,9 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, branch_name_color, build_sidebar_sections, filled_cells_for_progress, footer_line, freshness_color,
-  header_title, help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line, recent_commits_lines,
-  table_marker, tilde_compress_with_home, working_tree_status_line, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
-  RECENT_COMMITS_LIMIT,
+  header_title, help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line,
+  recent_commits_lines, table_marker, tilde_compress_with_home, working_tree_status_line, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -646,17 +646,18 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
   }
 }
 
-/// Colourise one `git status --short` porcelain line git-style (issue #179).
+/// Colourise one `git status --short` porcelain line (issue #179).
 ///
 /// The short format is `XY<space>PATH`, where `X` is the index (staged)
-/// status and `Y` the worktree (unstaged) status. Mirroring `git status -s`:
+/// status and `Y` the worktree status. Three distinct colours keep modified
+/// and created files visually apart:
 ///
-/// - `X` column → green when it carries a staged change,
-/// - `Y` column → red when it carries an unstaged change,
-/// - `??` (untracked) → both columns red,
-/// - the **file name** → the dominant status colour: red when the worktree
-///   side carries any change (unstaged or untracked), green when only the
-///   index side does.
+/// - staged change (`X` column) → cyan,
+/// - modified-in-worktree (`Y` column) → yellow,
+/// - `??` (untracked / created) → green,
+/// - the **file name** → the dominant status colour: green when untracked,
+///   else yellow when the worktree side carries a change, else cyan when only
+///   the index side does.
 ///
 /// The separator space is left unstyled. The rendered text is byte-for-byte
 /// identical to the input — only `Span` styling is added — so the sidebar
@@ -684,20 +685,33 @@ pub fn working_tree_status_line(raw: &str) -> Line<'static> {
   let path_at = sep_at + sep.len_utf8();
   let untracked = x == '?' && y == '?';
 
+  let cyan = Style::default().fg(Color::Cyan);
+  let yellow = Style::default().fg(Color::Yellow);
   let green = Style::default().fg(Color::Green);
-  let red = Style::default().fg(Color::Red);
+  // X column: untracked `?` → green (created), other staged change → cyan.
   let x_style = if x == '?' {
-    red
-  } else if x != ' ' {
     green
+  } else if x != ' ' {
+    cyan
   } else {
     Style::default()
   };
-  let y_style = if y != ' ' { red } else { Style::default() };
-  let name_style = if untracked || y != ' ' {
-    red
-  } else if x != ' ' {
+  // Y column: untracked `?` → green (created), worktree modification → yellow.
+  let y_style = if y == '?' {
     green
+  } else if y != ' ' {
+    yellow
+  } else {
+    Style::default()
+  };
+  // File name takes the dominant status colour: created (green) wins, then a
+  // worktree modification (yellow), then a staged-only change (cyan).
+  let name_style = if untracked {
+    green
+  } else if y != ' ' {
+    yellow
+  } else if x != ' ' {
+    cyan
   } else {
     Style::default()
   };

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -662,16 +662,26 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
 /// identical to the input — only `Span` styling is added — so the sidebar
 /// keeps showing the exact `git status --short` codes it always did.
 pub fn working_tree_status_line(raw: &str) -> Line<'static> {
-  // Defensive: porcelain short output is always `XY PATH`, but a truncated
-  // read must not panic on byte slicing. Anything shorter than the two
-  // status columns + separator is rendered verbatim.
-  let bytes = raw.as_bytes();
-  if bytes.len() < 3 {
-    return Line::from(raw.to_string());
-  }
-  // X and Y are always ASCII status codes, so byte indexing is sound.
-  let x = bytes[0] as char;
-  let y = bytes[1] as char;
+  // Porcelain short output is always `XY<space>PATH` with ASCII status
+  // codes, but the helper is `pub` — a non-git caller could pass arbitrary
+  // input. Split on char boundaries (not byte offsets) so a multi-byte
+  // leading codepoint can never slice mid-character and panic. Anything
+  // shorter than the two status columns + separator is rendered verbatim.
+  let mut indices = raw.char_indices();
+  let (x_at, x) = match indices.next() {
+    Some(c) => c,
+    None => return Line::from(raw.to_string()),
+  };
+  let (y_at, y) = match indices.next() {
+    Some(c) => c,
+    None => return Line::from(raw.to_string()),
+  };
+  let (sep_at, sep) = match indices.next() {
+    Some(c) => c,
+    None => return Line::from(raw.to_string()),
+  };
+  // Byte offset where the path begins (just past the separator char).
+  let path_at = sep_at + sep.len_utf8();
   let untracked = x == '?' && y == '?';
 
   let green = Style::default().fg(Color::Green);
@@ -693,10 +703,10 @@ pub fn working_tree_status_line(raw: &str) -> Line<'static> {
   };
 
   Line::from(vec![
-    Span::styled(raw[0..1].to_string(), x_style),
-    Span::styled(raw[1..2].to_string(), y_style),
-    Span::raw(raw[2..3].to_string()),
-    Span::styled(raw[3..].to_string(), name_style),
+    Span::styled(raw[x_at..y_at].to_string(), x_style),
+    Span::styled(raw[y_at..sep_at].to_string(), y_style),
+    Span::raw(raw[sep_at..path_at].to_string()),
+    Span::styled(raw[path_at..].to_string(), name_style),
   ])
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -638,12 +638,66 @@ fn working_tree_lines(w: &WorktreeInfo) -> Vec<Line<'static>> {
       "✓ clean".to_string(),
       Style::default().fg(Color::Green),
     ))],
-    Ok(s) => s.lines().map(|l| Line::from(l.to_string())).collect(),
+    Ok(s) => s.lines().map(working_tree_status_line).collect(),
     Err(e) => vec![Line::from(Span::styled(
       format!("! {}", e),
       Style::default().fg(Color::Red),
     ))],
   }
+}
+
+/// Colourise one `git status --short` porcelain line git-style (issue #179).
+///
+/// The short format is `XY<space>PATH`, where `X` is the index (staged)
+/// status and `Y` the worktree (unstaged) status. Mirroring `git status -s`:
+///
+/// - `X` column → green when it carries a staged change,
+/// - `Y` column → red when it carries an unstaged change,
+/// - `??` (untracked) → both columns red,
+/// - the **file name** → the dominant status colour: red when the worktree
+///   side carries any change (unstaged or untracked), green when only the
+///   index side does.
+///
+/// The separator space is left unstyled. The rendered text is byte-for-byte
+/// identical to the input — only `Span` styling is added — so the sidebar
+/// keeps showing the exact `git status --short` codes it always did.
+pub fn working_tree_status_line(raw: &str) -> Line<'static> {
+  // Defensive: porcelain short output is always `XY PATH`, but a truncated
+  // read must not panic on byte slicing. Anything shorter than the two
+  // status columns + separator is rendered verbatim.
+  let bytes = raw.as_bytes();
+  if bytes.len() < 3 {
+    return Line::from(raw.to_string());
+  }
+  // X and Y are always ASCII status codes, so byte indexing is sound.
+  let x = bytes[0] as char;
+  let y = bytes[1] as char;
+  let untracked = x == '?' && y == '?';
+
+  let green = Style::default().fg(Color::Green);
+  let red = Style::default().fg(Color::Red);
+  let x_style = if x == '?' {
+    red
+  } else if x != ' ' {
+    green
+  } else {
+    Style::default()
+  };
+  let y_style = if y != ' ' { red } else { Style::default() };
+  let name_style = if untracked || y != ' ' {
+    red
+  } else if x != ' ' {
+    green
+  } else {
+    Style::default()
+  };
+
+  Line::from(vec![
+    Span::styled(raw[0..1].to_string(), x_style),
+    Span::styled(raw[1..2].to_string(), y_style),
+    Span::raw(raw[2..3].to_string()),
+    Span::styled(raw[3..].to_string(), name_style),
+  ])
 }
 
 /// Default number of commits pulled into the Recent Commits block — chosen

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1939,6 +1939,73 @@ fn section_text_single(l: &ratatui::text::Line<'static>) -> String {
   l.spans.iter().map(|s| s.content.as_ref()).collect()
 }
 
+// ---- working_tree_status_line (issue #179) ---------------------------------
+// Git-style colourisation of each `git status --short` entry in the Working
+// Tree sidebar block: X column (staged) green, Y column (unstaged) red,
+// untracked `??` red, file name in the dominant status colour.
+use gwm::tui::working_tree_status_line;
+
+fn filename_span_fg(line: &ratatui::text::Line<'static>, needle: &str) -> Option<Color> {
+  line
+    .spans
+    .iter()
+    .find(|s| s.content.contains(needle))
+    .unwrap_or_else(|| panic!("no span carrying {:?} in {:?}", needle, section_text_single(line)))
+    .style
+    .fg
+}
+
+#[test]
+fn working_tree_status_line_preserves_raw_text() {
+  // Only Span styling is added — the rendered text must read back
+  // byte-for-byte identical to the raw `git status --short` line.
+  for raw in [
+    "A  staged.rs",
+    "AM both.rs",
+    " M tracked.rs",
+    "?? untracked.rs",
+    "R  old.rs -> new.rs",
+  ] {
+    assert_eq!(section_text_single(&working_tree_status_line(raw)), raw, "raw text preserved for {:?}", raw);
+  }
+}
+
+#[test]
+fn working_tree_status_line_staged_only_is_green() {
+  let line = working_tree_status_line("A  staged.rs");
+  assert_eq!(line.spans[0].content.as_ref(), "A");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Green), "X column (staged) → green");
+  assert_eq!(filename_span_fg(&line, "staged.rs"), Some(Color::Green), "staged-only filename → green");
+}
+
+#[test]
+fn working_tree_status_line_unstaged_modified_is_red() {
+  let line = working_tree_status_line(" M tracked.rs");
+  assert_eq!(line.spans[1].content.as_ref(), "M");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "Y column (unstaged) → red");
+  assert_eq!(filename_span_fg(&line, "tracked.rs"), Some(Color::Red), "unstaged filename → red");
+}
+
+#[test]
+fn working_tree_status_line_untracked_is_red() {
+  let line = working_tree_status_line("?? untracked.rs");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Red), "untracked `?` (X) → red");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "untracked `?` (Y) → red");
+  assert_eq!(filename_span_fg(&line, "untracked.rs"), Some(Color::Red), "untracked filename → red");
+}
+
+#[test]
+fn working_tree_status_line_partially_staged_splits_status_columns() {
+  // `AM`: index add (green) + worktree modify (red). The file name takes the
+  // dominant worktree colour (red) since it carries unstaged changes.
+  let line = working_tree_status_line("AM both.rs");
+  assert_eq!(line.spans[0].content.as_ref(), "A");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Green), "X=A staged → green");
+  assert_eq!(line.spans[1].content.as_ref(), "M");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "Y=M unstaged → red");
+  assert_eq!(filename_span_fg(&line, "both.rs"), Some(Color::Red), "filename with unstaged change → red");
+}
+
 #[test]
 fn sidebar_worktree_section_skips_irrelevant_badges() {
   // A non-main, unlocked, non-prunable worktree should NOT advertise

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1995,6 +1995,17 @@ fn working_tree_status_line_untracked_is_red() {
 }
 
 #[test]
+fn working_tree_status_line_handles_multibyte_leading_chars() {
+  // The helper is `pub` (exported for these tests), so a non-git caller can
+  // feed it arbitrary input. Splitting on byte offsets (`raw[0..1]`) would
+  // panic mid-codepoint when the first chars are multi-byte UTF-8. Split on
+  // char boundaries instead — no panic, and the exact text is preserved.
+  let raw = "éM café.rs"; // X='é' (2 bytes), Y='M', sep=' ', path="café.rs"
+  let line = working_tree_status_line(raw);
+  assert_eq!(section_text_single(&line), raw, "multi-byte text preserved without panic");
+}
+
+#[test]
 fn working_tree_status_line_partially_staged_splits_status_columns() {
   // `AM`: index add (green) + worktree modify (red). The file name takes the
   // dominant worktree colour (red) since it carries unstaged changes.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2055,7 +2055,12 @@ fn working_tree_status_line_preserves_raw_text() {
     "?? untracked.rs",
     "R  old.rs -> new.rs",
   ] {
-    assert_eq!(section_text_single(&working_tree_status_line(raw)), raw, "raw text preserved for {:?}", raw);
+    assert_eq!(
+      section_text_single(&working_tree_status_line(raw)),
+      raw,
+      "raw text preserved for {:?}",
+      raw
+    );
   }
 }
 
@@ -2064,15 +2069,27 @@ fn working_tree_status_line_staged_only_is_cyan() {
   let line = working_tree_status_line("A  staged.rs");
   assert_eq!(line.spans[0].content.as_ref(), "A");
   assert_eq!(line.spans[0].style.fg, Some(Color::Cyan), "X column (staged) → cyan");
-  assert_eq!(filename_span_fg(&line, "staged.rs"), Some(Color::Cyan), "staged-only filename → cyan");
+  assert_eq!(
+    filename_span_fg(&line, "staged.rs"),
+    Some(Color::Cyan),
+    "staged-only filename → cyan"
+  );
 }
 
 #[test]
 fn working_tree_status_line_unstaged_modified_is_yellow() {
   let line = working_tree_status_line(" M tracked.rs");
   assert_eq!(line.spans[1].content.as_ref(), "M");
-  assert_eq!(line.spans[1].style.fg, Some(Color::Yellow), "Y column (modified) → yellow");
-  assert_eq!(filename_span_fg(&line, "tracked.rs"), Some(Color::Yellow), "modified filename → yellow");
+  assert_eq!(
+    line.spans[1].style.fg,
+    Some(Color::Yellow),
+    "Y column (modified) → yellow"
+  );
+  assert_eq!(
+    filename_span_fg(&line, "tracked.rs"),
+    Some(Color::Yellow),
+    "modified filename → yellow"
+  );
 }
 
 #[test]
@@ -2080,7 +2097,11 @@ fn working_tree_status_line_untracked_is_green() {
   let line = working_tree_status_line("?? untracked.rs");
   assert_eq!(line.spans[0].style.fg, Some(Color::Green), "untracked `?` (X) → green");
   assert_eq!(line.spans[1].style.fg, Some(Color::Green), "untracked `?` (Y) → green");
-  assert_eq!(filename_span_fg(&line, "untracked.rs"), Some(Color::Green), "untracked filename → green");
+  assert_eq!(
+    filename_span_fg(&line, "untracked.rs"),
+    Some(Color::Green),
+    "untracked filename → green"
+  );
 }
 
 #[test]
@@ -2091,7 +2112,11 @@ fn working_tree_status_line_handles_multibyte_leading_chars() {
   // char boundaries instead — no panic, and the exact text is preserved.
   let raw = "éM café.rs"; // X='é' (2 bytes), Y='M', sep=' ', path="café.rs"
   let line = working_tree_status_line(raw);
-  assert_eq!(section_text_single(&line), raw, "multi-byte text preserved without panic");
+  assert_eq!(
+    section_text_single(&line),
+    raw,
+    "multi-byte text preserved without panic"
+  );
 }
 
 #[test]
@@ -2103,7 +2128,11 @@ fn working_tree_status_line_partially_staged_splits_status_columns() {
   assert_eq!(line.spans[0].style.fg, Some(Color::Cyan), "X=A staged → cyan");
   assert_eq!(line.spans[1].content.as_ref(), "M");
   assert_eq!(line.spans[1].style.fg, Some(Color::Yellow), "Y=M modified → yellow");
-  assert_eq!(filename_span_fg(&line, "both.rs"), Some(Color::Yellow), "filename with modified change → yellow");
+  assert_eq!(
+    filename_span_fg(&line, "both.rs"),
+    Some(Color::Yellow),
+    "filename with modified change → yellow"
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1940,9 +1940,12 @@ fn section_text_single(l: &ratatui::text::Line<'static>) -> String {
 }
 
 // ---- working_tree_status_line (issue #179) ---------------------------------
-// Git-style colourisation of each `git status --short` entry in the Working
-// Tree sidebar block: X column (staged) green, Y column (unstaged) red,
-// untracked `??` red, file name in the dominant status colour.
+// Colourisation of each `git status --short` entry in the Working Tree sidebar
+// block, with three distinct status colours so modified ≠ created at a glance:
+//   - staged (X column)        → cyan
+//   - modified (Y column)      → yellow
+//   - untracked (`??`)         → green
+// The file name takes the dominant status colour.
 use gwm::tui::working_tree_status_line;
 
 fn filename_span_fg(line: &ratatui::text::Line<'static>, needle: &str) -> Option<Color> {
@@ -1971,27 +1974,27 @@ fn working_tree_status_line_preserves_raw_text() {
 }
 
 #[test]
-fn working_tree_status_line_staged_only_is_green() {
+fn working_tree_status_line_staged_only_is_cyan() {
   let line = working_tree_status_line("A  staged.rs");
   assert_eq!(line.spans[0].content.as_ref(), "A");
-  assert_eq!(line.spans[0].style.fg, Some(Color::Green), "X column (staged) → green");
-  assert_eq!(filename_span_fg(&line, "staged.rs"), Some(Color::Green), "staged-only filename → green");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Cyan), "X column (staged) → cyan");
+  assert_eq!(filename_span_fg(&line, "staged.rs"), Some(Color::Cyan), "staged-only filename → cyan");
 }
 
 #[test]
-fn working_tree_status_line_unstaged_modified_is_red() {
+fn working_tree_status_line_unstaged_modified_is_yellow() {
   let line = working_tree_status_line(" M tracked.rs");
   assert_eq!(line.spans[1].content.as_ref(), "M");
-  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "Y column (unstaged) → red");
-  assert_eq!(filename_span_fg(&line, "tracked.rs"), Some(Color::Red), "unstaged filename → red");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Yellow), "Y column (modified) → yellow");
+  assert_eq!(filename_span_fg(&line, "tracked.rs"), Some(Color::Yellow), "modified filename → yellow");
 }
 
 #[test]
-fn working_tree_status_line_untracked_is_red() {
+fn working_tree_status_line_untracked_is_green() {
   let line = working_tree_status_line("?? untracked.rs");
-  assert_eq!(line.spans[0].style.fg, Some(Color::Red), "untracked `?` (X) → red");
-  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "untracked `?` (Y) → red");
-  assert_eq!(filename_span_fg(&line, "untracked.rs"), Some(Color::Red), "untracked filename → red");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Green), "untracked `?` (X) → green");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Green), "untracked `?` (Y) → green");
+  assert_eq!(filename_span_fg(&line, "untracked.rs"), Some(Color::Green), "untracked filename → green");
 }
 
 #[test]
@@ -2007,14 +2010,14 @@ fn working_tree_status_line_handles_multibyte_leading_chars() {
 
 #[test]
 fn working_tree_status_line_partially_staged_splits_status_columns() {
-  // `AM`: index add (green) + worktree modify (red). The file name takes the
-  // dominant worktree colour (red) since it carries unstaged changes.
+  // `AM`: index add (cyan) + worktree modify (yellow). The file name takes the
+  // dominant worktree colour (yellow) since it carries unstaged changes.
   let line = working_tree_status_line("AM both.rs");
   assert_eq!(line.spans[0].content.as_ref(), "A");
-  assert_eq!(line.spans[0].style.fg, Some(Color::Green), "X=A staged → green");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Cyan), "X=A staged → cyan");
   assert_eq!(line.spans[1].content.as_ref(), "M");
-  assert_eq!(line.spans[1].style.fg, Some(Color::Red), "Y=M unstaged → red");
-  assert_eq!(filename_span_fg(&line, "both.rs"), Some(Color::Red), "filename with unstaged change → red");
+  assert_eq!(line.spans[1].style.fg, Some(Color::Yellow), "Y=M modified → yellow");
+  assert_eq!(filename_span_fg(&line, "both.rs"), Some(Color::Yellow), "filename with modified change → yellow");
 }
 
 #[test]


### PR DESCRIPTION
## Description

The TUI sidebar's **Working Tree** block rendered `git status --short` as plain, uncolored text. This colourises each entry git-style so file state is readable at a glance, matching `git status -s` for the status codes and extending the colour to the file name (the lazygit-style touch the rest of the sidebar already uses).

Closes #179

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- New pure helper `working_tree_status_line(raw) -> Line` in `src/tui/ui.rs`: X column (staged) → green, Y column (unstaged) → red, `??` (untracked) → red, file name → dominant status colour (red when unstaged/untracked, green when staged-only). Only `Span` styling is added — the rendered text is byte-for-byte identical to the raw `git status --short` line.
- `working_tree_lines` now maps each status line through it; exported from `src/tui/mod.rs`.
- CHANGELOG entry under `[Unreleased] > Added`.

## Tests

- [x] `cargo test` passes locally (46 test binaries, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (5 cases in `tests/tui_app_tests.rs` covering each status class + raw-text preservation)

## Screenshots / TUI captures

Not captured — the change is colour-only on existing text. The colour contract is asserted at the `Span` level in the new unit tests (`Style.fg` per span) rather than via a terminal recording, keeping it deterministic and env-independent.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`feat/#179-working-tree-colors`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a — no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #179

## Notes for reviewers

- Theming these colours via `[theme]` roles (e.g. `staged`/`unstaged`/`untracked`) was deliberately left out to keep the PR atomic — `working_tree_lines` already hardcodes `Color::Green`/`Color::Red`, so this stays consistent with the surrounding code. A role-based follow-up is a reasonable next step if desired.
- Status-code colours are faithful to `git status -s` (X green / Y red / `??` red); the file-name colour is the lazygit-style extension that satisfies the issue's "colour on file names" ask.