### PR TITLE
♻️ refactor(tui): extract centered_abs, dedupe modal Rect blocks (#243)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,15 +55,16 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, chip_style, confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line,
-  create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line, filled_cells_for_progress,
-  footer_line, format_status, freshness_color, github_status_lines, header_line, help_body_section_color,
-  help_label_style, help_lines, help_rows, help_section_style, issue_badge_color, issue_pr_pane_title,
-  issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_line, modal_hint_line,
-  palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines,
-  recent_items_pane_title, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
-  working_tree_pane_title, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
-  HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  build_sidebar_sections, centered_abs, chip_style, confirm_buttons_line, confirm_delete_branch_line,
+  confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line,
+  filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines, header_line,
+  help_body_section_color, help_label_style, help_lines, help_rows, help_section_style, issue_badge_color,
+  issue_pr_pane_title, issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_line,
+  modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
+  recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
+  RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2705,16 +2705,26 @@ fn centered(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
     .split(v[1])[1]
 }
 
+/// Center a box of an **absolute** `width`/`height` (in cells) inside `area`,
+/// clamping each dimension to the area so an oversized modal cannot overflow
+/// the frame. Shared by the open-menu and link-prompt modals (issue #243) and
+/// the percentage-based [`centered_h`], unifying the three centering paths.
+pub fn centered_abs(width: u16, height: u16, area: Rect) -> Rect {
+  let width = width.min(area.width);
+  let height = height.min(area.height);
+  let x = area.x + area.width.saturating_sub(width) / 2;
+  let y = area.y + area.height.saturating_sub(height) / 2;
+  Rect { x, y, width, height }
+}
+
 /// Centre a box of `width_pct`% width and a fixed `height` (rows) in
 /// `area`. Unlike [`centered`], the height is absolute so an overlay can
 /// size itself to its content rather than a fixed percentage of the
 /// screen (#187 — the confirm modal was far taller than its few lines).
+/// Delegates the centering arithmetic to [`centered_abs`].
 fn centered_h(width_pct: u16, height: u16, area: Rect) -> Rect {
-  let height = height.min(area.height);
   let width = area.width.saturating_mul(width_pct) / 100;
-  let x = area.x + area.width.saturating_sub(width) / 2;
-  let y = area.y + area.height.saturating_sub(height) / 2;
-  Rect { x, y, width, height }
+  centered_abs(width, height, area)
 }
 
 /// Like [`centered_h`] but also caps the width at `max_width` columns so a
@@ -2801,13 +2811,8 @@ fn draw_open_menu(f: &mut Frame, app: &App) {
   let lines = link_open_modal_lines(app, "Open in Browser", Some(app.open_menu_selected));
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
   let term = f.area();
-  let width = link_prompt_modal_width(term.width).min(term.width);
-  let area = Rect {
-    x: term.x + term.width.saturating_sub(width) / 2,
-    y: term.y + term.height.saturating_sub(height) / 2,
-    width,
-    height: height.min(term.height),
-  };
+  let width = link_prompt_modal_width(term.width);
+  let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
@@ -2839,13 +2844,8 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   };
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
   let term = f.area();
-  let width = link_prompt_modal_width(term.width).min(term.width);
-  let area = Rect {
-    x: term.x + term.width.saturating_sub(width) / 2,
-    y: term.y + term.height.saturating_sub(height) / 2,
-    width,
-    height: height.min(term.height),
-  };
+  let width = link_prompt_modal_width(term.width);
+  let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -9,7 +9,7 @@ use gwm::tui::state::sidebar::SidebarMode;
 use gwm::tui::theme::Theme;
 use gwm::tui::ConfirmButton;
 use gwm::tui::{
-  badge_group_width, bootstrap_report_lines, confirm_buttons_line, create_buttons_line, ellipsize_middle,
+  badge_group_width, bootstrap_report_lines, centered_abs, confirm_buttons_line, create_buttons_line, ellipsize_middle,
   field_input_line, link_prompt_modal_width, link_target_line, modal_hint_line, pane_counter, recent_items_pane_title,
   status_pane_title, type_selector_line, working_tree_pane_title, worktrees_pane_title,
 };
@@ -17,6 +17,7 @@ use gwm::tui::{
   confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_section_style,
   issue_pr_pane_title,
 };
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 
 #[test]
@@ -457,4 +458,103 @@ fn help_body_section_colour_is_distinct_from_subtitle_colour() {
     ..Theme::default()
   };
   assert_eq!(help_body_section_color(&theme), Color::Blue);
+}
+
+// `centered_abs` (issue #243, plan P7): the absolute-width centering shared by
+// the open-menu and link-prompt modals, extracted from two byte-for-byte
+// identical `Rect{}` blocks. Characterisation pins the contract so the
+// extraction (and the `centered_h` delegation) stays behaviour-preserving.
+
+#[test]
+fn centered_abs_centers_a_box_that_fits() {
+  // Nominal: 40×10 box in a 100×40 area → centred both axes.
+  assert_eq!(
+    centered_abs(
+      40,
+      10,
+      Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 40
+      }
+    ),
+    Rect {
+      x: 30,
+      y: 15,
+      width: 40,
+      height: 10
+    }
+  );
+}
+
+#[test]
+fn centered_abs_honours_a_non_zero_area_origin() {
+  // The area's own x/y offset is added to the centred position.
+  assert_eq!(
+    centered_abs(
+      20,
+      6,
+      Rect {
+        x: 5,
+        y: 3,
+        width: 50,
+        height: 20
+      }
+    ),
+    Rect {
+      x: 20,
+      y: 10,
+      width: 20,
+      height: 6
+    }
+  );
+}
+
+#[test]
+fn centered_abs_caps_width_wider_than_the_area() {
+  // Width larger than the area is clamped to the area width; x collapses to 0.
+  assert_eq!(
+    centered_abs(
+      150,
+      10,
+      Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 40
+      }
+    ),
+    Rect {
+      x: 0,
+      y: 15,
+      width: 100,
+      height: 10
+    }
+  );
+}
+
+#[test]
+fn centered_abs_caps_height_taller_than_the_area() {
+  // Edge case the inline modal blocks relied on: a box taller than the
+  // terminal is clamped to the area height and pinned to the top (y = area.y),
+  // because `saturating_sub` floors the vertical gap at 0.
+  assert_eq!(
+    centered_abs(
+      40,
+      50,
+      Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 40
+      }
+    ),
+    Rect {
+      x: 30,
+      y: 0,
+      width: 40,
+      height: 40
+    }
+  );
 }


### PR DESCRIPTION
## Description

`draw_open_menu` and `draw_link_prompt` carried the **same byte-for-byte** absolute-width centering `Rect{}` block. This extracts a shared pure helper and routes the three centering paths through one implementation. Last item of the refactor plan (plan P7).

Closes #243

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- Add `pub fn centered_abs(width, height, area) -> Rect` in `src/tui/ui.rs` — centers an absolute-sized box, clamping both dimensions to the area.
- Route `draw_open_menu` and `draw_link_prompt` through it (the duplicated inline blocks are gone; the caller-side `.min(term.width)` folds into the helper).
- Make `centered_h` delegate to `centered_abs` (percentage → absolute width, then shared arithmetic).
- Re-export `centered_abs` from `src/tui/mod.rs` (test surface, per `lib.rs` "intentionally pub for testability").

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

4 characterisation tests in `tests/tui_ui_helpers_tests.rs` pin the contract: nominal centering, non-zero area origin, width wider than area (clamped), and the **height-taller-than-area** edge case the inline blocks relied on (`saturating_sub` floors the vertical gap → box pinned to the top). Written test-first against a deliberately-wrong stub (red on assertion mismatch) before the real body landed.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

No behaviour change — `centered_abs` (cap-first) is equivalent to both former inline blocks: when `height ≤ area.height` they are identical; when `height > area.height`, `saturating_sub` yields `y = area.y` in both the old and new code. The modal render net (`tui_app_tests`, 209 tests) guards the end-to-end overlay layout. CHANGELOG intentionally untouched (internal refactor, not user-facing).

Codex review (`--base dev`): no functional or blocking issue.