### PR TITLE
✨ feat(tui): statusbar contextuelle, modales, layout & focus polish (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Added
+
+- TUI: direct pane-focus keys — `1` focuses the worktrees pane,
+  `2` opens (if hidden) and focuses the status pane. Both are
+  rebindable as `focus_worktrees` / `focus_status` under `[tui.keys]`;
+  `Tab` keeps its toggle. (#217)
+- TUI: contextual statusbar — a context chip (`worktrees` / `status` /
+  `switch`) on the left, an animated loading spinner while a GitHub
+  fetch is inflight, contextual hints in the middle, and the action log
+  pinned right with absolute priority. (#217)
+- TUI: a bottom-right `selected of visible` counter on the worktrees
+  pane, lazygit-style. (#217)
+- TUI: GitHub issue/PR status (`F`) is fetched off-thread, so the
+  statusbar spinner animates during the `gh` shell-out instead of the
+  event loop blocking. (#217)
+
+### Changed
+
+- TUI: the sidebar now defaults to the stacked layout (status pane under
+  the worktrees table), and the split ratios are tuned per axis —
+  42% / 58% stacked, 55% / 45% side-by-side. The orientation cycle
+  (`V`) is unchanged. (#217)
+- TUI: panes are labelled `[1] Worktrees (N)` and the help overlay is
+  titled `Keybindings` with a centred context subtitle. (#217)
+- TUI: modal overlays centre their titles and gain internal padding; the
+  confirm-delete buttons render as flat coloured chips (` Confirm ` /
+  ` Cancel `) instead of `[ Confirm ]` / `[ Cancel ]`. (#217)
+
+### Fixed
+
+- TUI: the sidebar Issue/PR block prompted `press R to fetch status`,
+  but `R` runs the review launcher — it now resolves the live
+  `fetch_github` binding (`F` by default). (#217)
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,16 +34,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`V`) is unchanged. (#217)
 - TUI: panes are labelled `[1] Worktrees (N)` and `[2] Status` (the focus
   mnemonics for the `1` / `2` keys), and the help overlay is titled
-  `Keybindings` with a centred context subtitle. (#217)
+  `Keybindings` with a centred context subtitle in a distinct colour. Its
+  section headers are Title-Cased (`Global`, `List View`, `Issue / PR`,
+  `Create Form`, `Confirm Delete`), and the overlay now scrolls
+  (`j`/`k`, `g`/`G`) when it outgrows the modal. (#217)
 - TUI: modal overlays lift their title off the border into the frame as a
   centred line and gain interior padding on every side, so no content hugs
   the edge; the confirm-delete buttons render as flat coloured chips
   (` Confirm ` / ` Cancel `) instead of `[ Confirm ]` / `[ Cancel ]`. (#217)
 - TUI: the create-worktree modal is reworked — the branch type is a
-  horizontal `‹ name ›` selector (Left/Right or Up/Down), the issue and
-  description fields are single-row inputs with a background surface
-  (was 3-row bordered boxes), and the modal grows a ` Create ` / ` Cancel `
-  button row plus a control hint. (#217)
+  horizontal `‹ name ›` selector (Left/Right or Up/Down) whose focused
+  value reads as a highlighted chip, the issue and description fields are
+  single-row inputs with a background surface (was 3-row bordered boxes)
+  with vertical gaps between rows, the live branch/dir preview sits above
+  the inputs, the modal width is capped so it doesn't span a wide
+  terminal, and it grows a ` Create ` / ` Cancel ` button row plus a
+  control hint. (#217)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the worktrees table), and the split ratios are tuned per axis —
   42% / 58% stacked, 55% / 45% side-by-side. The orientation cycle
   (`V`) is unchanged. (#217)
-- TUI: panes are labelled `[1] Worktrees (N)` and the help overlay is
-  titled `Keybindings` with a centred context subtitle. (#217)
+- TUI: panes are labelled `[1] Worktrees (N)` and `[2] Status` (the focus
+  mnemonics for the `1` / `2` keys), and the help overlay is titled
+  `Keybindings` with a centred context subtitle. (#217)
 - TUI: modal overlays centre their titles and gain internal padding; the
   confirm-delete buttons render as flat coloured chips (` Confirm ` /
   ` Cancel `) instead of `[ Confirm ]` / `[ Cancel ]`. (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control hint. The branch type also cycles with `h` / `l` (vim), and the
   issue/description fields are length-capped so the resolved branch name
   stays within git's ref limit. (#217)
+- TUI: the create-worktree modal opens focused on the Issue field rather
+  than the cycle-only Type field, so the first keypress edits text
+  instead of being a silent no-op (the branch type keeps its default and
+  stays reachable via Shift-Tab). (#217)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with vertical gaps between rows, the live branch/dir preview sits above
   the inputs, the modal width is capped so it doesn't span a wide
   terminal, and it grows a ` Create ` / ` Cancel ` button row plus a
-  control hint. (#217)
+  control hint. The branch type also cycles with `h` / `l` (vim), and the
+  issue/description fields are length-capped so the resolved branch name
+  stays within git's ref limit. (#217)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than the cycle-only Type field, so the first keypress edits text
   instead of being a silent no-op (the branch type keeps its default and
   stays reachable via Shift-Tab). (#217)
+- TUI: the link prompt's target step is reworked into a titled (`Link`)
+  vertical selectable list — `j`/`k` (or arrows) move the highlight and
+  `Enter` links the highlighted row, while `i`/`p` stay direct picks. The
+  picker state machine and its key handler are extracted into a testable
+  `App::handle_link_prompt_key` (mirroring the create modal). (#217)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TUI: panes are labelled `[1] Worktrees (N)` and `[2] Status` (the focus
   mnemonics for the `1` / `2` keys), and the help overlay is titled
   `Keybindings` with a centred context subtitle. (#217)
-- TUI: modal overlays centre their titles and gain internal padding; the
-  confirm-delete buttons render as flat coloured chips (` Confirm ` /
-  ` Cancel `) instead of `[ Confirm ]` / `[ Cancel ]`. (#217)
+- TUI: modal overlays lift their title off the border into the frame as a
+  centred line and gain interior padding on every side, so no content hugs
+  the edge; the confirm-delete buttons render as flat coloured chips
+  (` Confirm ` / ` Cancel `) instead of `[ Confirm ]` / `[ Cancel ]`. (#217)
+- TUI: the create-worktree modal is reworked — the branch type is a
+  horizontal `‹ name ›` selector (Left/Right or Up/Down), the issue and
+  description fields are single-row inputs with a background surface
+  (was 3-row bordered boxes), and the modal grows a ` Create ` / ` Cancel `
+  button row plus a control hint. (#217)
 
 ### Fixed
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -394,20 +394,35 @@ const PR_JSON_FIELDS: &str = "number,title,state,isDraft,url,updatedAt,statusChe
 
 /// Run `gh issue view <n> --repo <slug> --json …` and parse the result.
 pub fn fetch_issue(slug: &str, number: u64) -> Result<IssueStatus> {
-  let stdout = run_gh([
-    "issue",
-    "view",
-    &number.to_string(),
-    "--repo",
-    slug,
-    "--json",
-    ISSUE_JSON_FIELDS,
-  ])?;
+  fetch_issue_with(&gh_program(), slug, number)
+}
+
+/// [`fetch_issue`] with an explicitly resolved `gh` program path. Used by
+/// the TUI's off-thread fetch (issue #217): the program is resolved on the
+/// main thread via [`gh_program`] and handed to the worker thread, so the
+/// thread never touches `GWM_GH` / the process environment concurrently
+/// with env-mutating callers.
+pub fn fetch_issue_with(program: &OsStr, slug: &str, number: u64) -> Result<IssueStatus> {
+  let stdout = run_gh_with(
+    program,
+    [
+      "issue",
+      "view",
+      &number.to_string(),
+      "--repo",
+      slug,
+      "--json",
+      ISSUE_JSON_FIELDS,
+    ],
+  )?;
   parse_issue_json(&stdout)
 }
 
-fn gh_command() -> Command {
-  Command::new(std::env::var_os("GWM_GH").unwrap_or_else(|| "gh".into()))
+/// Resolve the `gh` program to invoke: `$GWM_GH` when set (test / override
+/// hook), else `gh` on `PATH`. Read once on the calling thread so off-thread
+/// fetches can capture it without re-reading the environment.
+pub fn gh_program() -> OsString {
+  std::env::var_os("GWM_GH").unwrap_or_else(|| "gh".into())
 }
 
 pub fn create_issue(req: &IssueCreateRequest<'_>) -> Result<CreatedIssue> {
@@ -484,15 +499,25 @@ pub fn create_pr(req: &PrCreateRequest<'_>) -> Result<CreatedPr> {
 
 /// Run `gh pr view <n> --repo <slug> --json …` and parse the result.
 pub fn fetch_pr(slug: &str, number: u64) -> Result<PrStatus> {
-  let stdout = run_gh([
-    "pr",
-    "view",
-    &number.to_string(),
-    "--repo",
-    slug,
-    "--json",
-    PR_JSON_FIELDS,
-  ])?;
+  fetch_pr_with(&gh_program(), slug, number)
+}
+
+/// [`fetch_pr`] with an explicitly resolved `gh` program path — PR-side
+/// counterpart to [`fetch_issue_with`], used by the TUI off-thread fetch
+/// (issue #217).
+pub fn fetch_pr_with(program: &OsStr, slug: &str, number: u64) -> Result<PrStatus> {
+  let stdout = run_gh_with(
+    program,
+    [
+      "pr",
+      "view",
+      &number.to_string(),
+      "--repo",
+      slug,
+      "--json",
+      PR_JSON_FIELDS,
+    ],
+  )?;
   parse_pr_json(&stdout)
 }
 
@@ -549,7 +574,18 @@ where
   I: IntoIterator<Item = S>,
   S: AsRef<OsStr>,
 {
-  let output = gh_command()
+  run_gh_with(&gh_program(), args)
+}
+
+/// [`run_gh`] against an explicitly resolved `gh` program. Lets callers on
+/// a worker thread (issue #217) avoid re-reading `GWM_GH` / the process
+/// environment concurrently with env-mutating code on other threads.
+fn run_gh_with<I, S>(program: &OsStr, args: I) -> Result<String>
+where
+  I: IntoIterator<Item = S>,
+  S: AsRef<OsStr>,
+{
+  let output = Command::new(program)
     .args(args)
     .output()
     .map_err(|e| GwmError::CommandFailed(format!("gh: failed to spawn ({}). Is `gh` installed and on PATH?", e)))?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -703,15 +703,39 @@ impl App {
   }
 
   /// The live UI context driving the statusbar chip + help subtitle (issue
-  /// #217): `Picker` in `gwm switch`, `Status` when the sidebar holds focus,
-  /// `Worktrees` otherwise.
+  /// #217). An open modal / overlay wins over the pane focus (issue #217
+  /// review P2): when the create form is up, the statusbar must advertise
+  /// the form's keys, not the worktrees pane's `n new` — pressing `n` there
+  /// types text. Only `View::List` falls through to the pane context
+  /// (`Picker` in `gwm switch`, `Status` when the sidebar holds focus, else
+  /// `Worktrees`).
   pub fn hint_context(&self) -> super::ui::HintContext {
+    use super::ui::HintContext;
+    match self.view {
+      View::Create => HintContext::Create,
+      View::Confirm => HintContext::Confirm,
+      View::OpenMenu => HintContext::OpenMenu,
+      View::LinkPrompt => HintContext::LinkPrompt,
+      View::CommandPalette => HintContext::CommandPalette,
+      View::Report => HintContext::Report,
+      View::Help => HintContext::Help,
+      View::List => self.pane_hint_context(),
+    }
+  }
+
+  /// The underlying list-view pane context (issue #217), ignoring any open
+  /// overlay. Drives the help overlay's subtitle + picker-section gating:
+  /// `?` documents the keys for the pane you were on, so it must NOT collapse
+  /// to the `Help` context that [`Self::hint_context`] returns while the
+  /// overlay is up.
+  pub fn pane_hint_context(&self) -> super::ui::HintContext {
+    use super::ui::HintContext;
     if self.picker_mode {
-      super::ui::HintContext::Picker
+      HintContext::Picker
     } else if self.sidebar.open && self.sidebar.focused {
-      super::ui::HintContext::Status
+      HintContext::Status
     } else {
-      super::ui::HintContext::Worktrees
+      HintContext::Worktrees
     }
   }
 
@@ -1450,11 +1474,15 @@ impl App {
   pub fn drain_github_results(&mut self) -> bool {
     let mut applied = false;
     while let Ok(msg) = self.github_rx.try_recv() {
-      applied = true;
-      match msg {
+      // Only count results `complete_*` actually applied — a result whose
+      // inflight slot was invalidated mid-flight (#138) is dropped and must
+      // NOT trigger a status report over the current message (issue #217
+      // review P2).
+      let did_apply = match msg {
         GithubFetchMsg::Issue(n, r) => self.github.complete_issue(n, r),
         GithubFetchMsg::Pr(n, r) => self.github.complete_pr(n, r),
-      }
+      };
+      applied |= did_apply;
     }
     // Once nothing is left loading, swap the "fetching…" placeholder for the
     // real outcome (refreshed / partial failure / failure).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1423,10 +1423,18 @@ impl App {
   fn spawn_github_fetch(&self, key: super::state::github_fetch::FetchKey, slug: String) {
     use super::state::github_fetch::FetchKey;
     let tx = self.github_tx.clone();
+    // Resolve the `gh` program on THIS (main) thread and hand it to the
+    // worker, so the worker never reads `GWM_GH` / the process environment
+    // concurrently with env-mutating code elsewhere (the `env_lock`
+    // unsoundness the worker would otherwise reintroduce — issue #217).
+    let program = github::gh_program();
     std::thread::spawn(move || {
       let msg = match key {
-        FetchKey::Issue(n) => GithubFetchMsg::Issue(n, github::fetch_issue(&slug, n).map_err(|e| e.to_string())),
-        FetchKey::Pr(n) => GithubFetchMsg::Pr(n, github::fetch_pr(&slug, n).map_err(|e| e.to_string())),
+        FetchKey::Issue(n) => GithubFetchMsg::Issue(
+          n,
+          github::fetch_issue_with(&program, &slug, n).map_err(|e| e.to_string()),
+        ),
+        FetchKey::Pr(n) => GithubFetchMsg::Pr(n, github::fetch_pr_with(&program, &slug, n).map_err(|e| e.to_string())),
       };
       let _ = tx.send(msg);
     });

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,7 @@
 use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
-use super::state::create_form::CreateForm;
+use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
 use super::state::github_fetch::GitHubFetch;
 use super::state::link_prompt::LinkPrompt;
@@ -78,6 +78,20 @@ pub enum View {
   /// / `palette_cycle_*` / `accept_command_palette` /
   /// `close_command_palette`.
   CommandPalette,
+}
+
+/// What the run loop must do after [`App::handle_create_key`] processes a
+/// key in the create overlay (issue #217). Keeps the side effects
+/// (worktree creation, view transition) in the loop while the form
+/// mutations stay in the testable handler.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CreateKey {
+  /// The key mutated form state (or was ignored); stay in the overlay.
+  Handled,
+  /// `Enter` on the description field — the loop should run `submit_create`.
+  Submit,
+  /// `Esc` — the loop should close the overlay back to the list.
+  Cancel,
 }
 
 /// Target of an open / link action. Canonical definition lives in
@@ -1008,6 +1022,37 @@ impl App {
 
   pub fn create_pop_char(&mut self) {
     self.create_form.pop_char();
+  }
+
+  /// Handle one key in the create overlay and report what the run loop must
+  /// do next. Extracted from the inline `View::Create` match (issue #217)
+  /// so the input path — typing, type cycling, submit/cancel — is
+  /// unit-testable rather than only reachable through a live terminal.
+  ///
+  /// `h` / `l` mirror the `←` / `→` horizontal type selector, but **only**
+  /// when the Type field is focused; on a text field they are literal input
+  /// so the letters are never swallowed.
+  pub fn handle_create_key(&mut self, key: KeyEvent) -> CreateKey {
+    let on_type = self.create_form.field == Field::Type;
+    match key.code {
+      KeyCode::Esc => return CreateKey::Cancel,
+      KeyCode::Tab => self.create_next_field(),
+      KeyCode::BackTab => self.create_prev_field(),
+      KeyCode::Enter => {
+        if self.create_form.field == Field::Desc {
+          return CreateKey::Submit;
+        }
+        self.create_next_field();
+      }
+      KeyCode::Up | KeyCode::Left if on_type => self.create_prev_type(),
+      KeyCode::Down | KeyCode::Right if on_type => self.create_next_type(),
+      KeyCode::Char('h') if on_type => self.create_prev_type(),
+      KeyCode::Char('l') if on_type => self.create_next_type(),
+      KeyCode::Char(c) if !on_type => self.create_push_char(c),
+      KeyCode::Backspace if !on_type => self.create_pop_char(),
+      _ => {}
+    }
+    CreateKey::Handled
   }
 
   pub fn submit_create(&mut self) -> Result<()> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -997,6 +997,11 @@ impl App {
   pub fn enter_create(&mut self) {
     self.view = View::Create;
     self.create_form.reset();
+    // Open focused on Issue rather than the cycle-only Type field (#217 UX):
+    // the first keypress then edits text instead of being a silent no-op on
+    // Type. The type keeps its `reset()` default and stays reachable via
+    // Shift-Tab / the field rotation.
+    self.create_form.field = Field::Issue;
     self.status = "tab/shift-tab: switch field — enter on desc: submit — esc: cancel".into();
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -94,6 +94,21 @@ pub enum CreateKey {
   Cancel,
 }
 
+/// What the run loop must do after [`App::handle_link_prompt_key`] processes
+/// a key in the link prompt (issue #217). Mirrors [`CreateKey`]: the testable
+/// handler owns the picker / digit-buffer mutations, the loop owns the two
+/// side effects (the `github::link_*` shell-out, the view transition).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LinkPromptKey {
+  /// The key moved the highlight, committed a target, or edited the number
+  /// buffer (or was ignored); stay in the prompt.
+  Handled,
+  /// `Enter` on the number field — the loop should run `link_prompt_submit`.
+  Submit,
+  /// `Esc` — the loop should close the prompt back to the list.
+  Cancel,
+}
+
 /// Target of an open / link action. Canonical definition lives in
 /// `crate::cli::LinkTarget` (it carries the `clap::ValueEnum` derive
 /// for the CLI surface); the TUI re-exports the same type so a value
@@ -1675,7 +1690,43 @@ impl App {
   pub fn enter_link_prompt(&mut self) {
     self.view = View::LinkPrompt;
     self.link_prompt.reset();
-    self.status = "link: [i]ssue / [p]r · esc cancels".into();
+    self.status = "link: j/k move · enter links · i/p direct · esc cancels".into();
+  }
+
+  /// Highlighted row in the `ChooseTarget` picker (for the renderer).
+  pub fn link_prompt_selected(&self) -> LinkTarget {
+    self.link_prompt.selected
+  }
+
+  /// Testable key handler for the link prompt (issue #217), mirroring
+  /// [`App::handle_create_key`]. The picker / digit-buffer mutations and
+  /// the per-stage status copy stay here; the loop only acts on the
+  /// returned [`LinkPromptKey`] for the two genuine side effects
+  /// (submit shell-out, view transition).
+  pub fn handle_link_prompt_key(&mut self, key: KeyEvent) -> LinkPromptKey {
+    use crate::tui::state::link_prompt::LinkPromptStage;
+    match (self.link_prompt.stage, key.code) {
+      (_, KeyCode::Esc) => return LinkPromptKey::Cancel,
+      // ChooseTarget: a vertical selectable list. j/k (and arrows) move the
+      // highlight, Enter links the highlighted row, i/p stay direct picks.
+      // With exactly two targets, up and down land on the same other row, so
+      // a single flip serves j/k/Up/Down alike.
+      (LinkPromptStage::ChooseTarget, KeyCode::Char('j') | KeyCode::Char('k') | KeyCode::Down | KeyCode::Up) => {
+        self.link_prompt.toggle_selection()
+      }
+      (LinkPromptStage::ChooseTarget, KeyCode::Char('i')) => self.link_prompt_choose(LinkTarget::Issue),
+      (LinkPromptStage::ChooseTarget, KeyCode::Char('p')) => self.link_prompt_choose(LinkTarget::Pr),
+      (LinkPromptStage::ChooseTarget, KeyCode::Enter) => {
+        let target = self.link_prompt.selected;
+        self.link_prompt_choose(target);
+      }
+      // InputNumber: type the digits, Enter submits, Backspace deletes.
+      (LinkPromptStage::InputNumber, KeyCode::Enter) => return LinkPromptKey::Submit,
+      (LinkPromptStage::InputNumber, KeyCode::Char(c)) => self.link_prompt_push_char(c),
+      (LinkPromptStage::InputNumber, KeyCode::Backspace) => self.link_prompt_pop_char(),
+      _ => {}
+    }
+    LinkPromptKey::Handled
   }
 
   pub fn link_prompt_cancel(&mut self) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -135,6 +135,14 @@ pub struct App {
   // Bootstrap report
   pub report: Option<BootstrapReport>,
 
+  /// Keybindings (help) overlay scroll offset, in rows. Reset to 0 every
+  /// time the overlay opens; clamped to `help_max_scroll` (#217).
+  pub help_scroll: u16,
+  /// Maximum help scroll offset, republished by [`super::ui::draw_help`]
+  /// each frame as `content_rows.saturating_sub(viewport_rows)` so the
+  /// offset can never scroll past the last line into the void.
+  pub help_max_scroll: u16,
+
   /// Sidebar (git preview) panel state (extracted per #127). Owns the
   /// visibility / focus flags, the scroll offset + max bound, and the
   /// cached pre-rendered sections keyed by the selected worktree's
@@ -312,6 +320,8 @@ impl App {
       create_form: CreateForm::new(),
       branch_types,
       report: None,
+      help_scroll: 0,
+      help_max_scroll: 0,
       sidebar: SidebarState::new(),
       pending_g: false,
       pending_chord: Vec::new(),
@@ -752,6 +762,24 @@ impl App {
 
   pub fn sidebar_scroll_up(&mut self) {
     self.sidebar.scroll_up();
+  }
+
+  /// Open the Keybindings (help) overlay from the top (#217). Resetting
+  /// the scroll offset here keeps re-opens predictable.
+  pub fn enter_help(&mut self) {
+    self.view = View::Help;
+    self.help_scroll = 0;
+  }
+
+  /// Scroll the help overlay down one row, clamped to the renderer-published
+  /// `help_max_scroll` so it never scrolls past the last line.
+  pub fn help_scroll_down(&mut self) {
+    self.help_scroll = (self.help_scroll + 1).min(self.help_max_scroll);
+  }
+
+  /// Scroll the help overlay up one row, clamped at the top.
+  pub fn help_scroll_up(&mut self) {
+    self.help_scroll = self.help_scroll.saturating_sub(1);
   }
 
   /// Path to launch lazygit on, or `None` if nothing selected or lazygit is missing.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -20,6 +20,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::Repository;
 use ratatui::widgets::TableState;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 // Re-export the GitHub fetch state enum at its historical path
@@ -28,6 +29,17 @@ use std::time::{Duration, Instant};
 // `state::github_fetch` re-export landed) keep compiling. The owning
 // module is now `tui::state::github_fetch` — see #128.
 pub use super::state::github_fetch::GitHubFetchState;
+
+/// Result of an off-thread `gh issue view` / `gh pr view` shell-out
+/// (issue #217). The background fetch thread sends one of these back to
+/// the event loop over [`App::github_rx`]; [`App::drain_github_results`]
+/// applies it through the existing `GitHubFetch::complete_*` guards (so the
+/// #138 stale-result drop still holds). Carries owned, `Send` data only —
+/// no `git2::Repository` crosses the thread boundary.
+pub enum GithubFetchMsg {
+  Issue(u64, std::result::Result<IssueStatus, String>),
+  Pr(u64, std::result::Result<PrStatus, String>),
+}
 
 /// Spawnable launcher plan handed to the event loop by
 /// [`App::prepare_git_tui`] / [`App::prepare_review`]. Carries the
@@ -240,6 +252,13 @@ pub struct App {
   /// default when callers construct `App` directly, e.g. tests that
   /// don't care about the gate).
   pub trust_mode: crate::trust::TrustMode,
+
+  /// Sender cloned into each background GitHub fetch thread (issue #217).
+  github_tx: mpsc::Sender<GithubFetchMsg>,
+  /// Receiver drained by [`Self::drain_github_results`] each event-loop
+  /// tick. Held for the lifetime of the `App`; when the `App` drops, any
+  /// still-running fetch thread's `send` simply fails and is ignored.
+  github_rx: mpsc::Receiver<GithubFetchMsg>,
 }
 
 impl App {
@@ -279,6 +298,7 @@ impl App {
     if !worktrees.is_empty() {
       state.select(Some(0));
     }
+    let (github_tx, github_rx) = mpsc::channel();
     let mut out = Self {
       repo,
       repo_name,
@@ -308,6 +328,8 @@ impl App {
       link_prompt: LinkPrompt::new(),
       palette: PaletteState::new(),
       trust_mode: crate::trust::TrustMode::Prompt,
+      github_tx,
+      github_rx,
     };
     // Seed the sidebar position from `[tui] sidebar_position` (issue
     // #188). Orientation stays at its `Auto` default — runtime-only.
@@ -1315,19 +1337,24 @@ impl App {
     }
   }
 
-  /// Drive the issue/PR fetch synchronously. Called from the event loop
-  /// when the user presses `F` (refresh GitHub status). Routes through
-  /// the [`GitHubFetch`] dedupe layer: `request(key)` claims the
-  /// per-target inflight slot and flips `*_state = Loading`, the
-  /// shell-out runs, `complete_{issue,pr}` clears the slot and
-  /// stamps the result.
+  /// Kick off the issue/PR fetch. Called from the event loop when the
+  /// user presses `F` (refresh GitHub status). Routes through the
+  /// [`GitHubFetch`] dedupe layer: `request(key)` claims the per-target
+  /// inflight slot and flips `*_state = Loading`, then the `gh issue view`
+  /// / `gh pr view` shell-out runs **off-thread** (issue #217) so the TUI
+  /// stays responsive and the statusbar spinner can animate. Each thread
+  /// reports back over [`Self::github_tx`]; the event loop applies the
+  /// result via [`Self::drain_github_results`], which calls
+  /// `complete_{issue,pr}` — keeping the #128 dedupe and #138 stale-drop
+  /// guarantees intact.
   ///
-  /// This call path is the explicit user-initiated refresh, so it
-  /// flushes the cache via [`GitHubFetch::invalidate`] first — the
-  /// user just asked for fresh data, a `HitCache` short-circuit here
-  /// would be a bug. The inflight slot is still claimed via
-  /// `request`, so any concurrent visit-driven `request` for the
-  /// same key dedupes correctly (load-bearing payoff of #128).
+  /// The PR auto-detection (`gh pr list`, issue #181) stays synchronous:
+  /// it mutates `link` which the very next render needs, and it is a single
+  /// cheap call rather than the two `view` shell-outs the spinner is for.
+  ///
+  /// This call path is the explicit user-initiated refresh, so it flushes
+  /// the cache via [`GitHubFetch::invalidate`] first — the user just asked
+  /// for fresh data, a `HitCache` short-circuit here would be a bug.
   pub fn refresh_github_status(&mut self) {
     use super::state::github_fetch::{FetchAction, FetchKey};
 
@@ -1339,9 +1366,9 @@ impl App {
     self.github.clear_detected_pr();
 
     // Auto-detect the selected branch's PR when none is linked (issue
-    // #181). Runs on the same synchronous F-refresh path as the issue/PR
-    // fetch; needs a remote, so it's a no-op without a slug. An explicit
-    // `gwm link --pr` wins — `apply_detected_pr` only fills an empty slot.
+    // #181). Synchronous (see method doc); needs a remote, so it's a no-op
+    // without a slug. An explicit `gwm link --pr` wins — `apply_detected_pr`
+    // only fills an empty slot.
     if self.github.link.pr.is_none() {
       if let (Some(slug), Some(branch)) = (slug.as_deref(), self.selected_branch_name()) {
         let detected = github::find_pr_for_branch(slug, &branch).ok().flatten();
@@ -1361,19 +1388,82 @@ impl App {
     // request loop so `request` returns `Spawn` instead of `HitCache`
     // for previously-loaded keys.
     self.github.invalidate();
+    let mut spawned = 0u32;
     if let Some(n) = self.github.link.issue {
       if let FetchAction::Spawn(_) = self.github.request(FetchKey::Issue(n)) {
-        let r = github::fetch_issue(&slug, n).map_err(|e| e.to_string());
-        self.github.complete_issue(n, r);
+        self.spawn_github_fetch(FetchKey::Issue(n), slug.clone());
+        spawned += 1;
       }
     }
     if let Some(n) = self.github.link.pr {
       if let FetchAction::Spawn(_) = self.github.request(FetchKey::Pr(n)) {
-        let r = github::fetch_pr(&slug, n).map_err(|e| e.to_string());
-        self.github.complete_pr(n, r);
+        self.spawn_github_fetch(FetchKey::Pr(n), slug.clone());
+        spawned += 1;
       }
     }
-    self.report_github_refresh_status();
+    if spawned > 0 {
+      // Loading state is live; the spinner animates until `drain` applies
+      // the results and re-reports the outcome.
+      self.spinner.reset();
+      self.status = "fetching GitHub status…".into();
+    } else {
+      // Nothing actually spawned (all keys already terminal in cache) —
+      // report the current outcome immediately.
+      self.report_github_refresh_status();
+    }
+  }
+
+  /// Spawn one background `gh` shell-out for `key` and wire its result back
+  /// over the channel (issue #217). Deliberately a thin shell: it owns only
+  /// the off-thread dispatch + send, no state logic — the contract lives in
+  /// `request` / `complete_*` (tested in `tui_state_github_fetch_tests.rs`)
+  /// and in [`Self::drain_github_results`] (tested in `tui_app_tests.rs`).
+  /// A `send` failure (the `App`/receiver was dropped) is ignored: there is
+  /// no longer anyone to apply the result.
+  fn spawn_github_fetch(&self, key: super::state::github_fetch::FetchKey, slug: String) {
+    use super::state::github_fetch::FetchKey;
+    let tx = self.github_tx.clone();
+    std::thread::spawn(move || {
+      let msg = match key {
+        FetchKey::Issue(n) => GithubFetchMsg::Issue(n, github::fetch_issue(&slug, n).map_err(|e| e.to_string())),
+        FetchKey::Pr(n) => GithubFetchMsg::Pr(n, github::fetch_pr(&slug, n).map_err(|e| e.to_string())),
+      };
+      let _ = tx.send(msg);
+    });
+  }
+
+  /// Apply every GitHub fetch result that has arrived since the last call
+  /// (issue #217), draining the channel without blocking. Each result goes
+  /// through `complete_{issue,pr}`, so a result whose inflight slot was
+  /// cleared by an intervening navigation/`invalidate` is dropped (#138).
+  /// Returns `true` if at least one result was applied, so the event loop
+  /// can force a redraw. When the last inflight fetch lands, re-reports the
+  /// aggregate outcome on the status bar.
+  pub fn drain_github_results(&mut self) -> bool {
+    let mut applied = false;
+    while let Ok(msg) = self.github_rx.try_recv() {
+      applied = true;
+      match msg {
+        GithubFetchMsg::Issue(n, r) => self.github.complete_issue(n, r),
+        GithubFetchMsg::Pr(n, r) => self.github.complete_pr(n, r),
+      }
+    }
+    // Once nothing is left loading, swap the "fetching…" placeholder for the
+    // real outcome (refreshed / partial failure / failure).
+    if applied && !self.is_github_loading() {
+      self.report_github_refresh_status();
+    }
+    applied
+  }
+
+  /// A clone of the channel sender background fetch threads report over
+  /// (issue #217). Exposed so the async-apply path
+  /// ([`Self::drain_github_results`]) can be driven deterministically —
+  /// inject a [`GithubFetchMsg`] exactly as a thread would, then drain —
+  /// without spawning an OS thread or a real `gh` (the advisor-flagged
+  /// flaky-thread-test trap). `spawn_github_fetch` uses the same channel.
+  pub fn github_result_sender(&self) -> mpsc::Sender<GithubFetchMsg> {
+    self.github_tx.clone()
   }
 
   /// Compute the post-refresh status line message based on the actual

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -680,6 +680,26 @@ impl App {
     self.status = "focus: status".into();
   }
 
+  /// The live UI context driving the statusbar chip + help subtitle (issue
+  /// #217): `Picker` in `gwm switch`, `Status` when the sidebar holds focus,
+  /// `Worktrees` otherwise.
+  pub fn hint_context(&self) -> super::ui::HintContext {
+    if self.picker_mode {
+      super::ui::HintContext::Picker
+    } else if self.sidebar.open && self.sidebar.focused {
+      super::ui::HintContext::Status
+    } else {
+      super::ui::HintContext::Worktrees
+    }
+  }
+
+  /// `true` while a GitHub issue / PR fetch for the current link is inflight
+  /// (issue #217) — drives the statusbar loading spinner.
+  pub fn is_github_loading(&self) -> bool {
+    matches!(self.issue_fetch_state(), GitHubFetchState::Loading)
+      || matches!(self.pr_fetch_state(), GitHubFetchState::Loading)
+  }
+
   pub fn sidebar_scroll_down(&mut self) {
     self.sidebar.scroll_down();
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -666,6 +666,20 @@ impl App {
     self.sidebar.toggle_focus();
   }
 
+  /// Direct-focus the worktree table (issue #217, `1`). Orchestrator-shaped
+  /// for the status-bar copy, like the sidebar toggles.
+  pub fn focus_worktrees(&mut self) {
+    self.sidebar.focus_table();
+    self.status = "focus: worktrees".into();
+  }
+
+  /// Direct-focus the status (sidebar) pane (issue #217, `2`). Opens the
+  /// sidebar if needed and moves focus onto it.
+  pub fn focus_status(&mut self) {
+    self.sidebar.focus_panel();
+    self.status = "focus: status".into();
+  }
+
   pub fn sidebar_scroll_down(&mut self) {
     self.sidebar.scroll_down();
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1690,7 +1690,7 @@ impl App {
   pub fn enter_link_prompt(&mut self) {
     self.view = View::LinkPrompt;
     self.link_prompt.reset();
-    self.status = "link: j/k move · enter links · i/p direct · esc cancels".into();
+    self.status = "pick".into();
   }
 
   /// Highlighted row in the `ChooseTarget` picker (for the renderer).
@@ -1749,8 +1749,7 @@ impl App {
   pub fn link_prompt_choose(&mut self, target: LinkTarget) {
     self.link_prompt.commit_target(target);
     self.status = match target {
-      LinkTarget::Issue => "issue # — digits, enter to link, esc to cancel".into(),
-      LinkTarget::Pr => "pr # — digits, enter to link, esc to cancel".into(),
+      LinkTarget::Issue | LinkTarget::Pr => "num".into(),
     };
   }
 

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -524,6 +524,22 @@ impl Keymap {
   pub fn list(&self) -> Vec<Binding> {
     self.entries.clone()
   }
+
+  /// The canonical rendering of the **first** chord bound to `action`,
+  /// or `None` when the action is unbound. Used by UI copy that names a
+  /// key inline (e.g. the sidebar's "press F to fetch status" prompt,
+  /// issue #217) so the hint tracks user overrides under `[tui.keys]`
+  /// instead of hard-coding a default that may have been rebound. A
+  /// multi-chord action returns its first chord in declaration order,
+  /// matching what `gwm tui keys` lists first.
+  pub fn primary_chord(&self, action: Action) -> Option<String> {
+    self
+      .entries
+      .iter()
+      .find(|b| b.action == action)
+      .and_then(|b| b.chords.first())
+      .map(|chord| format_chord(chord))
+  }
 }
 
 /// Build a default `Binding` from a list of chord literals. Panics

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -108,6 +108,8 @@ define_actions! {
   CycleSidebarLayout => "cycle_sidebar_layout",
   ToggleSidebarPosition => "toggle_sidebar_position",
   FocusSwap         => "focus_swap",
+  FocusWorktrees    => "focus_worktrees",
+  FocusStatus       => "focus_status",
   // Filter
   Filter            => "filter",
   // Lifecycle / mutating
@@ -386,6 +388,8 @@ impl Keymap {
       def(Action::CycleSidebarLayout, &["V"]),
       def(Action::ToggleSidebarPosition, &["H"]),
       def(Action::FocusSwap, &["Tab"]),
+      def(Action::FocusWorktrees, &["1"]),
+      def(Action::FocusStatus, &["2"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f", "r"]),
       def(Action::Create, &["n"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,7 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{App, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
+pub use app::{App, GithubFetchMsg, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;
@@ -133,6 +133,16 @@ fn confirm_fire(app: &mut App) {
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> Result<Option<PathBuf>> {
   loop {
+    // Background GitHub fetch (issue #217): apply any results that arrived
+    // off-thread since the last iteration, and advance the loader while a
+    // fetch is still inflight so the statusbar spinner animates at the
+    // 200ms poll cadence. Drained before the draw so the frame reflects the
+    // freshly-applied results.
+    app.drain_github_results();
+    if app.is_github_loading() {
+      app.spinner.tick();
+    }
+
     terminal.draw(|f| ui::draw(f, &mut app))?;
 
     // Tick the confirm-overlay safety countdown (issue #30) before

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -53,11 +53,12 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
-  ellipsize_middle, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
-  header_title, help_lines, help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color,
-  pr_badge_color, pr_summary_line, recent_commits_lines, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
-  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color,
+  github_status_lines, header_line, header_title, help_lines, help_rows, issue_badge_color, issue_summary_line,
+  pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, status_line,
+  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {
@@ -262,8 +263,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
             app.create_next_field();
           }
         }
-        KeyCode::Up if app.create_form.field == Field::Type => app.create_prev_type(),
-        KeyCode::Down if app.create_form.field == Field::Type => app.create_next_type(),
+        // The branch type is now a horizontal `‹ ›` selector, so Left/Right
+        // cycle it too (issue #217); Up/Down stay bound for muscle memory.
+        KeyCode::Up | KeyCode::Left if app.create_form.field == Field::Type => app.create_prev_type(),
+        KeyCode::Down | KeyCode::Right if app.create_form.field == Field::Type => app.create_next_type(),
         KeyCode::Char(c) if app.create_form.field != Field::Type => app.create_push_char(c),
         KeyCode::Backspace if app.create_form.field != Field::Type => app.create_pop_char(),
         _ => {}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,9 +55,9 @@ pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
   ellipsize_middle, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
   header_title, help_lines, help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color,
-  pr_badge_color, pr_summary_line, recent_commits_lines, table_marker, tilde_compress_with_home,
-  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, SidebarSections,
-  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  pr_badge_color, pr_summary_line, recent_commits_lines, status_line, table_marker, tilde_compress_with_home,
+  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
+  SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,9 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
+pub use app::{
+  App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
+};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;
@@ -55,8 +57,8 @@ pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
   create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color,
   github_status_lines, header_line, header_title, help_lines, help_rows, issue_badge_color, issue_summary_line,
-  pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, status_line,
-  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
+  link_target_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
+  status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
   worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
   COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
@@ -305,18 +307,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         }
         _ => {}
       },
-      View::LinkPrompt => match (app.link_prompt_stage(), key.code) {
-        (_, KeyCode::Esc) => app.link_prompt_cancel(),
-        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('i')) => app.link_prompt_choose(LinkTarget::Issue),
-        (app::LinkPromptStage::ChooseTarget, KeyCode::Char('p')) => app.link_prompt_choose(LinkTarget::Pr),
-        (app::LinkPromptStage::InputNumber, KeyCode::Enter) => {
+      // Link-prompt keys live in a testable `App` method (issue #217); the
+      // loop only owns the two side effects (submit shell-out / close).
+      View::LinkPrompt => match app.handle_link_prompt_key(key) {
+        LinkPromptKey::Submit => {
           if let Err(e) = app.link_prompt_submit() {
             app.status = format!("link failed: {}", e);
           }
         }
-        (app::LinkPromptStage::InputNumber, KeyCode::Char(c)) => app.link_prompt_push_char(c),
-        (app::LinkPromptStage::InputNumber, KeyCode::Backspace) => app.link_prompt_pop_char(),
-        _ => {}
+        LinkPromptKey::Cancel => app.link_prompt_cancel(),
+        LinkPromptKey::Handled => {}
       },
       // Issue #32: command palette overlay. Palette entry names
       // are restricted to `[a-z0-9_-]` (see

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -53,10 +53,10 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, ellipsize_middle,
-  filled_cells_for_progress, footer_line, freshness_color, header_line, header_title, help_lines, help_rows,
-  issue_badge_color, issue_summary_line, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
-  table_marker, tilde_compress_with_home, working_tree_status_line, worktree_name_style, worktree_path_style, HelpRow,
-  SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line, header_title, help_lines,
+  help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
+  recent_commits_lines, table_marker, tilde_compress_with_home, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -57,10 +57,10 @@ pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
   create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color,
   github_status_lines, header_line, header_title, help_lines, help_rows, issue_badge_color, issue_summary_line,
-  link_target_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
-  status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
-  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  link_choose_hint, link_input_hint, link_target_line, pane_counter, panel_border_color, pr_badge_color,
+  pr_summary_line, recent_commits_lines, status_line, status_pane_title, table_marker, tilde_compress_with_home,
+  type_selector_line, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
+  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -52,11 +52,12 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
   }
 }
 pub use ui::{
-  author_initials, badge_group_width, branch_name_color, build_sidebar_sections, ellipsize_middle,
-  filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line, header_title, help_lines,
-  help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
-  recent_commits_lines, table_marker, tilde_compress_with_home, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
+  ellipsize_middle, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
+  header_title, help_lines, help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color,
+  pr_badge_color, pr_summary_line, recent_commits_lines, table_marker, tilde_compress_with_home,
+  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,9 +55,9 @@ pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
   ellipsize_middle, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
   header_title, help_lines, help_rows, issue_badge_color, issue_summary_line, pane_counter, panel_border_color,
-  pr_badge_color, pr_summary_line, recent_commits_lines, status_line, table_marker, tilde_compress_with_home,
-  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
-  SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  pr_badge_color, pr_summary_line, recent_commits_lines, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
+  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -418,6 +418,8 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     Action::CycleSidebarLayout => app.cycle_sidebar_layout(),
     Action::ToggleSidebarPosition => app.toggle_sidebar_position(),
     Action::FocusSwap => app.toggle_focus(),
+    Action::FocusWorktrees => app.focus_worktrees(),
+    Action::FocusStatus => app.focus_status(),
     Action::Filter => app.enter_filter(),
     Action::Refresh => app.refresh()?,
     Action::Help => app.view = View::Help,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,7 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{App, GithubFetchMsg, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
+pub use app::{App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;
@@ -255,26 +255,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         KeyCode::End | KeyCode::Char('G') => app.help_scroll = app.help_max_scroll,
         _ => {}
       },
-      View::Create => match key.code {
-        KeyCode::Esc => app.view = View::List,
-        KeyCode::Tab => app.create_next_field(),
-        KeyCode::BackTab => app.create_prev_field(),
-        KeyCode::Enter => {
-          if app.create_form.field == Field::Desc {
-            if let Err(e) = app.submit_create() {
-              app.status = format!("error: {}", e);
-            }
-          } else {
-            app.create_next_field();
+      // Create-overlay keys live in a testable `App` method (issue #217);
+      // the loop only owns the two side effects (submit / close).
+      View::Create => match app.handle_create_key(key) {
+        CreateKey::Submit => {
+          if let Err(e) = app.submit_create() {
+            app.status = format!("error: {}", e);
           }
         }
-        // The branch type is now a horizontal `‹ ›` selector, so Left/Right
-        // cycle it too (issue #217); Up/Down stay bound for muscle memory.
-        KeyCode::Up | KeyCode::Left if app.create_form.field == Field::Type => app.create_prev_type(),
-        KeyCode::Down | KeyCode::Right if app.create_form.field == Field::Type => app.create_next_type(),
-        KeyCode::Char(c) if app.create_form.field != Field::Type => app.create_push_char(c),
-        KeyCode::Backspace if app.create_form.field != Field::Type => app.create_pop_char(),
-        _ => {}
+        CreateKey::Cancel => app.view = View::List,
+        CreateKey::Handled => {}
       },
       View::Confirm => match key.code {
         // `y` confirms directly regardless of which button is focused

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -248,6 +248,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       }
       View::Help => match key.code {
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => app.view = View::List,
+        // Scroll the Keybindings overlay when it outgrows the modal (#217).
+        KeyCode::Down | KeyCode::Char('j') => app.help_scroll_down(),
+        KeyCode::Up | KeyCode::Char('k') => app.help_scroll_up(),
+        KeyCode::Home | KeyCode::Char('g') => app.help_scroll = 0,
+        KeyCode::End | KeyCode::Char('G') => app.help_scroll = app.help_max_scroll,
         _ => {}
       },
       View::Create => match key.code {
@@ -436,7 +441,7 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     Action::FocusStatus => app.focus_status(),
     Action::Filter => app.enter_filter(),
     Action::Refresh => app.refresh()?,
-    Action::Help => app.view = View::Help,
+    Action::Help => app.enter_help(),
     Action::Yank => yank_selected_path_to_clipboard(app),
     Action::Open => match app.resolve_open_target() {
       None => app.status = "nothing selected".into(),

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -132,6 +132,16 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "swap focus between worktree list and sidebar",
     },
     PaletteEntry {
+      action: Action::FocusWorktrees,
+      name: "focus-worktrees",
+      description: "focus the worktrees pane",
+    },
+    PaletteEntry {
+      action: Action::FocusStatus,
+      name: "focus-status",
+      description: "focus the status pane (opens it if hidden)",
+    },
+    PaletteEntry {
       action: Action::Top,
       name: "top",
       description: "jump to the first worktree",

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -7,6 +7,16 @@
 //! effects in `submit_create` (it composes `BranchSpec` from the form's
 //! values, then drives `worktree::add` + `bootstrap::run`).
 
+/// Max digits accepted in the issue-number field. Seven digits covers any
+/// realistic GitHub issue/PR number (up to 9,999,999) while keeping the
+/// resolved branch name well within git's 255-byte ref limit (#217).
+pub const MAX_ISSUE_LEN: usize = 7;
+
+/// Max characters accepted in the description (slug) field. Bounded so the
+/// `<type>/#<issue>-<desc>` branch name cannot exceed git's 255-byte ref
+/// limit even with the longest configured branch type (#217).
+pub const MAX_DESC_LEN: usize = 200;
+
 /// Which input is currently focused inside the create overlay. Selected
 /// via Tab / Shift-Tab; the Type field is special — it's cycled via
 /// `next_type` / `prev_type` rather than typed into.
@@ -90,8 +100,8 @@ impl CreateForm {
   /// downstream in `BranchSpec`). Type is no-op (cycled, not typed).
   pub fn push_char(&mut self, c: char) {
     match self.field {
-      Field::Issue if c.is_ascii_digit() => self.issue.push(c),
-      Field::Desc => self.desc.push(c),
+      Field::Issue if c.is_ascii_digit() && self.issue.chars().count() < MAX_ISSUE_LEN => self.issue.push(c),
+      Field::Desc if self.desc.chars().count() < MAX_DESC_LEN => self.desc.push(c),
       _ => {}
     }
   }

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -279,24 +279,31 @@ impl GitHubFetch {
   ///    `request(Issue(number))` returns `HitCache` instead of
   ///    re-spawning — see the module docs for the cache-on-error
   ///    rationale.
-  pub fn complete_issue(&mut self, number: u64, result: std::result::Result<IssueStatus, String>) {
+  ///
+  /// Returns `true` when the result was applied, `false` when dropped by
+  /// guard 1. Async callers use this to skip reporting a refresh outcome
+  /// for a result they silently discarded (issue #217 review).
+  pub fn complete_issue(&mut self, number: u64, result: std::result::Result<IssueStatus, String>) -> bool {
     // #138 guard: if invalidate() cleared the slot mid-flight, drop
     // the late result. Stamping it would corrupt the now-active
     // worktree's cache with the previous worktree's data.
     if !self.inflight.remove(&FetchKey::Issue(number)) {
-      return;
+      return false;
     }
     self.issue_cache.insert(number, into_state(result));
+    true
   }
 
   /// PR-side counterpart to [`Self::complete_issue`]. Same #138 guard
   /// applies: a late result whose inflight slot was cleared by an
-  /// intervening [`Self::invalidate`] is dropped.
-  pub fn complete_pr(&mut self, number: u64, result: std::result::Result<PrStatus, String>) {
+  /// intervening [`Self::invalidate`] is dropped. Returns `true` when the
+  /// result was applied, `false` when dropped.
+  pub fn complete_pr(&mut self, number: u64, result: std::result::Result<PrStatus, String>) -> bool {
     if !self.inflight.remove(&FetchKey::Pr(number)) {
-      return;
+      return false;
     }
     self.pr_cache.insert(number, into_state(result));
+    true
   }
 
   /// Stamp the issue fetch state from a fetch result. `Ok(s)` →

--- a/src/tui/state/link_prompt.rs
+++ b/src/tui/state/link_prompt.rs
@@ -40,22 +40,42 @@ pub enum LinkPromptStage {
 }
 
 /// Pure state for the two-stage issue/PR link prompt. `Default` opens
-/// the prompt in the initial state (stage = ChooseTarget, no target,
-/// empty number buffer).
-#[derive(Debug, Default)]
+/// the prompt in the initial state (stage = ChooseTarget, no committed
+/// target, `Issue` highlighted, empty number buffer).
+#[derive(Debug)]
 pub struct LinkPrompt {
   /// Which stage of the prompt we're in. Drives the keypress dispatch
-  /// (i/p during ChooseTarget, digits/Enter/Backspace during
+  /// (j/k/Enter/i/p during ChooseTarget, digits/Enter/Backspace during
   /// InputNumber) at the event-loop layer.
   pub stage: LinkPromptStage,
-  /// Chosen target. `None` while in `ChooseTarget`, `Some(Issue|Pr)`
-  /// after [`Self::commit_target`].
+  /// Committed target. `None` while in `ChooseTarget`, `Some(Issue|Pr)`
+  /// after [`Self::commit_target`]. Distinct from [`Self::selected`]:
+  /// the highlight can move freely while nothing is committed yet.
   pub target: Option<LinkTarget>,
+  /// The highlighted row in the `ChooseTarget` vertical picker (#217).
+  /// `j`/`k` move it via [`Self::toggle_selection`]; `Enter` commits it.
+  /// Opens on `Issue` — most branches link an issue first; a PR comes
+  /// later when the branch is pushed. Frozen once a target is committed
+  /// so a stray keystroke during `InputNumber` can't flip it.
+  pub selected: LinkTarget,
   /// Digits typed by the user during `InputNumber`. Always digits-only:
   /// [`Self::push_char`] drops non-digits, [`Self::pop_char`] is the
   /// backspace handler. The orchestrator's submit handler calls
   /// `.parse::<u64>()` on this directly.
   pub number: String,
+}
+
+impl Default for LinkPrompt {
+  fn default() -> Self {
+    Self {
+      stage: LinkPromptStage::default(),
+      target: None,
+      // `LinkTarget` is a shared `cli::ValueEnum` with no `Default`, so the
+      // open-highlight default lives here rather than on that CLI type.
+      selected: LinkTarget::Issue,
+      number: String::new(),
+    }
+  }
 }
 
 impl LinkPrompt {
@@ -64,28 +84,28 @@ impl LinkPrompt {
   }
 
   /// Return to the freshly-opened state (stage = ChooseTarget, no
-  /// target, empty buffer). Called by the orchestrator when the prompt
-  /// opens, cancels, or completes a successful submit.
+  /// committed target, `Issue` highlighted, empty buffer). Called by the
+  /// orchestrator when the prompt opens, cancels, or completes a
+  /// successful submit.
   pub fn reset(&mut self) {
     self.stage = LinkPromptStage::ChooseTarget;
     self.target = None;
+    self.selected = LinkTarget::Issue;
     self.number.clear();
   }
 
-  /// Rotate the highlighted target during `ChooseTarget`. `None` →
-  /// `Issue` → `Pr` → `Issue` → … The first call from a freshly-opened
-  /// prompt lands on `Issue` because that's the more common case in
-  /// practice (most branches link an issue first; a PR comes later when
-  /// the branch is pushed). No-op during `InputNumber` so a stray
+  /// Move the highlight in the `ChooseTarget` picker. With exactly two
+  /// targets, `j` (down) and `k` (up) land on the same other row, so a
+  /// single flip covers both. No-op during `InputNumber` so a stray
   /// keystroke after commit can't flip the user's choice mid-typing.
-  pub fn toggle_target(&mut self) {
+  pub fn toggle_selection(&mut self) {
     if self.stage != LinkPromptStage::ChooseTarget {
       return;
     }
-    self.target = Some(match self.target {
-      None | Some(LinkTarget::Pr) => LinkTarget::Issue,
-      Some(LinkTarget::Issue) => LinkTarget::Pr,
-    });
+    self.selected = match self.selected {
+      LinkTarget::Issue => LinkTarget::Pr,
+      LinkTarget::Pr => LinkTarget::Issue,
+    };
   }
 
   /// Commit a target and advance to `InputNumber`. Clears the buffer so

--- a/src/tui/state/sidebar.rs
+++ b/src/tui/state/sidebar.rs
@@ -49,13 +49,15 @@ pub const SIDEBAR_MIN_WIDTH: u16 = 120;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SidebarOrientation {
   /// Width-driven: side-by-side at `>= SIDEBAR_MIN_WIDTH`, stacked
-  /// below it. Default — restores a usable sidebar on narrow terminals
-  /// where it was previously hidden entirely.
-  #[default]
+  /// below it. Restores a usable sidebar on narrow terminals where it
+  /// was previously hidden entirely.
   Auto,
   /// Always beside the table (table | sidebar), even when narrow.
   SideBySide,
   /// Always stacked (table on top, sidebar below), even when wide.
+  /// Default since issue #217: the status pane reads best under the
+  /// worktrees table, where it gets the full terminal width.
+  #[default]
   Stacked,
 }
 
@@ -94,6 +96,22 @@ pub enum ResolvedSidebarLayout {
   SideBySide { sidebar_left: bool },
   /// Stacked split — table on top, sidebar below.
   Stacked,
+}
+
+impl ResolvedSidebarLayout {
+  /// The `(table_pct, sidebar_pct)` split this layout draws, or `None`
+  /// when the sidebar is hidden (the table takes the whole area). Issue
+  /// #217 tuned the ratios per axis: stacked vertically the status pane
+  /// gets the larger share (42% table / 58% status) so commits + issue/PR
+  /// have room; side-by-side the table stays dominant (55% / 45%). Pure +
+  /// ratatui-free so the contract is pinned without a backend.
+  pub fn split_percentages(self) -> Option<(u16, u16)> {
+    match self {
+      ResolvedSidebarLayout::Hidden => None,
+      ResolvedSidebarLayout::SideBySide { .. } => Some((55, 45)),
+      ResolvedSidebarLayout::Stacked => Some((42, 58)),
+    }
+  }
 }
 
 /// Which content the sidebar previews (issue #34).

--- a/src/tui/state/sidebar.rs
+++ b/src/tui/state/sidebar.rs
@@ -320,4 +320,20 @@ impl SidebarState {
     }
     self.focused = !self.focused;
   }
+
+  /// Direct-focus the worktree table (issue #217, `1`). Releases the
+  /// sidebar's navigation focus so `j` / `k` walk the worktree list. The
+  /// sidebar stays open — `1` is about *where the cursor is*, not
+  /// visibility (that's `v` / [`Self::toggle_open`]).
+  pub fn focus_table(&mut self) {
+    self.focused = false;
+  }
+
+  /// Direct-focus the status (sidebar) pane (issue #217, `2`). Opens the
+  /// sidebar if it was closed and moves the navigation focus onto it, so a
+  /// single keystroke both reveals and targets the pane.
+  pub fn focus_panel(&mut self) {
+    self.open = true;
+    self.focused = true;
+  }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1364,8 +1364,8 @@ impl HintContext {
       ],
       HintContext::OpenMenu => &[Hint::Lit("i", "issue"), Hint::Lit("p", "pr"), Hint::Lit("Esc", "close")],
       HintContext::LinkPrompt => &[
+        Hint::Lit("j/k", "move"),
         Hint::Lit("i/p", "kind"),
-        Hint::Lit("0-9", "number"),
         Hint::Lit("Enter", "link"),
         Hint::Lit("Esc", "cancel"),
       ],
@@ -1760,7 +1760,10 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     rows.push(HelpRow::Blank);
     rows.push(HelpRow::Section("Issue / PR (#67)".to_string()));
     rows.push(entry(Action::OpenMenu, "open menu — i=issue · p=pull request"));
-    rows.push(entry(Action::LinkPrompt, "link prompt — i / p then digits"));
+    rows.push(entry(
+      Action::LinkPrompt,
+      "link prompt — j/k + enter, or i/p, then digits",
+    ));
   }
   rows.push(entry(Action::Help, "this help"));
   if !picker_mode {
@@ -2101,6 +2104,24 @@ pub fn field_input_line(
     Span::styled(label.to_string(), Style::default().fg(muted)),
     Span::raw("  "),
     Span::styled(field, field_style),
+  ])
+}
+
+/// A single selectable row of the link prompt's `ChooseTarget` picker
+/// (issue #217): a `‹key›  Label` line whose highlighted variant reads in
+/// the accent (bold) with a `›` marker, and whose idle variant reads
+/// muted. `key` is the direct-pick shortcut (`i` / `p`). Pure so the
+/// highlight contract is pinned by `tests/tui_ui_helpers_tests.rs`.
+pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, muted: Color) -> Line<'static> {
+  let (marker, style) = if selected {
+    ("› ", Style::default().fg(accent).add_modifier(Modifier::BOLD))
+  } else {
+    ("  ", Style::default().fg(muted))
+  };
+  Line::from(vec![
+    Span::styled(marker, style),
+    Span::styled(format!("{key}  "), style),
+    Span::styled(label.to_string(), style),
   ])
 }
 
@@ -2489,11 +2510,30 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   let muted = app.theme.muted;
   let lines = match app.link_prompt_stage() {
     LinkPromptStage::ChooseTarget => {
-      let mut lines = overlay_title_lines("Link This Worktree To:", accent);
-      lines.push(Line::from("  i   a GitHub issue"));
-      lines.push(Line::from("  p   a pull request"));
+      // A vertical selectable list (#217): j/k move the highlight, Enter
+      // links the highlighted row, i/p stay direct picks. The highlighted
+      // row reads in the accent.
+      let selected = app.link_prompt_selected();
+      let mut lines = overlay_title_lines("Link", accent);
+      lines.push(link_target_line("i", "Issue", selected == super::app::LinkTarget::Issue, accent, muted).centered());
+      lines.push(
+        link_target_line(
+          "p",
+          "Pull Request",
+          selected == super::app::LinkTarget::Pr,
+          accent,
+          muted,
+        )
+        .centered(),
+      );
       lines.push(Line::from(""));
-      lines.push(Line::from(Span::styled("  esc to cancel", Style::default().fg(muted))));
+      lines.push(
+        Line::from(Span::styled(
+          "j/k move · enter links · i/p direct · esc cancels",
+          Style::default().fg(muted),
+        ))
+        .centered(),
+      );
       lines
     }
     LinkPromptStage::InputNumber => {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1490,6 +1490,8 @@ pub fn help_rows(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<HelpRow> 
     "toggle sidebar position (left / right)",
   ));
   rows.push(entry(Action::FocusSwap, "swap focus between worktree list and sidebar"));
+  rows.push(entry(Action::FocusWorktrees, "focus the worktrees pane"));
+  rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
   rows.push(entry(
     Action::Filter,
     "open fuzzy filter bar (enter: sticky, esc: clear)",

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2527,13 +2527,7 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
         .centered(),
       );
       lines.push(Line::from(""));
-      lines.push(
-        Line::from(Span::styled(
-          "j/k move · enter links · i/p direct · esc cancels",
-          Style::default().fg(muted),
-        ))
-        .centered(),
-      );
+      lines.push(Line::from(Span::styled(link_choose_hint(), Style::default().fg(muted))).centered());
       lines
     }
     LinkPromptStage::InputNumber => {
@@ -2548,16 +2542,26 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
       );
       lines.push(Line::from(format!("  {}{}_", label, app.link_prompt_number_input())));
       lines.push(Line::from(""));
-      lines.push(Line::from(Span::styled(
-        "  enter confirms · esc cancels · backspace deletes",
-        Style::default().fg(muted),
-      )));
+      lines.push(Line::from(Span::styled(link_input_hint(), Style::default().fg(muted))));
       lines
     }
   };
   let area = centered_h(50, lines.len() as u16 + 2 /* border */ + 2 /* padding */, f.area());
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
+}
+
+/// Compact control hint for the Link prompt target picker. The Link modal is
+/// 50% wide; on an 80-col terminal the padded inner width is 34 cells, so the
+/// hint must stay terse enough not to clip.
+pub fn link_choose_hint() -> &'static str {
+  "j/k move · Enter/i/p pick · Esc"
+}
+
+/// Compact control hint for the Link prompt number input. Same width budget as
+/// [`link_choose_hint`].
+pub fn link_input_hint() -> &'static str {
+  "digits · Enter link · Esc cancel"
 }
 
 /// Render the command palette overlay (issue #32).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1711,11 +1711,11 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     HelpRow::Title("Keybindings".to_string()),
     HelpRow::Subtitle(ctx.label().to_string()),
     HelpRow::Blank,
-    HelpRow::Section("global".to_string()),
+    HelpRow::Section("Global".to_string()),
     entry(Action::Quit, "quit (Esc also quits when filter is clear)"),
     fixed("Ctrl-C", "force quit (hard-coded escape hatch)"),
     HelpRow::Blank,
-    HelpRow::Section("list view".to_string()),
+    HelpRow::Section("List View".to_string()),
     entry(Action::Down, "next (scrolls sidebar when focused)"),
     entry(Action::Up, "prev (scrolls sidebar when focused)"),
     entry(Action::Top, "jump to first worktree"),
@@ -1758,7 +1758,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     rows.push(entry(Action::ToggleDeleteBranch, "toggle 'delete branch on remove'"));
     rows.push(fixed("enter", "show path in status bar"));
     rows.push(HelpRow::Blank);
-    rows.push(HelpRow::Section("issue / PR (#67)".to_string()));
+    rows.push(HelpRow::Section("Issue / PR (#67)".to_string()));
     rows.push(entry(Action::OpenMenu, "open menu — i=issue · p=pull request"));
     rows.push(entry(Action::LinkPrompt, "link prompt — i / p then digits"));
   }
@@ -1769,13 +1769,13 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
   if !picker_mode {
     rows.extend([
       HelpRow::Blank,
-      HelpRow::Section("create form".to_string()),
-      fixed("↑/↓", "change branch type"),
+      HelpRow::Section("Create Form".to_string()),
+      fixed("←/→ ↑/↓", "change branch type"),
       fixed("Tab/Shift-Tab", "next/prev field"),
       fixed("Enter (desc)", "submit"),
       fixed("Esc", "cancel"),
       HelpRow::Blank,
-      HelpRow::Section("confirm delete".to_string()),
+      HelpRow::Section("Confirm Delete".to_string()),
       fixed("←/→ Tab", "move focus between [ Confirm ] / [ Cancel ]"),
       fixed("Enter", "activate the focused button (defaults to Cancel)"),
       fixed("y", "confirm"),
@@ -1827,7 +1827,7 @@ pub fn badge_group_width(keys: &str) -> usize {
   badges + chords.len().saturating_sub(1)
 }
 
-fn draw_help(f: &mut Frame, app: &App) {
+fn draw_help(f: &mut Frame, app: &mut App) {
   let area = centered(60, 60, f.area());
   // Use the underlying pane context, not the view-priority `hint_context`
   // (which would be `Help` while this overlay is up) — `?` documents the
@@ -1862,9 +1862,10 @@ fn draw_help(f: &mut Frame, app: &App) {
     .max()
     .unwrap_or(0);
 
-  // Subtitle reads muted + italic so the context name sits quietly under the
-  // bold title (issue #217).
-  let subtitle_style = Style::default().fg(muted).add_modifier(Modifier::ITALIC);
+  // Subtitle reads in a distinct accent hue (the theme's branch colour) +
+  // italic, so the context name is clearly a different colour from both the
+  // bold title and the muted key labels (issue #217 follow-up).
+  let subtitle_style = Style::default().fg(app.theme.branch).add_modifier(Modifier::ITALIC);
 
   let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows.len());
   for row in rows {
@@ -1903,8 +1904,18 @@ fn draw_help(f: &mut Frame, app: &App) {
     }
   }
 
+  // Publish the scroll bound against the actual viewport so the Keybindings
+  // overlay can scroll when it outgrows the modal (#217). The renderer is
+  // the only place that knows both the content length and the inner height,
+  // so it clamps the offset here too.
+  let block = overlay_block(accent);
+  let viewport = block.inner(area).height as usize;
+  app.help_max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  app.help_scroll = app.help_scroll.min(app.help_max_scroll);
+  let scroll = app.help_scroll;
+
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
+  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, 0)), area);
 }
 
 fn draw_create(f: &mut Frame, app: &App) {
@@ -1923,10 +1934,11 @@ fn draw_create(f: &mut Frame, app: &App) {
   // buttons / hint centre themselves, the fields stay left) — no manual
   // Layout split, the rounded frame's `Padding` owns the breathing room
   // (issue #217). Height is the fixed row count plus the border + padding
-  // rows, so the box hugs its content.
-  const ROWS: u16 = 11; // title(2) + 3 fields + blank + 2 preview + blank + buttons + hint
+  // rows, so the box hugs its content; the width is capped so the input
+  // surfaces don't span a wide terminal.
+  const ROWS: u16 = 13; // title(2) + type + gap + 2 preview + gap + issue + gap + desc + gap + buttons + hint
   let height = ROWS + 2 /* border */ + 2 /* vertical padding */;
-  let area = centered_h(70, height, f.area());
+  let area = centered_box(70, 72, height, f.area());
   let block = overlay_block(clean);
   let inner_w = block.inner(area).width as usize;
 
@@ -1939,24 +1951,37 @@ fn draw_create(f: &mut Frame, app: &App) {
   let label = |s: &str| format!("{:<label_w$}", s);
   let branch = ellipsize_middle(
     &format!("{}/#{}-{}", type_str, app.create_form.issue, app.create_form.desc),
-    inner_w.saturating_sub("  branch : ".len()),
+    inner_w.saturating_sub("  Branch : ".len()),
   );
   let dirname = ellipsize_middle(
     &format!("{}-{}-{}", type_str, app.create_form.issue, app.create_form.desc),
-    inner_w.saturating_sub("  dir    : ".len()),
+    inner_w.saturating_sub("  Dir    : ".len()),
   );
 
-  let mut lines = overlay_title_lines("new worktree", clean);
+  let mut lines = overlay_title_lines("New Worktree", clean);
+  // Type selector first, then the live preview, then the editable fields —
+  // the preview sits above the inputs so the resulting names stay in view
+  // while typing (issue #217 follow-up).
   lines.push(type_selector_line(
-    &label("type"),
+    &label("Type"),
     type_str,
     type_desc,
     app.create_form.field == Field::Type,
     accent,
     muted,
   ));
+  lines.push(Line::from(String::new()));
+  lines.push(Line::from(vec![
+    Span::raw("  Branch : "),
+    Span::styled(branch, Style::default().fg(app.theme.branch)),
+  ]));
+  lines.push(Line::from(vec![
+    Span::raw("  Dir    : "),
+    Span::styled(dirname, Style::default().fg(app.theme.dirty)),
+  ]));
+  lines.push(Line::from(String::new()));
   lines.push(field_input_line(
-    &label("issue"),
+    &label("Issue"),
     &app.create_form.issue,
     app.create_form.field == Field::Issue,
     value_w,
@@ -1964,8 +1989,9 @@ fn draw_create(f: &mut Frame, app: &App) {
     muted,
     surface,
   ));
+  lines.push(Line::from(String::new()));
   lines.push(field_input_line(
-    &label("desc"),
+    &label("Desc"),
     &app.create_form.desc,
     app.create_form.field == Field::Desc,
     value_w,
@@ -1973,15 +1999,6 @@ fn draw_create(f: &mut Frame, app: &App) {
     muted,
     surface,
   ));
-  lines.push(Line::from(String::new()));
-  lines.push(Line::from(vec![
-    Span::raw("  branch : "),
-    Span::styled(branch, Style::default().fg(app.theme.branch)),
-  ]));
-  lines.push(Line::from(vec![
-    Span::raw("  dir    : "),
-    Span::styled(dirname, Style::default().fg(app.theme.dirty)),
-  ]));
   lines.push(Line::from(String::new()));
   lines.push(create_buttons_line(accent, muted).centered());
   lines.push(
@@ -2027,12 +2044,17 @@ pub fn type_selector_line(
   muted: Color,
 ) -> Line<'static> {
   let arrow_style = if focused {
-    Style::default().fg(accent)
+    Style::default().fg(accent).add_modifier(Modifier::BOLD)
   } else {
     Style::default().fg(muted)
   };
+  // Focused, the selected value reads as a reversed-accent chip (the same
+  // badge style as the buttons) so it stands out as an editable control;
+  // idle it is plain white text between muted arrows.
   let name_style = if focused {
-    Style::default().fg(accent).add_modifier(Modifier::BOLD)
+    Style::default()
+      .fg(accent)
+      .add_modifier(Modifier::REVERSED | Modifier::BOLD)
   } else {
     Style::default().fg(Color::White)
   };
@@ -2041,7 +2063,7 @@ pub fn type_selector_line(
     Span::styled(label.to_string(), Style::default().fg(muted)),
     Span::raw("  "),
     Span::styled("‹ ", arrow_style),
-    Span::styled(name.to_string(), name_style),
+    Span::styled(format!(" {name} "), name_style),
     Span::styled(" ›", arrow_style),
     Span::raw("  "),
     Span::styled(desc.to_string(), Style::default().fg(muted)),
@@ -2092,7 +2114,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   let block = overlay_block(danger);
 
   let Some(w) = app.selected() else {
-    let mut lines = overlay_title_lines("confirm delete", danger);
+    let mut lines = overlay_title_lines("Confirm Delete", danger);
     lines.push(Line::from("nothing selected").centered());
     let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
     let area = centered_h(40, height, f.area());
@@ -2115,7 +2137,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   );
 
   // --- title + description (centred) ---
-  let mut content: Vec<Line> = overlay_title_lines("confirm delete", danger);
+  let mut content: Vec<Line> = overlay_title_lines("Confirm Delete", danger);
   content.push(Line::from(vec![
     Span::raw("delete "),
     Span::styled(name, Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)),
@@ -2292,7 +2314,7 @@ pub fn filled_cells_for_progress(progress: f64, cells: usize) -> usize {
 }
 
 fn draw_report(f: &mut Frame, app: &App) {
-  let mut lines: Vec<Line> = overlay_title_lines("bootstrap report", app.theme.accent);
+  let mut lines: Vec<Line> = overlay_title_lines("Bootstrap Report", app.theme.accent);
   if let Some(report) = &app.report {
     for step in &report.steps {
       let sigil = step.status.sigil();
@@ -2368,6 +2390,19 @@ fn centered_h(width_pct: u16, height: u16, area: Rect) -> Rect {
   Rect { x, y, width, height }
 }
 
+/// Like [`centered_h`] but also caps the width at `max_width` columns so a
+/// form modal does not stretch edge-to-edge on a wide terminal (issue #217
+/// — the create overlay's input surfaces spanned the whole screen).
+fn centered_box(width_pct: u16, max_width: u16, height: u16, area: Rect) -> Rect {
+  let height = height.min(area.height);
+  let width = (area.width.saturating_mul(width_pct) / 100)
+    .min(max_width)
+    .min(area.width);
+  let x = area.x + area.width.saturating_sub(width) / 2;
+  let y = area.y + area.height.saturating_sub(height) / 2;
+  Rect { x, y, width, height }
+}
+
 /// A modal overlay frame: a rounded border in `color` with interior
 /// padding on every side. Shared by every overlay (#187) so the confirm /
 /// help / create / report / open / link / palette modals read consistently.
@@ -2436,7 +2471,7 @@ fn trunc(s: &str, max: usize) -> String {
 
 fn draw_open_menu(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let mut lines = overlay_title_lines("open in browser", accent);
+  let mut lines = overlay_title_lines("Open in Browser", accent);
   lines.push(Line::from("  i   linked issue"));
   lines.push(Line::from("  p   linked pull request"));
   lines.push(Line::from(""));
@@ -2454,7 +2489,7 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   let muted = app.theme.muted;
   let lines = match app.link_prompt_stage() {
     LinkPromptStage::ChooseTarget => {
-      let mut lines = overlay_title_lines("link this worktree to:", accent);
+      let mut lines = overlay_title_lines("Link This Worktree To:", accent);
       lines.push(Line::from("  i   a GitHub issue"));
       lines.push(Line::from("  p   a pull request"));
       lines.push(Line::from(""));
@@ -2518,7 +2553,7 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
   f.render_widget(
     Paragraph::new(
       Line::from(Span::styled(
-        "command palette",
+        "Command Palette",
         Style::default().fg(accent).add_modifier(Modifier::BOLD),
       ))
       .centered(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -304,6 +304,35 @@ pub fn panel_border_color(focused: bool, theme: &super::theme::Theme) -> Color {
   }
 }
 
+/// Title for the worktree pane block (issue #217). Carries the `[1]` focus
+/// mnemonic (the pane is focusable with the `1` key) and a `(N)` /
+/// `(visible/total)` counter. `query_empty` switches between the two counter
+/// forms: when no filter is active the full worktree count is shown, otherwise
+/// the visible-over-total ratio so the user sees how much the filter narrowed
+/// the list. Pure + width-free so the copy is pinned by
+/// `tests/tui_ui_helpers_tests.rs` without a ratatui backend.
+pub fn worktrees_pane_title(query_empty: bool, visible: usize, total: usize) -> String {
+  if query_empty {
+    format!(" [1] Worktrees ({}) ", total)
+  } else {
+    format!(" [1] Worktrees ({}/{}) ", visible, total)
+  }
+}
+
+/// Bottom-right `selected of visible` counter for a pane footer (issue
+/// #217), lazygit-style. `selected` is the 1-based cursor position;
+/// `visible` is the count of rows currently on screen. Returns `None` when
+/// the pane is empty so the footer disappears instead of rendering ` 0 of 0 `
+/// — mirroring the Recent Commits section, which also drops its counter when
+/// there is nothing to scroll.
+pub fn pane_counter(selected: usize, visible: usize) -> Option<String> {
+  if visible == 0 {
+    None
+  } else {
+    Some(format!(" {} of {} ", selected, visible))
+  }
+}
+
 fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   // Filter-aware: the visible rows are the filtered subset (issue #21). When
   // there is no active filter, this is the identity over `app.worktrees`.
@@ -370,21 +399,26 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let list_has_focus = !(app.sidebar.open && app.sidebar.focused);
   let border_color = panel_border_color(list_has_focus, &app.theme);
 
-  let title = if app.filter.query().is_empty() {
-    format!(" worktrees ({}) ", app.worktrees.len())
-  } else {
-    format!(" worktrees ({}/{}) ", visible.len(), app.worktrees.len())
-  };
+  let title = worktrees_pane_title(app.filter.query().is_empty(), visible.len(), app.worktrees.len());
+
+  // Bottom-right `selected of visible` counter (issue #217), mirroring the
+  // Recent Commits footer. `list_state.selected()` is 0-based; render it
+  // 1-based. Blank when nothing is visible so the footer disappears.
+  let selected_1based = app.list_state.selected().map(|i| i + 1).unwrap_or(0);
+  let counter = pane_counter(selected_1based, visible.len());
+
+  let mut block = Block::default()
+    .borders(Borders::ALL)
+    .title(title)
+    .border_style(Style::default().fg(border_color));
+  if let Some(counter) = counter {
+    block = block.title_bottom(Line::from(counter).right_aligned());
+  }
 
   let table = Table::new(rows, widths)
     .header(header)
     .column_spacing(1)
-    .block(
-      Block::default()
-        .borders(Borders::ALL)
-        .title(title)
-        .border_style(Style::default().fg(border_color)),
-    )
+    .block(block)
     .row_highlight_style(Style::default().bg(theme.selection_bg).add_modifier(Modifier::BOLD))
     .highlight_symbol("▶ ");
 
@@ -2138,7 +2172,7 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
 /// width of the Issue / PR block (chunk width minus 2 borders and the
 /// 1-char left padding applied by [`render_section`]); summary lines
 /// trim their variable parts so total visible width ≤ `max_width`.
-pub(super) fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
+pub fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   let link = app.current_link();
   let mut lines: Vec<Line<'static>> = Vec::new();
 
@@ -2170,8 +2204,15 @@ pub(super) fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'stat
   }
   if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
   {
+    // Resolve the live `FetchGithub` binding instead of hard-coding a key
+    // (issue #217). Pre-fix this read `press R`, but `R` is `Review`; the
+    // fetch action defaults to `F` and is rebindable under `[tui.keys]`.
+    let chord = app
+      .keymap
+      .primary_chord(super::keymap::Action::FetchGithub)
+      .unwrap_or_else(|| "F".to_string());
     lines.push(Line::from(Span::styled(
-      trunc("press R to fetch status", max_width),
+      trunc(&format!("press {} to fetch status", chord), max_width),
       Style::default().fg(app.theme.muted),
     )));
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
   layout::{Alignment, Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
+  widgets::{Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, Wrap},
   Frame,
 };
 use std::time::{Duration, Instant};
@@ -1853,12 +1853,14 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   );
 }
 
-/// The `[ Confirm ] [ Cancel ]` button row (#187). The focused button
-/// gets the reversed-bold accent chip — the same badge style as the
-/// bottom statusline and the help overlay — while the idle button reads
-/// muted-bold. Focus defaults to Cancel, so the destructive button is
-/// never the one a stray `Enter` lands on.
-fn confirm_buttons_line(focus: ConfirmButton, accent: Color, muted: Color) -> Line<'static> {
+/// The ` Confirm ` ` Cancel ` button row (#187, restyled in #217). The
+/// buttons are flat coloured chips — no square brackets: the focused one
+/// gets the reversed-bold accent chip (the same badge style as the bottom
+/// statusline and the help overlay), the idle one reads muted-bold. Focus
+/// defaults to Cancel, so the destructive button is never the one a stray
+/// `Enter` lands on. Pure so the chip contract is pinned by
+/// `tests/tui_ui_helpers_tests.rs`.
+pub fn confirm_buttons_line(focus: ConfirmButton, accent: Color, muted: Color) -> Line<'static> {
   let focused = Style::default()
     .fg(accent)
     .add_modifier(Modifier::REVERSED | Modifier::BOLD);
@@ -1868,9 +1870,9 @@ fn confirm_buttons_line(focus: ConfirmButton, accent: Color, muted: Color) -> Li
     ConfirmButton::Cancel => (idle, focused),
   };
   Line::from(vec![
-    Span::styled(" [ Confirm ] ", confirm_style),
+    Span::styled(" Confirm ", confirm_style),
     Span::raw("   "),
-    Span::styled(" [ Cancel ] ", cancel_style),
+    Span::styled(" Cancel ", cancel_style),
   ])
 }
 
@@ -2017,6 +2019,15 @@ fn overlay_block(title: &str, color: Color) -> Block<'static> {
       format!(" {title} "),
       Style::default().fg(color).add_modifier(Modifier::BOLD),
     ))
+    // Centre the title (issue #217) so every overlay reads consistently —
+    // matches the centred body content of the confirm / create modals.
+    .title_alignment(Alignment::Center)
+    // One column of horizontal breathing room inside the rounded frame for
+    // overlays that render their content straight into `block.inner()`
+    // (help / open / link / report / palette). The confirm / create modals
+    // position content with their own `margin(1)` layout, so this is inert
+    // for them.
+    .padding(Padding::horizontal(1))
     .border_style(Style::default().fg(color))
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1904,26 +1904,14 @@ fn draw_help(f: &mut Frame, app: &App) {
   }
 
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(overlay_block("help", accent)), area);
+  f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
 
 fn draw_create(f: &mut Frame, app: &App) {
-  // Three bordered fields (3 rows each) + a 3-line preview, sized to fit
-  // with the rounded frame instead of a fixed 60%-tall box (#187).
-  let area = centered_h(70, 15, f.area());
-  f.render_widget(Clear, area);
-  f.render_widget(overlay_block("new worktree", app.theme.clean), area);
-
-  let inner = Layout::default()
-    .direction(Direction::Vertical)
-    .margin(1)
-    .constraints([
-      Constraint::Length(3),
-      Constraint::Length(3),
-      Constraint::Length(3),
-      Constraint::Min(0),
-    ])
-    .split(area);
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let clean = app.theme.clean;
+  let surface = app.theme.selection_bg;
 
   let (type_str, type_desc) = app
     .branch_types
@@ -1931,70 +1919,167 @@ fn draw_create(f: &mut Frame, app: &App) {
     .map(|t| (t.name.as_str(), t.description.as_str()))
     .unwrap_or(("", "(no branch types configured)"));
 
-  let focus_color = app.theme.dirty;
-  let idle_color = app.theme.muted;
-  f.render_widget(
-    field_input(
-      "type (↑/↓)",
-      &format!("{} — {}", type_str, type_desc),
-      app.create_form.field == Field::Type,
-      focus_color,
-      idle_color,
-    ),
-    inner[0],
+  // The modal is a single Paragraph of per-line-aligned rows (the title /
+  // buttons / hint centre themselves, the fields stay left) — no manual
+  // Layout split, the rounded frame's `Padding` owns the breathing room
+  // (issue #217). Height is the fixed row count plus the border + padding
+  // rows, so the box hugs its content.
+  const ROWS: u16 = 11; // title(2) + 3 fields + blank + 2 preview + blank + buttons + hint
+  let height = ROWS + 2 /* border */ + 2 /* vertical padding */;
+  let area = centered_h(70, height, f.area());
+  let block = overlay_block(clean);
+  let inner_w = block.inner(area).width as usize;
+
+  // Width of the background-filled value field: the inner width minus the
+  // `  label  ` gutter (2 indent + label column + 2 gap).
+  let label_w = 5usize;
+  let gutter = 2 + label_w + 2;
+  let value_w = inner_w.saturating_sub(gutter);
+
+  let label = |s: &str| format!("{:<label_w$}", s);
+  let branch = ellipsize_middle(
+    &format!("{}/#{}-{}", type_str, app.create_form.issue, app.create_form.desc),
+    inner_w.saturating_sub("  branch : ".len()),
   );
-  f.render_widget(
-    field_input(
-      "issue (digits)",
-      &app.create_form.issue,
-      app.create_form.field == Field::Issue,
-      focus_color,
-      idle_color,
-    ),
-    inner[1],
-  );
-  f.render_widget(
-    field_input(
-      "description (kebab)",
-      &app.create_form.desc,
-      app.create_form.field == Field::Desc,
-      focus_color,
-      idle_color,
-    ),
-    inner[2],
+  let dirname = ellipsize_middle(
+    &format!("{}-{}-{}", type_str, app.create_form.issue, app.create_form.desc),
+    inner_w.saturating_sub("  dir    : ".len()),
   );
 
-  // Preview line
-  let branch = format!("{}/#{}-{}", type_str, app.create_form.issue, app.create_form.desc);
-  let dirname = format!("{}-{}-{}", type_str, app.create_form.issue, app.create_form.desc);
-  let preview = vec![
-    Line::from(Span::styled("preview", Style::default().fg(app.theme.muted))),
-    Line::from(vec![
-      Span::raw("  branch : "),
-      Span::styled(branch, Style::default().fg(app.theme.branch)),
-    ]),
-    Line::from(vec![
-      Span::raw("  dir    : "),
-      Span::styled(dirname, Style::default().fg(app.theme.dirty)),
-    ]),
-  ];
-  f.render_widget(Paragraph::new(preview), inner[3]);
+  let mut lines = overlay_title_lines("new worktree", clean);
+  lines.push(type_selector_line(
+    &label("type"),
+    type_str,
+    type_desc,
+    app.create_form.field == Field::Type,
+    accent,
+    muted,
+  ));
+  lines.push(field_input_line(
+    &label("issue"),
+    &app.create_form.issue,
+    app.create_form.field == Field::Issue,
+    value_w,
+    accent,
+    muted,
+    surface,
+  ));
+  lines.push(field_input_line(
+    &label("desc"),
+    &app.create_form.desc,
+    app.create_form.field == Field::Desc,
+    value_w,
+    accent,
+    muted,
+    surface,
+  ));
+  lines.push(Line::from(String::new()));
+  lines.push(Line::from(vec![
+    Span::raw("  branch : "),
+    Span::styled(branch, Style::default().fg(app.theme.branch)),
+  ]));
+  lines.push(Line::from(vec![
+    Span::raw("  dir    : "),
+    Span::styled(dirname, Style::default().fg(app.theme.dirty)),
+  ]));
+  lines.push(Line::from(String::new()));
+  lines.push(create_buttons_line(accent, muted).centered());
+  lines.push(
+    Line::from(Span::styled(
+      "Tab: field · ←/→: type · Enter: create · Esc: cancel",
+      Style::default().fg(muted),
+    ))
+    .centered(),
+  );
+
+  f.render_widget(Clear, area);
+  f.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-fn field_input(label: &str, value: &str, focused: bool, focus_color: Color, idle_color: Color) -> Paragraph<'static> {
-  let border_style = if focused {
-    Style::default().fg(focus_color)
+/// The create overlay's ` Create ` / ` Cancel ` button row (issue #217).
+/// Mirrors [`confirm_buttons_line`]'s flat coloured chips, but — the create
+/// action being non-destructive — primes `Create` as the reversed-accent
+/// chip rather than defaulting focus to Cancel. Pure so the chip contract
+/// is pinned by `tests/tui_ui_helpers_tests.rs`.
+pub fn create_buttons_line(accent: Color, muted: Color) -> Line<'static> {
+  let primary = Style::default()
+    .fg(accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let idle = Style::default().fg(muted).add_modifier(Modifier::BOLD);
+  Line::from(vec![
+    Span::styled(" Create ", primary),
+    Span::raw("   "),
+    Span::styled(" Cancel ", idle),
+  ])
+}
+
+/// A horizontal `‹ name ›` branch-type selector row for the create overlay
+/// (issue #217 — replaces the bordered up/down box). `label` leads the row
+/// muted; the arrows + selected name read in the accent when focused, and
+/// the type's description trails muted. Pure for
+/// `tests/tui_ui_helpers_tests.rs`.
+pub fn type_selector_line(
+  label: &str,
+  name: &str,
+  desc: &str,
+  focused: bool,
+  accent: Color,
+  muted: Color,
+) -> Line<'static> {
+  let arrow_style = if focused {
+    Style::default().fg(accent)
   } else {
-    Style::default().fg(idle_color)
+    Style::default().fg(muted)
   };
-  let title = format!(" {} ", label);
-  Paragraph::new(value.to_string()).block(
-    Block::default()
-      .borders(Borders::ALL)
-      .border_type(BorderType::Rounded)
-      .title(title)
-      .border_style(border_style),
-  )
+  let name_style = if focused {
+    Style::default().fg(accent).add_modifier(Modifier::BOLD)
+  } else {
+    Style::default().fg(Color::White)
+  };
+  Line::from(vec![
+    Span::raw("  "),
+    Span::styled(label.to_string(), Style::default().fg(muted)),
+    Span::raw("  "),
+    Span::styled("‹ ", arrow_style),
+    Span::styled(name.to_string(), name_style),
+    Span::styled(" ›", arrow_style),
+    Span::raw("  "),
+    Span::styled(desc.to_string(), Style::default().fg(muted)),
+  ])
+}
+
+/// A single-row labelled input with a background surface for the create
+/// overlay (issue #217 — replaces the 3-row bordered field). `label` leads
+/// muted; the value sits in a `value_width`-wide background-filled field so
+/// it reads as one input row. The focused field brightens to the accent
+/// background and shows a `_` cursor. Pure for
+/// `tests/tui_ui_helpers_tests.rs`.
+pub fn field_input_line(
+  label: &str,
+  value: &str,
+  focused: bool,
+  value_width: usize,
+  accent: Color,
+  muted: Color,
+  surface: Color,
+) -> Line<'static> {
+  let cursor = if focused { "_" } else { "" };
+  let mut field = format!(" {value}{cursor}");
+  let len = field.chars().count();
+  if len < value_width {
+    field.push_str(&" ".repeat(value_width - len));
+  }
+  let field_style = if focused {
+    Style::default().fg(Color::Black).bg(accent)
+  } else {
+    Style::default().fg(Color::White).bg(surface)
+  };
+  Line::from(vec![
+    Span::raw("  "),
+    Span::styled(label.to_string(), Style::default().fg(muted)),
+    Span::raw("  "),
+    Span::styled(field, field_style),
+  ])
 }
 
 fn draw_confirm(f: &mut Frame, app: &App) {
@@ -2004,26 +2089,24 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   // instead of the pre-#187 hard-coded `Red`.
   let danger = app.theme.prunable;
 
-  let block = overlay_block("confirm delete", danger);
+  let block = overlay_block(danger);
 
   let Some(w) = app.selected() else {
-    let area = centered_h(40, 5, f.area());
+    let mut lines = overlay_title_lines("confirm delete", danger);
+    lines.push(Line::from("nothing selected").centered());
+    let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
+    let area = centered_h(40, height, f.area());
     f.render_widget(Clear, area);
-    f.render_widget(
-      Paragraph::new("nothing selected")
-        .block(block)
-        .alignment(Alignment::Center),
-      area,
-    );
+    f.render_widget(Paragraph::new(lines).block(block), area);
     return;
   };
 
   // Width first (a fixed % of the terminal) so a long path / name can be
   // middle-ellipsized to one line instead of wrapping mid-path (#187
-  // review). `text_w` is the room inside the 1-col margins.
+  // review). `text_w` is the room inside the border + padding.
   let term = f.area();
   let outer_w = term.width.saturating_mul(62) / 100;
-  let text_w = outer_w.saturating_sub(2) as usize;
+  let text_w = outer_w.saturating_sub(6) as usize;
 
   let name = ellipsize_middle(&w.name, text_w.saturating_sub("delete ".len()));
   let path = ellipsize_middle(
@@ -2031,14 +2114,16 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     text_w.saturating_sub("at ".len()),
   );
 
-  // --- description (centred) ---
-  let mut content: Vec<Line> = vec![
-    Line::from(vec![
-      Span::raw("delete "),
-      Span::styled(name, Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)),
-    ]),
-    Line::from(Span::styled(format!("at {path}"), Style::default().fg(muted))),
-  ];
+  // --- title + description (centred) ---
+  let mut content: Vec<Line> = overlay_title_lines("confirm delete", danger);
+  content.push(Line::from(vec![
+    Span::raw("delete "),
+    Span::styled(name, Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)),
+  ]));
+  content.push(Line::from(Span::styled(
+    format!("at {path}"),
+    Style::default().fg(muted),
+  )));
   if let Some(b) = &w.branch {
     let branch = ellipsize_middle(b, text_w.saturating_sub("branch: ".len()));
     content.push(Line::from(vec![
@@ -2052,27 +2137,28 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     app.delete_branch_on_remove
   )));
 
-  // Size the modal to its content: the description rows plus the three
-  // fixed rows (loader / buttons / hint) and the rounded border — no
-  // more fixed 44%-tall box that dwarfed its few lines (#187 review).
-  let height = content.len() as u16 + 3 + 2;
+  // Size the modal to its content: the title + description rows plus the
+  // three fixed rows (loader / buttons / hint), the rounded border and the
+  // shared interior padding — no more fixed 44%-tall box that dwarfed its
+  // few lines (#187 review).
+  let height = content.len() as u16 + 3 + 2 /* border */ + 2 /* padding */;
   let area = centered_h(62, height, term);
   f.render_widget(Clear, area);
 
-  // Four stacked regions inside the border: the description, a
-  // loader/countdown row, the button row, and a muted key hint. The
+  // Four stacked regions inside the padded frame: the title + description,
+  // a loader/countdown row, the button row, and a muted key hint. The
   // loader row stays reserved (Length 1) even when idle so the buttons
-  // never jump as the countdown arms.
+  // never jump as the countdown arms. Split `block.inner` so the shared
+  // padding owns the breathing room (issue #217).
   let inner = Layout::default()
     .direction(Direction::Vertical)
-    .margin(1)
     .constraints([
-      Constraint::Min(1),    // description
+      Constraint::Min(1),    // title + description
       Constraint::Length(1), // loader / countdown
       Constraint::Length(1), // buttons
       Constraint::Length(1), // hint
     ])
-    .split(area);
+    .split(block.inner(area));
   f.render_widget(block, area);
 
   f.render_widget(
@@ -2206,7 +2292,7 @@ pub fn filled_cells_for_progress(progress: f64, cells: usize) -> usize {
 }
 
 fn draw_report(f: &mut Frame, app: &App) {
-  let mut lines: Vec<Line> = Vec::new();
+  let mut lines: Vec<Line> = overlay_title_lines("bootstrap report", app.theme.accent);
   if let Some(report) = &app.report {
     for step in &report.steps {
       let sigil = step.status.sigil();
@@ -2236,15 +2322,16 @@ fn draw_report(f: &mut Frame, app: &App) {
     Style::default().fg(app.theme.muted),
   )));
 
-  // Size to the report length (+ border), capped at 80% of the screen so
-  // a long report stays on-screen rather than a fixed 80%-tall box (#187).
+  // Size to the report length (+ border + padding), capped at 80% of the
+  // screen so a long report stays on-screen rather than a fixed 80%-tall
+  // box (#187).
   let term = f.area();
-  let height = (lines.len() as u16 + 2).min(term.height.saturating_mul(80) / 100);
+  let height = (lines.len() as u16 + 2 /* border */ + 2/* padding */).min(term.height.saturating_mul(80) / 100);
   let area = centered_h(80, height, term);
   f.render_widget(Clear, area);
   f.render_widget(
     Paragraph::new(lines)
-      .block(overlay_block("bootstrap report", app.theme.accent))
+      .block(overlay_block(app.theme.accent))
       .wrap(Wrap { trim: false }),
     area,
   );
@@ -2281,28 +2368,36 @@ fn centered_h(width_pct: u16, height: u16, area: Rect) -> Rect {
   Rect { x, y, width, height }
 }
 
-/// A modal overlay frame: a rounded border plus a bold title, both in
-/// `color`. Shared by every overlay (#187) so the confirm / help / create
-/// / report / open / link / palette modals read consistently instead of
-/// each hard-coding its own border kind and colour.
-fn overlay_block(title: &str, color: Color) -> Block<'static> {
+/// A modal overlay frame: a rounded border in `color` with interior
+/// padding on every side. Shared by every overlay (#187) so the confirm /
+/// help / create / report / open / link / palette modals read consistently.
+/// The title is *not* embedded in the border any more (issue #217): it
+/// lives inside the frame as its own centred line via [`overlay_title_lines`]
+/// so the border stays clean and no content hugs the edge. The padding
+/// (2 cols horizontal, 1 row vertical) is the breathing room callers must
+/// account for when sizing — inner height shrinks by 2 rows, inner width by
+/// 4 cols, on top of the 2-cell border.
+fn overlay_block(color: Color) -> Block<'static> {
   Block::default()
     .borders(Borders::ALL)
     .border_type(BorderType::Rounded)
-    .title(Span::styled(
-      format!(" {title} "),
+    .padding(Padding::symmetric(2, 1))
+    .border_style(Style::default().fg(color))
+}
+
+/// The detached modal title: a centred bold line in `color` followed by a
+/// blank spacer row, prepended to a modal's content so the title sits
+/// inside the rounded frame rather than embedded in the top border
+/// (issue #217). Returns two lines, so callers sizing to content add 2.
+fn overlay_title_lines(title: &str, color: Color) -> Vec<Line<'static>> {
+  vec![
+    Line::from(Span::styled(
+      title.to_string(),
       Style::default().fg(color).add_modifier(Modifier::BOLD),
     ))
-    // Centre the title (issue #217) so every overlay reads consistently —
-    // matches the centred body content of the confirm / create modals.
-    .title_alignment(Alignment::Center)
-    // One column of horizontal breathing room inside the rounded frame for
-    // overlays that render their content straight into `block.inner()`
-    // (help / open / link / report / palette). The confirm / create modals
-    // position content with their own `margin(1)` layout, so this is inert
-    // for them.
-    .padding(Padding::horizontal(1))
-    .border_style(Style::default().fg(color))
+    .centered(),
+    Line::from(String::new()),
+  ]
 }
 
 /// Middle-ellipsize `s` to at most `max` display columns, keeping the
@@ -2341,61 +2436,53 @@ fn trunc(s: &str, max: usize) -> String {
 
 fn draw_open_menu(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let lines = vec![
-    Line::from(Span::styled(
-      "open in browser",
-      Style::default().fg(accent).add_modifier(Modifier::BOLD),
-    )),
-    Line::from(""),
-    Line::from("  i   linked issue"),
-    Line::from("  p   linked pull request"),
-    Line::from(""),
-    Line::from(Span::styled("  esc to cancel", Style::default().fg(app.theme.muted))),
-  ];
-  let area = centered_h(40, lines.len() as u16 + 2, f.area());
+  let mut lines = overlay_title_lines("open in browser", accent);
+  lines.push(Line::from("  i   linked issue"));
+  lines.push(Line::from("  p   linked pull request"));
+  lines.push(Line::from(""));
+  lines.push(Line::from(Span::styled(
+    "  esc to cancel",
+    Style::default().fg(app.theme.muted),
+  )));
+  let area = centered_h(40, lines.len() as u16 + 2 /* border */ + 2 /* padding */, f.area());
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(overlay_block("open", accent)), area);
+  f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
 
 fn draw_link_prompt(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
   let muted = app.theme.muted;
   let lines = match app.link_prompt_stage() {
-    LinkPromptStage::ChooseTarget => vec![
-      Line::from(Span::styled(
-        "link this worktree to:",
-        Style::default().fg(accent).add_modifier(Modifier::BOLD),
-      )),
-      Line::from(""),
-      Line::from("  i   a GitHub issue"),
-      Line::from("  p   a pull request"),
-      Line::from(""),
-      Line::from(Span::styled("  esc to cancel", Style::default().fg(muted))),
-    ],
+    LinkPromptStage::ChooseTarget => {
+      let mut lines = overlay_title_lines("link this worktree to:", accent);
+      lines.push(Line::from("  i   a GitHub issue"));
+      lines.push(Line::from("  p   a pull request"));
+      lines.push(Line::from(""));
+      lines.push(Line::from(Span::styled("  esc to cancel", Style::default().fg(muted))));
+      lines
+    }
     LinkPromptStage::InputNumber => {
       let label = match app.link_prompt_target() {
         Some(super::app::LinkTarget::Issue) => "issue #",
         Some(super::app::LinkTarget::Pr) => "PR #",
         None => "#",
       };
-      vec![
-        Line::from(Span::styled(
-          format!("type the {} number", label.trim_end_matches('#').trim()),
-          Style::default().fg(accent).add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-        Line::from(format!("  {}{}_", label, app.link_prompt_number_input())),
-        Line::from(""),
-        Line::from(Span::styled(
-          "  enter confirms · esc cancels · backspace deletes",
-          Style::default().fg(muted),
-        )),
-      ]
+      let mut lines = overlay_title_lines(
+        &format!("type the {} number", label.trim_end_matches('#').trim()),
+        accent,
+      );
+      lines.push(Line::from(format!("  {}{}_", label, app.link_prompt_number_input())));
+      lines.push(Line::from(""));
+      lines.push(Line::from(Span::styled(
+        "  enter confirms · esc cancels · backspace deletes",
+        Style::default().fg(muted),
+      )));
+      lines
     }
   };
-  let area = centered_h(50, lines.len() as u16 + 2, f.area());
+  let area = centered_h(50, lines.len() as u16 + 2 /* border */ + 2 /* padding */, f.area());
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(overlay_block("link", accent)), area);
+  f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
 
 /// Render the command palette overlay (issue #32).
@@ -2411,15 +2498,33 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
   f.render_widget(Clear, area);
 
   let accent = app.theme.accent;
-  let outer = overlay_block("command palette", accent);
+  let outer = overlay_block(accent);
   let inner = outer.inner(area);
   f.render_widget(outer, area);
 
-  // Two rows: matches list (flex) + input bar (height 1).
+  // Four rows: a detached centred title, a blank spacer, the matches list
+  // (flex), and the input bar pinned to the bottom (issue #217 — the title
+  // moved off the border into the frame).
   let layout = Layout::default()
     .direction(Direction::Vertical)
-    .constraints([Constraint::Min(3), Constraint::Length(1)])
+    .constraints([
+      Constraint::Length(1), // title
+      Constraint::Length(1), // spacer
+      Constraint::Min(3),    // matches
+      Constraint::Length(1), // input bar
+    ])
     .split(inner);
+
+  f.render_widget(
+    Paragraph::new(
+      Line::from(Span::styled(
+        "command palette",
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+      ))
+      .centered(),
+    ),
+    layout[0],
+  );
 
   let entries = app.palette.matches();
   let highlight = app.palette.highlight();
@@ -2447,14 +2552,14 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
       Style::default().fg(app.theme.prunable),
     )));
   }
-  f.render_widget(Paragraph::new(lines), layout[0]);
+  f.render_widget(Paragraph::new(lines), layout[2]);
 
   let input_line = Line::from(vec![
     Span::styled(":", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
     Span::raw(app.palette.buffer().to_string()),
     Span::styled("_", Style::default().fg(app.theme.muted)),
   ]);
-  f.render_widget(Paragraph::new(input_line), layout[1]);
+  f.render_widget(Paragraph::new(input_line), layout[3]);
 }
 
 /// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1249,11 +1249,25 @@ fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, Colo
   (label, color)
 }
 
-/// Which pane / mode the TUI is in, the single source the help overlay
-/// subtitle and the contextual statusbar both read (issue #217). Keeping
-/// them on one enum means the discoverable hints (`?`) and the always-on
-/// statusbar chips can never advertise a different verb set for the same
-/// context.
+/// One statusbar hint specification (issue #217). Either a rebindable
+/// keymap [`Action`](super::keymap::Action) whose key is resolved live from
+/// the keymap, or a fixed literal for keys that are hard-coded contextual
+/// escape hatches (Esc / Enter / digits inside a modal) and so cannot be
+/// rebound.
+#[derive(Debug, Clone, Copy)]
+enum Hint {
+  /// Resolve the displayed key from the keymap (honours `[tui.keys]`).
+  Key(super::keymap::Action, &'static str),
+  /// A fixed key + label for a non-rebindable contextual keystroke.
+  Lit(&'static str, &'static str),
+}
+
+/// Which pane / mode / overlay the TUI is in — the single source the help
+/// overlay subtitle and the contextual statusbar both read (issue #217).
+/// Keeping them on one enum means the discoverable hints (`?`) and the
+/// always-on statusbar chips can never advertise a different verb set for
+/// the same context. An open modal takes priority over the pane focus (see
+/// [`App::hint_context`](super::app::App::hint_context)).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HintContext {
   /// Worktree table focused — the default list-view context.
@@ -1262,6 +1276,20 @@ pub enum HintContext {
   Status,
   /// `gwm switch` picker — mutating verbs are inert, Enter/Esc pick/cancel.
   Picker,
+  /// Create-worktree form modal.
+  Create,
+  /// Confirm-delete modal.
+  Confirm,
+  /// Open issue/PR URL menu.
+  OpenMenu,
+  /// Two-stage issue/PR link prompt.
+  LinkPrompt,
+  /// Command palette overlay.
+  CommandPalette,
+  /// Bootstrap report overlay.
+  Report,
+  /// Keybindings help overlay.
+  Help,
 }
 
 impl HintContext {
@@ -1272,51 +1300,99 @@ impl HintContext {
       HintContext::Worktrees => "worktrees",
       HintContext::Status => "status",
       HintContext::Picker => "switch",
+      HintContext::Create => "create",
+      HintContext::Confirm => "confirm",
+      HintContext::OpenMenu => "open",
+      HintContext::LinkPrompt => "link",
+      HintContext::CommandPalette => "command",
+      HintContext::Report => "report",
+      HintContext::Help => "help",
     }
   }
 
-  /// Compact `(key, label)` hints for the statusbar, tuned per context so
-  /// the row advertises the verbs that actually do something *here* rather
-  /// than a fixed global list. The keys are the default bindings; a user
-  /// override changes the dispatch but not this advisory copy (the help
-  /// overlay carries the authoritative, keymap-resolved bindings).
-  pub fn hints(self) -> &'static [(&'static str, &'static str)] {
+  /// Static hint specs for this context. List-view contexts use rebindable
+  /// [`Hint::Key`] verbs (resolved live by [`Self::resolve`]); modal /
+  /// overlay contexts use [`Hint::Lit`] because their keys are hard-coded
+  /// contextual escape hatches (Esc / Enter / digits), not keymap actions.
+  fn hint_specs(self) -> &'static [Hint] {
+    use super::keymap::Action::*;
     match self {
       HintContext::Worktrees => &[
-        ("n", "new"),
-        ("d", "del"),
-        ("b", "boot"),
-        ("o", "open"),
-        ("y", "yank"),
-        ("l", "git"),
-        ("R", "review"),
-        ("2", "status"),
-        ("/", "filter"),
-        ("?", "help"),
-        ("q", "quit"),
+        Hint::Key(Create, "new"),
+        Hint::Key(DeleteConfirm, "del"),
+        Hint::Key(Bootstrap, "boot"),
+        Hint::Key(Open, "open"),
+        Hint::Key(Yank, "yank"),
+        Hint::Key(GitTui, "git"),
+        Hint::Key(Review, "review"),
+        Hint::Key(FocusStatus, "status"),
+        Hint::Key(Filter, "filter"),
+        Hint::Key(Help, "help"),
+        Hint::Key(Quit, "quit"),
       ],
       HintContext::Status => &[
-        ("j/k", "scroll"),
-        ("s", "mode"),
-        ("V", "layout"),
-        ("F", "fetch"),
-        ("1", "worktrees"),
-        ("/", "filter"),
-        ("?", "help"),
-        ("q", "quit"),
+        Hint::Key(Down, "scroll"),
+        Hint::Key(ToggleSidebarMode, "mode"),
+        Hint::Key(CycleSidebarLayout, "layout"),
+        Hint::Key(FetchGithub, "fetch"),
+        Hint::Key(FocusWorktrees, "worktrees"),
+        Hint::Key(Filter, "filter"),
+        Hint::Key(Help, "help"),
+        Hint::Key(Quit, "quit"),
       ],
       HintContext::Picker => &[
-        ("enter", "select"),
-        ("esc", "cancel"),
-        ("o", "open"),
-        ("y", "yank"),
-        ("l", "git"),
-        ("Tab", "focus"),
-        ("/", "filter"),
-        ("?", "help"),
-        ("q", "quit"),
+        Hint::Lit("Enter", "select"),
+        Hint::Lit("Esc", "cancel"),
+        Hint::Key(Open, "open"),
+        Hint::Key(Yank, "yank"),
+        Hint::Key(GitTui, "git"),
+        Hint::Key(Filter, "filter"),
+        Hint::Key(Help, "help"),
+        Hint::Key(Quit, "quit"),
       ],
+      HintContext::Create => &[
+        Hint::Lit("Tab", "field"),
+        Hint::Lit("↑/↓", "type"),
+        Hint::Lit("Enter", "submit"),
+        Hint::Lit("Esc", "cancel"),
+      ],
+      HintContext::Confirm => &[
+        Hint::Lit("y", "confirm"),
+        Hint::Lit("←/→", "move"),
+        Hint::Lit("Enter", "activate"),
+        Hint::Lit("Esc", "cancel"),
+      ],
+      HintContext::OpenMenu => &[Hint::Lit("i", "issue"), Hint::Lit("p", "pr"), Hint::Lit("Esc", "close")],
+      HintContext::LinkPrompt => &[
+        Hint::Lit("i/p", "kind"),
+        Hint::Lit("0-9", "number"),
+        Hint::Lit("Enter", "link"),
+        Hint::Lit("Esc", "cancel"),
+      ],
+      HintContext::CommandPalette => &[
+        Hint::Lit("↑/↓", "move"),
+        Hint::Lit("Enter", "run"),
+        Hint::Lit("Esc", "cancel"),
+      ],
+      HintContext::Report => &[Hint::Lit("Enter/Esc", "close")],
+      HintContext::Help => &[Hint::Lit("Esc/q", "close")],
     }
+  }
+
+  /// Resolve this context's hints to `(key, label)` pairs for the statusbar,
+  /// reading the live keymap so rebindable verbs show the user's actual
+  /// binding (issue #217 review) — the same `primary_chord` source the help
+  /// overlay and the Issue/PR prompt use. An unbound action is dropped from
+  /// the row rather than advertised with a phantom key.
+  pub fn resolve(self, keymap: &super::keymap::Keymap) -> Vec<(String, String)> {
+    self
+      .hint_specs()
+      .iter()
+      .filter_map(|h| match h {
+        Hint::Key(action, label) => keymap.primary_chord(*action).map(|k| (k, label.to_string())),
+        Hint::Lit(key, label) => Some((key.to_string(), label.to_string())),
+      })
+      .collect()
   }
 }
 
@@ -1528,9 +1604,14 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   } else {
     None
   };
+  // Resolve the rebindable hint keys against the live keymap (issue #217
+  // review) so a user override shows through, then borrow into the slice
+  // `status_line` expects.
+  let resolved = ctx.resolve(&app.keymap);
+  let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
   let line = status_line(
     ctx.label(),
-    ctx.hints(),
+    &hints,
     &app.status,
     spinner,
     area.width as usize,
@@ -1748,7 +1829,10 @@ pub fn badge_group_width(keys: &str) -> usize {
 
 fn draw_help(f: &mut Frame, app: &App) {
   let area = centered(60, 60, f.area());
-  let rows = help_rows(&app.keymap, app.hint_context());
+  // Use the underlying pane context, not the view-priority `hint_context`
+  // (which would be `Help` while this overlay is up) — `?` documents the
+  // pane you opened it from, and the picker gating depends on it.
+  let rows = help_rows(&app.keymap, app.pane_hint_context());
 
   // Theme-driven colours so the overlay tracks `[theme]` like the rest
   // of the TUI (pre-#187 it was hard-coded `Cyan` + plain text).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -323,6 +323,15 @@ pub fn worktrees_pane_title(query_empty: bool, visible: usize, total: usize) -> 
   }
 }
 
+/// Title for the head section of the status (sidebar) pane (issue #217).
+/// Carries the `[2]` focus mnemonic (focusable with the `2` key), mirroring
+/// [`worktrees_pane_title`]'s `[1]`. The sidebar is a stack of sub-sections;
+/// this labels the first one so the pane reads as `[2] Status` without
+/// nesting an extra bordered frame.
+pub fn status_pane_title() -> &'static str {
+  " [2] Status "
+}
+
 /// Bottom-right `selected of visible` counter for a pane footer (issue
 /// #217), lazygit-style. `selected` is the 1-based cursor position;
 /// `visible` is the count of rows currently on screen. Returns `None` when
@@ -511,7 +520,15 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     .constraints(constraints)
     .split(area);
 
-  render_section(f, chunks[0], " Worktree ", sections.worktree, border_color, 0, None);
+  render_section(
+    f,
+    chunks[0],
+    status_pane_title(),
+    sections.worktree,
+    border_color,
+    0,
+    None,
+  );
   render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
   if !sections.working_tree.is_empty() {
     render_section(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1232,45 +1232,76 @@ fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, Colo
   (label, color)
 }
 
-/// `(key, label)` hints advertised in the full TUI footer, in display order.
-/// Picker mode hides the mutating actions (n/d/b/F) — they're inert in the
-/// picker event loop, so advertising them would be a lie.
-const FOOTER_HINTS: &[(&str, &str)] = &[
-  ("n", "new"),
-  ("d", "del"),
-  ("b", "boot"),
-  ("o", "open"),
-  ("y", "yank"),
-  ("l", "git"),
-  ("R", "review"),
-  ("v", "sidebar"),
-  ("Tab", "focus"),
-  ("/", "filter"),
-  ("gg/G", "top/bot"),
-  ("j/k", "nav"),
-  ("f", "refresh"),
-  ("F", "gh"),
-  ("?", "help"),
-  ("q", "quit"),
-];
+/// Which pane / mode the TUI is in, the single source the help overlay
+/// subtitle and the contextual statusbar both read (issue #217). Keeping
+/// them on one enum means the discoverable hints (`?`) and the always-on
+/// statusbar chips can never advertise a different verb set for the same
+/// context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HintContext {
+  /// Worktree table focused — the default list-view context.
+  Worktrees,
+  /// Status (sidebar) pane focused — `j` / `k` scroll the preview.
+  Status,
+  /// `gwm switch` picker — mutating verbs are inert, Enter/Esc pick/cancel.
+  Picker,
+}
 
-/// Picker-mode footer hints — `enter`/`esc` select/cancel instead of the
-/// mutating actions, matching the picker event loop.
-const PICKER_FOOTER_HINTS: &[(&str, &str)] = &[
-  ("enter", "select"),
-  ("esc", "cancel"),
-  ("o", "open"),
-  ("y", "yank"),
-  ("l", "git"),
-  ("v", "sidebar"),
-  ("Tab", "focus"),
-  ("/", "filter"),
-  ("gg/G", "top/bot"),
-  ("j/k", "nav"),
-  ("f", "refresh"),
-  ("?", "help"),
-  ("q", "quit"),
-];
+impl HintContext {
+  /// Short label rendered into the statusbar context chip and the help
+  /// overlay subtitle.
+  pub fn label(self) -> &'static str {
+    match self {
+      HintContext::Worktrees => "worktrees",
+      HintContext::Status => "status",
+      HintContext::Picker => "switch",
+    }
+  }
+
+  /// Compact `(key, label)` hints for the statusbar, tuned per context so
+  /// the row advertises the verbs that actually do something *here* rather
+  /// than a fixed global list. The keys are the default bindings; a user
+  /// override changes the dispatch but not this advisory copy (the help
+  /// overlay carries the authoritative, keymap-resolved bindings).
+  pub fn hints(self) -> &'static [(&'static str, &'static str)] {
+    match self {
+      HintContext::Worktrees => &[
+        ("n", "new"),
+        ("d", "del"),
+        ("b", "boot"),
+        ("o", "open"),
+        ("y", "yank"),
+        ("l", "git"),
+        ("R", "review"),
+        ("2", "status"),
+        ("/", "filter"),
+        ("?", "help"),
+        ("q", "quit"),
+      ],
+      HintContext::Status => &[
+        ("j/k", "scroll"),
+        ("s", "mode"),
+        ("V", "layout"),
+        ("F", "fetch"),
+        ("1", "worktrees"),
+        ("/", "filter"),
+        ("?", "help"),
+        ("q", "quit"),
+      ],
+      HintContext::Picker => &[
+        ("enter", "select"),
+        ("esc", "cancel"),
+        ("o", "open"),
+        ("y", "yank"),
+        ("l", "git"),
+        ("Tab", "focus"),
+        ("/", "filter"),
+        ("?", "help"),
+        ("q", "quit"),
+      ],
+    }
+  }
+}
 
 /// Build the single-line statusline (issue #180).
 ///
@@ -1364,14 +1395,131 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &T
   Line::from(spans)
 }
 
+/// Contextual statusbar (issue #217) — a superset of [`footer_line`] that
+/// leads with a context chip and an optional loading spinner. Layout,
+/// left-to-right:
+///
+/// ```text
+///  worktrees  ⠋  n  new  d  del  …                       [<status>]
+/// ```
+///
+/// Priority when space is tight, from most to least protected: the status
+/// log (right, clipped only if it alone overflows), the context chip and
+/// spinner (left, the load-bearing "where am I / am I busy" signals), then
+/// the hints (truncated with `…`). Pure + width-driven so the contract is
+/// pinned by `tests/tui_footer_tests.rs`; `footer_line` is kept intact for
+/// its own callers and tests.
+pub fn status_line(
+  context: &str,
+  hints: &[(&str, &str)],
+  status: &str,
+  spinner: Option<&str>,
+  width: usize,
+  theme: &Theme,
+) -> Line<'static> {
+  let chip_style = Style::default()
+    .fg(theme.accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let label_style = Style::default().fg(theme.muted);
+  let status_style = Style::default().fg(theme.dirty);
+  let spinner_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
+
+  if width == 0 {
+    return Line::default();
+  }
+
+  let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
+  let status_text = format!("[{}]", status);
+  let status_w = status_text.chars().count();
+
+  // Priority floor: if even the status cannot fit, show a clipped status
+  // alone — never a chip or hint at the log's expense.
+  if width <= status_w {
+    return Line::from(Span::styled(trunc(&status_text, width), status_style));
+  }
+
+  let avail = width - status_w; // columns to the left of the right-pinned status
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  let mut used = 0usize;
+
+  // Context chip — load-bearing, kept whenever it fits at all.
+  let ctx_chip = format!(" {} ", context);
+  let ctx_w = ctx_chip.chars().count();
+  if ctx_w <= avail {
+    spans.push(Span::styled(ctx_chip, chip_style));
+    used += ctx_w;
+  }
+
+  // Loading spinner — optional, rendered right after the chip when present
+  // and there is room.
+  if let Some(glyph) = spinner {
+    let padded = format!(" {} ", glyph);
+    let gw = padded.chars().count();
+    if used + gw <= avail {
+      spans.push(Span::styled(padded, spinner_style));
+      used += gw;
+    }
+  }
+
+  // Hint badges fill whatever is left, minus one column for the `…` marker.
+  let hint_budget = avail.saturating_sub(used).saturating_sub(1);
+  let mut truncated = false;
+  let mut hint_used = 0usize;
+  for (i, (key, label)) in hints.iter().enumerate() {
+    // A separating space before every badge except the very first one when
+    // there is no left cluster.
+    let sep = usize::from(i > 0 || used > 0);
+    let badge_w = key.chars().count() + 2 + 1 + label.chars().count();
+    if hint_used + sep + badge_w > hint_budget {
+      truncated = true;
+      break;
+    }
+    if sep == 1 {
+      spans.push(Span::raw(" "));
+      hint_used += 1;
+    }
+    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled(format!(" {}", label), label_style));
+    hint_used += badge_w;
+  }
+  used += hint_used;
+  if truncated {
+    if used > 0 {
+      spans.push(Span::raw(" "));
+      used += 1;
+    }
+    spans.push(Span::styled("…", label_style));
+    used += 1;
+  }
+
+  let pad = width.saturating_sub(used + status_w);
+  if pad > 0 {
+    spans.push(Span::raw(" ".repeat(pad)));
+  }
+  spans.push(Span::styled(status_text, status_style));
+  Line::from(spans)
+}
+
 fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
-  let hints = if app.picker_mode {
-    PICKER_FOOTER_HINTS
+  let ctx = app.hint_context();
+  // Spinner shows only while a GitHub fetch is inflight (issue #217). The
+  // frame advances at the poll cadence once the fetch runs off-thread
+  // (#217 async path); with a blocking fetch the Loading state is too brief
+  // to paint, which is exactly why the async path matters.
+  let spinner = if app.is_github_loading() {
+    Some(app.spinner.glyph(DOT_FRAMES))
   } else {
-    FOOTER_HINTS
+    None
   };
-  let line = footer_line(hints, &app.status, area.width as usize, &app.theme);
-  // No `Wrap`: the footer is a single hard-clipped row (issue #180).
+  let line = status_line(
+    ctx.label(),
+    ctx.hints(),
+    &app.status,
+    spinner,
+    area.width as usize,
+    &app.theme,
+  );
+  // No `Wrap`: the statusbar is a single hard-clipped row (issue #180).
   f.render_widget(Paragraph::new(line), area);
 }
 
@@ -1387,6 +1535,9 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
 pub enum HelpRow {
   /// Overlay title — always the first row.
   Title(String),
+  /// Context subtitle under the title (`worktrees` / `status` / `switch`),
+  /// issue #217. Reflects the focused pane / mode when `?` was opened.
+  Subtitle(String),
   /// Section header (`global`, `list view`, `issue / PR (#67)`, …).
   Section(String),
   /// Blank spacer row.
@@ -1409,8 +1560,15 @@ pub enum HelpRow {
 ///
 /// Exposed as `pub` (and re-exported through `tui::help_rows`) so the
 /// renderer and the state-machine tests share one source of truth.
-pub fn help_rows(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<HelpRow> {
+///
+/// `ctx` (issue #217) drives the title's context subtitle and whether the
+/// picker-only / non-picker sections render. `HintContext::Picker` is the
+/// `gwm switch` overlay; `Worktrees` / `Status` are the two list-view panes
+/// (same body, the subtitle just names the focused pane).
+pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
   use super::keymap::Action;
+
+  let picker_mode = matches!(ctx, HintContext::Picker);
 
   // Snapshot the keymap once. The pre-#87-review version called
   // `km.list()` inside `keys_for`, which cloned the entire bindings
@@ -1451,14 +1609,9 @@ pub fn help_rows(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<HelpRow> 
     }
   };
 
-  let title_text = if picker_mode {
-    "gwm switch — keys"
-  } else {
-    "gwm — keys"
-  };
-
   let mut rows: Vec<HelpRow> = vec![
-    HelpRow::Title(title_text.to_string()),
+    HelpRow::Title("Keybindings".to_string()),
+    HelpRow::Subtitle(ctx.label().to_string()),
     HelpRow::Blank,
     HelpRow::Section("global".to_string()),
     entry(Action::Quit, "quit (Esc also quits when filter is clear)"),
@@ -1540,10 +1693,18 @@ pub fn help_rows(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<HelpRow> 
 /// `  {keys:<13} {label}`, sections / title as their bare text, blanks
 /// as empty strings. The width 13 is wide enough for `Ctrl+Shift+Tab`.
 pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> {
-  help_rows(km, picker_mode)
+  // The bool signature is kept for `gwm tui keys` and the chord tests; map
+  // it to the context enum (issue #217). The list-view help body is the same
+  // for either pane, so `Worktrees` stands in for the non-picker case.
+  let ctx = if picker_mode {
+    HintContext::Picker
+  } else {
+    HintContext::Worktrees
+  };
+  help_rows(km, ctx)
     .into_iter()
     .map(|row| match row {
-      HelpRow::Title(s) | HelpRow::Section(s) => s,
+      HelpRow::Title(s) | HelpRow::Subtitle(s) | HelpRow::Section(s) => s,
       HelpRow::Blank => String::new(),
       HelpRow::Entry { keys, label } => {
         let keys = if keys.is_empty() { "(unbound)".to_string() } else { keys };
@@ -1570,7 +1731,7 @@ pub fn badge_group_width(keys: &str) -> usize {
 
 fn draw_help(f: &mut Frame, app: &App) {
   let area = centered(60, 60, f.area());
-  let rows = help_rows(&app.keymap, app.picker_mode);
+  let rows = help_rows(&app.keymap, app.hint_context());
 
   // Theme-driven colours so the overlay tracks `[theme]` like the rest
   // of the TUI (pre-#187 it was hard-coded `Cyan` + plain text).
@@ -1600,10 +1761,22 @@ fn draw_help(f: &mut Frame, app: &App) {
     .max()
     .unwrap_or(0);
 
+  // Subtitle reads muted + italic so the context name sits quietly under the
+  // bold title (issue #217).
+  let subtitle_style = Style::default().fg(muted).add_modifier(Modifier::ITALIC);
+
   let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows.len());
   for row in rows {
     match row {
-      HelpRow::Title(t) | HelpRow::Section(t) => {
+      // Title + subtitle are centred (issue #217); section headers stay
+      // left-aligned so they anchor their groups lazygit-style.
+      HelpRow::Title(t) => {
+        lines.push(Line::from(Span::styled(t, heading_style)).centered());
+      }
+      HelpRow::Subtitle(t) => {
+        lines.push(Line::from(Span::styled(t, subtitle_style)).centered());
+      }
+      HelpRow::Section(t) => {
         lines.push(Line::from(Span::styled(t, heading_style)));
       }
       HelpRow::Blank => lines.push(Line::from(String::new())),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -226,21 +226,25 @@ fn draw_filter_bar(f: &mut Frame, area: Rect, app: &App) {
 /// left-or-right side are decided by the pure
 /// [`SidebarState::resolve_layout`](super::state::sidebar::SidebarState::resolve_layout),
 /// so this function only translates that decision into ratatui splits
-/// (issue #188). The table keeps 60% of the split, the sidebar 40%, in
-/// both orientations.
+/// (issue #188). The table/sidebar ratio is per-axis (issue #217): 55/45
+/// side-by-side, 42/58 stacked — see
+/// [`ResolvedSidebarLayout::split_percentages`](super::state::sidebar::ResolvedSidebarLayout::split_percentages).
 fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
   use super::state::sidebar::ResolvedSidebarLayout as Resolved;
 
-  // Table 60% / sidebar 40% — shared by both split orientations.
-  let table_pct = Constraint::Percentage(60);
-  let sidebar_pct = Constraint::Percentage(40);
-
-  match app.sidebar.resolve_layout(area.width) {
-    Resolved::Hidden => {
+  let layout = app.sidebar.resolve_layout(area.width);
+  let (table_pct, sidebar_pct) = match layout.split_percentages() {
+    Some((t, s)) => (Constraint::Percentage(t), Constraint::Percentage(s)),
+    None => {
       // Sidebar not rendered → no scrollable surface → no max scroll to track.
       app.sidebar.max_scroll = 0;
       draw_list(f, area, app);
+      return;
     }
+  };
+
+  match layout {
+    Resolved::Hidden => unreachable!("Hidden returns None from split_percentages, handled above"),
     Resolved::SideBySide { sidebar_left } => {
       let split = Layout::default()
         .direction(Direction::Horizontal)
@@ -259,9 +263,9 @@ fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
       draw_sidebar(f, sidebar_area, app);
     }
     Resolved::Stacked => {
-      // Table on top, sidebar below — the narrow-terminal fallback that
-      // replaces pre-#188 hiding. The left/right position does not apply
-      // to a vertical stack.
+      // Table on top, sidebar below — the default layout (issue #217) and the
+      // narrow-terminal fallback. The left/right position does not apply to a
+      // vertical stack.
       let split = Layout::default()
         .direction(Direction::Vertical)
         .constraints([table_pct, sidebar_pct])

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -274,6 +274,33 @@ fn chord_that_is_strict_prefix_of_existing_binding_is_rejected() {
 }
 
 #[test]
+fn primary_chord_resolves_first_default_binding() {
+  // Issue #217: the sidebar's "press <key> to fetch status" prompt must
+  // resolve the live binding instead of hard-coding `R`. `primary_chord`
+  // returns the first chord bound to an action, rendered canonically.
+  let km = Keymap::defaults();
+  assert_eq!(km.primary_chord(Action::FetchGithub).as_deref(), Some("F"));
+  assert_eq!(km.primary_chord(Action::Help).as_deref(), Some("?"));
+  // Multi-chord actions return the first chord in declaration order.
+  assert_eq!(km.primary_chord(Action::Refresh).as_deref(), Some("f"));
+}
+
+#[test]
+fn primary_chord_follows_user_override() {
+  let mut km = Keymap::defaults();
+  km.apply_override(Action::FetchGithub, vec![KeyStroke::parse_chord("Ctrl+g").unwrap()])
+    .unwrap();
+  assert_eq!(km.primary_chord(Action::FetchGithub).as_deref(), Some("Ctrl+g"));
+}
+
+#[test]
+fn primary_chord_is_none_for_unbound_action() {
+  let mut km = Keymap::defaults();
+  km.apply_override(Action::FetchGithub, vec![]).unwrap();
+  assert_eq!(km.primary_chord(Action::FetchGithub), None);
+}
+
+#[test]
 fn list_returns_entries_with_source() {
   let mut km = Keymap::defaults();
   km.apply_override(Action::Down, vec![KeyStroke::parse_chord("J").unwrap()])

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3456,3 +3456,74 @@ fn help_scroll_clamps_between_zero_and_max() {
   app.enter_help();
   assert_eq!(app.help_scroll, 0, "(re)opening help returns to the top");
 }
+
+#[test]
+fn create_key_typing_appends_to_the_focused_text_field() {
+  // Issue #217 follow-up: the create key handling is an `App` method so the
+  // typing path is unit-testable (not just `push_char` in isolation).
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::CreateKey;
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  app.create_form.field = Field::Desc;
+  for c in "my-feat".chars() {
+    assert!(matches!(
+      app.handle_create_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)),
+      CreateKey::Handled
+    ));
+  }
+  assert_eq!(app.create_form.desc, "my-feat");
+}
+
+#[test]
+fn create_key_hl_cycles_the_type_only_when_type_is_focused() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  assert_eq!(app.create_form.field, Field::Type);
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+  assert_eq!(app.create_form.type_index, 1, "l advances the type");
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+  assert_eq!(app.create_form.type_index, 0, "h steps back");
+  // On a text field, h / l are literal input, not type cycling — otherwise
+  // we'd recreate the very "can't type these letters" bug we're avoiding.
+  app.create_form.field = Field::Desc;
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
+  assert_eq!(app.create_form.desc, "hl");
+  assert_eq!(app.create_form.type_index, 0, "type stays put while editing desc");
+}
+
+#[test]
+fn create_key_enter_advances_then_submits_on_desc() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::CreateKey;
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  app.create_form.field = Field::Issue;
+  assert!(matches!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    CreateKey::Handled
+  ));
+  assert_eq!(
+    app.create_form.field,
+    Field::Desc,
+    "Enter off the desc field advances focus"
+  );
+  assert!(matches!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    CreateKey::Submit
+  ));
+}
+
+#[test]
+fn create_key_esc_requests_cancel() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::CreateKey;
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  assert!(matches!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+    CreateKey::Cancel
+  ));
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1322,6 +1322,68 @@ fn apply_fetch_results_loads_issue_and_pr_state() {
   }
 }
 
+fn sample_issue(n: u64) -> gwm::github::IssueStatus {
+  gwm::github::IssueStatus {
+    number: n,
+    title: "x".into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  }
+}
+
+#[test]
+fn drain_applies_async_github_result() {
+  // Issue #217: a result delivered off-thread (over the channel) is applied
+  // by `drain_github_results`, flipping the inflight Loading state to Loaded.
+  use gwm::tui::{FetchKey, GithubFetchMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // Claim the inflight slot exactly as `refresh_github_status` would.
+  app.github.request(FetchKey::Issue(42));
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Loading));
+  assert!(app.is_github_loading(), "request must mark the app as loading");
+
+  // A background thread reports back; we inject through the same channel.
+  app
+    .github_result_sender()
+    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .unwrap();
+  let applied = app.drain_github_results();
+
+  assert!(applied, "drain must report it applied a result");
+  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Loaded(_)));
+  assert!(!app.is_github_loading(), "no fetch should be inflight after draining");
+}
+
+#[test]
+fn drain_drops_async_result_invalidated_mid_flight() {
+  // Issue #217 keeps the #138 guarantee on the async path: a result whose
+  // inflight slot was cleared by an intervening navigation/invalidate is
+  // dropped rather than stamped into the now-active worktree's cache.
+  use gwm::tui::{FetchKey, GithubFetchMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.github.request(FetchKey::Issue(42));
+  // User navigates away → the cache + inflight set are flushed.
+  app.github.invalidate();
+  // The late shell-out result arrives after the invalidate.
+  app
+    .github_result_sender()
+    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .unwrap();
+  app.drain_github_results();
+  assert!(
+    matches!(app.issue_fetch_state(), GitHubFetchState::Idle),
+    "a result invalidated mid-flight must be dropped, not applied"
+  );
+}
+
+#[test]
+fn drain_is_a_noop_with_no_pending_results() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  assert!(!app.drain_github_results(), "empty channel must report nothing applied");
+}
+
 #[test]
 fn apply_fetch_error_stores_error_state() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -146,11 +146,17 @@ fn new_loads_main_worktree() {
 }
 
 #[test]
-fn enter_create_initializes_form() {
+fn enter_create_opens_focused_on_the_issue_field() {
+  // Issue #217 UX: the modal opens focused on Issue (not the cycle-only
+  // Type field) so the very first keypress edits text instead of being a
+  // silent no-op — the trap that read as "typing is broken". The Type
+  // field keeps its sensible default (index 0) and stays reachable via
+  // Shift-Tab / the field rotation.
   let (_dir, mut app) = make_app();
   app.enter_create();
   assert_eq!(app.view, View::Create);
-  assert_eq!(app.create_form.field, Field::Type);
+  assert_eq!(app.create_form.field, Field::Issue);
+  assert_eq!(app.create_form.type_index, 0, "type keeps its default");
   assert!(app.create_form.issue.is_empty());
   assert!(app.create_form.desc.is_empty());
 }
@@ -159,6 +165,9 @@ fn enter_create_initializes_form() {
 fn create_field_navigation_loops() {
   let (_dir, mut app) = make_app();
   app.enter_create();
+  // Pin the start to Type so this exercises the full rotation contract
+  // independently of where the modal opens its focus (#217).
+  app.create_form.field = Field::Type;
   app.create_next_field();
   assert_eq!(app.create_form.field, Field::Issue);
   app.create_next_field();
@@ -3480,7 +3489,9 @@ fn create_key_hl_cycles_the_type_only_when_type_is_focused() {
   use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   let (_dir, mut app) = make_app();
   app.enter_create();
-  assert_eq!(app.create_form.field, Field::Type);
+  // h/l type cycling only fires while the Type field is focused; pin it
+  // here since the modal now opens on Issue (#217).
+  app.create_form.field = Field::Type;
   app.handle_create_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE));
   assert_eq!(app.create_form.type_index, 1, "l advances the type");
   app.handle_create_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -74,6 +74,18 @@ fn focus_worktrees_releases_sidebar_focus() {
 }
 
 #[test]
+fn hint_context_follows_focus() {
+  // Issue #217: the statusbar chip + help subtitle read the live focus. The
+  // worktrees pane is the default; focusing the sidebar switches to Status.
+  use gwm::tui::HintContext;
+  let (_dir, mut app) = make_app();
+  app.focus_worktrees();
+  assert_eq!(app.hint_context(), HintContext::Worktrees);
+  app.focus_status();
+  assert_eq!(app.hint_context(), HintContext::Status);
+}
+
+#[test]
 fn focused_panel_border_wears_the_theme_focus_colour() {
   // #185: the focus-swappable panel borders (worktree list ↔ sidebar,
   // toggled with Tab) must paint with the theme `focus` role, not a

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1385,6 +1385,49 @@ fn drain_is_a_noop_with_no_pending_results() {
 }
 
 #[test]
+fn drain_does_not_report_when_only_stale_results_arrive() {
+  // Issue #217 review (P2): a result whose inflight slot was invalidated
+  // (the user navigated away) is dropped by `complete_*`; the drain must NOT
+  // then stamp "github status refreshed" over the current status message.
+  use gwm::tui::{FetchKey, GithubFetchMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.github.request(FetchKey::Issue(42));
+  app.github.invalidate(); // navigated away → inflight cleared
+  app.status = "path: /somewhere/else".into();
+  app
+    .github_result_sender()
+    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .unwrap();
+
+  let applied = app.drain_github_results();
+
+  assert!(!applied, "a dropped stale result must not count as applied");
+  assert_eq!(
+    app.status, "path: /somewhere/else",
+    "a stale result must not overwrite the current status message"
+  );
+}
+
+#[test]
+fn hint_context_prioritises_an_open_modal_over_pane_focus() {
+  // Issue #217 review (P2): when a modal is open the statusbar must show the
+  // modal's context, not the pane behind it. Pressing `n` in the create form
+  // types text — advertising the worktrees `n new` hint there is misleading.
+  use gwm::tui::{HintContext, View};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.focus_status(); // pane focus would otherwise resolve to Status
+  app.view = View::Create;
+  assert_eq!(app.hint_context(), HintContext::Create);
+  app.view = View::Confirm;
+  assert_eq!(app.hint_context(), HintContext::Confirm);
+  app.view = View::CommandPalette;
+  assert_eq!(app.hint_context(), HintContext::CommandPalette);
+  // Back on the list, the pane focus is honoured again.
+  app.view = View::List;
+  assert_eq!(app.hint_context(), HintContext::Status);
+}
+
+#[test]
 fn apply_fetch_error_stores_error_state() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
   app.apply_issue_fetch_result(Err("gh not found".into()));

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1288,6 +1288,109 @@ fn link_prompt_cancel_returns_to_list() {
 }
 
 #[test]
+fn enter_link_prompt_opens_with_issue_highlighted() {
+  // Issue #217: ChooseTarget is a vertical selectable list that opens
+  // highlighting Issue (the common case).
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert_eq!(app.link_prompt_selected(), LinkTarget::Issue);
+}
+
+#[test]
+fn link_prompt_key_jk_moves_the_highlight_without_committing() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::LinkPromptKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert!(matches!(
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+    LinkPromptKey::Handled
+  ));
+  assert_eq!(app.link_prompt_selected(), LinkTarget::Pr, "j moves the highlight down");
+  assert_eq!(
+    app.link_prompt_stage(),
+    LinkPromptStage::ChooseTarget,
+    "moving commits nothing"
+  );
+  app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+  assert_eq!(app.link_prompt_selected(), LinkTarget::Issue, "k moves it back");
+}
+
+#[test]
+fn link_prompt_key_enter_links_the_highlighted_target() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::LinkPromptKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)); // highlight Pr
+  assert!(matches!(
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    LinkPromptKey::Handled
+  ));
+  assert_eq!(
+    app.link_prompt_stage(),
+    LinkPromptStage::InputNumber,
+    "Enter commits + advances"
+  );
+  assert_eq!(
+    app.link_prompt_target(),
+    Some(LinkTarget::Pr),
+    "it links the highlighted row"
+  );
+}
+
+#[test]
+fn link_prompt_key_i_and_p_remain_direct_picks() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE));
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::InputNumber);
+  assert_eq!(app.link_prompt_target(), Some(LinkTarget::Pr), "p picks PR directly");
+
+  app.enter_link_prompt(); // reset
+  app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+  assert_eq!(
+    app.link_prompt_target(),
+    Some(LinkTarget::Issue),
+    "i picks Issue directly"
+  );
+}
+
+#[test]
+fn link_prompt_key_digits_then_enter_requests_submit() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::LinkPromptKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  app.handle_link_prompt_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // link highlighted Issue
+  for c in "4a2".chars() {
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+  }
+  assert_eq!(
+    app.link_prompt_number_input(),
+    "42",
+    "non-digits dropped during InputNumber"
+  );
+  assert!(matches!(
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    LinkPromptKey::Submit
+  ));
+}
+
+#[test]
+fn link_prompt_key_esc_requests_cancel() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::LinkPromptKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert!(matches!(
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+    LinkPromptKey::Cancel
+  ));
+}
+
+#[test]
 fn github_fetch_state_default_is_idle() {
   let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2296,6 +2296,29 @@ fn line_visible_width(line: &ratatui::text::Line<'static>) -> usize {
 }
 
 #[test]
+fn github_status_idle_prompt_resolves_fetch_binding_not_r() {
+  // Issue #217: the sidebar's Issue/PR block showed `press R to fetch
+  // status`, but `R` is bound to `Review` — the real fetch binding is `F`
+  // (`Action::FetchGithub`). The prompt must resolve the live keymap, never
+  // hard-code a key.
+  let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
+  let lines = gwm::tui::github_status_lines(&app, 80);
+  let text: String = lines
+    .iter()
+    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref().to_string()))
+    .collect::<Vec<_>>()
+    .join(" ");
+  assert!(
+    text.contains("press F to fetch status"),
+    "idle prompt must resolve the FetchGithub binding (F): {text}"
+  );
+  assert!(
+    !text.contains("press R"),
+    "stale `R` prompt leaked into the sidebar: {text}"
+  );
+}
+
+#[test]
 fn issue_summary_line_truncates_loaded_state_to_budget() {
   // Regression: with a 48-column sidebar, a fully-loaded issue line was
   // `#67 (auto) [open] <40-char title>` ≈ 58 chars, overflowing the

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -51,6 +51,29 @@ fn make_app() -> (tempfile::TempDir, App) {
 }
 
 #[test]
+fn focus_status_opens_and_focuses_the_sidebar() {
+  // Issue #217: pressing `2` (focus_status) must open the sidebar if it was
+  // closed and move the navigation focus onto it.
+  let (_dir, mut app) = make_app();
+  app.sidebar.open = false;
+  app.sidebar.focused = false;
+  app.focus_status();
+  assert!(app.sidebar.open, "focus_status must open a closed sidebar");
+  assert!(app.sidebar.focused, "focus_status must focus the sidebar");
+}
+
+#[test]
+fn focus_worktrees_releases_sidebar_focus() {
+  // Pressing `1` (focus_worktrees) returns navigation focus to the table so
+  // `j` / `k` walk the worktree list, leaving the sidebar open but unfocused.
+  let (_dir, mut app) = make_app();
+  app.sidebar.open = true;
+  app.sidebar.focused = true;
+  app.focus_worktrees();
+  assert!(!app.sidebar.focused, "focus_worktrees must release sidebar focus");
+}
+
+#[test]
 fn focused_panel_border_wears_the_theme_focus_colour() {
   // #185: the focus-swappable panel borders (worktree list ↔ sidebar,
   // toggled with Tab) must paint with the theme `focus` role, not a

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3424,3 +3424,35 @@ fn fresh_app_spinner_starts_at_first_frame() {
   let (_dir, app) = make_app();
   assert_eq!(app.spinner.glyph(DOT_FRAMES), DOT_FRAMES[0]);
 }
+
+#[test]
+fn help_scroll_clamps_between_zero_and_max() {
+  // Issue #217 follow-up: the Keybindings overlay scrolls when the help
+  // outgrows the modal. `help_max_scroll` is published by the renderer
+  // each frame; the offset clamps to `[0, max]` and resets on (re)open.
+  let (_dir, mut app) = make_app();
+  app.enter_help();
+  assert_eq!(app.view, View::Help);
+  assert_eq!(app.help_scroll, 0, "a freshly opened help starts at the top");
+
+  // Simulate the renderer having measured 3 rows of overflow.
+  app.help_max_scroll = 3;
+  app.help_scroll_down();
+  app.help_scroll_down();
+  assert_eq!(app.help_scroll, 2);
+  app.help_scroll_down();
+  app.help_scroll_down();
+  assert_eq!(app.help_scroll, 3, "scroll-down clamps at the published max");
+
+  app.help_scroll_up();
+  assert_eq!(app.help_scroll, 2);
+  for _ in 0..10 {
+    app.help_scroll_up();
+  }
+  assert_eq!(app.help_scroll, 0, "scroll-up clamps at the top");
+
+  // Re-opening help resets the offset.
+  app.help_scroll = 2;
+  app.enter_help();
+  assert_eq!(app.help_scroll, 0, "(re)opening help returns to the top");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1245,6 +1245,37 @@ fn enter_link_prompt_starts_at_choose_target() {
 }
 
 #[test]
+fn link_prompt_status_copy_stays_footer_sized() {
+  // The statusbar pins `app.status` at the right edge. Long modal-control
+  // prose gets clipped at 80 columns, so Link prompt status copy should stay
+  // short; the modal itself owns the detailed key hints.
+  const MAX_STATUS_CHARS: usize = 4;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+
+  app.enter_link_prompt();
+  assert!(
+    app.status.chars().count() <= MAX_STATUS_CHARS,
+    "choose-target status is too long for the footer: {:?}",
+    app.status
+  );
+
+  app.link_prompt_choose(LinkTarget::Issue);
+  assert!(
+    app.status.chars().count() <= MAX_STATUS_CHARS,
+    "issue-input status is too long for the footer: {:?}",
+    app.status
+  );
+
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Pr);
+  assert!(
+    app.status.chars().count() <= MAX_STATUS_CHARS,
+    "pr-input status is too long for the footer: {:?}",
+    app.status
+  );
+}
+
+#[test]
 fn link_prompt_choose_issue_advances_to_input() {
   let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
   app.enter_link_prompt();

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -146,6 +146,60 @@ fn uppercase_binding_matches_shift_modifier_variants() {
 }
 
 #[test]
+fn digit_keys_dispatch_pane_focus_actions() {
+  // Issue #217: `1` focuses the worktrees pane, `2` the status (sidebar)
+  // pane. Both are rebindable verbs so they route through the keymap.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('1')), Some(Action::FocusWorktrees));
+  assert_eq!(app.dispatch_key(press('2')), Some(Action::FocusStatus));
+}
+
+#[test]
+fn focus_actions_respect_user_keymap_override() {
+  // `[tui.keys]` must be able to rebind the new focus verbs like any other
+  // action — the override replaces the default `2`.
+  let (dir, _) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[tui.keys]
+focus_status = ["F2"]
+"#,
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  assert_eq!(
+    app.dispatch_key(press('2')),
+    None,
+    "default 2 must be replaced by the override"
+  );
+  assert_eq!(
+    app.dispatch_key(press_named(KeyCode::F(2))),
+    Some(Action::FocusStatus),
+    "the F2 override must fire focus_status"
+  );
+}
+
+#[test]
+fn help_overlay_lists_pane_focus_bindings() {
+  use gwm::tui::help_lines;
+  use gwm::tui::keymap::Keymap;
+
+  let km = Keymap::defaults();
+  let lines = help_lines(&km, false);
+  assert!(
+    lines.iter().any(|l| l.starts_with("  1 ")),
+    "expected the default `1` focus binding in the help overlay:\n{}",
+    lines.join("\n")
+  );
+  assert!(
+    lines.iter().any(|l| l.starts_with("  2 ")),
+    "expected the default `2` focus binding in the help overlay:\n{}",
+    lines.join("\n")
+  );
+}
+
+#[test]
 fn s_dispatches_toggle_sidebar_mode() {
   // Issue #34: pressing `s` in the list view must cycle the sidebar
   // preview mode (Commits ↔ Stashes). The binding is wired through

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -327,14 +327,14 @@ fn help_rows_structures_title_sections_and_entries() {
     "expected a `worktrees` context subtitle"
   );
   assert!(
-    rows.iter().any(|r| matches!(r, HelpRow::Section(s) if s == "global")),
-    "expected a `global` section header"
+    rows.iter().any(|r| matches!(r, HelpRow::Section(s) if s == "Global")),
+    "expected a `Global` section header"
   );
   assert!(
     rows
       .iter()
-      .any(|r| matches!(r, HelpRow::Section(s) if s == "confirm delete")),
-    "expected a `confirm delete` section header"
+      .any(|r| matches!(r, HelpRow::Section(s) if s == "Confirm Delete")),
+    "expected a `Confirm Delete` section header"
   );
   // The `Down` action's default `j` binding must surface as an Entry
   // with the resolved chord in its `keys`, not baked into a string.

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -308,15 +308,23 @@ fn help_rows_structures_title_sections_and_entries() {
   // surface as their own variants (not flattened strings).
   use gwm::tui::help_rows;
   use gwm::tui::keymap::{Action, Keymap};
-  use gwm::tui::HelpRow;
+  use gwm::tui::{HelpRow, HintContext};
 
   let km = Keymap::defaults();
-  let rows = help_rows(&km, false);
+  let rows = help_rows(&km, HintContext::Worktrees);
 
+  // Issue #217: the overlay title is now "Keybindings", followed by a
+  // context subtitle reflecting the focused pane.
   assert!(
-    matches!(rows.first(), Some(HelpRow::Title(t)) if t == "gwm — keys"),
-    "first row must be the title, got: {:?}",
+    matches!(rows.first(), Some(HelpRow::Title(t)) if t == "Keybindings"),
+    "first row must be the Keybindings title, got: {:?}",
     rows.first()
+  );
+  assert!(
+    rows
+      .iter()
+      .any(|r| matches!(r, HelpRow::Subtitle(s) if s == "worktrees")),
+    "expected a `worktrees` context subtitle"
   );
   assert!(
     rows.iter().any(|r| matches!(r, HelpRow::Section(s) if s == "global")),
@@ -357,14 +365,19 @@ fn help_lines_is_help_rows_flattened() {
   // this file) is preserved byte-for-byte after the refactor. This pins
   // the two builders together so they can never drift.
   use gwm::tui::keymap::Keymap;
-  use gwm::tui::{help_lines, help_rows, HelpRow};
+  use gwm::tui::{help_lines, help_rows, HelpRow, HintContext};
 
   let km = Keymap::defaults();
   for picker_mode in [false, true] {
-    let expected: Vec<String> = help_rows(&km, picker_mode)
+    let ctx = if picker_mode {
+      HintContext::Picker
+    } else {
+      HintContext::Worktrees
+    };
+    let expected: Vec<String> = help_rows(&km, ctx)
       .into_iter()
       .map(|row| match row {
-        HelpRow::Title(s) | HelpRow::Section(s) => s,
+        HelpRow::Title(s) | HelpRow::Subtitle(s) | HelpRow::Section(s) => s,
         HelpRow::Blank => String::new(),
         HelpRow::Entry { keys, label } => {
           let keys = if keys.is_empty() { "(unbound)".to_string() } else { keys };
@@ -373,5 +386,27 @@ fn help_lines_is_help_rows_flattened() {
       })
       .collect();
     assert_eq!(help_lines(&km, picker_mode), expected, "picker_mode={picker_mode}");
+  }
+}
+
+#[test]
+fn help_subtitle_tracks_the_pane_context() {
+  // Issue #217: opening `?` while the status pane is focused shows a
+  // `status` subtitle; the picker shows `switch`.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  for (ctx, want) in [
+    (HintContext::Worktrees, "worktrees"),
+    (HintContext::Status, "status"),
+    (HintContext::Picker, "switch"),
+  ] {
+    let rows = help_rows(&km, ctx);
+    assert!(
+      rows.iter().any(|r| matches!(r, HelpRow::Subtitle(s) if s == want)),
+      "expected `{want}` subtitle for {want} context"
+    );
   }
 }

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -199,6 +199,20 @@ fn status_line_keeps_context_and_log_when_narrow_dropping_hints() {
 }
 
 #[test]
+fn link_prompt_status_line_keeps_short_log_at_80_cols() {
+  use gwm::tui::keymap::Keymap;
+  let km = Keymap::defaults();
+  let resolved = HintContext::LinkPrompt.resolve(&km);
+  let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+
+  let line = status_line("link", &hints, "pick", None, 80, &Theme::default());
+  let text = plain(&line);
+
+  assert!(display_width(&line) <= 80, "overflowed 80: {text:?}");
+  assert!(text.contains("[pick]"), "short Link status was clipped: {text:?}");
+}
+
+#[test]
 fn hint_context_exposes_label_and_hints() {
   use gwm::tui::keymap::Keymap;
   // The same context source feeds the help subtitle and the statusbar chip.

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -200,15 +200,54 @@ fn status_line_keeps_context_and_log_when_narrow_dropping_hints() {
 
 #[test]
 fn hint_context_exposes_label_and_hints() {
+  use gwm::tui::keymap::Keymap;
   // The same context source feeds the help subtitle and the statusbar chip.
   assert_eq!(HintContext::Worktrees.label(), "worktrees");
   assert_eq!(HintContext::Status.label(), "status");
   assert_eq!(HintContext::Picker.label(), "switch");
-  for ctx in [HintContext::Worktrees, HintContext::Status, HintContext::Picker] {
+  assert_eq!(HintContext::Create.label(), "create");
+  assert_eq!(HintContext::Confirm.label(), "confirm");
+  let km = Keymap::defaults();
+  for ctx in [
+    HintContext::Worktrees,
+    HintContext::Status,
+    HintContext::Picker,
+    HintContext::Create,
+    HintContext::Confirm,
+    HintContext::OpenMenu,
+    HintContext::LinkPrompt,
+    HintContext::CommandPalette,
+  ] {
     assert!(
-      !ctx.hints().is_empty(),
+      !ctx.resolve(&km).is_empty(),
       "context {:?} must advertise hints",
       ctx.label()
     );
   }
+}
+
+#[test]
+fn status_hints_resolve_user_rebindings() {
+  // Issue #217 review (P2): the statusbar must show the *live* binding, not
+  // the hard-coded default — the keymap actions are rebindable. `fetch` is
+  // `F` by default; rebind it and the resolved hint follows.
+  use gwm::tui::keymap::{Action, KeyStroke, Keymap};
+  let mut km = Keymap::defaults();
+  let default = HintContext::Status.resolve(&km);
+  assert!(
+    default.iter().any(|(k, l)| k == "F" && l == "fetch"),
+    "default status hints should advertise the `F` fetch binding: {default:?}"
+  );
+
+  km.apply_override(Action::FetchGithub, vec![KeyStroke::parse_chord("Ctrl+g").unwrap()])
+    .unwrap();
+  let resolved = HintContext::Status.resolve(&km);
+  assert!(
+    resolved.iter().any(|(k, l)| k == "Ctrl+g" && l == "fetch"),
+    "rebinding fetch_github must change the statusbar hint key: {resolved:?}"
+  );
+  assert!(
+    !resolved.iter().any(|(k, _)| k == "F"),
+    "the stale default `F` must not linger after the rebind: {resolved:?}"
+  );
 }

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -8,8 +8,8 @@
 //! `footer_line` is a pure builder (like `header_title` / `help_lines`) so the
 //! layout contract is pinned here without spinning up a ratatui backend.
 
-use gwm::tui::footer_line;
 use gwm::tui::theme::Theme;
+use gwm::tui::{footer_line, status_line, HintContext};
 use ratatui::style::{Color, Modifier};
 use ratatui::text::Line;
 
@@ -130,4 +130,85 @@ fn zero_width_emits_an_empty_line_without_overflowing() {
     "footer overflowed a zero width: {:?}",
     plain(&line)
   );
+}
+
+// ---------------------------------------------------------------------------
+// Contextual statusbar (issue #217): a context chip on the left, an optional
+// loading spinner, the contextual hints in the middle, and the action log
+// pinned right with absolute priority.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn status_line_shows_context_chip_at_the_left() {
+  let line = status_line(
+    "worktrees",
+    HINTS,
+    "ready",
+    None,
+    120,
+    &Theme {
+      accent: Color::Magenta,
+      ..Theme::default()
+    },
+  );
+  let text = plain(&line);
+  // The context label leads the row.
+  assert!(
+    text.trim_start().starts_with("worktrees") || text.contains("worktrees"),
+    "context chip missing at the left: {text:?}"
+  );
+  // …and it is a reversed accent chip, like the hint badges.
+  let has_ctx_chip = line.spans.iter().any(|s| {
+    s.style.add_modifier.contains(Modifier::REVERSED)
+      && s.style.fg == Some(Color::Magenta)
+      && s.content.contains("worktrees")
+  });
+  assert!(has_ctx_chip, "context label is not a reversed accent chip: {text:?}");
+}
+
+#[test]
+fn status_line_renders_the_loading_spinner_when_present() {
+  let with = status_line("status", HINTS, "loading", Some("⠋"), 120, &Theme::default());
+  assert!(plain(&with).contains('⠋'), "spinner glyph missing when loading");
+  // Absent when not loading.
+  let without = status_line("status", HINTS, "idle", None, 120, &Theme::default());
+  assert!(!plain(&without).contains('⠋'), "spinner glyph leaked when not loading");
+}
+
+#[test]
+fn status_line_pins_the_log_right_and_fits_width() {
+  let line = status_line("worktrees", HINTS, "opened foo", None, 120, &Theme::default());
+  let text = plain(&line);
+  assert!(display_width(&line) <= 120, "overflowed 120: {text:?}");
+  assert!(!text.contains('\n'), "statusline must stay one row");
+  assert!(
+    text.trim_end().ends_with("[opened foo]"),
+    "log not pinned at end: {text:?}"
+  );
+}
+
+#[test]
+fn status_line_keeps_context_and_log_when_narrow_dropping_hints() {
+  // Tight width: hints get truncated but both the context chip and the log
+  // survive — they are the load-bearing signals.
+  let line = status_line("worktrees", HINTS, "busy", Some("⠙"), 44, &Theme::default());
+  let text = plain(&line);
+  assert!(display_width(&line) <= 44, "overflowed 44: {text:?}");
+  assert!(text.contains("worktrees"), "context dropped under pressure: {text:?}");
+  assert!(text.contains("[busy]"), "log dropped under pressure: {text:?}");
+}
+
+#[test]
+fn hint_context_exposes_label_and_hints() {
+  // The same context source feeds the help subtitle and the statusbar chip.
+  assert_eq!(HintContext::Worktrees.label(), "worktrees");
+  assert_eq!(HintContext::Status.label(), "status");
+  assert_eq!(HintContext::Picker.label(), "switch");
+  for ctx in [HintContext::Worktrees, HintContext::Status, HintContext::Picker] {
+    assert!(
+      !ctx.hints().is_empty(),
+      "context {:?} must advertise hints",
+      ctx.label()
+    );
+  }
 }

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -6,7 +6,7 @@
 //! side-effecting `submit_create` which wires the form's resolved values
 //! into `BranchSpec` + `worktree::add` + `bootstrap::run`.
 
-use gwm::tui::state::create_form::{CreateForm, Field};
+use gwm::tui::state::create_form::{CreateForm, Field, MAX_DESC_LEN, MAX_ISSUE_LEN};
 
 #[test]
 fn reset_returns_form_to_initial_state() {
@@ -134,4 +134,38 @@ fn pop_char_on_empty_is_noop() {
   form.field = Field::Desc;
   form.pop_char();
   assert!(form.desc.is_empty());
+}
+
+#[test]
+fn push_char_caps_the_issue_field_length() {
+  // Issue #217 follow-up: the inputs grow a length cap so the resolved
+  // branch name stays within GitHub's git-ref limits. The issue number is
+  // bounded to `MAX_ISSUE_LEN` digits.
+  let mut form = CreateForm::new();
+  form.field = Field::Issue;
+  for _ in 0..(MAX_ISSUE_LEN + 20) {
+    form.push_char('9');
+  }
+  assert_eq!(
+    form.issue.chars().count(),
+    MAX_ISSUE_LEN,
+    "issue must not grow past the cap"
+  );
+}
+
+#[test]
+fn push_char_caps_the_desc_field_length() {
+  // The description (slug) is bounded to `MAX_DESC_LEN` so the
+  // `<type>/#<issue>-<desc>` branch name stays under the 255-byte git ref
+  // limit.
+  let mut form = CreateForm::new();
+  form.field = Field::Desc;
+  for _ in 0..(MAX_DESC_LEN + 50) {
+    form.push_char('a');
+  }
+  assert_eq!(
+    form.desc.chars().count(),
+    MAX_DESC_LEN,
+    "desc must not grow past the cap"
+  );
 }

--- a/tests/tui_state_github_fetch_tests.rs
+++ b/tests/tui_state_github_fetch_tests.rs
@@ -355,3 +355,30 @@ fn clear_detected_pr_leaves_an_explicit_link_pinned() {
   assert_eq!(gh.link.pr, Some(61));
   assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Explicit);
 }
+
+#[test]
+fn complete_reports_whether_the_result_was_applied() {
+  // Issue #217 review (P2): `complete_*` must signal whether it actually
+  // stamped the result, so the async drain can avoid reporting "refreshed"
+  // for a result it silently dropped (#138 stale-drop).
+  let mut gh = GitHubFetch::new();
+  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
+  assert!(
+    gh.complete_issue(42, Ok(sample_issue(42))),
+    "a result for an inflight key must report applied=true"
+  );
+
+  // A second completion for the same (now-terminal) key has no inflight slot.
+  assert!(
+    !gh.complete_issue(42, Ok(sample_issue(42))),
+    "a result with no inflight slot must report applied=false"
+  );
+
+  // PR side, dropped after invalidate.
+  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::Spawn(_)));
+  gh.invalidate();
+  assert!(
+    !gh.complete_pr(7, Ok(sample_pr(7))),
+    "a result invalidated mid-flight must report applied=false"
+  );
+}

--- a/tests/tui_state_link_prompt_tests.rs
+++ b/tests/tui_state_link_prompt_tests.rs
@@ -17,27 +17,45 @@ use gwm::tui::state::link_prompt::{LinkPrompt, LinkPromptStage};
 use gwm::tui::LinkTarget;
 
 #[test]
-fn new_starts_in_choose_target_with_empty_buffer_and_no_target() {
+fn new_starts_in_choose_target_with_empty_buffer_no_target_and_issue_selected() {
   let prompt = LinkPrompt::new();
   assert_eq!(prompt.stage, LinkPromptStage::ChooseTarget);
   assert!(prompt.number.is_empty());
-  assert_eq!(prompt.target, None);
+  assert_eq!(prompt.target, None, "no target is committed until commit_target");
+  assert_eq!(
+    prompt.selected,
+    LinkTarget::Issue,
+    "the vertical picker opens highlighting Issue (the common case)"
+  );
 }
 
 #[test]
-fn toggle_target_rotates_issue_to_pr_and_back() {
-  // The two-stage prompt's ChooseTarget step lets the user flip between
-  // Issue and Pr without committing. Starts with Issue as the default
-  // hint so a single Enter on a fresh prompt lands on the most common
-  // case.
+fn toggle_selection_flips_the_highlight_between_issue_and_pr() {
+  // ChooseTarget is now a vertical selectable list (#217): j/k move the
+  // highlight, Enter links the highlighted item. The highlight is a
+  // separate `selected` field — `target` stays None until a commit — so
+  // moving it never looks like a half-committed choice.
   let mut prompt = LinkPrompt::new();
-  assert_eq!(prompt.target, None);
-  prompt.toggle_target();
-  assert_eq!(prompt.target, Some(LinkTarget::Issue));
-  prompt.toggle_target();
-  assert_eq!(prompt.target, Some(LinkTarget::Pr));
-  prompt.toggle_target();
-  assert_eq!(prompt.target, Some(LinkTarget::Issue), "wraps back to Issue");
+  assert_eq!(prompt.selected, LinkTarget::Issue);
+  prompt.toggle_selection();
+  assert_eq!(prompt.selected, LinkTarget::Pr);
+  prompt.toggle_selection();
+  assert_eq!(prompt.selected, LinkTarget::Issue, "wraps back to Issue");
+  assert_eq!(prompt.target, None, "moving the highlight commits nothing");
+}
+
+#[test]
+fn toggle_selection_is_noop_during_input_number() {
+  // Once a target is committed and the user is typing the number, a stray
+  // j/k must not flip the selection underneath them.
+  let mut prompt = LinkPrompt::new();
+  prompt.commit_target(LinkTarget::Pr);
+  prompt.toggle_selection();
+  assert_eq!(
+    prompt.selected,
+    LinkTarget::Issue,
+    "selection is frozen during InputNumber (still its open default)"
+  );
 }
 
 #[test]
@@ -113,6 +131,7 @@ fn pop_char_is_noop_during_choose_target_stage() {
 #[test]
 fn reset_returns_prompt_to_initial_state() {
   let mut prompt = LinkPrompt::new();
+  prompt.toggle_selection(); // move highlight off the default
   prompt.commit_target(LinkTarget::Issue);
   prompt.push_char('4');
   prompt.push_char('2');
@@ -120,4 +139,5 @@ fn reset_returns_prompt_to_initial_state() {
   assert_eq!(prompt.stage, LinkPromptStage::ChooseTarget);
   assert!(prompt.number.is_empty());
   assert_eq!(prompt.target, None);
+  assert_eq!(prompt.selected, LinkTarget::Issue, "highlight resets to Issue");
 }

--- a/tests/tui_state_sidebar_tests.rs
+++ b/tests/tui_state_sidebar_tests.rs
@@ -243,12 +243,13 @@ fn invalidate_drops_cache_keeps_scroll() {
 // ---- Responsive layout + position (issue #188) ----------------------------
 
 #[test]
-fn default_position_is_right_orientation_is_auto() {
-  // Pre-#188 behaviour: sidebar on the right, width-driven layout. `App`
+fn default_position_is_right_orientation_is_stacked() {
+  // Sidebar on the right; default orientation is now `Stacked` (issue #217)
+  // so the status pane sits under the worktrees table by default. `App`
   // overrides `position` from `[tui] sidebar_position` at construction.
   let s = SidebarState::new();
   assert_eq!(s.position, SidebarPosition::Right);
-  assert_eq!(s.orientation, SidebarOrientation::Auto);
+  assert_eq!(s.orientation, SidebarOrientation::Stacked);
 }
 
 #[test]
@@ -261,7 +262,8 @@ fn resolve_layout_hidden_when_closed_regardless_of_width() {
 
 #[test]
 fn resolve_layout_auto_is_side_by_side_at_or_above_min_width() {
-  let s = SidebarState::new(); // open, Auto, Right
+  let mut s = SidebarState::new(); // open, Right
+  s.orientation = SidebarOrientation::Auto; // opt into width-driven layout
   assert_eq!(
     s.resolve_layout(SIDEBAR_MIN_WIDTH),
     ResolvedSidebarLayout::SideBySide { sidebar_left: false },
@@ -277,7 +279,8 @@ fn resolve_layout_auto_is_side_by_side_at_or_above_min_width() {
 fn resolve_layout_auto_stacks_below_min_width() {
   // The headline #188 change: narrow no longer hides the sidebar, it
   // stacks it under the table.
-  let s = SidebarState::new();
+  let mut s = SidebarState::new();
+  s.orientation = SidebarOrientation::Auto;
   assert_eq!(s.resolve_layout(SIDEBAR_MIN_WIDTH - 1), ResolvedSidebarLayout::Stacked);
   assert_eq!(s.resolve_layout(0), ResolvedSidebarLayout::Stacked);
 }
@@ -285,6 +288,7 @@ fn resolve_layout_auto_stacks_below_min_width() {
 #[test]
 fn resolve_layout_auto_honours_left_position() {
   let mut s = SidebarState::new();
+  s.orientation = SidebarOrientation::Auto;
   s.position = SidebarPosition::Left;
   assert_eq!(
     s.resolve_layout(SIDEBAR_MIN_WIDTH),
@@ -318,14 +322,20 @@ fn resolve_layout_forced_stacked_ignores_wide_width() {
 
 #[test]
 fn cycle_orientation_walks_auto_side_by_side_stacked_and_wraps() {
+  // The cycle order itself is unchanged (Auto → SideBySide → Stacked → …);
+  // only the default starting point moved to `Stacked` (issue #217).
   let mut s = SidebarState::new();
+  assert_eq!(s.orientation, SidebarOrientation::Stacked);
+  s.cycle_orientation();
   assert_eq!(s.orientation, SidebarOrientation::Auto);
   s.cycle_orientation();
   assert_eq!(s.orientation, SidebarOrientation::SideBySide);
   s.cycle_orientation();
-  assert_eq!(s.orientation, SidebarOrientation::Stacked);
-  s.cycle_orientation();
-  assert_eq!(s.orientation, SidebarOrientation::Auto, "cycle wraps back to Auto");
+  assert_eq!(
+    s.orientation,
+    SidebarOrientation::Stacked,
+    "cycle wraps back to Stacked"
+  );
 }
 
 #[test]
@@ -336,6 +346,24 @@ fn toggle_position_flips_left_right() {
   assert_eq!(s.position, SidebarPosition::Left);
   s.toggle_position();
   assert_eq!(s.position, SidebarPosition::Right);
+}
+
+#[test]
+fn split_percentages_favour_the_status_pane_vertically_and_the_table_horizontally() {
+  // Issue #217 ratios: stacked (vertical) gives the status pane the lion's
+  // share (42% table / 58% status) so commits + issue/PR breathe; side-by-side
+  // keeps the table dominant (55% / 45%). Hidden has no split.
+  assert_eq!(ResolvedSidebarLayout::Stacked.split_percentages(), Some((42, 58)));
+  assert_eq!(
+    ResolvedSidebarLayout::SideBySide { sidebar_left: false }.split_percentages(),
+    Some((55, 45))
+  );
+  assert_eq!(
+    ResolvedSidebarLayout::SideBySide { sidebar_left: true }.split_percentages(),
+    Some((55, 45)),
+    "the table/sidebar ratio is independent of which side the sidebar sits on"
+  );
+  assert_eq!(ResolvedSidebarLayout::Hidden.split_percentages(), None);
 }
 
 #[test]

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -3,7 +3,7 @@
 //! the confirm modal, and the badge-group width used to align the help
 //! overlay's per-chord key badges.
 
-use gwm::tui::{badge_group_width, ellipsize_middle};
+use gwm::tui::{badge_group_width, ellipsize_middle, pane_counter, worktrees_pane_title};
 
 #[test]
 fn ellipsize_middle_returns_input_when_it_fits() {
@@ -65,4 +65,37 @@ fn badge_group_width_unbound_renders_one_muted_badge() {
   let expected = "(unbound)".chars().count() + 2;
   assert_eq!(badge_group_width("(unbound)"), expected);
   assert_eq!(badge_group_width(""), expected);
+}
+
+// ---------------------------------------------------------------------------
+// Worktrees pane title + counter (issue #217)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn worktrees_pane_title_unfiltered_shows_total_with_focus_index() {
+  // No active filter → the `(N)` counter is the full worktree count, and the
+  // pane carries the `[1]` focus mnemonic (focusable with the `1` key). The
+  // casing is fixed to `Worktrees` (was lowercase `worktrees`).
+  assert_eq!(worktrees_pane_title(true, 5, 5), " [1] Worktrees (5) ");
+}
+
+#[test]
+fn worktrees_pane_title_filtered_shows_visible_over_total() {
+  // Active filter → `(visible/total)` so the user sees how much the filter
+  // narrowed the list.
+  assert_eq!(worktrees_pane_title(false, 3, 5), " [1] Worktrees (3/5) ");
+}
+
+#[test]
+fn pane_counter_is_blank_when_nothing_visible() {
+  // Empty list → no `N of M` footer at all (mirrors the Recent Commits
+  // section, which drops its counter when there is nothing to scroll).
+  assert_eq!(pane_counter(0, 0), None);
+}
+
+#[test]
+fn pane_counter_formats_selected_of_visible() {
+  // Bottom-right footer of the worktrees pane, lazygit-style: the 1-based
+  // selected position over the visible count (e.g. `3 of 12`).
+  assert_eq!(pane_counter(3, 12).as_deref(), Some(" 3 of 12 "));
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -5,8 +5,8 @@
 
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
-  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_target_line,
-  pane_counter, status_pane_title, type_selector_line, worktrees_pane_title,
+  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_choose_hint,
+  link_input_hint, link_target_line, pane_counter, status_pane_title, type_selector_line, worktrees_pane_title,
 };
 use ratatui::style::{Color, Modifier};
 
@@ -283,4 +283,20 @@ fn link_target_line_highlights_the_selected_row() {
     idle.spans.iter().all(|s| s.style.fg != Some(Color::Magenta)),
     "an unselected row must not wear the accent: {itext:?}"
   );
+}
+
+#[test]
+fn link_prompt_hints_fit_the_80_col_modal_budget() {
+  // The Link modal uses `centered_h(50, ...)`: at 80 columns its outer
+  // width is 40, and the rounded border + horizontal padding leave 34 cells
+  // for content. The visual smoke caught the previous long hints clipping at
+  // exactly this common terminal width.
+  const INNER_WIDTH_AT_80_COLS: usize = 34;
+
+  for hint in [link_choose_hint(), link_input_hint()] {
+    assert!(
+      hint.chars().count() <= INNER_WIDTH_AT_80_COLS,
+      "Link prompt hint clips at 80 cols: {hint:?}"
+    );
+  }
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -3,7 +3,9 @@
 //! the confirm modal, and the badge-group width used to align the help
 //! overlay's per-chord key badges.
 
-use gwm::tui::{badge_group_width, ellipsize_middle, pane_counter, worktrees_pane_title};
+use gwm::tui::ConfirmButton;
+use gwm::tui::{badge_group_width, confirm_buttons_line, ellipsize_middle, pane_counter, worktrees_pane_title};
+use ratatui::style::{Color, Modifier};
 
 #[test]
 fn ellipsize_middle_returns_input_when_it_fits() {
@@ -98,4 +100,42 @@ fn pane_counter_formats_selected_of_visible() {
   // Bottom-right footer of the worktrees pane, lazygit-style: the 1-based
   // selected position over the visible count (e.g. `3 of 12`).
   assert_eq!(pane_counter(3, 12).as_deref(), Some(" 3 of 12 "));
+}
+
+// ---------------------------------------------------------------------------
+// Confirm modal buttons (issue #217)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn confirm_buttons_render_as_chips_without_brackets() {
+  // Issue #217: the confirm modal buttons are flat coloured chips
+  // (` Confirm ` / ` Cancel `), not the pre-#217 `[ Confirm ]` / `[ Cancel ]`
+  // bracket pairs. The focused button wears the reversed-accent chip; the
+  // idle one reads muted.
+  let line = confirm_buttons_line(ConfirmButton::Cancel, Color::Magenta, Color::Gray);
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(text.contains("Confirm"), "missing Confirm label: {text:?}");
+  assert!(text.contains("Cancel"), "missing Cancel label: {text:?}");
+  assert!(!text.contains('['), "square bracket leaked into a chip: {text:?}");
+  assert!(!text.contains(']'), "square bracket leaked into a chip: {text:?}");
+
+  // The focused button (Cancel here — the safe default) is the reversed chip.
+  let cancel = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Cancel"))
+    .expect("a Cancel span");
+  assert!(
+    cancel.style.add_modifier.contains(Modifier::REVERSED),
+    "focused Cancel button must be a reversed chip"
+  );
+  let confirm = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Confirm"))
+    .expect("a Confirm span");
+  assert!(
+    !confirm.style.add_modifier.contains(Modifier::REVERSED),
+    "idle Confirm button must not be reversed"
+  );
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -4,7 +4,9 @@
 //! overlay's per-chord key badges.
 
 use gwm::tui::ConfirmButton;
-use gwm::tui::{badge_group_width, confirm_buttons_line, ellipsize_middle, pane_counter, worktrees_pane_title};
+use gwm::tui::{
+  badge_group_width, confirm_buttons_line, ellipsize_middle, pane_counter, status_pane_title, worktrees_pane_title,
+};
 use ratatui::style::{Color, Modifier};
 
 #[test]
@@ -86,6 +88,13 @@ fn worktrees_pane_title_filtered_shows_visible_over_total() {
   // Active filter → `(visible/total)` so the user sees how much the filter
   // narrowed the list.
   assert_eq!(worktrees_pane_title(false, 3, 5), " [1] Worktrees (3/5) ");
+}
+
+#[test]
+fn status_pane_title_carries_the_focus_index() {
+  // The sidebar reads as the `[2] Status` pane (focusable with `2`),
+  // mirroring `[1] Worktrees`.
+  assert_eq!(status_pane_title(), " [2] Status ");
 }
 
 #[test]

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -213,6 +213,12 @@ fn type_selector_shows_horizontal_arrows_and_focus_accent() {
     name.style.add_modifier.contains(Modifier::BOLD),
     "focused type name is bold"
   );
+  // The focused selection reads as a reversed-accent chip (like the
+  // confirm / create buttons) so it stands out as an editable control.
+  assert!(
+    name.style.add_modifier.contains(Modifier::REVERSED),
+    "focused type name is a reversed chip"
+  );
 
   // Idle → the name is not painted in the accent.
   let idle = type_selector_line("type", "feat", "x", false, Color::Magenta, Color::Gray);

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -5,7 +5,8 @@
 
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
-  badge_group_width, confirm_buttons_line, ellipsize_middle, pane_counter, status_pane_title, worktrees_pane_title,
+  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, pane_counter,
+  status_pane_title, type_selector_line, worktrees_pane_title,
 };
 use ratatui::style::{Color, Modifier};
 
@@ -147,4 +148,110 @@ fn confirm_buttons_render_as_chips_without_brackets() {
     !confirm.style.add_modifier.contains(Modifier::REVERSED),
     "idle Confirm button must not be reversed"
   );
+}
+
+// ---------------------------------------------------------------------------
+// Create modal: buttons, horizontal type selector, single-line bg inputs
+// (issue #217 follow-up — the modal polish pass)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_buttons_render_as_chips_with_create_highlighted() {
+  // The create overlay grows a button row mirroring the confirm modal's
+  // flat coloured chips (no `[ ]` brackets). Unlike confirm — whose safe
+  // default is Cancel — the non-destructive create primes `Create` as the
+  // reversed-accent chip; `Cancel` reads muted.
+  let line = create_buttons_line(Color::Magenta, Color::Gray);
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(text.contains("Create"), "missing Create label: {text:?}");
+  assert!(text.contains("Cancel"), "missing Cancel label: {text:?}");
+  assert!(!text.contains('['), "square bracket leaked into a chip: {text:?}");
+  assert!(!text.contains(']'), "square bracket leaked into a chip: {text:?}");
+
+  let create = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Create"))
+    .expect("a Create span");
+  assert!(
+    create.style.add_modifier.contains(Modifier::REVERSED),
+    "primary Create button must be the reversed chip"
+  );
+  assert_eq!(create.style.fg, Some(Color::Magenta), "Create chip carries the accent");
+  let cancel = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Cancel"))
+    .expect("a Cancel span");
+  assert!(
+    !cancel.style.add_modifier.contains(Modifier::REVERSED),
+    "idle Cancel button must not be reversed"
+  );
+}
+
+#[test]
+fn type_selector_shows_horizontal_arrows_and_focus_accent() {
+  // The branch-type field is a horizontal `‹ name ›` selector (was a
+  // bordered up/down box). Focused, the selected type reads in the accent.
+  let focused = type_selector_line("type", "feat", "a new feature", true, Color::Magenta, Color::Gray);
+  let text: String = focused.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    text.contains('‹') && text.contains('›'),
+    "horizontal arrows missing: {text:?}"
+  );
+  assert!(text.contains("type"), "field label missing: {text:?}");
+  assert!(text.contains("feat"), "type name missing: {text:?}");
+  assert!(text.contains("a new feature"), "description missing: {text:?}");
+
+  let name = focused
+    .spans
+    .iter()
+    .find(|s| s.content.contains("feat"))
+    .expect("a type-name span");
+  assert_eq!(name.style.fg, Some(Color::Magenta), "focused type reads in the accent");
+  assert!(
+    name.style.add_modifier.contains(Modifier::BOLD),
+    "focused type name is bold"
+  );
+
+  // Idle → the name is not painted in the accent.
+  let idle = type_selector_line("type", "feat", "x", false, Color::Magenta, Color::Gray);
+  let iname = idle
+    .spans
+    .iter()
+    .find(|s| s.content.contains("feat"))
+    .expect("a type-name span");
+  assert_ne!(
+    iname.style.fg,
+    Some(Color::Magenta),
+    "idle type must not wear the accent"
+  );
+}
+
+#[test]
+fn field_input_fills_a_single_row_with_a_background() {
+  // The issue / description fields are single-row inputs with a background
+  // surface (was a 3-row bordered box). Idle shows the surface bg and no
+  // cursor; focused brightens to the accent bg and shows a `_` cursor.
+  let idle = field_input_line("issue", "123", false, 20, Color::Magenta, Color::Gray, Color::DarkGray);
+  let text: String = idle.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(text.contains("issue"), "label missing: {text:?}");
+  assert!(text.contains("123"), "value missing: {text:?}");
+  assert!(!text.contains('_'), "idle field must not show a cursor: {text:?}");
+  let val = idle
+    .spans
+    .iter()
+    .find(|s| s.content.contains("123"))
+    .expect("a value span");
+  assert_eq!(val.style.bg, Some(Color::DarkGray), "idle input wears the surface bg");
+
+  let focused = field_input_line("issue", "123", true, 20, Color::Magenta, Color::Gray, Color::DarkGray);
+  let ftext: String = focused.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(ftext.contains('_'), "focused field shows a cursor: {ftext:?}");
+  let fval = focused
+    .spans
+    .iter()
+    .find(|s| s.content.contains("123"))
+    .expect("a value span");
+  assert_eq!(fval.style.bg, Some(Color::Magenta), "focused input bg = accent");
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -5,8 +5,8 @@
 
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
-  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, pane_counter,
-  status_pane_title, type_selector_line, worktrees_pane_title,
+  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_target_line,
+  pane_counter, status_pane_title, type_selector_line, worktrees_pane_title,
 };
 use ratatui::style::{Color, Modifier};
 
@@ -260,4 +260,27 @@ fn field_input_fills_a_single_row_with_a_background() {
     .find(|s| s.content.contains("123"))
     .expect("a value span");
   assert_eq!(fval.style.bg, Some(Color::Magenta), "focused input bg = accent");
+}
+
+#[test]
+fn link_target_line_highlights_the_selected_row() {
+  // The link prompt's ChooseTarget step is a vertical selectable list
+  // (#217): each row shows its direct-pick key + label, and the
+  // highlighted row reads in the accent while the others stay muted.
+  let selected = link_target_line("i", "Issue", true, Color::Magenta, Color::Gray);
+  let stext: String = selected.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(stext.contains("Issue"), "label missing: {stext:?}");
+  assert!(stext.contains('i'), "pick key missing: {stext:?}");
+  assert!(
+    selected.spans.iter().any(|s| s.style.fg == Some(Color::Magenta)),
+    "the selected row must read in the accent: {stext:?}"
+  );
+
+  let idle = link_target_line("p", "Pull Request", false, Color::Magenta, Color::Gray);
+  let itext: String = idle.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(itext.contains("Pull Request"), "label missing: {itext:?}");
+  assert!(
+    idle.spans.iter().all(|s| s.style.fg != Some(Color::Magenta)),
+    "an unselected row must not wear the accent: {itext:?}"
+  );
 }


### PR DESCRIPTION
## Description

Polish du TUI : statusbar contextuelle, modales, layout/focus des panes, refresh GitHub non bloquant, refonte Create et Link prompt. Aucune nouvelle dépendance.

Closes #217

## Type of change

- [x] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

Découpé en commits atomiques (TDD rouge→vert par partie) :

- **Panes & compteurs** : `[1] Worktrees (N)` / `[2] Status` (mnémoniques des touches `1`/`2`), footer `selected of visible` sur le pane worktrees.
- **Focus** : nouvelles actions keymap `focus_worktrees` (`1`) / `focus_status` (`2`), configurables dans `[tui.keys]` ; `Tab` reste un toggle. `2` ouvre la sidebar si masquée.
- **Layout** : sidebar `Stacked` par défaut ; ratios par axe `42/58` (vertical) et `55/45` (side-by-side) via `ResolvedSidebarLayout::split_percentages`.
- **Modales** : `overlay_block` centre son titre + padding interne ; boutons confirm/create en chips colorées, sans crochets.
- **Create modal** : titre détaché, preview Branch/Dir, focus initial sur `Issue`, `h/l` et flèches pour le type, limites de saisie testées.
- **Link prompt** : titre `Link`, choix vertical Issue / Pull Request, `j/k` et flèches pour naviguer, `Enter` surligne, `i/p` restent des raccourcis directs, statut/hints compactés pour 80 colonnes.
- **Help & statusbar contextuels** : source unique `HintContext` (worktrees / status / switch / modales) → sous-titre `Keybindings` + chip de contexte + hints de la statusbar. Spinner de chargement animé. `footer_line` conservé intact.
- **Fix** : le bloc Issue/PR affichait `press R to fetch status` (or `R` = review) → binding réel résolu de `fetch_github` (`F` par défaut), via `Keymap::primary_chord`.
- **Async GitHub** : `gh issue/pr view` exécuté hors thread (mpsc + drain au tick), garanties #128/#138 conservées ; le binaire `gh` est résolu sur le thread principal pour ne pas lire `GWM_GH` en concurrence (soundness `env_lock`).

## Tests

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test` passes
- [x] New tests added under `tests/` (TDD: create handler, link prompt state/handler/render helpers, footer/status budgets)
- [x] PTY smoke: bare `gwm` opens; Create opens on `Issue` and accepts issue/desc input; Link opens/navigates and renders compact hints at 80 columns

## Screenshots / TUI captures

Pas de capture jointe. Le rendu a été smoke-testé en pseudo-terminal local ; les surfaces visuelles critiques sont aussi couvertes par des tests de builders purs (titres de panes, chips, statusbar, help subtitle, Link prompt hint/status budgets).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — pas de changement CLI)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a — pas de changement de schéma obligatoire ; `focus_worktrees`/`focus_status` sont des slugs `[tui.keys]` optionnels)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## ⚠️ À ratifier par le mainteneur

1. **Défaut sidebar `Auto → Stacked`** : c'est un vrai changement de comportement. Avant, `Auto` choisissait automatiquement le side-by-side sur écran large (objectif de #188) ; désormais le défaut est empilé quelle que soit la largeur (l'utilisateur peut revenir à `Auto`/`SideBySide` via `V`). Demandé par le plan, mais à valider.
2. **`[2] Status`** : faute de captures de référence, j'ai appliqué le défaut le moins coûteux — relabel de la section de tête de la sidebar (pas de cadre englobant imbriqué qui aurait volé 2 lignes + dupliqué la bordure). À ajuster si le rendu attendu diffère.

## Follow-up

- #219 : rendre les touches modales rebindables avec actions contextualisées. Hors scope volontaire de cette PR pour garder #218 atomique.

## Linked issues / docs

- Issue: #217
- Follow-up: #219

## Notes for reviewers

- Points de vigilance : la garantie #138 (drop des résultats périmés) est re-testée sur le chemin async (`drain_drops_async_result_invalidated_mid_flight`) ; le thread de fetch est une coquille fine non testée (contrat testé par injection via `github_result_sender` + `drain_github_results`, sans thread ni `gh` réel).
- `footer_line` est conservé ; la statusbar contextuelle est une fonction distincte `status_line`.