### PR TITLE
♻️ refactor(tui): dedupe ui.rs — summary_line, chip_style, branch-status colour

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,16 +54,16 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
   }
 }
 pub use ui::{
-  author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, build_sidebar_sections,
+  author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, build_sidebar_sections, chip_style,
   confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title,
   ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color, github_status_lines,
-  header_line, header_title, help_body_section_color, help_lines, help_rows, help_section_style, issue_badge_color,
-  issue_pr_pane_title, issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines,
-  link_prompt_modal_width, link_target_line, modal_hint_line, pane_counter, panel_border_color, pr_badge_color,
-  pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
-  RECENT_COMMITS_LIMIT,
+  header_line, header_title, help_body_section_color, help_label_style, help_lines, help_rows, help_section_style,
+  issue_badge_color, issue_pr_pane_title, issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines,
+  link_prompt_modal_width, link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color,
+  pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title,
+  table_marker, tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -54,16 +54,17 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
   }
 }
 pub use ui::{
-  author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, build_sidebar_sections, chip_style,
-  confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title,
-  ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, freshness_color, github_status_lines,
-  header_line, header_title, help_body_section_color, help_label_style, help_lines, help_rows, help_section_style,
-  issue_badge_color, issue_pr_pane_title, issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines,
-  link_prompt_modal_width, link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color,
-  pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title,
-  table_marker, tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line,
-  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
+  build_sidebar_sections, chip_style, confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line,
+  create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line, filled_cells_for_progress,
+  footer_line, format_status, freshness_color, github_status_lines, header_line, header_title, help_body_section_color,
+  help_label_style, help_lines, help_rows, help_section_style, issue_badge_color, issue_pr_pane_title,
+  issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines, link_prompt_modal_width,
+  link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color,
+  pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
+  RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3016,44 +3016,63 @@ pub fn issue_summary_line(
   issue_summary_line_with_spinner(n, src, state, max_width, theme, None)
 }
 
-fn issue_summary_line_with_spinner(
-  n: u64,
-  src: LinkSource,
-  state: &GitHubFetchState<crate::github::IssueStatus>,
+/// Resolved render inputs for a GitHub summary line, after the caller has
+/// collapsed the issue/PR-specific `match` into the shared shape. The
+/// `Loaded` arm carries the already-picked badge label + colour and an
+/// optional `trailing` segment (issue: empty; PR: ` · checks N/M`) placed
+/// between the closing `]` and the final space+title.
+enum SummaryState<'a> {
+  Idle,
+  Loading,
+  Loaded {
+    badge: &'a str,
+    badge_color: Color,
+    trailing: String,
+    title: &'a str,
+  },
+  Error(&'a str),
+}
+
+/// Shared renderer behind [`issue_summary_line`] and [`pr_summary_line`].
+/// Both twins resolve their `head` ("Issue #…" vs "PR    #…"), badge, and
+/// `trailing` segment, then delegate here so the truncation budget, the
+/// narrow-fallback flatten, and the Idle/Loading/Error arms live in one
+/// place. The `trailing` param is what keeps the two byte-identical: issue
+/// passes "" → renders `] title`; PR passes ` · checks 1/2` → renders
+/// `]· checks 1/2 title`, exactly as the inlined versions did.
+fn summary_line(
+  head: String,
+  state: SummaryState,
   max_width: usize,
   theme: &Theme,
   spinner: Option<&str>,
 ) -> Line<'static> {
-  let head = format!("Issue #{}{}", n, source_marker(src));
   // The `head` carries no status signal, only identity — it paints with
   // the `name` role (issue #210; default `White`) while the badge colour
-  // tracks the issue state.
+  // tracks the GitHub state.
   match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
-    GitHubFetchState::Loading => {
+    SummaryState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
+    SummaryState::Loading => {
       let glyph = spinner.unwrap_or("…");
       Line::from(trunc(&format!("{} {} loading", head, glyph), max_width))
     }
-    GitHubFetchState::Loaded(s) => {
-      // Mirror `issue_badge_color` exactly so the summary line and the
-      // sidebar header dot never disagree for the same issue: closed maps
-      // to `locked` ("moved on"), not `prunable` ("alarming"). Pre-#170
-      // this site hard-coded `Color::Red` while the dot used `Magenta` —
-      // a latent inconsistency the audit closes (Copilot review #209).
-      let badge_color = issue_badge_color(s.state, theme);
-      let badge = match s.state {
-        IssueState::Open => "open",
-        IssueState::Closed => "closed",
-      };
-      // Fixed prefix = "<head> [<badge>] " — try to preserve in full and
-      // trim the title to whatever budget remains. If the prefix alone
-      // already exceeds the width budget (very narrow sidebar), fall
+    SummaryState::Loaded {
+      badge,
+      badge_color,
+      trailing,
+      title,
+    } => {
+      // Fixed prefix = "<head> [<badge>]<trailing> " — try to preserve in
+      // full and trim the title to whatever budget remains. If the prefix
+      // alone already exceeds the width budget (very narrow sidebar), fall
       // back to flattening the line into a single styled string and
       // truncating it — preserves no badge color but stays inside the
-      // block.
-      let fixed = head.chars().count() + 4 + badge.chars().count(); // " [" + badge + "] "
+      // block. `trailing` is empty for issues and ` · checks N/M` for PRs;
+      // count chars (the `·` is U+00B7: 2 bytes, 1 column) so the budget
+      // arithmetic matches the pre-dedup twins exactly.
+      let fixed = head.chars().count() + 3 + badge.chars().count() + trailing.chars().count() + 1; // " [" + badge + "]" + trailing + " "
       if fixed >= max_width {
-        let raw = format!("{} [{}] {}", head, badge, s.title);
+        let raw = format!("{} [{}]{} {}", head, badge, trailing, title);
         return Line::from(trunc(&raw, max_width));
       }
       let budget = max_width - fixed;
@@ -3064,11 +3083,13 @@ fn issue_summary_line_with_spinner(
           badge.to_string(),
           Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
         ),
-        Span::raw("] "),
-        Span::raw(trunc(&s.title, budget)),
+        Span::raw("]"),
+        Span::raw(trailing),
+        Span::raw(" "),
+        Span::raw(trunc(title, budget)),
       ])
     }
-    GitHubFetchState::Error(e) => {
+    SummaryState::Error(e) => {
       let fixed = head.chars().count() + 2; // " " + "!"
       let budget = max_width.saturating_sub(fixed);
       Line::from(vec![
@@ -3078,6 +3099,40 @@ fn issue_summary_line_with_spinner(
       ])
     }
   }
+}
+
+fn issue_summary_line_with_spinner(
+  n: u64,
+  src: LinkSource,
+  state: &GitHubFetchState<crate::github::IssueStatus>,
+  max_width: usize,
+  theme: &Theme,
+  spinner: Option<&str>,
+) -> Line<'static> {
+  let head = format!("Issue #{}{}", n, source_marker(src));
+  let resolved = match state {
+    GitHubFetchState::Idle => SummaryState::Idle,
+    GitHubFetchState::Loading => SummaryState::Loading,
+    GitHubFetchState::Loaded(s) => {
+      // Mirror `issue_badge_color` exactly so the summary line and the
+      // sidebar header dot never disagree for the same issue: closed maps
+      // to `locked` ("moved on"), not `prunable` ("alarming"). Pre-#170
+      // this site hard-coded `Color::Red` while the dot used `Magenta` —
+      // a latent inconsistency the audit closes (Copilot review #209).
+      let badge = match s.state {
+        IssueState::Open => "open",
+        IssueState::Closed => "closed",
+      };
+      SummaryState::Loaded {
+        badge,
+        badge_color: issue_badge_color(s.state, theme),
+        trailing: String::new(),
+        title: &s.title,
+      }
+    }
+    GitHubFetchState::Error(e) => SummaryState::Error(e),
+  };
+  summary_line(head, resolved, max_width, theme, spinner)
 }
 
 /// Render the Loaded / Idle / Loading / Error variants for a PR link
@@ -3103,58 +3158,36 @@ fn pr_summary_line_with_spinner(
   spinner: Option<&str>,
 ) -> Line<'static> {
   let head = format!("PR    #{}{}", n, source_marker(src));
-  // The `head` carries no status signal, only identity — it paints with
-  // the `name` role (issue #210; default `White`) while the badge colour
-  // tracks the PR state.
-  match state {
-    GitHubFetchState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
-    GitHubFetchState::Loading => {
-      let glyph = spinner.unwrap_or("…");
-      Line::from(trunc(&format!("{} {} loading", head, glyph), max_width))
-    }
+  let resolved = match state {
+    GitHubFetchState::Idle => SummaryState::Idle,
+    GitHubFetchState::Loading => SummaryState::Loading,
     GitHubFetchState::Loaded(s) => {
-      let (badge, badge_color) = match s.state {
-        PrState::Open => ("open", theme.clean),
-        PrState::Draft => ("draft", theme.muted),
-        PrState::Closed => ("closed", theme.prunable),
-        PrState::Merged => ("merged", theme.locked),
+      // Route the badge colour through `pr_badge_color` (mirroring how the
+      // issue side calls `issue_badge_color`) so the summary line and the
+      // sidebar header dot never disagree for the same PR. Only the label
+      // stays inline. Pre-#239 this site duplicated the colour map (Copilot
+      // review #209).
+      let badge = match s.state {
+        PrState::Open => "open",
+        PrState::Draft => "draft",
+        PrState::Closed => "closed",
+        PrState::Merged => "merged",
       };
-      let checks = if s.checks_total > 0 {
+      let trailing = if s.checks_total > 0 {
         format!(" · checks {}/{}", s.checks_passed, s.checks_total)
       } else {
         String::new()
       };
-      let fixed = head.chars().count() + 3 + badge.chars().count() + checks.chars().count() + 1; // " [" + badge + "]" + checks + " "
-      if fixed >= max_width {
-        // Very narrow sidebar — fall back to a single truncated string.
-        // Drops the badge color but keeps the line inside the block.
-        let raw = format!("{} [{}]{} {}", head, badge, checks, s.title);
-        return Line::from(trunc(&raw, max_width));
+      SummaryState::Loaded {
+        badge,
+        badge_color: pr_badge_color(s.state, theme),
+        trailing,
+        title: &s.title,
       }
-      let budget = max_width - fixed;
-      Line::from(vec![
-        Span::styled(head, Style::default().fg(theme.name).add_modifier(Modifier::BOLD)),
-        Span::raw(" ["),
-        Span::styled(
-          badge.to_string(),
-          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("]"),
-        Span::raw(checks),
-        Span::raw(" "),
-        Span::raw(trunc(&s.title, budget)),
-      ])
     }
-    GitHubFetchState::Error(e) => {
-      let fixed = head.chars().count() + 2; // " " + "!"
-      let budget = max_width.saturating_sub(fixed);
-      Line::from(vec![
-        Span::styled(head, Style::default().fg(theme.name)),
-        Span::raw(" "),
-        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(theme.prunable)),
-      ])
-    }
-  }
+    GitHubFetchState::Error(e) => SummaryState::Error(e),
+  };
+  summary_line(head, resolved, max_width, theme, spinner)
 }
 
 // ---- Issue #73: lazygit-style colour helpers -------------------------------

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -128,18 +128,12 @@ pub fn header_line(
   let repo = sanitize(repo_name);
   let path = sanitize(workdir_display);
 
-  let version_style = Style::default()
-    .fg(theme.accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
-  let dir_badge_style = Style::default()
-    .fg(theme.name)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let version_style = chip_style(theme.accent);
+  let dir_badge_style = chip_style(theme.name);
   // Picker chip uses the `dirty` role (not the accent) so the mode warning
   // reads as distinct from the always-present version chip — pre-theme this
   // was a hard-coded `Color::Yellow`.
-  let picker_style = Style::default()
-    .fg(theme.dirty)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let picker_style = chip_style(theme.dirty);
   let path_style = Style::default().fg(theme.muted);
 
   let version_text = format!(" gwm {} ", env!("CARGO_PKG_VERSION"));
@@ -1274,6 +1268,39 @@ pub fn worktree_path_style(theme: &Theme) -> Style {
   Style::default().fg(theme.path)
 }
 
+/// The shared "chip" style: a reverse-video, bold badge painted on `color`
+/// (issue #240). This is the single source of truth for the `` key `` /
+/// button / badge treatment that recurs across the header, footer,
+/// statusbar, help overlay and modal buttons — `REVERSED` paints `color`
+/// as the chip's background, `BOLD` keeps the glyph legible against it.
+/// Extracted so the ~14 inline `fg(c).add_modifier(REVERSED | BOLD)`
+/// repetitions resolve through one definition; sites that add a `bg` or
+/// extra modifiers keep their bespoke style.
+pub fn chip_style(color: Color) -> Style {
+  Style::default()
+    .fg(color)
+    .add_modifier(Modifier::REVERSED | Modifier::BOLD)
+}
+
+/// Style for a *non-highlighted* command name in the command palette
+/// (issue #210 follow-up). Routes through the `name` role (default
+/// `White`) so a `[theme]` override / light preset recolours it, instead
+/// of the pre-#240 hard-coded `Color::White` that bypassed the theme.
+/// Extracted so the route is pinned by `tests/tui_theme_audit_tests.rs`
+/// (`draw_command_palette` is private Frame render code).
+pub fn palette_name_style(theme: &Theme) -> Style {
+  Style::default().fg(theme.name)
+}
+
+/// Style for a Keybindings-overlay entry *label* (the action description
+/// trailing each key chip). Routes through the `name` role (default
+/// `White`) for the same reason as [`palette_name_style`]: the pre-#240
+/// literal `Color::White` ignored a `[theme]` override. Pinned by
+/// `tests/tui_theme_audit_tests.rs`.
+pub fn help_label_style(theme: &Theme) -> Style {
+  Style::default().fg(theme.name)
+}
+
 fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16, theme: &Theme) -> Row<'static> {
   let (marker_label, marker_color) = table_marker(w, theme);
   let branch_text = w.branch.clone().unwrap_or_else(|| "-".into());
@@ -1553,9 +1580,7 @@ pub fn recent_items_pane_title(mode: SidebarMode, keymap: &Keymap) -> String {
 }
 
 pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
-  let chip_style = Style::default()
-    .fg(theme.accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let chip_style = chip_style(theme.accent);
   let label_style = Style::default().fg(theme.muted);
   let mut spans: Vec<Span<'static>> = Vec::new();
   for (i, (key, label)) in hints.iter().enumerate() {
@@ -1600,9 +1625,7 @@ fn push_modal_hint(lines: &mut Vec<Line<'static>>, ctx: HintContext, keymap: &Ke
 /// are measured with `chars().count()` to match the rest of `ui.rs` (keys,
 /// labels and the bracketed status are ASCII / single-width in practice).
 pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &Theme) -> Line<'static> {
-  let chip_style = Style::default()
-    .fg(theme.accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let chip_style = chip_style(theme.accent);
   let label_style = Style::default().fg(theme.muted);
   let status_style = Style::default().fg(theme.dirty);
 
@@ -1693,12 +1716,8 @@ pub fn status_line(
   width: usize,
   theme: &Theme,
 ) -> Line<'static> {
-  let context_style = Style::default()
-    .fg(theme.focus)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
-  let chip_style = Style::default()
-    .fg(theme.accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let context_style = chip_style(theme.focus);
+  let chip_style = chip_style(theme.accent);
   let label_style = Style::default().fg(theme.muted);
   let status_style = Style::default().fg(theme.dirty);
   let spinner_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
@@ -2038,11 +2057,9 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   // the title share the bold-accent heading style. Labels stay white
   // for contrast; an `(unbound)` action renders muted instead of a chip
   // so it reads as "no binding" rather than a live key.
-  let chip_style = Style::default()
-    .fg(accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let chip_style = chip_style(accent);
   let heading_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
-  let label_style = Style::default().fg(Color::White);
+  let label_style = help_label_style(&app.theme);
   let muted_style = Style::default().fg(muted);
 
   // Align every label to the same column: pad each badge *group* out to
@@ -2217,9 +2234,7 @@ fn draw_create(f: &mut Frame, app: &App) {
 /// chip rather than defaulting focus to Cancel. Pure so the chip contract
 /// is pinned by `tests/tui_ui_helpers_tests.rs`.
 pub fn create_buttons_line(accent: Color, muted: Color) -> Line<'static> {
-  let primary = Style::default()
-    .fg(accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let primary = chip_style(accent);
   let idle = Style::default().fg(muted).add_modifier(Modifier::BOLD);
   Line::from(vec![
     Span::styled(" Create ", primary),
@@ -2250,9 +2265,7 @@ pub fn type_selector_line(
   // badge style as the buttons) so it stands out as an editable control;
   // idle it is plain white text between muted arrows.
   let name_style = if focused {
-    Style::default()
-      .fg(accent)
-      .add_modifier(Modifier::REVERSED | Modifier::BOLD)
+    chip_style(accent)
   } else {
     Style::default().fg(Color::White)
   };
@@ -2312,9 +2325,7 @@ pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, m
   let button = format!(" {key}  {label} ");
   let button = format!("{button:<BUTTON_WIDTH$}");
   if selected {
-    let chip = Style::default()
-      .fg(accent)
-      .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+    let chip = chip_style(accent);
     return Line::from(vec![Span::raw("  "), Span::styled(button, chip)]);
   }
 
@@ -2367,12 +2378,8 @@ pub fn confirm_delete_branch_line(
   accent: Color,
   muted: Color,
 ) -> Line<'static> {
-  let key_style = Style::default()
-    .fg(accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
-  let value_style = Style::default()
-    .fg(if enabled { accent } else { muted })
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let key_style = chip_style(accent);
+  let value_style = chip_style(if enabled { accent } else { muted });
   Line::from(vec![
     Span::styled(
       format!("{:<label_width$}  ", "Delete Branch", label_width = label_width),
@@ -2541,9 +2548,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
 /// `Enter` lands on. Pure so the chip contract is pinned by
 /// `tests/tui_ui_helpers_tests.rs`.
 pub fn confirm_buttons_line(focus: ConfirmButton, accent: Color, muted: Color) -> Line<'static> {
-  let focused = Style::default()
-    .fg(accent)
-    .add_modifier(Modifier::REVERSED | Modifier::BOLD);
+  let focused = chip_style(accent);
   let idle = Style::default().fg(muted).add_modifier(Modifier::BOLD);
   let (confirm_style, cancel_style) = match focus {
     ConfirmButton::Confirm => (focused, idle),
@@ -2915,7 +2920,7 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
       let name_style = if i == highlight {
         Style::default().fg(accent).add_modifier(Modifier::BOLD)
       } else {
-        Style::default().fg(Color::White)
+        palette_name_style(&app.theme)
       };
       Line::from(vec![
         Span::raw(prefix),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1233,7 +1233,14 @@ fn branch_status_label(s: &BranchStatus) -> String {
   }
 }
 
-fn branch_status_color(s: &BranchStatus, theme: &Theme) -> Color {
+/// Worst-status accent colour for a [`BranchStatus`]: `unknown` → `muted`,
+/// `dirty`/`behind` → `dirty`, `ahead`-only → `accent`, else `clean`. The
+/// single source of truth shared by the sidebar status badge (`badges_line`)
+/// and the table status cell ([`format_status`], issue #241) — each builds its
+/// own label/sigils, but the colour is derived here once. Exported so the
+/// dedup is pinned by `tests/tui_theme_audit_tests.rs` (both call sites are
+/// private render code).
+pub fn branch_status_color(s: &BranchStatus, theme: &Theme) -> Color {
   if s.unknown {
     theme.muted
   } else if s.is_dirty || s.behind > 0 {
@@ -1364,8 +1371,12 @@ fn build_status_cell(w: &WorktreeInfo, width: usize, theme: &Theme) -> Cell<'sta
   Cell::from(label).style(Style::default().fg(color))
 }
 
-/// Pick a compact label + accent colour for a `BranchStatus`.
-fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, Color) {
+/// Pick a compact label + accent colour for a `BranchStatus`. The colour is
+/// derived through the shared [`branch_status_color`] so the table cell and
+/// the sidebar status agree (issue #241); the label/sigil logic stays
+/// table-specific (the sidebar builds its own badge in `badges_line`).
+/// Exported so the colour route is pinned by `tests/tui_theme_audit_tests.rs`.
+pub fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, Color) {
   if s.unknown {
     return ("unknown".into(), theme.muted);
   }
@@ -1391,15 +1402,11 @@ fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, Colo
   let joined = parts.join(" ");
   let label = trunc(&joined, width.max(4));
 
-  // Worst-status colour: dirty/behind = dirty, ahead-only = accent, synced/clean = clean.
-  let color = if s.is_dirty || s.behind > 0 {
-    theme.dirty
-  } else if s.ahead > 0 {
-    theme.accent
-  } else {
-    theme.clean
-  };
-  (label, color)
+  // Worst-status colour, shared with the sidebar (issue #241). `unknown` was
+  // already handled by the early return above, so reaching `branch_status_color`
+  // here is byte-identical to the former inline `dirty/behind → ahead → clean`
+  // chain while keeping a single source of truth.
+  (label, branch_status_color(s, theme))
 }
 
 /// One statusbar hint specification (issue #217). Either a rebindable

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -35,9 +35,9 @@ use gwm::tui::commit_graph::{render_pipe_set, test_row, Pipe, PipeKind};
 use gwm::tui::state::sidebar::SidebarMode;
 use gwm::tui::theme::Theme;
 use gwm::tui::{
-  branch_name_color, build_sidebar_sections, footer_line, freshness_color, header_line, help_label_style,
-  issue_badge_color, palette_name_style, pr_badge_color, table_marker, working_tree_status_line, worktree_name_style,
-  worktree_path_style,
+  branch_name_color, branch_status_color, build_sidebar_sections, footer_line, format_status, freshness_color,
+  header_line, help_label_style, issue_badge_color, palette_name_style, pr_badge_color, table_marker,
+  working_tree_status_line, worktree_name_style, worktree_path_style,
 };
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::style::{Color, Modifier};
@@ -117,6 +117,75 @@ fn branch_name_color_resolves_every_state_through_theme_roles() {
     ..BranchStatus::default()
   };
   assert_eq!(branch_name_color(&unknown, &t), t.muted, "unknown → muted");
+}
+
+/// Representative `BranchStatus` values spanning every colour branch of the
+/// worst-status chain: unknown, dirty, behind-only, ahead-only, synced,
+/// unpublished/clean.
+fn status_color_cases() -> Vec<(&'static str, BranchStatus)> {
+  vec![
+    (
+      "unknown",
+      BranchStatus {
+        unknown: true,
+        ..BranchStatus::default()
+      },
+    ),
+    ("dirty", dirty_status()),
+    (
+      "behind-only",
+      BranchStatus {
+        has_upstream: true,
+        behind: 3,
+        ..BranchStatus::default()
+      },
+    ),
+    (
+      "ahead-only",
+      BranchStatus {
+        has_upstream: true,
+        ahead: 2,
+        ..BranchStatus::default()
+      },
+    ),
+    (
+      "synced",
+      BranchStatus {
+        has_upstream: true,
+        ..BranchStatus::default()
+      },
+    ),
+    ("unpublished-clean", BranchStatus::default()),
+  ]
+}
+
+#[test]
+fn branch_status_color_resolves_worst_status_through_theme_roles() {
+  let t = audit_theme();
+  let role = |label: &str| match label {
+    "unknown" => t.muted,
+    "dirty" | "behind-only" => t.dirty,
+    "ahead-only" => t.accent,
+    _ => t.clean,
+  };
+  for (label, s) in status_color_cases() {
+    assert_eq!(branch_status_color(&s, &t), role(label), "{label} → expected role");
+  }
+}
+
+#[test]
+fn format_status_colour_routes_through_branch_status_color() {
+  // Issue #241: the table status cell (`format_status`) and the sidebar status
+  // share one colour derivation. Pin the dedup so a future re-inline that
+  // diverges from `branch_status_color` is caught.
+  let t = audit_theme();
+  for (label, s) in status_color_cases() {
+    assert_eq!(
+      format_status(&s, 16, &t).1,
+      branch_status_color(&s, &t),
+      "{label}: format_status colour must equal branch_status_color"
+    );
+  }
 }
 
 #[test]

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -270,6 +270,42 @@ fn issue_summary_line_closed_badge_agrees_with_the_header_dot() {
   );
 }
 
+#[test]
+fn pr_summary_line_merged_badge_routes_through_pr_badge_color() {
+  // #239 / Copilot review #209 follow-up: the PR Loaded arm used to inline
+  // its own badge-colour map. After the dedup it must resolve through
+  // `pr_badge_color`, exactly as the issue side calls `issue_badge_color`.
+  // `audit_theme()` gives `locked` a value distinct from clean/muted/prunable
+  // so a Merged PR's badge can only match if the route is honoured.
+  let t = audit_theme();
+  let status = gwm::github::PrStatus {
+    number: 42,
+    title: "shipped".into(),
+    state: PrState::Merged,
+    url: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    updated_at: String::new(),
+  };
+  let line = gwm::tui::pr_summary_line(
+    42,
+    gwm::github::LinkSource::Explicit,
+    &gwm::tui::GitHubFetchState::Loaded(status),
+    80,
+    &t,
+  );
+  assert_eq!(
+    fg_containing(&line, "merged"),
+    Some(t.locked),
+    "merged PR badge → locked, matching pr_badge_color"
+  );
+  assert_eq!(
+    fg_containing(&line, "merged"),
+    Some(pr_badge_color(PrState::Merged, &t)),
+    "summary line and the header dot must use the same role for merged PRs"
+  );
+}
+
 // ---------------------------------------------------------------------------
 // #210: `name` / `path` chrome roles
 // ---------------------------------------------------------------------------

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -35,8 +35,9 @@ use gwm::tui::commit_graph::{render_pipe_set, test_row, Pipe, PipeKind};
 use gwm::tui::state::sidebar::SidebarMode;
 use gwm::tui::theme::Theme;
 use gwm::tui::{
-  branch_name_color, build_sidebar_sections, footer_line, freshness_color, header_line, issue_badge_color,
-  pr_badge_color, table_marker, working_tree_status_line, worktree_name_style, worktree_path_style,
+  branch_name_color, build_sidebar_sections, footer_line, freshness_color, header_line, help_label_style,
+  issue_badge_color, palette_name_style, pr_badge_color, table_marker, working_tree_status_line, worktree_name_style,
+  worktree_path_style,
 };
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::style::{Color, Modifier};
@@ -332,6 +333,41 @@ fn name_and_path_styles_default_to_legacy_white_and_gray() {
   let d = Theme::default();
   assert_eq!(worktree_name_style(&d).fg, Some(Color::White), "default name → White");
   assert_eq!(worktree_path_style(&d).fg, Some(Color::Gray), "default path → Gray");
+}
+
+#[test]
+fn palette_and_help_labels_resolve_through_name_role() {
+  // #240(b): the command-palette non-highlighted command name and the
+  // Keybindings-overlay entry label used to paint with a hard-coded
+  // `Color::White` that bypassed `theme.name`, so a light / non-default
+  // preset could not recolour them (#210). They now route through the
+  // `name` role. `audit_theme()` gives `name` a value distinct from
+  // White, so a regression back to the literal is caught here.
+  let t = audit_theme();
+  assert_eq!(
+    palette_name_style(&t).fg,
+    Some(t.name),
+    "palette command name → name role"
+  );
+  assert_eq!(help_label_style(&t).fg, Some(t.name), "help entry label → name role");
+}
+
+#[test]
+fn palette_and_help_labels_default_to_legacy_white() {
+  // Guard the "no visible change without [theme]" contract for #240(b):
+  // the default `name` role is White, so the default palette / help output
+  // is byte-identical to the pre-#240 hard-coded literal.
+  let d = Theme::default();
+  assert_eq!(
+    palette_name_style(&d).fg,
+    Some(Color::White),
+    "default palette command name → White"
+  );
+  assert_eq!(
+    help_label_style(&d).fg,
+    Some(Color::White),
+    "default help entry label → White"
+  );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Three sequential, no-behaviour-change `ui.rs` dedup refactors (plan items P3/P4/P5), each its own atomic commit. Bundled into one PR because all three touch `src/tui/ui.rs` and the shared `tests/tui_theme_audit_tests.rs`, so splitting would force cherry-pick conflicts; the atomic commit history is preserved.

Closes #239
Closes #240
Closes #241

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

**#239 — `summary_line` (`738084f`)**
- Extract a shared `summary_line` helper (+ `SummaryState` enum) that the twin `issue_summary_line_with_spinner` / `pr_summary_line_with_spinner` delegate to. Output is byte-identical (the asymmetric `checks`/spacing handled via an optional `trailing` segment; `fixed`-width arithmetic reduces exactly to the old per-side formulas). Net −72 lines.
- Route the PR Loaded badge colour through the existing `pr_badge_color` instead of an inline map (mirrors the issue side's `issue_badge_color`; #209 follow-up).

**#240 — `chip_style` + theme bypass (`f022853`)**
- Extract `chip_style(color)` (the `REVERSED | BOLD` chip) and replace all 14 literal occurrences. Extra-modifier / `bg` / BOLD-only sites left bespoke.
- Route the two hard-coded `Color::White` labels in `draw_command_palette` / `draw_help` through `theme.name` (default `name` is White → default output unchanged; fixes non-default/light themes, #210). Create-form Whites + deliberate neutrals (`sidebar_status_dot`, `table_marker`) left untouched.

**#241 — status colour dedup (`8e01676`)**
- `format_status` now derives its colour via `branch_status_color` instead of re-inlining the byte-identical map. `format_status`' width/sigil logic and the distinct `branch_name_color` (lazygit scheme) are untouched.

## Tests

- [x] `cargo test` passes locally (full suite green on the stacked HEAD)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` — 5 new theme-audit assertions: PR badge routes via `pr_badge_color`; palette/help labels resolve via `theme.name` (+ default-White guard); `format_status` colour == `branch_status_color`; worst-status resolution through theme roles

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (3 atomic commits)
- [ ] CHANGELOG.md updated under `## [Unreleased]` — N/A: pure refactors, no user-facing change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- All three are no-behaviour-change refactors verified green on a warm build (clippy `-D warnings` + full `cargo test`), backed by the modal render net from #245.
- **#239 byte-identity** is the subtle one: the issue line renders `head [badge] title`, the PR line `head [badge]<checks> title`; the shared helper places an optional `trailing` between `]` and the final space+title, so issue (trailing="") and PR (trailing=" · checks N/M") both reproduce the prior output exactly. The narrow-sidebar fallback string and `fixed`-width math were checked to collapse identically.
- Test-depth caveat (consistent with the existing audit suite): the palette/help theme assertions pin that the helpers resolve to `theme.name`, not that the draw fns call them — a render-level colour check isn't feasible since the modal net runs the default theme where `name == White`.