### PR TITLE
♻️ refactor(worktree): move trunk resolution into domain module

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1285,7 +1285,7 @@ fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Resu
   let desc = branch_spec.as_ref().map(|s| s.desc.clone()).unwrap_or_default();
 
   let base = base_override
-    .or_else(|| resolve_pr_base(&repo, &config.doctor.trunks))
+    .or_else(|| worktree::resolve_trunk(&repo, &config.doctor.trunks))
     .unwrap_or_else(|| "main".into());
 
   let commits = worktree::git_log_subject_between(&workdir, &base, &head_name)
@@ -1353,32 +1353,6 @@ fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Resu
     eprintln!("note: could not record gwm-pr config for {}: {}", head_name, e);
   }
   Ok(())
-}
-
-/// Pick a base ref for `gwm pr` by walking the configured `[doctor].trunks`
-/// list first, then the common defaults (`main`, `master`, `dev`,
-/// `develop`, `trunk`) so a repo whose local trunk is `master` and which
-/// hasn't customised `[doctor]` doesn't fall back to a non-existent
-/// `"main"`. Returns `None` only if none of the candidates resolve to a
-/// local branch — the caller then uses `"main"` as a last resort so the
-/// downstream `gh pr create --base main` produces a clean error message
-/// instead of a panic.
-fn resolve_pr_base(repo: &Repository, trunks: &[String]) -> Option<String> {
-  const COMMON_TRUNKS: &[&str] = &["main", "master", "dev", "develop", "trunk"];
-  for trunk in trunks {
-    if repo.find_branch(trunk, git2::BranchType::Local).is_ok() {
-      return Some(trunk.clone());
-    }
-  }
-  for trunk in COMMON_TRUNKS {
-    if trunks.iter().any(|t| t == trunk) {
-      continue; // already tried as a configured trunk above
-    }
-    if repo.find_branch(trunk, git2::BranchType::Local).is_ok() {
-      return Some((*trunk).to_string());
-    }
-  }
-  None
 }
 
 fn pr_title(ctx: &PrTemplateContext) -> String {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -811,3 +811,29 @@ pub fn find_fuzzy(repo: &Repository, pattern: &str) -> Result<WorktreeInfo> {
     ))),
   }
 }
+
+/// Pick a base ref for `gwm pr` by walking the `configured` trunks list
+/// first, then the common defaults (`main`, `master`, `dev`, `develop`,
+/// `trunk`) so a repo whose local trunk is `master` and which hasn't
+/// customised `[doctor]` doesn't fall back to a non-existent `"main"`.
+/// Returns `None` only if none of the candidates resolve to a local
+/// branch — the caller then uses `"main"` as a last resort so the
+/// downstream `gh pr create --base main` produces a clean error message
+/// instead of a panic.
+pub fn resolve_trunk(repo: &Repository, configured: &[String]) -> Option<String> {
+  const COMMON_TRUNKS: &[&str] = &["main", "master", "dev", "develop", "trunk"];
+  for trunk in configured {
+    if repo.find_branch(trunk, BranchType::Local).is_ok() {
+      return Some(trunk.clone());
+    }
+  }
+  for trunk in COMMON_TRUNKS {
+    if configured.iter().any(|t| t == trunk) {
+      continue; // already tried as a configured trunk above
+    }
+    if repo.find_branch(trunk, BranchType::Local).is_ok() {
+      return Some((*trunk).to_string());
+    }
+  }
+  None
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -845,3 +845,55 @@ fn git_stash_list_respects_limit() {
   let limited = worktree::git_stash_list(dir.path(), 2).unwrap();
   assert_eq!(limited.len(), 2, "limit must cap the result vec");
 }
+
+#[test]
+fn resolve_trunk_falls_back_to_master_when_no_main() {
+  // A repo whose only trunk-ish branch is `master` (no `main`) must
+  // resolve to "master" via the COMMON_TRUNKS fallback even when the
+  // caller passes no configured trunks.
+  let (_dir, repo) = init_repo();
+
+  // init_repo seeds `main`; create `master` at the same commit, point
+  // HEAD at it, then drop `main` so `master` is the sole local branch.
+  let head_oid = repo.head().unwrap().target().unwrap();
+  let head_commit = repo.find_commit(head_oid).unwrap();
+  repo.branch("master", &head_commit, false).unwrap();
+  repo.set_head("refs/heads/master").unwrap();
+  repo
+    .find_branch("main", git2::BranchType::Local)
+    .unwrap()
+    .delete()
+    .unwrap();
+
+  assert!(
+    repo.find_branch("main", git2::BranchType::Local).is_err(),
+    "main should be gone for this test"
+  );
+
+  let resolved = worktree::resolve_trunk(&repo, &[]);
+  assert_eq!(resolved.as_deref(), Some("master"));
+}
+
+#[test]
+fn resolve_trunk_prefers_configured_over_fallback() {
+  // With both `dev` and `main` present, a configured trunk of `dev`
+  // must win over the COMMON_TRUNKS fallback (which would otherwise
+  // pick `main` first).
+  let (_dir, repo) = init_repo();
+
+  let head_oid = repo.head().unwrap().target().unwrap();
+  let head_commit = repo.find_commit(head_oid).unwrap();
+  repo.branch("dev", &head_commit, false).unwrap();
+
+  assert!(
+    repo.find_branch("main", git2::BranchType::Local).is_ok(),
+    "main should exist for this test"
+  );
+  assert!(
+    repo.find_branch("dev", git2::BranchType::Local).is_ok(),
+    "dev should exist for this test"
+  );
+
+  let resolved = worktree::resolve_trunk(&repo, &["dev".to_string()]);
+  assert_eq!(resolved.as_deref(), Some("dev"));
+}


### PR DESCRIPTION
## Description

Move trunk-resolution out of the CLI layer into its domain module. No behaviour change.

Closes #242

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- `src/worktree.rs`: new `pub fn resolve_trunk(repo, configured) -> Option<String>` — the exact logic formerly in `cli.rs::resolve_pr_base` (configured trunks first, then the `COMMON_TRUNKS` = `[main, master, dev, develop, trunk]` fallback skipping already-tried ones; `COMMON_TRUNKS` kept as a fn-local const).
- `src/cli.rs`: `cmd_pr` now calls `worktree::resolve_trunk(&repo, &config.doctor.trunks)`; the private `resolve_pr_base` + its doc comment are removed. The surrounding `.or_else(...).unwrap_or_else(|| "main".into())` last-resort chain is unchanged.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` — `worktree_integration.rs`: `resolve_trunk_falls_back_to_master_when_no_main` + `resolve_trunk_prefers_configured_over_fallback`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]` — N/A: pure refactor, no user-facing change
- [x] No `unwrap()` on user-facing paths (test-only unwraps)
- [x] No `println!` in TUI render code

## Notes for reviewers

- Pure code move; `grep resolve_pr_base src/ tests/` is empty afterwards. `BranchType` already imported in worktree.rs; `Repository`/`git2` still used elsewhere in cli.rs.