### PR TITLE
🔥 refactor(tui): remove dead helpers left by #185/#217 churn

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -57,14 +57,13 @@ pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
   build_sidebar_sections, chip_style, confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line,
   create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line, filled_cells_for_progress,
-  footer_line, format_status, freshness_color, github_status_lines, header_line, header_title, help_body_section_color,
+  footer_line, format_status, freshness_color, github_status_lines, header_line, help_body_section_color,
   help_label_style, help_lines, help_rows, help_section_style, issue_badge_color, issue_pr_pane_title,
-  issue_summary_line, link_choose_hint, link_input_hint, link_open_modal_lines, link_prompt_modal_width,
-  link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color,
-  pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
-  RECENT_COMMITS_LIMIT,
+  issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_line, modal_hint_line,
+  palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
+  recent_items_pane_title, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
+  working_tree_pane_title, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
+  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -81,19 +81,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
   }
 }
 
-/// Format the TUI header title `" <repo> <path> gwm <version> "`.
-/// The version comes from `CARGO_PKG_VERSION` so it stays in lockstep
-/// with `gwm --version` without a second source of truth — important
-/// for users juggling multiple installs (a `cargo install`-ed gwm next
-/// to a worktree-built dev binary). Extracted from `draw_header` so
-/// the format can be pinned by a unit test without spinning up the
-/// ratatui backend.
-pub fn header_title(repo_name: &str, workdir_display: &str) -> String {
-  format!(" {} {} gwm {} ", repo_name, workdir_display, env!("CARGO_PKG_VERSION"))
-}
-
 /// Styled, width-driven header builder (issue #185). Replaces the flat
-/// `header_title` string in the rendered TUI with a clear visual hierarchy
+/// header-title string in the rendered TUI with a clear visual hierarchy
 /// that mirrors the #180 footer's chip language:
 ///
 /// - **Current directory** — a leading reverse-video badge.
@@ -2099,7 +2088,7 @@ fn draw_help(f: &mut Frame, app: &mut App) {
       HelpRow::Section(t) => {
         lines.push(Line::from(Span::styled(
           t,
-          help_section_style(accent, help_body_section_color(&app.theme)),
+          help_section_style(help_body_section_color(&app.theme)),
         )));
       }
       HelpRow::Blank => lines.push(Line::from(String::new())),
@@ -2353,7 +2342,7 @@ pub fn link_prompt_modal_width(term_width: u16) -> u16 {
 
 /// Section-heading style for the Keybindings overlay body. Kept pure so the
 /// title/body colour split is pinned outside the ratatui renderer.
-pub fn help_section_style(_accent: Color, section: Color) -> Style {
+pub fn help_section_style(section: Color) -> Style {
   Style::default().fg(section).add_modifier(Modifier::BOLD)
 }
 
@@ -2859,19 +2848,6 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   };
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
-}
-
-/// Compact legacy control hint for the Link prompt target picker. The live
-/// modal now renders statusbar-style badges from [`HintContext::LinkPrompt`],
-/// but this helper stays exported for callers that still need a plain string.
-pub fn link_choose_hint() -> &'static str {
-  "j/k move · F fetch · Enter/i/p pick · Esc"
-}
-
-/// Compact legacy control hint for the Link prompt number input. Same width
-/// budget as [`link_choose_hint`].
-pub fn link_input_hint() -> &'static str {
-  "digits · F fetch · Enter link · Esc cancel"
 }
 
 /// Render the command palette overlay (issue #32).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4,7 +4,7 @@ use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
 use gwm::tui::theme::Theme;
 use gwm::tui::{
-  branch_name_color, filled_cells_for_progress, freshness_color, header_title, panel_border_color, pr_badge_color, App,
+  branch_name_color, filled_cells_for_progress, freshness_color, panel_border_color, pr_badge_color, App,
   ConfirmKeyAction, CountdownTickOutcome, Field, View,
 };
 use gwm::worktree::{BranchStatus, WorktreeInfo};
@@ -102,37 +102,6 @@ fn focused_panel_border_wears_the_theme_focus_colour() {
     panel_border_color(false, &theme),
     theme.muted,
     "unfocused panel wears the theme muted role (#170)"
-  );
-}
-
-#[test]
-fn header_title_includes_running_version_repo_and_workdir() {
-  // The TUI header surfaces `<repo> <workdir> gwm <version>`.
-  // Cross-check both halves: the version comes from CARGO_PKG_VERSION
-  // (the same string `gwm --version` prints) and the format keeps the
-  // current-dir name first and the version last.
-  let title = header_title("gwm-cli", "/Users/kbrdn1/Projects/Perso/gwm-cli");
-  assert!(title.contains("gwm-cli"), "missing repo name: {}", title);
-  assert!(
-    title.contains("/Users/kbrdn1/Projects/Perso/gwm-cli"),
-    "missing workdir: {}",
-    title
-  );
-  let version_token = env!("CARGO_PKG_VERSION");
-  assert!(
-    title.contains(version_token),
-    "missing running version `{}`: {}",
-    version_token,
-    title
-  );
-  // Pin the exact layout so a refactor moving the version pre/post
-  // would have to update this assertion deliberately.
-  assert_eq!(
-    title,
-    format!(
-      " gwm-cli /Users/kbrdn1/Projects/Perso/gwm-cli gwm {} ",
-      env!("CARGO_PKG_VERSION")
-    )
   );
 }
 

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -5,7 +5,7 @@
 //! visible at the right edge — hints are what gets truncated when the
 //! terminal is narrow, never the log.
 //!
-//! `footer_line` is a pure builder (like `header_title` / `help_lines`) so the
+//! `footer_line` is a pure builder (like `header_line` / `help_lines`) so the
 //! layout contract is pinned here without spinning up a ratatui backend.
 
 use gwm::tui::theme::Theme;

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -10,9 +10,8 @@ use gwm::tui::theme::Theme;
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
   badge_group_width, bootstrap_report_lines, confirm_buttons_line, create_buttons_line, ellipsize_middle,
-  field_input_line, link_choose_hint, link_input_hint, link_prompt_modal_width, link_target_line, modal_hint_line,
-  pane_counter, recent_items_pane_title, status_pane_title, type_selector_line, working_tree_pane_title,
-  worktrees_pane_title,
+  field_input_line, link_prompt_modal_width, link_target_line, modal_hint_line, pane_counter, recent_items_pane_title,
+  status_pane_title, type_selector_line, working_tree_pane_title, worktrees_pane_title,
 };
 use gwm::tui::{
   confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_section_style,
@@ -380,22 +379,8 @@ fn link_prompt_width_stays_compact_on_wide_terminals() {
 }
 
 #[test]
-fn link_prompt_hints_fit_the_80_col_modal_budget() {
-  // At 80 columns the Link/Open modal is 64 columns wide, and the rounded
-  // border + horizontal padding leave 58 cells for content.
-  const INNER_WIDTH_AT_80_COLS: usize = 58;
-
-  for hint in [link_choose_hint(), link_input_hint()] {
-    assert!(
-      hint.chars().count() <= INNER_WIDTH_AT_80_COLS,
-      "Link prompt hint clips at 80 cols: {hint:?}"
-    );
-  }
-}
-
-#[test]
 fn help_section_style_uses_body_section_colour() {
-  let style = help_section_style(Color::Magenta, Color::Green);
+  let style = help_section_style(Color::Green);
   assert_eq!(
     style.fg,
     Some(Color::Green),


### PR DESCRIPTION
## Description

Remove dead, test-only TUI helpers orphaned by the #185 (header) / #217 (link prompt) reworks. `src/lib.rs` documents the module surface as "intentionally `pub` for testability" — `gwm::tui` is a test surface, not a public external library API, so removing these unused `pub` helpers is safe. No behaviour change.

Closes #244

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- Remove `header_title` (superseded by `header_line`; `draw_header` uses the latter) — fn, `mod.rs` re-export, its `tui_app_tests.rs` test + import, and the prose doc-comment references on `header_line` and in `tui_footer_tests.rs`.
- Remove `link_choose_hint` + `link_input_hint` (the live modal renders `HintContext::LinkPrompt` badges now) — fns, re-exports, and the `tui_ui_helpers_tests.rs` test + imports.
- Drop the unused `_accent` first param of `help_section_style` (the fn stays — still used by the help overlay) and update the single caller; the call-site `accent` binding stays used by `chip_style`/`heading_style`/`overlay_block`, so no unused-binding warning.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (proves no dangling reference / no newly-unused binding)
- [ ] New tests added under `tests/` — N/A: this is a deletion of dead, test-only symbols; their tests are removed and the compiler + clippy prove no live reference remains

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]` — N/A: internal dead-code removal, no user-facing change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- Each symbol was grepped to confirm it had no production caller before removal (only the `mod.rs` re-export, doc-comments, and test usages). `help_section_style` itself is kept — only its dead first param goes.