### PR TITLE
✨ feat(tui): Command Logs modal on `3` (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Command Logs overlay: press `3` to open a lazygit-style, scrollable
+  transcript of the external commands gwm ran — the resolved command line,
+  duration, exit status, and captured output — newest-first over a ~90%
+  fullscreen modal. Scrolls like the help overlay (`j`/`k`, `g`/`G`,
+  `h`/`l`); `Esc` / `q` / `3` closes it. Completes the `1`/`2`/`3`
+  pane-key family and gives the single-line statusbar action log a full
+  scrollback. The transcript records `gh` GitHub calls, bootstrap shell
+  steps, and lifecycle hooks; read-only sidebar previews are excluded to
+  keep it signal-rich. Reachable by name via `:command-logs`; the `3`
+  binding is rebindable through `[tui.keys] command_logs`.
+  ([#226](https://github.com/kbrdn1/gwm-cli/issues/226))
 - Off-thread worktree list refresh: pressing `f` / `r` now re-lists the
   worktrees on a background worker instead of blocking the event loop, so a
   large repo or slow filesystem no longer freezes the TUI mid-refresh. The

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,10 +90,15 @@ If an issue still shows `open` on GitHub even though its work shipped, it's a tr
 
 Near-term TUI work, listed in **rough implementation order** — each item builds on the one above it. This is a dependency ordering, not a date commitment.
 
-1. [#231](https://github.com/kbrdn1/gwm-cli/issues/231) — **Async-task layer + better loader render** — the foundation. Generalise #217's off-thread GitHub fetch into a shared worker-thread + loader so list refresh (`f`), `sync`, bootstrap (`b`), and launcher spawns stop blocking the event loop, all rendering through one consistent loader widget. Everything below shows its loading state through this layer.
-2. [#226](https://github.com/kbrdn1/gwm-cli/issues/226) — **Command Logs modal (`3`)** — first consumer of the modal-on-a-number-key pattern; a scrollable transcript of every command gwm runs (argv, timing, exit, output), streamed through the new loader. Completes the `1`/`2`/`3` panel family and gives the single-line statusbar action log (#217) a full scrollback.
-3. [#232](https://github.com/kbrdn1/gwm-cli/issues/232) — **Configuration panel (`4`)** — the next pane in the family; a ~90% fullscreen modal (same pattern as #226 / #35, outside the `Tab` cycle) showing the **resolved** `.gwm.toml` (repo deep-merged with the user-level config, with a source column), reusing the merge logic already behind `gwm config list`.
-4. [#233](https://github.com/kbrdn1/gwm-cli/issues/233) — **Open docs in the browser (`.`)** — dependency-free quick win; a `.` key that opens the docs, reusing the `O` / `gwm open` browser-spawn path. Can land at any point.
+**Landed on `dev`** (unreleased — moves into the shipped table when the next version is cut):
+
+- [#231](https://github.com/kbrdn1/gwm-cli/issues/231) — **Async-task layer** — the foundation. A generic off-thread spine (`TaskRunner`: coalescing + late-result drop) that moved the worktree list refresh (`f` / `r`) off the event loop, rendering its loading state through the statusbar spinner. ([PR #254](https://github.com/kbrdn1/gwm-cli/pull/254)) Follow-ups: [#255](https://github.com/kbrdn1/gwm-cli/issues/255) (migrate the GitHub fetch onto the spine), [#256](https://github.com/kbrdn1/gwm-cli/issues/256) (bootstrap `b` off-thread), [#257](https://github.com/kbrdn1/gwm-cli/issues/257) (standalone loader widget — deferred to land with its first real consumer, #232 / #4), [#258](https://github.com/kbrdn1/gwm-cli/issues/258) (expose `gwm sync` as a TUI action).
+- [#226](https://github.com/kbrdn1/gwm-cli/issues/226) — **Command Logs modal (`3`)** — a lazygit-style, scrollable transcript of the external commands gwm ran (`gh` calls, bootstrap shell steps, lifecycle hooks) with resolved argv, timing, exit status, and captured output, newest-first over a ~90% fullscreen modal. Completes the `1`/`2`/`3` pane-key family and gives the single-line statusbar action log (#217) a full scrollback. ([PR #259](https://github.com/kbrdn1/gwm-cli/pull/259))
+
+**Queued**, in rough implementation order:
+
+1. [#232](https://github.com/kbrdn1/gwm-cli/issues/232) — **Configuration panel (`4`)** — the next pane in the family; a ~90% fullscreen modal (same pattern as #226 / #35, outside the `Tab` cycle) showing the **resolved** `.gwm.toml` (repo deep-merged with the user-level config, with a source column), reusing the merge logic already behind `gwm config list`. The natural first home for the standalone loader widget ([#257](https://github.com/kbrdn1/gwm-cli/issues/257)), which has a genuine async loading area here.
+2. [#233](https://github.com/kbrdn1/gwm-cli/issues/233) — **Open docs in the browser (`.`)** — dependency-free quick win; a `.` key that opens the docs, reusing the `O` / `gwm open` browser-spawn path. Can land at any point.
 
 ## Ambitious
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -616,8 +616,11 @@ fn exec_shell(step: &CommandStep, cwd: &Path) -> Result<String> {
   // generalised in #65 so other subcommands (gwm tmux / gwm zellij)
   // don't inherit a misleading "bootstrap" prefix on their own
   // spawn failures.
-  let out = cmd
-    .output()
+  // Record on the Command Logs transcript (issue #226): a bootstrap step
+  // is an external command gwm ran. The logged line is the user-authored
+  // shell script, not the `sh -c` wrapper, so the transcript reads like the
+  // command the user wrote.
+  let out = crate::command_log::run_logged(&mut cmd, step.run.clone())
     .map_err(|e| GwmError::CommandFailed(format!("bootstrap step '{}': {}", step.name, e)))?;
   let stdout = String::from_utf8_lossy(&out.stdout).to_string();
   let stderr = String::from_utf8_lossy(&out.stderr).to_string();

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -168,10 +168,17 @@ pub fn reset() {
 fn bound_output(stdout: &[u8], stderr: &[u8]) -> String {
   let stdout = String::from_utf8_lossy(stdout);
   let stdout = stdout.trim();
-  let combined = if stdout.is_empty() {
-    String::from_utf8_lossy(stderr).trim().to_string()
-  } else {
-    stdout.to_string()
+  let stderr = String::from_utf8_lossy(stderr);
+  let stderr = stderr.trim();
+  // Keep BOTH streams: a command that writes progress to stdout and its
+  // diagnostics to stderr before failing must not lose the error text in
+  // the transcript — the modal is for troubleshooting (Codex review #259).
+  // Stdout first, stderr after, joined when both are present.
+  let combined = match (stdout.is_empty(), stderr.is_empty()) {
+    (true, true) => String::new(),
+    (false, true) => stdout.to_string(),
+    (true, false) => stderr.to_string(),
+    (false, false) => format!("{stdout}\n{stderr}"),
   };
   if combined.len() <= MAX_OUTPUT_BYTES {
     return combined;

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -1,0 +1,215 @@
+//! In-memory transcript of the external commands gwm runs (issue #226).
+//!
+//! gwm shells out to `gh` (GitHub status), bootstrap shell steps, and
+//! lifecycle hooks. The single-line statusbar action log (#217) shows only
+//! the most recent action and is ephemeral; this module keeps a bounded,
+//! scrollable history behind the lazygit-style Command Logs modal.
+//!
+//! ## Why a process-global ring
+//!
+//! The exec chokepoints live in library modules with no `App` handle
+//! (`github::run_gh_with` runs on a worker thread, #217), so the sink has
+//! to be reachable without threading a logger through every call site. A
+//! `LazyLock<Mutex<…>>` ring mirrors the existing static caches
+//! (`naming`'s compiled regexes, the recent-commits cache) and tolerates
+//! cross-thread writes from the off-thread GitHub fetch.
+//!
+//! The TUI never renders straight off this global: `App` takes a
+//! [`snapshot`] into `state::command_logs` so the modal renders from owned
+//! `App` state. That keeps the render path testable without the global and
+//! is the boundary the modal-render tests inject through.
+//!
+//! ## Scope (deliberately narrow for the first cut)
+//!
+//! Only the **captured-output** shell commands are logged: `gh`, bootstrap
+//! steps, hooks. The read-only sidebar previews (`worktree::run_git` for
+//! `git log` / `git status`) are *not* — they fire on every selection
+//! change and would bury the real operations in noise. Interactive
+//! launchers (`.status()` / `.spawn()`, which inherit the terminal and have
+//! no captured output) and the libgit2 worktree ops (which run no
+//! subprocess) are out of scope here; `gwm sync` joins once it has a TUI
+//! action (#258).
+
+use std::collections::VecDeque;
+use std::process::{Command, Output};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+/// Upper bound on retained entries. Old entries are evicted FIFO once the
+/// ring is full — a transcript, not an audit trail (the operation journal
+/// behind `gwm undo` / `gwm history` is the durable record).
+pub const MAX_ENTRIES: usize = 256;
+
+/// Cap on the captured output stored per entry. Keeps a chatty command
+/// (a verbose hook, a large `gh … --json`) from ballooning the in-memory
+/// log; the tail is kept since that is where errors surface.
+const MAX_OUTPUT_BYTES: usize = 8 * 1024;
+
+/// How a logged command finished.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandStatus {
+  /// The process ran to completion. `Some(code)` is its exit status;
+  /// `None` means it was terminated by a signal (no code on Unix).
+  Exited(Option<i32>),
+  /// The process could not be spawned at all (binary missing, etc.).
+  Spawn,
+}
+
+impl CommandStatus {
+  /// `true` only for a clean `exit 0`. A signal death or spawn failure is
+  /// never a success.
+  pub fn is_success(&self) -> bool {
+    matches!(self, CommandStatus::Exited(Some(0)))
+  }
+}
+
+/// One executed command in the transcript: the resolved command line, how
+/// long it took, how it finished, and its captured (bounded) output.
+#[derive(Debug, Clone)]
+pub struct CommandLogEntry {
+  /// Human-readable resolved command line, e.g. `gh issue view 226 --json …`.
+  pub command: String,
+  /// Wall-clock duration of the call.
+  pub duration: Duration,
+  /// How the command finished.
+  pub status: CommandStatus,
+  /// Captured stdout (or stderr when stdout was empty), trimmed and
+  /// tail-bounded to [`MAX_OUTPUT_BYTES`]. Empty when nothing was captured.
+  pub output: String,
+}
+
+impl CommandLogEntry {
+  /// `true` when the command exited cleanly. Drives the green/red colour
+  /// of the status line in the modal.
+  pub fn is_success(&self) -> bool {
+    self.status.is_success()
+  }
+}
+
+/// Bounded FIFO ring of [`CommandLogEntry`]. Pure state — no global, no
+/// I/O — so its push/evict/snapshot contract is unit-testable in
+/// isolation.
+#[derive(Debug, Default)]
+pub struct CommandLog {
+  entries: VecDeque<CommandLogEntry>,
+}
+
+impl CommandLog {
+  /// An empty log.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Append `entry`, evicting the oldest when the ring is already at
+  /// [`MAX_ENTRIES`].
+  pub fn push(&mut self, entry: CommandLogEntry) {
+    if self.entries.len() == MAX_ENTRIES {
+      self.entries.pop_front();
+    }
+    self.entries.push_back(entry);
+  }
+
+  /// Number of retained entries.
+  pub fn len(&self) -> usize {
+    self.entries.len()
+  }
+
+  /// `true` when nothing has been logged yet.
+  pub fn is_empty(&self) -> bool {
+    self.entries.is_empty()
+  }
+
+  /// Oldest-first iterator over the retained entries.
+  pub fn iter(&self) -> impl Iterator<Item = &CommandLogEntry> {
+    self.entries.iter()
+  }
+
+  /// Owned, oldest-first clone of the retained entries — the boundary the
+  /// TUI copies across so it never renders off the live global.
+  pub fn snapshot(&self) -> Vec<CommandLogEntry> {
+    self.entries.iter().cloned().collect()
+  }
+
+  /// Drop every entry.
+  pub fn clear(&mut self) {
+    self.entries.clear();
+  }
+}
+
+/// The process-global transcript. Written from the exec chokepoints
+/// (including the off-thread GitHub fetch worker), read by `App` via
+/// [`snapshot`].
+static GLOBAL: LazyLock<Mutex<CommandLog>> = LazyLock::new(|| Mutex::new(CommandLog::new()));
+
+/// Record a finished command on the global log. Lock-poison-safe: a
+/// poisoned mutex drops the entry rather than panicking — logging must
+/// never take down a real operation.
+pub fn record(entry: CommandLogEntry) {
+  if let Ok(mut log) = GLOBAL.lock() {
+    log.push(entry);
+  }
+}
+
+/// Oldest-first snapshot of the global log. Returns empty on a poisoned
+/// lock rather than panicking.
+pub fn snapshot() -> Vec<CommandLogEntry> {
+  GLOBAL.lock().map(|log| log.snapshot()).unwrap_or_default()
+}
+
+/// Clear the global log. Used by the (future) in-TUI "clear logs" action
+/// and by tests that need a clean slate.
+pub fn reset() {
+  if let Ok(mut log) = GLOBAL.lock() {
+    log.clear();
+  }
+}
+
+/// Trim and tail-bound captured output for storage on an entry.
+fn bound_output(stdout: &[u8], stderr: &[u8]) -> String {
+  let stdout = String::from_utf8_lossy(stdout);
+  let stdout = stdout.trim();
+  let combined = if stdout.is_empty() {
+    String::from_utf8_lossy(stderr).trim().to_string()
+  } else {
+    stdout.to_string()
+  };
+  if combined.len() <= MAX_OUTPUT_BYTES {
+    return combined;
+  }
+  // Keep the tail (where errors land), snapped to a char boundary.
+  let cut = combined.len() - MAX_OUTPUT_BYTES;
+  let start = (cut..combined.len())
+    .find(|&i| combined.is_char_boundary(i))
+    .unwrap_or(combined.len());
+  combined[start..].to_string()
+}
+
+/// Run `cmd`, recording an entry on the global log, and return the raw
+/// [`Output`] exactly as [`Command::output`] would.
+///
+/// `command` is the resolved, human-readable command line stored on the
+/// entry (the caller builds it so the transcript shows the real argv, not
+/// an opaque `sh -c`). Times the call, captures stdout/stderr + exit, and
+/// records the entry whether the command succeeded, failed, or could not be
+/// spawned. The returned `Result` is the caller's to handle — this wrapper
+/// only observes, it never swallows the error.
+pub fn run_logged(cmd: &mut Command, command: String) -> std::io::Result<Output> {
+  let start = Instant::now();
+  let result = cmd.output();
+  let duration = start.elapsed();
+  match &result {
+    Ok(out) => record(CommandLogEntry {
+      command,
+      duration,
+      status: CommandStatus::Exited(out.status.code()),
+      output: bound_output(&out.stdout, &out.stderr),
+    }),
+    Err(_) => record(CommandLogEntry {
+      command,
+      duration,
+      status: CommandStatus::Spawn,
+      output: String::new(),
+    }),
+  }
+  result
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -585,9 +585,18 @@ where
   I: IntoIterator<Item = S>,
   S: AsRef<OsStr>,
 {
-  let output = Command::new(program)
-    .args(args)
-    .output()
+  // Collect the args once so they can both drive the spawn and build the
+  // human-readable command line stored on the Command Logs transcript
+  // (issue #226): the resolved `gh <args…>`, not an opaque handle.
+  let collected: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
+  let mut cmdline = program.to_string_lossy().into_owned();
+  for arg in &collected {
+    cmdline.push(' ');
+    cmdline.push_str(&arg.to_string_lossy());
+  }
+  let mut cmd = Command::new(program);
+  cmd.args(&collected);
+  let output = crate::command_log::run_logged(&mut cmd, cmdline)
     .map_err(|e| GwmError::CommandFailed(format!("gh: failed to spawn ({}). Is `gh` installed and on PATH?", e)))?;
   if !output.status.success() {
     return Err(GwmError::CommandFailed(format!(

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,6 +15,7 @@ use crate::naming::parse_branch;
 use git2::Repository;
 use serde::Deserialize;
 use std::ffi::{OsStr, OsString};
+use std::path::Path;
 use std::process::Command;
 use std::sync::LazyLock;
 
@@ -577,6 +578,25 @@ where
   run_gh_with(&gh_program(), args)
 }
 
+/// Build the human-readable command line stored on the Command Logs
+/// transcript (issue #226) for a `gh` invocation: the program's *file name*
+/// (so a `GWM_GH=/usr/bin/gh` override still reads as `gh issue view …`
+/// rather than leaking the full path) followed by the resolved args. Kept
+/// pure and `pub` so its argv format is unit-testable without spawning `gh`
+/// (which CI runners do not have).
+pub fn gh_command_line(program: &OsStr, args: &[OsString]) -> String {
+  let name = Path::new(program)
+    .file_name()
+    .map(|n| n.to_string_lossy().into_owned())
+    .unwrap_or_else(|| program.to_string_lossy().into_owned());
+  let mut line = name;
+  for arg in args {
+    line.push(' ');
+    line.push_str(&arg.to_string_lossy());
+  }
+  line
+}
+
 /// [`run_gh`] against an explicitly resolved `gh` program. Lets callers on
 /// a worker thread (issue #217) avoid re-reading `GWM_GH` / the process
 /// environment concurrently with env-mutating code on other threads.
@@ -588,12 +608,8 @@ where
   // Collect the args once so they can both drive the spawn and build the
   // human-readable command line stored on the Command Logs transcript
   // (issue #226): the resolved `gh <args…>`, not an opaque handle.
-  let collected: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
-  let mut cmdline = program.to_string_lossy().into_owned();
-  for arg in &collected {
-    cmdline.push(' ');
-    cmdline.push_str(&arg.to_string_lossy());
-  }
+  let collected: Vec<OsString> = args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
+  let cmdline = gh_command_line(program, &collected);
   let mut cmd = Command::new(program);
   cmd.args(&collected);
   let output = crate::command_log::run_logged(&mut cmd, cmdline)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod aliases;
 pub mod bootstrap;
 pub mod cli;
+pub mod command_log;
 pub mod config;
 pub mod config_cli;
 pub mod doctor;

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -234,11 +234,14 @@ fn run_step(step: &HookStep, ctx: &HookContext) -> std::result::Result<String, S
     .map(|(key, value)| (key.clone(), expand_placeholders(value, ctx)))
     .collect::<HashMap<_, _>>();
   let mut cmd = Command::new("sh");
-  cmd.arg("-c").arg(run).current_dir(&ctx.cwd);
+  cmd.arg("-c").arg(&run).current_dir(&ctx.cwd);
   for (key, value) in env {
     cmd.env(key, value);
   }
-  let out = cmd.output().map_err(|e| format!("failed to spawn: {}", e))?;
+  // Record on the Command Logs transcript (issue #226): a lifecycle hook is
+  // an external command gwm ran. Log the placeholder-expanded script the
+  // user authored, not the `sh -c` wrapper.
+  let out = crate::command_log::run_logged(&mut cmd, run.clone()).map_err(|e| format!("failed to spawn: {}", e))?;
   let stdout = String::from_utf8_lossy(&out.stdout).to_string();
   let stderr = String::from_utf8_lossy(&out.stderr).to_string();
   let detail = if stdout.is_empty() { stderr } else { stdout };

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
 use super::state::async_task::{TaskKind, TaskMsg, TaskRunner};
+use super::state::command_logs::CommandLogs;
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -79,6 +80,11 @@ pub enum View {
   /// / `palette_cycle_*` / `accept_command_palette` /
   /// `close_command_palette`.
   CommandPalette,
+  /// Command Logs overlay (issue #226). A ~90% fullscreen modal over a
+  /// dimmed list showing the lazygit-style transcript of the external
+  /// commands gwm ran. Opened on `3`, scrolled like the help overlay;
+  /// state lives on [`App::command_logs`].
+  CommandLogs,
 }
 
 /// What the run loop must do after [`App::handle_create_key`] processes a
@@ -316,6 +322,11 @@ pub struct App {
   /// tick. Mirrors the GitHub channel; a worker whose `App` has dropped
   /// simply fails its `send` and is ignored.
   task_rx: mpsc::Receiver<TaskMsg>,
+
+  /// Command Logs overlay state (issue #226): the scroll cursor plus an
+  /// owned snapshot of the [`crate::command_log`] global, so the modal
+  /// renders off `App` state rather than locking the global mid-frame.
+  pub command_logs: CommandLogs,
 }
 
 impl App {
@@ -396,6 +407,7 @@ impl App {
       tasks: TaskRunner::new(),
       task_tx,
       task_rx,
+      command_logs: CommandLogs::new(),
     };
     // Seed the sidebar position from `[tui] sidebar_position` (issue
     // #188). Orientation stays at its `Auto` default — runtime-only.
@@ -894,6 +906,10 @@ impl App {
       View::CommandPalette => HintContext::CommandPalette,
       View::Report => HintContext::Report,
       View::Help => HintContext::Help,
+      // The Command Logs overlay (issue #226) is a ~90% fullscreen modal;
+      // the statusbar behind it shows the underlying pane's context, as the
+      // List view does.
+      View::CommandLogs => self.pane_hint_context(),
       View::List => self.pane_hint_context(),
     }
   }
@@ -935,6 +951,16 @@ impl App {
     self.view = View::Help;
     self.help_scroll = 0;
     self.help_x_scroll = 0;
+  }
+
+  /// Open the Command Logs overlay (issue #226). Snapshots the global
+  /// command log into owned state and resets the scroll cursor so a
+  /// previously-scrolled session starts fresh at the top. The renderer
+  /// republishes `max_scroll` against the live viewport.
+  pub fn enter_command_logs(&mut self) {
+    self.command_logs.sync();
+    self.command_logs.reset();
+    self.view = View::CommandLogs;
   }
 
   /// Scroll the help overlay down one row, clamped to the renderer-published

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -127,6 +127,7 @@ define_actions! {
   LinkPrompt        => "link",
   FetchGithub       => "fetch_github",
   // Overlays
+  CommandLogs       => "command_logs",
   Help              => "help",
   Quit              => "quit",
   // Future surface — bound to ':' by default, picked up by #32.
@@ -390,6 +391,7 @@ impl Keymap {
       def(Action::FocusSwap, &["Tab"]),
       def(Action::FocusWorktrees, &["1"]),
       def(Action::FocusStatus, &["2"]),
+      def(Action::CommandLogs, &["3"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f", "r"]),
       def(Action::Create, &["n"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,6 +28,7 @@ pub use app::{
   App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
 };
 pub use state::async_task::{TaskKind, TaskMsg, TaskRunner};
+pub use state::command_logs::CommandLogs;
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -164,6 +164,14 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       app.spinner.tick();
     }
 
+    // Keep the Command Logs overlay live (issue #226): re-snapshot the
+    // global log each tick while it is open so a command that finishes
+    // off-thread (e.g. the GitHub fetch) appears without reopening. The
+    // scroll cursor is preserved; the renderer re-clamps it.
+    if app.view == View::CommandLogs {
+      app.command_logs.sync();
+    }
+
     terminal.draw(|f| ui::draw(f, &mut app))?;
 
     // Tick the confirm-overlay safety countdown (issue #30) before
@@ -275,6 +283,20 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         KeyCode::Left | KeyCode::Char('h') => app.help_scroll_left(),
         KeyCode::Home | KeyCode::Char('g') => app.help_scroll = 0,
         KeyCode::End | KeyCode::Char('G') => app.help_scroll = app.help_max_scroll,
+        _ => {}
+      },
+      // Command Logs overlay (issue #226). Scrolls like the help overlay;
+      // closes on Esc / `q` or the bound `command_logs` key (default `3`)
+      // so the open key toggles it shut even when rebound.
+      View::CommandLogs => match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
+        KeyCode::Down | KeyCode::Char('j') => app.command_logs.scroll_down(),
+        KeyCode::Up | KeyCode::Char('k') => app.command_logs.scroll_up(),
+        KeyCode::Right | KeyCode::Char('l') => app.command_logs.scroll_right(),
+        KeyCode::Left | KeyCode::Char('h') => app.command_logs.scroll_left(),
+        KeyCode::Home | KeyCode::Char('g') => app.command_logs.scroll_to_top(),
+        KeyCode::End | KeyCode::Char('G') => app.command_logs.scroll_to_bottom(),
+        _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
         _ => {}
       },
       // Create-overlay keys live in a testable `App` method (issue #217);
@@ -498,6 +520,10 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     // CommandPalette → run_action loop terminates cleanly (the
     // overlay just stays open).
     Action::CommandPalette => app.open_command_palette(),
+    // Issue #226: `3` opens the Command Logs overlay. Not picker-gated —
+    // it is a read-only transcript, harmless inside `gwm switch`, and
+    // mirrors Help / the palette which also open from any List state.
+    Action::CommandLogs => app.enter_command_logs(),
     // Picker-mode-gated actions fall through to no-op when the
     // guard fails (i.e. the user pressed them inside `gwm switch`).
     // Same fallthrough catches future actions not yet wired into

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -162,6 +162,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "select the previous worktree",
     },
     PaletteEntry {
+      action: Action::CommandLogs,
+      name: "command-logs",
+      description: "show the command logs overlay",
+    },
+    PaletteEntry {
       action: Action::Help,
       name: "help",
       description: "show the help overlay",

--- a/src/tui/state/command_logs.rs
+++ b/src/tui/state/command_logs.rs
@@ -1,0 +1,87 @@
+//! Command Logs modal state (issue #226).
+//!
+//! The scroll cursor for the lazygit-style Command Logs overlay plus an
+//! owned snapshot of the [`crate::command_log`] global. The `App` calls
+//! [`CommandLogs::sync`] when the overlay opens (and on each tick while it
+//! is up) so the renderer paints from this owned state rather than locking
+//! the global mid-frame — the same boundary the modal-render tests inject
+//! through.
+//!
+//! Scroll mirrors the help overlay (`App::help_scroll` / `help_max_scroll`):
+//! the cursor lives here, but `max_scroll` / `max_x_scroll` are republished
+//! by the renderer each frame against the real viewport, since only the
+//! renderer knows both the content length and the inner modal height. The
+//! scroll methods clamp against whatever bound the last frame published.
+
+use crate::command_log::{self, CommandLogEntry};
+
+/// Owned state for the Command Logs overlay: the snapshotted entries and
+/// the (vertical + horizontal) scroll cursor with its renderer-published
+/// bounds.
+#[derive(Debug, Default)]
+pub struct CommandLogs {
+  /// Snapshot of the global command log, oldest-first (the renderer paints
+  /// it newest-first). Refreshed by [`Self::sync`].
+  pub entries: Vec<CommandLogEntry>,
+  /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
+  pub scroll: u16,
+  /// Maximum vertical scroll offset, republished by the renderer each
+  /// frame as `content_rows.saturating_sub(viewport_rows)`.
+  pub max_scroll: u16,
+  /// Horizontal scroll offset, in columns. Clamped to `max_x_scroll`.
+  pub x_scroll: u16,
+  /// Maximum horizontal scroll offset, republished by the renderer.
+  pub max_x_scroll: u16,
+}
+
+impl CommandLogs {
+  /// An empty overlay at the origin.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Copy the global command log into [`Self::entries`]. Cheap clone of a
+  /// bounded ring (≤ `command_log::MAX_ENTRIES`); called on open and per
+  /// tick while the overlay is up so it tracks commands that finish (e.g.
+  /// an off-thread GitHub fetch) while the user is reading.
+  pub fn sync(&mut self) {
+    self.entries = command_log::snapshot();
+  }
+
+  /// Scroll down one row, never past the last line.
+  pub fn scroll_down(&mut self) {
+    self.scroll = (self.scroll + 1).min(self.max_scroll);
+  }
+
+  /// Scroll up one row, never above the top.
+  pub fn scroll_up(&mut self) {
+    self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Scroll right one column, never past the widest line.
+  pub fn scroll_right(&mut self) {
+    self.x_scroll = (self.x_scroll + 1).min(self.max_x_scroll);
+  }
+
+  /// Scroll left one column, never before the first.
+  pub fn scroll_left(&mut self) {
+    self.x_scroll = self.x_scroll.saturating_sub(1);
+  }
+
+  /// Jump to the first row (`g`).
+  pub fn scroll_to_top(&mut self) {
+    self.scroll = 0;
+  }
+
+  /// Jump to the last row (`G`).
+  pub fn scroll_to_bottom(&mut self) {
+    self.scroll = self.max_scroll;
+  }
+
+  /// Reset the scroll cursor to the origin, keeping the snapshotted
+  /// entries. Called when the overlay opens.
+  pub fn reset(&mut self) {
+    self.scroll = 0;
+    self.x_scroll = 0;
+  }
+}

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! Decomposition order (one PR per slice, all tracking #102):
 //!
+//! - `command_logs` — scroll + snapshot for the Command Logs overlay (#226)
 //! - `confirm` — safety countdown for the destructive-action modal (#125)
 //! - `create_form` — issue/type/slug input form (#123)
 //! - `filter` — fuzzy filter buffer + memoised indices (#124)
@@ -14,6 +15,7 @@
 //! - `async_task` — generic off-thread spine (coalescing + late-drop) for slow ops (#231)
 
 pub mod async_task;
+pub mod command_logs;
 pub mod confirm;
 pub mod create_form;
 pub mod filter;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1477,6 +1477,7 @@ impl HintContext {
         Hint::Key(GitTui, "git"),
         Hint::Key(Review, "review"),
         Hint::Key(FocusStatus, "status"),
+        Hint::Key(CommandLogs, "logs"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -1487,6 +1488,7 @@ impl HintContext {
         Hint::Key(CycleSidebarLayout, "layout"),
         Hint::Key(FetchGithub, "fetch"),
         Hint::Key(FocusWorktrees, "worktrees"),
+        Hint::Key(CommandLogs, "logs"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -1953,6 +1955,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
   rows.push(entry(Action::FocusSwap, "swap focus between worktree list and sidebar"));
   rows.push(entry(Action::FocusWorktrees, "focus the worktrees pane"));
   rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
+  rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
   rows.push(entry(
     Action::Filter,
     "open fuzzy filter bar (enter: sticky, esc: clear)",

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2157,10 +2157,7 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let mut lines: Vec<Line<'static>> = overlay_title_lines("Command Logs", accent);
 
   if app.command_logs.entries.is_empty() {
-    lines.push(Line::from(Span::styled(
-      "No commands run yet.",
-      muted_style,
-    )));
+    lines.push(Line::from(Span::styled("No commands run yet.", muted_style)));
   } else {
     // Newest-first: the most recent command is what the user opened the
     // overlay to see, so it sits at the top without scrolling.
@@ -2173,13 +2170,17 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
       // Outcome line, coloured by exit status.
       let (color, detail) = match &entry.status {
         CommandStatus::Exited(Some(0)) => (ok_color, format!("→ exit 0 ({} ms)", entry.duration.as_millis())),
-        CommandStatus::Exited(Some(code)) => {
-          (err_color, format!("→ exit {} ({} ms)", code, entry.duration.as_millis()))
-        }
+        CommandStatus::Exited(Some(code)) => (
+          err_color,
+          format!("→ exit {} ({} ms)", code, entry.duration.as_millis()),
+        ),
         CommandStatus::Exited(None) => (err_color, format!("→ terminated ({} ms)", entry.duration.as_millis())),
         CommandStatus::Spawn => (err_color, "✗ failed to spawn".to_string()),
       };
-      lines.push(Line::from(vec![Span::raw("  "), Span::styled(detail, Style::default().fg(color))]));
+      lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(detail, Style::default().fg(color)),
+      ]));
       // Captured output, tail-capped so one chatty command cannot dominate
       // the transcript (the tail is where errors surface).
       if !entry.output.is_empty() {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -6,6 +6,7 @@ use super::state::sidebar::SidebarMode;
 use super::state::spinner::DOT_FRAMES;
 use super::theme::Theme;
 use crate::bootstrap::{BootstrapReport, StepStatus};
+use crate::command_log::CommandStatus;
 use crate::github::{IssueState, LinkSource, PrState};
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
@@ -77,6 +78,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::OpenMenu => draw_open_menu(f, app),
     View::LinkPrompt => draw_link_prompt(f, app),
     View::CommandPalette => draw_command_palette(f, app),
+    View::CommandLogs => draw_command_logs(f, app),
     View::List => {}
   }
 }
@@ -2131,6 +2133,94 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   app.help_x_scroll = app.help_x_scroll.min(app.help_max_x_scroll);
   let scroll = app.help_scroll;
   let x_scroll = app.help_x_scroll;
+
+  f.render_widget(Clear, area);
+  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
+}
+
+/// Render the Command Logs overlay (issue #226): a ~90% fullscreen modal
+/// over the dimmed list showing the lazygit-style transcript of the
+/// external commands gwm ran, newest-first. Scrolls like the help overlay —
+/// the renderer republishes `command_logs.max_scroll` / `max_x_scroll`
+/// against the live viewport so `App`'s scroll cursor can never run past
+/// the content. Colours track `[theme]` roles (`clean` ok / `prunable`
+/// fail / `muted` output) so a theme override applies here too.
+fn draw_command_logs(f: &mut Frame, app: &mut App) {
+  let area = centered(90, 85, f.area());
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let ok_color = app.theme.clean;
+  let err_color = app.theme.prunable;
+  let label_style = help_label_style(&app.theme);
+  let muted_style = Style::default().fg(muted);
+
+  let mut lines: Vec<Line<'static>> = overlay_title_lines("Command Logs", accent);
+
+  if app.command_logs.entries.is_empty() {
+    lines.push(Line::from(Span::styled(
+      "No commands run yet.",
+      muted_style,
+    )));
+  } else {
+    // Newest-first: the most recent command is what the user opened the
+    // overlay to see, so it sits at the top without scrolling.
+    for entry in app.command_logs.entries.iter().rev() {
+      // The resolved argv, prefixed lazygit-style with `$`.
+      lines.push(Line::from(vec![
+        Span::styled("$ ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+        Span::styled(entry.command.clone(), label_style),
+      ]));
+      // Outcome line, coloured by exit status.
+      let (color, detail) = match &entry.status {
+        CommandStatus::Exited(Some(0)) => (ok_color, format!("→ exit 0 ({} ms)", entry.duration.as_millis())),
+        CommandStatus::Exited(Some(code)) => {
+          (err_color, format!("→ exit {} ({} ms)", code, entry.duration.as_millis()))
+        }
+        CommandStatus::Exited(None) => (err_color, format!("→ terminated ({} ms)", entry.duration.as_millis())),
+        CommandStatus::Spawn => (err_color, "✗ failed to spawn".to_string()),
+      };
+      lines.push(Line::from(vec![Span::raw("  "), Span::styled(detail, Style::default().fg(color))]));
+      // Captured output, tail-capped so one chatty command cannot dominate
+      // the transcript (the tail is where errors surface).
+      if !entry.output.is_empty() {
+        const MAX_OUTPUT_LINES: usize = 6;
+        let out: Vec<&str> = entry.output.lines().collect();
+        let start = out.len().saturating_sub(MAX_OUTPUT_LINES);
+        if start > 0 {
+          lines.push(Line::from(Span::styled(
+            format!("    … {} earlier line(s)", start),
+            muted_style,
+          )));
+        }
+        for l in &out[start..] {
+          lines.push(Line::from(Span::styled(format!("    {}", l), muted_style)));
+        }
+      }
+      lines.push(Line::from(String::new()));
+    }
+  }
+
+  // Footer hint: scroll + close. A plain muted line (not `push_modal_hint`,
+  // whose contexts are pane-specific) keeps the overlay self-documenting.
+  lines.push(Line::from(Span::styled(
+    "j/k scroll · g/G top/bottom · esc close",
+    muted_style.add_modifier(Modifier::ITALIC),
+  )));
+
+  // Publish the scroll bounds against the live viewport (mirrors
+  // `draw_help`): the renderer is the only place that knows both the
+  // content length and the inner modal height, so it clamps here.
+  let block = overlay_block(accent);
+  let inner = block.inner(area);
+  let viewport = inner.height as usize;
+  app.command_logs.max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  app.command_logs.scroll = app.command_logs.scroll.min(app.command_logs.max_scroll);
+  let viewport_w = inner.width as usize;
+  let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
+  app.command_logs.max_x_scroll = content_w.saturating_sub(viewport_w) as u16;
+  app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
+  let scroll = app.command_logs.scroll;
+  let x_scroll = app.command_logs.x_scroll;
 
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);

--- a/tests/bootstrap_tests.rs
+++ b/tests/bootstrap_tests.rs
@@ -318,6 +318,36 @@ fn command_runs_when_condition_satisfied() {
 }
 
 #[test]
+fn command_step_is_recorded_on_the_command_log() {
+  // Issue #226: a bootstrap shell step is one of the external commands gwm
+  // runs, so it must land on the Command Logs transcript. Unique sentinel
+  // keeps the assertion robust against entries a sibling test recorded
+  // concurrently (presence, not count).
+  let sentinel = "gwm-bootstrap-cmdlog-3e8f";
+  let (main, wt, mut cfg) = dirs();
+  cfg.bootstrap.command.push(CommandStep {
+    name: "echo".into(),
+    run: format!("echo {sentinel}"),
+    when: None,
+    env: HashMap::new(),
+  });
+  let ctx = BootstrapCtx {
+    main_repo: main.path(),
+    worktree: wt.path(),
+    config: &cfg,
+  };
+  bootstrap::run(&ctx).unwrap();
+
+  let recorded = gwm::command_log::snapshot();
+  let mine = recorded
+    .iter()
+    .find(|e| e.command.contains(sentinel))
+    .expect("bootstrap shell step recorded on the command log");
+  assert!(mine.is_success(), "the echo step exited cleanly");
+  assert!(mine.output.contains(sentinel), "captured stdout is stored");
+}
+
+#[test]
 fn command_failure_recorded() {
   let (main, wt, mut cfg) = dirs();
   cfg.bootstrap.command.push(CommandStep {

--- a/tests/command_log_tests.rs
+++ b/tests/command_log_tests.rs
@@ -103,6 +103,29 @@ fn run_logged_records_a_successful_command_with_its_output() {
 }
 
 #[test]
+fn run_logged_keeps_stderr_for_a_mixed_output_failure() {
+  // Codex review (#259): a command that writes to stdout *and* puts its
+  // diagnostics on stderr before failing must not lose the error text — the
+  // transcript is for troubleshooting. Both streams are kept.
+  let out_sentinel = "gwm-cmdlog-mixed-out-a1";
+  let err_sentinel = "gwm-cmdlog-mixed-err-b2";
+  let mut cmd = Command::new("sh");
+  cmd
+    .arg("-c")
+    .arg(format!("echo {out_sentinel}; echo {err_sentinel} >&2; exit 1"));
+  let _ = command_log::run_logged(&mut cmd, format!("sh -c mixed # {err_sentinel}"));
+
+  let recorded = command_log::snapshot();
+  let mine = recorded
+    .iter()
+    .find(|e| e.command.contains(err_sentinel))
+    .expect("the failing command was recorded");
+  assert_eq!(mine.status, CommandStatus::Exited(Some(1)));
+  assert!(mine.output.contains(out_sentinel), "stdout is kept");
+  assert!(mine.output.contains(err_sentinel), "stderr diagnostics are not dropped");
+}
+
+#[test]
 fn run_logged_records_a_nonzero_exit() {
   let sentinel = "gwm-cmdlog-fail-b219";
   let mut cmd = Command::new("sh");

--- a/tests/command_log_tests.rs
+++ b/tests/command_log_tests.rs
@@ -1,0 +1,121 @@
+//! Command-log ring buffer + logged-exec helper (issue #226).
+//!
+//! The command log is the data behind the lazygit-style Command Logs modal:
+//! a bounded, in-memory transcript of the external commands gwm shells out
+//! to (the `gh` GitHub calls, bootstrap shell steps, lifecycle hooks). This
+//! file pins two layers:
+//!
+//!   1. [`CommandLog`] — the pure ring buffer (push / bound / snapshot /
+//!      clear), tested in isolation with no global state so the assertions
+//!      are deterministic under `cargo test`'s parallel runner.
+//!   2. [`command_log::run_logged`] — the exec wrapper that times a child
+//!      process, captures its output + exit, and records an entry on the
+//!      process-global log. The global-touching tests use a unique sentinel
+//!      command string and assert *presence* (never an exact count), so a
+//!      sibling test recording concurrently cannot make them flake.
+
+use gwm::command_log::{self, CommandLog, CommandLogEntry, CommandStatus, MAX_ENTRIES};
+use std::process::Command;
+use std::time::Duration;
+
+fn entry(command: &str, code: i32) -> CommandLogEntry {
+  CommandLogEntry {
+    command: command.into(),
+    duration: Duration::from_millis(1),
+    status: CommandStatus::Exited(Some(code)),
+    output: String::new(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CommandLog — pure ring buffer (no global, no I/O)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn push_appends_in_order_and_snapshot_clones() {
+  let mut log = CommandLog::new();
+  assert!(log.is_empty());
+  log.push(entry("gh issue view 1", 0));
+  log.push(entry("gh pr list", 0));
+  assert_eq!(log.len(), 2);
+  let snap = log.snapshot();
+  assert_eq!(snap.len(), 2);
+  assert_eq!(snap[0].command, "gh issue view 1");
+  assert_eq!(snap[1].command, "gh pr list");
+}
+
+#[test]
+fn ring_drops_the_oldest_entry_past_the_cap() {
+  let mut log = CommandLog::new();
+  // One past the cap: the very first push must have been evicted.
+  for i in 0..=MAX_ENTRIES {
+    log.push(entry(&format!("cmd {i}"), 0));
+  }
+  assert_eq!(log.len(), MAX_ENTRIES, "ring is bounded to MAX_ENTRIES");
+  let snap = log.snapshot();
+  assert_eq!(snap.first().unwrap().command, "cmd 1", "oldest (cmd 0) evicted");
+  assert_eq!(snap.last().unwrap().command, format!("cmd {MAX_ENTRIES}"));
+}
+
+#[test]
+fn clear_empties_the_ring() {
+  let mut log = CommandLog::new();
+  log.push(entry("x", 0));
+  log.clear();
+  assert!(log.is_empty());
+  assert_eq!(log.len(), 0);
+}
+
+#[test]
+fn is_success_tracks_the_exit_code() {
+  assert!(entry("ok", 0).is_success());
+  assert!(!entry("bad", 1).is_success());
+  let spawn = CommandLogEntry {
+    command: "missing-bin".into(),
+    duration: Duration::from_millis(0),
+    status: CommandStatus::Spawn,
+    output: String::new(),
+  };
+  assert!(!spawn.is_success(), "a spawn failure is never a success");
+}
+
+// ---------------------------------------------------------------------------
+// run_logged — exec wrapper feeding the process-global log
+// ---------------------------------------------------------------------------
+
+#[test]
+fn run_logged_records_a_successful_command_with_its_output() {
+  // Unique sentinel so a concurrent test recording to the same global log
+  // cannot collide with this assertion (presence, not count).
+  let sentinel = "gwm-cmdlog-success-7f3a";
+  let mut cmd = Command::new("sh");
+  cmd.arg("-c").arg(format!("echo {sentinel}"));
+  let out = command_log::run_logged(&mut cmd, format!("sh -c echo {sentinel}")).expect("spawns");
+  assert!(out.status.success());
+
+  let recorded = command_log::snapshot();
+  let mine = recorded
+    .iter()
+    .find(|e| e.command.contains(sentinel))
+    .expect("the executed command was recorded on the global log");
+  assert_eq!(mine.status, CommandStatus::Exited(Some(0)));
+  assert!(mine.output.contains(sentinel), "captured stdout is stored on the entry");
+}
+
+#[test]
+fn run_logged_records_a_nonzero_exit() {
+  let sentinel = "gwm-cmdlog-fail-b219";
+  let mut cmd = Command::new("sh");
+  // `: marker` keeps the sentinel in the argv string we log without
+  // emitting it to stdout; the command itself exits 3.
+  cmd.arg("-c").arg("exit 3");
+  let _ = command_log::run_logged(&mut cmd, format!("sh -c exit 3 # {sentinel}"));
+
+  let recorded = command_log::snapshot();
+  let mine = recorded
+    .iter()
+    .find(|e| e.command.contains(sentinel))
+    .expect("a failing command is still recorded");
+  assert_eq!(mine.status, CommandStatus::Exited(Some(3)));
+  assert!(!mine.is_success());
+}

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -739,3 +739,24 @@ fn parse_pr_list_number_returns_none_for_empty_array() {
 fn parse_pr_list_number_errors_on_malformed_json() {
   assert!(github::parse_pr_list_number("not json").is_err());
 }
+
+#[test]
+fn gh_command_line_uses_the_program_basename_and_joins_args() {
+  use std::ffi::{OsStr, OsString};
+  // Issue #226: the Command Logs transcript shows the resolved `gh <args…>`
+  // (the user's chosen lazygit-style argv). A `GWM_GH` override pointing at
+  // a full path must still read as `gh …`, not leak the path.
+  let args: Vec<OsString> = ["issue", "view", "226", "--json", "title,body"]
+    .iter()
+    .map(OsString::from)
+    .collect();
+  assert_eq!(
+    github::gh_command_line(OsStr::new("/opt/homebrew/bin/gh"), &args),
+    "gh issue view 226 --json title,body"
+  );
+  // A bare program name is preserved as-is.
+  assert_eq!(
+    github::gh_command_line(OsStr::new("gh"), &args),
+    "gh issue view 226 --json title,body"
+  );
+}

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -215,6 +215,18 @@ fn default_keymap_binds_sidebar_layout_and_position() {
 }
 
 #[test]
+fn default_keymap_binds_command_logs_to_3() {
+  // Issue #226: `3` opens the Command Logs modal, completing the `1` / `2`
+  // / `3` pane-key family (focus_worktrees / focus_status / command_logs).
+  let km = Keymap::defaults();
+  let three = KeyStroke::parse_chord("3").unwrap();
+  assert!(matches!(
+    km.lookup(&three),
+    ChordResolution::Matched(Action::CommandLogs)
+  ));
+}
+
+#[test]
 fn user_override_replaces_default_for_one_action() {
   let mut km = Keymap::defaults();
   km.apply_override(Action::Down, vec![KeyStroke::parse_chord("Ctrl+n").unwrap()])

--- a/tests/lifecycle_tests.rs
+++ b/tests/lifecycle_tests.rs
@@ -1,0 +1,53 @@
+//! Lifecycle hook execution → Command Logs transcript (issue #226).
+//!
+//! A lifecycle hook is one of the external commands gwm runs, so running a
+//! phase must record its shell step on the command log. `HookContext` has
+//! public fields, so the test builds one directly (no `git2::Repository`
+//! fixture needed) and drives `run_phase` against a `tempdir` cwd. Unique
+//! sentinel keeps the assertion robust against entries a sibling test
+//! recorded concurrently (presence, not count).
+
+use gwm::config::{Config, HookStep};
+use gwm::lifecycle::{self, HookContext, HookPhase, HookSkips};
+use std::collections::HashMap;
+use std::path::Path;
+
+fn ctx_at(cwd: &Path) -> HookContext {
+  HookContext {
+    main_repo: cwd.to_path_buf(),
+    cwd: cwd.to_path_buf(),
+    path: cwd.to_path_buf(),
+    branch: "feat/#226-demo".into(),
+    branch_type: "feat".into(),
+    issue: "226".into(),
+    desc: "demo".into(),
+    user: "tester".into(),
+    owner: "kbrdn1".into(),
+    repo: "gwm-cli".into(),
+  }
+}
+
+#[test]
+fn post_create_hook_is_recorded_on_the_command_log() {
+  let sentinel = "gwm-hook-cmdlog-5b7a";
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cfg = Config::default();
+  cfg.hooks.post_create.push(HookStep {
+    name: "echo".into(),
+    run: format!("echo {sentinel}"),
+    when: None,
+    env: HashMap::new(),
+    on_fail: gwm::config::HookOnFail::default(),
+  });
+
+  let ctx = ctx_at(dir.path());
+  lifecycle::run_phase(&cfg, HookPhase::PostCreate, &ctx, &HookSkips::default(), false).unwrap();
+
+  let recorded = gwm::command_log::snapshot();
+  let mine = recorded
+    .iter()
+    .find(|e| e.command.contains(sentinel))
+    .expect("post_create hook recorded on the command log");
+  assert!(mine.is_success(), "the echo hook exited cleanly");
+  assert!(mine.output.contains(sentinel), "captured stdout is stored");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -74,6 +74,37 @@ fn focus_worktrees_releases_sidebar_focus() {
 }
 
 #[test]
+fn enter_command_logs_opens_the_overlay_syncs_and_resets_scroll() {
+  // Issue #226: `3` opens the Command Logs modal. Opening must (1) switch
+  // to the overlay view, (2) sync the global command log into owned state,
+  // and (3) reset the scroll cursor so a previously-scrolled session starts
+  // fresh at the top.
+  use gwm::command_log::{self, CommandLogEntry, CommandStatus};
+  use std::time::Duration;
+
+  let sentinel = "gwm-enter-cmdlog-9a1c";
+  command_log::record(CommandLogEntry {
+    command: format!("gh pr list # {sentinel}"),
+    duration: Duration::from_millis(1),
+    status: CommandStatus::Exited(Some(0)),
+    output: String::new(),
+  });
+
+  let (_dir, mut app) = make_app();
+  app.command_logs.scroll = 9;
+  app.command_logs.x_scroll = 3;
+  app.enter_command_logs();
+
+  assert_eq!(app.view, View::CommandLogs);
+  assert_eq!(app.command_logs.scroll, 0, "scroll resets on open");
+  assert_eq!(app.command_logs.x_scroll, 0, "horizontal scroll resets on open");
+  assert!(
+    app.command_logs.entries.iter().any(|e| e.command.contains(sentinel)),
+    "opening the overlay snapshots the global command log"
+  );
+}
+
+#[test]
 fn hint_context_follows_focus() {
   // Issue #217: the statusbar chip + help subtitle read the live focus. The
   // worktrees pane is the default; focusing the sidebar switches to Status.

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -250,6 +250,22 @@ fn hint_context_exposes_label_and_hints() {
 }
 
 #[test]
+fn worktrees_and_status_hints_advertise_the_command_logs_key() {
+  // Issue #226: the statusbar which-key must advertise `3 logs` so the
+  // Command Logs overlay is discoverable, alongside the `1`/`2` pane keys.
+  use gwm::tui::keymap::Keymap;
+  let km = Keymap::defaults();
+  for ctx in [HintContext::Worktrees, HintContext::Status] {
+    let resolved = ctx.resolve(&km);
+    assert!(
+      resolved.iter().any(|(k, l)| k == "3" && l == "logs"),
+      "context {:?} must advertise the `3 logs` hint: {resolved:?}",
+      ctx.label()
+    );
+  }
+}
+
+#[test]
 fn status_hints_resolve_user_rebindings() {
   // Issue #217 review (P2): the statusbar must show the *live* binding, not
   // the hard-coded default — the keymap actions are rebindable. `fetch` is

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -196,6 +196,37 @@ fn report_modal_renders_title_and_step_labels() {
 }
 
 #[test]
+fn command_logs_modal_renders_title_and_entry_argv() {
+  use gwm::command_log::{CommandLogEntry, CommandStatus};
+  use std::time::Duration;
+
+  let (_dir, mut app) = make_app();
+  // Inject entries directly into owned state so the render is deterministic
+  // and never touches the process-global log (the event loop is what syncs
+  // the global in; here we pin the *render*).
+  app.command_logs.entries = vec![CommandLogEntry {
+    command: "gh issue view 226 --json title,body".into(),
+    duration: Duration::from_millis(412),
+    status: CommandStatus::Exited(Some(0)),
+    output: "ok".into(),
+  }];
+  app.view = View::CommandLogs;
+  let buf = render(&mut app);
+  assert_present(&buf, "Command Logs", "command logs title");
+  assert_present(&buf, "gh issue view 226", "logged command argv");
+}
+
+#[test]
+fn command_logs_modal_renders_empty_placeholder() {
+  let (_dir, mut app) = make_app();
+  app.command_logs.entries.clear();
+  app.view = View::CommandLogs;
+  let buf = render(&mut app);
+  assert_present(&buf, "Command Logs", "command logs title");
+  assert_present(&buf, "No commands", "empty-state placeholder");
+}
+
+#[test]
 fn open_menu_modal_renders_title_and_targets() {
   let (_dir, mut app) = make_app();
   app.enter_open_menu();

--- a/tests/tui_state_command_logs_tests.rs
+++ b/tests/tui_state_command_logs_tests.rs
@@ -1,0 +1,104 @@
+//! Command Logs modal state slice (issue #226).
+//!
+//! Pure-state contract for `tui::state::command_logs::CommandLogs`: the
+//! scroll cursor (vertical + horizontal) clamped against bounds the
+//! renderer republishes each frame, and the `sync` that copies the global
+//! command-log into owned `App` state so the modal never renders off the
+//! live global. Mirrors the help-overlay scroll model (`help_scroll` /
+//! `help_max_scroll`) and the sidebar slice's clamp tests — ratatui-free,
+//! no terminal backend.
+
+use gwm::command_log::{self, CommandLogEntry, CommandStatus};
+use gwm::tui::CommandLogs;
+use std::time::Duration;
+
+#[test]
+fn new_starts_empty_at_the_origin() {
+  let logs = CommandLogs::new();
+  assert!(logs.entries.is_empty());
+  assert_eq!(logs.scroll, 0);
+  assert_eq!(logs.x_scroll, 0);
+  assert_eq!(logs.max_scroll, 0);
+  assert_eq!(logs.max_x_scroll, 0);
+}
+
+#[test]
+fn scroll_down_clamps_to_max_scroll() {
+  let mut logs = CommandLogs::new();
+  logs.max_scroll = 3;
+  for _ in 0..10 {
+    logs.scroll_down();
+  }
+  assert_eq!(logs.scroll, 3, "never scrolls past the last line");
+}
+
+#[test]
+fn scroll_up_saturates_at_zero() {
+  let mut logs = CommandLogs::new();
+  logs.max_scroll = 5;
+  logs.scroll = 2;
+  logs.scroll_up();
+  logs.scroll_up();
+  logs.scroll_up();
+  assert_eq!(logs.scroll, 0);
+}
+
+#[test]
+fn horizontal_scroll_clamps_both_ways() {
+  let mut logs = CommandLogs::new();
+  logs.max_x_scroll = 2;
+  for _ in 0..5 {
+    logs.scroll_right();
+  }
+  assert_eq!(logs.x_scroll, 2);
+  for _ in 0..5 {
+    logs.scroll_left();
+  }
+  assert_eq!(logs.x_scroll, 0);
+}
+
+#[test]
+fn scroll_to_top_and_bottom_jump_to_the_bounds() {
+  let mut logs = CommandLogs::new();
+  logs.max_scroll = 7;
+  logs.scroll_to_bottom();
+  assert_eq!(logs.scroll, 7);
+  logs.scroll_to_top();
+  assert_eq!(logs.scroll, 0);
+}
+
+#[test]
+fn reset_zeroes_the_cursor_but_keeps_entries() {
+  let mut logs = CommandLogs::new();
+  logs.entries.push(CommandLogEntry {
+    command: "gh pr list".into(),
+    duration: Duration::from_millis(1),
+    status: CommandStatus::Exited(Some(0)),
+    output: String::new(),
+  });
+  logs.scroll = 4;
+  logs.x_scroll = 2;
+  logs.reset();
+  assert_eq!(logs.scroll, 0);
+  assert_eq!(logs.x_scroll, 0);
+  assert_eq!(logs.entries.len(), 1, "reset clears the cursor, not the data");
+}
+
+#[test]
+fn sync_copies_the_global_command_log_into_the_slice() {
+  // Unique sentinel keeps this assertion robust against entries a sibling
+  // test recorded concurrently (presence, not exact contents).
+  let sentinel = "gwm-slice-sync-c4d1";
+  command_log::record(CommandLogEntry {
+    command: format!("gh issue view 226 # {sentinel}"),
+    duration: Duration::from_millis(2),
+    status: CommandStatus::Exited(Some(0)),
+    output: String::new(),
+  });
+  let mut logs = CommandLogs::new();
+  logs.sync();
+  assert!(
+    logs.entries.iter().any(|e| e.command.contains(sentinel)),
+    "sync pulls the global log into the slice"
+  );
+}


### PR DESCRIPTION
## Description

Adds a lazygit-style **Command Logs** overlay (`3`): a scrollable, ~90%
fullscreen transcript of the external commands gwm runs — the resolved
command line, duration, exit status, and captured output — newest-first
over a dimmed list. Completes the `1`/`2`/`3` pane-key family and gives
the single-line statusbar action log (#217) a full scrollback.

Closes #226

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **`src/command_log.rs`** (new): a process-global, bounded ring (cap 256,
  FIFO) of `CommandLogEntry` + a `run_logged(cmd, argv)` helper that times a
  child process, captures bounded output + exit, and records an entry. The
  ring is global because the exec chokepoints live in library modules with
  no `App` handle (the GitHub fetch runs off-thread); the TUI snapshots it
  into owned `App` state rather than rendering off the live global.
- **`src/tui/state/command_logs.rs`** (new): owned scroll cursor (vertical +
  horizontal) + entries snapshot, mirroring the help-overlay scroll model.
- **TUI wiring**: `View::CommandLogs`, a `command_logs` action bound to `3`
  (rebindable via `[tui.keys]`), `enter_command_logs` (snapshot + reset),
  `draw_command_logs` (newest-first, theme-role colours), help-overlay-style
  scrolling (`j`/`k`, `g`/`G`, `h`/`l`), close on `Esc`/`q`/`3`, and a live
  re-sync each tick while open. Palette entry `:command-logs`.
- **Instrumentation**: `github::run_gh_with`, `bootstrap::exec_shell`, and
  `lifecycle::run_step` route through `run_logged`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

New/updated test files: `command_log_tests.rs`, `tui_state_command_logs_tests.rs`,
`keymap_tests.rs`, `tui_app_tests.rs`, `tui_modal_render_tests.rs`,
`bootstrap_tests.rs` (step → log), `lifecycle_tests.rs` (hook → log),
`github_tests.rs` (`gh_command_line` argv format), `palette_tests.rs` (covered automatically).

## Screenshots / TUI captures

_None — the modal layout is pinned by `tui_modal_render_tests.rs` (TestBackend), the convention for TUI render in this repo._

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — n/a (TUI-only, no CLI subcommand)
- [ ] `examples/gwm.toml.example` updated if config schema changed — n/a (no schema change; the `[tui.keys]` slug `command_logs` rides the existing keymap surface)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Notes for reviewers

- **Scope (deliberately narrow first cut)**: only the **captured-output**
  commands are logged — `gh`, bootstrap shell steps, lifecycle hooks.
  Read-only sidebar previews (`worktree::run_git` for `git log`/`status`)
  are **excluded** on purpose: they fire on every selection change and would
  bury the real operations in noise.
- **Out of scope, by design**: interactive launchers (`.status()`/`.spawn()`,
  no captured output) and the libgit2 worktree ops (no subprocess). `gwm
  sync` joins once it has a TUI action — that's #258 (the validated mock
  shows a `git fetch` line; it lands with #258, not here).
- **#257 (loader widget)**: deferred to #4 (Configuration panel), which has a
  genuine async loading area. The command log is in-memory/instant, so it had
  no real consumer for a standalone loader — #257 explicitly sanctions "with
  #226 **or** #4".
- **Global ring + test isolation**: the ring is global (worker-thread reach +
  argv capture), but the modal renders from an `App` snapshot, so render
  tests inject into `App` state and never touch the global. Global-touching
  tests assert on a unique sentinel (presence, not count) to stay
  parallel-safe.
- **Minor live-sync behaviour**: if an off-thread fetch finishes while the
  overlay is open and scrolled, the new (newest-first) entry inserts at the
  top and shifts content. MVP-acceptable.

## Linked issues / docs

- Issue: #226
- Follow-ups referenced: #257 (→ #4), #258 (sync TUI action)