### PR TITLE
✨ feat(github): ephemeral PR auto-detection across status, list & TUI sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ephemeral **PR auto-detection** for a branch's pull request. When no PR is explicitly linked (`gwm link --pr`), gwm now resolves the branch's PR from GitHub (`gh pr list --head <branch> --state all`) and surfaces it marked `detected` — never written to git config, so it stays fresh and an explicit link always wins. Wired into `gwm status` (always, one worktree), the TUI sidebar (on the `F` refresh, marked " (detected)"), and a new opt-in `gwm list --detect-pr` flag that adds a `PR` column (one `gh` call per worktree; plain `gwm list` stays network-free). New `LinkSource::Detected` provenance alongside `branch-name` / `explicit`. (#181)
 - `{repo_path}` and `{repo_parent}` placeholders for `.gwm.toml` paths/patterns. `{repo_path}` expands to the main repo's absolute working directory and `{repo_parent}` to its parent, so a base can be expressed relative to the repo on disk — e.g. `base = "{repo_parent}/worktrees"` puts worktrees in a sibling `worktrees/` dir, matching an editor's `../worktrees` convention (Zed's `git.worktree_directory`) without a per-project editor config. Purely additive; existing `{home}`/`{repo}` bases are unchanged. (#175)
 
 ## Past releases

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -112,16 +112,19 @@ On success the new PR number is recorded under `branch.<head>.gwm-pr` (same key 
 
 Body resolution and placeholder semantics are documented under [Configuration → `[pr_template]`](/configuration/gwm-toml#pr-template-issue-84).
 
-## `gwm list [--format=table|names]`
+## `gwm list [--format=table|names] [--detect-pr]`
 
 List the worktrees in the current repo.
 
 ```bash
 gwm list                       # human-readable table
 gwm list --format=names        # one worktree name per line (for shell completion)
+gwm list --detect-pr           # add a PR column, auto-detecting each branch's PR via gh
 ```
 
 The `names` format excludes the main workdir — `gwm path / remove / bootstrap` never accept it as a target, so emitting it as a completion candidate would be misleading.
+
+`--detect-pr` adds a `PR` column populated by [PR auto-detection](/integrations/github-linking#auto-detection) (`gh pr list --head <branch>` per worktree). It is **off by default** so the plain listing stays network-free — one `gh` call per worktree is only paid when the flag is set. Ignored with `--format=names`.
 
 ## `gwm path <pattern>` (alias: `gwm cd <pattern>`)
 

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -1,6 +1,6 @@
 ---
 title: GitHub issue / PR linking
-description: Auto-link branches to issues, fetch live state via `gh`, surface in the TUI sidebar.
+description: Auto-link branches to issues, auto-detect their PR, fetch live state via `gh`, surface in the TUI sidebar.
 ---
 
 # GitHub issue / PR linking
@@ -33,7 +33,20 @@ chore/#5-rename             → issue #5 auto-linked
 release-1.x                 → no auto-link (no #N pattern)
 ```
 
-PR numbers are **not** auto-detected — there's no convention that maps a branch to a PR number. Link them explicitly:
+PR numbers have no branch-name convention, so they are detected a different way: [#181](https://github.com/kbrdn1/gwm-cli/issues/181) added **ephemeral PR auto-detection**. When a branch has no explicit PR link, gwm asks GitHub which PR was opened from it (`gh pr list --head <branch> --state all`) and surfaces it marked `detected`:
+
+```
+$ gwm status --json | jq '.pr.source'
+"detected"          # vs "explicit" for a `gwm link --pr`, "branch-name" for issues
+```
+
+Detection is **never persisted** — it is resolved live on each read, so it is always fresh and an explicit `gwm link --pr` always wins. Because each lookup is a `gh` call, detection runs only where it is cheap or asked for:
+
+- **`gwm status`** — always (one worktree).
+- **TUI sidebar** — on the `F` refresh (one selected worktree, deduped).
+- **`gwm list --detect-pr`** — opt-in flag; adds a `PR` column at the cost of one `gh` call per worktree. Plain `gwm list` stays network-free.
+
+To pin a durable, explicit link instead (e.g. a PR not opened from this branch's head):
 
 ```bash
 gwm link pr 61

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2052,6 +2052,7 @@ fn link_source_str(s: LinkSource) -> &'static str {
     LinkSource::None => "none",
     LinkSource::BranchName => "branch-name",
     LinkSource::Explicit => "explicit",
+    LinkSource::Detected => "detected",
   }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,12 @@ pub enum Command {
     /// Output format. `names` prints one worktree name per line (for shell completion).
     #[arg(long, value_enum, default_value_t = ListFormat::Table)]
     format: ListFormat,
+    /// Add a PR column, auto-detecting each worktree's pull request via
+    /// `gh pr list --head <branch>` (issue #181). Off by default: it
+    /// makes one `gh` call per worktree, so the plain listing stays
+    /// network-free. Ignored with `--format names`.
+    #[arg(long)]
+    detect_pr: bool,
   },
   /// Create a new worktree (and matching branch).
   Create {
@@ -732,7 +738,7 @@ pub fn run(cli: Cli) -> Result<()> {
 
   match cmd {
     Command::Init => cmd_init(),
-    Command::List { format } => cmd_list(format),
+    Command::List { format, detect_pr } => cmd_list(format, detect_pr),
     Command::Create {
       branch_type,
       issue,
@@ -961,7 +967,7 @@ fn cmd_init() -> Result<()> {
   Ok(())
 }
 
-fn cmd_list(format: ListFormat) -> Result<()> {
+fn cmd_list(format: ListFormat, detect_pr: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let trees = worktree::list(&repo)?;
 
@@ -975,6 +981,26 @@ fn cmd_list(format: ListFormat) -> Result<()> {
     return Ok(());
   }
 
+  // PR auto-detection (issue #181): off by default to keep the listing
+  // network-free. When `--detect-pr` is set and a GitHub remote resolves,
+  // detect each branch's PR via `gh pr list --head <branch>` — one `gh`
+  // call per worktree. The detected number is rendered in an extra
+  // column; an explicit `gwm link --pr` still wins via `read_link`.
+  let detected_prs: Vec<Option<u64>> = if detect_pr {
+    let slug = github::repo_slug(&repo).ok();
+    trees
+      .iter()
+      .map(|w| {
+        let (branch, slug) = (w.branch.as_deref()?, slug.as_deref()?);
+        github::read_link_with_pr_detection(&repo, branch, slug)
+          .ok()
+          .and_then(|l| l.pr)
+      })
+      .collect()
+  } else {
+    Vec::new()
+  };
+
   // Dynamic widths based on observed content.
   let name_w = trees.iter().map(|w| w.name.len()).max().unwrap_or(4).clamp(4, 40);
   let branch_w = trees
@@ -984,31 +1010,64 @@ fn cmd_list(format: ListFormat) -> Result<()> {
     .unwrap_or(6)
     .clamp(6, 40);
   let status_w = 14;
+  let pr_w = 6;
 
-  println!(
-    "  {:<nw$}  {:<bw$}  {:<sw$}  PATH",
-    "NAME",
-    "BRANCH",
-    "STATUS",
-    nw = name_w,
-    bw = branch_w,
-    sw = status_w,
-  );
-  for w in trees {
-    let mark = if w.is_main { "*" } else { " " };
-    let branch = w.branch.clone().unwrap_or_else(|| "-".into());
-    let status = format_status_text(&w);
+  if detect_pr {
     println!(
-      "{} {:<nw$}  {:<bw$}  {:<sw$}  {}",
-      mark,
-      w.name,
-      branch,
-      status,
-      w.path.display(),
+      "  {:<nw$}  {:<bw$}  {:<sw$}  {:<pw$}  PATH",
+      "NAME",
+      "BRANCH",
+      "STATUS",
+      "PR",
+      nw = name_w,
+      bw = branch_w,
+      sw = status_w,
+      pw = pr_w,
+    );
+  } else {
+    println!(
+      "  {:<nw$}  {:<bw$}  {:<sw$}  PATH",
+      "NAME",
+      "BRANCH",
+      "STATUS",
       nw = name_w,
       bw = branch_w,
       sw = status_w,
     );
+  }
+  for (i, w) in trees.iter().enumerate() {
+    let mark = if w.is_main { "*" } else { " " };
+    let branch = w.branch.clone().unwrap_or_else(|| "-".into());
+    let status = format_status_text(w);
+    if detect_pr {
+      let pr = detected_prs.get(i).copied().flatten();
+      let pr_cell = pr.map(|n| format!("#{n}")).unwrap_or_else(|| "-".into());
+      println!(
+        "{} {:<nw$}  {:<bw$}  {:<sw$}  {:<pw$}  {}",
+        mark,
+        w.name,
+        branch,
+        status,
+        pr_cell,
+        w.path.display(),
+        nw = name_w,
+        bw = branch_w,
+        sw = status_w,
+        pw = pr_w,
+      );
+    } else {
+      println!(
+        "{} {:<nw$}  {:<bw$}  {:<sw$}  {}",
+        mark,
+        w.name,
+        branch,
+        status,
+        w.path.display(),
+        nw = name_w,
+        bw = branch_w,
+        sw = status_w,
+      );
+    }
   }
   Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2006,11 +2006,17 @@ fn spawn_opener(url: &str) -> Result<()> {
 
 fn cmd_status(worktree: Option<String>, json: bool) -> Result<()> {
   let (repo, branch, _path) = resolve_target_repo(worktree)?;
-  let link = github::read_link(&repo, &branch)?;
 
   // Slug + fetched status are best-effort: if there's no GitHub remote
   // or `gh` isn't installed, we still print the local link.
   let slug = github::repo_slug(&repo).ok();
+  // When a remote is present, auto-detect the branch's PR if none is
+  // explicitly linked (issue #181). Falls back to the plain local read
+  // with no remote — keeping the "local link only" mode network-free.
+  let link = match slug.as_deref() {
+    Some(s) => github::read_link_with_pr_detection(&repo, &branch, s)?,
+    None => github::read_link(&repo, &branch)?,
+  };
   let (issue_status, pr_status) = fetch_link_status(&link, slug.as_deref());
 
   if json {

--- a/src/github.rs
+++ b/src/github.rs
@@ -35,6 +35,11 @@ pub enum LinkSource {
   BranchName,
   /// Explicit override set via `gwm link …` (lives in git branch config).
   Explicit,
+  /// Auto-detected from GitHub: a PR whose head ref is this branch was
+  /// found via `gh pr list --head <branch>` (issue #181). Ephemeral —
+  /// never written to the git config, so an explicit `gwm link --pr`
+  /// always wins on the next read.
+  Detected,
 }
 
 /// Resolved link for one branch: which issue (if any), which PR (if any),
@@ -92,6 +97,43 @@ pub fn read_link(repo: &Repository, branch: &str) -> Result<BranchLink> {
     issue_source,
     pr_source,
   })
+}
+
+/// Stamp an auto-detected PR number onto `link` when no PR is already
+/// linked. Pure helper (issue #181): the caller supplies the detection
+/// result — typically `find_pr_for_branch(slug, branch).ok().flatten()` —
+/// and this decides whether to apply it.
+///
+/// An explicit (or previously-detected) PR always wins: when `link.pr`
+/// is already `Some`, this is a no-op so a `gwm link --pr` override is
+/// never clobbered. The applied number is marked [`LinkSource::Detected`]
+/// and is *never* persisted to the git config by this function — it lives
+/// only on the in-memory [`BranchLink`].
+pub fn apply_detected_pr(link: &mut BranchLink, detected: Option<u64>) {
+  if link.pr.is_none() {
+    if let Some(n) = detected {
+      link.pr = Some(n);
+      link.pr_source = LinkSource::Detected;
+    }
+  }
+}
+
+/// Resolve the link for `branch` and, when no PR is explicitly linked,
+/// auto-detect the branch's PR from GitHub via `gh` (issue #181). The
+/// detected PR is marked [`LinkSource::Detected`] and is never persisted.
+///
+/// Detection is best-effort: a `gh` failure (not installed, no network,
+/// no PR for the branch) degrades silently to "no PR" rather than
+/// erroring — the local link is still returned. This shells out, so
+/// callers on hot paths (per-worktree listing) must opt in deliberately
+/// rather than route every read through here.
+pub fn read_link_with_pr_detection(repo: &Repository, branch: &str, slug: &str) -> Result<BranchLink> {
+  let mut link = read_link(repo, branch)?;
+  if link.pr.is_none() {
+    let detected = find_pr_for_branch(slug, branch).ok().flatten();
+    apply_detected_pr(&mut link, detected);
+  }
+  Ok(link)
 }
 
 pub fn link_issue(repo: &Repository, branch: &str, number: u64) -> Result<()> {
@@ -459,14 +501,42 @@ pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
 /// `Ok(None)` otherwise. Callers that need state-aware filtering should
 /// pair this with `fetch_pr` to inspect `PrState` afterwards.
 pub fn find_pr_for_branch(slug: &str, branch: &str) -> Result<Option<u64>> {
-  let stdout = run_gh([
-    "pr", "list", "--repo", slug, "--head", branch, "--state", "all", "--json", "number", "--limit", "1",
-  ])?;
+  let stdout = run_gh(find_pr_argv(slug, branch))?;
+  parse_pr_list_number(&stdout)
+}
+
+/// Argv for `gh pr list --repo <slug> --head <branch> --state all --json
+/// number --limit 1`. Extracted so the test suite can pin the `gh`
+/// contract without shelling out; [`find_pr_for_branch`] is the caller
+/// that actually invokes it. `--state all` is the load-bearing bit: a
+/// closed or merged PR for the branch is still detected (its `PrState`
+/// is resolved later via [`fetch_pr`]).
+pub fn find_pr_argv(slug: &str, branch: &str) -> Vec<String> {
+  vec![
+    "pr".into(),
+    "list".into(),
+    "--repo".into(),
+    slug.into(),
+    "--head".into(),
+    branch.into(),
+    "--state".into(),
+    "all".into(),
+    "--json".into(),
+    "number".into(),
+    "--limit".into(),
+    "1".into(),
+  ]
+}
+
+/// Parse the JSON array printed by `gh pr list --json number --limit 1`,
+/// returning the first PR number if any. Exposed for unit tests so the
+/// parse contract is covered without a `gh` shell-out.
+pub fn parse_pr_list_number(s: &str) -> Result<Option<u64>> {
   #[derive(Deserialize)]
   struct PrRef {
     number: u64,
   }
-  let arr: Vec<PrRef> = serde_json::from_str(&stdout).map_err(|e| GwmError::GhJsonParse {
+  let arr: Vec<PrRef> = serde_json::from_str(s).map_err(|e| GwmError::GhJsonParse {
     kind: "pr list",
     source: e,
   })?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1248,11 +1248,24 @@ impl App {
   pub fn refresh_github_status(&mut self) {
     use super::state::github_fetch::{FetchAction, FetchKey};
 
+    let slug = self.github.link_slug.clone();
+
+    // Auto-detect the selected branch's PR when none is linked (issue
+    // #181). Runs on the same synchronous F-refresh path as the issue/PR
+    // fetch; needs a remote, so it's a no-op without a slug. An explicit
+    // `gwm link --pr` wins — `apply_detected_pr` only fills an empty slot.
+    if self.github.link.pr.is_none() {
+      if let (Some(slug), Some(branch)) = (slug.as_deref(), self.selected_branch_name()) {
+        let detected = github::find_pr_for_branch(slug, &branch).ok().flatten();
+        self.github.apply_detected_pr(detected);
+      }
+    }
+
     if self.github.link.issue.is_none() && self.github.link.pr.is_none() {
       self.status = "nothing linked — press L to link an issue or PR".into();
       return;
     }
-    let Some(slug) = self.github.link_slug.clone() else {
+    let Some(slug) = slug else {
       self.status = "no GitHub remote — cannot fetch status".into();
       return;
     };

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1250,6 +1250,11 @@ impl App {
 
     let slug = self.github.link_slug.clone();
 
+    // Drop a prior auto-detection so this refresh re-resolves it live
+    // (issue #181): a detected PR must not stick across `F` presses if
+    // the branch's PR changed. Explicit / branch-name links stay pinned.
+    self.github.clear_detected_pr();
+
     // Auto-detect the selected branch's PR when none is linked (issue
     // #181). Runs on the same synchronous F-refresh path as the issue/PR
     // fetch; needs a remote, so it's a no-op without a slug. An explicit

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -199,6 +199,17 @@ impl GitHubFetch {
     self.inflight.clear();
   }
 
+  /// Stamp an auto-detected PR onto the resolved `link` when none is
+  /// already linked (issue #181). Pure: the `App` orchestrator owns the
+  /// `gh pr list --head <branch>` shell-out and feeds the detected number
+  /// here so the sidebar's `pr_fetch_state()` can resolve it. Delegates
+  /// to [`github::apply_detected_pr`], so an explicit `gwm link --pr`
+  /// (already on `link.pr`) always wins and the result is marked
+  /// `LinkSource::Detected` — never persisted.
+  pub fn apply_detected_pr(&mut self, detected: Option<u64>) {
+    github::apply_detected_pr(&mut self.link, detected);
+  }
+
   /// Decide what the orchestrator should do for `key`. Three cases:
   ///
   /// 1. The per-key cache holds a terminal `Loaded` or `Error` for

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -210,6 +210,18 @@ impl GitHubFetch {
     github::apply_detected_pr(&mut self.link, detected);
   }
 
+  /// Drop a previously auto-detected PR so the next refresh re-resolves
+  /// it from GitHub (issue #181 — the detected link is "resolved live",
+  /// so a PR that was opened/closed/replaced while sitting on the same
+  /// worktree must not stick across `F` presses). A no-op for an
+  /// explicit (`gwm link --pr`) or branch-name link — those stay pinned.
+  pub fn clear_detected_pr(&mut self) {
+    if self.link.pr_source == github::LinkSource::Detected {
+      self.link.pr = None;
+      self.link.pr_source = github::LinkSource::None;
+    }
+  }
+
   /// Decide what the orchestrator should do for `key`. Three cases:
   ///
   /// 1. The per-key cache holds a terminal `Loaded` or `Error` for

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1516,6 +1516,7 @@ fn source_marker(s: LinkSource) -> &'static str {
     LinkSource::None => "",
     LinkSource::BranchName => " (auto)",
     LinkSource::Explicit => "",
+    LinkSource::Detected => " (detected)",
   }
 }
 

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -801,6 +801,45 @@ fn create_outside_git_repo_fails() {
 }
 
 #[test]
+fn list_detect_pr_flag_adds_pr_column_with_detected_number() {
+  // E2E (issue #181): `gwm list --detect-pr` shows a PR column populated
+  // by `gh pr list` detection for each worktree's branch.
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+
+  let fake_bin = tempfile::TempDir::new().unwrap();
+  let fake_gh = write_dispatch_gh(fake_bin.path(), r#"[{"number":128}]"#, r#"{}"#);
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_GH", &fake_gh)
+    .env("PATH", prepend_path(fake_bin.path()))
+    .args(["list", "--detect-pr"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("PR"))
+    .stdout(predicate::str::contains("#128"));
+}
+
+#[test]
+fn list_without_detect_pr_flag_has_no_pr_column() {
+  // Default `gwm list` stays network-free: no PR column, no `#` markers.
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["list"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("STATUS"))
+    .stdout(predicate::str::contains("PATH"))
+    .stdout(predicate::str::contains('#').not());
+}
+
+#[test]
 fn completions_zsh_emits_compdef_header() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["completions", "zsh"]);

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1341,6 +1341,74 @@ fn unlink_issue_falls_back_to_branch_name_auto_detect() {
 }
 
 #[test]
+fn status_auto_detects_pr_when_none_explicitly_linked() {
+  // E2E (issue #181): a branch with a GitHub remote and no explicit PR
+  // link. `gwm status --json` should detect the branch's PR via `gh pr
+  // list` and report it with source "detected".
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  // No issue number in the name → isolates the PR-detection path.
+  repo.branch("detect-me", &head, false).unwrap();
+  repo.set_head("refs/heads/detect-me").unwrap();
+
+  let fake_bin = tempfile::TempDir::new().unwrap();
+  let fake_gh = write_dispatch_gh(
+    fake_bin.path(),
+    r#"[{"number":128}]"#,
+    r#"{"number":128,"title":"Auto-detect PR","state":"OPEN","isDraft":false,"url":"https://github.com/kbrdn1/gwm-cli/pull/128"}"#,
+  );
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_GH", &fake_gh)
+    .env("PATH", prepend_path(fake_bin.path()))
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"number\":128"))
+    .stdout(predicate::str::contains("\"source\":\"detected\""));
+}
+
+#[test]
+fn status_explicit_pr_link_wins_over_detection() {
+  // An explicit `gwm link --pr` must not be clobbered by detection: the
+  // reported source stays "explicit" even though `gh pr list` would
+  // return a different number.
+  let (dir, repo) = init_repo();
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch("detect-me", &head, false).unwrap();
+  repo.set_head("refs/heads/detect-me").unwrap();
+
+  let fake_bin = tempfile::TempDir::new().unwrap();
+  let fake_gh = write_dispatch_gh(
+    fake_bin.path(),
+    r#"[{"number":999}]"#,
+    r#"{"number":61,"title":"Explicit","state":"OPEN","isDraft":false,"url":"https://github.com/kbrdn1/gwm-cli/pull/61"}"#,
+  );
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["link", "pr", "61"])
+    .assert()
+    .success();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_GH", &fake_gh)
+    .env("PATH", prepend_path(fake_bin.path()))
+    .args(["status", "--json"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"number\":61"))
+    .stdout(predicate::str::contains("\"source\":\"explicit\""));
+}
+
+#[test]
 fn open_print_url_emits_url_without_spawning_browser() {
   // `--print-url` is the test-friendly mode: we want to assert the URL
   // construction without actually shelling out to `open`/`xdg-open`.
@@ -1523,6 +1591,52 @@ fn prepend_path(dir: &Path) -> String {
   let mut paths = vec![dir.to_path_buf()];
   paths.extend(std::env::split_paths(&old));
   std::env::join_paths(paths).unwrap().to_string_lossy().into_owned()
+}
+
+/// Fake `gh` that dispatches on the first two args, used to exercise the
+/// PR auto-detection path (issue #181): `gh pr list …` returns
+/// `pr_list_json`, `gh pr view …` returns `pr_view_json`. Both arms emit
+/// the JSON verbatim so the real `find_pr_for_branch` / `fetch_pr` parse
+/// it. Unix + Windows variants so CI stays green on both.
+fn write_dispatch_gh(root: &Path, pr_list_json: &str, pr_view_json: &str) -> PathBuf {
+  #[cfg(unix)]
+  {
+    let script = root.join("gh");
+    fs::write(
+      &script,
+      format!(
+        r#"#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '%s' '{list}'
+elif [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s' '{view}'
+fi
+"#,
+        list = pr_list_json.replace('\'', "'\\''"),
+        view = pr_view_json.replace('\'', "'\\''"),
+      ),
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+  }
+  #[cfg(windows)]
+  {
+    let script = root.join("gh.cmd");
+    fs::write(
+      &script,
+      format!(
+        "@echo off\r\nif \"%~1\"==\"pr\" if \"%~2\"==\"list\" echo {list}\r\nif \"%~1\"==\"pr\" if \"%~2\"==\"view\" echo {view}\r\n",
+        list = pr_list_json,
+        view = pr_view_json,
+      ),
+    )
+    .unwrap();
+    script
+  }
 }
 
 fn write_fake_gh(root: &Path, issue_url: &str) -> PathBuf {

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -647,3 +647,95 @@ fn delete_label_refuses_dash_prefixed_remote_name_before_shelling_out() {
     msg
   );
 }
+
+// --- PR auto-detection (issue #181) --------------------------------------
+
+#[test]
+fn apply_detected_pr_sets_pr_with_detected_source_when_none_linked() {
+  // Branch carries an issue from its name but no PR link. Feeding a
+  // detected PR number stamps it with the `Detected` provenance.
+  let mut link = BranchLink {
+    issue: Some(42),
+    pr: None,
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::None,
+  };
+
+  github::apply_detected_pr(&mut link, Some(128));
+
+  assert_eq!(link.pr, Some(128));
+  assert_eq!(link.pr_source, LinkSource::Detected);
+  // The issue side is left untouched.
+  assert_eq!(link.issue, Some(42));
+  assert_eq!(link.issue_source, LinkSource::BranchName);
+}
+
+#[test]
+fn apply_detected_pr_leaves_explicit_pr_untouched() {
+  // An explicit `gwm link --pr` always wins: detection must not clobber it.
+  let mut link = BranchLink {
+    issue: None,
+    pr: Some(61),
+    issue_source: LinkSource::None,
+    pr_source: LinkSource::Explicit,
+  };
+
+  github::apply_detected_pr(&mut link, Some(128));
+
+  assert_eq!(link.pr, Some(61));
+  assert_eq!(link.pr_source, LinkSource::Explicit);
+}
+
+#[test]
+fn apply_detected_pr_is_noop_when_nothing_detected() {
+  let mut link = BranchLink::empty();
+
+  github::apply_detected_pr(&mut link, None);
+
+  assert_eq!(link.pr, None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
+fn detected_pr_renders_in_summary_like_any_pr() {
+  let mut link = BranchLink::empty();
+  github::apply_detected_pr(&mut link, Some(128));
+  assert_eq!(link.summary(), "PR #128");
+}
+
+#[test]
+fn find_pr_argv_pins_the_gh_pr_list_contract() {
+  let argv = github::find_pr_argv("kbrdn1/gwm-cli", "feat/#181-auto-detect-pr");
+  assert_eq!(
+    argv,
+    vec![
+      "pr",
+      "list",
+      "--repo",
+      "kbrdn1/gwm-cli",
+      "--head",
+      "feat/#181-auto-detect-pr",
+      "--state",
+      "all",
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ]
+  );
+}
+
+#[test]
+fn parse_pr_list_number_returns_first_pr() {
+  assert_eq!(github::parse_pr_list_number(r#"[{"number":128}]"#).unwrap(), Some(128));
+}
+
+#[test]
+fn parse_pr_list_number_returns_none_for_empty_array() {
+  assert_eq!(github::parse_pr_list_number("[]").unwrap(), None);
+}
+
+#[test]
+fn parse_pr_list_number_errors_on_malformed_json() {
+  assert!(github::parse_pr_list_number("not json").is_err());
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -9,7 +9,21 @@ use gwm::tui::{
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::style::Color;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
+
+/// Process-global lock guarding every test in this binary that mutates
+/// `std::env`. `set_var` / `remove_var` are `unsafe` because the libc
+/// calls aren't thread-safe; under `cargo test`'s default thread pool,
+/// two env-mutating tests running in parallel can race and trigger UB.
+/// Every test fn here that touches env vars MUST take this lock before
+/// any `set_var` / `remove_var` (the trust-gate tests and the GitHub
+/// PR-detection refresh test, #181). Mirrors the same pattern in
+/// `trust_tests.rs` / `history_tests.rs`.
+fn env_lock() -> &'static Mutex<()> {
+  static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+  LOCK.get_or_init(|| Mutex::new(()))
+}
 
 /// Build a synthetic worktree row for state-machine tests that need a known
 /// list shape (fuzzy filter ranking, multi-row navigation). Lets the test
@@ -1393,27 +1407,44 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
   app.refresh_link();
 
   let gh = dir.path().join("fake-gh");
-  std::fs::write(
-    &gh,
-    "#!/bin/sh\n\
-     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
-       printf '%s' '[{\"number\":128}]'\n\
-     elif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
-       printf '%s' '{\"number\":128,\"title\":\"x\",\"state\":\"OPEN\",\"isDraft\":false,\"url\":\"https://example.test/pull/128\"}'\n\
-     fi\n",
-  )
-  .unwrap();
-  let mut perms = std::fs::metadata(&gh).unwrap().permissions();
-  perms.set_mode(0o755);
-  std::fs::set_permissions(&gh, perms).unwrap();
+  // Write a fake `gh` that detects PR `n` (both `pr list` and `pr view`).
+  let write_gh = |n: u64| {
+    std::fs::write(
+      &gh,
+      format!(
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
+           printf '%s' '[{{\"number\":{n}}}]'\n\
+         elif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+           printf '%s' '{{\"number\":{n},\"title\":\"x\",\"state\":\"OPEN\",\"isDraft\":false,\"url\":\"https://example.test/pull/{n}\"}}'\n\
+         fi\n"
+      ),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&gh).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&gh, perms).unwrap();
+  };
+  write_gh(128);
 
+  // Serialise against the other env-mutating tests in this binary.
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
   let prior = std::env::var("GWM_GH").ok();
-  // SAFETY: this test is the sole GWM_GH mutator in this binary; the
-  // var is restored immediately after the call, before any assert.
+  // SAFETY: env mutation is guarded by `env_lock()` above; GWM_GH is
+  // restored at the end of the test, before returning.
   unsafe {
     std::env::set_var("GWM_GH", &gh);
   }
 
+  // First refresh: nothing linked → detect PR #128.
+  app.refresh_github_status();
+  assert_eq!(app.current_link().pr, Some(128));
+  assert_eq!(app.current_link().pr_source, LinkSource::Detected);
+
+  // The branch's PR changed (e.g. closed + reopened as #200). A detected
+  // link is "resolved live", so a second refresh must re-detect rather
+  // than stick to #128 (issue #181 — Copilot review on PR #184).
+  write_gh(200);
   app.refresh_github_status();
 
   unsafe {
@@ -1423,7 +1454,11 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
     }
   }
 
-  assert_eq!(app.current_link().pr, Some(128));
+  assert_eq!(
+    app.current_link().pr,
+    Some(200),
+    "a detected PR must re-resolve on refresh"
+  );
   assert_eq!(app.current_link().pr_source, LinkSource::Detected);
 }
 
@@ -2822,13 +2857,12 @@ fn tui_gate_refuses_untrusted_config_in_prompt_mode() {
   // at the CLI gate / env bypass.
   let ledger_dir = tempfile::TempDir::new().unwrap();
   let ledger = ledger_dir.path().join("trust.toml");
-  // Hold the env lock + clean up afterwards to keep the harness
-  // hermetic against the trust_tests env-mutation test.
+  // Serialise against the other env-mutating tests in this binary
+  // (the PR-detection refresh test also mutates env, #181).
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
   let prior_ledger = std::env::var("GWM_TRUST_LEDGER").ok();
   let prior_allow = std::env::var("GWM_ALLOW_BOOTSTRAP").ok();
-  // SAFETY: this test is the sole env mutator inside this binary.
-  // The `trust_tests` env tests live in a separate test binary and
-  // run in their own process, so there's no cross-binary race.
+  // SAFETY: env mutation is guarded by `env_lock()` above.
   unsafe {
     std::env::set_var("GWM_TRUST_LEDGER", &ledger);
     std::env::remove_var("GWM_ALLOW_BOOTSTRAP");
@@ -2925,6 +2959,7 @@ fn tui_submit_create_aborts_on_untrusted_config() {
   let ledger_dir = tempfile::TempDir::new().unwrap();
   let ledger = ledger_dir.path().join("trust.toml");
   let base_dir = tempfile::TempDir::new().unwrap();
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
   let prior_ledger = std::env::var("GWM_TRUST_LEDGER").ok();
   let prior_allow = std::env::var("GWM_ALLOW_BOOTSTRAP").ok();
   // SAFETY: see comment on `tui_gate_refuses_untrusted_config_in_prompt_mode`.
@@ -2994,6 +3029,7 @@ fn tui_bootstrap_selected_aborts_on_untrusted_config() {
   // (re-run bootstrap on an existing worktree) takes the same gate.
   let ledger_dir = tempfile::TempDir::new().unwrap();
   let ledger = ledger_dir.path().join("trust.toml");
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
   let prior_ledger = std::env::var("GWM_TRUST_LEDGER").ok();
   let prior_allow = std::env::var("GWM_ALLOW_BOOTSTRAP").ok();
   // SAFETY: same rationale as the previous test.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1376,6 +1376,57 @@ fn refresh_github_status_message_reflects_partial_failure() {
   );
 }
 
+#[cfg(unix)]
+#[test]
+fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
+  use std::os::unix::fs::PermissionsExt;
+
+  // A branch with no issue number in its name and no explicit PR link.
+  // Pre-#181 refresh_github_status bailed with "nothing linked"; now it
+  // detects the branch's PR via `gh pr list` and surfaces it with
+  // source `Detected`. Gated #[cfg(unix)] — the cross-OS gh contract is
+  // covered by the pure github_tests + the cli_binary status E2E (which
+  // ships a Windows fake-gh too).
+  let (dir, repo, mut app) = make_app_on_branch("detect-me");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  // Re-resolve the slug now that the remote exists.
+  app.refresh_link();
+
+  let gh = dir.path().join("fake-gh");
+  std::fs::write(
+    &gh,
+    "#!/bin/sh\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
+       printf '%s' '[{\"number\":128}]'\n\
+     elif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+       printf '%s' '{\"number\":128,\"title\":\"x\",\"state\":\"OPEN\",\"isDraft\":false,\"url\":\"https://example.test/pull/128\"}'\n\
+     fi\n",
+  )
+  .unwrap();
+  let mut perms = std::fs::metadata(&gh).unwrap().permissions();
+  perms.set_mode(0o755);
+  std::fs::set_permissions(&gh, perms).unwrap();
+
+  let prior = std::env::var("GWM_GH").ok();
+  // SAFETY: this test is the sole GWM_GH mutator in this binary; the
+  // var is restored immediately after the call, before any assert.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh);
+  }
+
+  app.refresh_github_status();
+
+  unsafe {
+    match prior {
+      Some(v) => std::env::set_var("GWM_GH", v),
+      None => std::env::remove_var("GWM_GH"),
+    }
+  }
+
+  assert_eq!(app.current_link().pr, Some(128));
+  assert_eq!(app.current_link().pr_source, LinkSource::Detected);
+}
+
 // ---- Configurable launchers (issue #75) --------------------------------
 //
 // The `R` key in the worktree-list view now triggers the [review]

--- a/tests/tui_state_github_fetch_tests.rs
+++ b/tests/tui_state_github_fetch_tests.rs
@@ -297,3 +297,37 @@ fn complete_pr_after_invalidate_drops_the_stale_result() {
     action
   );
 }
+
+// ---- PR auto-detection on the slice (issue #181) --------------------------
+
+#[test]
+fn apply_detected_pr_fills_empty_pr_slot_with_detected_source() {
+  let mut gh = GitHubFetch::new();
+  // Cold link: no PR.
+  assert_eq!(gh.link.pr, None);
+
+  gh.apply_detected_pr(Some(128));
+
+  assert_eq!(gh.link.pr, Some(128));
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Detected);
+}
+
+#[test]
+fn apply_detected_pr_does_not_override_explicit_pr() {
+  let mut gh = GitHubFetch::new();
+  gh.link.pr = Some(61);
+  gh.link.pr_source = gwm::github::LinkSource::Explicit;
+
+  gh.apply_detected_pr(Some(128));
+
+  assert_eq!(gh.link.pr, Some(61));
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Explicit);
+}
+
+#[test]
+fn apply_detected_pr_is_noop_when_nothing_detected() {
+  let mut gh = GitHubFetch::new();
+  gh.apply_detected_pr(None);
+  assert_eq!(gh.link.pr, None);
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::None);
+}

--- a/tests/tui_state_github_fetch_tests.rs
+++ b/tests/tui_state_github_fetch_tests.rs
@@ -331,3 +331,27 @@ fn apply_detected_pr_is_noop_when_nothing_detected() {
   assert_eq!(gh.link.pr, None);
   assert_eq!(gh.link.pr_source, gwm::github::LinkSource::None);
 }
+
+#[test]
+fn clear_detected_pr_drops_a_detected_link_so_it_re_resolves() {
+  let mut gh = GitHubFetch::new();
+  gh.apply_detected_pr(Some(128));
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Detected);
+
+  gh.clear_detected_pr();
+
+  assert_eq!(gh.link.pr, None);
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::None);
+}
+
+#[test]
+fn clear_detected_pr_leaves_an_explicit_link_pinned() {
+  let mut gh = GitHubFetch::new();
+  gh.link.pr = Some(61);
+  gh.link.pr_source = gwm::github::LinkSource::Explicit;
+
+  gh.clear_detected_pr();
+
+  assert_eq!(gh.link.pr, Some(61));
+  assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Explicit);
+}


### PR DESCRIPTION
## Description

Auto-detect a branch's pull request when none is explicitly linked. The
plumbing (`github::find_pr_for_branch` → `gh pr list --head <branch>`) was
dead code; this wires it in behind a new `LinkSource::Detected` provenance.
Detection is **ephemeral** — resolved live on each read, never written to
git config — so it stays fresh and an explicit `gwm link --pr` always wins.

Closes #181

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `LinkSource::Detected` variant + pure helpers `apply_detected_pr` /
  `read_link_with_pr_detection`; `find_pr_argv` / `parse_pr_list_number`
  extracted from `find_pr_for_branch` for unit testing without shelling out.
- `gwm status` (one worktree → always-on): detects the PR when none is
  linked; human + `--json` output gain `source: "detected"`.
- `gwm list --detect-pr` (opt-in flag): adds a `PR` column, one `gh` call
  per worktree. Plain `gwm list` is byte-for-byte unchanged and network-free.
- TUI sidebar: `refresh_github_status` (`F`) detects the PR before the
  "nothing linked" guard, so an unlinked branch still surfaces its PR
  (marked " (detected)"). Synchronous, on the existing dedupe/cache path.
- Docs: CHANGELOG, `integrations/github-linking`, `cli/reference`.

## Trade-offs (honest)

- Detection is a `gh` shell-out per branch. Bounded for `status` (1 worktree)
  and the TUI (1 selected, deduped); for `list` it would be N round-trips, so
  it's gated behind `--detect-pr` rather than always-on.
- Not persisted by design (rejected auto-link-to-config: a changed/closed PR
  would leave a stale pin). `gwm link --pr` remains the durable, explicit path.
- The App-level TUI wiring test is `#[cfg(unix)]` (fake-gh shebang script).
  The cross-OS `gh` contract is covered by the pure `github_tests` + the
  `cli_binary` status E2E, which ships a Windows fake-gh too.

## Tests

- [x] `cargo test` passes locally (46 test sections green, under a CI-like
  minimal `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: red first on each surface)
  - `github_tests`: `apply_detected_pr` ×4, `find_pr_argv`, `parse_pr_list_number` ×3
  - `cli_binary`: `status_auto_detects_pr…`, `status_explicit_pr_link_wins…`,
    `list_detect_pr_flag_adds_pr_column…`, `list_without_detect_pr_flag…`
  - `tui_state_github_fetch_tests`: `apply_detected_pr` ×3
  - `tui_app_tests`: `refresh_github_status_auto_detects_pr…` (cfg unix)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README/docs updated (CLI surface changed: `gwm list --detect-pr`)
- [ ] `examples/gwm.toml.example` updated if config schema changed — n/a (no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #181
- Docs: `docs/5.integrations/1.github-linking.md`, `docs/3.cli/1.reference.md`

## Notes for reviewers

The reorder in `refresh_github_status` is the one behavioural subtlety:
detection now runs **before** the "nothing linked" early-return, so a branch
with no issue-in-name and no explicit PR can still fetch a detected PR. The
`#[cfg(unix)]` App test pins exactly that path.