### PR TITLE
💄 feat(tui): filter in the pane title + input-first command palette (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   off-thread mechanism, not two. Behaviour-preserving for the happy path; the
   spine's per-key generation counter is what fixes the race below.
   ([#255](https://github.com/kbrdn1/gwm-cli/issues/255))
+- The fuzzy filter (`/`) now renders inside the worktrees pane title instead
+  of a separate row below the table: the `/query`, cursor, and
+  `(visible/total)` ratio read in the pane border, attached to the list they
+  narrow. The standalone filter bar is gone, giving the table one more row.
+  ([#262](https://github.com/kbrdn1/gwm-cli/issues/262))
+- The command palette (`:`) input moved to the top of the modal (above the
+  matches) and adopts the New Worktree modal's background-filled input style,
+  so the palette reads input-then-results like the create form.
+  ([#262](https://github.com/kbrdn1/gwm-cli/issues/262))
 
 ### Fixed
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -39,37 +39,18 @@ pub struct SidebarSections {
 }
 
 pub fn draw(f: &mut Frame, app: &mut App) {
-  // Filter bar is shown while the user is typing, AND while a sticky filter
-  // remains in effect (so they can see what's filtering the list).
-  let filter_visible = app.filter.active || !app.filter.query().is_empty();
-
-  // Header is a single borderless row (#185) — same one-line treatment as the
-  // footer, so the worktree table gets two extra rows of vertical space.
-  let chunks = if filter_visible {
-    Layout::default()
-      .direction(Direction::Vertical)
-      .constraints([
-        Constraint::Length(1),
-        Constraint::Min(0),
-        Constraint::Length(1),
-        Constraint::Length(1),
-      ])
-      .split(f.area())
-  } else {
-    Layout::default()
-      .direction(Direction::Vertical)
-      .constraints([Constraint::Length(1), Constraint::Min(0), Constraint::Length(1)])
-      .split(f.area())
-  };
+  // Header and footer are single borderless rows (#185); the body fills the
+  // rest. The fuzzy filter no longer claims its own row — it renders inside
+  // the worktrees pane title (#262), so the layout is a stable header / body /
+  // footer split whether or not a filter is active.
+  let chunks = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([Constraint::Length(1), Constraint::Min(0), Constraint::Length(1)])
+    .split(f.area());
 
   draw_header(f, chunks[0], app);
   draw_body(f, chunks[1], app);
-  if filter_visible {
-    draw_filter_bar(f, chunks[2], app);
-    draw_footer(f, chunks[3], app);
-  } else {
-    draw_footer(f, chunks[2], app);
-  }
+  draw_footer(f, chunks[2], app);
 
   match app.view {
     View::Help => draw_help(f, app),
@@ -192,31 +173,6 @@ pub fn header_line(
   Line::from(spans)
 }
 
-/// Single-line filter bar rendered between the table and the footer.
-/// Mirrors Vim's `/` prompt: leading slash, the live query, and a block cursor
-/// while the user is actively typing.
-fn draw_filter_bar(f: &mut Frame, area: Rect, app: &App) {
-  // The `/` prompt and the block cursor use the `dirty` role (their
-  // historical `Color::Yellow`); the sticky-filter hint uses `muted`.
-  let mut spans = vec![
-    Span::styled("/", Style::default().fg(app.theme.dirty).add_modifier(Modifier::BOLD)),
-    Span::raw(app.filter.query()),
-  ];
-  if app.filter.active {
-    spans.push(Span::styled(
-      "█",
-      Style::default().fg(app.theme.dirty).add_modifier(Modifier::SLOW_BLINK),
-    ));
-  } else {
-    // Sticky filter: hint how to clear / refine without re-entering the bar.
-    spans.push(Span::styled(
-      "   (sticky — / to refine, esc on list to clear)",
-      Style::default().fg(app.theme.muted),
-    ));
-  }
-  f.render_widget(Paragraph::new(Line::from(spans)), area);
-}
-
 /// Lay out the worktree table and the optional preview sidebar for the
 /// body region. The layout (hidden / side-by-side / stacked) and the
 /// left-or-right side are decided by the pure
@@ -304,19 +260,51 @@ pub fn panel_border_color(focused: bool, theme: &super::theme::Theme) -> Color {
   }
 }
 
-/// Title for the worktree pane block (issue #217). Carries the `[1]` focus
-/// mnemonic (the pane is focusable with the `1` key) and a `(N)` /
-/// `(visible/total)` counter. `query_empty` switches between the two counter
-/// forms: when no filter is active the full worktree count is shown, otherwise
-/// the visible-over-total ratio so the user sees how much the filter narrowed
-/// the list. Pure + width-free so the copy is pinned by
-/// `tests/tui_ui_helpers_tests.rs` without a ratatui backend.
-pub fn worktrees_pane_title(query_empty: bool, visible: usize, total: usize) -> String {
-  if query_empty {
-    format!(" [1] Worktrees ({}) ", total)
-  } else {
-    format!(" [1] Worktrees ({}/{}) ", visible, total)
+/// Title for the worktree pane block (issue #217; carries the inline fuzzy
+/// filter since #262). Always leads with the `[1]` focus mnemonic (the pane
+/// is focusable with the `1` key). When a filter is live — the user is typing
+/// (`active`) or a sticky query remains — the title embeds the `/query`
+/// prompt (in `filter_color`), a block cursor while `active`, and the
+/// `(visible/total)` ratio so the user sees how much the filter narrowed the
+/// list. With no filter it shows just the `(total)` count. This replaces the
+/// standalone filter bar row (#262): the filter now reads in the pane border,
+/// attached to the list it narrows. Pure + width-free so the copy + the
+/// prompt colour are pinned by `tests/tui_ui_helpers_tests.rs` without a
+/// ratatui backend.
+pub fn worktrees_pane_title(
+  query: &str,
+  active: bool,
+  visible: usize,
+  total: usize,
+  filter_color: Color,
+) -> Line<'static> {
+  let mut spans = vec![Span::raw(" [1] Worktrees ")];
+  // Live filter (typing or sticky): show the `/query` prompt + optional
+  // cursor, mirroring the Vim-style bar the title replaced.
+  if active || !query.is_empty() {
+    spans.push(Span::styled(
+      "/",
+      Style::default().fg(filter_color).add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::raw(query.to_string()));
+    if active {
+      spans.push(Span::styled(
+        "\u{2588}",
+        Style::default().fg(filter_color).add_modifier(Modifier::SLOW_BLINK),
+      ));
+    }
+    spans.push(Span::raw(" "));
   }
+  // Counter: the visible/total ratio only once a query actually narrows the
+  // list; an empty query (even while the bar is open) matches all, so the
+  // plain `(total)` form reads cleaner.
+  let counter = if query.is_empty() {
+    format!("({}) ", total)
+  } else {
+    format!("({}/{}) ", visible, total)
+  };
+  spans.push(Span::raw(counter));
+  Line::from(spans)
 }
 
 /// Title for the head section of the status (sidebar) pane (issue #217).
@@ -408,7 +396,13 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let list_has_focus = !(app.sidebar.open && app.sidebar.focused);
   let border_color = panel_border_color(list_has_focus, &app.theme);
 
-  let title = worktrees_pane_title(app.filter.query().is_empty(), visible.len(), app.worktrees.len());
+  let title = worktrees_pane_title(
+    app.filter.query(),
+    app.filter.active,
+    visible.len(),
+    app.worktrees.len(),
+    app.theme.dirty,
+  );
 
   // Bottom-right `selected of visible` counter (issue #217), mirroring the
   // Recent Commits footer. `list_state.selected()` is 0-based; render it
@@ -3046,18 +3040,21 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
   let inner = outer.inner(area);
   f.render_widget(outer, area);
 
-  // Six rows: a detached centred title, a blank spacer, the matches list
-  // (flex), a hint gap, statusbar-style hints, and the input bar pinned to the bottom (issue #217 — the title
-  // moved off the border into the frame).
+  // Input-first layout (issue #262): a detached centred title, a blank
+  // spacer, the `:` input field (background-filled, mirroring the New
+  // Worktree modal's `field_input_line`), a spacer, the matches list (flex),
+  // a hint gap, and the statusbar-style hint. The input moved to the top so
+  // the modal reads input-then-results like the create form.
   let layout = Layout::default()
     .direction(Direction::Vertical)
     .constraints([
       Constraint::Length(1), // title
       Constraint::Length(1), // spacer
+      Constraint::Length(1), // input field
+      Constraint::Length(1), // spacer
       Constraint::Min(3),    // matches
       Constraint::Length(1), // hint gap
       Constraint::Length(1), // hint
-      Constraint::Length(1), // input bar
     ])
     .split(inner);
 
@@ -3070,6 +3067,25 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
       .centered(),
     ),
     layout[0],
+  );
+
+  // The `:` input field, styled like the create modal's fields: a `:` label
+  // then a background-filled value box. The palette input is always focused
+  // (the user is typing into it), so it carries the accent fill + cursor.
+  let label = ":";
+  let gutter = 2 + label.chars().count() + 2; // field_input_line's `  label  ` gutter
+  let value_w = (inner.width as usize).saturating_sub(gutter);
+  f.render_widget(
+    Paragraph::new(field_input_line(
+      label,
+      app.palette.buffer(),
+      true,
+      value_w,
+      accent,
+      app.theme.muted,
+      app.theme.selection_bg,
+    )),
+    layout[2],
   );
 
   let entries = app.palette.matches();
@@ -3098,22 +3114,15 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
       Style::default().fg(app.theme.prunable),
     )));
   }
-  f.render_widget(Paragraph::new(lines), layout[2]);
+  f.render_widget(Paragraph::new(lines), layout[4]);
   f.render_widget(
     Paragraph::new(modal_hint_for_context(
       HintContext::CommandPalette,
       &app.keymap,
       &app.theme,
     )),
-    layout[4],
+    layout[6],
   );
-
-  let input_line = Line::from(vec![
-    Span::styled(":", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
-    Span::raw(app.palette.buffer().to_string()),
-    Span::styled("_", Style::default().fg(app.theme.muted)),
-  ]);
-  f.render_widget(Paragraph::new(input_line), layout[5]);
 }
 
 /// Body of the Issue / PR sidebar block. The block title (`" Issue / PR "`)

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -309,3 +309,32 @@ fn command_palette_modal_renders_title_and_entries() {
     row_strings(&buf).join("\n")
   );
 }
+
+#[test]
+fn command_palette_renders_the_input_above_the_matches() {
+  // Issue #262: the palette input moved to the top (input-first), above the
+  // matches list. Type a query that still matches a command, then assert the
+  // typed text's row sits above the matched command's row.
+  let (_dir, mut app) = make_app();
+  app.open_command_palette();
+  // A distinctive query that is a subsequence of `create` so a match remains.
+  for c in "cre".chars() {
+    app.palette.push_char(c);
+  }
+  let buf = render(&mut app);
+  let rows = row_strings(&buf);
+  let input_row = rows
+    .iter()
+    .position(|r| r.contains("cre"))
+    .expect("the typed query must render in the input field");
+  let match_row = rows
+    .iter()
+    .position(|r| r.contains("create"))
+    .expect("a matching command row must render");
+  assert!(
+    input_row < match_row,
+    "the palette input must render above the matches list (input-first), \
+     input_row={input_row} match_row={match_row} — buffer rows:\n{}",
+    rows.join("\n")
+  );
+}

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -86,19 +86,57 @@ fn badge_group_width_unbound_renders_one_muted_badge() {
 // Worktrees pane title + counter (issue #217)
 // ---------------------------------------------------------------------------
 
-#[test]
-fn worktrees_pane_title_unfiltered_shows_total_with_focus_index() {
-  // No active filter → the `(N)` counter is the full worktree count, and the
-  // pane carries the `[1]` focus mnemonic (focusable with the `1` key). The
-  // casing is fixed to `Worktrees` (was lowercase `worktrees`).
-  assert_eq!(worktrees_pane_title(true, 5, 5), " [1] Worktrees (5) ");
+/// Flatten a `Line` into its visible text (span contents concatenated).
+fn title_text(line: &ratatui::text::Line<'_>) -> String {
+  line.spans.iter().map(|s| s.content.as_ref()).collect()
 }
 
 #[test]
-fn worktrees_pane_title_filtered_shows_visible_over_total() {
-  // Active filter → `(visible/total)` so the user sees how much the filter
-  // narrowed the list.
-  assert_eq!(worktrees_pane_title(false, 3, 5), " [1] Worktrees (3/5) ");
+fn worktrees_pane_title_unfiltered_shows_total_with_focus_index() {
+  // No filter (empty query, not active) → the `(N)` counter is the full
+  // worktree count, and the pane carries the `[1]` focus mnemonic (focusable
+  // with the `1` key). Casing is fixed to `Worktrees`.
+  let line = worktrees_pane_title("", false, 5, 5, Color::Yellow);
+  assert_eq!(title_text(&line), " [1] Worktrees (5) ");
+}
+
+#[test]
+fn worktrees_pane_title_active_filter_shows_query_cursor_and_ratio() {
+  // Issue #262: the live `/` filter renders in the pane title. While typing
+  // (active), the title carries the `/query`, a block cursor, and the
+  // `(visible/total)` ratio so the user sees how much the filter narrowed.
+  let line = worktrees_pane_title("au", true, 3, 5, Color::Yellow);
+  assert_eq!(title_text(&line), " [1] Worktrees /au\u{2588} (3/5) ");
+}
+
+#[test]
+fn worktrees_pane_title_sticky_filter_shows_query_without_cursor() {
+  // Sticky (committed) filter: the query stays visible in the title for
+  // context, but with no cursor (the bar is closed) and a compact form — no
+  // oversized hint.
+  let line = worktrees_pane_title("au", false, 3, 5, Color::Yellow);
+  assert_eq!(title_text(&line), " [1] Worktrees /au (3/5) ");
+}
+
+#[test]
+fn worktrees_pane_title_active_empty_query_shows_prompt_and_total() {
+  // Just opened the bar with an empty buffer: the `/` prompt + cursor show,
+  // but the counter stays the `(total)` form (an empty query matches all).
+  let line = worktrees_pane_title("", true, 5, 5, Color::Yellow);
+  assert_eq!(title_text(&line), " [1] Worktrees /\u{2588} (5) ");
+}
+
+#[test]
+fn worktrees_pane_title_paints_the_slash_in_the_filter_colour() {
+  // The `/` prompt keeps its dedicated filter colour (historically the
+  // `dirty` role) so it reads as an editable affordance, not chrome.
+  let line = worktrees_pane_title("au", true, 3, 5, Color::Yellow);
+  let slash = line
+    .spans
+    .iter()
+    .find(|s| s.content.as_ref() == "/")
+    .expect("title must carry a styled '/' prompt span");
+  assert_eq!(slash.style.fg, Some(Color::Yellow));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Two small TUI input-affordance polish items surfaced while finishing #255:

1. **Fuzzy filter → worktrees pane title.** The `/` filter renders in the pane
   border (query + cursor + `(visible/total)`) instead of a separate row.
2. **Command palette input-first.** The `:` input moves to the top of the modal
   and adopts the New Worktree modal's background-filled field style.

Closes #262

## Type of change

- [x] 💄 UI / polish (feature-level, no logic change to the filter/palette state)

## Changes

- `worktrees_pane_title` now returns a styled `Line` carrying the `/query`
  prompt (in the `dirty` filter colour), a block cursor while active, and the
  `(visible/total)` ratio. Empty/sticky/active forms handled; sticky shows a
  compact `/query (n/total)` with no oversized hint.
- Removed `draw_filter_bar` and the filter row in `draw`; the layout is a stable
  header/body/footer split, so the table gains a row.
- `draw_command_palette`: input field moved above the matches list and rendered
  via `field_input_line` (reused from the create modal) instead of the
  hand-rolled `:buffer_` bottom line.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests under `tests/`: rewrote the `worktrees_pane_title` helper tests
  to the `Line` contract (unfiltered / active / sticky / empty-active + prompt
  colour); added a modal-render-net test pinning the palette input above the
  matches
- [x] Env-minimal run green

## Notes for reviewers

- PR 2 of 2 from the session (follow-up to #255 / PR #261, branched off updated
  `dev`). Both touch `src/tui/ui.rs`, so sequenced after #255 per the
  no-deep-stacking rule.
- Not visually verified in a live terminal (no interactive TTY here); the render
  is pinned via the pure title helper + the modal-render net (real `draw` →
  `TestBackend` buffer). A long query in a narrow pane will clip in the title the
  same way the existing counter does — acceptable, queries are short.
- The two changes share `ui.rs` (different fns), so they land as one cohesive
  commit + a changelog commit rather than a risky hunk-split.

## Linked issues / docs

- Issue: #262