### PR TITLE
🐛 fix(config): hermetic config-loading seams so tests ignore the real global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Test hermeticity** — config-dependent tests no longer read the contributor's real `~/.config/gwm/config.toml`. After #190 added the global-config layer, `aliases::load` and `App::new_at` merged the runner's actual global config, so `cargo test` failed on any machine whose global config diverged from the built-in defaults (e.g. a `[theme] preset` unknown to the checked-out build). Added injectable seams `aliases::load_layered(repo, global, user)` and `App::new_at_layered(start, global)` mirroring `Config::load_layered` (#190); the leaking tests now inject `None` for a fully repo-only, deterministic resolution. Runtime behaviour of `aliases::load` / `App::new_at` is unchanged — they still read the real global config. (#194)
 - The focused panel border (worktree list ↔ sidebar, toggled with `Tab`) now paints with the theme `focus` role instead of a hardcoded `Color::Cyan`, so the active "tab" honours the configured palette (e.g. the `claude-dark` preset's orange) rather than always rendering cyan. The default theme is unchanged (`focus` is still `Cyan`), so default-theme users see no difference. (#185)
 
 ## Past releases

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -133,6 +133,12 @@ impl ResolvedAliases {
 /// `~/.config/gwm/aliases.toml`; an explicit path is honoured even if
 /// it doesn't exist (returns empty user map).
 ///
+/// Production entry point: the repo step merges the **real** user-level
+/// global config (`global_config_path()`) underneath `.gwm.toml`, exactly
+/// like `Config::load_for_repo`. Tests that must not read the runner's
+/// real `~/.config/gwm/` should drive [`load_layered`] instead, which
+/// takes both the global and user paths explicitly (issue #194).
+///
 /// Errors:
 ///   - `GwmError::Config` when a TOML parse fails, an alias shadows a
 ///     built-in subcommand, an alias value contains shell pipeline
@@ -141,25 +147,45 @@ impl ResolvedAliases {
 ///   - `GwmError::Io` if the file exists but can't be read.
 ///   - `GwmError::TomlParse` propagates the underlying serde error.
 pub fn load(repo_root: Option<&Path>, user_path: Option<&Path>) -> Result<ResolvedAliases> {
+  // Resolve the two real-world fallbacks here, then delegate to the
+  // injectable seam so runtime behaviour is unchanged: the repo step sees
+  // the real global config, the user step sees `~/.config/gwm/aliases.toml`
+  // when no explicit path was given.
+  let global = crate::config::global_config_path();
+  let resolved_user_path = user_path.map(PathBuf::from).or_else(default_user_path);
+  load_layered(repo_root, global.as_deref(), resolved_user_path.as_deref())
+}
+
+/// Injectable variant of [`load`] with **no** hidden environment reads
+/// (issue #194). The repo step layers `global_path` underneath the repo's
+/// `.gwm.toml` via [`crate::config::Config::load_layered`]; `user_path` is
+/// taken literally (no `default_user_path` fallback). Passing `None` for
+/// both yields a fully hermetic, repo-only resolution — the seam tests use
+/// so they never depend on the runner's real `~/.config/gwm/`. Mirrors the
+/// `Config::load_for_repo` / `Config::load_layered` pair added in #190.
+pub fn load_layered(
+  repo_root: Option<&Path>,
+  global_path: Option<&Path>,
+  user_path: Option<&Path>,
+) -> Result<ResolvedAliases> {
   let built_in = BUILT_IN_ALIASES.to_vec();
 
-  // Repo: read `.gwm.toml`'s `[aliases]` block via `Config::load_for_repo`,
-  // which already validates the same shadow / shell-pipeline rules via
-  // its dedicated `validate_aliases` method (called below).
+  // Repo: read `.gwm.toml`'s `[aliases]` block via `Config::load_layered`
+  // (injected global), which already validates the same shadow /
+  // shell-pipeline rules via its dedicated `validate_aliases` method.
   let repo = match repo_root {
     Some(root) => {
-      let cfg = crate::config::Config::load_for_repo(root)?;
+      let cfg = crate::config::Config::load_layered(root, global_path)?;
       cfg.aliases
     }
     None => BTreeMap::new(),
   };
 
   // User: same shape, validated through the standalone helper so the
-  // file path appears in the error message.
-  let resolved_user_path = user_path.map(PathBuf::from).or_else(default_user_path);
-  let user = match resolved_user_path {
+  // file path appears in the error message. `user_path` is literal here.
+  let user = match user_path {
     Some(path) if path.exists() => {
-      let raw = std::fs::read_to_string(&path)?;
+      let raw = std::fs::read_to_string(path)?;
       let file: AliasesFile = toml::from_str(&raw)?;
       let map = file.aliases;
       validate_aliases(&map, &format!("{} `[aliases]`", path.display()))?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -248,10 +248,20 @@ impl App {
   }
 
   pub fn new_at(start: Option<&Path>) -> Result<Self> {
+    Self::new_at_layered(start, crate::config::global_config_path().as_deref())
+  }
+
+  /// Injectable variant of [`Self::new_at`] (issue #194): `global_path`
+  /// is the user-level global config layered under the repo's `.gwm.toml`
+  /// (`None` = repo-only, no environment read). Tests pass `None` so `App`
+  /// construction never depends on the runner's real
+  /// `~/.config/gwm/config.toml`. `new_at` delegates with the real
+  /// `global_config_path()`, so runtime behaviour is unchanged.
+  pub fn new_at_layered(start: Option<&Path>, global_path: Option<&Path>) -> Result<Self> {
     let repo = worktree::discover_repo(start)?;
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
     let repo_name = worktree::repo_name(&repo);
-    let config = Config::load_for_repo(&workdir)?;
+    let config = Config::load_layered(&workdir, global_path)?;
     let branch_types = config.resolved_branch_types().types;
     // Resolve the keymap once at construction. Config::load_for_repo
     // already validated the overrides, so this should not surface a

--- a/tests/aliases_tests.rs
+++ b/tests/aliases_tests.rs
@@ -42,7 +42,7 @@ ll = "list --format names"
   )
   .unwrap();
 
-  let cfg = Config::load_for_repo(dir.path()).unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
   assert_eq!(cfg.aliases.len(), 2);
   assert_eq!(cfg.aliases.get("wip").map(String::as_str), Some("create feat 0 wip"));
   assert_eq!(cfg.aliases.get("ll").map(String::as_str), Some("list --format names"));
@@ -63,7 +63,7 @@ list = "create feat 0 wip"
   )
   .unwrap();
 
-  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  let err = Config::load_layered(dir.path(), None).unwrap_err();
   match err {
     GwmError::Config(msg) => {
       assert!(msg.contains("list"), "error must name the offending alias: {msg}");
@@ -92,7 +92,7 @@ fn config_aliases_rejects_shadow_of_visible_built_in_alias() {
       ),
     )
     .unwrap();
-    let err = Config::load_for_repo(dir.path()).unwrap_err();
+    let err = Config::load_layered(dir.path(), None).unwrap_err();
     match err {
       GwmError::Config(msg) => {
         assert!(msg.contains(shadow), "error must name '{shadow}': {msg}");
@@ -126,7 +126,7 @@ copy = "{bad_value}"
       ),
     )
     .unwrap();
-    let err = Config::load_for_repo(dir.path()).unwrap_err();
+    let err = Config::load_layered(dir.path(), None).unwrap_err();
     match err {
       GwmError::Config(msg) => {
         assert!(
@@ -152,7 +152,7 @@ wip = ""
 "#,
   )
   .unwrap();
-  let err = Config::load_for_repo(dir.path()).unwrap_err();
+  let err = Config::load_layered(dir.path(), None).unwrap_err();
   match err {
     GwmError::Config(msg) => assert!(msg.contains("wip"), "{msg}"),
     other => panic!("expected GwmError::Config, got {other:?}"),
@@ -168,7 +168,7 @@ fn resolved_aliases_contains_built_in_set() {
   // Empty repo + no user config still surfaces every visible-alias
   // entry from clap.
   let dir = TempDir::new().unwrap();
-  let resolved = aliases::load(Some(dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(dir.path()), None, None).unwrap();
   assert!(!resolved.built_in.is_empty());
   // Sanity: `s → switch` is the canonical example from issue #43;
   // it MUST live in the built-in list for the chain to be honest.
@@ -209,7 +209,7 @@ ll = "list --format names"
   .unwrap();
   let user_path = user_dir.path().join("aliases.toml");
 
-  let resolved = aliases::load(Some(repo_dir.path()), Some(&user_path)).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, Some(&user_path)).unwrap();
 
   // Repo entry present and wins for "copy".
   assert_eq!(resolved.repo.get("copy").map(String::as_str), Some("path bar"));
@@ -236,7 +236,7 @@ ll = "list --format names"
   .unwrap();
   let user_path = user_dir.path().join("aliases.toml");
 
-  let resolved = aliases::load(Some(repo_dir.path()), Some(&user_path)).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, Some(&user_path)).unwrap();
   assert!(resolved.repo.is_empty());
   assert_eq!(resolved.user.get("ll").map(String::as_str), Some("list --format names"));
 }
@@ -246,7 +246,12 @@ fn resolved_aliases_user_missing_file_is_no_op() {
   // An absent user file is the common case (fresh install). It must
   // not fail load, it must resolve to an empty user map.
   let repo_dir = TempDir::new().unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), Some(std::path::Path::new("/nope/aliases.toml"))).unwrap();
+  let resolved = aliases::load_layered(
+    Some(repo_dir.path()),
+    None,
+    Some(std::path::Path::new("/nope/aliases.toml")),
+  )
+  .unwrap();
   assert!(resolved.repo.is_empty());
   assert!(resolved.user.is_empty());
 }
@@ -266,7 +271,7 @@ copy = "path | pbcopy"
   )
   .unwrap();
   let user_path = user_dir.path().join("aliases.toml");
-  let err = aliases::load(None, Some(&user_path)).unwrap_err();
+  let err = aliases::load_layered(None, None, Some(&user_path)).unwrap_err();
   match err {
     GwmError::Config(msg) => {
       assert!(msg.contains("copy"), "{msg}");
@@ -288,7 +293,7 @@ list = "list --format names"
   )
   .unwrap();
   let user_path = user_dir.path().join("aliases.toml");
-  let err = aliases::load(None, Some(&user_path)).unwrap_err();
+  let err = aliases::load_layered(None, None, Some(&user_path)).unwrap_err();
   match err {
     GwmError::Config(msg) => assert!(msg.contains("list"), "{msg}"),
     other => panic!("expected GwmError::Config, got {other:?}"),
@@ -301,7 +306,7 @@ list = "list --format names"
 fn expand_argv_no_match_passes_through_unchanged() {
   // Argv that doesn't start with an alias is returned verbatim. The
   // dispatcher (clap) still sees what the user typed.
-  let resolved = aliases::load(None, None).unwrap();
+  let resolved = aliases::load_layered(None, None, None).unwrap();
   let argv = vec!["gwm".into(), "list".into(), "--format".into(), "names".into()];
   assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
 }
@@ -317,7 +322,7 @@ wip = "create feat 0 wip"
 "#,
   )
   .unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, None).unwrap();
   let argv = vec!["gwm".into(), "wip".into()];
   assert_eq!(
     aliases::expand_argv(argv, &resolved),
@@ -365,7 +370,7 @@ wip = "create feat 0 wip"
 "#,
   )
   .unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, None).unwrap();
   let argv = vec!["gwm".into(), "wip".into(), "--no-bootstrap".into()];
   assert_eq!(
     aliases::expand_argv(argv, &resolved),
@@ -388,7 +393,7 @@ wip = "create feat 0 wip"
   )
   .unwrap();
   let user_path = user_dir.path().join("aliases.toml");
-  let resolved = aliases::load(None, Some(&user_path)).unwrap();
+  let resolved = aliases::load_layered(None, None, Some(&user_path)).unwrap();
   let argv = vec!["gwm".into(), "create".into(), "feat".into(), "86".into(), "wip".into()];
   assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
 }
@@ -411,7 +416,7 @@ ll = "list --format names"
 "#,
   )
   .unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, None).unwrap();
   let argv = vec!["gwm".into(), "wip".into()];
   // After ONE expansion, argv[1] is `ll` — recursion would substitute
   // it again, but we explicitly don't.
@@ -421,7 +426,7 @@ ll = "list --format names"
 #[test]
 fn expand_argv_empty_argv_passes_through() {
   // `gwm` (no args, opens the TUI) must not be touched.
-  let resolved = aliases::load(None, None).unwrap();
+  let resolved = aliases::load_layered(None, None, None).unwrap();
   let argv = vec!["gwm".into()];
   assert_eq!(aliases::expand_argv(argv.clone(), &resolved), argv);
 }
@@ -443,7 +448,7 @@ wip = "create feat 0 wip"
 "#,
   )
   .unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, None).unwrap();
   let argv = vec!["gwm".into(), "--allow-bootstrap".into(), "wip".into()];
   assert_eq!(
     aliases::expand_argv(argv, &resolved),
@@ -470,7 +475,7 @@ wip = "create feat 0 wip"
 "#,
   )
   .unwrap();
-  let resolved = aliases::load(Some(repo_dir.path()), None).unwrap();
+  let resolved = aliases::load_layered(Some(repo_dir.path()), None, None).unwrap();
   let argv: Vec<OsString> = vec!["gwm".into(), "--allow-bootstrap".into(), "wip".into()];
   let expected: Vec<OsString> = vec![
     "gwm".into(),
@@ -492,7 +497,7 @@ fn expand_argv_os_passes_non_utf8_token_through_unchanged() {
   // let clap surface the unknown subcommand verbatim".
   use std::ffi::OsString;
   use std::os::unix::ffi::OsStringExt;
-  let resolved = aliases::load(None, None).unwrap();
+  let resolved = aliases::load_layered(None, None, None).unwrap();
   let bad: OsString = OsString::from_vec(vec![0xff, 0xfe, 0x80]);
   let argv: Vec<OsString> = vec!["gwm".into(), bad.clone()];
   let out = aliases::expand_argv_os(argv.clone(), &resolved);
@@ -512,7 +517,7 @@ fn expand_argv_os_expands_alias_after_non_utf8_flag_value() {
   // String), and argv flows through unchanged.
   use std::ffi::OsString;
   use std::os::unix::ffi::OsStringExt;
-  let resolved = aliases::load(None, None).unwrap();
+  let resolved = aliases::load_layered(None, None, None).unwrap();
   let bad: OsString = OsString::from_vec(vec![0xff]);
   let argv: Vec<OsString> = vec!["gwm".into(), "--verbose".into(), bad.clone()];
   let out = aliases::expand_argv_os(argv.clone(), &resolved);

--- a/tests/tui_theme_integration_tests.rs
+++ b/tests/tui_theme_integration_tests.rs
@@ -16,7 +16,7 @@ fn app_theme_defaults_when_no_config() {
   // The pre-#33 hardcoded palette is preserved verbatim (the Claude
   // orange is opt-in via the `claude-dark` preset, not the default).
   let (dir, _) = init_repo();
-  let app = App::new_at(Some(dir.path())).unwrap();
+  let app = App::new_at_layered(Some(dir.path()), None).unwrap();
   assert_eq!(app.theme, Theme::default());
   assert_eq!(app.theme.focus, Color::Cyan);
 }
@@ -36,7 +36,7 @@ preset = "catppuccin"
 "#,
   )
   .unwrap();
-  let app = App::new_at(Some(dir.path())).unwrap();
+  let app = App::new_at_layered(Some(dir.path()), None).unwrap();
   assert_ne!(app.theme, Theme::default(), "preset must change at least one role");
 }
 
@@ -51,7 +51,7 @@ focus = "red"
 "#,
   )
   .unwrap();
-  let app = App::new_at(Some(dir.path())).unwrap();
+  let app = App::new_at_layered(Some(dir.path()), None).unwrap();
   assert_eq!(app.theme.focus, Color::Red);
   // Other roles untouched.
   assert_eq!(app.theme.branch, Theme::default().branch);


### PR DESCRIPTION
## Description

After #190 added the user-level global config layer, config-dependent tests
became **non-hermetic**: anything loading via `Config::load_for_repo` — directly,
or through `aliases::load` / `App::new_at` — merged the contributor's real
`~/.config/gwm/config.toml`. On a machine whose global config diverges from the
built-in defaults, `cargo test` fails independently of the code under test.

Witnessed locally: a global `[theme] preset = "claude-dark"` (a preset only on
the unmerged #186) makes `theme.resolve()` reject the merged config, panicking
`aliases_tests.rs` (10 tests) and `tui_theme_integration_tests.rs` (2 tests) on
`.unwrap()`. CI is green only because it exports `GWM_NO_GLOBAL_CONFIG=1` (#191);
local runs have no such guard.

Closes #194

## Type of change
- [x] 🐛 Fix (bug fix)

## Changes
- Add `aliases::load_layered(repo, global, user)` — mirrors `Config::load_layered`
  (#190); repo step reads via `Config::load_layered`, user step takes the path
  literally (no implicit `default_user_path` fallback).
- Add `App::new_at_layered(start, global)` — same seam for the TUI app builder.
- `aliases::load` / `App::new_at` keep their signatures and runtime behaviour:
  they resolve the real global/user paths then delegate.
- Convert the leaking tests to inject `None` global (and explicit/`None` user
  paths) so the suite is deterministic without `GWM_NO_GLOBAL_CONFIG`.

## Tests
- [x] `cargo test` passes locally **without** `GWM_NO_GLOBAL_CONFIG` (the whole point — verified against a real `~/.config/gwm/config.toml` containing `claude-dark`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` — the converted tests now exercise the new seams

## Checklist
- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a — no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs
- Issue: #194

## Notes for reviewers
- Purely additive on the production side (`load_layered` / `new_at_layered` are
  new seams); the existing entry points are unchanged for real runtime use.
- This is the same hermeticity pattern #190 established in `tests/config_global_tests.rs`, now propagated to the two remaining leak paths.
- Independent of #188 (sidebar) — surfaced while validating that branch locally.