### PR TITLE
🐛 fix(tui): polish remaining modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TUI: polish remaining modal follow-ups — Delete Worktree casing and
+  toggle badges, shared Link/Open Issue/PR layouts with Refresh, and
+  horizontal Keybindings scrolling with clearer section spacing. (#222)
 - TUI: polish modal follow-ups after the statusbar pass — compact Link
   prompt with chip selection, clearer create Issue feedback, distinct
   Keybindings section colour, and aligned Confirm Delete details. (#220)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -105,6 +105,8 @@ pub enum LinkPromptKey {
   Handled,
   /// `Enter` on the number field — the loop should run `link_prompt_submit`.
   Submit,
+  /// The resolved `fetch_github` key — the loop should refresh status.
+  Refresh,
   /// `Esc` — the loop should close the prompt back to the list.
   Cancel,
 }
@@ -167,10 +169,14 @@ pub struct App {
   /// Keybindings (help) overlay scroll offset, in rows. Reset to 0 every
   /// time the overlay opens; clamped to `help_max_scroll` (#217).
   pub help_scroll: u16,
+  /// Keybindings (help) overlay horizontal scroll offset, in columns (#222).
+  pub help_x_scroll: u16,
   /// Maximum help scroll offset, republished by [`super::ui::draw_help`]
   /// each frame as `content_rows.saturating_sub(viewport_rows)` so the
   /// offset can never scroll past the last line into the void.
   pub help_max_scroll: u16,
+  /// Maximum horizontal help scroll offset, republished by the renderer.
+  pub help_max_x_scroll: u16,
 
   /// Sidebar (git preview) panel state (extracted per #127). Owns the
   /// visibility / focus flags, the scroll offset + max bound, and the
@@ -350,7 +356,9 @@ impl App {
       branch_types,
       report: None,
       help_scroll: 0,
+      help_x_scroll: 0,
       help_max_scroll: 0,
+      help_max_x_scroll: 0,
       sidebar: SidebarState::new(),
       pending_g: false,
       pending_chord: Vec::new(),
@@ -623,6 +631,13 @@ impl App {
     outcome
   }
 
+  pub fn key_matches_action(&self, key: KeyEvent, action: Action) -> bool {
+    matches!(
+      self.keymap.lookup(&[KeyStroke::from_event(&key)]),
+      ChordResolution::Matched(found) if found == action
+    )
+  }
+
   /// Mirror the new `pending_chord` buffer into the legacy
   /// `pending_g` boolean so pre-#87 tests that read it as a field
   /// stay green. Removed when those tests migrate to
@@ -798,6 +813,7 @@ impl App {
   pub fn enter_help(&mut self) {
     self.view = View::Help;
     self.help_scroll = 0;
+    self.help_x_scroll = 0;
   }
 
   /// Scroll the help overlay down one row, clamped to the renderer-published
@@ -809,6 +825,14 @@ impl App {
   /// Scroll the help overlay up one row, clamped at the top.
   pub fn help_scroll_up(&mut self) {
     self.help_scroll = self.help_scroll.saturating_sub(1);
+  }
+
+  pub fn help_scroll_right(&mut self) {
+    self.help_x_scroll = (self.help_x_scroll + 1).min(self.help_max_x_scroll);
+  }
+
+  pub fn help_scroll_left(&mut self) {
+    self.help_x_scroll = self.help_x_scroll.saturating_sub(1);
   }
 
   /// Path to launch lazygit on, or `None` if nothing selected or lazygit is missing.
@@ -1708,6 +1732,9 @@ impl App {
   /// (submit shell-out, view transition).
   pub fn handle_link_prompt_key(&mut self, key: KeyEvent) -> LinkPromptKey {
     use crate::tui::state::link_prompt::LinkPromptStage;
+    if self.key_matches_action(key, Action::FetchGithub) {
+      return LinkPromptKey::Refresh;
+    }
     match (self.link_prompt.stage, key.code) {
       (_, KeyCode::Esc) => return LinkPromptKey::Cancel,
       // ChooseTarget: a vertical selectable list. j/k (and arrows) move the

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,11 +55,12 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
-  confirm_detail_line, create_buttons_line, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line,
-  freshness_color, github_status_lines, header_line, header_title, help_lines, help_rows, help_section_style,
-  issue_badge_color, issue_summary_line, link_choose_hint, link_input_hint, link_prompt_modal_width, link_target_line,
-  pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, status_line,
-  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
+  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
+  field_input_line, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
+  header_title, help_body_section_color, help_lines, help_rows, help_section_style, issue_badge_color,
+  issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines, link_prompt_modal_width,
+  link_target_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
+  status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
   worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
   COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
@@ -254,6 +255,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         // Scroll the Keybindings overlay when it outgrows the modal (#217).
         KeyCode::Down | KeyCode::Char('j') => app.help_scroll_down(),
         KeyCode::Up | KeyCode::Char('k') => app.help_scroll_up(),
+        KeyCode::Right | KeyCode::Char('l') => app.help_scroll_right(),
+        KeyCode::Left | KeyCode::Char('h') => app.help_scroll_left(),
         KeyCode::Home | KeyCode::Char('g') => app.help_scroll = 0,
         KeyCode::End | KeyCode::Char('G') => app.help_scroll = app.help_max_scroll,
         _ => {}
@@ -306,6 +309,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
             open_url(&url, &mut app);
           }
         }
+        _ if app.key_matches_action(key, Action::FetchGithub) => app.refresh_github_status(),
         _ => {}
       },
       // Link-prompt keys live in a testable `App` method (issue #217); the
@@ -316,6 +320,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
             app.status = format!("link failed: {}", e);
           }
         }
+        LinkPromptKey::Refresh => app.refresh_github_status(),
         LinkPromptKey::Cancel => app.link_prompt_cancel(),
         LinkPromptKey::Handled => {}
       },

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,4 +1,4 @@
-use super::app::{App, GitHubFetchState, LinkPromptStage, View};
+use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::Field;
 use super::state::spinner::DOT_FRAMES;
@@ -1375,7 +1375,11 @@ impl HintContext {
         Hint::Lit("Esc", "cancel"),
       ],
       HintContext::Report => &[Hint::Lit("Enter/Esc", "close")],
-      HintContext::Help => &[Hint::Lit("Esc/q", "close")],
+      HintContext::Help => &[
+        Hint::Lit("j/k", "scroll"),
+        Hint::Lit("h/l", "pan"),
+        Hint::Lit("Esc/q", "close"),
+      ],
     }
   }
 
@@ -1712,10 +1716,12 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     HelpRow::Subtitle(ctx.label().to_string()),
     HelpRow::Blank,
     HelpRow::Section("Global".to_string()),
+    HelpRow::Blank,
     entry(Action::Quit, "quit (Esc also quits when filter is clear)"),
     fixed("Ctrl-C", "force quit (hard-coded escape hatch)"),
     HelpRow::Blank,
     HelpRow::Section("List View".to_string()),
+    HelpRow::Blank,
     entry(Action::Down, "next (scrolls sidebar when focused)"),
     entry(Action::Up, "prev (scrolls sidebar when focused)"),
     entry(Action::Top, "jump to first worktree"),
@@ -1759,6 +1765,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     rows.push(fixed("enter", "show path in status bar"));
     rows.push(HelpRow::Blank);
     rows.push(HelpRow::Section("Issue / PR (#67)".to_string()));
+    rows.push(HelpRow::Blank);
     rows.push(entry(Action::OpenMenu, "open menu — i=issue · p=pull request"));
     rows.push(entry(
       Action::LinkPrompt,
@@ -1773,13 +1780,15 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     rows.extend([
       HelpRow::Blank,
       HelpRow::Section("Create Form".to_string()),
+      HelpRow::Blank,
       fixed("←/→ ↑/↓", "change branch type"),
       fixed("Tab/Shift-Tab", "next/prev field"),
       fixed("Enter (desc)", "submit"),
       fixed("Esc", "cancel"),
       HelpRow::Blank,
-      HelpRow::Section("Confirm Delete".to_string()),
-      fixed("←/→ Tab", "move focus between [ Confirm ] / [ Cancel ]"),
+      HelpRow::Section("Delete Worktree".to_string()),
+      HelpRow::Blank,
+      fixed("←/→ Tab", "move focus between Confirm / Cancel"),
       fixed("Enter", "activate the focused button (defaults to Cancel)"),
       fixed("y", "confirm"),
       fixed("n / Esc", "cancel"),
@@ -1884,7 +1893,7 @@ fn draw_help(f: &mut Frame, app: &mut App) {
       HelpRow::Section(t) => {
         lines.push(Line::from(Span::styled(
           t,
-          help_section_style(accent, app.theme.branch),
+          help_section_style(accent, help_body_section_color(&app.theme)),
         )));
       }
       HelpRow::Blank => lines.push(Line::from(String::new())),
@@ -1915,13 +1924,19 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   // the only place that knows both the content length and the inner height,
   // so it clamps the offset here too.
   let block = overlay_block(accent);
-  let viewport = block.inner(area).height as usize;
+  let inner_area = block.inner(area);
+  let viewport = inner_area.height as usize;
   app.help_max_scroll = (lines.len().saturating_sub(viewport)) as u16;
   app.help_scroll = app.help_scroll.min(app.help_max_scroll);
+  let viewport_width = inner_area.width as usize;
+  let content_width = lines.iter().map(Line::width).max().unwrap_or(0);
+  app.help_max_x_scroll = content_width.saturating_sub(viewport_width) as u16;
+  app.help_x_scroll = app.help_x_scroll.min(app.help_max_x_scroll);
   let scroll = app.help_scroll;
+  let x_scroll = app.help_x_scroll;
 
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, 0)), area);
+  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
 }
 
 fn draw_create(f: &mut Frame, app: &App) {
@@ -2116,15 +2131,18 @@ pub fn field_input_line(
 /// muted. `key` is the direct-pick shortcut (`i` / `p`). Pure so the
 /// highlight contract is pinned by `tests/tui_ui_helpers_tests.rs`.
 pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, muted: Color) -> Line<'static> {
+  const BUTTON_WIDTH: usize = 17; // " p  Pull Request "
+  let button = format!(" {key}  {label} ");
+  let button = format!("{button:<BUTTON_WIDTH$}");
   if selected {
     let chip = Style::default()
       .fg(accent)
       .add_modifier(Modifier::REVERSED | Modifier::BOLD);
-    return Line::from(vec![Span::raw("  "), Span::styled(format!(" {key}  {label} "), chip)]);
+    return Line::from(vec![Span::raw("  "), Span::styled(button, chip)]);
   }
 
   let idle = Style::default().fg(muted);
-  Line::from(vec![Span::raw("  "), Span::styled(format!("{key}  {label}"), idle)])
+  Line::from(vec![Span::raw("  "), Span::styled(button, idle)])
 }
 
 /// Modal width for the Link prompt. Pure so the visual budget remains pinned
@@ -2156,6 +2174,64 @@ pub fn confirm_detail_line(
   ])
 }
 
+pub fn delete_worktree_title() -> &'static str {
+  "Delete Worktree"
+}
+
+pub fn confirm_delete_branch_line(
+  enabled: bool,
+  key: &str,
+  label_width: usize,
+  accent: Color,
+  muted: Color,
+) -> Line<'static> {
+  let key_style = Style::default()
+    .fg(accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let value_style = Style::default()
+    .fg(if enabled { accent } else { muted })
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  Line::from(vec![
+    Span::styled(
+      format!("{:<label_width$}  ", "Delete Branch", label_width = label_width),
+      Style::default().fg(muted),
+    ),
+    Span::styled(format!(" {key} "), key_style),
+    Span::raw("  "),
+    Span::styled(format!(" {enabled} "), value_style),
+  ])
+}
+
+pub fn help_body_section_color(theme: &Theme) -> Color {
+  theme.locked
+}
+
+fn line_text(line: &Line<'static>) -> String {
+  line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+pub fn link_open_modal_lines(app: &App, title: &str, selected: Option<LinkTarget>) -> Vec<Line<'static>> {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let mut lines = overlay_title_lines(title, accent);
+  lines.extend(
+    github_status_lines(app, 36)
+      .into_iter()
+      .filter(|line| !line_text(line).starts_with("press ")),
+  );
+  lines.push(Line::from(""));
+  lines.push(link_target_line("i", "Issue", selected == Some(LinkTarget::Issue), accent, muted).centered());
+  lines.push(link_target_line("p", "Pull Request", selected == Some(LinkTarget::Pr), accent, muted).centered());
+  let refresh_key = app
+    .keymap
+    .primary_chord(super::keymap::Action::FetchGithub)
+    .unwrap_or_else(|| "F".to_string());
+  lines.push(link_target_line(&refresh_key, "Refresh", false, accent, muted).centered());
+  lines.push(Line::from(""));
+  lines.push(Line::from(Span::styled(link_choose_hint(), Style::default().fg(muted))).centered());
+  lines
+}
+
 fn draw_confirm(f: &mut Frame, app: &App) {
   let muted = app.theme.muted;
   // The destructive modal reads in the theme's "danger" colour (the
@@ -2166,7 +2242,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   let block = overlay_block(danger);
 
   let Some(w) = app.selected() else {
-    let mut lines = overlay_title_lines("Confirm Delete", danger);
+    let mut lines = overlay_title_lines(delete_worktree_title(), danger);
     lines.push(Line::from("nothing selected").centered());
     let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
     let area = centered_h(40, height, f.area());
@@ -2181,7 +2257,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   let term = f.area();
   let outer_w = term.width.saturating_mul(62) / 100;
   let text_w = outer_w.saturating_sub(6) as usize;
-  let label_w = "delete branch".chars().count();
+  let label_w = "Delete Branch".chars().count();
   let value_w = text_w.saturating_sub(label_w + 2).max(1);
 
   let name = ellipsize_middle(&w.name, value_w);
@@ -2189,16 +2265,16 @@ fn draw_confirm(f: &mut Frame, app: &App) {
 
   // Title stays centred; details use an aligned label/value grid so the
   // destructive target is easier to scan (#220 visual follow-up).
-  let mut content: Vec<Line> = overlay_title_lines("Confirm Delete", danger);
+  let mut content: Vec<Line> = overlay_title_lines(delete_worktree_title(), danger);
   content.push(confirm_detail_line(
-    "worktree",
+    "Worktree",
     name,
     label_w,
     muted,
     Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD),
   ));
   content.push(confirm_detail_line(
-    "path",
+    "Path",
     path,
     label_w,
     muted,
@@ -2207,7 +2283,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   if let Some(b) = &w.branch {
     let branch = ellipsize_middle(b, value_w);
     content.push(confirm_detail_line(
-      "branch",
+      "Branch",
       branch,
       label_w,
       muted,
@@ -2215,17 +2291,12 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     ));
   }
   content.push(Line::from(""));
-  let delete_branch_style = if app.delete_branch_on_remove {
-    Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)
-  } else {
-    Style::default().fg(muted)
-  };
-  content.push(confirm_detail_line(
-    "delete branch",
-    format!("{}  p toggles", app.delete_branch_on_remove),
+  content.push(confirm_delete_branch_line(
+    app.delete_branch_on_remove,
+    "p",
     label_w,
+    app.theme.accent,
     muted,
-    delete_branch_style,
   ));
 
   // Size the modal to its content: the title + description rows plus the
@@ -2535,15 +2606,16 @@ fn trunc(s: &str, max: usize) -> String {
 
 fn draw_open_menu(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let mut lines = overlay_title_lines("Open in Browser", accent);
-  lines.push(Line::from("  i   linked issue"));
-  lines.push(Line::from("  p   linked pull request"));
-  lines.push(Line::from(""));
-  lines.push(Line::from(Span::styled(
-    "  esc to cancel",
-    Style::default().fg(app.theme.muted),
-  )));
-  let area = centered_h(40, lines.len() as u16 + 2 /* border */ + 2 /* padding */, f.area());
+  let lines = link_open_modal_lines(app, "Open in Browser", None);
+  let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
+  let term = f.area();
+  let width = link_prompt_modal_width(term.width).min(term.width);
+  let area = Rect {
+    x: term.x + term.width.saturating_sub(width) / 2,
+    y: term.y + term.height.saturating_sub(height) / 2,
+    width,
+    height: height.min(term.height),
+  };
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
@@ -2557,21 +2629,7 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
       // links the highlighted row, i/p stay direct picks. The highlighted
       // row reads in the accent.
       let selected = app.link_prompt_selected();
-      let mut lines = overlay_title_lines("Link", accent);
-      lines.push(link_target_line("i", "Issue", selected == super::app::LinkTarget::Issue, accent, muted).centered());
-      lines.push(
-        link_target_line(
-          "p",
-          "Pull Request",
-          selected == super::app::LinkTarget::Pr,
-          accent,
-          muted,
-        )
-        .centered(),
-      );
-      lines.push(Line::from(""));
-      lines.push(Line::from(Span::styled(link_choose_hint(), Style::default().fg(muted))).centered());
-      lines
+      link_open_modal_lines(app, "Link", Some(selected))
     }
     LinkPromptStage::InputNumber => {
       let label = match app.link_prompt_target() {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1236,6 +1236,34 @@ fn open_menu_pick_returns_none_when_no_link() {
 }
 
 #[test]
+fn link_open_modal_lines_include_available_links_and_refresh_button() {
+  use gwm::tui::{link_open_modal_lines, LinkTarget};
+  let (dir, repo) = init_repo();
+  {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("random-branch", &head, false).unwrap();
+  }
+  repo.set_head("refs/heads/random-branch").unwrap();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.random-branch.gwm-issue", "42").unwrap();
+    cfg.set_str("branch.random-branch.gwm-pr", "7").unwrap();
+  }
+  let app = App::new_at_layered(Some(dir.path()), None).unwrap();
+
+  let text = link_open_modal_lines(&app, "Open in Browser", Some(LinkTarget::Issue))
+    .into_iter()
+    .map(|line| spans_to_text(&line.spans))
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  assert!(text.contains("Issue #42"), "Issue summary missing: {text:?}");
+  assert!(text.contains("PR"), "PR summary missing: {text:?}");
+  assert!(text.contains("#7"), "PR number missing: {text:?}");
+  assert!(text.contains("Refresh"), "Refresh action missing: {text:?}");
+}
+
+#[test]
 fn enter_link_prompt_starts_at_choose_target() {
   let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
   app.enter_link_prompt();
@@ -1418,6 +1446,18 @@ fn link_prompt_key_esc_requests_cancel() {
   assert!(matches!(
     app.handle_link_prompt_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
     LinkPromptKey::Cancel
+  ));
+}
+
+#[test]
+fn link_prompt_key_fetch_requests_refresh() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::LinkPromptKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert!(matches!(
+    app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::NONE)),
+    LinkPromptKey::Refresh
   ));
 }
 
@@ -3598,6 +3638,30 @@ fn help_scroll_clamps_between_zero_and_max() {
   app.help_scroll = 2;
   app.enter_help();
   assert_eq!(app.help_scroll, 0, "(re)opening help returns to the top");
+}
+
+#[test]
+fn help_horizontal_scroll_clamps_between_zero_and_max() {
+  let (_dir, mut app) = make_app();
+  app.enter_help();
+  assert_eq!(app.help_x_scroll, 0);
+
+  app.help_max_x_scroll = 2;
+  app.help_scroll_right();
+  assert_eq!(app.help_x_scroll, 1);
+  app.help_scroll_right();
+  app.help_scroll_right();
+  assert_eq!(app.help_x_scroll, 2, "scroll-right clamps at the published max");
+
+  app.help_scroll_left();
+  assert_eq!(app.help_x_scroll, 1);
+  app.help_scroll_left();
+  app.help_scroll_left();
+  assert_eq!(app.help_x_scroll, 0, "scroll-left clamps at the left edge");
+
+  app.help_x_scroll = 2;
+  app.enter_help();
+  assert_eq!(app.help_x_scroll, 0, "(re)opening help returns to the left edge");
 }
 
 #[test]

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -333,9 +333,18 @@ fn help_rows_structures_title_sections_and_entries() {
   assert!(
     rows
       .iter()
-      .any(|r| matches!(r, HelpRow::Section(s) if s == "Confirm Delete")),
-    "expected a `Confirm Delete` section header"
+      .any(|r| matches!(r, HelpRow::Section(s) if s == "Delete Worktree")),
+    "expected a `Delete Worktree` section header"
   );
+  for pair in rows.windows(2) {
+    if matches!(pair[0], HelpRow::Section(_)) {
+      assert!(
+        matches!(pair[1], HelpRow::Blank),
+        "section headings should be followed by a visual gap, got {:?}",
+        pair
+      );
+    }
+  }
   // The `Down` action's default `j` binding must surface as an Entry
   // with the resolved chord in its `keys`, not baked into a string.
   let keys = km

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -3,13 +3,16 @@
 //! the confirm modal, and the badge-group width used to align the help
 //! overlay's per-chord key badges.
 
+use gwm::tui::theme::Theme;
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
   badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_choose_hint,
   link_input_hint, link_prompt_modal_width, link_target_line, pane_counter, status_pane_title, type_selector_line,
   worktrees_pane_title,
 };
-use gwm::tui::{confirm_detail_line, help_section_style};
+use gwm::tui::{
+  confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_section_style,
+};
 use ratatui::style::{Color, Modifier, Style};
 
 #[test]
@@ -345,4 +348,64 @@ fn confirm_detail_line_aligns_label_column() {
   assert_eq!(line.spans[0].style.fg, Some(Color::Gray));
   assert_eq!(line.spans[1].content.as_ref(), "feat/#220");
   assert_eq!(line.spans[1].style, value_style);
+}
+
+#[test]
+fn delete_worktree_title_replaces_confirm_delete() {
+  assert_eq!(delete_worktree_title(), "Delete Worktree");
+}
+
+#[test]
+fn confirm_delete_branch_line_renders_title_case_key_and_value_badges() {
+  let line = confirm_delete_branch_line(false, "p", 13, Color::Magenta, Color::Gray);
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    text.starts_with("Delete Branch"),
+    "delete branch label should be Title Case: {text:?}"
+  );
+  let key = line.spans.iter().find(|s| s.content.contains("p")).expect("key badge");
+  assert!(
+    key.style.add_modifier.contains(Modifier::REVERSED),
+    "toggle key should render as a badge: {key:?}"
+  );
+  let value = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("false"))
+    .expect("value badge");
+  assert!(
+    value.style.add_modifier.contains(Modifier::REVERSED),
+    "boolean state should render as a badge: {value:?}"
+  );
+}
+
+#[test]
+fn link_target_buttons_keep_equal_visual_widths() {
+  let issue = link_target_line("i", "Issue", true, Color::Magenta, Color::Gray);
+  let pr = link_target_line("p", "Pull Request", true, Color::Magenta, Color::Gray);
+  let issue_chip = issue
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Issue"))
+    .expect("issue chip");
+  let pr_chip = pr
+    .spans
+    .iter()
+    .find(|s| s.content.contains("Pull Request"))
+    .expect("pr chip");
+  assert_eq!(
+    issue_chip.content.chars().count(),
+    pr_chip.content.chars().count(),
+    "Link/Open action buttons should align to the same width"
+  );
+}
+
+#[test]
+fn help_body_section_colour_is_distinct_from_subtitle_colour() {
+  let theme = Theme {
+    branch: Color::Green,
+    locked: Color::Blue,
+    ..Theme::default()
+  };
+  assert_eq!(help_body_section_color(&theme), Color::Blue);
 }


### PR DESCRIPTION
## Description

Polishes the remaining TUI modal follow-ups reported after the modal/statusbar pass: Delete Worktree wording/layout, shared Link/Open Issue/PR content, Refresh actions, and Keybindings horizontal scroll/spacing.

Closes #222

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Rename the delete modal to `Delete Worktree`, Title Case its detail labels, and render `Delete Branch` as `p` + true/false badges.
- Reuse one Link/Open modal line builder so both show available Issue/PR information and equal-width Issue / Pull Request / Refresh action buttons.
- Add horizontal Keybindings scroll via `h`/`l` and arrows, reset/clamp the x-offset, add section gaps, and switch body section colour away from the subtitle colour.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Not captured in this PR. The modal contracts are pinned with ratatui-free helper/state tests.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #222
- Related PR: #221

## Notes for reviewers

Local validation:

- `cargo fmt --check`
- `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test tui_ui_helpers_tests help_body_section_colour_is_distinct_from_subtitle_colour`

Bonus local setup handled before the PR: inspected `.gwm.toml`, approved trust for `https://github.com/kbrdn1/gwm-cli.git` hash `3dc7331476a9`, and verified `gwm create` worked without `--allow-bootstrap`.
