### PR TITLE
✨ feat(tui): async-task layer + off-thread worktree refresh (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Off-thread worktree list refresh: pressing `f` / `r` now re-lists the
+  worktrees on a background worker instead of blocking the event loop, so a
+  large repo or slow filesystem no longer freezes the TUI mid-refresh. The
+  statusbar spinner animates with a `refreshing worktrees…` label and `q` /
+  `Esc` stay responsive while it runs; a failed re-list surfaces on the
+  status bar instead of tearing down the session. Built on a new generic
+  async-task spine (coalescing + late-result drop) that the GitHub fetch,
+  bootstrap, and future panels can adopt.
+  ([#231](https://github.com/kbrdn1/gwm-cli/issues/231))
+
 ### Changed
 
 - Sidebar rendering no longer deep-clones the cached sections on every frame.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,6 @@
 use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
+use super::state::async_task::{TaskKind, TaskMsg, TaskRunner};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -303,6 +304,18 @@ pub struct App {
   /// tick. Held for the lifetime of the `App`; when the `App` drops, any
   /// still-running fetch thread's `send` simply fails and is ignored.
   github_rx: mpsc::Receiver<GithubFetchMsg>,
+
+  /// Generic off-thread task spine (issue #231): coalescing + late-drop
+  /// for slow one-shot ops, starting with the worktree list refresh.
+  /// Public for the same reason `github` is — the state-machine tests
+  /// claim a generation directly without spawning an OS thread.
+  pub tasks: TaskRunner,
+  /// Sender cloned into each background task worker (issue #231).
+  task_tx: mpsc::Sender<TaskMsg>,
+  /// Receiver drained by [`Self::drain_task_results`] each event-loop
+  /// tick. Mirrors the GitHub channel; a worker whose `App` has dropped
+  /// simply fails its `send` and is ignored.
+  task_rx: mpsc::Receiver<TaskMsg>,
 }
 
 impl App {
@@ -343,6 +356,7 @@ impl App {
       state.select(Some(0));
     }
     let (github_tx, github_rx) = mpsc::channel();
+    let (task_tx, task_rx) = mpsc::channel();
     let mut out = Self {
       repo,
       repo_name,
@@ -379,6 +393,9 @@ impl App {
       trust_mode: crate::trust::TrustMode::Prompt,
       github_tx,
       github_rx,
+      tasks: TaskRunner::new(),
+      task_tx,
+      task_rx,
     };
     // Seed the sidebar position from `[tui] sidebar_position` (issue
     // #188). Orientation stays at its `Auto` default — runtime-only.
@@ -454,19 +471,121 @@ impl App {
     Ok(app)
   }
 
+  /// Synchronous worktree list refresh. Kept for internal post-mutation
+  /// callers (create / delete / report-close) that need the list fresh
+  /// *before* the next render; the user-initiated `f` / `r` key path goes
+  /// through the off-thread [`Self::request_refresh`] instead (issue
+  /// #231). Both converge on [`Self::apply_refreshed_worktrees`] so the
+  /// two paths can never drift on the post-list bookkeeping.
   pub fn refresh(&mut self) -> Result<()> {
-    self.worktrees = worktree::list(&self.repo)?;
-    // The cached fuzzy-match indices reference the previous worktrees
-    // vec; drop them so the next render recomputes against the fresh
-    // list. (A length-change auto-invalidates too, but a refresh that
-    // produces a same-length vec with different contents would not —
-    // so the explicit flush is the safe play.)
+    // A synchronous re-list (create / delete / report-close) produces
+    // authoritative fresh state, so any older async refresh still in flight
+    // is by definition stale — bump its generation so `drain_task_results`
+    // drops the late result instead of clobbering this post-mutation list
+    // with a pre-mutation snapshot (issue #231, the #138 race class). A
+    // harmless counter bump when no task is running. Lives here and not in
+    // `apply_refreshed_worktrees` so the async drain, which shares that
+    // tail, does not re-invalidate the run it just applied.
+    self.tasks.invalidate(TaskKind::RefreshWorktrees);
+    let worktrees = worktree::list(&self.repo)?;
+    self.apply_refreshed_worktrees(worktrees);
+    Ok(())
+  }
+
+  /// Swap in a freshly-listed worktree vec and run the bookkeeping every
+  /// refresh path shares: drop the cached fuzzy-match indices (they point
+  /// at the previous vec — a length change auto-invalidates, but a
+  /// same-length list with different contents would not, so the explicit
+  /// flush is the safe play), re-clamp the selection (which re-resolves
+  /// the link cache), invalidate the sidebar preview, and report the
+  /// count. Called by the synchronous [`Self::refresh`] and by the
+  /// off-thread drain in [`Self::drain_task_results`].
+  fn apply_refreshed_worktrees(&mut self, worktrees: Vec<WorktreeInfo>) {
+    self.worktrees = worktrees;
     self.filter.invalidate();
-    // `clamp_selection_to_filter` re-resolves the link cache for us.
     self.clamp_selection_to_filter();
     self.invalidate_sidebar_cache();
     self.status = format!("refreshed — {} worktree(s)", self.worktrees.len());
-    Ok(())
+  }
+
+  /// Off-thread worktree list refresh for the `f` / `r` key (issue #231):
+  /// spawn a worker that re-lists the worktrees and posts the result back
+  /// to the event loop, so a large repo / slow filesystem no longer
+  /// freezes the TUI. Coalesces onto an in-flight run (a second press
+  /// while loading is a no-op) and seeds the loader label + spinner. The
+  /// result is applied by [`Self::drain_task_results`].
+  pub fn request_refresh(&mut self) {
+    let Some(generation) = self.tasks.request(TaskKind::RefreshWorktrees) else {
+      // A refresh is already in flight — coalesce onto it.
+      return;
+    };
+    // Start the loader from a deterministic frame and surface the label.
+    self.spinner.reset();
+    self.status = TaskKind::RefreshWorktrees.loading_label().into();
+    self.spawn_refresh(generation);
+  }
+
+  /// Spawn one background worktree-list worker tagged with `generation`
+  /// (issue #231). A thin shell, mirroring [`Self::spawn_github_fetch`]:
+  /// it owns only the off-thread dispatch + send, no state logic (the
+  /// coalescing / late-drop contract lives in [`TaskRunner`], tested in
+  /// `tui_state_async_task_tests.rs`). `git2::Repository` is not `Send`,
+  /// so the worker opens its *own* repo from the owned `workdir` path
+  /// rather than borrowing `self.repo` — the same "only owned `Send` data
+  /// crosses the boundary" discipline as the GitHub worker. A `send`
+  /// failure (the `App`/receiver dropped) is ignored.
+  fn spawn_refresh(&self, generation: u64) {
+    let tx = self.task_tx.clone();
+    let workdir = self.workdir.clone();
+    std::thread::spawn(move || {
+      let result = worktree::discover_repo(Some(&workdir))
+        .and_then(|repo| worktree::list(&repo))
+        .map_err(|e| e.to_string());
+      let _ = tx.send(TaskMsg::RefreshWorktrees(generation, result));
+    });
+  }
+
+  /// Apply every background task result that has arrived since the last
+  /// call (issue #231), draining the channel without blocking. Each
+  /// result goes through [`TaskRunner::complete`], so a result whose
+  /// generation was bumped mid-flight is dropped (#138 guard, generalised).
+  /// A failed refresh surfaces on the status bar and leaves the list
+  /// intact — what used to be a fatal `refresh()?` that tore down the
+  /// event loop is now a graceful message. Returns `true` if at least one
+  /// result was applied, so the loop can force a redraw.
+  pub fn drain_task_results(&mut self) -> bool {
+    let mut applied = false;
+    while let Ok(msg) = self.task_rx.try_recv() {
+      match msg {
+        TaskMsg::RefreshWorktrees(generation, result) => {
+          if !self.tasks.complete(TaskKind::RefreshWorktrees, generation) {
+            // Late result — a newer run (or an invalidate) superseded it.
+            continue;
+          }
+          match result {
+            Ok(worktrees) => self.apply_refreshed_worktrees(worktrees),
+            Err(e) => self.status = format!("refresh failed: {}", e),
+          }
+          applied = true;
+        }
+      }
+    }
+    applied
+  }
+
+  /// `true` while any background task is in flight (issue #231) — drives
+  /// the statusbar spinner alongside [`Self::is_github_loading`].
+  pub fn is_task_loading(&self) -> bool {
+    self.tasks.is_any_loading()
+  }
+
+  /// A clone of the task channel sender background workers report over
+  /// (issue #231). Exposed so the async-apply path
+  /// ([`Self::drain_task_results`]) can be driven deterministically in
+  /// tests — inject a [`TaskMsg`] exactly as a worker would, then drain —
+  /// without spawning an OS thread. Mirrors [`Self::github_result_sender`].
+  pub fn task_result_sender(&self) -> mpsc::Sender<TaskMsg> {
+    self.task_tx.clone()
   }
 
   /// Drop the cached sidebar content. Call on any change that may have altered

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
 };
+pub use state::async_task::{TaskKind, TaskMsg, TaskRunner};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;
@@ -155,7 +156,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
     // 200ms poll cadence. Drained before the draw so the frame reflects the
     // freshly-applied results.
     app.drain_github_results();
-    if app.is_github_loading() {
+    // Generic off-thread tasks (issue #231): apply any worker results that
+    // landed since the last tick — e.g. an off-thread worktree refresh.
+    app.drain_task_results();
+    if app.is_github_loading() || app.is_task_loading() {
       app.spinner.tick();
     }
 
@@ -454,7 +458,10 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     Action::FocusWorktrees => app.focus_worktrees(),
     Action::FocusStatus => app.focus_status(),
     Action::Filter => app.enter_filter(),
-    Action::Refresh => app.refresh()?,
+    // Issue #231: the user-initiated refresh runs off-thread so a large
+    // repo / slow filesystem no longer freezes the TUI. A failed re-list
+    // now surfaces on the status bar instead of tearing down the loop.
+    Action::Refresh => app.request_refresh(),
     Action::Help => app.enter_help(),
     Action::Yank => yank_selected_path_to_clipboard(app),
     Action::Open => match app.resolve_open_target() {

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -1,0 +1,154 @@
+//! Generic background-task spine for the TUI (issue #231).
+//!
+//! Generalises the off-thread pattern introduced for the GitHub fetch
+//! (#217) so any slow, one-shot operation — currently the worktree list
+//! refresh (`f` / `r`), with bootstrap / launcher-prep to follow — runs
+//! on a worker thread and posts its result back to the event loop rather
+//! than blocking it. The event loop keeps rendering (the statusbar
+//! spinner animates, `q` / `Esc` stay responsive); a result whose run
+//! was superseded mid-flight is dropped.
+//!
+//! Unlike [`super::github_fetch`] this is **not** a result cache. The
+//! GitHub layer caches `(target, number)` lookups and dedupes them; a
+//! refresh / sync / bootstrap is a one-shot "run it, give me a fresh
+//! result" with nothing worth caching by key. So the spine keeps only
+//! two things from that design — *coalescing* and the *late-result
+//! drop* — and drops the per-key cache:
+//!
+//! - `request(kind)` → `Some(generation)` for a cold slot (the caller
+//!   spawns a worker tagged with that generation), or `None` when a run
+//!   of the same `kind` is already in flight (coalesced — no second
+//!   worker).
+//! - the worker computes owned, `Send` data off-thread and posts it back
+//!   tagged with the `generation` it was handed.
+//! - `complete(kind, generation)` → `true` while the generation is still
+//!   authoritative (apply the result), `false` when a later
+//!   `invalidate` / `request` bumped the generation mid-flight (drop the
+//!   late result — the #138 guard, generalised to non-keyed ops).
+//! - `invalidate(kind)` bumps the generation and frees the slot, so any
+//!   in-flight result is dropped and a fresh run may start.
+//!
+//! The threading itself (the `mpsc` channel + `thread::spawn` + the
+//! "resolve owned `Send` data on the main thread" discipline) lives on
+//! the `App` orchestrator, exactly as the GitHub channel does. This
+//! module is pure state — no I/O, no `App` dependency — so the contract
+//! is pinned by `tests/tui_state_async_task_tests.rs`.
+
+use crate::worktree::WorktreeInfo;
+use std::collections::{HashMap, HashSet};
+
+/// Identity of a background task — the coalescing key and the source of
+/// the loader label. One variant per migrated op; bootstrap / sync /
+/// launcher-prep join here as their call sites move off-thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskKind {
+  /// Off-thread worktree list refresh (the `f` / `r` key path). The
+  /// synchronous `App::refresh` stays for internal post-mutation callers
+  /// (create / delete / report-close) that need the list fresh before the
+  /// next render.
+  RefreshWorktrees,
+}
+
+impl TaskKind {
+  /// Human label the loader shows while this task is in flight, mirroring
+  /// the GitHub fetch's "fetching GitHub status…" so every async site
+  /// reads consistently.
+  pub fn loading_label(self) -> &'static str {
+    match self {
+      TaskKind::RefreshWorktrees => "refreshing worktrees…",
+    }
+  }
+}
+
+/// Result of an off-thread task, posted from a worker thread back to the
+/// event loop over `App`'s task channel (issue #231). Carries owned,
+/// `Send` data only (no `git2::Repository` crosses the thread boundary)
+/// plus the `generation` the worker was spawned with, so
+/// [`TaskRunner::complete`] can drop a superseded late result.
+pub enum TaskMsg {
+  /// A worktree list refresh result: the freshly-listed worktrees, or a
+  /// stringified error from the off-thread `discover_repo` + `list`.
+  RefreshWorktrees(u64, std::result::Result<Vec<WorktreeInfo>, String>),
+}
+
+/// Coalescing + late-drop spine for background tasks (issue #231).
+///
+/// See the module docs for the full contract. The short version: the
+/// `App` calls [`Self::request`] before spawning a worker, branches on
+/// the returned generation, and reports the worker's result back via
+/// [`Self::complete`] so a superseded late result is dropped.
+#[derive(Debug, Default)]
+pub struct TaskRunner {
+  /// Current authoritative generation per kind. Bumped on each `request`
+  /// (a cold spawn) and on each `invalidate`; a result whose generation
+  /// no longer matches is dropped. Absent keys are generation 0.
+  generation: HashMap<TaskKind, u64>,
+  /// Kinds with a worker currently in flight. A `request` for a kind
+  /// already here is coalesced (returns `None`); drives the loader's
+  /// "is anything loading" signal.
+  running: HashSet<TaskKind>,
+}
+
+impl TaskRunner {
+  /// Construct an empty runner — no generations claimed, nothing in
+  /// flight. The `App` constructor calls this once.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Claim a run of `kind`. Returns `Some(generation)` for a cold slot —
+  /// the caller owns the off-thread spawn and must tag the worker's
+  /// result with that generation — or `None` when a run of the same
+  /// `kind` is already in flight (coalesced; no second worker).
+  pub fn request(&mut self, kind: TaskKind) -> Option<u64> {
+    // Coalesce: a run of this kind is already in flight, so a second
+    // request rides on it instead of spawning a redundant worker.
+    if self.running.contains(&kind) {
+      return None;
+    }
+    let generation = self.generation.entry(kind).or_insert(0);
+    *generation += 1;
+    let claimed = *generation;
+    self.running.insert(kind);
+    Some(claimed)
+  }
+
+  /// Drop any in-flight run of `kind` and bump the generation so a late
+  /// result is discarded, freeing the slot for a fresh run.
+  pub fn invalidate(&mut self, kind: TaskKind) {
+    *self.generation.entry(kind).or_insert(0) += 1;
+    self.running.remove(&kind);
+  }
+
+  /// Decide whether a result tagged `generation` for `kind` is still
+  /// authoritative. Returns `true` (apply it) only when the generation
+  /// matches the current one and a run was in flight, clearing the slot;
+  /// returns `false` for a late result whose generation was bumped by an
+  /// intervening `invalidate` / `request` (the #138 guard).
+  pub fn complete(&mut self, kind: TaskKind, generation: u64) -> bool {
+    let current = self.generation.get(&kind).copied().unwrap_or(0);
+    // Short-circuit on a stale generation so the still-authoritative slot
+    // of a *newer* run is never cleared by an older worker's late report.
+    if generation != current {
+      return false;
+    }
+    self.running.remove(&kind)
+  }
+
+  /// `true` while a run of `kind` is in flight.
+  pub fn is_loading(&self, kind: TaskKind) -> bool {
+    self.running.contains(&kind)
+  }
+
+  /// `true` while any task is in flight — drives the statusbar spinner
+  /// alongside the GitHub fetch's own loading signal.
+  pub fn is_any_loading(&self) -> bool {
+    !self.running.is_empty()
+  }
+
+  /// The loader label for an in-flight task, if any. `None` when nothing
+  /// is loading.
+  pub fn loading_label(&self) -> Option<&'static str> {
+    self.running.iter().next().map(|kind| kind.loading_label())
+  }
+}

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -11,7 +11,9 @@
 //! - `link_prompt` — two-stage issue/PR linking prompt (#126)
 //! - `sidebar` — scroll offsets + commit-line cache (#127)
 //! - `github_fetch` — TTL cache + inflight dedupe for `gh` shell-outs (#128, this PR)
+//! - `async_task` — generic off-thread spine (coalescing + late-drop) for slow ops (#231)
 
+pub mod async_task;
 pub mod confirm;
 pub mod create_form;
 pub mod filter;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1796,11 +1796,12 @@ pub fn status_line(
 
 fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   let ctx = app.hint_context();
-  // Spinner shows only while a GitHub fetch is inflight (issue #217). The
-  // frame advances at the poll cadence once the fetch runs off-thread
-  // (#217 async path); with a blocking fetch the Loading state is too brief
-  // to paint, which is exactly why the async path matters.
-  let spinner = if app.is_github_loading() {
+  // Spinner shows while any async op is inflight: a GitHub fetch (issue
+  // #217) or a generic background task such as the off-thread worktree
+  // refresh (issue #231). Both render through the same statusbar spinner +
+  // per-op label (carried on `app.status`) so "loading" reads consistently
+  // across every async site. The frame advances at the poll cadence.
+  let spinner = if app.is_github_loading() || app.is_task_loading() {
     Some(app.spinner.glyph(DOT_FRAMES))
   } else {
     None

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3764,3 +3764,131 @@ fn create_key_esc_requests_cancel() {
     CreateKey::Cancel
   ));
 }
+
+// ---------------------------------------------------------------------------
+// Async-task layer — off-thread worktree refresh (issue #231)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn drain_applies_async_refresh_result() {
+  // Issue #231: a worktree list refresh delivered off-thread (over the task
+  // channel) is applied by `drain_task_results`, swapping in the fresh list
+  // and clearing the loading slot — the deterministic analogue of the
+  // background worker, with no real OS thread (the flaky-thread-test trap).
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  // Claim the slot exactly as `request_refresh` would, without spawning.
+  let generation = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  assert!(app.is_task_loading(), "request must mark the app as loading");
+
+  let fresh = vec![worktree_fixture("alpha"), worktree_fixture("beta")];
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorktrees(generation, Ok(fresh)))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "drain must report it applied a result");
+  assert_eq!(app.worktrees.len(), 2, "the fresh list replaces the old one");
+  assert!(!app.is_task_loading(), "no task should be inflight after draining");
+  assert!(
+    app.status.contains("refreshed"),
+    "status reports the refresh outcome: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn drain_drops_async_refresh_invalidated_mid_flight() {
+  // Issue #231 carries the #138 guarantee onto the generic spine: a refresh
+  // result whose generation was bumped by an intervening invalidate is
+  // dropped, leaving the current list untouched.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let before = app.worktrees.len();
+  let stale = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  // The run is superseded (e.g. a fresh `f` or a future invalidation hook).
+  app.tasks.invalidate(TaskKind::RefreshWorktrees);
+  // The late worker reports back after the bump.
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorktrees(stale, Ok(vec![worktree_fixture("ghost")])))
+    .unwrap();
+  app.drain_task_results();
+  assert_eq!(
+    app.worktrees.len(),
+    before,
+    "a refresh invalidated mid-flight must be dropped, not applied"
+  );
+}
+
+#[test]
+fn drain_async_refresh_failure_surfaces_status_without_touching_the_list() {
+  // Off-thread refresh converts what used to be a fatal `refresh()?` (which
+  // tore down the event loop) into a graceful status message; the list is
+  // left as-is so the UI keeps showing the last good state.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let before = app.worktrees.len();
+  let generation = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorktrees(generation, Err("boom".into())))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "a failure still counts as a drained result");
+  assert_eq!(app.worktrees.len(), before, "a failed refresh leaves the list intact");
+  assert!(!app.is_task_loading(), "the slot clears even on failure");
+  assert!(
+    app.status.contains("boom"),
+    "the error reaches the status bar: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn request_refresh_coalesces_onto_an_inflight_run() {
+  // A second `f` press while a refresh is already in flight must not spawn a
+  // second worker — `request_refresh` coalesces and returns early (so this
+  // test spawns zero threads).
+  use gwm::tui::state::async_task::TaskKind;
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  app.request_refresh(); // coalesced — no panic, no second worker
+  assert!(app.is_task_loading());
+  assert!(
+    app.tasks.complete(TaskKind::RefreshWorktrees, generation),
+    "the original run is still the authoritative one after a coalesced press"
+  );
+}
+
+#[test]
+fn sync_refresh_invalidates_an_inflight_async_refresh() {
+  // Issue #231 race guard: a synchronous `refresh()` (the create / delete /
+  // report-close path) must bump the task generation so a still-in-flight
+  // async refresh — spawned with a *pre-mutation* snapshot — is dropped
+  // rather than clobbering the authoritative post-mutation list.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  // An async refresh is in flight (claimed exactly as `request_refresh` would).
+  let stale = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  // A delete/create lands and re-lists synchronously while the worker runs.
+  app.refresh().unwrap();
+  let authoritative = app.worktrees.len();
+  // The pre-mutation worker now reports its stale snapshot.
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorktrees(stale, Ok(vec![worktree_fixture("ghost")])))
+    .unwrap();
+  app.drain_task_results();
+  assert_eq!(
+    app.worktrees.len(),
+    authoritative,
+    "the stale pre-mutation snapshot must not replace the sync-refreshed list"
+  );
+  assert!(
+    !app.worktrees.iter().any(|w| w.name == "ghost"),
+    "the dropped result's payload must never reach the list"
+  );
+}

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -1,0 +1,104 @@
+//! Unit tests for the pure `TaskRunner` spine (issue #231).
+//!
+//! `TaskRunner` is the generalised off-thread spine extracted from the
+//! GitHub fetch (#217). Unlike `state::github_fetch` (a per-key result
+//! *cache* + dedupe), this is a *coalescing + late-drop* layer for
+//! one-shot ops that always want a fresh result:
+//!
+//! - `request(kind)` on a cold slot returns `Some(generation)` (the
+//!   caller spawns a worker tagged with that generation); a second
+//!   `request` while a run is in flight returns `None` (coalesced — no
+//!   second worker).
+//! - `complete(kind, generation)` returns `true` only while the
+//!   generation is still authoritative; a late result whose generation
+//!   was bumped by an intervening `invalidate`/`request` returns `false`
+//!   and is dropped (the #138 stale-result guard, generalised to
+//!   non-keyed ops).
+//! - `invalidate(kind)` bumps the generation and frees the slot.
+
+use gwm::tui::state::async_task::{TaskKind, TaskRunner};
+
+#[test]
+fn request_on_cold_slot_returns_a_generation_and_marks_loading() {
+  let mut runner = TaskRunner::new();
+  assert!(!runner.is_loading(TaskKind::RefreshWorktrees));
+  let gen = runner.request(TaskKind::RefreshWorktrees);
+  assert_eq!(gen, Some(1), "first request claims generation 1");
+  assert!(runner.is_loading(TaskKind::RefreshWorktrees));
+  assert!(runner.is_any_loading());
+}
+
+#[test]
+fn second_request_while_inflight_is_coalesced() {
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.request(TaskKind::RefreshWorktrees), Some(1));
+  // A run is already in flight → no second worker is spawned.
+  assert_eq!(
+    runner.request(TaskKind::RefreshWorktrees),
+    None,
+    "a concurrent request must coalesce onto the in-flight run"
+  );
+}
+
+#[test]
+fn complete_with_matching_generation_applies_and_clears_loading() {
+  let mut runner = TaskRunner::new();
+  let gen = runner.request(TaskKind::RefreshWorktrees).unwrap();
+  assert!(
+    runner.complete(TaskKind::RefreshWorktrees, gen),
+    "a result tagged with the live generation is authoritative"
+  );
+  assert!(
+    !runner.is_loading(TaskKind::RefreshWorktrees),
+    "completing the run clears the loading slot"
+  );
+  assert!(!runner.is_any_loading());
+}
+
+#[test]
+fn late_result_after_invalidate_is_dropped() {
+  // The #138 guard generalised: spawn gen 1, invalidate (bumps to gen 2),
+  // then a worker from gen 1 reports back → dropped, not applied.
+  let mut runner = TaskRunner::new();
+  let stale = runner.request(TaskKind::RefreshWorktrees).unwrap();
+  runner.invalidate(TaskKind::RefreshWorktrees);
+  assert!(
+    !runner.is_loading(TaskKind::RefreshWorktrees),
+    "invalidate frees the slot"
+  );
+  assert!(
+    !runner.complete(TaskKind::RefreshWorktrees, stale),
+    "a result from the invalidated generation must be dropped"
+  );
+}
+
+#[test]
+fn invalidate_frees_the_slot_for_a_fresh_run_with_a_new_generation() {
+  let mut runner = TaskRunner::new();
+  let first = runner.request(TaskKind::RefreshWorktrees).unwrap();
+  runner.invalidate(TaskKind::RefreshWorktrees);
+  let second = runner
+    .request(TaskKind::RefreshWorktrees)
+    .expect("slot is free after invalidate");
+  assert!(second > first, "a fresh run claims a newer generation");
+  // The new run is authoritative; the stale one is not.
+  assert!(!runner.complete(TaskKind::RefreshWorktrees, first));
+  assert!(runner.complete(TaskKind::RefreshWorktrees, second));
+}
+
+#[test]
+fn complete_on_a_kind_never_requested_is_dropped() {
+  let mut runner = TaskRunner::new();
+  assert!(
+    !runner.complete(TaskKind::RefreshWorktrees, 1),
+    "no run was ever claimed → nothing to apply"
+  );
+}
+
+#[test]
+fn loading_label_surfaces_the_inflight_task_label() {
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.loading_label(), None);
+  runner.request(TaskKind::RefreshWorktrees);
+  assert_eq!(runner.loading_label(), Some("refreshing worktrees…"));
+}


### PR DESCRIPTION
## Description

Generalise the off-thread pattern from the #217 GitHub fetch into a reusable **async-task spine**, and migrate the user-initiated worktree list refresh (`f` / `r`) onto it so a large repo / slow filesystem no longer freezes the TUI event loop. This is the foundation the near-term panels build their loading state on (#226 logs modal, #4 config panel).

Closes #231

## Type of change

- [x] ✨ Feature (new functionality)
- [x] ⚡ Perf (non-blocking event loop)

## Changes

- **`state/async_task.rs`** — a pure `TaskRunner` spine. Unlike `state::github_fetch` (a per-key result *cache* + dedupe), it keeps only the two parts that generalise — **coalescing** (one worker per `TaskKind` in flight) and the **late-result drop** (a generation counter; a report whose generation was bumped by an intervening `invalidate`/`request` is discarded — the #138 guard generalised). No result cache: a refresh/sync/bootstrap always wants fresh data.
- **Off-thread refresh** — `Action::Refresh` now calls `request_refresh`, which spawns a worker that opens its *own* `git2::Repository` from the owned `workdir` (`Repository` is not `Send`) and posts the fresh list back. The loop drains it via `drain_task_results` and applies it through the same `apply_refreshed_worktrees` tail the synchronous `refresh` uses, so the two paths can't drift.
- **Sync/async coordination** — the synchronous `refresh` (kept for internal post-create/delete/report-close callers that need the list fresh before the next render) bumps the task generation, so a pre-mutation async snapshot still in flight is dropped instead of clobbering the post-mutation list (regression-tested).
- **Graceful failure** — a failed off-thread re-list surfaces on the status bar instead of tearing down the loop via `refresh()?`.
- **Consistent loader render** — the statusbar spinner animates while *either* a GitHub fetch or a background task is in flight, with the per-op label (`refreshing worktrees…`) on the status line, so "loading" reads the same across async sites.

## Scope / follow-ups

Kept atomic (per house rules). Deferred to follow-ups, noted here:
- migrate the existing GitHub fetch channel onto the spine (render is already unified; threading stays on its own channel for now);
- move bootstrap (`b`) off-thread (it transitions to `View::Report` on completion — more invasive);
- a standalone loader **widget** for the dedicated-area panels (#226 / #4) — no real consumer exists yet, so building it now would be dead code (YAGNI). `gwm sync` is not wired into the TUI today, so it's out of scope.

## Tests

- [x] `cargo test` passes locally (full suite, also under a stripped `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD)

TDD: `tui_state_async_task_tests.rs` pins the pure spine (generation, coalescing, late-drop) — written red against a wrong stub first. `tui_app_tests.rs` adds the app-level drain (happy / late-drop / failure / coalescing) and the **sync↔async race guard** (verified red without the one-line generation bump, green with it), all driven deterministically through `task_result_sender()` with no real OS thread.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

The load-bearing subtlety is the **generation late-drop** and its coordination with the surviving synchronous `refresh()` — the bug an early version had (a pre-mutation worker clobbering a post-delete list) is now pinned by `sync_refresh_invalidates_an_inflight_async_refresh`. The worker only ever moves owned `Send` data across the thread boundary (it opens its own repo from `workdir`), mirroring the #217 GitHub worker.