### PR TITLE
♻️ refactor(worktree): promote run_git, dedupe 5 git spawns

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -14,7 +14,6 @@ use crate::error::{GwmError, Result};
 use crate::worktree;
 use git2::{BranchType, Repository};
 use std::path::Path;
-use std::process::Command;
 
 /// How `gwm sync` reconciles the local branch when it is behind its
 /// upstream. Defaults to rebase (linear history, the repo convention);
@@ -135,8 +134,8 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
   // 3. Fetch. After this the in-memory `repo` ref cache is stale, so
   //    everything past here re-resolves against a freshly opened repo.
   match &remote {
-    Some(r) => run_git(&workdir, &["fetch", r])?,
-    None => run_git(&workdir, &["fetch"])?,
+    Some(r) => worktree::run_git(&workdir, &["fetch", r])?,
+    None => worktree::run_git(&workdir, &["fetch"])?,
   };
 
   // 4. Recompute ahead/behind against the now-updated upstream.
@@ -157,8 +156,8 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
   // 5. Integrate. On failure (conflicts), abort so the worktree is
   //    not left mid-rebase/merge, then surface a conflict error.
   let integrate = match strategy {
-    SyncStrategy::Rebase => run_git(&workdir, &["rebase", &upstream_short]),
-    SyncStrategy::Merge => run_git(&workdir, &["merge", "--no-edit", &upstream_short]),
+    SyncStrategy::Rebase => worktree::run_git(&workdir, &["rebase", &upstream_short]),
+    SyncStrategy::Merge => worktree::run_git(&workdir, &["merge", "--no-edit", &upstream_short]),
   };
   if let Err(e) = integrate {
     // Distinguish a genuine conflict from any other failure (a failing
@@ -171,7 +170,7 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
       .and_then(|r| r.index().ok())
       .map(|idx| idx.has_conflicts())
       .unwrap_or(false);
-    let _ = run_git(&workdir, &[strategy.verb(), "--abort"]);
+    let _ = worktree::run_git(&workdir, &[strategy.verb(), "--abort"]);
     if conflicted {
       return Err(GwmError::Other(format!(
         "{} onto {} hit conflicts and was aborted; reconcile manually with `git {} {}`",
@@ -220,24 +219,4 @@ fn ahead_behind(repo: &Repository, branch: &str) -> Result<(usize, usize)> {
     .ok_or_else(|| GwmError::Other("sync: upstream has no commit".into()))?;
   let (ahead, behind) = repo.graph_ahead_behind(local_oid, up_oid)?;
   Ok((ahead, behind))
-}
-
-/// Run `git -C <dir> <args>`, returning stdout on success or a
-/// `CommandFailed` error carrying the verb and stderr on failure.
-fn run_git(dir: &Path, args: &[&str]) -> Result<String> {
-  let out = Command::new("git")
-    .arg("-C")
-    .arg(dir)
-    .args(args)
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git {} failed to spawn: {}", args.join(" "), e)))?;
-  if !out.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git {} exited {}: {}",
-      args.join(" "),
-      out.status,
-      String::from_utf8_lossy(&out.stderr).trim()
-    )));
-  }
-  Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -578,24 +578,38 @@ fn parse_git_log_with_author_output(raw: &str) -> Result<Vec<CommitRow>> {
   Ok(rows)
 }
 
+/// Run `git -C <dir> <args>`, returning stdout verbatim on success or a
+/// [`GwmError::CommandFailed`] carrying the verb and git's stderr on a
+/// non-zero exit (or the spawn error if `git` could not be launched).
+///
+/// This is the single shell-out helper for the read-side git invocations
+/// (sidebar previews, PR-body fillers) and for `gwm sync`'s mutating steps
+/// (issue #237 deduped five hand-rolled copies of this exact pattern).
+/// Callers that need trimming, truncation, or field parsing post-process the
+/// returned `String` themselves.
+pub fn run_git(dir: &Path, args: &[&str]) -> Result<String> {
+  let out = Command::new("git")
+    .arg("-C")
+    .arg(dir)
+    .args(args)
+    .output()
+    .map_err(|e| GwmError::CommandFailed(format!("git {} failed to spawn: {}", args.join(" "), e)))?;
+  if !out.status.success() {
+    return Err(GwmError::CommandFailed(format!(
+      "git {} exited {}: {}",
+      args.join(" "),
+      out.status,
+      String::from_utf8_lossy(&out.stderr).trim()
+    )));
+  }
+  Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
 /// Shell out to `git log --oneline -n <n>` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview recent commits of the selected worktree.
 pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["log", "--oneline", "-n"])
-    .arg(n.to_string())
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git log failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git log exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+  let n = n.to_string();
+  run_git(path, &["log", "--oneline", "-n", &n])
 }
 
 /// Shell out to `git log --pretty=- %s <base>..<head>` inside `path`
@@ -605,21 +619,8 @@ pub fn git_log_oneline(path: &Path, n: usize) -> Result<String> {
 /// PR body without extra formatting.
 pub fn git_log_subject_between(path: &Path, base: &str, head: &str) -> Result<String> {
   let range = format!("{}..{}", base, head);
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["log", "--pretty=format:- %s"])
-    .arg(&range)
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git log failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git log exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
+  let out = run_git(path, &["log", "--pretty=format:- %s", &range])?;
+  Ok(out.trim_end().to_string())
 }
 
 /// Shell out to `git diff --stat <base>..<head>` inside `path`. The
@@ -627,21 +628,7 @@ pub fn git_log_subject_between(path: &Path, base: &str, head: &str) -> Result<St
 /// doesn't blow up the PR body (issue #84: 30-line cap by convention).
 pub fn git_diff_stat_between(path: &Path, base: &str, head: &str, max_lines: usize) -> Result<String> {
   let range = format!("{}..{}", base, head);
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["diff", "--stat"])
-    .arg(&range)
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git diff failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git diff exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  let raw = String::from_utf8_lossy(&output.stdout);
+  let raw = run_git(path, &["diff", "--stat", &range])?;
   let mut lines: Vec<&str> = raw.lines().collect();
   let truncated = lines.len() > max_lines;
   if truncated {
@@ -695,20 +682,7 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   // past the cap. Pre-review the limit was applied client-side after
   // the full stdout was read.
   let limit_arg = format!("-n{}", limit);
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["stash", "list", "--pretty=format:%gd\x1f%s", &limit_arg])
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git stash list failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git stash list exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  let raw = String::from_utf8_lossy(&output.stdout);
+  let raw = run_git(path, &["stash", "list", "--pretty=format:%gd\x1f%s", &limit_arg])?;
   let entries = raw
     .lines()
     .filter(|line| !line.is_empty())
@@ -726,20 +700,7 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
 /// Shell out to `git status --short` inside `path` and return raw stdout.
 /// Used by the TUI sidebar to preview the working-tree state.
 pub fn git_status_short(path: &Path) -> Result<String> {
-  let output = Command::new("git")
-    .arg("-C")
-    .arg(path)
-    .args(["status", "--short"])
-    .output()
-    .map_err(|e| GwmError::CommandFailed(format!("git status failed to spawn: {}", e)))?;
-  if !output.status.success() {
-    return Err(GwmError::CommandFailed(format!(
-      "git status exited {}: {}",
-      output.status,
-      String::from_utf8_lossy(&output.stderr).trim()
-    )));
-  }
-  Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+  run_git(path, &["status", "--short"])
 }
 
 /// Time elapsed since the *oldest* commit on `branch` that's not also on a

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -306,6 +306,42 @@ fn git_log_oneline_errors_outside_repo() {
   assert!(err.is_err(), "expected error outside a git repo, got: {:?}", err);
 }
 
+// ---- run_git (issue #237) ---------------------------------------------------
+// The shared `git -C <dir> <args>` helper that the sidebar/PR shell-outs and
+// `gwm sync` both route through. These pin the two-branch contract the dedup
+// must preserve: stdout verbatim on success, and a non-zero git exit mapped to
+// `GwmError::CommandFailed` carrying git's own stderr.
+
+#[test]
+fn run_git_returns_stdout_on_success() {
+  let (dir, _) = init_repo();
+  let out = worktree::run_git(dir.path(), &["rev-parse", "--is-inside-work-tree"]).unwrap();
+  assert_eq!(
+    out.trim(),
+    "true",
+    "rev-parse stdout should be returned verbatim, got: {:?}",
+    out
+  );
+}
+
+#[test]
+fn run_git_maps_nonzero_exit_to_command_failed_with_stderr() {
+  let (dir, _) = init_repo();
+  // `git` runs and exits non-zero (the ref does not exist) — this exercises
+  // the status-failure branch, not the spawn-failure branch.
+  let err = worktree::run_git(dir.path(), &["rev-parse", "--verify", "definitely-missing-ref"]);
+  match err {
+    Err(gwm::error::GwmError::CommandFailed(msg)) => {
+      assert!(
+        msg.contains("fatal"),
+        "CommandFailed must carry git's stderr (expected 'fatal'), got: {}",
+        msg
+      );
+    }
+    other => panic!("expected GwmError::CommandFailed, got: {:?}", other),
+  }
+}
+
 // Issue #73: relative-duration formatter + branch age. The formatter is a
 // pure function (table-driven tests below); `branch_age` walks the commit
 // graph and needs a real repo with controlled commit timestamps.


### PR DESCRIPTION
## Description

Hoists the `run_git(dir, args) -> Result<String>` shell-out helper from `sync.rs` into `worktree.rs` and collapses 5 hand-rolled `spawn + status.success() + stderr` copies into one-liners around it. No behaviour change.

Closes #237

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- `run_git` promoted to `pub fn` in `src/worktree.rs`; the 5 sites (`git_log_oneline`, `git_log_subject_between`, `git_diff_stat_between`, `git_stash_list`, `git_status_short`) reduced to one-liners.
- `src/sync.rs` now calls `worktree::run_git`; its local duplicate + the now-unused `std::process::Command` import removed.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` — `worktree_integration.rs`: `run_git` returns stdout on success; non-zero exit maps to `GwmError::CommandFailed` carrying stderr (the branch the dedup must preserve)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]` — N/A: pure refactor, no user-facing change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- **Hard boundary respected**: `lifecycle.rs` / `bootstrap.rs` `sh -c` user-hook spawns (different, deliberate `String` error convention) left untouched.
- Sole observable difference: the error verb now includes the full argv (`"git log --oneline -n 5 exited …"`). A `src/` + `tests/` grep confirmed no caller/test relies on the old wording (`error_variants_tests.rs` hand-builds its own string into the variant; unaffected).
- `launcher.rs` keeps its own `git diff` spawn — outside the issue's 5-site list, no scope creep.