### PR TITLE
fix(tui): polish modal follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TUI: polish modal follow-ups after the statusbar pass — compact Link
+  prompt with chip selection, clearer create Issue feedback, distinct
+  Keybindings section colour, and aligned Confirm Delete details. (#220)
 - TUI: the sidebar Issue/PR block prompted `press R to fetch status`,
   but `R` runs the review launcher — it now resolves the live
   `fetch_github` binding (`F` by default). (#217)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1068,6 +1068,9 @@ impl App {
       KeyCode::Down | KeyCode::Right if on_type => self.create_next_type(),
       KeyCode::Char('h') if on_type => self.create_prev_type(),
       KeyCode::Char('l') if on_type => self.create_next_type(),
+      KeyCode::Char(c) if self.create_form.field == Field::Issue && !c.is_ascii_digit() => {
+        self.status = "issue accepts digits only".into();
+      }
       KeyCode::Char(c) if !on_type => self.create_push_char(c),
       KeyCode::Backspace if !on_type => self.create_pop_char(),
       _ => {}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,12 +55,13 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
-  create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color,
-  github_status_lines, header_line, header_title, help_lines, help_rows, issue_badge_color, issue_summary_line,
-  link_choose_hint, link_input_hint, link_target_line, pane_counter, panel_border_color, pr_badge_color,
-  pr_summary_line, recent_commits_lines, status_line, status_pane_title, table_marker, tilde_compress_with_home,
-  type_selector_line, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
-  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  confirm_detail_line, create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line,
+  freshness_color, github_status_lines, header_line, header_title, help_lines, help_rows, help_section_style,
+  issue_badge_color, issue_summary_line, link_choose_hint, link_input_hint, link_prompt_modal_width, link_target_line,
+  pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, status_line,
+  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1882,7 +1882,10 @@ fn draw_help(f: &mut Frame, app: &mut App) {
         lines.push(Line::from(Span::styled(t, subtitle_style)).centered());
       }
       HelpRow::Section(t) => {
-        lines.push(Line::from(Span::styled(t, heading_style)));
+        lines.push(Line::from(Span::styled(
+          t,
+          help_section_style(accent, app.theme.branch),
+        )));
       }
       HelpRow::Blank => lines.push(Line::from(String::new())),
       HelpRow::Entry { keys, label } => {
@@ -2108,20 +2111,48 @@ pub fn field_input_line(
 }
 
 /// A single selectable row of the link prompt's `ChooseTarget` picker
-/// (issue #217): a `‹key›  Label` line whose highlighted variant reads in
-/// the accent (bold) with a `›` marker, and whose idle variant reads
+/// (issue #217, polished in #220): the selected row uses the same
+/// reversed-bold accent chip treatment as modal buttons; idle rows stay
 /// muted. `key` is the direct-pick shortcut (`i` / `p`). Pure so the
 /// highlight contract is pinned by `tests/tui_ui_helpers_tests.rs`.
 pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, muted: Color) -> Line<'static> {
-  let (marker, style) = if selected {
-    ("› ", Style::default().fg(accent).add_modifier(Modifier::BOLD))
-  } else {
-    ("  ", Style::default().fg(muted))
-  };
+  if selected {
+    let chip = Style::default()
+      .fg(accent)
+      .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+    return Line::from(vec![Span::raw("  "), Span::styled(format!(" {key}  {label} "), chip)]);
+  }
+
+  let idle = Style::default().fg(muted);
+  Line::from(vec![Span::raw("  "), Span::styled(format!("{key}  {label}"), idle)])
+}
+
+/// Modal width for the Link prompt. Pure so the visual budget remains pinned
+/// without a terminal renderer in `tests/tui_ui_helpers_tests.rs`.
+pub fn link_prompt_modal_width(term_width: u16) -> u16 {
+  (term_width.saturating_mul(50) / 100).min(42).min(term_width)
+}
+
+/// Section-heading style for the Keybindings overlay body. Kept pure so the
+/// title/body colour split is pinned outside the ratatui renderer.
+pub fn help_section_style(_accent: Color, section: Color) -> Style {
+  Style::default().fg(section).add_modifier(Modifier::BOLD)
+}
+
+/// One aligned detail row for destructive confirmation summaries.
+pub fn confirm_detail_line(
+  label: &str,
+  value: impl Into<String>,
+  label_width: usize,
+  label_color: Color,
+  value_style: Style,
+) -> Line<'static> {
   Line::from(vec![
-    Span::styled(marker, style),
-    Span::styled(format!("{key}  "), style),
-    Span::styled(label.to_string(), style),
+    Span::styled(
+      format!("{label:<label_width$}  ", label_width = label_width),
+      Style::default().fg(label_color),
+    ),
+    Span::styled(value.into(), value_style),
   ])
 }
 
@@ -2150,35 +2181,52 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   let term = f.area();
   let outer_w = term.width.saturating_mul(62) / 100;
   let text_w = outer_w.saturating_sub(6) as usize;
+  let label_w = "delete branch".chars().count();
+  let value_w = text_w.saturating_sub(label_w + 2).max(1);
 
-  let name = ellipsize_middle(&w.name, text_w.saturating_sub("delete ".len()));
-  let path = ellipsize_middle(
-    &tilde_compress(&w.path.display().to_string()),
-    text_w.saturating_sub("at ".len()),
-  );
+  let name = ellipsize_middle(&w.name, value_w);
+  let path = ellipsize_middle(&tilde_compress(&w.path.display().to_string()), value_w);
 
-  // --- title + description (centred) ---
+  // Title stays centred; details use an aligned label/value grid so the
+  // destructive target is easier to scan (#220 visual follow-up).
   let mut content: Vec<Line> = overlay_title_lines("Confirm Delete", danger);
-  content.push(Line::from(vec![
-    Span::raw("delete "),
-    Span::styled(name, Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)),
-  ]));
-  content.push(Line::from(Span::styled(
-    format!("at {path}"),
+  content.push(confirm_detail_line(
+    "worktree",
+    name,
+    label_w,
+    muted,
+    Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD),
+  ));
+  content.push(confirm_detail_line(
+    "path",
+    path,
+    label_w,
+    muted,
     Style::default().fg(muted),
-  )));
+  ));
   if let Some(b) = &w.branch {
-    let branch = ellipsize_middle(b, text_w.saturating_sub("branch: ".len()));
-    content.push(Line::from(vec![
-      Span::raw("branch: "),
-      Span::styled(branch, Style::default().fg(app.theme.branch)),
-    ]));
+    let branch = ellipsize_middle(b, value_w);
+    content.push(confirm_detail_line(
+      "branch",
+      branch,
+      label_w,
+      muted,
+      Style::default().fg(app.theme.branch),
+    ));
   }
   content.push(Line::from(""));
-  content.push(Line::from(format!(
-    "delete branch too: {}  (press p to toggle)",
-    app.delete_branch_on_remove
-  )));
+  let delete_branch_style = if app.delete_branch_on_remove {
+    Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)
+  } else {
+    Style::default().fg(muted)
+  };
+  content.push(confirm_detail_line(
+    "delete branch",
+    format!("{}  p toggles", app.delete_branch_on_remove),
+    label_w,
+    muted,
+    delete_branch_style,
+  ));
 
   // Size the modal to its content: the title + description rows plus the
   // three fixed rows (loader / buttons / hint), the rounded border and the
@@ -2204,12 +2252,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     .split(block.inner(area));
   f.render_widget(block, area);
 
-  f.render_widget(
-    Paragraph::new(content)
-      .alignment(Alignment::Center)
-      .wrap(Wrap { trim: false }),
-    inner[0],
-  );
+  f.render_widget(Paragraph::new(content).wrap(Wrap { trim: false }), inner[0]);
 
   // --- loader + countdown (only while the safety countdown is armed) ---
   if app.confirm_is_countdown_mode() && app.confirm.is_armed() {
@@ -2242,13 +2285,13 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   // --- key hint ---
   let hint = if app.confirm_is_countdown_mode() {
     if app.confirm.is_armed() {
-      "y: cancel countdown   ←/→ Tab: move   Enter: activate   n/Esc: cancel".to_string()
+      "y cancel countdown · Tab move · Enter · Esc cancel".to_string()
     } else {
       let total = app.confirm_countdown_total().as_secs();
-      format!("y: arm {total}s countdown   ←/→ Tab: move   Enter: activate   n/Esc: cancel")
+      format!("y arm {total}s · Tab move · Enter · Esc cancel")
     }
   } else {
-    "y: confirm   ←/→ Tab: move   Enter: activate   n/Esc: cancel".to_string()
+    "y confirm · Tab move · Enter · Esc cancel".to_string()
   };
   f.render_widget(
     Paragraph::new(Span::styled(hint, Style::default().fg(muted))).alignment(Alignment::Center),
@@ -2546,7 +2589,15 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
       lines
     }
   };
-  let area = centered_h(50, lines.len() as u16 + 2 /* border */ + 2 /* padding */, f.area());
+  let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
+  let term = f.area();
+  let width = link_prompt_modal_width(term.width).min(term.width);
+  let area = Rect {
+    x: term.x + term.width.saturating_sub(width) / 2,
+    y: term.y + term.height.saturating_sub(height) / 2,
+    width,
+    height: height.min(term.height),
+  };
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3619,6 +3619,37 @@ fn create_key_typing_appends_to_the_focused_text_field() {
 }
 
 #[test]
+fn create_key_rejects_issue_letters_with_status_feedback() {
+  // Issue #220 visual pass: the modal opens on the digits-only Issue field.
+  // A stray letter must not leak into Desc, but it also must not look like
+  // typing is broken; the status bar explains the contract.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::CreateKey;
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  assert_eq!(app.create_form.field, Field::Issue);
+
+  assert!(matches!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+    CreateKey::Handled
+  ));
+  assert!(app.create_form.issue.is_empty());
+  assert!(
+    app.create_form.desc.is_empty(),
+    "non-digit Issue input must stay on Issue and never append to Desc"
+  );
+  assert!(
+    app.status.contains("digits"),
+    "status should explain the digits-only Issue field, got {:?}",
+    app.status
+  );
+
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('7'), KeyModifiers::NONE));
+  assert_eq!(app.create_form.issue, "7");
+  assert!(app.create_form.desc.is_empty());
+}
+
+#[test]
 fn create_key_hl_cycles_the_type_only_when_type_is_focused() {
   use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   let (_dir, mut app) = make_app();

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -6,9 +6,11 @@
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
   badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_choose_hint,
-  link_input_hint, link_target_line, pane_counter, status_pane_title, type_selector_line, worktrees_pane_title,
+  link_input_hint, link_prompt_modal_width, link_target_line, pane_counter, status_pane_title, type_selector_line,
+  worktrees_pane_title,
 };
-use ratatui::style::{Color, Modifier};
+use gwm::tui::{confirm_detail_line, help_section_style};
+use ratatui::style::{Color, Modifier, Style};
 
 #[test]
 fn ellipsize_middle_returns_input_when_it_fits() {
@@ -275,6 +277,19 @@ fn link_target_line_highlights_the_selected_row() {
     selected.spans.iter().any(|s| s.style.fg == Some(Color::Magenta)),
     "the selected row must read in the accent: {stext:?}"
   );
+  let selected_chip = selected
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Issue"))
+    .expect("selected label span");
+  assert!(
+    selected_chip.style.add_modifier.contains(Modifier::REVERSED),
+    "selected link row must use the same reversed chip treatment as modal buttons: {selected_chip:?}"
+  );
+  assert!(
+    !stext.contains('›'),
+    "the selected link row should read as a chip, not a marker-prefixed list item: {stext:?}"
+  );
 
   let idle = link_target_line("p", "Pull Request", false, Color::Magenta, Color::Gray);
   let itext: String = idle.spans.iter().map(|s| s.content.as_ref()).collect();
@@ -286,11 +301,21 @@ fn link_target_line_highlights_the_selected_row() {
 }
 
 #[test]
+fn link_prompt_width_stays_compact_on_wide_terminals() {
+  assert_eq!(link_prompt_modal_width(80), 40);
+  assert_eq!(
+    link_prompt_modal_width(120),
+    42,
+    "Link prompt should cap instead of growing to half the terminal"
+  );
+}
+
+#[test]
 fn link_prompt_hints_fit_the_80_col_modal_budget() {
-  // The Link modal uses `centered_h(50, ...)`: at 80 columns its outer
-  // width is 40, and the rounded border + horizontal padding leave 34 cells
-  // for content. The visual smoke caught the previous long hints clipping at
-  // exactly this common terminal width.
+  // At 80 columns the compact Link modal remains 40 columns wide, and the
+  // rounded border + horizontal padding leave 34 cells for content. The
+  // visual smoke caught the previous long hints clipping at exactly this
+  // common terminal width.
   const INNER_WIDTH_AT_80_COLS: usize = 34;
 
   for hint in [link_choose_hint(), link_input_hint()] {
@@ -299,4 +324,25 @@ fn link_prompt_hints_fit_the_80_col_modal_budget() {
       "Link prompt hint clips at 80 cols: {hint:?}"
     );
   }
+}
+
+#[test]
+fn help_section_style_uses_body_section_colour() {
+  let style = help_section_style(Color::Magenta, Color::Green);
+  assert_eq!(
+    style.fg,
+    Some(Color::Green),
+    "body section headings should not reuse the modal title accent"
+  );
+  assert!(style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn confirm_detail_line_aligns_label_column() {
+  let value_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
+  let line = confirm_detail_line("branch", "feat/#220", 8, Color::Gray, value_style);
+  assert_eq!(line.spans[0].content.as_ref(), "branch    ");
+  assert_eq!(line.spans[0].style.fg, Some(Color::Gray));
+  assert_eq!(line.spans[1].content.as_ref(), "feat/#220");
+  assert_eq!(line.spans[1].style, value_style);
 }


### PR DESCRIPTION
## Description

Polishes the TUI modal regressions caught during the #218 visual pass: Link prompt sizing/selection, create Issue input feedback, Keybindings section colour, and Confirm Delete alignment.

Closes #220

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Compact the Link prompt width on wide terminals and render the selected target as a reversed chip like other modal buttons.
- Keep create Issue input digits-only while surfacing a status message when letters are rejected, so the field no longer looks broken.
- Give Keybindings body section headings a distinct colour and reorganize Confirm Delete details into aligned label/value rows with shorter hints.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Visual follow-up from local screenshots attached to #220. No fresh terminal capture added; the changed contracts are pinned by ratatui-free helper/state tests.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #220
- Related PR: #218

## Notes for reviewers

Validation run locally:

- `cargo fmt --check`
- `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`
- `cargo clippy --all-targets -- -D warnings`
