### PR TITLE
♻️ refactor(cli): extract repo_context prelude helper

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1108,6 +1108,45 @@ fn format_status_text(w: &worktree::WorktreeInfo) -> String {
   parts.join(" ")
 }
 
+/// The repo prelude shared by most CLI subcommands: an open
+/// [`Repository`], its working directory, and the resolved
+/// [`Config`]. Owned values so call sites keep borrowing `&repo`,
+/// `&workdir`, `&config` exactly as they did when the triplet was
+/// inlined.
+pub struct RepoContext {
+  pub repo: Repository,
+  pub workdir: PathBuf,
+  pub config: Config,
+}
+
+/// Discover the repo, resolve its workdir, and load `.gwm.toml`.
+///
+/// `start` mirrors [`worktree::discover_repo`]: `None` discovers from
+/// the current directory (the behaviour every CLI call site relies
+/// on), `Some(path)` discovers from an explicit root (used by tests).
+///
+/// Surfaces [`GwmError::NotInGitRepo`] outside a repo or in a bare
+/// repo (no workdir), and propagates any `.gwm.toml` parse error from
+/// [`Config::load_for_repo`].
+pub fn repo_context(start: Option<&Path>) -> Result<RepoContext> {
+  let repo = worktree::discover_repo(start)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  let config = Config::load_for_repo(&workdir)?;
+  Ok(RepoContext { repo, workdir, config })
+}
+
+/// Like [`repo_context`], but tolerates a missing or malformed
+/// `.gwm.toml` by falling back to [`Config::default`]. The repo and
+/// workdir gates stay strict — only the config *load* is lenient.
+/// Used by `gwm doctor`, which must run even when the config it is
+/// about to diagnose is broken.
+pub fn repo_context_lenient(start: Option<&Path>) -> Result<RepoContext> {
+  let repo = worktree::discover_repo(start)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  let config = Config::load_for_repo(&workdir).unwrap_or_default();
+  Ok(RepoContext { repo, workdir, config })
+}
+
 fn cmd_create(
   branch_type: String,
   issue: String,
@@ -1117,11 +1156,9 @@ fn cmd_create(
   skip_hooks: Option<String>,
   trust_mode: TrustMode,
 ) -> Result<()> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  let RepoContext { repo, workdir, config } = repo_context(None)?;
   let repo_name = worktree::repo_name(&repo);
 
-  let config = Config::load_for_repo(&workdir)?;
   let resolved_types = config.resolved_branch_types();
   let spec = BranchSpec::new_with_types(branch_type, issue, desc, &resolved_types.types)?;
   let branch = spec.branch_name(&config.worktree, &repo_name)?;
@@ -1187,10 +1224,8 @@ fn cmd_new(
   skip_hooks: Option<String>,
   trust_mode: TrustMode,
 ) -> Result<()> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+  let RepoContext { repo, config, .. } = repo_context(None)?;
   let repo_name = worktree::repo_name(&repo);
-  let config = Config::load_for_repo(&workdir)?;
   let resolved_types = config.resolved_branch_types();
   let spec = BranchSpec::new_with_types(branch_type.clone(), "0", desc, &resolved_types.types)?;
   let draft = issue_templates::render_issue_draft(&repo, &config, &spec.type_, &spec.desc)?;
@@ -1238,9 +1273,7 @@ fn cmd_new(
 const PR_FILES_CHANGED_MAX_LINES: usize = 30;
 
 fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Result<()> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  let config = Config::load_for_repo(&workdir)?;
+  let RepoContext { repo, workdir, config } = repo_context(None)?;
   let head_name = current_branch(&repo)?;
   let branch_spec = parse_branch(&head_name);
 
@@ -1544,9 +1577,7 @@ fn cmd_path(pattern: String) -> Result<()> {
 }
 
 fn cmd_bootstrap(target: Option<String>, skip_hooks: Option<String>, trust_mode: TrustMode) -> Result<()> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  let config = Config::load_for_repo(&workdir)?;
+  let RepoContext { repo, workdir, config } = repo_context(None)?;
 
   let mut worktree_branch: Option<String> = None;
   let worktree_path: PathBuf = match target {
@@ -1664,9 +1695,7 @@ fn cmd_prune(dry_run: bool) -> Result<()> {
 }
 
 fn cmd_doctor() -> Result<()> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  let config = Config::load_for_repo(&workdir).unwrap_or_default();
+  let RepoContext { repo, workdir, config } = repo_context_lenient(None)?;
 
   let ctx = DoctorCtx {
     repo_workdir: &workdir,
@@ -2309,9 +2338,7 @@ fn cmd_labels_push(dry_run: bool, prune: bool, random_colors: bool) -> Result<()
 /// push`; both surface a uniform "not inside a git repository" error
 /// before they touch network or config-resolve logic.
 fn load_labels_config() -> Result<Config> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  Config::load_for_repo(&workdir)
+  Ok(repo_context(None)?.config)
 }
 
 /// Resolve the `origin` remote slug. Called *after* `resolve_labels`
@@ -2425,9 +2452,7 @@ fn cmd_milestones_push(dry_run: bool, prune: bool) -> Result<()> {
 /// push`; both surface a uniform "not inside a git repository" error
 /// before they touch network or config-resolve logic.
 fn load_milestones_config() -> Result<Config> {
-  let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  Config::load_for_repo(&workdir)
+  Ok(repo_context(None)?.config)
 }
 
 /// Resolve the `origin` remote slug. Called *after* `resolve_milestones`

--- a/tests/cli_repo_context_tests.rs
+++ b/tests/cli_repo_context_tests.rs
@@ -1,0 +1,97 @@
+//! Pin the contract of the shared CLI repo prelude `gwm::cli::repo_context`
+//! (and its lenient sibling) extracted in issue #236. The triplet
+//! `discover_repo → workdir → Config::load_for_repo` used to be copy-pasted
+//! across ~half a dozen subcommands; these tests lock its two observable
+//! branches so the dedupe stays behaviour-preserving:
+//!
+//! - Outside a git repository (or in a bare repo with no workdir) the
+//!   prelude must surface `GwmError::NotInGitRepo`.
+//! - Inside a real working tree the repo, workdir, and config must all
+//!   resolve, with `workdir` pointing at the discovered tree.
+//!
+//! Both helpers take an explicit `start` path (mirroring
+//! `worktree::discover_repo`), so the tests target a `tempfile::TempDir`
+//! directly without mutating the process-wide current directory — no
+//! cross-test cwd races.
+
+mod common;
+
+use gwm::cli::{repo_context, repo_context_lenient, RepoContext};
+use gwm::error::GwmError;
+use tempfile::TempDir;
+
+/// `repo_context` against a directory that is not a git repository must
+/// fail with the `NotInGitRepo` gate, not panic or load a config.
+#[test]
+fn repo_context_outside_repo_is_not_in_git_repo() {
+  let not_a_repo = TempDir::new().unwrap();
+
+  match repo_context(Some(not_a_repo.path())) {
+    Err(GwmError::NotInGitRepo) => {}
+    Err(other) => panic!("expected NotInGitRepo, got {other:?}"),
+    Ok(_) => panic!("a bare tempdir is not a git repo, expected an error"),
+  }
+}
+
+/// The lenient variant keeps the repo/workdir gate strict: outside a repo
+/// it must still surface `NotInGitRepo` (it is lenient only on the config
+/// *load*, not on the repo discovery).
+#[test]
+fn repo_context_lenient_outside_repo_is_not_in_git_repo() {
+  let not_a_repo = TempDir::new().unwrap();
+
+  match repo_context_lenient(Some(not_a_repo.path())) {
+    Err(GwmError::NotInGitRepo) => {}
+    Err(other) => panic!("expected NotInGitRepo, got {other:?}"),
+    Ok(_) => panic!("a bare tempdir is not a git repo, expected an error"),
+  }
+}
+
+/// Happy path: inside a real working tree the repo opens, the workdir
+/// resolves to that tree, and the config is actually loaded *from that
+/// tree's* `.gwm.toml` (not silently defaulted). We prove the latter by
+/// writing a non-default `[[branch_types]]` block and asserting it
+/// replaces the built-in list — distinguishing "loaded from disk" from
+/// "hard-coded to default".
+#[test]
+fn repo_context_inside_repo_resolves_repo_workdir_and_config() {
+  let (dir, _repo) = common::init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[[branch_types]]
+name = "spike"
+description = "Throwaway exploration"
+"#,
+  )
+  .unwrap();
+
+  let Ok(RepoContext { repo, workdir, config }) = repo_context(Some(dir.path())) else {
+    panic!("temp repo should resolve a repo context");
+  };
+
+  // The discovered repo points at the same working tree we created.
+  assert!(
+    common::paths_equal(repo.workdir().unwrap(), dir.path()),
+    "repo.workdir() {:?} should match the temp repo {:?}",
+    repo.workdir(),
+    dir.path()
+  );
+  assert!(
+    common::paths_equal(&workdir, dir.path()),
+    "context workdir {:?} should match the temp repo {:?}",
+    workdir,
+    dir.path()
+  );
+
+  // The config was read from this tree's `.gwm.toml`: the custom
+  // `[[branch_types]]` replaces the built-in list. A defaulted config
+  // would carry `feat`/`fix`/… and never `spike`.
+  let resolved = config.resolved_branch_types();
+  let names: Vec<&str> = resolved.types.iter().map(|t| t.name.as_str()).collect();
+  assert_eq!(
+    names,
+    vec!["spike"],
+    "config must come from the repo's .gwm.toml, not a silent default"
+  );
+}


### PR DESCRIPTION
## Description

Dedupes the copy-pasted CLI repo prelude (`discover_repo → workdir → Config::load_for_repo`) behind a shared `RepoContext` + two helpers. No behaviour change.

Closes #236

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- New `pub struct RepoContext { repo, workdir, config }` (owned values — call sites keep using `&repo`).
- `repo_context(start)` (strict: `NotInGitRepo` gate + `Config::load_for_repo`) and `repo_context_lenient(start)` (`Config::default()` fallback on config-load only).
- Folded 6 genuine triplet sites (`cmd_create`, `cmd_new`, `cmd_pr`, `cmd_bootstrap`, `load_labels_config`, `load_milestones_config`) + `cmd_doctor` onto the lenient variant.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` — `tests/cli_repo_context_tests.rs`: `NotInGitRepo` branch (strict + lenient) + TempDir happy path proving config is loaded from the tree's `.gwm.toml`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]` — N/A: pure refactor, no user-facing change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- `start` defaults to `None` at every call site (mirrors `worktree::discover_repo`), so runtime is identical; the param exists only to make the helper unit-testable without cwd mutation.
- **Deliberately NOT folded** (judgment, not misses): `cmd_remove` (loads config after the `dry_run` guard — eager load would add an error to the dry-run path), `cmd_types` (tolerates no-repo, which an owned `RepoContext` can't represent), `labels_slug`/`milestones_slug` (repo+slug only, no workdir/config).
- `RepoContext` can't derive `Debug` (`git2::Repository` isn't `Debug`); tests assert via `match`/`let-else`.