### PR TITLE
🐛 fix(tui): polish panes and modal follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TUI: polish pane/modal follow-ups — Bootstrap Report logs now sit in a
+  pane, sidebar titles surface their live bindings, GitHub loading uses
+  an animated loader, Link/Open modals are wider without a Refresh button,
+  modal hints use statusbar-style badges, and Delete Worktree honours the
+  delete-branch toggle binding while open. (#224)
 - TUI: polish remaining modal follow-ups — Delete Worktree casing and
-  toggle badges, shared Link/Open Issue/PR layouts with Refresh, and
+  toggle badges, shared Link/Open Issue/PR layouts, and
   horizontal Keybindings scrolling with clearer section spacing. (#222)
 - TUI: polish modal follow-ups after the statusbar pass — compact Link
   prompt with chip selection, clearer create Issue feedback, distinct

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -152,6 +152,7 @@ pub struct App {
   pub view: View,
   pub status: String,
   pub delete_branch_on_remove: bool,
+  pub open_menu_selected: LinkTarget,
 
   // Create form state
   /// Create-worktree overlay state (extracted per #123). Holds field
@@ -352,6 +353,7 @@ impl App {
       view: View::List,
       status: String::from("press ? for help"),
       delete_branch_on_remove: false,
+      open_menu_selected: LinkTarget::Issue,
       create_form: CreateForm::new(),
       branch_types,
       report: None,
@@ -1672,11 +1674,19 @@ impl App {
     // Re-resolve link + slug in case the user just linked something
     // (`gwm link …` from a parallel terminal) or moved the origin remote.
     self.refresh_link();
+    self.open_menu_selected = LinkTarget::Issue;
     self.view = View::OpenMenu;
   }
 
   pub fn exit_open_menu(&mut self) {
     self.view = View::List;
+  }
+
+  pub fn open_menu_toggle_selection(&mut self) {
+    self.open_menu_selected = match self.open_menu_selected {
+      LinkTarget::Issue => LinkTarget::Pr,
+      LinkTarget::Pr => LinkTarget::Issue,
+    };
   }
 
   /// Pick a target from the open menu. Returns the URL to open, or `None`

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -531,8 +531,8 @@ impl Keymap {
 
   /// The canonical rendering of the **first** chord bound to `action`,
   /// or `None` when the action is unbound. Used by UI copy that names a
-  /// key inline (e.g. the sidebar's "press F to fetch status" prompt,
-  /// issue #217) so the hint tracks user overrides under `[tui.keys]`
+  /// key inline (e.g. pane titles such as `Issue / PR [F]`,
+  /// issue #224) so the hint tracks user overrides under `[tui.keys]`
   /// instead of hard-coding a default that may have been rebound. A
   /// multi-chord action returns its first chord in declaration order,
   /// matching what `gwm tui keys` lists first.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,15 +54,16 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
   }
 }
 pub use ui::{
-  author_initials, badge_group_width, branch_name_color, build_sidebar_sections, confirm_buttons_line,
-  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
-  field_input_line, filled_cells_for_progress, footer_line, freshness_color, github_status_lines, header_line,
-  header_title, help_body_section_color, help_lines, help_rows, help_section_style, issue_badge_color,
-  issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines, link_prompt_modal_width,
-  link_target_line, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
-  status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_status_line,
-  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, build_sidebar_sections,
+  confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title,
+  ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color, github_status_lines,
+  header_line, header_title, help_body_section_color, help_lines, help_rows, help_section_style, issue_badge_color,
+  issue_pr_pane_title, issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines,
+  link_prompt_modal_width, link_target_line, modal_hint_line, pane_counter, panel_border_color, pr_badge_color,
+  pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
+  RECENT_COMMITS_LIMIT,
 };
 
 pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {
@@ -283,6 +284,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           ConfirmButton::Cancel => app.confirm_dismiss(),
         },
         KeyCode::Char('n') | KeyCode::Esc => app.confirm_dismiss(),
+        _ if app.key_matches_action(key, Action::ToggleDeleteBranch) => app.toggle_delete_branch(),
         // Button focus navigation (#187). `←` / `h` → Confirm,
         // `→` / `l` → Cancel, `Tab` toggles.
         KeyCode::Left | KeyCode::Char('h') => app.confirm.focus_confirm(),
@@ -299,6 +301,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       },
       View::OpenMenu => match key.code {
         KeyCode::Esc | KeyCode::Char('q') => app.exit_open_menu(),
+        KeyCode::Char('j') | KeyCode::Char('k') | KeyCode::Down | KeyCode::Up => app.open_menu_toggle_selection(),
+        KeyCode::Enter => {
+          if let Some(url) = app.open_menu_pick(app.open_menu_selected) {
+            open_url(&url, &mut app);
+          }
+        }
         KeyCode::Char('i') => {
           if let Some(url) = app.open_menu_pick(LinkTarget::Issue) {
             open_url(&url, &mut app);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,9 +1,11 @@
 use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
+use super::keymap::{Action, Keymap};
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::Field;
+use super::state::sidebar::SidebarMode;
 use super::state::spinner::DOT_FRAMES;
 use super::theme::Theme;
-use crate::bootstrap::StepStatus;
+use crate::bootstrap::{BootstrapReport, StepStatus};
 use crate::github::{IssueState, LinkSource, PrState};
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
@@ -79,7 +81,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
   }
 }
 
-/// Format the TUI header title `" gwm v<version> — <repo> (<path>) "`.
+/// Format the TUI header title `" <repo> <path> gwm <version> "`.
 /// The version comes from `CARGO_PKG_VERSION` so it stays in lockstep
 /// with `gwm --version` without a second source of truth — important
 /// for users juggling multiple installs (a `cargo install`-ed gwm next
@@ -87,30 +89,25 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 /// the format can be pinned by a unit test without spinning up the
 /// ratatui backend.
 pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
-  format!(
-    " gwm v{} — {} ({}) ",
-    env!("CARGO_PKG_VERSION"),
-    repo_name,
-    workdir_display
-  )
+  format!(" {} {} gwm {} ", repo_name, workdir_display, env!("CARGO_PKG_VERSION"))
 }
 
 /// Styled, width-driven header builder (issue #185). Replaces the flat
 /// `header_title` string in the rendered TUI with a clear visual hierarchy
 /// that mirrors the #180 footer's chip language:
 ///
-/// - **Version** — a reverse-video badge chip (` gwm v<version> `) painted on
-///   `accent`, the same treatment as the footer hint chips. The version still
-///   comes from `CARGO_PKG_VERSION`, so `gwm --version` parity is preserved.
+/// - **Current directory** — a leading reverse-video badge.
+/// - **Working directory** — dimmed (`DarkGray`), stable after the badge and
+///   dropped/truncated under width pressure.
 /// - **`picker`** — an accent-distinct (yellow) chip flagging a `gwm switch`
-///   picker session, kept right after the version so the mode is unmissable.
-/// - **Repo name** — bold, the primary emphasis.
-/// - **Working directory** — dimmed (`DarkGray`), parenthesised, secondary
-///   context that is the first thing dropped/truncated under width pressure.
+///   picker session.
+/// - **Version** — a right-pinned reverse-video badge (` gwm <version> `)
+///   painted on `accent`. The version still comes from `CARGO_PKG_VERSION`,
+///   so `gwm --version` parity is preserved.
 ///
 /// Priority when the terminal is narrow: the version chip survives (clipped
-/// only if it alone exceeds `width`), then the picker chip, then the repo
-/// name (truncated), and the path is sacrificed first. Pure and measured with
+/// only if it alone exceeds `width`), then the current-dir badge, then the
+/// picker chip, and the path is sacrificed first. Pure and measured with
 /// `chars().count()` so the contract is pinned by `tests/tui_header_tests.rs`
 /// without a ratatui backend; control chars are collapsed to spaces so a
 /// pathological path can never split the single row.
@@ -131,8 +128,11 @@ pub fn header_line(
   let repo = sanitize(repo_name);
   let path = sanitize(workdir_display);
 
-  let chip_style = Style::default()
+  let version_style = Style::default()
     .fg(theme.accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let dir_badge_style = Style::default()
+    .fg(theme.name)
     .add_modifier(Modifier::REVERSED | Modifier::BOLD);
   // Picker chip uses the `dirty` role (not the accent) so the mode warning
   // reads as distinct from the always-present version chip — pre-theme this
@@ -140,58 +140,67 @@ pub fn header_line(
   let picker_style = Style::default()
     .fg(theme.dirty)
     .add_modifier(Modifier::REVERSED | Modifier::BOLD);
-  let repo_style = Style::default().add_modifier(Modifier::BOLD);
   let path_style = Style::default().fg(theme.muted);
 
-  let version_text = format!(" gwm v{} ", env!("CARGO_PKG_VERSION"));
-  let chip_w = version_text.chars().count();
+  let version_text = format!(" gwm {} ", env!("CARGO_PKG_VERSION"));
+  let version_w = version_text.chars().count();
+  let dir_text = format!(" {} ", repo);
+  let dir_w = dir_text.chars().count();
 
-  // Priority floor: if even the version chip cannot fit, show it clipped
-  // alone — never an empty header.
-  if width < chip_w {
-    return Line::from(Span::styled(trunc(&version_text, width), chip_style));
+  // Priority floor: if even the right-pinned version chip cannot fit, show it
+  // clipped alone — never an empty header.
+  if width < version_w {
+    return Line::from(Span::styled(trunc(&version_text, width), version_style));
   }
 
   let mut spans: Vec<Span<'static>> = Vec::new();
-  let mut used = chip_w;
-  spans.push(Span::styled(version_text, chip_style));
+  let mut used = 0usize;
 
-  // Picker chip — mode-safety indicator, kept right after the version.
+  // Current-directory badge first. If the row is too narrow for the full
+  // badge plus the pinned version, trim the badge rather than move the path
+  // or version around.
+  let dir_budget = width.saturating_sub(version_w + 1);
+  if dir_w <= dir_budget {
+    spans.push(Span::styled(dir_text, dir_badge_style));
+    used += dir_w;
+  } else if dir_budget > 0 {
+    let clipped = trunc(&dir_text, dir_budget);
+    used += clipped.chars().count();
+    spans.push(Span::styled(clipped, dir_badge_style));
+  }
+
+  // Picker chip — mode-safety indicator, kept right after the current-dir
+  // badge when there is room.
   if picker_mode {
     let picker_text = " picker ".to_string();
     let need = 1 + picker_text.chars().count(); // leading space + chip
-    if used + need <= width {
+    if used + need + version_w < width {
       spans.push(Span::raw(" "));
       spans.push(Span::styled(picker_text, picker_style));
       used += need;
     }
   }
 
-  // Repo name — bold, primary emphasis. Truncated to fit; the 2-space gap is
-  // only spent when at least one repo char survives.
-  let gap = 2usize;
-  if used + gap < width {
-    let avail = width - used - gap;
-    let repo_disp = trunc(&repo, avail);
-    if !repo_disp.is_empty() {
-      let w = repo_disp.chars().count();
+  // Path — dimmed secondary context. It stays immediately after the current
+  // directory badge and is dropped/truncated under pressure; the version chip
+  // remains pinned at the end of the row.
+  let path_gap = 2usize;
+  if used + path_gap + version_w < width {
+    let avail = width - used - path_gap - version_w;
+    let path_disp = trunc(&path, avail);
+    if !path_disp.is_empty() {
+      let w = path_disp.chars().count();
       spans.push(Span::raw("  "));
-      spans.push(Span::styled(repo_disp, repo_style));
-      used += gap + w;
+      spans.push(Span::styled(path_disp, path_style));
+      used += path_gap + w;
     }
   }
 
-  // Path — dimmed secondary context in parens. ` (` + path + `)` ⇒ 3 fixed
-  // columns; dropped first under pressure.
-  let fixed = 3usize; // leading space + "(" + ")"
-  if used + fixed < width {
-    let avail = width - used - fixed;
-    let path_disp = trunc(&path, avail);
-    if !path_disp.is_empty() {
-      spans.push(Span::raw(" "));
-      spans.push(Span::styled(format!("({})", path_disp), path_style));
-    }
+  let pad = width.saturating_sub(used + version_w);
+  if pad > 0 {
+    spans.push(Span::raw(" ".repeat(pad)));
   }
+  spans.push(Span::styled(version_text, version_style));
 
   Line::from(spans)
 }
@@ -529,12 +538,20 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     0,
     None,
   );
-  render_section(f, chunks[1], " Issue / PR ", issue_pr_lines, border_color, 0, None);
+  render_section(
+    f,
+    chunks[1],
+    issue_pr_pane_title(&app.keymap),
+    issue_pr_lines,
+    border_color,
+    0,
+    None,
+  );
   if !sections.working_tree.is_empty() {
     render_section(
       f,
       chunks[2],
-      " Working Tree ",
+      working_tree_pane_title(&app.keymap),
       sections.working_tree,
       border_color,
       0,
@@ -559,7 +576,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   // hint switches to "Enter: copy stash@{N}" in stashes mode.
   let (panel_title, panel_footer) = match active_mode {
     super::state::sidebar::SidebarMode::Commits => {
-      let title = " Recent Commits — commits ".to_string();
+      let title = recent_items_pane_title(active_mode, &app.keymap);
       let footer = if commits_len == 0 {
         None
       } else {
@@ -569,7 +586,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       (title, footer)
     }
     super::state::sidebar::SidebarMode::Stashes => {
-      let title = " Stashes — stashes ".to_string();
+      let title = recent_items_pane_title(active_mode, &app.keymap);
       // The "Enter on stash …" hint from the issue is the operative
       // affordance in this mode — it's worth more than the i/N
       // counter because the user needs to know they can paste the
@@ -753,38 +770,51 @@ fn stash_lines(w: &WorktreeInfo, limit: usize, theme: &Theme) -> Vec<Line<'stati
 /// false to avoid visual noise.
 fn worktree_identity_lines(w: &WorktreeInfo, theme: &Theme) -> Vec<Line<'static>> {
   let mut out: Vec<Line<'static>> = Vec::with_capacity(4);
+  let label_w = "Created".chars().count();
+  let label_style = Style::default().fg(theme.muted);
 
-  // Line 1 — "<branch> · <short head>". Branch colour follows the
+  // Line 1 — "Branch  <branch> · <short head>". Branch colour follows the
   // lazygit scheme (PR #73): worst-state wins (dirty → red,
   // ahead/behind → yellow, unpublished → magenta, synced → green,
   // unknown → dark gray) so the most actionable signal stays at eye
   // level.
   let branch_color = branch_name_color(&w.status, theme);
   let branch = w.branch.clone().unwrap_or_else(|| "-".into());
-  let mut spans = vec![Span::styled(branch, Style::default().fg(branch_color))];
+  let mut spans = vec![
+    Span::styled(format!("{:<label_w$}  ", "Branch", label_w = label_w), label_style),
+    Span::styled(branch, Style::default().fg(branch_color)),
+  ];
   if let Some(head) = w.head.as_deref() {
     spans.push(Span::styled("  ·  ".to_string(), Style::default().fg(theme.muted)));
     spans.push(Span::styled(short_oid(head), Style::default().fg(theme.dirty)));
   }
   out.push(Line::from(spans));
 
-  // Line 2 — "Created: <age>" (compact relative duration, colour-coded
+  // Line 2 — "Created  <age>" (compact relative duration, colour-coded
   // by freshness — PR #73). Skipped when the branch has no measurable
   // age (trunk, detached HEAD, or repo open failure).
   out.push(Line::from(vec![
-    Span::styled("Created: ".to_string(), Style::default().fg(theme.muted)),
+    Span::styled(format!("{:<label_w$}  ", "Created", label_w = label_w), label_style),
     Span::styled(branch_age_label(w), Style::default().fg(branch_age_color(w, theme))),
   ]));
 
-  // Line 3 — status badge + optional flag badges. Only renders the badges
+  // Line 3 — "State  <badges>" with optional flag badges. Only renders the badges
   // that are *true* / *interesting*; the false cases stay invisible.
-  out.push(badges_line(w, theme));
+  let mut state_spans = vec![Span::styled(
+    format!("{:<label_w$}  ", "State", label_w = label_w),
+    label_style,
+  )];
+  state_spans.extend(badges_line(w, theme).spans);
+  out.push(Line::from(state_spans));
 
-  // Line 4 — path, tilde-compressed for compactness.
-  out.push(Line::from(Span::styled(
-    tilde_compress(&w.path.display().to_string()),
-    Style::default().fg(theme.muted),
-  )));
+  // Line 4 — "Path  <path>", tilde-compressed for compactness.
+  out.push(Line::from(vec![
+    Span::styled(format!("{:<label_w$}  ", "Path", label_w = label_w), label_style),
+    Span::styled(
+      tilde_compress(&w.path.display().to_string()),
+      Style::default().fg(theme.muted),
+    ),
+  ]));
 
   out
 }
@@ -1358,15 +1388,22 @@ impl HintContext {
       ],
       HintContext::Confirm => &[
         Hint::Lit("y", "confirm"),
+        Hint::Key(ToggleDeleteBranch, "branch"),
         Hint::Lit("←/→", "move"),
         Hint::Lit("Enter", "activate"),
         Hint::Lit("Esc", "cancel"),
       ],
-      HintContext::OpenMenu => &[Hint::Lit("i", "issue"), Hint::Lit("p", "pr"), Hint::Lit("Esc", "close")],
+      HintContext::OpenMenu => &[
+        Hint::Lit("i", "issue"),
+        Hint::Lit("p", "pr"),
+        Hint::Key(FetchGithub, "fetch"),
+        Hint::Lit("Esc", "close"),
+      ],
       HintContext::LinkPrompt => &[
         Hint::Lit("j/k", "move"),
         Hint::Lit("i/p", "kind"),
         Hint::Lit("Enter", "link"),
+        Hint::Key(FetchGithub, "fetch"),
         Hint::Lit("Esc", "cancel"),
       ],
       HintContext::CommandPalette => &[
@@ -1398,6 +1435,52 @@ impl HintContext {
       })
       .collect()
   }
+}
+
+fn action_chord(keymap: &Keymap, action: Action, fallback: &str) -> String {
+  keymap.primary_chord(action).unwrap_or_else(|| fallback.to_string())
+}
+
+pub fn issue_pr_pane_title(keymap: &Keymap) -> String {
+  format!(" Issue / PR [{}] ", action_chord(keymap, Action::FetchGithub, "F"))
+}
+
+pub fn working_tree_pane_title(keymap: &Keymap) -> String {
+  format!(" Working Tree [{}] ", action_chord(keymap, Action::Review, "R"))
+}
+
+pub fn recent_items_pane_title(mode: SidebarMode, keymap: &Keymap) -> String {
+  match mode {
+    SidebarMode::Commits => format!(" Recent Commits [{}] ", action_chord(keymap, Action::GitTui, "l")),
+    SidebarMode::Stashes => format!(" Stashes [{}] ", action_chord(keymap, Action::GitTui, "l")),
+  }
+}
+
+pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
+  let chip_style = Style::default()
+    .fg(theme.accent)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let label_style = Style::default().fg(theme.muted);
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  for (i, (key, label)) in hints.iter().enumerate() {
+    if i > 0 {
+      spans.push(Span::raw(" "));
+    }
+    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled(format!(" {}", label), label_style));
+  }
+  Line::from(spans).centered()
+}
+
+fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, theme: &Theme) -> Line<'static> {
+  let resolved = ctx.resolve(keymap);
+  let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+  modal_hint_line(&hints, theme)
+}
+
+fn push_modal_hint(lines: &mut Vec<Line<'static>>, ctx: HintContext, keymap: &Keymap, theme: &Theme) {
+  lines.push(Line::from(String::new()));
+  lines.push(modal_hint_for_context(ctx, keymap, theme));
 }
 
 /// Build the single-line statusline (issue #180).
@@ -1514,6 +1597,9 @@ pub fn status_line(
   width: usize,
   theme: &Theme,
 ) -> Line<'static> {
+  let context_style = Style::default()
+    .fg(theme.focus)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
   let chip_style = Style::default()
     .fg(theme.accent)
     .add_modifier(Modifier::REVERSED | Modifier::BOLD);
@@ -1543,7 +1629,7 @@ pub fn status_line(
   let ctx_chip = format!(" {} ", context);
   let ctx_w = ctx_chip.chars().count();
   if ctx_w <= avail {
-    spans.push(Span::styled(ctx_chip, chip_style));
+    spans.push(Span::styled(ctx_chip, context_style));
     used += ctx_w;
   }
 
@@ -1918,6 +2004,7 @@ fn draw_help(f: &mut Frame, app: &mut App) {
       }
     }
   }
+  push_modal_hint(&mut lines, HintContext::Help, &app.keymap, &app.theme);
 
   // Publish the scroll bound against the actual viewport so the Keybindings
   // overlay can scroll when it outgrows the modal (#217). The renderer is
@@ -1957,7 +2044,7 @@ fn draw_create(f: &mut Frame, app: &App) {
   // (issue #217). Height is the fixed row count plus the border + padding
   // rows, so the box hugs its content; the width is capped so the input
   // surfaces don't span a wide terminal.
-  const ROWS: u16 = 13; // title(2) + type + gap + 2 preview + gap + issue + gap + desc + gap + buttons + hint
+  const ROWS: u16 = 14; // title(2) + type + gap + 2 preview + gap + issue + gap + desc + gap + buttons + gap + hint
   let height = ROWS + 2 /* border */ + 2 /* vertical padding */;
   let area = centered_box(70, 72, height, f.area());
   let block = overlay_block(clean);
@@ -2022,13 +2109,7 @@ fn draw_create(f: &mut Frame, app: &App) {
   ));
   lines.push(Line::from(String::new()));
   lines.push(create_buttons_line(accent, muted).centered());
-  lines.push(
-    Line::from(Span::styled(
-      "Tab: field · ←/→: type · Enter: create · Esc: cancel",
-      Style::default().fg(muted),
-    ))
-    .centered(),
-  );
+  push_modal_hint(&mut lines, HintContext::Create, &app.keymap, &app.theme);
 
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(block), area);
@@ -2148,7 +2229,12 @@ pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, m
 /// Modal width for the Link prompt. Pure so the visual budget remains pinned
 /// without a terminal renderer in `tests/tui_ui_helpers_tests.rs`.
 pub fn link_prompt_modal_width(term_width: u16) -> u16 {
-  (term_width.saturating_mul(50) / 100).min(42).min(term_width)
+  let width = if term_width <= 80 {
+    term_width.saturating_mul(80) / 100
+  } else {
+    term_width.saturating_mul(60) / 100
+  };
+  width.min(72).min(term_width)
 }
 
 /// Section-heading style for the Keybindings overlay body. Kept pure so the
@@ -2206,29 +2292,20 @@ pub fn help_body_section_color(theme: &Theme) -> Color {
   theme.locked
 }
 
-fn line_text(line: &Line<'static>) -> String {
-  line.spans.iter().map(|s| s.content.as_ref()).collect()
-}
-
 pub fn link_open_modal_lines(app: &App, title: &str, selected: Option<LinkTarget>) -> Vec<Line<'static>> {
   let accent = app.theme.accent;
   let muted = app.theme.muted;
   let mut lines = overlay_title_lines(title, accent);
-  lines.extend(
-    github_status_lines(app, 36)
-      .into_iter()
-      .filter(|line| !line_text(line).starts_with("press ")),
-  );
+  lines.extend(github_status_lines(app, 56));
   lines.push(Line::from(""));
   lines.push(link_target_line("i", "Issue", selected == Some(LinkTarget::Issue), accent, muted).centered());
   lines.push(link_target_line("p", "Pull Request", selected == Some(LinkTarget::Pr), accent, muted).centered());
-  let refresh_key = app
-    .keymap
-    .primary_chord(super::keymap::Action::FetchGithub)
-    .unwrap_or_else(|| "F".to_string());
-  lines.push(link_target_line(&refresh_key, "Refresh", false, accent, muted).centered());
-  lines.push(Line::from(""));
-  lines.push(Line::from(Span::styled(link_choose_hint(), Style::default().fg(muted))).centered());
+  let ctx = if title == "Link" {
+    HintContext::LinkPrompt
+  } else {
+    HintContext::OpenMenu
+  };
+  push_modal_hint(&mut lines, ctx, &app.keymap, &app.theme);
   lines
 }
 
@@ -2300,15 +2377,15 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   ));
 
   // Size the modal to its content: the title + description rows plus the
-  // three fixed rows (loader / buttons / hint), the rounded border and the
+  // fixed rows (loader / buttons / hint gap / hint), the rounded border and the
   // shared interior padding — no more fixed 44%-tall box that dwarfed its
   // few lines (#187 review).
-  let height = content.len() as u16 + 3 + 2 /* border */ + 2 /* padding */;
+  let height = content.len() as u16 + 4 + 2 /* border */ + 2 /* padding */;
   let area = centered_h(62, height, term);
   f.render_widget(Clear, area);
 
-  // Four stacked regions inside the padded frame: the title + description,
-  // a loader/countdown row, the button row, and a muted key hint. The
+  // Five stacked regions inside the padded frame: the title + description,
+  // a loader/countdown row, the button row, a gap, and a statusbar-style hint. The
   // loader row stays reserved (Length 1) even when idle so the buttons
   // never jump as the countdown arms. Split `block.inner` so the shared
   // padding owns the breathing room (issue #217).
@@ -2318,6 +2395,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
       Constraint::Min(1),    // title + description
       Constraint::Length(1), // loader / countdown
       Constraint::Length(1), // buttons
+      Constraint::Length(1), // hint gap
       Constraint::Length(1), // hint
     ])
     .split(block.inner(area));
@@ -2353,20 +2431,9 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     inner[2],
   );
 
-  // --- key hint ---
-  let hint = if app.confirm_is_countdown_mode() {
-    if app.confirm.is_armed() {
-      "y cancel countdown · Tab move · Enter · Esc cancel".to_string()
-    } else {
-      let total = app.confirm_countdown_total().as_secs();
-      format!("y arm {total}s · Tab move · Enter · Esc cancel")
-    }
-  } else {
-    "y confirm · Tab move · Enter · Esc cancel".to_string()
-  };
   f.render_widget(
-    Paragraph::new(Span::styled(hint, Style::default().fg(muted))).alignment(Alignment::Center),
-    inner[3],
+    Paragraph::new(modal_hint_for_context(HintContext::Confirm, &app.keymap, &app.theme)),
+    inner[4],
   );
 }
 
@@ -2448,49 +2515,77 @@ pub fn filled_cells_for_progress(progress: f64, cells: usize) -> usize {
   raw.min(cells.saturating_sub(1))
 }
 
-fn draw_report(f: &mut Frame, app: &App) {
-  let mut lines: Vec<Line> = overlay_title_lines("Bootstrap Report", app.theme.accent);
-  if let Some(report) = &app.report {
+pub fn bootstrap_report_lines(report: Option<&BootstrapReport>, theme: &Theme) -> Vec<Line<'static>> {
+  let mut lines: Vec<Line<'static>> = Vec::new();
+  if let Some(report) = report {
     for step in &report.steps {
       let sigil = step.status.sigil();
       let color = match step.status {
-        StepStatus::Ok => app.theme.clean,
-        StepStatus::Skipped => app.theme.muted,
-        StepStatus::Warning => app.theme.dirty,
-        StepStatus::Failed => app.theme.prunable,
+        StepStatus::Ok => theme.clean,
+        StepStatus::Skipped => theme.muted,
+        StepStatus::Warning => theme.dirty,
+        StepStatus::Failed => theme.prunable,
       };
       lines.push(Line::from(vec![
         Span::styled(
           format!(" {} ", sigil),
           Style::default().fg(color).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(step.label.clone(), Style::default().fg(Color::White)),
+        Span::styled(step.label.clone(), Style::default().fg(theme.name)),
       ]));
       for detail_line in step.detail.lines() {
-        lines.push(Line::from(format!("      {}", detail_line)));
+        lines.push(Line::from(Span::styled(
+          format!("      {}", detail_line),
+          Style::default().fg(theme.muted),
+        )));
       }
     }
   } else {
     lines.push(Line::from("(no report)"));
   }
-  lines.push(Line::from(""));
-  lines.push(Line::from(Span::styled(
-    "Enter / Esc — close",
-    Style::default().fg(app.theme.muted),
-  )));
+  lines
+}
+
+fn draw_report(f: &mut Frame, app: &App) {
+  let accent = app.theme.accent;
+  let logs = bootstrap_report_lines(app.report.as_ref(), &app.theme);
 
   // Size to the report length (+ border + padding), capped at 80% of the
   // screen so a long report stays on-screen rather than a fixed 80%-tall
   // box (#187).
   let term = f.area();
-  let height = (lines.len() as u16 + 2 /* border */ + 2/* padding */).min(term.height.saturating_mul(80) / 100);
+  let logs_height = (logs.len() as u16 + 2/* nested border */).max(3);
+  let height = (2 /* title */ + logs_height + 2 /* gap + hint */ + 2 /* border */ + 2/* padding */)
+    .min(term.height.saturating_mul(80) / 100);
   let area = centered_h(80, height, term);
+  let block = overlay_block(accent);
+  let inner = block.inner(area);
+  let layout = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([
+      Constraint::Length(1), // title
+      Constraint::Length(1), // title gap
+      Constraint::Min(3),    // logs pane
+      Constraint::Length(1), // hint gap
+      Constraint::Length(1), // hint
+    ])
+    .split(inner);
   f.render_widget(Clear, area);
+  f.render_widget(block, area);
   f.render_widget(
-    Paragraph::new(lines)
-      .block(overlay_block(app.theme.accent))
-      .wrap(Wrap { trim: false }),
-    area,
+    Paragraph::new(
+      Line::from(Span::styled(
+        "Bootstrap Report",
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+      ))
+      .centered(),
+    ),
+    layout[0],
+  );
+  render_section(f, layout[2], " Logs ", logs, accent, 0, None);
+  f.render_widget(
+    Paragraph::new(modal_hint_for_context(HintContext::Report, &app.keymap, &app.theme)),
+    layout[4],
   );
 }
 
@@ -2606,7 +2701,7 @@ fn trunc(s: &str, max: usize) -> String {
 
 fn draw_open_menu(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let lines = link_open_modal_lines(app, "Open in Browser", None);
+  let lines = link_open_modal_lines(app, "Open in Browser", Some(app.open_menu_selected));
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
   let term = f.area();
   let width = link_prompt_modal_width(term.width).min(term.width);
@@ -2622,7 +2717,6 @@ fn draw_open_menu(f: &mut Frame, app: &App) {
 
 fn draw_link_prompt(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let muted = app.theme.muted;
   let lines = match app.link_prompt_stage() {
     LinkPromptStage::ChooseTarget => {
       // A vertical selectable list (#217): j/k move the highlight, Enter
@@ -2642,8 +2736,7 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
         accent,
       );
       lines.push(Line::from(format!("  {}{}_", label, app.link_prompt_number_input())));
-      lines.push(Line::from(""));
-      lines.push(Line::from(Span::styled(link_input_hint(), Style::default().fg(muted))));
+      push_modal_hint(&mut lines, HintContext::LinkPrompt, &app.keymap, &app.theme);
       lines
     }
   };
@@ -2660,17 +2753,17 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
 
-/// Compact control hint for the Link prompt target picker. The Link modal is
-/// 50% wide; on an 80-col terminal the padded inner width is 34 cells, so the
-/// hint must stay terse enough not to clip.
+/// Compact legacy control hint for the Link prompt target picker. The live
+/// modal now renders statusbar-style badges from [`HintContext::LinkPrompt`],
+/// but this helper stays exported for callers that still need a plain string.
 pub fn link_choose_hint() -> &'static str {
-  "j/k move · Enter/i/p pick · Esc"
+  "j/k move · F fetch · Enter/i/p pick · Esc"
 }
 
-/// Compact control hint for the Link prompt number input. Same width budget as
-/// [`link_choose_hint`].
+/// Compact legacy control hint for the Link prompt number input. Same width
+/// budget as [`link_choose_hint`].
 pub fn link_input_hint() -> &'static str {
-  "digits · Enter link · Esc cancel"
+  "digits · F fetch · Enter link · Esc cancel"
 }
 
 /// Render the command palette overlay (issue #32).
@@ -2690,8 +2783,8 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
   let inner = outer.inner(area);
   f.render_widget(outer, area);
 
-  // Four rows: a detached centred title, a blank spacer, the matches list
-  // (flex), and the input bar pinned to the bottom (issue #217 — the title
+  // Six rows: a detached centred title, a blank spacer, the matches list
+  // (flex), a hint gap, statusbar-style hints, and the input bar pinned to the bottom (issue #217 — the title
   // moved off the border into the frame).
   let layout = Layout::default()
     .direction(Direction::Vertical)
@@ -2699,6 +2792,8 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
       Constraint::Length(1), // title
       Constraint::Length(1), // spacer
       Constraint::Min(3),    // matches
+      Constraint::Length(1), // hint gap
+      Constraint::Length(1), // hint
       Constraint::Length(1), // input bar
     ])
     .split(inner);
@@ -2741,13 +2836,21 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
     )));
   }
   f.render_widget(Paragraph::new(lines), layout[2]);
+  f.render_widget(
+    Paragraph::new(modal_hint_for_context(
+      HintContext::CommandPalette,
+      &app.keymap,
+      &app.theme,
+    )),
+    layout[4],
+  );
 
   let input_line = Line::from(vec![
     Span::styled(":", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
     Span::raw(app.palette.buffer().to_string()),
     Span::styled("_", Style::default().fg(app.theme.muted)),
   ]);
-  f.render_widget(Paragraph::new(input_line), layout[3]);
+  f.render_widget(Paragraph::new(input_line), layout[5]);
 }
 
 /// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)
@@ -2769,36 +2872,26 @@ pub fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   }
 
   if let Some(n) = link.issue {
-    lines.push(issue_summary_line(
+    let spinner = app.spinner.glyph(DOT_FRAMES);
+    lines.push(issue_summary_line_with_spinner(
       n,
       link.issue_source,
       app.issue_fetch_state(),
       max_width,
       &app.theme,
+      Some(spinner),
     ));
   }
   if let Some(n) = link.pr {
-    lines.push(pr_summary_line(
+    let spinner = app.spinner.glyph(DOT_FRAMES);
+    lines.push(pr_summary_line_with_spinner(
       n,
       link.pr_source,
       app.pr_fetch_state(),
       max_width,
       &app.theme,
+      Some(spinner),
     ));
-  }
-  if matches!(app.issue_fetch_state(), GitHubFetchState::Idle) && matches!(app.pr_fetch_state(), GitHubFetchState::Idle)
-  {
-    // Resolve the live `FetchGithub` binding instead of hard-coding a key
-    // (issue #217). Pre-fix this read `press R`, but `R` is `Review`; the
-    // fetch action defaults to `F` and is rebindable under `[tui.keys]`.
-    let chord = app
-      .keymap
-      .primary_chord(super::keymap::Action::FetchGithub)
-      .unwrap_or_else(|| "F".to_string());
-    lines.push(Line::from(Span::styled(
-      trunc(&format!("press {} to fetch status", chord), max_width),
-      Style::default().fg(app.theme.muted),
-    )));
   }
   lines
 }
@@ -2824,13 +2917,27 @@ pub fn issue_summary_line(
   max_width: usize,
   theme: &Theme,
 ) -> Line<'static> {
+  issue_summary_line_with_spinner(n, src, state, max_width, theme, None)
+}
+
+fn issue_summary_line_with_spinner(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::IssueStatus>,
+  max_width: usize,
+  theme: &Theme,
+  spinner: Option<&str>,
+) -> Line<'static> {
   let head = format!("Issue #{}{}", n, source_marker(src));
   // The `head` carries no status signal, only identity — it paints with
   // the `name` role (issue #210; default `White`) while the badge colour
   // tracks the issue state.
   match state {
     GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
-    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
+    GitHubFetchState::Loading => {
+      let glyph = spinner.unwrap_or("…");
+      Line::from(trunc(&format!("{} {} loading", head, glyph), max_width))
+    }
     GitHubFetchState::Loaded(s) => {
       // Mirror `issue_badge_color` exactly so the summary line and the
       // sidebar header dot never disagree for the same issue: closed maps
@@ -2888,13 +2995,27 @@ pub fn pr_summary_line(
   max_width: usize,
   theme: &Theme,
 ) -> Line<'static> {
+  pr_summary_line_with_spinner(n, src, state, max_width, theme, None)
+}
+
+fn pr_summary_line_with_spinner(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::PrStatus>,
+  max_width: usize,
+  theme: &Theme,
+  spinner: Option<&str>,
+) -> Line<'static> {
   let head = format!("PR    #{}{}", n, source_marker(src));
   // The `head` carries no status signal, only identity — it paints with
   // the `name` role (issue #210; default `White`) while the badge colour
   // tracks the PR state.
   match state {
     GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
-    GitHubFetchState::Loading => Line::from(trunc(&format!("{} …loading", head), max_width)),
+    GitHubFetchState::Loading => {
+      let glyph = spinner.unwrap_or("…");
+      Line::from(trunc(&format!("{} {} loading", head, glyph), max_width))
+    }
     GitHubFetchState::Loaded(s) => {
       let (badge, badge_color) = match s.state {
         PrState::Open => ("open", theme.clean),

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -107,12 +107,10 @@ fn focused_panel_border_wears_the_theme_focus_colour() {
 
 #[test]
 fn header_title_includes_running_version_repo_and_workdir() {
-  // The TUI header surfaces `gwm v<version> — <repo> (<workdir>)`.
+  // The TUI header surfaces `<repo> <workdir> gwm <version>`.
   // Cross-check both halves: the version comes from CARGO_PKG_VERSION
-  // (the same string `gwm --version` prints) and the format wraps
-  // each piece exactly as the docstring describes — so a regression
-  // dropping the `v` prefix, the em-dash, or the repo name fails the
-  // test for the right reason.
+  // (the same string `gwm --version` prints) and the format keeps the
+  // current-dir name first and the version last.
   let title = header_title("gwm-cli", "/Users/kbrdn1/Projects/Perso/gwm-cli");
   assert!(title.contains("gwm-cli"), "missing repo name: {}", title);
   assert!(
@@ -120,9 +118,9 @@ fn header_title_includes_running_version_repo_and_workdir() {
     "missing workdir: {}",
     title
   );
-  let version_token = format!("v{}", env!("CARGO_PKG_VERSION"));
+  let version_token = env!("CARGO_PKG_VERSION");
   assert!(
-    title.contains(&version_token),
+    title.contains(version_token),
     "missing running version `{}`: {}",
     version_token,
     title
@@ -132,7 +130,7 @@ fn header_title_includes_running_version_repo_and_workdir() {
   assert_eq!(
     title,
     format!(
-      " gwm v{} — gwm-cli (/Users/kbrdn1/Projects/Perso/gwm-cli) ",
+      " gwm-cli /Users/kbrdn1/Projects/Perso/gwm-cli gwm {} ",
       env!("CARGO_PKG_VERSION")
     )
   );
@@ -1210,6 +1208,17 @@ fn enter_open_menu_transitions_view() {
 }
 
 #[test]
+fn open_menu_selection_toggles_like_link_prompt() {
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.enter_open_menu();
+  assert_eq!(app.open_menu_selected, LinkTarget::Issue);
+  app.open_menu_toggle_selection();
+  assert_eq!(app.open_menu_selected, LinkTarget::Pr);
+  app.open_menu_toggle_selection();
+  assert_eq!(app.open_menu_selected, LinkTarget::Issue);
+}
+
+#[test]
 fn open_menu_choose_issue_returns_url_when_linked_and_slug_available() {
   let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
   repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
@@ -1236,7 +1245,7 @@ fn open_menu_pick_returns_none_when_no_link() {
 }
 
 #[test]
-fn link_open_modal_lines_include_available_links_and_refresh_button() {
+fn link_open_modal_lines_include_available_links_without_refresh_button() {
   use gwm::tui::{link_open_modal_lines, LinkTarget};
   let (dir, repo) = init_repo();
   {
@@ -1260,7 +1269,10 @@ fn link_open_modal_lines_include_available_links_and_refresh_button() {
   assert!(text.contains("Issue #42"), "Issue summary missing: {text:?}");
   assert!(text.contains("PR"), "PR summary missing: {text:?}");
   assert!(text.contains("#7"), "PR number missing: {text:?}");
-  assert!(text.contains("Refresh"), "Refresh action missing: {text:?}");
+  assert!(
+    !text.contains("Refresh"),
+    "refresh should be advertised in the hint row, not as a third action button: {text:?}"
+  );
 }
 
 #[test]
@@ -2619,11 +2631,9 @@ fn line_visible_width(line: &ratatui::text::Line<'static>) -> usize {
 }
 
 #[test]
-fn github_status_idle_prompt_resolves_fetch_binding_not_r() {
-  // Issue #217: the sidebar's Issue/PR block showed `press R to fetch
-  // status`, but `R` is bound to `Review` — the real fetch binding is `F`
-  // (`Action::FetchGithub`). The prompt must resolve the live keymap, never
-  // hard-code a key.
+fn github_status_idle_body_does_not_render_fetch_prompt() {
+  // The fetch affordance lives in the pane title (`Issue / PR [F]`) and in
+  // statusbar/modal hints, not as a body row competing with issue/PR data.
   let (_dir, _repo, app) = make_app_on_branch("feat/#42-tui-search");
   let lines = gwm::tui::github_status_lines(&app, 80);
   let text: String = lines
@@ -2632,13 +2642,31 @@ fn github_status_idle_prompt_resolves_fetch_binding_not_r() {
     .collect::<Vec<_>>()
     .join(" ");
   assert!(
-    text.contains("press F to fetch status"),
-    "idle prompt must resolve the FetchGithub binding (F): {text}"
+    !text.contains("press "),
+    "fetch prompt should not render inside the Issue/PR body: {text}"
   );
-  assert!(
-    !text.contains("press R"),
-    "stale `R` prompt leaked into the sidebar: {text}"
-  );
+}
+
+#[test]
+fn github_status_loading_uses_the_animated_spinner_frame() {
+  use gwm::tui::FetchKey;
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.github.request(FetchKey::Issue(42));
+
+  let first = gwm::tui::github_status_lines(&app, 80)
+    .into_iter()
+    .map(|line| spans_to_text(&line.spans))
+    .collect::<Vec<_>>()
+    .join("\n");
+  app.spinner.tick();
+  let second = gwm::tui::github_status_lines(&app, 80)
+    .into_iter()
+    .map(|line| spans_to_text(&line.spans))
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  assert!(first.contains("loading"), "loading label missing: {first:?}");
+  assert_ne!(first, second, "loading rows should animate with the App spinner");
 }
 
 #[test]

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -148,6 +148,7 @@ fn status_line_shows_context_chip_at_the_left() {
     120,
     &Theme {
       accent: Color::Magenta,
+      focus: Color::Green,
       ..Theme::default()
     },
   );
@@ -160,10 +161,18 @@ fn status_line_shows_context_chip_at_the_left() {
   // …and it is a reversed accent chip, like the hint badges.
   let has_ctx_chip = line.spans.iter().any(|s| {
     s.style.add_modifier.contains(Modifier::REVERSED)
-      && s.style.fg == Some(Color::Magenta)
+      && s.style.fg == Some(Color::Green)
       && s.content.contains("worktrees")
   });
-  assert!(has_ctx_chip, "context label is not a reversed accent chip: {text:?}");
+  assert!(has_ctx_chip, "context label is not a reversed focus chip: {text:?}");
+  assert!(
+    line
+      .spans
+      .iter()
+      .filter(|s| s.style.add_modifier.contains(Modifier::REVERSED))
+      .any(|s| s.style.fg == Some(Color::Magenta) && s.content.contains(" n ")),
+    "hint key badges should keep the accent colour while context uses focus: {text:?}"
+  );
 }
 
 #[test]
@@ -263,5 +272,15 @@ fn status_hints_resolve_user_rebindings() {
   assert!(
     !resolved.iter().any(|(k, _)| k == "F"),
     "the stale default `F` must not linger after the rebind: {resolved:?}"
+  );
+}
+
+#[test]
+fn confirm_hints_include_delete_branch_toggle_binding() {
+  use gwm::tui::keymap::Keymap;
+  let resolved = HintContext::Confirm.resolve(&Keymap::defaults());
+  assert!(
+    resolved.iter().any(|(k, l)| k == "p" && l == "branch"),
+    "Delete Worktree hints should advertise the branch toggle binding: {resolved:?}"
   );
 }

--- a/tests/tui_header_tests.rs
+++ b/tests/tui_header_tests.rs
@@ -30,7 +30,7 @@ fn span_with<'a, 'b>(line: &'a Line<'b>, needle: &str) -> Option<&'a Span<'b>> {
 }
 
 fn version_token() -> String {
-  format!("v{}", env!("CARGO_PKG_VERSION"))
+  env!("CARGO_PKG_VERSION").to_string()
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn version_renders_as_a_reverse_video_chip_on_the_accent_colour() {
       ..Theme::default()
     },
   );
-  let chip = span_with(&line, "gwm v").expect("version chip span present");
+  let chip = span_with(&line, "gwm ").expect("version chip span present");
   assert_eq!(chip.style.fg, Some(Color::Magenta), "chip not painted on accent");
   assert!(
     chip.style.add_modifier.contains(Modifier::REVERSED),
@@ -79,18 +79,32 @@ fn version_renders_as_a_reverse_video_chip_on_the_accent_colour() {
 }
 
 #[test]
-fn repo_name_is_bold_and_path_is_dimmed() {
+fn current_dir_name_is_a_leading_badge_and_path_is_dimmed() {
   let line = header_line("gwm-cli", "/Users/me/Projects/gwm-cli", false, 120, &Theme::default());
   let repo = span_with(&line, "gwm-cli").expect("repo span present");
   assert!(
+    repo.style.add_modifier.contains(Modifier::REVERSED),
+    "current dir name must render as a leading badge"
+  );
+  assert!(
     repo.style.add_modifier.contains(Modifier::BOLD),
-    "repo name must be bold"
+    "current dir name badge must be bold"
   );
   let path = span_with(&line, "/Users/me/Projects/gwm-cli").expect("path span present");
   assert_eq!(
     path.style.fg,
     Some(Color::DarkGray),
     "path must be dimmed as secondary context"
+  );
+}
+
+#[test]
+fn version_chip_is_pinned_to_the_end_when_wide() {
+  let line = header_line("gwm-cli", "/Users/me/Projects/gwm-cli", false, 120, &Theme::default());
+  let text = plain(&line);
+  assert!(
+    text.trim_end().ends_with(&format!("gwm {}", version_token())),
+    "version chip must end the header row: {text:?}"
   );
 }
 
@@ -113,7 +127,7 @@ fn picker_chip_present_only_in_picker_mode() {
 #[test]
 fn narrow_width_drops_path_but_keeps_version_chip_and_repo() {
   // Wide enough for the version chip + repo name, but not the long path.
-  let width = format!(" gwm {} ", version_token()).chars().count() + 2 + "gwm-cli".len() + 4;
+  let width = format!(" gwm {} ", version_token()).chars().count() + 2 + " gwm-cli ".len() + 4;
   let line = header_line(
     "gwm-cli",
     "/Users/me/some/really/long/path/that/will/not/fit/gwm-cli",

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -337,7 +337,8 @@ fn summary_line_heads_resolve_through_name_role() {
 fn header_line_resolves_chrome_through_theme_roles() {
   let t = audit_theme();
   let line = header_line("repo", "/home/u/repo", true, 120, &t);
-  assert_eq!(fg_containing(&line, "gwm v"), Some(t.accent), "version chip → accent");
+  assert_eq!(fg_containing(&line, "gwm "), Some(t.accent), "version chip → accent");
+  assert_eq!(fg_containing(&line, "repo"), Some(t.name), "current-dir badge → name");
   assert_eq!(fg_containing(&line, "picker"), Some(t.dirty), "picker chip → dirty");
   assert_eq!(fg_containing(&line, "/home/u/repo"), Some(t.muted), "path → muted");
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -3,15 +3,20 @@
 //! the confirm modal, and the badge-group width used to align the help
 //! overlay's per-chord key badges.
 
+use gwm::bootstrap::{BootstrapReport, StepResult};
+use gwm::tui::keymap::{Action, KeyStroke, Keymap};
+use gwm::tui::state::sidebar::SidebarMode;
 use gwm::tui::theme::Theme;
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
-  badge_group_width, confirm_buttons_line, create_buttons_line, ellipsize_middle, field_input_line, link_choose_hint,
-  link_input_hint, link_prompt_modal_width, link_target_line, pane_counter, status_pane_title, type_selector_line,
+  badge_group_width, bootstrap_report_lines, confirm_buttons_line, create_buttons_line, ellipsize_middle,
+  field_input_line, link_choose_hint, link_input_hint, link_prompt_modal_width, link_target_line, modal_hint_line,
+  pane_counter, recent_items_pane_title, status_pane_title, type_selector_line, working_tree_pane_title,
   worktrees_pane_title,
 };
 use gwm::tui::{
   confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_section_style,
+  issue_pr_pane_title,
 };
 use ratatui::style::{Color, Modifier, Style};
 
@@ -104,6 +109,31 @@ fn status_pane_title_carries_the_focus_index() {
 }
 
 #[test]
+fn sidebar_subpane_titles_surface_live_bindings() {
+  let mut km = Keymap::defaults();
+  assert_eq!(issue_pr_pane_title(&km), " Issue / PR [F] ");
+  assert_eq!(working_tree_pane_title(&km), " Working Tree [R] ");
+  assert_eq!(
+    recent_items_pane_title(SidebarMode::Commits, &km),
+    " Recent Commits [l] "
+  );
+
+  km.apply_override(Action::FetchGithub, vec![KeyStroke::parse_chord("Ctrl+g").unwrap()])
+    .unwrap();
+  km.apply_override(Action::Review, vec![KeyStroke::parse_chord("Ctrl+r").unwrap()])
+    .unwrap();
+  km.apply_override(Action::GitTui, vec![KeyStroke::parse_chord("Ctrl+l").unwrap()])
+    .unwrap();
+
+  assert_eq!(issue_pr_pane_title(&km), " Issue / PR [Ctrl+g] ");
+  assert_eq!(working_tree_pane_title(&km), " Working Tree [Ctrl+r] ");
+  assert_eq!(
+    recent_items_pane_title(SidebarMode::Commits, &km),
+    " Recent Commits [Ctrl+l] "
+  );
+}
+
+#[test]
 fn pane_counter_is_blank_when_nothing_visible() {
   // Empty list → no `N of M` footer at all (mirrors the Recent Commits
   // section, which drops its counter when there is nothing to scroll).
@@ -153,6 +183,42 @@ fn confirm_buttons_render_as_chips_without_brackets() {
     !confirm.style.add_modifier.contains(Modifier::REVERSED),
     "idle Confirm button must not be reversed"
   );
+}
+
+#[test]
+fn modal_hint_line_uses_statusbar_badge_treatment() {
+  let line = modal_hint_line(&[("F", "fetch"), ("Esc", "close")], &Theme::default());
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(text.contains("fetch"), "hint label missing: {text:?}");
+  let fetch = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("F"))
+    .expect("fetch key badge");
+  assert!(
+    fetch.style.add_modifier.contains(Modifier::REVERSED),
+    "modal key hints should use statusbar-like badges"
+  );
+}
+
+#[test]
+fn bootstrap_report_lines_keep_step_logs_as_pane_rows() {
+  let report = BootstrapReport {
+    steps: vec![
+      StepResult::ok_with_detail("cargo fetch", "done"),
+      StepResult::skipped("direnv allow", "when false"),
+    ],
+  };
+  let lines = bootstrap_report_lines(Some(&report), &Theme::default());
+  let text: String = lines
+    .iter()
+    .flat_map(|line| line.spans.iter().map(|span| span.content.as_ref()))
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  assert!(text.contains("cargo fetch"), "step label missing: {text:?}");
+  assert!(text.contains("done"), "step detail missing: {text:?}");
+  assert!(text.contains("direnv allow"), "skipped label missing: {text:?}");
 }
 
 // ---------------------------------------------------------------------------
@@ -305,21 +371,19 @@ fn link_target_line_highlights_the_selected_row() {
 
 #[test]
 fn link_prompt_width_stays_compact_on_wide_terminals() {
-  assert_eq!(link_prompt_modal_width(80), 40);
+  assert_eq!(link_prompt_modal_width(80), 64);
   assert_eq!(
     link_prompt_modal_width(120),
-    42,
-    "Link prompt should cap instead of growing to half the terminal"
+    72,
+    "Link/Open prompts should be wide enough for Issue/PR summaries but still cap on wide terminals"
   );
 }
 
 #[test]
 fn link_prompt_hints_fit_the_80_col_modal_budget() {
-  // At 80 columns the compact Link modal remains 40 columns wide, and the
-  // rounded border + horizontal padding leave 34 cells for content. The
-  // visual smoke caught the previous long hints clipping at exactly this
-  // common terminal width.
-  const INNER_WIDTH_AT_80_COLS: usize = 34;
+  // At 80 columns the Link/Open modal is 64 columns wide, and the rounded
+  // border + horizontal padding leave 58 cells for content.
+  const INNER_WIDTH_AT_80_COLS: usize = 58;
 
   for hint in [link_choose_hint(), link_input_hint()] {
     assert!(


### PR DESCRIPTION
## Description

Polishes the remaining TUI pane/modal follow-ups from #224: pane titles now surface live bindings, GitHub loading animates in the Issue/PR pane, modal hints use the statusbar badge language, and Link/Open/Delete/Bootstrap Report align with the requested modal behaviour.

Closes #224

## Type of change

- [x] 🐛 Fix (bug fix)
- [ ] ✨ Feature (new functionality)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Headerbar starts with a current-dir badge, keeps the path stable, and pins `gwm <version>` to the right.
- Sidebar panes surface live bindings: `Issue / PR [F]`, `Working Tree [R]`, `Recent Commits [l]`; Recent Commits drops the extra `— commits` suffix.
- Issue/PR loading uses the animated app spinner and no longer renders the fetch prompt in the body.
- Bootstrap Report renders logs in a nested pane; Status/Worktree identity uses aligned label/value rows.
- Link/Open modals are wider, show Issue/PR info, drop the Refresh button, and render statusbar-style hint badges.
- Open in Browser gains Link-style selection; Delete Worktree honors the delete-branch toggle binding while open.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Not captured locally; changes are covered through pure TUI helper/state tests. Visual eyeball still recommended before merge.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #224
- Related PR: #223

## Notes for reviewers

Focus on TUI layout/readability: the implementation deliberately keeps behaviour in pure helpers/state-machine tests where possible, with no CLI/config schema changes.