### PR TITLE
✨ feat(tui): in-TUI Configuration panel bound to `4` (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configuration panel: press `4` to open a ~90% fullscreen, scrollable
+  view of the **resolved** `.gwm.toml` — the user-level global config
+  (`~/.config/gwm/config.toml`) deep-merged under the repo file, exactly
+  as `gwm config list` resolves it. Rows are grouped by `[section]` and
+  each carries a colour-coded source column (**repo** / **user** /
+  **default**) marking which layer won — provenance the CLI never
+  exposed. Scrolls like the help overlay (`j`/`k`, `g`/`G`, `h`/`l`);
+  `Esc` / `q` / `4` closes it. Read-first: inline editing stays a
+  follow-up. Completes the `1`/`2`/`3`/`4` pane-key family; reachable by
+  name via `:config-panel` and rebindable through `[tui.keys] config_panel`.
+  ([#232](https://github.com/kbrdn1/gwm-cli/issues/232))
 - Command Logs overlay: press `3` to open a lazygit-style, scrollable
   transcript of the external commands gwm ran — the resolved command line,
   duration, exit status, and captured output — newest-first over a ~90%

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -42,6 +42,8 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `Tab`       | swap focus between the worktree list and the sidebar                                              |
 | `1`         | focus the worktrees pane (rebindable action `focus_worktrees`)                                    |
 | `2`         | open (if hidden) and focus the status pane (rebindable action `focus_status`)                     |
+| `3`         | open the Command Logs overlay — scrollable transcript of the commands gwm ran (rebindable action `command_logs`) |
+| `4`         | open the Configuration panel — resolved `.gwm.toml` with a per-row source column (rebindable action `config_panel`) |
 | `/`         | open the [fuzzy filter](/tui/filter) bar (`Enter` confirms · `Esc` clears)                        |
 | `p`         | toggle "delete branch on remove"                                                                  |
 | `Enter`     | show selected path in status bar                                                                  |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -43,6 +43,8 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `Tab`       | échanger le focus entre la liste des worktrees et la barre latérale                               |
 | `1`         | donner le focus au panneau des worktrees (action remappable `focus_worktrees`)                    |
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (action remappable `focus_status`)     |
+| `3`         | ouvrir l'overlay Command Logs — transcription scrollable des commandes lancées par gwm (action remappable `command_logs`) |
+| `4`         | ouvrir le panneau Configuration — `.gwm.toml` résolu avec une colonne de source par ligne (action remappable `config_panel`) |
 | `/`         | ouvrir la barre de [filtre flou](/fr/tui/filter) (`Enter` confirme · `Esc` efface)                |
 | `p`         | basculer « supprimer la branche au retrait »                                                      |
 | `Enter`     | afficher le chemin sélectionné dans la barre de statut                                            |

--- a/src/config.rs
+++ b/src/config.rs
@@ -708,6 +708,47 @@ fn merge_toml(base: toml::Value, over: toml::Value) -> toml::Value {
   }
 }
 
+/// Flatten a (possibly nested) TOML value into `key = display` rows,
+/// dotted for tables and `name[i]` for arrays-of-tables, leaving scalar
+/// leaves as-is. Shared by `gwm config list` (the CLI surface) and the
+/// in-TUI Configuration panel (issue #232) so neither can drift from the
+/// other's key shape. Pure — pushes onto `rows` in table-iteration order
+/// (`toml::Value::Table` is a `BTreeMap`, so keys come out sorted).
+pub(crate) fn flatten_value(prefix: &str, value: &toml::Value, rows: &mut Vec<(String, String)>) {
+  match value {
+    toml::Value::Table(table) => {
+      for (key, value) in table {
+        let next = if prefix.is_empty() {
+          key.to_string()
+        } else {
+          format!("{}.{}", prefix, key)
+        };
+        flatten_value(&next, value, rows);
+      }
+    }
+    toml::Value::Array(values) if values.iter().all(toml::Value::is_table) => {
+      for (i, value) in values.iter().enumerate() {
+        flatten_value(&format!("{}[{}]", prefix, i), value, rows);
+      }
+    }
+    _ => rows.push((prefix.to_string(), format_list_value(value))),
+  }
+}
+
+/// Render a single TOML scalar (or non-table aggregate) the way
+/// `gwm config list` does: strings quoted, scalars bare, arrays/tables
+/// via their `Display`. Shared with the Configuration panel (issue #232).
+pub(crate) fn format_list_value(value: &toml::Value) -> String {
+  match value {
+    toml::Value::String(s) => format!("{:?}", s),
+    toml::Value::Integer(i) => i.to_string(),
+    toml::Value::Float(f) => f.to_string(),
+    toml::Value::Boolean(b) => b.to_string(),
+    toml::Value::Datetime(d) => d.to_string(),
+    toml::Value::Array(_) | toml::Value::Table(_) => value.to_string(),
+  }
+}
+
 /// On-disk location of the user-level global config under a given
 /// XDG config-home directory: `<config_home>/gwm/config.toml`. Pure
 /// (no env / FS access) so the path contract is unit-testable. Issue

--- a/src/config.rs
+++ b/src/config.rs
@@ -735,6 +735,97 @@ pub(crate) fn flatten_value(prefix: &str, value: &toml::Value, rows: &mut Vec<(S
   }
 }
 
+/// Which configuration layer a resolved value came from (issue #232).
+/// Ordered by precedence so the panel can colour the strongest source
+/// distinctly: a repo `.gwm.toml` overrides the user-level global, which
+/// overrides the built-in defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+  /// The value is a built-in default — set in neither config file.
+  Default,
+  /// The value comes from the user-level global config
+  /// (`~/.config/gwm/config.toml`).
+  User,
+  /// The value comes from the repo's `.gwm.toml`.
+  Repo,
+}
+
+impl ConfigSource {
+  /// Stable lowercase label for the panel's source column and tests.
+  pub fn label(self) -> &'static str {
+    match self {
+      ConfigSource::Default => "default",
+      ConfigSource::User => "user",
+      ConfigSource::Repo => "repo",
+    }
+  }
+}
+
+/// One resolved configuration row: the flattened `key`, its `value`
+/// rendered exactly as `gwm config list` prints it, and the layer that
+/// `source`d it. Consumed by the in-TUI Configuration panel (issue #232).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigRow {
+  pub key: String,
+  pub value: String,
+  pub source: ConfigSource,
+}
+
+/// Flatten the raw (un-defaulted) TOML at `path` into the set of keys it
+/// literally declares — the membership probe behind source attribution.
+/// An absent file contributes no keys (every value then comes from a
+/// lower layer). Issue #232.
+fn declared_keys(path: &Path) -> Result<std::collections::HashSet<String>> {
+  if !path.exists() {
+    return Ok(std::collections::HashSet::new());
+  }
+  let value = read_config_value(path)?;
+  let mut rows = Vec::new();
+  flatten_value("", &value, &mut rows);
+  Ok(rows.into_iter().map(|(key, _)| key).collect())
+}
+
+/// Resolve the effective configuration the way `gwm config list` does
+/// (user-level global deep-merged under the repo `.gwm.toml`, defaults
+/// filled), then attribute each flattened key to the layer that provided
+/// it — repo over user over default. `global_path` is injected so the
+/// attribution can be pinned by a test without touching the real
+/// `$HOME` / `$XDG_CONFIG_HOME` (mirrors [`Config::load_layered`]).
+/// Issue #232.
+pub fn resolved_rows(repo_root: &Path, global_path: Option<&Path>) -> Result<Vec<ConfigRow>> {
+  // The merged + defaulted config, serialised back to a value so the
+  // key/value shape is identical to `gwm config list`.
+  let cfg = Config::load_layered(repo_root, global_path)?;
+  let value = toml::Value::try_from(cfg).map_err(|e| GwmError::Config(e.to_string()))?;
+  let mut flat = Vec::new();
+  flatten_value("", &value, &mut flat);
+
+  // Per-layer declared keys probe which layer owns each merged key. Both
+  // layers and the merged value flow through the same `flatten_value`, so
+  // a key present in a layer's raw file matches the merged key verbatim.
+  let repo_keys = declared_keys(&repo_root.join(CONFIG_FILE))?;
+  let user_keys = match global_path {
+    Some(p) => declared_keys(p)?,
+    None => std::collections::HashSet::new(),
+  };
+
+  Ok(
+    flat
+      .into_iter()
+      .map(|(key, value)| {
+        let source = if repo_keys.contains(&key) {
+          ConfigSource::Repo
+        } else if user_keys.contains(&key) {
+          ConfigSource::User
+        } else {
+          ConfigSource::Default
+        };
+        ConfigRow { key, value, source }
+      })
+      .collect(),
+  )
+}
+
 /// Render a single TOML scalar (or non-table aggregate) the way
 /// `gwm config list` does: strings quoted, scalars bare, arrays/tables
 /// via their `Display`. Shared with the Configuration panel (issue #232).

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -35,7 +35,7 @@ pub fn set(key: &str, raw_value: Option<&str>) -> Result<()> {
   let resolved_key = set_value(doc.as_table_mut(), &segments, value)?;
   write_and_validate(&path, &doc)?;
   let rendered = resolved_value(&Config::load_for_repo(&root)?, &resolved_key)?;
-  println!("{} = {}", resolved_key, format_list_value(&rendered));
+  println!("{} = {}", resolved_key, crate::config::format_list_value(&rendered));
   Ok(())
 }
 
@@ -68,7 +68,7 @@ pub fn list(prefix: Option<&str>) -> Result<()> {
   let cfg = Config::load_for_repo(&root)?;
   let value = toml::Value::try_from(cfg).map_err(|e| GwmError::Config(e.to_string()))?;
   let mut rows = Vec::new();
-  flatten_value("", &value, &mut rows);
+  crate::config::flatten_value("", &value, &mut rows);
   for (key, value) in rows {
     if prefix
       .map(|p| key == p || key.starts_with(&format!("{}.", p)) || key.starts_with(&format!("{}[", p)))
@@ -329,42 +329,10 @@ fn remove_value(table: &mut Table, segments: &[Segment]) -> Result<()> {
   }
 }
 
-fn flatten_value(prefix: &str, value: &toml::Value, rows: &mut Vec<(String, String)>) {
-  match value {
-    toml::Value::Table(table) => {
-      for (key, value) in table {
-        let next = if prefix.is_empty() {
-          key.to_string()
-        } else {
-          format!("{}.{}", prefix, key)
-        };
-        flatten_value(&next, value, rows);
-      }
-    }
-    toml::Value::Array(values) if values.iter().all(toml::Value::is_table) => {
-      for (i, value) in values.iter().enumerate() {
-        flatten_value(&format!("{}[{}]", prefix, i), value, rows);
-      }
-    }
-    _ => rows.push((prefix.to_string(), format_list_value(value))),
-  }
-}
-
 fn format_get_value(value: &toml::Value) -> String {
   match value {
     toml::Value::String(s) => s.clone(),
-    _ => format_list_value(value),
-  }
-}
-
-fn format_list_value(value: &toml::Value) -> String {
-  match value {
-    toml::Value::String(s) => format!("{:?}", s),
-    toml::Value::Integer(i) => i.to_string(),
-    toml::Value::Float(f) => f.to_string(),
-    toml::Value::Boolean(b) => b.to_string(),
-    toml::Value::Datetime(d) => d.to_string(),
-    toml::Value::Array(_) | toml::Value::Table(_) => value.to_string(),
+    _ => crate::config::format_list_value(value),
   }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,6 +2,7 @@ use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
 use super::state::async_task::{TaskKind, TaskMsg, TaskRunner};
 use super::state::command_logs::CommandLogs;
+use super::state::config_panel::ConfigPanel;
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -85,6 +86,12 @@ pub enum View {
   /// commands gwm ran. Opened on `3`, scrolled like the help overlay;
   /// state lives on [`App::command_logs`].
   CommandLogs,
+  /// Configuration panel (issue #232). A ~90% fullscreen modal over a
+  /// dimmed list showing the resolved `.gwm.toml` (user-level global
+  /// deep-merged under the repo file) with a per-row source column
+  /// (repo / user / default). Opened on `4`, scrolled like the help
+  /// overlay; state lives on [`App::config_panel`].
+  Config,
 }
 
 /// What the run loop must do after [`App::handle_create_key`] processes a
@@ -327,6 +334,17 @@ pub struct App {
   /// owned snapshot of the [`crate::command_log`] global, so the modal
   /// renders off `App` state rather than locking the global mid-frame.
   pub command_logs: CommandLogs,
+
+  /// Configuration panel overlay state (issue #232): the scroll cursor
+  /// plus the resolved-row snapshot, filled by [`Self::enter_config_panel`].
+  pub config_panel: ConfigPanel,
+
+  /// The user-level global config path this `App` was constructed with
+  /// (issue #232). Stored so [`Self::enter_config_panel`] resolves the
+  /// panel's source attribution against the *same* layers the running
+  /// config was loaded from — `None` in tests / sandboxed runs with no
+  /// global file, matching [`Config::load_layered`]'s injection point.
+  global_path: Option<PathBuf>,
 }
 
 impl App {
@@ -408,6 +426,8 @@ impl App {
       task_tx,
       task_rx,
       command_logs: CommandLogs::new(),
+      config_panel: ConfigPanel::new(),
+      global_path: global_path.map(Path::to_path_buf),
     };
     // Seed the sidebar position from `[tui] sidebar_position` (issue
     // #188). Orientation stays at its `Auto` default — runtime-only.
@@ -910,6 +930,9 @@ impl App {
       // the statusbar behind it shows the underlying pane's context, as the
       // List view does.
       View::CommandLogs => self.pane_hint_context(),
+      // The Configuration panel (issue #232) is likewise a ~90% fullscreen
+      // modal; the statusbar behind it keeps the underlying pane context.
+      View::Config => self.pane_hint_context(),
       View::List => self.pane_hint_context(),
     }
   }
@@ -961,6 +984,24 @@ impl App {
     self.command_logs.sync();
     self.command_logs.reset();
     self.view = View::CommandLogs;
+  }
+
+  /// Open the Configuration panel (issue #232). Resolves the effective
+  /// config — the user-level global deep-merged under the repo `.gwm.toml`,
+  /// with per-row source attribution — into owned state, then resets the
+  /// scroll cursor so a re-open starts fresh at the top. The reads are
+  /// cheap local TOML parses; on failure the panel still opens (empty)
+  /// with the error on the statusbar rather than refusing to open.
+  pub fn enter_config_panel(&mut self) {
+    match crate::config::resolved_rows(&self.workdir, self.global_path.as_deref()) {
+      Ok(rows) => self.config_panel.rows = rows,
+      Err(e) => {
+        self.config_panel.rows = Vec::new();
+        self.status = format!("error: {}", e);
+      }
+    }
+    self.config_panel.reset();
+    self.view = View::Config;
   }
 
   /// Scroll the help overlay down one row, clamped to the renderer-published

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -128,6 +128,7 @@ define_actions! {
   FetchGithub       => "fetch_github",
   // Overlays
   CommandLogs       => "command_logs",
+  ConfigPanel       => "config_panel",
   Help              => "help",
   Quit              => "quit",
   // Future surface — bound to ':' by default, picked up by #32.
@@ -392,6 +393,7 @@ impl Keymap {
       def(Action::FocusWorktrees, &["1"]),
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
+      def(Action::ConfigPanel, &["4"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f", "r"]),
       def(Action::Create, &["n"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -29,6 +29,7 @@ pub use app::{
 };
 pub use state::async_task::{TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
+pub use state::config_panel::ConfigPanel;
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -300,6 +300,20 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
         _ => {}
       },
+      // Configuration panel (issue #232). Scrolls like the help / Command
+      // Logs overlays; closes on Esc / `q` or the bound `config_panel` key
+      // (default `4`) so the open key toggles it shut even when rebound.
+      View::Config => match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
+        KeyCode::Down | KeyCode::Char('j') => app.config_panel.scroll_down(),
+        KeyCode::Up | KeyCode::Char('k') => app.config_panel.scroll_up(),
+        KeyCode::Right | KeyCode::Char('l') => app.config_panel.scroll_right(),
+        KeyCode::Left | KeyCode::Char('h') => app.config_panel.scroll_left(),
+        KeyCode::Home | KeyCode::Char('g') => app.config_panel.scroll_to_top(),
+        KeyCode::End | KeyCode::Char('G') => app.config_panel.scroll_to_bottom(),
+        _ if app.key_matches_action(key, Action::ConfigPanel) => app.view = View::List,
+        _ => {}
+      },
       // Create-overlay keys live in a testable `App` method (issue #217);
       // the loop only owns the two side effects (submit / close).
       View::Create => match app.handle_create_key(key) {
@@ -525,6 +539,10 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     // it is a read-only transcript, harmless inside `gwm switch`, and
     // mirrors Help / the palette which also open from any List state.
     Action::CommandLogs => app.enter_command_logs(),
+    // Issue #232: `4` opens the Configuration panel. Like the Command Logs
+    // overlay it is read-only and not picker-gated — harmless inside
+    // `gwm switch`, opening from any List state.
+    Action::ConfigPanel => app.enter_config_panel(),
     // Picker-mode-gated actions fall through to no-op when the
     // guard fails (i.e. the user pressed them inside `gwm switch`).
     // Same fallthrough catches future actions not yet wired into

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -167,6 +167,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "show the command logs overlay",
     },
     PaletteEntry {
+      action: Action::ConfigPanel,
+      name: "config-panel",
+      description: "show the resolved configuration panel",
+    },
+    PaletteEntry {
       action: Action::Help,
       name: "help",
       description: "show the help overlay",

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -1,0 +1,79 @@
+//! Configuration panel modal state (issue #232).
+//!
+//! The scroll cursor for the ~90% fullscreen Configuration overlay plus
+//! the owned, already-resolved [`crate::config::ConfigRow`] snapshot the
+//! renderer paints. Unlike the Command Logs slice there is no `sync`:
+//! the `App` resolves the rows once on open (cheap local TOML reads via
+//! [`crate::config::resolved_rows`]) and assigns them here, so the panel
+//! renders from owned state with no I/O on the render path.
+//!
+//! Scroll mirrors the help / Command Logs overlays: the cursor lives
+//! here, but `max_scroll` / `max_x_scroll` are republished by the
+//! renderer each frame against the live viewport, since only the renderer
+//! knows both the content length and the inner modal height. The scroll
+//! methods clamp against whatever bound the last frame published.
+
+use crate::config::ConfigRow;
+
+/// Owned state for the Configuration overlay: the resolved rows and the
+/// (vertical + horizontal) scroll cursor with its renderer-published
+/// bounds.
+#[derive(Debug, Default)]
+pub struct ConfigPanel {
+  /// Resolved config rows (key, value, source), grouped section-first by
+  /// the renderer. Assigned by [`crate::tui::App::enter_config_panel`].
+  pub rows: Vec<ConfigRow>,
+  /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
+  pub scroll: u16,
+  /// Maximum vertical scroll offset, republished by the renderer each
+  /// frame as `content_rows.saturating_sub(viewport_rows)`.
+  pub max_scroll: u16,
+  /// Horizontal scroll offset, in columns. Clamped to `max_x_scroll`.
+  pub x_scroll: u16,
+  /// Maximum horizontal scroll offset, republished by the renderer.
+  pub max_x_scroll: u16,
+}
+
+impl ConfigPanel {
+  /// An empty overlay at the origin.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Scroll down one row, never past the last line.
+  pub fn scroll_down(&mut self) {
+    self.scroll = (self.scroll + 1).min(self.max_scroll);
+  }
+
+  /// Scroll up one row, never above the top.
+  pub fn scroll_up(&mut self) {
+    self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Scroll right one column, never past the widest line.
+  pub fn scroll_right(&mut self) {
+    self.x_scroll = (self.x_scroll + 1).min(self.max_x_scroll);
+  }
+
+  /// Scroll left one column, never before the first.
+  pub fn scroll_left(&mut self) {
+    self.x_scroll = self.x_scroll.saturating_sub(1);
+  }
+
+  /// Jump to the first row (`g`).
+  pub fn scroll_to_top(&mut self) {
+    self.scroll = 0;
+  }
+
+  /// Jump to the last row (`G`).
+  pub fn scroll_to_bottom(&mut self) {
+    self.scroll = self.max_scroll;
+  }
+
+  /// Reset the scroll cursor to the origin, keeping the resolved rows.
+  /// Called when the overlay opens.
+  pub fn reset(&mut self) {
+    self.scroll = 0;
+    self.x_scroll = 0;
+  }
+}

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -13,9 +13,11 @@
 //! - `sidebar` — scroll offsets + commit-line cache (#127)
 //! - `github_fetch` — TTL cache + inflight dedupe for `gh` shell-outs (#128, this PR)
 //! - `async_task` — generic off-thread spine (coalescing + late-drop) for slow ops (#231)
+//! - `config_panel` — scroll + resolved-row snapshot for the Configuration overlay (#232)
 
 pub mod async_task;
 pub mod command_logs;
+pub mod config_panel;
 pub mod confirm;
 pub mod create_form;
 pub mod filter;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2260,17 +2260,15 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
     // changes, mirroring `gwm config list`'s grouping.
     let mut current_section: Option<String> = None;
     for row in &app.config_panel.rows {
-      let section = row
-        .key
-        .split(|c| c == '.' || c == '[')
-        .next()
-        .unwrap_or("")
-        .to_string();
+      let section = row.key.split(['.', '[']).next().unwrap_or("").to_string();
       if current_section.as_deref() != Some(section.as_str()) {
         if current_section.is_some() {
           lines.push(Line::from(String::new()));
         }
-        lines.push(Line::from(Span::styled(format!("[{section}]"), help_section_style(accent))));
+        lines.push(Line::from(Span::styled(
+          format!("[{section}]"),
+          help_section_style(accent),
+        )));
         current_section = Some(section);
       }
       // Leading source column, colour-coded and padded so keys align: repo

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7,6 +7,7 @@ use super::state::spinner::DOT_FRAMES;
 use super::theme::Theme;
 use crate::bootstrap::{BootstrapReport, StepStatus};
 use crate::command_log::CommandStatus;
+use crate::config::ConfigSource;
 use crate::github::{IssueState, LinkSource, PrState};
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
@@ -79,6 +80,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::LinkPrompt => draw_link_prompt(f, app),
     View::CommandPalette => draw_command_palette(f, app),
     View::CommandLogs => draw_command_logs(f, app),
+    View::Config => draw_config_panel(f, app),
     View::List => {}
   }
 }
@@ -2225,6 +2227,87 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
   let scroll = app.command_logs.scroll;
   let x_scroll = app.command_logs.x_scroll;
+
+  f.render_widget(Clear, area);
+  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
+}
+
+/// Render the Configuration panel overlay (issue #232): a ~90% fullscreen
+/// modal listing the resolved config (user-level global merged under the
+/// repo `.gwm.toml`) grouped by top-level section, each row carrying a
+/// leading colour-coded source column (repo / user / default). Scrolls
+/// like the help / Command Logs overlays — the renderer republishes
+/// `config_panel.max_scroll` / `max_x_scroll` against the live viewport.
+fn draw_config_panel(f: &mut Frame, app: &mut App) {
+  let area = centered(90, 85, f.area());
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let repo_color = app.theme.clean;
+  let user_color = app.theme.branch;
+  let label_style = help_label_style(&app.theme);
+  let muted_style = Style::default().fg(muted);
+
+  let mut lines: Vec<Line<'static>> = overlay_title_lines("Configuration", accent);
+
+  if app.config_panel.rows.is_empty() {
+    lines.push(Line::from(Span::styled("No configuration resolved.", muted_style)));
+  } else {
+    // Rows arrive sorted (the flatten walks a `BTreeMap`), so each
+    // top-level section is contiguous — emit a `[section]` heading when it
+    // changes, mirroring `gwm config list`'s grouping.
+    let mut current_section: Option<String> = None;
+    for row in &app.config_panel.rows {
+      let section = row
+        .key
+        .split(|c| c == '.' || c == '[')
+        .next()
+        .unwrap_or("")
+        .to_string();
+      if current_section.as_deref() != Some(section.as_str()) {
+        if current_section.is_some() {
+          lines.push(Line::from(String::new()));
+        }
+        lines.push(Line::from(Span::styled(format!("[{section}]"), help_section_style(accent))));
+        current_section = Some(section);
+      }
+      // Leading source column, colour-coded and padded so keys align: repo
+      // overrides read strongest, user next, defaults muted.
+      let src_color = match row.source {
+        ConfigSource::Repo => repo_color,
+        ConfigSource::User => user_color,
+        ConfigSource::Default => muted,
+      };
+      lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(format!("{:<7}", row.source.label()), Style::default().fg(src_color)),
+        Span::raw("  "),
+        Span::styled(row.key.clone(), label_style),
+        Span::styled(" = ", muted_style),
+        Span::styled(row.value.clone(), Style::default().fg(Color::White)),
+      ]));
+    }
+  }
+
+  // Footer hint: scroll + close, matching the Command Logs overlay.
+  lines.push(Line::from(String::new()));
+  lines.push(Line::from(Span::styled(
+    "j/k scroll · g/G top/bottom · esc close",
+    muted_style.add_modifier(Modifier::ITALIC),
+  )));
+
+  // Publish the scroll bounds against the live viewport (mirrors
+  // `draw_command_logs` / `draw_help`).
+  let block = overlay_block(accent);
+  let inner = block.inner(area);
+  let viewport = inner.height as usize;
+  app.config_panel.max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  app.config_panel.scroll = app.config_panel.scroll.min(app.config_panel.max_scroll);
+  let viewport_w = inner.width as usize;
+  let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
+  app.config_panel.max_x_scroll = content_w.saturating_sub(viewport_w) as u16;
+  app.config_panel.x_scroll = app.config_panel.x_scroll.min(app.config_panel.max_x_scroll);
+  let scroll = app.config_panel.scroll;
+  let x_scroll = app.config_panel.x_scroll;
 
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1480,6 +1480,7 @@ impl HintContext {
         Hint::Key(Review, "review"),
         Hint::Key(FocusStatus, "status"),
         Hint::Key(CommandLogs, "logs"),
+        Hint::Key(ConfigPanel, "config"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -1491,6 +1492,7 @@ impl HintContext {
         Hint::Key(FetchGithub, "fetch"),
         Hint::Key(FocusWorktrees, "worktrees"),
         Hint::Key(CommandLogs, "logs"),
+        Hint::Key(ConfigPanel, "config"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -1958,6 +1960,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
   rows.push(entry(Action::FocusWorktrees, "focus the worktrees pane"));
   rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
   rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
+  rows.push(entry(Action::ConfigPanel, "show the resolved configuration panel"));
   rows.push(entry(
     Action::Filter,
     "open fuzzy filter bar (enter: sticky, esc: clear)",

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use gwm::config::{
-  expand_placeholders, review_tool_preset, BranchTypesSource, Config, SidebarPosition, TuiOpenMode, WorktreeConfig,
-  CONFIG_FILE,
+  expand_placeholders, resolved_rows, review_tool_preset, BranchTypesSource, Config, ConfigRow, ConfigSource,
+  SidebarPosition, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
 };
 use tempfile::TempDir;
 
@@ -1787,4 +1787,63 @@ focus = "not_a_color"
   let err = Config::load_layered(dir.path(), None).expect_err("invalid color must reject");
   let msg = format!("{}", err).to_lowercase();
   assert!(msg.contains("not_a_color"), "got: {msg}");
+}
+
+// --- Resolved config rows + source attribution (issue #232) -------------
+
+fn row_for<'a>(rows: &'a [ConfigRow], key: &str) -> &'a ConfigRow {
+  rows
+    .iter()
+    .find(|r| r.key == key)
+    .unwrap_or_else(|| panic!("key {key:?} missing from resolved rows"))
+}
+
+#[test]
+fn resolved_rows_attributes_each_key_to_its_winning_layer() {
+  let repo = TempDir::new().unwrap();
+  let global_dir = TempDir::new().unwrap();
+  let global_path = global_dir.path().join("config.toml");
+
+  // User (global) layer sets worktree.base AND tui.confirm_countdown_secs.
+  std::fs::write(
+    &global_path,
+    "[worktree]\nbase = \"/tmp/global-wt\"\n[tui]\nconfirm_countdown_secs = 7\n",
+  )
+  .unwrap();
+  // Repo layer overrides worktree.base only.
+  std::fs::write(repo.path().join(CONFIG_FILE), "[worktree]\nbase = \"/tmp/repo-wt\"\n").unwrap();
+
+  let rows = resolved_rows(repo.path(), Some(&global_path)).unwrap();
+
+  // Repo wins on a key set in both layers, and the resolved value is the
+  // repo's — identical formatting to `gwm config list`.
+  let base = row_for(&rows, "worktree.base");
+  assert_eq!(base.source, ConfigSource::Repo);
+  assert_eq!(base.value, "\"/tmp/repo-wt\"");
+
+  // The user layer provides a key the repo never mentions.
+  let countdown = row_for(&rows, "tui.confirm_countdown_secs");
+  assert_eq!(countdown.source, ConfigSource::User);
+  assert_eq!(countdown.value, "7");
+
+  // A key set in neither layer falls back to the built-in default.
+  assert_eq!(row_for(&rows, "worktree.path_pattern").source, ConfigSource::Default);
+}
+
+#[test]
+fn resolved_rows_with_no_files_marks_everything_default() {
+  let repo = TempDir::new().unwrap();
+  let rows = resolved_rows(repo.path(), None).unwrap();
+  assert!(!rows.is_empty(), "defaults still produce rows");
+  assert!(
+    rows.iter().all(|r| r.source == ConfigSource::Default),
+    "with no repo/global config every row is a built-in default"
+  );
+}
+
+#[test]
+fn config_source_labels_are_stable() {
+  assert_eq!(ConfigSource::Repo.label(), "repo");
+  assert_eq!(ConfigSource::User.label(), "user");
+  assert_eq!(ConfigSource::Default.label(), "default");
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1842,6 +1842,35 @@ fn resolved_rows_with_no_files_marks_everything_default() {
 }
 
 #[test]
+fn resolved_rows_attributes_array_of_tables_entries() {
+  // The common real-world shape is an array-of-tables (`[[labels]]`,
+  // `[[branch_types]]`), where the merged value goes through serde's struct
+  // serialisation and the raw layer through a bare file parse. This pins
+  // that those key shapes (`labels[0].name`, …) match so a repo-declared
+  // entry attributes to Repo rather than silently reading as a default.
+  let repo = TempDir::new().unwrap();
+  std::fs::write(
+    repo.path().join(CONFIG_FILE),
+    "[[labels]]\nname = \"bug\"\ncolor = \"d73a4a\"\n\n[[branch_types]]\nname = \"feat\"\ndescription = \"a feature\"\n",
+  )
+  .unwrap();
+
+  let rows = resolved_rows(repo.path(), None).unwrap();
+
+  assert_eq!(row_for(&rows, "labels[0].name").source, ConfigSource::Repo);
+  assert_eq!(row_for(&rows, "labels[0].name").value, "\"bug\"");
+  assert_eq!(row_for(&rows, "labels[0].color").source, ConfigSource::Repo);
+  assert_eq!(row_for(&rows, "branch_types[0].name").source, ConfigSource::Repo);
+
+  // An unset optional sub-field (`labels[0].description`) is omitted by the
+  // TOML serialiser (Option::None), so it produces no phantom default row.
+  assert!(
+    !rows.iter().any(|r| r.key == "labels[0].description"),
+    "unset optional sub-fields must not surface as default rows"
+  );
+}
+
+#[test]
 fn config_source_labels_are_stable() {
   assert_eq!(ConfigSource::Repo.label(), "repo");
   assert_eq!(ConfigSource::User.label(), "user");

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -227,6 +227,19 @@ fn default_keymap_binds_command_logs_to_3() {
 }
 
 #[test]
+fn default_keymap_binds_config_panel_to_4() {
+  // Issue #232: `4` opens the Configuration panel, extending the `1` / `2`
+  // / `3` / `4` pane-key family (focus_worktrees / focus_status /
+  // command_logs / config_panel).
+  let km = Keymap::defaults();
+  let four = KeyStroke::parse_chord("4").unwrap();
+  assert!(matches!(
+    km.lookup(&four),
+    ChordResolution::Matched(Action::ConfigPanel)
+  ));
+}
+
+#[test]
 fn user_override_replaces_default_for_one_action() {
   let mut km = Keymap::defaults();
   km.apply_override(Action::Down, vec![KeyStroke::parse_chord("Ctrl+n").unwrap()])

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -105,6 +105,37 @@ fn enter_command_logs_opens_the_overlay_syncs_and_resets_scroll() {
 }
 
 #[test]
+fn enter_config_panel_opens_resolves_rows_and_resets_scroll() {
+  // Issue #232: `4` opens the Configuration panel. Opening must (1) switch
+  // to the overlay view, (2) resolve the effective config into owned rows,
+  // and (3) reset the scroll cursor so a previously-scrolled session starts
+  // fresh at the top.
+  use gwm::config::ConfigSource;
+
+  let (_dir, mut app) = make_app();
+  app.config_panel.scroll = 9;
+  app.config_panel.x_scroll = 3;
+  app.enter_config_panel();
+
+  assert_eq!(app.view, View::Config);
+  assert_eq!(app.config_panel.scroll, 0, "scroll resets on open");
+  assert_eq!(app.config_panel.x_scroll, 0, "horizontal scroll resets on open");
+  assert!(
+    !app.config_panel.rows.is_empty(),
+    "opening resolves the effective config into rows"
+  );
+  // The fixture has no repo `.gwm.toml` and no global config, so every
+  // resolved value is a built-in default.
+  let base = app
+    .config_panel
+    .rows
+    .iter()
+    .find(|r| r.key == "worktree.base")
+    .expect("worktree.base resolved");
+  assert_eq!(base.source, ConfigSource::Default);
+}
+
+#[test]
 fn hint_context_follows_focus() {
   // Issue #217: the statusbar chip + help subtitle read the live focus. The
   // worktrees pane is the default; focusing the sidebar switches to Status.

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -266,6 +266,22 @@ fn worktrees_and_status_hints_advertise_the_command_logs_key() {
 }
 
 #[test]
+fn worktrees_and_status_hints_advertise_the_config_panel_key() {
+  // Issue #232: the statusbar which-key must advertise `4 config` so the
+  // Configuration panel is discoverable, alongside the `1`/`2`/`3` pane keys.
+  use gwm::tui::keymap::Keymap;
+  let km = Keymap::defaults();
+  for ctx in [HintContext::Worktrees, HintContext::Status] {
+    let resolved = ctx.resolve(&km);
+    assert!(
+      resolved.iter().any(|(k, l)| k == "4" && l == "config"),
+      "context {:?} must advertise the `4 config` hint: {resolved:?}",
+      ctx.label()
+    );
+  }
+}
+
+#[test]
 fn status_hints_resolve_user_rebindings() {
   // Issue #217 review (P2): the statusbar must show the *live* binding, not
   // the hard-coded default — the keymap actions are rebindable. `fetch` is

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -227,6 +227,34 @@ fn command_logs_modal_renders_empty_placeholder() {
 }
 
 #[test]
+fn config_panel_modal_renders_title_section_and_source_column() {
+  use gwm::config::{ConfigRow, ConfigSource};
+
+  let (_dir, mut app) = make_app();
+  // Inject rows directly so the render is deterministic (the event loop is
+  // what resolves the real config on open; here we pin the *render*).
+  app.config_panel.rows = vec![
+    ConfigRow {
+      key: "worktree.base".into(),
+      value: "\"/tmp/repo-wt\"".into(),
+      source: ConfigSource::Repo,
+    },
+    ConfigRow {
+      key: "worktree.path_pattern".into(),
+      value: "\"{type}-{issue}-{desc}\"".into(),
+      source: ConfigSource::Default,
+    },
+  ];
+  app.view = View::Config;
+  let buf = render(&mut app);
+  assert_present(&buf, "Configuration", "config panel title");
+  assert_present(&buf, "[worktree]", "grouped section heading");
+  assert_present(&buf, "worktree.base", "resolved config key");
+  assert_present(&buf, "repo", "source column marker");
+  assert_present(&buf, "default", "default source marker");
+}
+
+#[test]
 fn open_menu_modal_renders_title_and_targets() {
   let (_dir, mut app) = make_app();
   app.enter_open_menu();

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -1,0 +1,85 @@
+//! Configuration panel modal state slice (issue #232).
+//!
+//! Pure-state contract for `tui::state::config_panel::ConfigPanel`: the
+//! scroll cursor (vertical + horizontal) clamped against bounds the
+//! renderer republishes each frame, plus the owned resolved-row snapshot
+//! the modal paints. Mirrors the Command Logs slice's clamp tests —
+//! ratatui-free, no terminal backend.
+
+use gwm::config::{ConfigRow, ConfigSource};
+use gwm::tui::ConfigPanel;
+
+fn sample_row() -> ConfigRow {
+  ConfigRow {
+    key: "worktree.base".into(),
+    value: "\"/tmp/wt\"".into(),
+    source: ConfigSource::Repo,
+  }
+}
+
+#[test]
+fn new_starts_empty_at_the_origin() {
+  let panel = ConfigPanel::new();
+  assert!(panel.rows.is_empty());
+  assert_eq!(panel.scroll, 0);
+  assert_eq!(panel.x_scroll, 0);
+  assert_eq!(panel.max_scroll, 0);
+  assert_eq!(panel.max_x_scroll, 0);
+}
+
+#[test]
+fn scroll_down_clamps_to_max_scroll() {
+  let mut panel = ConfigPanel::new();
+  panel.max_scroll = 3;
+  for _ in 0..10 {
+    panel.scroll_down();
+  }
+  assert_eq!(panel.scroll, 3, "never scrolls past the last line");
+}
+
+#[test]
+fn scroll_up_saturates_at_zero() {
+  let mut panel = ConfigPanel::new();
+  panel.max_scroll = 5;
+  panel.scroll = 2;
+  panel.scroll_up();
+  panel.scroll_up();
+  panel.scroll_up();
+  assert_eq!(panel.scroll, 0);
+}
+
+#[test]
+fn horizontal_scroll_clamps_both_ways() {
+  let mut panel = ConfigPanel::new();
+  panel.max_x_scroll = 2;
+  for _ in 0..5 {
+    panel.scroll_right();
+  }
+  assert_eq!(panel.x_scroll, 2);
+  for _ in 0..5 {
+    panel.scroll_left();
+  }
+  assert_eq!(panel.x_scroll, 0);
+}
+
+#[test]
+fn scroll_to_top_and_bottom_jump_to_the_bounds() {
+  let mut panel = ConfigPanel::new();
+  panel.max_scroll = 7;
+  panel.scroll_to_bottom();
+  assert_eq!(panel.scroll, 7);
+  panel.scroll_to_top();
+  assert_eq!(panel.scroll, 0);
+}
+
+#[test]
+fn reset_zeroes_the_cursor_but_keeps_rows() {
+  let mut panel = ConfigPanel::new();
+  panel.rows.push(sample_row());
+  panel.scroll = 4;
+  panel.x_scroll = 2;
+  panel.reset();
+  assert_eq!(panel.scroll, 0);
+  assert_eq!(panel.x_scroll, 0);
+  assert_eq!(panel.rows.len(), 1, "reset clears the cursor, not the data");
+}


### PR DESCRIPTION
## Description

Adds a ~90% fullscreen **Configuration panel** on `4`, completing the
`1`/`2`/`3`/`4` pane-key family (worktrees / status / command-logs /
config). It shows the **resolved** `.gwm.toml` — the user-level global
config deep-merged under the repo file, exactly as `gwm config list`
resolves it — grouped by `[section]`, with a per-row **source column**
(repo / user / default) marking which layer won. That provenance is new
behaviour the CLI never exposed.

Read-first MVP per the issue: browse + scroll only; inline editing stays
a follow-up.

Closes #232

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `config::resolved_rows(repo_root, global_path)` + `ConfigSource`
  (repo/user/default) + `ConfigRow`: merges the layers like `config list`,
  then attributes each flattened key to the layer that declared it by
  probing each raw layer's literal keys (repo > user > default).
- Shared `flatten_value` / `format_list_value` moved into `config.rs`
  (`pub(crate)`) so the panel reuses the exact key shape `config list`
  emits — no drift between the two surfaces.
- `View::Config` + rebindable `Action::ConfigPanel` (default `4`), palette
  entry `config-panel`, which-key hint `4 config` (Worktrees + Status) and
  a help-overlay row. Read-only and not picker-gated, like Command Logs.
- `App::enter_config_panel` resolves rows once on open against the same
  global path the App loaded (`App::global_path`) — cheap local reads, so
  no async/loader (see note on #257 below).
- `ConfigPanel` state slice (rows + help-style scroll cursor) and
  `draw_config_panel` (grouped sections + colour-coded source column).
- Docs: CHANGELOG `[Unreleased]`, TUI keybindings table EN + FR (added `4`
  and backfilled the `3` row #226 had left out).

## Tests

- [x] `cargo test` passes locally (full suite, minimal PATH per CLAUDE.md)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

New/updated tests:
- `config_tests.rs` — source attribution: both-layers/repo-wins, user-only,
  default fallback, all-default with no files, **array-of-tables**
  (`labels[0].name` / `branch_types[0].name` → Repo, no phantom row for an
  unset `Option` sub-field), label stability.
- `tui_state_config_panel_tests.rs` — slice scroll/clamp/reset.
- `tui_app_tests.rs` — `enter_config_panel` transition + resolve + scroll reset.
- `keymap_tests.rs` — default `4` → `config_panel`.
- `tui_footer_tests.rs` — Worktrees + Status advertise `4 config`.
- `tui_modal_render_tests.rs` — title / `[section]` / source column render.
- Palette registry coverage enforced by existing `palette_tests`.

## Screenshots / TUI captures

Not captured (offline run). The render is pinned by
`tui_modal_render_tests::config_panel_modal_renders_title_section_and_source_column`.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (N/A — no CLI surface change; TUI docs updated)
- [x] `examples/gwm.toml.example` updated if config schema changed (N/A — no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #232
- Docs: `docs/2.tui/1.keybindings.md` (+ FR mirror)

## Notes for reviewers

- **#257 (standalone loader widget) is intentionally deferred, with user
  sign-off.** The panel renders from `self.config` — already resolved in
  memory; opening re-reads two local TOML files (sub-ms), so there is no
  genuine async/loading area. Wiring #257 here would be a loader that never
  renders — the exact dead-code trap #257's own text warns against. It is
  tracked to land with #255 (GitHub fetch) or #256 (bootstrap off-thread),
  which have real slow callers.
- The headline new behaviour is **layered source attribution**, which
  `gwm config list` does not provide — the array-of-tables test is the one
  to scrutinise (merged-struct vs raw-file key shapes).
- `View::Config` key dispatch (scroll/Esc/q/`4`-close) is exercised via the
  same boundary as the Command Logs overlay (loop-level, not unit-tested),
  consistent with that accepted pattern.