### PR TITLE
⬆️ chore(deps): migrate to git2 0.21 (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+
+- ⬆️ `git2` `0.20` → `0.21` ([#169](https://github.com/kbrdn1/gwm-cli/issues/169)). A breaking source migration, not just a version bump: git2 0.21 reworks the UTF-8 accessors `Reference::shorthand` / `Reference::name` / `Remote::url` / `Buf::as_str` to return `Result<&str, git2::Error>` (was `Option<&str>`), `Commit::summary` to `Result<Option<&str>, _>`, and `StringArray::iter` to yield `Result<Option<&str>, _>`; `Oid::zero` is deprecated in favour of the `Oid::ZERO_SHA1` constant. All call sites now collapse the new `Err` arm to `None` via `.ok()` so the observable behaviour (a non-UTF-8 / absent name is treated as missing) is preserved. Side effect: git2 0.21 drops its `url` dependency, pruning the whole `idna` / `icu_*` transitive tree from `Cargo.lock`. Closes Dependabot [#157](https://github.com/kbrdn1/gwm-cli/pull/157).
+
 ### Docs
 
 - 📝 Sync the root `README.md` landing page to the v0.8.0 surface and fix the MSRV badge (`1.80+` → `1.82+`) ([#203](https://github.com/kbrdn1/gwm-cli/issues/203)). The "what gwm does" list now covers the config CLI + user-level global config, lifecycle hooks, CLI aliases + Gitmoji, the GitHub `gwm new` / `gwm pr` workflow with PR auto-detection, safety-daily (`--dry-run`, `gwm undo` / `gwm history`), `gwm sync`, and TUI personalisation (themes / remappable keymap / command palette / stashes). Follow-up to the #199 docs refresh — landing page only, every feature keeps its dedicated section under `docs/`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,17 +631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,15 +743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,15 +814,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -966,88 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,27 +955,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -1258,12 +1134,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1485,12 +1355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,15 +1494,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "powerfmt"
@@ -2100,12 +1955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,17 +2007,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2315,16 +2153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,24 +2260,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2906,35 +2716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,60 +2729,6 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ clap = { version = "4.5", features = ["derive", "color"] }
 clap_complete = "4.5"
 ratatui = "0.30"
 crossterm = "0.29"
-git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
+git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1976,6 +1976,7 @@ fn current_branch(repo: &Repository) -> Result<String> {
   })?;
   head
     .shorthand()
+    .ok()
     .map(|s| s.to_string())
     .ok_or_else(|| GwmError::UnbornHead {
       reason: "HEAD has no shorthand (detached?)".into(),
@@ -2620,7 +2621,7 @@ fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -
 fn origin_url_for_repo(repo: Option<&Repository>) -> Option<String> {
   let r = repo?;
   let remote = r.find_remote("origin").ok()?;
-  remote.url().map(|s| s.to_string())
+  remote.url().ok().map(|s| s.to_string())
 }
 
 /// Interactive y/N/show loop. Prints a one-shot summary of the

--- a/src/github.rs
+++ b/src/github.rs
@@ -197,6 +197,7 @@ pub fn repo_slug(repo: &Repository) -> Result<String> {
     .map_err(|_| GwmError::Other("no 'origin' remote configured".into()))?;
   let url = remote
     .url()
+    .ok()
     .ok_or_else(|| GwmError::Other("origin remote has no URL (non-utf8?)".into()))?
     .to_string();
   parse_github_slug(&url)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -102,11 +102,12 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
   }
   let branch_short = head
     .shorthand()
+    .ok()
     .ok_or_else(|| GwmError::UnbornHead {
       reason: "sync: HEAD has no branch name".into(),
     })?
     .to_string();
-  let head_refname = head.name().map(|s| s.to_string());
+  let head_refname = head.name().ok().map(|s| s.to_string());
 
   let local = repo
     .find_branch(&branch_short, BranchType::Local)
@@ -129,7 +130,7 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
   let remote = head_refname
     .as_deref()
     .and_then(|rn| repo.branch_upstream_remote(rn).ok())
-    .and_then(|buf| buf.as_str().map(|s| s.to_string()));
+    .and_then(|buf| buf.as_str().ok().map(|s| s.to_string()));
 
   // 3. Fetch. After this the in-memory `repo` ref cache is stale, so
   //    everything past here re-resolves against a freshly opened repo.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -343,7 +343,7 @@ impl App {
       .repo
       .find_remote("origin")
       .ok()
-      .and_then(|r| r.url().map(String::from));
+      .and_then(|r| r.url().ok().map(String::from));
     let origin = trust::resolve_origin_key(origin_url.as_deref(), &self.workdir);
 
     match trust::evaluate(&self.workdir, &origin, self.trust_mode)? {
@@ -1244,10 +1244,13 @@ impl App {
   }
 
   fn selected_branch_name(&self) -> Option<String> {
-    self
-      .selected()
-      .and_then(|w| w.branch.clone())
-      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))
+    self.selected().and_then(|w| w.branch.clone()).or_else(|| {
+      self
+        .repo
+        .head()
+        .ok()
+        .and_then(|h| h.shorthand().ok().map(|s| s.to_string()))
+    })
   }
 
   pub fn current_link(&self) -> &BranchLink {
@@ -1483,7 +1486,13 @@ impl App {
     let branch = self
       .selected()
       .and_then(|w| w.branch.clone())
-      .or_else(|| self.repo.head().ok().and_then(|h| h.shorthand().map(|s| s.to_string())))
+      .or_else(|| {
+        self
+          .repo
+          .head()
+          .ok()
+          .and_then(|h| h.shorthand().ok().map(|s| s.to_string()))
+      })
       .ok_or_else(|| GwmError::Other("no branch resolved for selected worktree".into()))?;
     match target {
       LinkTarget::Issue => github::link_issue(&self.repo, &branch, n)?,

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -152,7 +152,7 @@ pub fn box_drawing_chars(up: bool, down: bool, left: bool, right: bool) -> (char
 /// commit. Zero OID is outside normal `git log` output and keeps pipe
 /// comparisons allocation-free.
 fn start_hash() -> Oid {
-  Oid::zero()
+  Oid::ZERO_SHA1
 }
 
 /// Walk `commits` once, producing the per-row pipe sets. This is the

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -203,7 +203,9 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
   }
 
   let names = repo.worktrees()?;
-  for name in names.iter().flatten().flatten() {
+  // `StringArray::iter` yields `Result<Option<&str>, _>`; skip both the
+  // `Err` (non-UTF-8 entry) and `None` arms so `name` is a plain `&str`.
+  for name in names.iter().filter_map(|r| r.ok().flatten()) {
     let wt = match repo.find_worktree(name) {
       Ok(w) => w,
       Err(_) => continue,
@@ -396,7 +398,9 @@ pub struct PrunableEntry {
 pub fn prunable_worktrees(repo: &Repository) -> Result<Vec<PrunableEntry>> {
   let names = repo.worktrees()?;
   let mut out = Vec::new();
-  for name in names.iter().flatten().flatten() {
+  // `StringArray::iter` yields `Result<Option<&str>, _>`; skip both the
+  // `Err` (non-UTF-8 entry) and `None` arms so `name` is a plain `&str`.
+  for name in names.iter().filter_map(|r| r.ok().flatten()) {
     let wt = match repo.find_worktree(name) {
       Ok(w) => w,
       Err(_) => continue,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -120,7 +120,7 @@ fn compute_status(repo: &Repository) -> BranchStatus {
 
   // Ahead / behind vs upstream
   if let Ok(head_ref) = repo.head() {
-    if let Some(shorthand) = head_ref.shorthand() {
+    if let Ok(shorthand) = head_ref.shorthand() {
       if let Ok(local_branch) = repo.find_branch(shorthand, BranchType::Local) {
         if let Ok(upstream) = local_branch.upstream() {
           if let (Some(local_oid), Some(up_oid)) = (head_ref.target(), upstream.into_reference().target()) {
@@ -176,7 +176,9 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
   // The main worktree is not listed by git2::Repository::worktrees(); add it manually.
   if let Some(workdir) = repo.workdir() {
     let head_ref = repo.head().ok();
-    let branch = head_ref.as_ref().and_then(|r| r.shorthand().map(|s| s.to_string()));
+    let branch = head_ref
+      .as_ref()
+      .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
     let head = head_ref.as_ref().and_then(|r| r.target().map(|o| o.to_string()));
     let link = branch
       .as_deref()
@@ -201,7 +203,7 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
   }
 
   let names = repo.worktrees()?;
-  for name in names.iter().flatten() {
+  for name in names.iter().flatten().flatten() {
     let wt = match repo.find_worktree(name) {
       Ok(w) => w,
       Err(_) => continue,
@@ -217,7 +219,9 @@ pub fn list(repo: &Repository) -> Result<Vec<WorktreeInfo>> {
     let (branch, head, status, age) = match Repository::open(&path) {
       Ok(sub) => {
         let head_ref = sub.head().ok();
-        let b = head_ref.as_ref().and_then(|r| r.shorthand().map(|s| s.to_string()));
+        let b = head_ref
+          .as_ref()
+          .and_then(|r| r.shorthand().ok().map(|s| s.to_string()));
         let h = head_ref.as_ref().and_then(|r| r.target().map(|o| o.to_string()));
         let s = compute_status(&sub);
         // The trunk-baseline lookup must run against the main repo's
@@ -294,7 +298,7 @@ pub fn add(
   // record points at the actual parent (`main` / `dev` / a release
   // train), not the freshly-created `branch_name` itself.
   let head_ref = repo.head()?;
-  let head_short = head_ref.shorthand().map(|s| s.to_string());
+  let head_short = head_ref.shorthand().ok().map(|s| s.to_string());
   let head_commit = head_ref.peel_to_commit()?;
   let branch = match repo.find_branch(branch_name, git2::BranchType::Local) {
     Ok(b) => {
@@ -340,7 +344,7 @@ pub fn remove(repo: &Repository, name: &str, delete_branch: bool) -> Result<()> 
 
   // Capture the branch (if any) so we can drop it after pruning.
   let branch_name = match Repository::open(&path) {
-    Ok(sub) => sub.head().ok().and_then(|r| r.shorthand().map(|s| s.to_string())),
+    Ok(sub) => sub.head().ok().and_then(|r| r.shorthand().ok().map(|s| s.to_string())),
     Err(_) => None,
   };
 
@@ -392,7 +396,7 @@ pub struct PrunableEntry {
 pub fn prunable_worktrees(repo: &Repository) -> Result<Vec<PrunableEntry>> {
   let names = repo.worktrees()?;
   let mut out = Vec::new();
-  for name in names.iter().flatten() {
+  for name in names.iter().flatten().flatten() {
     let wt = match repo.find_worktree(name) {
       Ok(w) => w,
       Err(_) => continue,
@@ -533,7 +537,7 @@ fn recent_commits_revwalk(repo: &Repository, tip: git2::Oid, limit: usize) -> Re
       hash: oid,
       author: commit.author().name().unwrap_or("").to_string(),
       parents: commit.parent_ids().collect(),
-      subject: commit.summary().unwrap_or("").to_string(),
+      subject: commit.summary().ok().flatten().unwrap_or("").to_string(),
     });
   }
   Ok(rows)


### PR DESCRIPTION
## Description

Migrate `git2` `0.20` → `0.21`. This is the deferred follow-up to Dependabot #157: the bump is a **breaking source migration**, not a mechanical version change, so it was kept out of the v0.8.0-rc.3 cut (house rule: *follow-up issues beat scope creep*) and tracked as #169.

Closes #169

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

git2 0.21 reworks its UTF-8 accessors from `Option` to `Result`. Adapted every call site, collapsing the new `Err` arm to `None` with `.ok()` so observable behaviour is **unchanged** (a non-UTF-8 / absent name still reads as "missing"):

- `Reference::shorthand` / `Reference::name` / `Remote::url` / `Buf::as_str`: `Option<&str>` → `Result<&str, git2::Error>`.
- `Commit::summary`: `Option<&str>` → `Result<Option<&str>, _>` (now `.ok().flatten()`).
- `StringArray::iter`: yields `Result<Option<&str>, _>` → the worktree-listing loops gain a second `.flatten()`.
- `Oid::zero` (deprecated) → `Oid::ZERO_SHA1` constant.
- Touched: `src/cli.rs`, `src/github.rs`, `src/sync.rs`, `src/tui/app.rs`, `src/tui/commit_graph.rs`, `src/worktree.rs`.
- **Side effect**: git2 0.21 drops its `url` dependency, pruning the whole `idna` / `icu_*` transitive tree from `Cargo.lock` (−294 lines, lock only).

## Tests

- [x] `cargo test` passes locally (all suites green, incl. `tests/worktree_integration.rs`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

> **TDD note.** Per CLAUDE.md, a behaviour-preserving dependency migration is the one carve-out where *CI green is the test*. The accessor changes are covered by the existing `tests/worktree_integration.rs` suite. No new test was added because the migration is observably a no-op: the new `Err` arm (non-UTF-8 ref / remote URL) collapses to the same `None` the 0.20 API already returned, so no new code path is reachable from the public surface. Confirmed the full suite passes against a stripped CI-like `PATH`.

## Screenshots / TUI captures

N/A — no rendering change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a — no surface change)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## MSRV

- [x] `cargo clippy --all-targets -- -W clippy::incompatible_msrv` clean against MSRV 1.82 — git2 0.21 introduces no newer-than-1.82 API on the paths we touch.

## Linked issues / docs

- Issue: #169
- Related PR: #157 (Dependabot — superseded by this PR; will be closed)

## Notes for reviewers

- The `.ok()` conversions are deliberately behaviour-preserving; the alternative (propagating the new `Err`) would change the "non-UTF-8 ref → treated as absent" contract that several call sites rely on.
- The large `Cargo.lock` delta is entirely the `url`/`idna`/`icu_*` tree that git2 0.21 no longer pulls — no first-party crate was downgraded.
