### PR TITLE
✨ feat(tui): single-line statusline with badge chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `{repo_path}` and `{repo_parent}` placeholders for `.gwm.toml` paths/patterns. `{repo_path}` expands to the main repo's absolute working directory and `{repo_parent}` to its parent, so a base can be expressed relative to the repo on disk — e.g. `base = "{repo_parent}/worktrees"` puts worktrees in a sibling `worktrees/` dir, matching an editor's `../worktrees` convention (Zed's `git.worktree_directory`) without a per-project editor config. Purely additive; existing `{home}`/`{repo}` bases are unchanged. (#175)
 
+### Changed
+
+- TUI statusline is now a single line. Key hints render as reverse-video badge chips (the key painted with the theme accent, followed by a short label) and the status message (action log) is pinned flush-right with absolute priority — when the terminal is too narrow, the hint list is truncated with an `…` marker while the log stays visible. Previously the footer occupied two rows and wrapped, which could push the log off-screen. No keybindings changed. (#180)
+
 ## Past releases
 
 In reverse chronological order:

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -52,9 +52,10 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
   }
 }
 pub use ui::{
-  author_initials, branch_name_color, build_sidebar_sections, filled_cells_for_progress, freshness_color, header_title,
-  help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line, recent_commits_lines,
-  table_marker, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  author_initials, branch_name_color, build_sidebar_sections, filled_cells_for_progress, footer_line, freshness_color,
+  header_title, help_lines, issue_badge_color, issue_summary_line, pr_badge_color, pr_summary_line,
+  recent_commits_lines, table_marker, tilde_compress_with_home, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
+  RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -47,13 +47,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         Constraint::Length(3),
         Constraint::Min(0),
         Constraint::Length(1),
-        Constraint::Length(2),
+        Constraint::Length(1),
       ])
       .split(f.area())
   } else {
     Layout::default()
       .direction(Direction::Vertical)
-      .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(2)])
+      .constraints([Constraint::Length(3), Constraint::Min(0), Constraint::Length(1)])
       .split(f.area())
   };
 
@@ -928,20 +928,133 @@ fn format_status(s: &BranchStatus, width: usize) -> (String, Color) {
   (label, color)
 }
 
+/// `(key, label)` hints advertised in the full TUI footer, in display order.
+/// Picker mode hides the mutating actions (n/d/b/F) — they're inert in the
+/// picker event loop, so advertising them would be a lie.
+const FOOTER_HINTS: &[(&str, &str)] = &[
+  ("n", "new"),
+  ("d", "del"),
+  ("b", "boot"),
+  ("o", "open"),
+  ("y", "yank"),
+  ("l", "git"),
+  ("R", "review"),
+  ("v", "sidebar"),
+  ("Tab", "focus"),
+  ("/", "filter"),
+  ("gg/G", "top/bot"),
+  ("j/k", "nav"),
+  ("f", "refresh"),
+  ("F", "gh"),
+  ("?", "help"),
+  ("q", "quit"),
+];
+
+/// Picker-mode footer hints — `enter`/`esc` select/cancel instead of the
+/// mutating actions, matching the picker event loop.
+const PICKER_FOOTER_HINTS: &[(&str, &str)] = &[
+  ("enter", "select"),
+  ("esc", "cancel"),
+  ("o", "open"),
+  ("y", "yank"),
+  ("l", "git"),
+  ("v", "sidebar"),
+  ("Tab", "focus"),
+  ("/", "filter"),
+  ("gg/G", "top/bot"),
+  ("j/k", "nav"),
+  ("f", "refresh"),
+  ("?", "help"),
+  ("q", "quit"),
+];
+
+/// Build the single-line statusline (issue #180).
+///
+/// Layout, left-to-right:
+///
+/// ```text
+///  n  new  d  del  …                                   [<status>]
+/// ```
+///
+/// Each hint renders as a reverse-video badge chip (` key ` painted with the
+/// theme `accent` as background via `REVERSED`) followed by a dim label. The
+/// status message (the action log) is pinned flush-right and has **absolute
+/// priority**: when `width` is too small for every hint, the hint list is cut
+/// short with an `…` marker, but the status is always kept — clipped only if
+/// it alone exceeds `width`. There is no wrapping: the caller renders this
+/// without `Wrap`, so the row is hard-clipped at the terminal edge.
+///
+/// Pure and width-driven so the contract is pinned by
+/// `tests/tui_footer_tests.rs` without spinning up a ratatui backend. Widths
+/// are measured with `chars().count()` to match the rest of `ui.rs` (keys,
+/// labels and the bracketed status are ASCII / single-width in practice).
+pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, accent: Color) -> Line<'static> {
+  let chip_style = Style::default()
+    .fg(accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let label_style = Style::default().fg(Color::DarkGray);
+  let status_style = Style::default().fg(Color::Yellow);
+
+  let status_text = format!("[{}]", status);
+  let status_w = status_text.chars().count();
+
+  // Priority floor: if even the status cannot fit, show a clipped status
+  // alone — never a hint at the log's expense.
+  if width <= status_w {
+    return Line::from(Span::styled(trunc(&status_text, width), status_style));
+  }
+
+  // One column minimum gap between the hints and the right-pinned status,
+  // plus one column held in reserve for the `…` truncation marker.
+  let hint_budget = (width - status_w - 1).saturating_sub(1);
+
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  let mut used = 0usize; // display columns consumed by hint badges so far
+  let mut truncated = false;
+  for (i, (key, label)) in hints.iter().enumerate() {
+    let sep = usize::from(i > 0); // single space between badges
+                                  // chip ` key ` (key + 2 pad) + ` label` (label + 1 leading space)
+    let badge_w = key.chars().count() + 2 + 1 + label.chars().count();
+    if used + sep + badge_w > hint_budget {
+      truncated = true;
+      break;
+    }
+    if sep == 1 {
+      spans.push(Span::raw(" "));
+      used += 1;
+    }
+    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled(format!(" {}", label), label_style));
+    used += badge_w;
+  }
+
+  if truncated {
+    if used > 0 {
+      spans.push(Span::raw(" "));
+      used += 1;
+    }
+    spans.push(Span::styled("…", label_style));
+    used += 1;
+  }
+
+  // Pad so the status sits flush right (priority: the log is at the end).
+  let pad = width.saturating_sub(used + status_w);
+  if pad > 0 {
+    spans.push(Span::raw(" ".repeat(pad)));
+  }
+  spans.push(Span::styled(status_text, status_style));
+  Line::from(spans)
+}
+
 fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
-  // Picker mode hides the mutating actions (n/d/b/p) — they're inert in the
-  // event loop, so advertising them would be a lie.
-  let help = if app.picker_mode {
-    "enter:select esc:cancel o:open y:yank l:git_tui v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh ?:help q:quit"
+  let hints = if app.picker_mode {
+    PICKER_FOOTER_HINTS
   } else {
-    "n:new d:del b:boot o:open y:yank l:git_tui R:review v:sidebar Tab:focus /:filter gg/G:top/bot j/k:nav f:refresh F:gh ?:help q:quit"
+    FOOTER_HINTS
   };
-  let text = Line::from(vec![
-    Span::styled(help, Style::default().fg(Color::DarkGray)),
-    Span::raw("  "),
-    Span::styled(format!("[{}]", app.status), Style::default().fg(Color::Yellow)),
-  ]);
-  f.render_widget(Paragraph::new(text).wrap(Wrap { trim: true }), area);
+  let line = footer_line(hints, &app.status, area.width as usize, app.theme.accent);
+  // No `Wrap`: the footer is a single hard-clipped row (issue #180).
+  f.render_widget(Paragraph::new(line), area);
 }
 
 /// Pure builder for the help overlay body (issue #87).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -995,6 +995,17 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, accent: C
   let label_style = Style::default().fg(Color::DarkGray);
   let status_style = Style::default().fg(Color::Yellow);
 
+  // A zero-width row can hold nothing — return an empty line rather than let
+  // the `trunc()` floor below emit a 1-column `…`.
+  if width == 0 {
+    return Line::default();
+  }
+
+  // Action logs are sometimes error strings carrying embedded newlines /
+  // tabs. `Wrap` is disabled, but a raw `\n` would still split the row in
+  // two, so collapse every control char to a single space first — the footer
+  // must stay one visual line.
+  let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
   let status_text = format!("[{}]", status);
   let status_w = status_text.chars().count();
 
@@ -1004,8 +1015,11 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, accent: C
     return Line::from(Span::styled(trunc(&status_text, width), status_style));
   }
 
-  // One column minimum gap between the hints and the right-pinned status,
-  // plus one column held in reserve for the `…` truncation marker.
+  // Budget for the hint badges: the width left after the right-pinned status,
+  // minus one column reserved for the `…` truncation marker. The gap between
+  // the hints and the status is best-effort — it shows up as left-over
+  // padding only when at least one badge fits; in the tight band just above
+  // `status_w` there may be room for neither a badge nor a gap.
   let hint_budget = (width - status_w - 1).saturating_sub(1);
 
   let mut spans: Vec<Span<'static>> = Vec::new();

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -96,3 +96,29 @@ fn keys_render_as_reverse_video_chips_on_the_accent_colour() {
   // Labels are still present so the row stays self-documenting.
   assert!(plain(&line).contains("new"));
 }
+
+#[test]
+fn newlines_in_status_never_break_the_single_line_contract() {
+  // Action logs are sometimes error strings that embed `\n` / `\r`
+  // (e.g. a multi-line template error). With `Wrap` disabled a raw newline
+  // would still split the row in two — the builder must neutralise them so
+  // the footer stays one visual line (PR #183 review).
+  let line = footer_line(HINTS, "template error:\nbad line\r\nsecond", 80, Color::Cyan);
+  let text = plain(&line);
+  assert!(!text.contains('\n'), "status newline leaked into footer: {text:?}");
+  assert!(!text.contains('\r'), "status CR leaked into footer: {text:?}");
+  assert!(display_width(&line) <= 80, "overflowed 80: {text:?}");
+}
+
+#[test]
+fn zero_width_emits_an_empty_line_without_overflowing() {
+  // Degenerate terminal width: the row must not be wider than asked. The
+  // pre-fix `trunc()` floor returned "…" (width 1) for width 0 (PR #183 review).
+  let line = footer_line(HINTS, "anything", 0, Color::Cyan);
+  assert_eq!(
+    display_width(&line),
+    0,
+    "footer overflowed a zero width: {:?}",
+    plain(&line)
+  );
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -1,0 +1,98 @@
+//! Contract tests for the single-line statusline builder (`footer_line`).
+//!
+//! Issue #180: the footer must render on ONE line, present its key hints as
+//! reverse-video badge chips, and keep the status message (the action log)
+//! visible at the right edge — hints are what gets truncated when the
+//! terminal is narrow, never the log.
+//!
+//! `footer_line` is a pure builder (like `header_title` / `help_lines`) so the
+//! layout contract is pinned here without spinning up a ratatui backend.
+
+use gwm::tui::footer_line;
+use ratatui::style::{Color, Modifier};
+use ratatui::text::Line;
+
+/// Flatten a `Line` back to its rendered plain text by concatenating every
+/// span's content — what the user sees on the row, minus styling.
+fn plain(line: &Line<'_>) -> String {
+  line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+fn display_width(line: &Line<'_>) -> usize {
+  plain(line).chars().count()
+}
+
+const HINTS: &[(&str, &str)] = &[
+  ("n", "new"),
+  ("d", "del"),
+  ("b", "boot"),
+  ("o", "open"),
+  ("y", "yank"),
+  ("l", "git"),
+  ("R", "review"),
+  ("v", "sidebar"),
+  ("Tab", "focus"),
+  ("/", "filter"),
+  ("?", "help"),
+  ("q", "quit"),
+];
+
+#[test]
+fn footer_fits_on_a_single_line_within_the_given_width() {
+  let line = footer_line(HINTS, "press ? for help", 120, Color::Cyan);
+  // No wrapping: the rendered text never exceeds the width handed in.
+  assert!(
+    display_width(&line) <= 120,
+    "footer width {} exceeded 120: {:?}",
+    display_width(&line),
+    plain(&line)
+  );
+  // And it is genuinely a single line — no embedded newline.
+  assert!(!plain(&line).contains('\n'));
+}
+
+#[test]
+fn status_is_pinned_at_the_end_and_kept_intact_when_wide() {
+  let line = footer_line(HINTS, "opened foo", 120, Color::Cyan);
+  let text = plain(&line);
+  // The log lives at the very end of the row, in priority.
+  assert!(
+    text.trim_end().ends_with("[opened foo]"),
+    "status not pinned at end: {text:?}"
+  );
+}
+
+#[test]
+fn hints_are_truncated_with_ellipsis_when_narrow_but_status_survives() {
+  let line = footer_line(HINTS, "opened foo", 40, Color::Cyan);
+  let text = plain(&line);
+  assert!(display_width(&line) <= 40, "overflowed 40: {text:?}");
+  // The status (log) is preserved …
+  assert!(text.contains("[opened foo]"), "status dropped: {text:?}");
+  assert!(text.trim_end().ends_with("[opened foo]"), "status not at end: {text:?}");
+  // … while the hint list is cut short with an ellipsis marker.
+  assert!(text.contains('…'), "expected truncation ellipsis: {text:?}");
+}
+
+#[test]
+fn status_has_absolute_priority_when_space_is_tiny() {
+  // Width barely fits the status: no hint labels should appear, but the log
+  // must still be shown (possibly clipped), never sacrificed for hints.
+  let line = footer_line(HINTS, "x", 5, Color::Cyan);
+  let text = plain(&line);
+  assert!(display_width(&line) <= 5, "overflowed 5: {text:?}");
+  assert!(text.contains("[x]") || text.contains('x'), "status missing: {text:?}");
+  assert!(!text.contains("new"), "hint label leaked into a tiny footer: {text:?}");
+}
+
+#[test]
+fn keys_render_as_reverse_video_chips_on_the_accent_colour() {
+  let line = footer_line(HINTS, "ready", 120, Color::Magenta);
+  // At least one span is a chip: reverse-video, accent-coloured, carrying a key.
+  let has_chip = line.spans.iter().any(|s| {
+    s.style.add_modifier.contains(Modifier::REVERSED) && s.style.fg == Some(Color::Magenta) && s.content.contains('n')
+  });
+  assert!(has_chip, "no reverse-video accent chip found in footer spans");
+  // Labels are still present so the row stays self-documenting.
+  assert!(plain(&line).contains("new"));
+}


### PR DESCRIPTION
## Description

La statusline (ligne du bas du TUI) tient désormais sur **une seule ligne**.
Les raccourcis sont rendus en **badges/chips vidéo inversée** (touche peinte avec
la couleur d'accent du thème + label court en gris), et le message de statut
(le log d'action) est **épinglé à droite, prioritaire** : quand le terminal est
trop étroit, c'est la liste des raccourcis qui est tronquée avec un marqueur `…`,
jamais le log. Auparavant le footer occupait 2 lignes (`Length(2)` + `Wrap`) et
pouvait repousser le log hors écran.

Closes #180

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- Nouveau builder pur `footer_line(hints, status, width, accent) -> Line` dans `src/tui/ui.rs` : chips inversés sur l'accent du thème, troncature `…` des hints, status pinné flush-right avec priorité absolue.
- `draw_footer` réécrit sans `Wrap` (clip dur mono-ligne) ; contrainte de layout du footer ramenée de `Length(2)` à `Length(1)` (branches filtre visible / masqué).
- `footer_line` re-exporté via `gwm::tui::footer_line`.
- Aucun raccourci ajouté/retiré : seul le rendu change.

## Tests

- [x] `cargo test` passes locally (toutes cibles vertes ; `tests/tui_footer_tests.rs` = 5/5)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD : red → green sur `footer_line`)

## Screenshots / TUI captures

<!-- Rendu non capturé en CLI ; le contrat visuel (mono-ligne, chips, priorité du log) est pinné par tests/tui_footer_tests.rs. -->

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — pas de changement de surface CLI)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a — pas de changement de schéma)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #180
- Related PR: #

## Notes for reviewers

Le builder est width-driven et testé sans backend ratatui (mesure en `chars().count()`,
cohérent avec le reste de `ui.rs`). Point d'attention : sur un terminal ~80 colonnes,
la liste complète des 16 raccourcis ne tient pas — c'est le compromis voulu (badges +
troncature `…`, log prioritaire). La liste exhaustive reste accessible via `?` (help).