### PR TITLE
♻️ refactor(tui): run the GitHub fetch on the shared task spine (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The warm-cache draw path now renders the cached lines by reference; on a
   300-commit sidebar this is ~19% faster per frame (no perceptible change
   otherwise). ([#238](https://github.com/kbrdn1/gwm-cli/issues/238))
+- The off-thread GitHub issue / PR fetch (`F`) now runs on the same shared
+  async-task spine as the worktree refresh instead of its own channel — one
+  off-thread mechanism, not two. Behaviour-preserving for the happy path; the
+  spine's per-key generation counter is what fixes the race below.
+  ([#255](https://github.com/kbrdn1/gwm-cli/issues/255))
+
+### Fixed
+
+- GitHub status refresh no longer shows stale issue / PR data after a quick
+  re-fetch. Pressing `F` (or navigating away and back) while a fetch was still
+  in flight could let the *older* worker's result win the race and overwrite
+  the fresh one, because the previous dedupe had no per-fetch generation. The
+  fetch now rides the async-task spine, so a superseded worker's late result
+  is dropped regardless of arrival order.
+  ([#255](https://github.com/kbrdn1/gwm-cli/issues/255))
 
 ## Past releases
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use super::state::config_panel::ConfigPanel;
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
-use super::state::github_fetch::GitHubFetch;
+use super::state::github_fetch::{FetchKey, GitHubFetch};
 use super::state::link_prompt::LinkPrompt;
 use super::state::sidebar::SidebarState;
 use super::state::spinner::Spinner;
@@ -32,17 +32,6 @@ use std::time::{Duration, Instant};
 // `state::github_fetch` re-export landed) keep compiling. The owning
 // module is now `tui::state::github_fetch` — see #128.
 pub use super::state::github_fetch::GitHubFetchState;
-
-/// Result of an off-thread `gh issue view` / `gh pr view` shell-out
-/// (issue #217). The background fetch thread sends one of these back to
-/// the event loop over [`App::github_rx`]; [`App::drain_github_results`]
-/// applies it through the existing `GitHubFetch::complete_*` guards (so the
-/// #138 stale-result drop still holds). Carries owned, `Send` data only —
-/// no `git2::Repository` crosses the thread boundary.
-pub enum GithubFetchMsg {
-  Issue(u64, std::result::Result<IssueStatus, String>),
-  Pr(u64, std::result::Result<PrStatus, String>),
-}
 
 /// Spawnable launcher plan handed to the event loop by
 /// [`App::prepare_git_tui`] / [`App::prepare_review`]. Carries the
@@ -311,23 +300,17 @@ pub struct App {
   /// don't care about the gate).
   pub trust_mode: crate::trust::TrustMode,
 
-  /// Sender cloned into each background GitHub fetch thread (issue #217).
-  github_tx: mpsc::Sender<GithubFetchMsg>,
-  /// Receiver drained by [`Self::drain_github_results`] each event-loop
-  /// tick. Held for the lifetime of the `App`; when the `App` drops, any
-  /// still-running fetch thread's `send` simply fails and is ignored.
-  github_rx: mpsc::Receiver<GithubFetchMsg>,
-
-  /// Generic off-thread task spine (issue #231): coalescing + late-drop
-  /// for slow one-shot ops, starting with the worktree list refresh.
+  /// Generic off-thread task spine (issue #231; GitHub fetch folded in by
+  /// #255): coalescing + per-key generation late-drop for slow one-shot
+  /// ops — the worktree list refresh and the `gh issue/pr view` fetches.
   /// Public for the same reason `github` is — the state-machine tests
   /// claim a generation directly without spawning an OS thread.
   pub tasks: TaskRunner,
-  /// Sender cloned into each background task worker (issue #231).
+  /// Sender cloned into each background task worker (issue #231; carries the
+  /// GitHub fetch results too since #255).
   task_tx: mpsc::Sender<TaskMsg>,
-  /// Receiver drained by [`Self::drain_task_results`] each event-loop
-  /// tick. Mirrors the GitHub channel; a worker whose `App` has dropped
-  /// simply fails its `send` and is ignored.
+  /// Receiver drained by [`Self::drain_task_results`] each event-loop tick.
+  /// A worker whose `App` has dropped simply fails its `send` and is ignored.
   task_rx: mpsc::Receiver<TaskMsg>,
 
   /// Command Logs overlay state (issue #226): the scroll cursor plus an
@@ -384,7 +367,6 @@ impl App {
     if !worktrees.is_empty() {
       state.select(Some(0));
     }
-    let (github_tx, github_rx) = mpsc::channel();
     let (task_tx, task_rx) = mpsc::channel();
     let mut out = Self {
       repo,
@@ -420,8 +402,6 @@ impl App {
       link_prompt: LinkPrompt::new(),
       palette: PaletteState::new(),
       trust_mode: crate::trust::TrustMode::Prompt,
-      github_tx,
-      github_rx,
       tasks: TaskRunner::new(),
       task_tx,
       task_rx,
@@ -578,15 +558,24 @@ impl App {
   }
 
   /// Apply every background task result that has arrived since the last
-  /// call (issue #231), draining the channel without blocking. Each
-  /// result goes through [`TaskRunner::complete`], so a result whose
-  /// generation was bumped mid-flight is dropped (#138 guard, generalised).
+  /// call (issue #231; GitHub fetch results folded in by #255), draining
+  /// the channel without blocking. Each result goes through
+  /// [`TaskRunner::complete`], so a result whose per-key generation was
+  /// bumped mid-flight is dropped (#138 guard, generalised) — this is what
+  /// makes a stale GitHub worker lose to a fresh one in the retry race.
+  ///
   /// A failed refresh surfaces on the status bar and leaves the list
   /// intact — what used to be a fatal `refresh()?` that tore down the
-  /// event loop is now a graceful message. Returns `true` if at least one
-  /// result was applied, so the loop can force a redraw.
+  /// event loop is now a graceful message. A GitHub result is stamped into
+  /// the per-key cache via `complete_{issue,pr}` (pure writes now that the
+  /// drop decision lives on the spine); once nothing GitHub-side is left
+  /// loading, the aggregate outcome is re-reported on the status bar — the
+  /// same end state `drain_github_results` produced pre-#255. Returns `true`
+  /// if at least one result was applied, so the loop can force a redraw.
   pub fn drain_task_results(&mut self) -> bool {
     let mut applied = false;
+    let mut github_applied = false;
+    let mut refresh_applied = false;
     while let Ok(msg) = self.task_rx.try_recv() {
       match msg {
         TaskMsg::RefreshWorktrees(generation, result) => {
@@ -599,8 +588,41 @@ impl App {
             Err(e) => self.status = format!("refresh failed: {}", e),
           }
           applied = true;
+          refresh_applied = true;
+        }
+        TaskMsg::GithubIssue(generation, number, result) => {
+          // Generation guard: a stale worker whose slot was bumped by an
+          // intervening invalidate/re-request is dropped here, before it can
+          // stamp the cache (the Codex-flagged race, fixed by the spine).
+          if !self.tasks.complete(TaskKind::GithubIssue(number), generation) {
+            continue;
+          }
+          self.github.complete_issue(number, result);
+          applied = true;
+          github_applied = true;
+        }
+        TaskMsg::GithubPr(generation, number, result) => {
+          if !self.tasks.complete(TaskKind::GithubPr(number), generation) {
+            continue;
+          }
+          self.github.complete_pr(number, result);
+          applied = true;
+          github_applied = true;
         }
       }
+    }
+    // Once nothing GitHub-side is left loading, swap the "fetching…"
+    // placeholder for the real outcome (refreshed / partial failure /
+    // failure) — only when a GitHub result actually applied, so a dropped
+    // stale result never overwrites the current status (issue #217 review P2).
+    //
+    // Skip it when a worktree refresh also landed this tick: pre-#255 the
+    // event loop drained the GitHub channel *before* the task channel, so a
+    // simultaneous completion left `apply_refreshed_worktrees`' "refreshed —
+    // N" message standing last. The `!refresh_applied` guard preserves that
+    // ordering now that both drain in one pass.
+    if github_applied && !refresh_applied && !self.is_github_loading() {
+      self.report_github_refresh_status();
     }
     applied
   }
@@ -612,10 +634,10 @@ impl App {
   }
 
   /// A clone of the task channel sender background workers report over
-  /// (issue #231). Exposed so the async-apply path
-  /// ([`Self::drain_task_results`]) can be driven deterministically in
-  /// tests — inject a [`TaskMsg`] exactly as a worker would, then drain —
-  /// without spawning an OS thread. Mirrors [`Self::github_result_sender`].
+  /// (issue #231; GitHub fetch workers too since #255). Exposed so the
+  /// async-apply path ([`Self::drain_task_results`]) can be driven
+  /// deterministically in tests — inject a [`TaskMsg`] exactly as a worker
+  /// would, then drain — without spawning an OS thread or a real `gh`.
   pub fn task_result_sender(&self) -> mpsc::Sender<TaskMsg> {
     self.task_tx.clone()
   }
@@ -1629,6 +1651,12 @@ impl App {
   pub fn refresh_link(&mut self) {
     let branch = self.selected_branch_name();
     self.github.refresh_link(&self.repo, branch.as_deref());
+    // Navigation invariant (issue #255): the cache clear above must be paired
+    // with a spine generation-bump so any in-flight `gh` worker for the
+    // previous worktree's link is dropped instead of stamping the now-active
+    // worktree's cache. `refresh_link` no longer holds the old issue/PR
+    // numbers, so invalidate by predicate.
+    self.tasks.invalidate_matching(TaskKind::is_github);
   }
 
   fn selected_branch_name(&self) -> Option<String> {
@@ -1670,26 +1698,25 @@ impl App {
   }
 
   /// Kick off the issue/PR fetch. Called from the event loop when the
-  /// user presses `F` (refresh GitHub status). Routes through the
-  /// [`GitHubFetch`] dedupe layer: `request(key)` claims the per-target
-  /// inflight slot and flips `*_state = Loading`, then the `gh issue view`
-  /// / `gh pr view` shell-out runs **off-thread** (issue #217) so the TUI
-  /// stays responsive and the statusbar spinner can animate. Each thread
-  /// reports back over [`Self::github_tx`]; the event loop applies the
-  /// result via [`Self::drain_github_results`], which calls
-  /// `complete_{issue,pr}` — keeping the #128 dedupe and #138 stale-drop
-  /// guarantees intact.
+  /// user presses `F` (refresh GitHub status). Each `gh issue view` /
+  /// `gh pr view` shell-out runs **off-thread** on the shared async-task
+  /// spine (issue #255, migrated from #217's dedicated channel): the `App`
+  /// checks the per-key cache, claims a generation from
+  /// [`TaskRunner::request`], marks the cache `Loading`, and spawns a
+  /// worker tagged with that generation. The worker reports a
+  /// `TaskMsg::Github{Issue,Pr}` back; [`Self::drain_task_results`] applies
+  /// it only if the generation is still authoritative — so a stale worker
+  /// from a previous fetch loses the retry race to a fresh one.
   ///
   /// The PR auto-detection (`gh pr list`, issue #181) stays synchronous:
   /// it mutates `link` which the very next render needs, and it is a single
   /// cheap call rather than the two `view` shell-outs the spinner is for.
   ///
   /// This call path is the explicit user-initiated refresh, so it flushes
-  /// the cache via [`GitHubFetch::invalidate`] first — the user just asked
-  /// for fresh data, a `HitCache` short-circuit here would be a bug.
+  /// the cache + drops any in-flight worker via [`Self::invalidate_github`]
+  /// first — the user just asked for fresh data, a cache short-circuit here
+  /// would be a bug.
   pub fn refresh_github_status(&mut self) {
-    use super::state::github_fetch::{FetchAction, FetchKey};
-
     let slug = self.github.link_slug.clone();
 
     // Drop a prior auto-detection so this refresh re-resolves it live
@@ -1716,20 +1743,18 @@ impl App {
       self.status = "no GitHub remote — cannot fetch status".into();
       return;
     };
-    // Explicit user-initiated refresh: flush the cache before the
-    // request loop so `request` returns `Spawn` instead of `HitCache`
-    // for previously-loaded keys.
-    self.github.invalidate();
+    // Explicit user-initiated refresh: flush the cache (so the cold-cache
+    // branch fires instead of a hit) and drop any in-flight worker on the
+    // spine, so previously-loaded keys re-fetch.
+    self.invalidate_github();
     let mut spawned = 0u32;
     if let Some(n) = self.github.link.issue {
-      if let FetchAction::Spawn(_) = self.github.request(FetchKey::Issue(n)) {
-        self.spawn_github_fetch(FetchKey::Issue(n), slug.clone());
+      if self.spawn_github_issue(n, &slug) {
         spawned += 1;
       }
     }
     if let Some(n) = self.github.link.pr {
-      if let FetchAction::Spawn(_) = self.github.request(FetchKey::Pr(n)) {
-        self.spawn_github_fetch(FetchKey::Pr(n), slug.clone());
+      if self.spawn_github_pr(n, &slug) {
         spawned += 1;
       }
     }
@@ -1745,16 +1770,59 @@ impl App {
     }
   }
 
-  /// Spawn one background `gh` shell-out for `key` and wire its result back
-  /// over the channel (issue #217). Deliberately a thin shell: it owns only
-  /// the off-thread dispatch + send, no state logic — the contract lives in
-  /// `request` / `complete_*` (tested in `tui_state_github_fetch_tests.rs`)
-  /// and in [`Self::drain_github_results`] (tested in `tui_app_tests.rs`).
-  /// A `send` failure (the `App`/receiver was dropped) is ignored: there is
+  /// Flush the GitHub result cache **and** drop any in-flight GitHub worker
+  /// on the spine (issue #255). The navigation invariant: the cache clear
+  /// and the spine generation-bump must always move together, or a stale
+  /// worker's late result could outlive the cache flush. Routed through one
+  /// helper so the pairing can't desync — `refresh_github_status` and
+  /// (via the predicate) `refresh_link` are the only callers.
+  fn invalidate_github(&mut self) {
+    self.github.invalidate();
+    self.tasks.invalidate_matching(TaskKind::is_github);
+  }
+
+  /// Claim a spine generation for `Issue(n)` and spawn its `gh issue view`
+  /// worker (issue #255), returning `true` when a worker was actually
+  /// started. A terminal cache hit (the explicit refresh flushed the cache
+  /// first, so this only fires on a redundant call) or a coalesced spine
+  /// slot (a worker for this key is already in flight) returns `false`
+  /// without spawning a second subprocess.
+  fn spawn_github_issue(&mut self, n: u64, slug: &str) -> bool {
+    let key = FetchKey::Issue(n);
+    if self.github.is_cached(key) {
+      return false;
+    }
+    let Some(generation) = self.tasks.request(TaskKind::GithubIssue(n)) else {
+      return false;
+    };
+    self.github.mark_loading(key);
+    self.spawn_github_fetch(key, slug.to_string(), generation);
+    true
+  }
+
+  /// PR-side counterpart to [`Self::spawn_github_issue`] (issue #255).
+  fn spawn_github_pr(&mut self, n: u64, slug: &str) -> bool {
+    let key = FetchKey::Pr(n);
+    if self.github.is_cached(key) {
+      return false;
+    }
+    let Some(generation) = self.tasks.request(TaskKind::GithubPr(n)) else {
+      return false;
+    };
+    self.github.mark_loading(key);
+    self.spawn_github_fetch(key, slug.to_string(), generation);
+    true
+  }
+
+  /// Spawn one background `gh` shell-out for `key` tagged with `generation`
+  /// and wire its result back over the shared task channel (issue #255,
+  /// migrated from #217's dedicated channel). Deliberately a thin shell: it
+  /// owns only the off-thread dispatch + send, no state logic — the
+  /// coalescing / late-drop contract lives on the [`TaskRunner`] spine. A
+  /// `send` failure (the `App`/receiver was dropped) is ignored: there is
   /// no longer anyone to apply the result.
-  fn spawn_github_fetch(&self, key: super::state::github_fetch::FetchKey, slug: String) {
-    use super::state::github_fetch::FetchKey;
-    let tx = self.github_tx.clone();
+  fn spawn_github_fetch(&self, key: FetchKey, slug: String, generation: u64) {
+    let tx = self.task_tx.clone();
     // Resolve the `gh` program on THIS (main) thread and hand it to the
     // worker, so the worker never reads `GWM_GH` / the process environment
     // concurrently with env-mutating code elsewhere (the `env_lock`
@@ -1762,52 +1830,19 @@ impl App {
     let program = github::gh_program();
     std::thread::spawn(move || {
       let msg = match key {
-        FetchKey::Issue(n) => GithubFetchMsg::Issue(
+        FetchKey::Issue(n) => TaskMsg::GithubIssue(
+          generation,
           n,
           github::fetch_issue_with(&program, &slug, n).map_err(|e| e.to_string()),
         ),
-        FetchKey::Pr(n) => GithubFetchMsg::Pr(n, github::fetch_pr_with(&program, &slug, n).map_err(|e| e.to_string())),
+        FetchKey::Pr(n) => TaskMsg::GithubPr(
+          generation,
+          n,
+          github::fetch_pr_with(&program, &slug, n).map_err(|e| e.to_string()),
+        ),
       };
       let _ = tx.send(msg);
     });
-  }
-
-  /// Apply every GitHub fetch result that has arrived since the last call
-  /// (issue #217), draining the channel without blocking. Each result goes
-  /// through `complete_{issue,pr}`, so a result whose inflight slot was
-  /// cleared by an intervening navigation/`invalidate` is dropped (#138).
-  /// Returns `true` if at least one result was applied, so the event loop
-  /// can force a redraw. When the last inflight fetch lands, re-reports the
-  /// aggregate outcome on the status bar.
-  pub fn drain_github_results(&mut self) -> bool {
-    let mut applied = false;
-    while let Ok(msg) = self.github_rx.try_recv() {
-      // Only count results `complete_*` actually applied — a result whose
-      // inflight slot was invalidated mid-flight (#138) is dropped and must
-      // NOT trigger a status report over the current message (issue #217
-      // review P2).
-      let did_apply = match msg {
-        GithubFetchMsg::Issue(n, r) => self.github.complete_issue(n, r),
-        GithubFetchMsg::Pr(n, r) => self.github.complete_pr(n, r),
-      };
-      applied |= did_apply;
-    }
-    // Once nothing is left loading, swap the "fetching…" placeholder for the
-    // real outcome (refreshed / partial failure / failure).
-    if applied && !self.is_github_loading() {
-      self.report_github_refresh_status();
-    }
-    applied
-  }
-
-  /// A clone of the channel sender background fetch threads report over
-  /// (issue #217). Exposed so the async-apply path
-  /// ([`Self::drain_github_results`]) can be driven deterministically —
-  /// inject a [`GithubFetchMsg`] exactly as a thread would, then drain —
-  /// without spawning an OS thread or a real `gh` (the advisor-flagged
-  /// flaky-thread-test trap). `spawn_github_fetch` uses the same channel.
-  pub fn github_result_sender(&self) -> mpsc::Sender<GithubFetchMsg> {
-    self.github_tx.clone()
   }
 
   /// Compute the post-refresh status line message based on the actual

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,16 +24,14 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-pub use app::{
-  App, CreateKey, GithubFetchMsg, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
-};
+pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::async_task::{TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
 pub use state::config_panel::ConfigPanel;
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;
-pub use state::github_fetch::{FetchAction, FetchKey, GitHubFetch, GitHubFetchState};
+pub use state::github_fetch::{FetchKey, GitHubFetch, GitHubFetchState};
 pub use state::link_prompt::LinkPrompt;
 pub use state::sidebar::SidebarState;
 
@@ -152,14 +150,12 @@ fn confirm_fire(app: &mut App) {
 
 fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) -> Result<Option<PathBuf>> {
   loop {
-    // Background GitHub fetch (issue #217): apply any results that arrived
-    // off-thread since the last iteration, and advance the loader while a
-    // fetch is still inflight so the statusbar spinner animates at the
-    // 200ms poll cadence. Drained before the draw so the frame reflects the
-    // freshly-applied results.
-    app.drain_github_results();
-    // Generic off-thread tasks (issue #231): apply any worker results that
-    // landed since the last tick — e.g. an off-thread worktree refresh.
+    // Generic off-thread tasks (issue #231; GitHub fetch folded in by #255):
+    // apply any worker results that landed since the last tick — the
+    // off-thread worktree refresh and the `gh issue/pr view` fetches all
+    // report over this one channel now. Drained before the draw so the frame
+    // reflects the freshly-applied results, and the loader animates below
+    // while any of them is still in flight (200ms poll cadence).
     app.drain_task_results();
     if app.is_github_loading() || app.is_task_loading() {
       app.spinner.tick();

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -34,6 +34,7 @@
 //! module is pure state — no I/O, no `App` dependency — so the contract
 //! is pinned by `tests/tui_state_async_task_tests.rs`.
 
+use crate::github::{IssueStatus, PrStatus};
 use crate::worktree::WorktreeInfo;
 use std::collections::{HashMap, HashSet};
 
@@ -47,6 +48,16 @@ pub enum TaskKind {
   /// (create / delete / report-close) that need the list fresh before the
   /// next render.
   RefreshWorktrees,
+  /// Off-thread `gh issue view` fetch for the linked issue, keyed by issue
+  /// number (issue #255 — migrated from the separate `github_tx`/`inflight`
+  /// channel). The number is the coalescing key, so `Issue(42)` and
+  /// `Issue(43)` are independent slots with independent generations — the
+  /// per-key identity the late-drop guard needs to discard a stale worker
+  /// without clobbering a newer one's slot (the #138 guarantee, now keyed).
+  GithubIssue(u64),
+  /// PR-side counterpart to [`Self::GithubIssue`] (`gh pr view`). Keyed by
+  /// PR number; never collides with an issue of the same number.
+  GithubPr(u64),
 }
 
 impl TaskKind {
@@ -56,7 +67,17 @@ impl TaskKind {
   pub fn loading_label(self) -> &'static str {
     match self {
       TaskKind::RefreshWorktrees => "refreshing worktrees…",
+      TaskKind::GithubIssue(_) | TaskKind::GithubPr(_) => "fetching GitHub status…",
     }
+  }
+
+  /// `true` for the GitHub fetch kinds (`GithubIssue` / `GithubPr`). Used
+  /// as the predicate for [`TaskRunner::invalidate_matching`] so the `App`
+  /// can drop every in-flight GitHub fetch on navigation / explicit refresh
+  /// without naming the (now-stale) issue/PR numbers it no longer holds
+  /// (issue #255).
+  pub fn is_github(self) -> bool {
+    matches!(self, TaskKind::GithubIssue(_) | TaskKind::GithubPr(_))
   }
 }
 
@@ -69,6 +90,13 @@ pub enum TaskMsg {
   /// A worktree list refresh result: the freshly-listed worktrees, or a
   /// stringified error from the off-thread `discover_repo` + `list`.
   RefreshWorktrees(u64, std::result::Result<Vec<WorktreeInfo>, String>),
+  /// A `gh issue view` result (issue #255): the worker's `generation`, the
+  /// issue `number` it fetched, and the parsed [`IssueStatus`] (or a
+  /// stringified error). The generation lets [`TaskRunner::complete`] drop a
+  /// stale worker's result; the number keys it back into the GitHub cache.
+  GithubIssue(u64, u64, std::result::Result<IssueStatus, String>),
+  /// PR-side counterpart to [`Self::GithubIssue`] (`gh pr view`).
+  GithubPr(u64, u64, std::result::Result<PrStatus, String>),
 }
 
 /// Coalescing + late-drop spine for background tasks (issue #231).
@@ -118,6 +146,21 @@ impl TaskRunner {
   pub fn invalidate(&mut self, kind: TaskKind) {
     *self.generation.entry(kind).or_insert(0) += 1;
     self.running.remove(&kind);
+  }
+
+  /// [`Self::invalidate`] every in-flight kind matching `pred` (issue #255).
+  /// The GitHub fetch needs this because, on navigation, the `App` clears
+  /// the per-key cache for *all* GitHub fetches but no longer holds the
+  /// (stale) issue/PR numbers to invalidate them by key — a
+  /// `|k| k.is_github()` predicate drops every running GitHub worker's slot
+  /// so a fresh fetch starts at a new generation and the stale worker's late
+  /// result is discarded by [`Self::complete`]. Only running kinds are
+  /// touched: an idle kind has no in-flight worker to drop.
+  pub fn invalidate_matching<F: Fn(TaskKind) -> bool>(&mut self, pred: F) {
+    let hits: Vec<TaskKind> = self.running.iter().copied().filter(|&k| pred(k)).collect();
+    for kind in hits {
+      self.invalidate(kind);
+    }
   }
 
   /// Decide whether a result tagged `generation` for `kind` is still

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -1,5 +1,6 @@
 //! GitHub fetch state for the TUI (issue #128, part 6/6 of the
-//! `tui::app::App` decomposition #102).
+//! `tui::app::App` decomposition #102; threading migrated onto the
+//! shared async-task spine in #255).
 //!
 //! Owns the slice of `App` state that tracks issue / PR linking + the
 //! cached results of the `gh issue view` / `gh pr view` shell-outs:
@@ -12,51 +13,48 @@
 //! - `issue_cache` / `pr_cache` — per-(target, number) caches keyed
 //!   by issue / PR number. Each entry is a [`GitHubFetchState`]: cold
 //!   entries are simply absent from the map (treated as `Idle` by
-//!   the accessors), `Loading` while a shell-out is inflight,
+//!   the accessors), `Loading` while a shell-out is in flight,
 //!   `Loaded(T)` on success, `Error(msg)` on failure. Per-key identity
 //!   matters: pre-#138 the cache was a single per-target slot, so
 //!   completing `Issue(42)` falsely "warmed" `Issue(43)` (the cache
 //!   identity ignored the number).
-//! - `inflight` — an internal `HashSet<FetchKey>` that is the
-//!   load-bearing payoff of #128: it dedupes concurrent visit events
-//!   so two near-simultaneous calls into [`GitHubFetch::request`] for
-//!   the same `(target, number)` only spawn one `gh` subprocess.
 //!
-//! The orchestrator pattern: `App` does NOT shell out directly anymore
-//! on the dedupe path. It calls `self.github.request(key)`; if the
-//! return is [`FetchAction::Spawn`], the caller actually invokes
-//! `crate::github::fetch_{issue,pr}` and then reports the outcome via
-//! `self.github.complete_{issue,pr}(number, result)`. On
-//! [`FetchAction::HitCache`] the cached state is already in the
-//! per-key map; on [`FetchAction::AlreadyInflight`] a previous request
-//! is still in flight and the caller is expected to be a no-op.
+//! **What this module is, post-#255:** a *result cache* + link state.
+//! It deliberately no longer owns the off-thread coalescing / dedupe /
+//! late-result-drop — that machinery is now the generic
+//! [`super::async_task::TaskRunner`] spine, shared with the worktree
+//! refresh, so there is one off-thread mechanism instead of two. Pre-
+//! #255 this module also held an `inflight: HashSet<FetchKey>` that
+//! deduped concurrent fetches and gated the #138 late-drop, but it had
+//! **no per-fetch generation**: two workers for the same key (the
+//! request → invalidate → request retry path) were indistinguishable,
+//! so a stale worker that reported first could win the slot and a fresh
+//! result be dropped (Codex adversarial-review finding on PR #260). The
+//! spine's per-key generation counter fixes that race.
 //!
-//! Why an explicit dedupe layer? Pre-#128, every event that called
-//! `refresh_github_status` (worktree navigation, explicit `F` key,
-//! visit-driven refresh) would unconditionally spawn `gh issue view`
-//! and `gh pr view`. A user rapidly arrow-keying through five
-//! worktrees would queue ten `gh` subprocesses in flight, and the
-//! shell-out cost dominates the TUI redraw cost. The new contract:
-//! every spawn goes through `request(key)`, and a concurrent visit
-//! event to a still-loading target is dropped at the state boundary
-//! instead of all the way down in the shell.
+//! The orchestrator pattern (post-#255): `App` checks
+//! [`GitHubFetch::is_cached`] for a terminal hit; on a miss it claims a
+//! generation from the spine ([`TaskRunner::request`]), marks the cache
+//! [`GitHubFetchState::Loading`] via [`GitHubFetch::mark_loading`], and
+//! spawns the `gh` worker tagged with that generation. The worker posts
+//! a `TaskMsg::Github{Issue,Pr}` back; the event loop applies it only
+//! when [`TaskRunner::complete`] confirms the generation is still
+//! authoritative, then stamps the terminal result here via
+//! [`GitHubFetch::complete_issue`] / [`GitHubFetch::complete_pr`] (pure
+//! cache writes — the drop decision lives on the spine now).
 //!
 //! The explicit user-initiated refresh (`F` key →
-//! `App::refresh_github_status`) still bypasses the cache via
-//! [`GitHubFetch::invalidate`] before its `request` loop — the user
-//! just asked for fresh data, so a `HitCache` short-circuit there
-//! would be a bug. The inflight slot is still claimed so a
-//! concurrent visit-driven `request` dedupes correctly.
-//!
-//! Late-result handling (issue #138): `complete_*` checks whether the
-//! inflight slot survived an intervening `invalidate()` and silently
-//! drops the result if not. Pre-fix, a shell-out that completed after
-//! the user navigated away (and `invalidate()` cleared the slot)
-//! would stamp stale data into the now-active worktree's cache.
+//! `App::refresh_github_status`) flushes the cache via
+//! [`GitHubFetch::invalidate`] before re-requesting — the user just
+//! asked for fresh data, so a `HitCache` short-circuit there would be a
+//! bug — and the `App` pairs that flush with a spine
+//! `invalidate_matching(is_github)` so any in-flight worker's late
+//! result is dropped (the navigation invariant: cache clear and spine
+//! generation-bump always move together).
 
 use crate::github::{self, BranchLink, IssueStatus, PrStatus};
 use git2::Repository;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// State of a background GitHub fetch (issue or PR). Generic over `T`
 /// so the same enum drives both `IssueStatus` and `PrStatus`. The
@@ -100,33 +98,15 @@ pub enum FetchKey {
   Pr(u64),
 }
 
-/// Outcome of [`GitHubFetch::request`]. Three states, decided by the
-/// state of the per-key cache + the inflight set:
-///
-/// - [`Self::HitCache`] — the per-key cache already carries a terminal
-///   `Loaded` or `Error` variant for this key. The caller is a no-op;
-///   the rendered UI reads the cached state via the keyed accessors.
-/// - [`Self::AlreadyInflight`] — the cache holds `Loading` AND the key
-///   is in the inflight set. A previous `request` is still pending
-///   its `complete` call. The caller is a no-op (no shell-out, no UI
-///   change).
-/// - [`Self::Spawn`] — cold cache. The caller owns the side-effecting
-///   `gh` shell-out; the [`FetchKey`] payload tells it which
-///   subcommand to dispatch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FetchAction {
-  HitCache,
-  AlreadyInflight,
-  Spawn(FetchKey),
-}
-
-/// GitHub fetch state slice of the TUI `App` (issue #128).
+/// GitHub fetch state slice of the TUI `App` (issue #128; threading on
+/// the async-task spine since #255).
 ///
 /// See the module docs for the full contract; the short version is:
-/// `App` calls [`Self::request`] before any `gh` shell-out, branches
-/// on the returned [`FetchAction`], and reports the result back via
-/// [`Self::complete_issue`] / [`Self::complete_pr`] so the next
-/// `request` for the same key hits the cache instead of re-spawning.
+/// `App` checks [`Self::is_cached`], marks [`Self::mark_loading`] before
+/// spawning the `gh` worker on the [`super::async_task::TaskRunner`]
+/// spine, and stamps the terminal result back via
+/// [`Self::complete_issue`] / [`Self::complete_pr`] once the spine
+/// confirms the worker's generation is still authoritative.
 pub struct GitHubFetch {
   pub link: BranchLink,
   pub link_slug: Option<String>,
@@ -136,14 +116,6 @@ pub struct GitHubFetch {
   issue_cache: HashMap<u64, GitHubFetchState<IssueStatus>>,
   /// PR-side counterpart to [`Self::issue_cache`].
   pr_cache: HashMap<u64, GitHubFetchState<PrStatus>>,
-  /// Dedupe set: keys whose `gh` shell-out is currently inflight (the
-  /// caller got `Spawn` and hasn't called `complete_*` yet). A
-  /// concurrent `request` for a key in this set returns
-  /// `AlreadyInflight` — the load-bearing fix for #128. Also acts as
-  /// the "still authoritative" gate for `complete_*` (#138): a result
-  /// arriving for a key not in `inflight` was invalidated mid-flight
-  /// and gets dropped.
-  inflight: HashSet<FetchKey>,
 }
 
 impl Default for GitHubFetch {
@@ -153,27 +125,26 @@ impl Default for GitHubFetch {
 }
 
 impl GitHubFetch {
-  /// Construct an empty `GitHubFetch` with no link, no slug, empty
-  /// per-key caches, and an empty inflight set. The `App` constructor
-  /// calls this once and then immediately runs [`Self::refresh_link`]
-  /// against the repo so the cold state lasts only as long as the
-  /// constructor itself.
+  /// Construct an empty `GitHubFetch` with no link, no slug, and empty
+  /// per-key caches. The `App` constructor calls this once and then
+  /// immediately runs [`Self::refresh_link`] against the repo so the
+  /// cold state lasts only as long as the constructor itself.
   pub fn new() -> Self {
     Self {
       link: BranchLink::empty(),
       link_slug: None,
       issue_cache: HashMap::new(),
       pr_cache: HashMap::new(),
-      inflight: HashSet::new(),
     }
   }
 
   /// Re-read the link for `branch` against `repo`, re-resolve the
   /// repo slug from the `origin` remote, and reset every cached
-  /// fetch state + inflight slot. Called by `App::refresh_link`
-  /// after the user navigates to a different worktree — the cached
-  /// state refers to a different `(issue, pr)` tuple and would be
-  /// misleading if reused.
+  /// fetch state. Called by `App::refresh_link` after the user
+  /// navigates to a different worktree — the cached state refers to a
+  /// different `(issue, pr)` tuple and would be misleading if reused.
+  /// (`App::refresh_link` separately drops any in-flight GitHub worker
+  /// on the spine — see [`Self::invalidate`] for the pairing.)
   pub fn refresh_link(&mut self, repo: &Repository, branch: Option<&str>) {
     self.link = branch
       .and_then(|b| github::read_link(repo, b).ok())
@@ -182,21 +153,23 @@ impl GitHubFetch {
     self.invalidate();
   }
 
-  /// Flush every cached fetch state + inflight slot. Equivalent to
-  /// "the cached `(issue, pr)` tuples are no longer authoritative".
-  /// Called by [`Self::refresh_link`]; exposed standalone for
-  /// callers (e.g. an explicit "force refresh" key like `F`) that
-  /// want to wipe the cache without re-reading the link.
+  /// Flush every cached fetch state. Equivalent to "the cached
+  /// `(issue, pr)` tuples are no longer authoritative". Called by
+  /// [`Self::refresh_link`]; exposed standalone for callers (e.g. an
+  /// explicit "force refresh" key like `F`) that want to wipe the cache
+  /// without re-reading the link.
   ///
-  /// Clearing `inflight` here is load-bearing for #138: any `gh`
-  /// shell-out still in flight will report back via `complete_*`,
-  /// and the empty inflight set is how `complete_*` knows to drop
-  /// that late result instead of stamping it into the freshly-active
-  /// worktree's cache.
+  /// Post-#255 this clears only the result cache. Dropping any *in-
+  /// flight* worker's late result is the spine's job: the `App` pairs
+  /// every `invalidate()` with a
+  /// [`TaskRunner::invalidate_matching(is_github)`](super::async_task::TaskRunner::invalidate_matching)
+  /// so the stale generation is bumped and its result discarded by
+  /// [`TaskRunner::complete`](super::async_task::TaskRunner::complete).
+  /// That pairing is the navigation invariant — cache clear and spine
+  /// generation-bump always move together.
   pub fn invalidate(&mut self) {
     self.issue_cache.clear();
     self.pr_cache.clear();
-    self.inflight.clear();
   }
 
   /// Stamp an auto-detected PR onto the resolved `link` when none is
@@ -222,40 +195,14 @@ impl GitHubFetch {
     }
   }
 
-  /// Decide what the orchestrator should do for `key`. Three cases:
-  ///
-  /// 1. The per-key cache holds a terminal `Loaded` or `Error` for
-  ///    this key — return [`FetchAction::HitCache`]. The caller is a
-  ///    no-op; the renderer reads the cached state via the keyed
-  ///    accessors.
-  /// 2. The key is in the inflight set — return
-  ///    [`FetchAction::AlreadyInflight`]. The caller is a no-op; a
-  ///    previous `request(key)` is still pending its `complete`.
-  /// 3. Otherwise — cold cache. Insert `Loading` at the key, claim
-  ///    the inflight slot, return [`FetchAction::Spawn(key)`]. The
-  ///    caller owns the shell-out and MUST call
-  ///    `complete_{issue,pr}` to clear the inflight slot.
-  ///
-  /// The (target, number) tuple is the dedupe identity: `Issue(42)`
-  /// and `Pr(42)` are independent slots; `Issue(42)` and `Issue(43)`
-  /// are independent slots (the per-key cache enforces this, post-
-  /// #138). See `tests/tui_state_github_fetch_tests.rs` for the
-  /// pinned contract.
-  pub fn request(&mut self, key: FetchKey) -> FetchAction {
-    // Cache hit: prior `complete_*` already populated the per-key
-    // entry with a terminal variant. No shell-out, no inflight change.
-    if self.is_cached(key) {
-      return FetchAction::HitCache;
-    }
-    // Inflight: a prior `request(key)` is still pending its
-    // `complete_*`. Dedupe — the redundant `gh` shell-out is exactly
-    // what #128 closes.
-    if self.inflight.contains(&key) {
-      return FetchAction::AlreadyInflight;
-    }
-    // Cold cache: flip to Loading, claim the inflight slot, hand the
-    // caller the key so it knows which subcommand to dispatch.
-    self.inflight.insert(key);
+  /// Flip the per-key cache entry for `key` to
+  /// [`GitHubFetchState::Loading`] (issue #255). Called by the `App`
+  /// after it has claimed a generation from the spine and is about to
+  /// spawn the `gh` worker, so the sidebar paints a "…loading" badge and
+  /// [`App::is_github_loading`](crate::tui::App) reads `true` until the
+  /// terminal result lands. Pure: coalescing (skip the spawn if a worker
+  /// is already running) is the spine's call, not this module's.
+  pub fn mark_loading(&mut self, key: FetchKey) {
     match key {
       FetchKey::Issue(n) => {
         self.issue_cache.insert(n, GitHubFetchState::Loading);
@@ -264,56 +211,44 @@ impl GitHubFetch {
         self.pr_cache.insert(n, GitHubFetchState::Loading);
       }
     }
-    FetchAction::Spawn(key)
   }
 
-  /// Report the outcome of an issue fetch. The contract has two
-  /// guards (post-#138):
+  /// `true` when the per-key cache already carries a terminal `Loaded`
+  /// or `Error` for `key` (issue #255). The `App` consults this before
+  /// claiming a spine generation so an explicit-but-already-warm key
+  /// skips a redundant `gh` spawn. The `(target, number)` identity is
+  /// the cache key: `Issue(42)` / `Pr(42)` / `Issue(43)` are all
+  /// independent (post-#138).
+  pub fn is_cached(&self, key: FetchKey) -> bool {
+    self.has_terminal(key)
+  }
+
+  /// Stamp the terminal outcome of an issue fetch into the per-key cache
+  /// (issue #255). Pure cache write — `Ok` → `Loaded`, `Err` → `Error`,
+  /// keyed by `number`. After this call,
+  /// [`Self::is_cached(Issue(number))`](Self::is_cached) returns `true`.
   ///
-  /// 1. If the inflight slot for `Issue(number)` was already cleared
-  ///    (typically by an intervening [`Self::invalidate`]), the
-  ///    result is dropped — the user has navigated away and the
-  ///    late shell-out result is no longer authoritative.
-  /// 2. Otherwise, the per-key cache entry is stamped with `Loaded`
-  ///    on `Ok` or `Error` on `Err`. After this call,
-  ///    `request(Issue(number))` returns `HitCache` instead of
-  ///    re-spawning — see the module docs for the cache-on-error
-  ///    rationale.
-  ///
-  /// Returns `true` when the result was applied, `false` when dropped by
-  /// guard 1. Async callers use this to skip reporting a refresh outcome
-  /// for a result they silently discarded (issue #217 review).
-  pub fn complete_issue(&mut self, number: u64, result: std::result::Result<IssueStatus, String>) -> bool {
-    // #138 guard: if invalidate() cleared the slot mid-flight, drop
-    // the late result. Stamping it would corrupt the now-active
-    // worktree's cache with the previous worktree's data.
-    if !self.inflight.remove(&FetchKey::Issue(number)) {
-      return false;
-    }
+  /// Post-#255 there is no late-result guard here: the drop decision for
+  /// a superseded worker lives on the spine
+  /// ([`TaskRunner::complete`](super::async_task::TaskRunner::complete)),
+  /// which the `App` checks *before* calling this. So by the time we
+  /// stamp, the result is already known authoritative.
+  pub fn complete_issue(&mut self, number: u64, result: std::result::Result<IssueStatus, String>) {
     self.issue_cache.insert(number, into_state(result));
-    true
   }
 
-  /// PR-side counterpart to [`Self::complete_issue`]. Same #138 guard
-  /// applies: a late result whose inflight slot was cleared by an
-  /// intervening [`Self::invalidate`] is dropped. Returns `true` when the
-  /// result was applied, `false` when dropped.
-  pub fn complete_pr(&mut self, number: u64, result: std::result::Result<PrStatus, String>) -> bool {
-    if !self.inflight.remove(&FetchKey::Pr(number)) {
-      return false;
-    }
+  /// PR-side counterpart to [`Self::complete_issue`] — pure cache write,
+  /// no late-result guard (the spine owns that since #255).
+  pub fn complete_pr(&mut self, number: u64, result: std::result::Result<PrStatus, String>) {
     self.pr_cache.insert(number, into_state(result));
-    true
   }
 
   /// Stamp the issue fetch state from a fetch result. `Ok(s)` →
   /// `Loaded(s)` (keyed by `s.number`), `Err(msg)` → `Error(msg)`
   /// (keyed by the current `link.issue` if any). Test-friendly
-  /// wrapper used by `App::apply_issue_fetch_result`; does NOT
-  /// touch the inflight set (that's [`Self::complete_issue`]'s job)
-  /// and does NOT honour the late-result drop, because there's no
-  /// inflight slot to consult — the helper is for tests that stamp
-  /// state directly without going through `request → complete`.
+  /// wrapper used by `App::apply_issue_fetch_result`; the helper is for
+  /// tests that stamp state directly without going through the spine's
+  /// `request → complete` generation flow.
   ///
   /// If `Err` is given and no link issue is set, the helper is a
   /// no-op (there's no number to key by). Tests that exercise the
@@ -363,11 +298,11 @@ impl GitHubFetch {
   }
 
   /// `true` when the per-key cache carries a terminal variant
-  /// (`Loaded` or `Error`) for `key`. Used by [`Self::request`] to
-  /// decide between `HitCache` and the cold-cache branch. Post-#138
-  /// the cache is keyed by number, so `is_cached(Issue(43))` after
-  /// a `complete_issue(42, …)` correctly returns `false`.
-  fn is_cached(&self, key: FetchKey) -> bool {
+  /// (`Loaded` or `Error`) for `key`. Backs the public
+  /// [`Self::is_cached`]. Post-#138 the cache is keyed by number, so
+  /// `has_terminal(Issue(43))` after a `complete_issue(42, …)` correctly
+  /// returns `false`.
+  fn has_terminal(&self, key: FetchKey) -> bool {
     match key {
       FetchKey::Issue(n) => matches!(
         self.issue_cache.get(&n),

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1549,9 +1549,13 @@ fn apply_fetch_results_loads_issue_and_pr_state() {
 }
 
 fn sample_issue(n: u64) -> gwm::github::IssueStatus {
+  sample_issue_titled(n, "x")
+}
+
+fn sample_issue_titled(n: u64, title: &str) -> gwm::github::IssueStatus {
   gwm::github::IssueStatus {
     number: n,
-    title: "x".into(),
+    title: title.into(),
     state: gwm::github::IssueState::Open,
     url: String::new(),
     labels: vec![],
@@ -1559,23 +1563,119 @@ fn sample_issue(n: u64) -> gwm::github::IssueStatus {
   }
 }
 
+/// Drive the spine exactly as `refresh_github_status` does for one issue
+/// fetch: claim a generation and flip the cache to `Loading`. Returns the
+/// generation the (simulated) worker must tag its result with. Mirrors the
+/// real spawn path without an OS thread or a real `gh`.
+fn request_github_issue(app: &mut gwm::tui::App, n: u64) -> u64 {
+  use gwm::tui::{FetchKey, TaskKind};
+  let generation = app
+    .tasks
+    .request(TaskKind::GithubIssue(n))
+    .expect("a cold GitHub issue slot must hand out a generation");
+  app.github.mark_loading(FetchKey::Issue(n));
+  generation
+}
+
+/// Invalidate the GitHub side exactly as navigation / explicit `F` does:
+/// drop any in-flight worker on the spine AND flush the result cache (the
+/// navigation invariant — the two always move together).
+fn invalidate_github_for_test(app: &mut gwm::tui::App) {
+  use gwm::tui::TaskKind;
+  app.tasks.invalidate_matching(TaskKind::is_github);
+  app.github.invalidate();
+}
+
+#[test]
+fn stale_github_fetch_result_loses_to_a_newer_generation() {
+  // Codex adversarial-review (PR #260) finding, fixed by #255: pre-spine the
+  // GitHub fetch deduped on a per-key `inflight` HashSet with NO generation,
+  // so two workers for the SAME key (request → invalidate → request) were
+  // indistinguishable. Whichever result drained first claimed the single
+  // slot; if the STALE worker reported before the FRESH one, the stale data
+  // was stamped and the fresh result dropped. On the spine each fetch owns a
+  // generation, so the fresh (newer-generation) result wins regardless of
+  // arrival order.
+  use gwm::tui::TaskMsg;
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+
+  // Worker A claims the first generation for Issue(42).
+  let gen_a = request_github_issue(&mut app, 42);
+  // User navigates away and back (or presses F again): the slot is freed and
+  // the generation bumped, then Worker B claims a fresh generation.
+  invalidate_github_for_test(&mut app);
+  let gen_b = request_github_issue(&mut app, 42);
+  assert_ne!(gen_a, gen_b, "the second fetch must own a distinct generation");
+
+  // Both workers finish. Drain FRESH (B) FIRST, STALE (A) LAST — the
+  // discriminating order: plain last-write-wins would let the stale result
+  // clobber the fresh one, so only a working generation guard (drop A as
+  // superseded) yields FRESH. The reverse order would pass even with a
+  // broken always-apply guard, so it can't catch a regression.
+  let tx = app.task_result_sender();
+  tx.send(TaskMsg::GithubIssue(gen_b, 42, Ok(sample_issue_titled(42, "FRESH"))))
+    .unwrap();
+  tx.send(TaskMsg::GithubIssue(gen_a, 42, Ok(sample_issue_titled(42, "STALE"))))
+    .unwrap();
+  app.drain_task_results();
+
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(s) => assert_eq!(
+      s.title, "FRESH",
+      "the fresh (newer-generation) result must win the retry race, not the stale one"
+    ),
+    other => panic!("expected Loaded(FRESH), got {:?}", other),
+  }
+}
+
+#[test]
+fn a_simultaneous_refresh_keeps_its_status_over_the_github_report() {
+  // Behaviour-preserving guard (issue #255): pre-spine the event loop drained
+  // the GitHub channel before the task channel, so when a worktree refresh and
+  // a GitHub fetch completed on the same tick, `apply_refreshed_worktrees`'
+  // "refreshed — N" message ran last and stood. Now both drain in one pass; the
+  // post-loop GitHub report is gated on `!refresh_applied` to preserve that.
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+
+  // A GitHub fetch and a worktree refresh are both in flight.
+  let g_gen = request_github_issue(&mut app, 42);
+  let r_gen = app
+    .tasks
+    .request(TaskKind::RefreshWorktrees)
+    .expect("a cold refresh slot must hand out a generation");
+
+  // Both land on the same drain.
+  let tx = app.task_result_sender();
+  tx.send(TaskMsg::GithubIssue(g_gen, 42, Ok(sample_issue(42)))).unwrap();
+  tx.send(TaskMsg::RefreshWorktrees(r_gen, Ok(Vec::new()))).unwrap();
+  app.drain_task_results();
+
+  assert!(
+    app.status.starts_with("refreshed —"),
+    "the refresh message must win a simultaneous completion (pre-#255 order), got {:?}",
+    app.status
+  );
+}
+
 #[test]
 fn drain_applies_async_github_result() {
-  // Issue #217: a result delivered off-thread (over the channel) is applied
-  // by `drain_github_results`, flipping the inflight Loading state to Loaded.
-  use gwm::tui::{FetchKey, GithubFetchMsg};
+  // Issue #217 (threading on the spine since #255): a result delivered
+  // off-thread (over the task channel) is applied by `drain_task_results`,
+  // flipping the Loading state to Loaded.
+  use gwm::tui::TaskMsg;
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  // Claim the inflight slot exactly as `refresh_github_status` would.
-  app.github.request(FetchKey::Issue(42));
+  // Claim a generation + mark Loading exactly as `refresh_github_status` would.
+  let generation = request_github_issue(&mut app, 42);
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Loading));
   assert!(app.is_github_loading(), "request must mark the app as loading");
 
-  // A background thread reports back; we inject through the same channel.
+  // A background worker reports back; we inject through the same channel.
   app
-    .github_result_sender()
-    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .task_result_sender()
+    .send(TaskMsg::GithubIssue(generation, 42, Ok(sample_issue(42))))
     .unwrap();
-  let applied = app.drain_github_results();
+  let applied = app.drain_task_results();
 
   assert!(applied, "drain must report it applied a result");
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Loaded(_)));
@@ -1584,20 +1684,21 @@ fn drain_applies_async_github_result() {
 
 #[test]
 fn drain_drops_async_result_invalidated_mid_flight() {
-  // Issue #217 keeps the #138 guarantee on the async path: a result whose
-  // inflight slot was cleared by an intervening navigation/invalidate is
-  // dropped rather than stamped into the now-active worktree's cache.
-  use gwm::tui::{FetchKey, GithubFetchMsg};
+  // The #138 guarantee on the spine (issue #255): a result whose generation
+  // was bumped by an intervening navigation/invalidate is dropped rather
+  // than stamped into the now-active worktree's cache.
+  use gwm::tui::TaskMsg;
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  app.github.request(FetchKey::Issue(42));
-  // User navigates away → the cache + inflight set are flushed.
-  app.github.invalidate();
-  // The late shell-out result arrives after the invalidate.
+  let generation = request_github_issue(&mut app, 42);
+  // User navigates away → the cache is flushed and the spine slot bumped.
+  invalidate_github_for_test(&mut app);
+  // The late shell-out result arrives after the invalidate, tagged with the
+  // now-stale generation.
   app
-    .github_result_sender()
-    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .task_result_sender()
+    .send(TaskMsg::GithubIssue(generation, 42, Ok(sample_issue(42))))
     .unwrap();
-  app.drain_github_results();
+  app.drain_task_results();
   assert!(
     matches!(app.issue_fetch_state(), GitHubFetchState::Idle),
     "a result invalidated mid-flight must be dropped, not applied"
@@ -1607,25 +1708,26 @@ fn drain_drops_async_result_invalidated_mid_flight() {
 #[test]
 fn drain_is_a_noop_with_no_pending_results() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  assert!(!app.drain_github_results(), "empty channel must report nothing applied");
+  assert!(!app.drain_task_results(), "empty channel must report nothing applied");
 }
 
 #[test]
 fn drain_does_not_report_when_only_stale_results_arrive() {
-  // Issue #217 review (P2): a result whose inflight slot was invalidated
-  // (the user navigated away) is dropped by `complete_*`; the drain must NOT
-  // then stamp "github status refreshed" over the current status message.
-  use gwm::tui::{FetchKey, GithubFetchMsg};
+  // Issue #217 review (P2), preserved on the spine: a result whose
+  // generation was bumped (the user navigated away) is dropped by the
+  // generation guard; the drain must NOT then stamp "github status
+  // refreshed" over the current status message.
+  use gwm::tui::TaskMsg;
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  app.github.request(FetchKey::Issue(42));
-  app.github.invalidate(); // navigated away → inflight cleared
+  let generation = request_github_issue(&mut app, 42);
+  invalidate_github_for_test(&mut app); // navigated away → slot bumped
   app.status = "path: /somewhere/else".into();
   app
-    .github_result_sender()
-    .send(GithubFetchMsg::Issue(42, Ok(sample_issue(42))))
+    .task_result_sender()
+    .send(TaskMsg::GithubIssue(generation, 42, Ok(sample_issue(42))))
     .unwrap();
 
-  let applied = app.drain_github_results();
+  let applied = app.drain_task_results();
 
   assert!(!applied, "a dropped stale result must not count as applied");
   assert_eq!(
@@ -2682,7 +2784,7 @@ fn github_status_idle_body_does_not_render_fetch_prompt() {
 fn github_status_loading_uses_the_animated_spinner_frame() {
   use gwm::tui::FetchKey;
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  app.github.request(FetchKey::Issue(42));
+  app.github.mark_loading(FetchKey::Issue(42));
 
   let first = gwm::tui::github_status_lines(&app, 80)
     .into_iter()

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -102,3 +102,78 @@ fn loading_label_surfaces_the_inflight_task_label() {
   runner.request(TaskKind::RefreshWorktrees);
   assert_eq!(runner.loading_label(), Some("refreshing worktrees…"));
 }
+
+// ---- GitHub fetch kinds on the spine (issue #255) -------------------------
+
+#[test]
+fn github_kinds_report_the_shared_fetch_label() {
+  // Every GitHub fetch reads as the same statusbar copy regardless of which
+  // issue / PR number it carries, mirroring the pre-migration "fetching
+  // GitHub status…" line.
+  assert_eq!(TaskKind::GithubIssue(42).loading_label(), "fetching GitHub status…");
+  assert_eq!(TaskKind::GithubPr(7).loading_label(), "fetching GitHub status…");
+}
+
+#[test]
+fn is_github_is_true_only_for_github_kinds() {
+  assert!(TaskKind::GithubIssue(1).is_github());
+  assert!(TaskKind::GithubPr(1).is_github());
+  assert!(!TaskKind::RefreshWorktrees.is_github());
+}
+
+#[test]
+fn github_issue_and_pr_with_same_number_are_independent_slots() {
+  // The (target, number) identity carries onto the spine: Issue(42) and
+  // Pr(42) never coalesce or share a generation.
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.request(TaskKind::GithubIssue(42)), Some(1));
+  assert_eq!(
+    runner.request(TaskKind::GithubPr(42)),
+    Some(1),
+    "Pr(42) must claim its own slot, not coalesce onto Issue(42)"
+  );
+  assert!(runner.is_loading(TaskKind::GithubIssue(42)));
+  assert!(runner.is_loading(TaskKind::GithubPr(42)));
+}
+
+#[test]
+fn invalidate_matching_drops_only_running_github_slots() {
+  // The navigation path: a refresh worker and two GitHub fetches are in
+  // flight; `invalidate_matching(is_github)` must drop both GitHub slots and
+  // bump their generations, while leaving the refresh slot untouched.
+  let mut runner = TaskRunner::new();
+  runner.request(TaskKind::RefreshWorktrees);
+  let stale_issue = runner.request(TaskKind::GithubIssue(42)).unwrap();
+  let stale_pr = runner.request(TaskKind::GithubPr(7)).unwrap();
+
+  runner.invalidate_matching(|k| k.is_github());
+
+  assert!(
+    runner.is_loading(TaskKind::RefreshWorktrees),
+    "a non-GitHub task must survive invalidate_matching(is_github)"
+  );
+  assert!(!runner.is_loading(TaskKind::GithubIssue(42)), "GitHub issue slot freed");
+  assert!(!runner.is_loading(TaskKind::GithubPr(7)), "GitHub pr slot freed");
+  // The stale generations are now superseded — their late results drop.
+  assert!(!runner.complete(TaskKind::GithubIssue(42), stale_issue));
+  assert!(!runner.complete(TaskKind::GithubPr(7), stale_pr));
+}
+
+#[test]
+fn a_stale_github_worker_loses_to_a_newer_generation_after_invalidate() {
+  // The Codex-flagged race at the spine level: Worker A claims gen 1 for
+  // Issue(42); an invalidate (navigate away/back) bumps the generation;
+  // Worker B claims a fresh generation. Whatever the arrival order, A's
+  // result is dropped and B's is authoritative.
+  let mut runner = TaskRunner::new();
+  let gen_a = runner.request(TaskKind::GithubIssue(42)).unwrap();
+  runner.invalidate_matching(|k| k.is_github());
+  let gen_b = runner.request(TaskKind::GithubIssue(42)).unwrap();
+  assert_ne!(gen_a, gen_b, "the fresh run must own a distinct generation");
+
+  // Stale worker A reports first — dropped.
+  assert!(!runner.complete(TaskKind::GithubIssue(42), gen_a));
+  // Fresh worker B reports second — applied, and clears the slot.
+  assert!(runner.complete(TaskKind::GithubIssue(42), gen_b));
+  assert!(!runner.is_loading(TaskKind::GithubIssue(42)));
+}

--- a/tests/tui_state_github_fetch_tests.rs
+++ b/tests/tui_state_github_fetch_tests.rs
@@ -1,29 +1,25 @@
 //! Unit tests for the pure `GitHubFetch` sub-struct (issue #128, part
-//! 6/6 of the `tui::app::App` decomposition #102).
+//! 6/6 of the `tui::app::App` decomposition #102; threading migrated onto
+//! the async-task spine in #255).
 //!
-//! Exercises the GitHub fetch state slice in isolation — `GitHubFetch`
-//! owns `link`, `link_slug`, `issue_state`, `pr_state`, and the
-//! inflight-dedupe layer that closes the load-bearing payoff of #128:
-//! "multiple concurrent visit events to the same target trigger
-//! redundant `gh` shell-outs because there's no dedupe layer". The
-//! `App` orchestrator keeps the side-effecting shell-out
-//! (`gh issue view`, `gh pr view`); this module's tests pin the pure
-//! state machine + dedupe contract.
+//! Post-#255 `GitHubFetch` is a *result cache* + link state: it owns
+//! `link`, `link_slug`, and the per-(target, number) `issue_cache` /
+//! `pr_cache`. The off-thread coalescing, the inflight dedupe, and the
+//! late-result drop it used to hold are now the generic
+//! `state::async_task::TaskRunner` spine (covered by
+//! `tui_state_async_task_tests.rs`). These tests pin what the cache still
+//! owns:
 //!
-//! Dedupe contract:
-//!
-//! - `request(key)` on a cold cache returns `Spawn` and marks the key
-//!   inflight so a concurrent caller can dedupe.
-//! - A second `request(key)` while inflight returns `AlreadyInflight`
-//!   (no redundant shell-out).
-//! - `complete(key, result)` clears the inflight flag and stores the
-//!   loaded / errored state on `issue_state` or `pr_state` so the
-//!   next `request(key)` returns `HitCache` instead of re-spawning.
-//! - Different keys (e.g. `Issue(42)` vs `Pr(42)`) never collide — the
-//!   target discriminant is part of the dedupe identity.
+//! - `mark_loading(key)` flips the per-key entry to `Loading`.
+//! - `complete_{issue,pr}(n, result)` stamps the terminal `Loaded` /
+//!   `Error` variant (a pure write — the drop decision lives on the spine).
+//! - `is_cached(key)` is `true` only for a terminal variant, and the
+//!   `(target, number)` tuple is the cache identity: `Issue(42)`,
+//!   `Pr(42)`, and `Issue(43)` are all independent (the #138 keying).
+//! - `invalidate()` clears the cache.
 
 use gwm::github::{IssueState, IssueStatus, PrState, PrStatus};
-use gwm::tui::state::github_fetch::{FetchAction, FetchKey, GitHubFetch, GitHubFetchState};
+use gwm::tui::state::github_fetch::{FetchKey, GitHubFetch, GitHubFetchState};
 
 fn sample_issue(n: u64) -> IssueStatus {
   IssueStatus {
@@ -48,254 +44,131 @@ fn sample_pr(n: u64) -> PrStatus {
   }
 }
 
-// ---- Cold cache returns Spawn ---------------------------------------------
+// ---- mark_loading flips the per-key entry to Loading ----------------------
 
 #[test]
-fn request_on_cold_cache_returns_spawn_for_issue() {
+fn mark_loading_flips_issue_to_loading() {
   let mut gh = GitHubFetch::new();
-  let action = gh.request(FetchKey::Issue(42));
-  assert!(matches!(action, FetchAction::Spawn(FetchKey::Issue(42))));
-  // And the per-key entry flips to `Loading` so the UI can paint an
-  // in-flight badge — same contract the pre-extraction
-  // `refresh_github_status` used; post-#138 it's read via the keyed
-  // accessor instead of a per-target field.
+  assert!(matches!(gh.issue_fetch_state(42), GitHubFetchState::Idle));
+  gh.mark_loading(FetchKey::Issue(42));
   assert!(matches!(gh.issue_fetch_state(42), GitHubFetchState::Loading));
 }
 
 #[test]
-fn request_on_cold_cache_returns_spawn_for_pr() {
+fn mark_loading_flips_pr_to_loading() {
   let mut gh = GitHubFetch::new();
-  let action = gh.request(FetchKey::Pr(7));
-  assert!(matches!(action, FetchAction::Spawn(FetchKey::Pr(7))));
+  gh.mark_loading(FetchKey::Pr(7));
   assert!(matches!(gh.pr_fetch_state(7), GitHubFetchState::Loading));
 }
 
-// ---- Dedupe: second request while inflight returns AlreadyInflight --------
+// ---- is_cached is true only for a terminal variant ------------------------
 
 #[test]
-fn second_request_while_inflight_returns_already_inflight() {
-  let mut gh = GitHubFetch::new();
-  let first = gh.request(FetchKey::Issue(42));
-  assert!(matches!(first, FetchAction::Spawn(_)));
+fn is_cached_is_false_on_a_cold_cache() {
+  let gh = GitHubFetch::new();
+  assert!(!gh.is_cached(FetchKey::Issue(42)));
+  assert!(!gh.is_cached(FetchKey::Pr(7)));
+}
 
-  // Concurrent visit event hits the same key before completion. Without
-  // dedupe, this would trigger a redundant `gh issue view 42 …` — the
-  // load-bearing payoff of #128 is that it doesn't.
-  let second = gh.request(FetchKey::Issue(42));
+#[test]
+fn is_cached_is_false_while_loading() {
+  // A Loading entry is not terminal — the `App` must still let the worker
+  // finish, not short-circuit on a half-populated slot.
+  let mut gh = GitHubFetch::new();
+  gh.mark_loading(FetchKey::Issue(42));
   assert!(
-    matches!(second, FetchAction::AlreadyInflight),
-    "expected AlreadyInflight on second request to the same key, got {:?}",
-    second
+    !gh.is_cached(FetchKey::Issue(42)),
+    "a Loading entry must not count as cached"
   );
 }
 
 #[test]
-fn third_request_while_inflight_still_returns_already_inflight() {
+fn complete_issue_stamps_loaded_and_marks_cached() {
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Pr(11)), FetchAction::Spawn(_)));
-  assert!(matches!(gh.request(FetchKey::Pr(11)), FetchAction::AlreadyInflight));
-  assert!(matches!(gh.request(FetchKey::Pr(11)), FetchAction::AlreadyInflight));
-}
-
-// ---- After complete: cache is warm, request hits cache --------------------
-
-#[test]
-fn after_complete_request_returns_hit_cache_for_issue() {
-  let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
+  gh.mark_loading(FetchKey::Issue(42));
   gh.complete_issue(42, Ok(sample_issue(42)));
-  let action = gh.request(FetchKey::Issue(42));
-  assert!(
-    matches!(action, FetchAction::HitCache),
-    "expected HitCache after successful complete, got {:?}",
-    action
-  );
-  // And the loaded state is observable via the keyed accessor.
   assert!(matches!(gh.issue_fetch_state(42), GitHubFetchState::Loaded(_)));
+  assert!(gh.is_cached(FetchKey::Issue(42)));
 }
 
 #[test]
-fn after_complete_request_returns_hit_cache_for_pr() {
+fn complete_pr_stamps_loaded_and_marks_cached() {
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::Spawn(_)));
+  gh.mark_loading(FetchKey::Pr(7));
   gh.complete_pr(7, Ok(sample_pr(7)));
-  let action = gh.request(FetchKey::Pr(7));
-  assert!(matches!(action, FetchAction::HitCache));
   assert!(matches!(gh.pr_fetch_state(7), GitHubFetchState::Loaded(_)));
+  assert!(gh.is_cached(FetchKey::Pr(7)));
 }
 
 #[test]
-fn after_errored_complete_request_returns_hit_cache() {
-  // An errored fetch is still "completed" — re-shelling out on every
-  // visit event after a hard `gh` failure would be a noise amplifier,
-  // not a fix. Cache the error, let the explicit `F` (refresh) key
-  // bypass via `invalidate()`.
+fn an_errored_complete_is_still_terminal_and_cached() {
+  // An errored fetch is still "completed" — re-shelling out on every visit
+  // event after a hard `gh` failure would be a noise amplifier. Cache the
+  // error; the explicit `F` (refresh) key bypasses via `invalidate()`.
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
+  gh.mark_loading(FetchKey::Issue(42));
   gh.complete_issue(42, Err("gh: connection refused".into()));
-  let action = gh.request(FetchKey::Issue(42));
-  assert!(matches!(action, FetchAction::HitCache));
   assert!(matches!(gh.issue_fetch_state(42), GitHubFetchState::Error(_)));
+  assert!(gh.is_cached(FetchKey::Issue(42)));
 }
 
-// ---- Different keys (Issue 42 vs PR 42) don't collide ---------------------
+// ---- (target, number) is the cache identity (#138 keying) -----------------
 
 #[test]
-fn issue_and_pr_with_same_number_do_not_collide_in_dedupe() {
+fn issue_and_pr_with_same_number_are_independent_in_the_cache() {
+  // Same number, different target — completing one must not warm the other.
   let mut gh = GitHubFetch::new();
-  // Issue 42 goes inflight.
-  let issue_action = gh.request(FetchKey::Issue(42));
-  assert!(matches!(issue_action, FetchAction::Spawn(_)));
-  // PR 42 — same number, different target — must still Spawn. If the
-  // dedupe key only hashed the number, this would wrongly return
-  // AlreadyInflight and the PR fetch would never fire.
-  let pr_action = gh.request(FetchKey::Pr(42));
-  assert!(
-    matches!(pr_action, FetchAction::Spawn(_)),
-    "Issue(42) and Pr(42) must not collide in dedupe, got {:?}",
-    pr_action
-  );
-}
-
-#[test]
-fn completing_issue_does_not_clear_inflight_pr() {
-  let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
-  assert!(matches!(gh.request(FetchKey::Pr(42)), FetchAction::Spawn(_)));
-  // Completing the issue must NOT clear the PR's inflight flag.
   gh.complete_issue(42, Ok(sample_issue(42)));
-  let pr_action = gh.request(FetchKey::Pr(42));
+  assert!(gh.is_cached(FetchKey::Issue(42)));
   assert!(
-    matches!(pr_action, FetchAction::AlreadyInflight),
-    "complete_issue must not free Pr(42)'s inflight slot, got {:?}",
-    pr_action
+    !gh.is_cached(FetchKey::Pr(42)),
+    "Issue(42) and Pr(42) must not share a cache slot"
   );
 }
 
 #[test]
-fn different_issue_numbers_do_not_collide() {
+fn caching_one_issue_number_does_not_warm_another() {
+  // Pre-#138 the cache was a single per-target slot, so any terminal
+  // Issue(_) made every Issue(*) falsely hit. The cache is keyed by
+  // (target, number), so Issue(43) stays cold after completing Issue(42).
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
-  // A different issue # must Spawn — dedupe is per-(target, number),
-  // not just per-target.
-  assert!(matches!(gh.request(FetchKey::Issue(43)), FetchAction::Spawn(_)));
-}
-
-// ---- complete() clears the inflight slot so a follow-up request is Spawn
-//      after explicit invalidation ----------------------------------------
-
-#[test]
-fn complete_clears_inflight_slot() {
-  let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
   gh.complete_issue(42, Ok(sample_issue(42)));
-  // Cache is warm — a `request` returns HitCache, not AlreadyInflight.
-  // The inflight slot itself was cleared by `complete`.
-  let action = gh.request(FetchKey::Issue(42));
-  assert!(matches!(action, FetchAction::HitCache));
-  // Invalidate (simulates `refresh_link` after the user navigates to
-  // a different worktree) and request again — should Spawn, not
-  // AlreadyInflight (the slot was correctly freed by `complete`).
-  gh.invalidate();
-  let action = gh.request(FetchKey::Issue(42));
+  assert!(gh.is_cached(FetchKey::Issue(42)));
   assert!(
-    matches!(action, FetchAction::Spawn(_)),
-    "after complete + invalidate, request should Spawn (inflight slot was freed by complete), got {:?}",
-    action
-  );
-}
-
-// ---- Bug #138 / pin 1: cache identity must include the FetchKey number ----
-//
-// Pre-fix: `is_cached` looked only at the per-target `*_state` enum, so
-// any terminal variant for `Issue(_)` made every `Issue(*)` key falsely
-// hit the cache. After completing Issue(42), a request for Issue(43)
-// must STILL return Spawn — Issue 43 was never fetched, so the cache
-// for 43 is cold.
-
-#[test]
-fn request_after_complete_for_different_number_returns_spawn_not_hit_cache() {
-  let mut gh = GitHubFetch::new();
-  // Warm Issue(42).
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
-  gh.complete_issue(42, Ok(sample_issue(42)));
-  // Issue(42) is now cached — sanity check.
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::HitCache));
-  // Different number, same target — MUST Spawn. The cache is keyed by
-  // `(target, number)`, and Issue(43) was never fetched.
-  let action = gh.request(FetchKey::Issue(43));
-  assert!(
-    matches!(action, FetchAction::Spawn(FetchKey::Issue(43))),
-    "Issue(43) was never fetched, but is_cached(Issue(43)) wrongly returned true — \
-     cache identity ignores the FetchKey number field (bug #138). got {:?}",
-    action
+    !gh.is_cached(FetchKey::Issue(43)),
+    "Issue(43) was never fetched — the cache identity must include the number (bug #138)"
   );
 }
 
 #[test]
-fn request_after_complete_for_different_pr_number_returns_spawn_not_hit_cache() {
-  // PR-side mirror of the issue bug — same shape, different target.
+fn caching_one_pr_number_does_not_warm_another() {
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::Spawn(_)));
   gh.complete_pr(7, Ok(sample_pr(7)));
-  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::HitCache));
-  let action = gh.request(FetchKey::Pr(8));
+  assert!(gh.is_cached(FetchKey::Pr(7)));
   assert!(
-    matches!(action, FetchAction::Spawn(FetchKey::Pr(8))),
-    "Pr(8) was never fetched, but is_cached(Pr(8)) wrongly returned true — \
-     cache identity ignores the FetchKey number field (bug #138). got {:?}",
-    action
+    !gh.is_cached(FetchKey::Pr(8)),
+    "Pr(8) was never fetched — the cache identity must include the number (bug #138)"
   );
 }
 
-// ---- Bug #138 / pin 2: complete_* must drop result if invalidated mid-flight
-//
-// Pre-fix: `complete_issue`/`complete_pr` unconditionally stamped the
-// result onto `*_state`, even when an intervening `invalidate()` had
-// already cleared the inflight slot. The race:
-//
-//   1. request(Issue(42))      → Spawn, inflight = {Issue(42)}
-//   2. invalidate()            → inflight = {} (user navigated away)
-//   3. complete_issue(42, Ok(...)) → stamps Loaded() into the
-//      now-active state, corrupting the new worktree's cache.
-//
-// The fix: complete_* must check whether the inflight slot survived
-// the invalidation and silently drop the result if not.
+// ---- invalidate clears the cache ------------------------------------------
 
 #[test]
-fn complete_after_invalidate_drops_the_stale_result() {
+fn invalidate_clears_the_cache() {
+  // Simulates `refresh_link` after the user navigates to a different
+  // worktree: the cached (issue, pr) tuple is no longer authoritative.
   let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
-  // User navigates away → invalidate() clears the inflight slot.
-  gh.invalidate();
-  // The shell-out finally returns. complete_issue must drop it because
-  // the slot is no longer claimed — anything else corrupts the cache
-  // for the now-active worktree (bug #138).
   gh.complete_issue(42, Ok(sample_issue(42)));
-  // The cache must remain cold for Issue(42) — the late result was
-  // dropped, so a fresh request must Spawn, not HitCache.
-  let action = gh.request(FetchKey::Issue(42));
-  assert!(
-    matches!(action, FetchAction::Spawn(_)),
-    "complete_issue stamped a stale result into a cache that was invalidated mid-flight — \
-     the late result must be dropped (bug #138). got {:?}",
-    action
-  );
-}
-
-#[test]
-fn complete_pr_after_invalidate_drops_the_stale_result() {
-  let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::Spawn(_)));
-  gh.invalidate();
   gh.complete_pr(7, Ok(sample_pr(7)));
-  let action = gh.request(FetchKey::Pr(7));
-  assert!(
-    matches!(action, FetchAction::Spawn(_)),
-    "complete_pr stamped a stale result into a cache that was invalidated mid-flight — \
-     the late result must be dropped (bug #138). got {:?}",
-    action
-  );
+  assert!(gh.is_cached(FetchKey::Issue(42)));
+  assert!(gh.is_cached(FetchKey::Pr(7)));
+
+  gh.invalidate();
+
+  assert!(!gh.is_cached(FetchKey::Issue(42)));
+  assert!(!gh.is_cached(FetchKey::Pr(7)));
+  assert!(matches!(gh.issue_fetch_state(42), GitHubFetchState::Idle));
+  assert!(matches!(gh.pr_fetch_state(7), GitHubFetchState::Idle));
 }
 
 // ---- PR auto-detection on the slice (issue #181) --------------------------
@@ -354,31 +227,4 @@ fn clear_detected_pr_leaves_an_explicit_link_pinned() {
 
   assert_eq!(gh.link.pr, Some(61));
   assert_eq!(gh.link.pr_source, gwm::github::LinkSource::Explicit);
-}
-
-#[test]
-fn complete_reports_whether_the_result_was_applied() {
-  // Issue #217 review (P2): `complete_*` must signal whether it actually
-  // stamped the result, so the async drain can avoid reporting "refreshed"
-  // for a result it silently dropped (#138 stale-drop).
-  let mut gh = GitHubFetch::new();
-  assert!(matches!(gh.request(FetchKey::Issue(42)), FetchAction::Spawn(_)));
-  assert!(
-    gh.complete_issue(42, Ok(sample_issue(42))),
-    "a result for an inflight key must report applied=true"
-  );
-
-  // A second completion for the same (now-terminal) key has no inflight slot.
-  assert!(
-    !gh.complete_issue(42, Ok(sample_issue(42))),
-    "a result with no inflight slot must report applied=false"
-  );
-
-  // PR side, dropped after invalidate.
-  assert!(matches!(gh.request(FetchKey::Pr(7)), FetchAction::Spawn(_)));
-  gh.invalidate();
-  assert!(
-    !gh.complete_pr(7, Ok(sample_pr(7))),
-    "a result invalidated mid-flight must report applied=false"
-  );
 }


### PR DESCRIPTION
## Description

Migrates the off-thread GitHub issue / PR fetch (`F`) off its dedicated
`github_tx`/`github_rx` channel onto the shared `state::async_task::TaskRunner`
spine that already backs the worktree refresh (#231). One off-thread mechanism
instead of two — and the spine's per-key generation counter fixes a real race.

Closes #255

## Type of change

- [x] ♻️ Refactor (no behaviour change on the happy path)
- [x] 🐛 Fix (stale GitHub status winning a refresh race)

## Changes

- **Spine** (`state::async_task`): add `TaskKind::GithubIssue(u64)` /
  `GithubPr(u64)` (per-number keys → independent generations), the matching
  `TaskMsg` variants carrying `(generation, number, result)`, `TaskKind::is_github`,
  and `TaskRunner::invalidate_matching(pred)`.
- **`GitHubFetch`** reduced to a pure per-`(target, number)` result cache + link
  state: dropped `inflight`, `FetchAction`, `request`; added `mark_loading` +
  public `is_cached`; `complete_{issue,pr}` are now pure cache writes (the
  late-drop decision moved to the spine).
- **`App`**: removed `github_tx`/`github_rx`, `GithubFetchMsg`,
  `drain_github_results`, `github_result_sender`. GitHub workers now report over
  `task_tx`; `drain_task_results` applies a result only when
  `TaskRunner::complete` confirms the generation, then stamps the cache. New
  `invalidate_github` helper pairs the cache flush with a spine generation-bump
  (navigation invariant) — called from `refresh_github_status` and `refresh_link`.
- Event loop drops the second drain call; one `drain_task_results()` now covers
  both refresh and GitHub.

## The race this fixes (Codex adversarial-review, PR #260)

Pre-spine the fetch deduped on a per-key `inflight` HashSet with **no
generation**. Two workers for the same key (`F` → navigate/`F` again) were
indistinguishable: whichever drained first claimed the single slot, so a STALE
worker reporting before the FRESH one stamped stale data and the fresh result was
dropped. The per-key generation drops the superseded worker's late result
regardless of arrival order.

Pinned by `stale_github_fetch_result_loses_to_a_newer_generation` (app level,
drained FRESH-first/STALE-last so it actually discriminates a broken guard) and
`a_stale_github_worker_loses_to_a_newer_generation_after_invalidate` (spine
level, asserts the `complete` verdicts directly — the load-bearing guard). The
app test failed on the pre-spine code and passes now.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` — spine github-kind + `invalidate_matching`
  + race tests; rewrote `tui_state_github_fetch_tests` to the cache contract;
  migrated the app drain tests to the spine API
- [x] Env-minimal run (`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`) green

## Behaviour-preservation note

`apply_refreshed_worktrees` sets `self.status`. Pre-#255 the loop drained the
GitHub channel *before* the task channel, so on a tick where a refresh **and** a
GitHub fetch both completed, the "refreshed — N" message stood last. The unified
drain now gates the post-loop GitHub status report on `!refresh_applied` to
preserve that exact ordering — pinned by
`a_simultaneous_refresh_keeps_its_status_over_the_github_report`.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]` (Changed + Fixed)
- [ ] README updated if CLI surface changed (n/a — no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #255
- Follow-ups still open: #256 (bootstrap off-thread), #257 (loader widget), #258 (sync TUI action)

## Notes for reviewers

- This is **PR 1 of 2** from the session; a separate issue + PR will carry the
  TUI bonus (fuzzy filter into the worktrees pane title, command-palette input
  restyle) off updated `dev`.
- Coalescing is vestigial for GitHub (the only entry, `refresh_github_status`,
  always invalidates first, and Issue/Pr keys never collide) — kept the generic
  spine path anyway; the load-bearing payoff here is the generation late-drop.
- `is_github_loading()` still reads the cache (per-current-link Loading), so the
  `is_github_loading() || is_task_loading()` spinner gate is unchanged in meaning.