### PR TITLE
👷 ci(pre-release): bump deprecated Node 20 actions (#229)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -64,7 +64,7 @@ jobs:
             echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.name }}
 
@@ -114,7 +114,7 @@ jobs:
           Set-Content -Path "dist/$STAGE.zip.sha256" -Encoding ascii -Value "$hash  $STAGE.zip"
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gwm-${{ matrix.target }}
           path: |
@@ -139,12 +139,12 @@ jobs:
             echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.name }}
 
       - name: download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Description

`pre-release.yml` was the lone workflow still pinned to the Node-20 `actions/*` that the `v0.9.0-rc.2` run flagged as deprecated (forced to Node 24 from 2026-06-16). This aligns it with the majors already running green in `release.yml`.

Closes #229

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `.github/workflows/pre-release.yml`:
  - `actions/checkout` `@v4` → `@v6` (×2)
  - `actions/upload-artifact` `@v4` → `@v7`
  - `actions/download-artifact` `@v4` → `@v8`
- `softprops/action-gh-release@v3` left untouched (already latest major, not Node-20-flagged).

## Tests

- [x] `cargo test` / `fmt` / `clippy` — N/A (no source change; YAML-only)
- [x] New tests added under `tests/` — N/A (CI workflow change)

**Validation**: `release.yml` already pairs `upload-artifact@v7` + `download-artifact@v8` with the identical `name: gwm-${{ matrix.target }}` upload and `path: dist` + `merge-multiple: true` download, so this is a 1:1 alignment of an already-green configuration. The `pre-release.yml` path only runs on `-rc.N` tags, so it can't be exercised by this PR's CI matrix — it's proven the next time an RC tag is pushed; the matching `release.yml` config is the evidence it works.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated — N/A (CI internals, no user-facing behaviour)
- [x] No `unwrap()` / `println!` concerns — N/A

## Linked issues / docs

- Issue: #229
- Surfaced by: PR #227 (v0.9.0-rc.2 cut)

## Notes for reviewers

YAML-only, 4 lines. The only thing to confirm is the version pairing, which mirrors `release.yml` exactly.
