### PR TITLE
✨ feat(tui): expose `gwm sync` as a TUI action bound to `S` (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- TUI `sync` action: press `S` to run `gwm sync` on the selected worktree —
+  fetch + rebase its branch onto the configured upstream — without leaving the
+  TUI. Runs off-thread on the shared async-task spine (statusbar spinner +
+  `syncing…` label, `q` / `Esc` stay responsive), then refreshes the list so
+  the new ahead/behind state shows and reports the outcome (up-to-date /
+  rebased N commits / dirty-refused / conflict). Default key is `S` (`s` is
+  the sidebar-mode toggle); rebindable via `[tui.keys] sync` and reachable by
+  name through `:sync`. ([#258](https://github.com/kbrdn1/gwm-cli/issues/258))
+
 - Configuration panel: press `4` to open a ~90% fullscreen, scrollable
   view of the **resolved** `.gwm.toml` — the user-level global config
   (`~/.config/gwm/config.toml`) deep-merged under the repo file, exactly

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -34,6 +34,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `L`         | link prompt — type `i` or `p`, then digits, to attach an issue / PR                               |
 | `F`         | refresh the GitHub issue / PR status (off-thread `gh` fetch — the statusbar spinner animates while it runs) |
 | `f`         | refresh the worktree list (alias: `r`)                                                            |
+| `S`         | sync the selected worktree onto its upstream — fetch + rebase, off-thread (statusbar spinner); refuses a dirty tree / missing upstream / conflicts (rebindable action `sync`) |
 | `v`         | toggle the details sidebar (on a narrow terminal it stacks under the table instead of hiding)     |
 | `s`         | toggle the sidebar Details mode — `commits` ↔ `stashes` (rebindable action `toggle_sidebar_mode`) — see [stashes mode](/tui/sidebar#stashes-mode) |
 | `V`         | cycle the sidebar layout — `auto` (width-driven) → `side-by-side` → `stacked`                      |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -35,6 +35,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `L`         | invite de liaison — tapez `i` ou `p`, puis des chiffres, pour rattacher une issue / PR            |
 | `F`         | rafraîchir le statut de l'issue / PR GitHub (fetch `gh` hors thread — le spinner de la barre de statut s'anime pendant) |
 | `f`         | rafraîchir la liste des worktrees (alias : `r`)                                                   |
+| `S`         | synchroniser le worktree sélectionné sur son upstream — fetch + rebase, hors thread (spinner de la barre de statut) ; refuse un arbre sale / un upstream manquant / des conflits (action remappable `sync`) |
 | `v`         | basculer la barre latérale de détails (sur un terminal étroit, elle se place sous la table au lieu de disparaître) |
 | `s`         | basculer le mode Détails de la barre latérale — `commits` ↔ `stashes` (action remappable `toggle_sidebar_mode`) — voir [mode stashes](/fr/tui/sidebar#mode-stashes) |
 | `V`         | faire défiler la disposition de la barre latérale — `auto` (pilotée par la largeur) → `side-by-side` → `stacked` |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -557,6 +557,42 @@ impl App {
     });
   }
 
+  /// Off-thread `gwm sync` of the selected worktree for the `S` key (issue
+  /// #258): fetch + rebase its branch onto upstream on a worker thread, so a
+  /// slow network fetch / rebase does not freeze the event loop. Coalesces
+  /// onto an in-flight sync (a second `S` while one runs is a no-op, so two
+  /// rebases never race). The outcome is applied by
+  /// [`Self::drain_task_results`], which reports it and refreshes the list so
+  /// the new ahead/behind state shows. Default strategy is rebase (the repo
+  /// convention); a `--merge` variant is deferred (see #258).
+  pub fn request_sync(&mut self) {
+    let Some((path, name)) = self.selected().map(|w| (w.path.clone(), w.name.clone())) else {
+      self.status = "no worktree selected to sync".into();
+      return;
+    };
+    let Some(generation) = self.tasks.request(TaskKind::Sync) else {
+      // A sync is already in flight — coalesce onto it.
+      return;
+    };
+    self.spinner.reset();
+    self.status = TaskKind::Sync.loading_label().into();
+    self.spawn_sync(generation, path, name);
+  }
+
+  /// Spawn one background `gwm sync` worker tagged with `generation` (issue
+  /// #258). Mirrors [`Self::spawn_refresh`]: it moves only owned `Send` data
+  /// (the worktree `path` + `name`) across the boundary and runs the existing
+  /// [`crate::sync::sync`] logic, which discovers its own repo from `path` and
+  /// shells out to `git` for fetch/rebase. A `send` failure (the `App`/receiver
+  /// dropped) is ignored.
+  fn spawn_sync(&self, generation: u64, path: PathBuf, name: String) {
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let result = crate::sync::sync(&path, crate::sync::SyncStrategy::Rebase).map_err(|e| e.to_string());
+      let _ = tx.send(TaskMsg::Sync(generation, name, result));
+    });
+  }
+
   /// Apply every background task result that has arrived since the last
   /// call (issue #231; GitHub fetch results folded in by #255), draining
   /// the channel without blocking. Each result goes through
@@ -608,6 +644,33 @@ impl App {
           self.github.complete_pr(number, result);
           applied = true;
           github_applied = true;
+        }
+        TaskMsg::Sync(generation, name, result) => {
+          if !self.tasks.complete(TaskKind::Sync, generation) {
+            // Late result — a newer sync (or an invalidate) superseded it.
+            continue;
+          }
+          match result {
+            Ok(report) => {
+              // Re-list so the new ahead/behind state shows (this also bumps
+              // the refresh generation — the #138 race guard). The worker
+              // mutated refs in a subprocess, but a libgit2 read re-reads them
+              // from disk, so the synchronous `self.refresh()` (`self.repo`)
+              // sees the rebased state — verified end-to-end by the
+              // ahead/behind assertion in `sync_tests::
+              // tui_sync_action_relists_to_the_rebased_state_from_disk`.
+              // `refresh` sets its own "refreshed — N" status, so overwrite it
+              // with the sync outcome afterwards — the user pressed `S`, the
+              // sync result is what they want to read.
+              let _ = self.refresh();
+              self.status = crate::cli::format_sync_report(&name, &report).trim_end().to_string();
+            }
+            Err(e) => self.status = format!("sync failed: {}", e),
+          }
+          applied = true;
+          // The sync owns the status line this tick — keep the post-loop
+          // GitHub report from overwriting it (same guard the refresh uses).
+          refresh_applied = true;
         }
       }
     }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -114,6 +114,7 @@ define_actions! {
   Filter            => "filter",
   // Lifecycle / mutating
   Refresh           => "refresh",
+  Sync              => "sync",
   Create            => "create",
   DeleteConfirm     => "delete",
   Bootstrap         => "bootstrap",
@@ -396,6 +397,9 @@ impl Keymap {
       def(Action::ConfigPanel, &["4"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f", "r"]),
+      // `s` is taken by ToggleSidebarMode, so Sync defaults to `S` — an
+      // uppercase lifecycle verb alongside `F` (FetchGithub) / `R` (Review).
+      def(Action::Sync, &["S"]),
       def(Action::Create, &["n"]),
       def(Action::DeleteConfirm, &["d"]),
       def(Action::Bootstrap, &["b"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -515,6 +515,9 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
     Action::Create if !app.picker_mode => app.enter_create(),
     Action::DeleteConfirm if !app.picker_mode => app.enter_confirm_delete(),
     Action::Bootstrap if !app.picker_mode => app.bootstrap_selected(),
+    // Issue #258: `gwm sync` of the selected worktree, off-thread on the
+    // spine. Mutating, so disabled in picker mode like create / delete.
+    Action::Sync if !app.picker_mode => app.request_sync(),
     Action::ToggleDeleteBranch if !app.picker_mode => app.toggle_delete_branch(),
     Action::OpenMenu if !app.picker_mode => app.enter_open_menu(),
     Action::LinkPrompt if !app.picker_mode => app.enter_link_prompt(),

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -62,6 +62,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "refresh the worktree list",
     },
     PaletteEntry {
+      action: Action::Sync,
+      name: "sync",
+      description: "sync the selected worktree onto its upstream (rebase)",
+    },
+    PaletteEntry {
       action: Action::Open,
       name: "open",
       description: "open the selected worktree (shell / editor / finder)",

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -35,6 +35,7 @@
 //! is pinned by `tests/tui_state_async_task_tests.rs`.
 
 use crate::github::{IssueStatus, PrStatus};
+use crate::sync::SyncReport;
 use crate::worktree::WorktreeInfo;
 use std::collections::{HashMap, HashSet};
 
@@ -58,6 +59,11 @@ pub enum TaskKind {
   /// PR-side counterpart to [`Self::GithubIssue`] (`gh pr view`). Keyed by
   /// PR number; never collides with an issue of the same number.
   GithubPr(u64),
+  /// Off-thread `gwm sync` of the selected worktree (issue #258): fetch +
+  /// rebase/merge its branch onto upstream. A single global op like
+  /// [`Self::RefreshWorktrees`] — one sync in flight at a time, so a second
+  /// `S` press while one runs coalesces instead of racing a second rebase.
+  Sync,
 }
 
 impl TaskKind {
@@ -68,6 +74,7 @@ impl TaskKind {
     match self {
       TaskKind::RefreshWorktrees => "refreshing worktrees…",
       TaskKind::GithubIssue(_) | TaskKind::GithubPr(_) => "fetching GitHub status…",
+      TaskKind::Sync => "syncing…",
     }
   }
 
@@ -97,6 +104,10 @@ pub enum TaskMsg {
   GithubIssue(u64, u64, std::result::Result<IssueStatus, String>),
   /// PR-side counterpart to [`Self::GithubIssue`] (`gh pr view`).
   GithubPr(u64, u64, std::result::Result<PrStatus, String>),
+  /// A `gwm sync` result (issue #258): the worker's `generation`, the synced
+  /// worktree's display `name` (for the status line), and the [`SyncReport`]
+  /// (or a stringified error — dirty tree, no upstream, conflicts).
+  Sync(u64, String, std::result::Result<SyncReport, String>),
 }
 
 /// Coalescing + late-drop spine for background tasks (issue #231).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1961,6 +1961,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
   ));
   rows.push(entry(Action::Refresh, "refresh worktree list"));
   if !picker_mode {
+    rows.push(entry(Action::Sync, "sync selected worktree onto its upstream (rebase)"));
     rows.push(entry(Action::FetchGithub, "refresh GitHub issue/PR status via `gh`"));
     rows.push(entry(Action::Review, "run [review] launcher against the resolved base"));
     rows.push(entry(Action::ToggleDeleteBranch, "toggle 'delete branch on remove'"));

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -215,6 +215,25 @@ fn default_keymap_binds_sidebar_layout_and_position() {
 }
 
 #[test]
+fn default_keymap_binds_sync_to_uppercase_s() {
+  // Issue #258: `S` runs `gwm sync` on the selected worktree. It must be
+  // uppercase `S` because lowercase `s` is already ToggleSidebarMode — the
+  // mnemonic sits with the other uppercase lifecycle verbs (`F`, `R`).
+  let km = Keymap::defaults();
+
+  let sync = KeyStroke::parse_chord("S").unwrap();
+  assert!(matches!(km.lookup(&sync), ChordResolution::Matched(Action::Sync)));
+
+  // Guard the conflict that motivated the choice: lowercase `s` stays the
+  // sidebar-mode toggle, untouched.
+  let sidebar_mode = KeyStroke::parse_chord("s").unwrap();
+  assert!(matches!(
+    km.lookup(&sidebar_mode),
+    ChordResolution::Matched(Action::ToggleSidebarMode)
+  ));
+}
+
+#[test]
 fn default_keymap_binds_command_logs_to_3() {
   // Issue #226: `3` opens the Command Logs modal, completing the `1` / `2`
   // / `3` pane-key family (focus_worktrees / focus_status / command_logs).

--- a/tests/sync_tests.rs
+++ b/tests/sync_tests.rs
@@ -234,3 +234,76 @@ fn sync_aborts_and_errors_on_conflict() {
     "sync must abort the rebase so the worktree is left usable"
   );
 }
+
+// ---- TUI sync action drain (issue #258) -----------------------------------
+
+#[test]
+fn tui_sync_action_relists_to_the_rebased_state_from_disk() {
+  // End-to-end guard for the #258 TUI action: after a real `sync` rebases the
+  // branch (a subprocess `git rebase` + `git fetch` mutate refs on disk), the
+  // App's post-sync re-list in `drain_task_results` must reflect the rebased
+  // HEAD and the fetched upstream's ahead/behind. (libgit2 re-reads refs from
+  // disk on each lookup, so the synchronous refresh through the long-lived
+  // repo is not stale — this pins that the count is right whichever way the
+  // re-list is implemented.)
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::App;
+
+  let (td, origin, local) = local_tracking_origin();
+  // Upstream advances by one commit...
+  push_upstream_commit(td.path(), &origin, "up.txt", "upstream\n", "ahead");
+  // ...and the local branch has its own commit, so the sync genuinely rebases
+  // (HEAD must move to a new OID, not just fast-forward in place).
+  write(&local.join("local.txt"), "local\n");
+  git(&local, &["add", "-A"]);
+  git(&local, &["commit", "-m", "local work"]);
+
+  // Build the App on the local repo and snapshot the pre-sync HEAD.
+  let mut app = App::new_at_layered(Some(&local), None).unwrap();
+  let head_before = app.worktrees[0].head.clone();
+
+  // Claim a sync slot (as `request_sync` would) and run the real sync.
+  let generation = app.tasks.request(TaskKind::Sync).unwrap();
+  let report = sync::sync(&local, SyncStrategy::Rebase).unwrap();
+  assert_eq!(report.action, SyncAction::Integrated, "the behind branch must rebase");
+
+  // Feed the worker's result through the drain exactly as the OS thread would.
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sync(generation, "local".into(), Ok(report)))
+    .unwrap();
+  app.drain_task_results();
+
+  // The re-listed HEAD must be the rebased one — different from before, and
+  // matching what git reports on disk.
+  let head_after = app.worktrees[0].head.clone();
+  let disk_head = git_out(&local, &["rev-parse", "HEAD"]);
+  assert_ne!(
+    head_after, head_before,
+    "post-sync re-list must show the rebased HEAD, not the stale pre-sync one"
+  );
+  assert_eq!(
+    head_after.as_deref(),
+    Some(disk_head.as_str()),
+    "the re-listed HEAD must match the on-disk HEAD after the rebase"
+  );
+  // The ahead/behind must reflect the *fetched* upstream. The worker's `git
+  // fetch` advanced the remote-tracking `origin/main`; reading it through the
+  // App's long-lived `self.repo` (whose ref cache predates the fetch) would
+  // miscount the ahead side. After the rebase the branch is exactly one commit
+  // ahead of the updated upstream and zero behind. This is the dimension
+  // `sync.rs` flags as stale-prone, so it is what makes the fresh-repo re-list
+  // load-bearing rather than cosmetic.
+  let status = &app.worktrees[0].status;
+  assert_eq!(status.behind, 0, "rebased branch must be 0 behind the fetched upstream");
+  assert_eq!(
+    status.ahead, 1,
+    "rebased branch is exactly 1 ahead of the fetched upstream (a stale origin/main read overcounts)"
+  );
+  // And the status line reports the sync outcome, not the refresh line.
+  assert!(
+    app.status.contains("rebased"),
+    "status must report the sync outcome: {:?}",
+    app.status
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4011,6 +4011,124 @@ fn drain_async_refresh_failure_surfaces_status_without_touching_the_list() {
   );
 }
 
+fn sync_report_integrated(behind: usize) -> gwm::sync::SyncReport {
+  gwm::sync::SyncReport {
+    branch: "feat/#258-x".into(),
+    upstream: "origin/main".into(),
+    strategy: gwm::sync::SyncStrategy::Rebase,
+    ahead_before: 0,
+    behind_before: behind,
+    action: gwm::sync::SyncAction::Integrated,
+  }
+}
+
+#[test]
+fn drain_applies_sync_report_and_reports_the_outcome() {
+  // Issue #258: a `gwm sync` result delivered off-thread is applied by
+  // `drain_task_results`, which re-lists the worktrees (so the new
+  // ahead/behind shows) and reports the sync outcome on the status bar.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  // Claim the Sync slot exactly as `request_sync` would, without spawning.
+  let generation = app.tasks.request(TaskKind::Sync).unwrap();
+  assert!(app.is_task_loading(), "request must mark the app as loading");
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sync(generation, "alpha".into(), Ok(sync_report_integrated(3))))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "drain must report it applied a result");
+  assert!(!app.is_task_loading(), "the sync slot clears after draining");
+  assert!(
+    app.status.contains("rebased 3 commits"),
+    "status reports the sync outcome, not the refresh line: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn drain_sync_failure_surfaces_on_the_status_bar() {
+  // A refused/failed sync (dirty tree, no upstream, conflicts) surfaces as a
+  // status message rather than tearing anything down.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::Sync).unwrap();
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sync(
+      generation,
+      "alpha".into(),
+      Err("branch 'feat/#258-x' has no upstream configured".into()),
+    ))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "a failure still counts as a drained result");
+  assert!(!app.is_task_loading(), "the slot clears even on failure");
+  assert!(
+    app.status.contains("sync failed") && app.status.contains("no upstream"),
+    "the sync error reaches the status bar: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn drain_drops_a_superseded_sync_result() {
+  // The #138 guard on the sync path: a worker whose generation was bumped by
+  // an intervening invalidate is dropped, leaving the status untouched.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let stale = app.tasks.request(TaskKind::Sync).unwrap();
+  app.tasks.invalidate(TaskKind::Sync);
+  app.status = "untouched".into();
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sync(stale, "alpha".into(), Ok(sync_report_integrated(2))))
+    .unwrap();
+  app.drain_task_results();
+  assert_eq!(
+    app.status, "untouched",
+    "a sync result invalidated mid-flight must be dropped, not reported"
+  );
+}
+
+#[test]
+fn request_sync_coalesces_onto_an_inflight_run() {
+  // A second `S` press while a sync is already in flight must not spawn a
+  // second rebase — `request_sync` coalesces and returns early (zero threads).
+  use gwm::tui::state::async_task::TaskKind;
+  let (_dir, mut app) = make_app();
+  // The main worktree is selected by default, so request_sync gets past the
+  // selection check and reaches the coalesce branch.
+  let generation = app.tasks.request(TaskKind::Sync).unwrap();
+  app.request_sync(); // coalesced — no panic, no second worker
+  assert!(app.is_task_loading());
+  assert!(
+    app.tasks.complete(TaskKind::Sync, generation),
+    "the original sync is still authoritative after a coalesced press"
+  );
+}
+
+#[test]
+fn request_sync_with_no_selection_reports_and_does_not_claim_a_slot() {
+  use gwm::tui::state::async_task::TaskKind;
+  let (_dir, mut app) = make_app();
+  // Drop the selection so there is no worktree to sync.
+  app.list_state.select(None);
+  app.request_sync();
+  assert!(
+    !app.tasks.is_loading(TaskKind::Sync),
+    "with nothing selected, request_sync must not claim a sync slot"
+  );
+  assert!(
+    app.status.contains("no worktree selected"),
+    "request_sync reports the missing selection: {:?}",
+    app.status
+  );
+}
+
 #[test]
 fn request_refresh_coalesces_onto_an_inflight_run() {
   // A second `f` press while a refresh is already in flight must not spawn a

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -177,3 +177,39 @@ fn a_stale_github_worker_loses_to_a_newer_generation_after_invalidate() {
   assert!(runner.complete(TaskKind::GithubIssue(42), gen_b));
   assert!(!runner.is_loading(TaskKind::GithubIssue(42)));
 }
+
+// ---- Sync task on the spine (issue #258) ----------------------------------
+
+#[test]
+fn sync_task_reports_the_syncing_label() {
+  assert_eq!(TaskKind::Sync.loading_label(), "syncing…");
+  assert!(!TaskKind::Sync.is_github(), "Sync is not a GitHub kind");
+}
+
+#[test]
+fn second_sync_request_while_inflight_is_coalesced() {
+  // Only one sync runs at a time — a second `S` press while a rebase is in
+  // flight must not spawn a second concurrent rebase.
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.request(TaskKind::Sync), Some(1));
+  assert_eq!(
+    runner.request(TaskKind::Sync),
+    None,
+    "a second sync request while one is inflight must coalesce"
+  );
+  assert!(runner.is_loading(TaskKind::Sync));
+}
+
+#[test]
+fn a_late_sync_result_after_invalidate_is_dropped() {
+  // The generalised #138 guard for sync: a worker whose generation was bumped
+  // by an intervening invalidate (e.g. a post-sync refresh) is dropped.
+  let mut runner = TaskRunner::new();
+  let stale = runner.request(TaskKind::Sync).unwrap();
+  runner.invalidate(TaskKind::Sync);
+  assert!(!runner.is_loading(TaskKind::Sync), "invalidate frees the slot");
+  assert!(
+    !runner.complete(TaskKind::Sync, stale),
+    "a result from the invalidated generation must be dropped"
+  );
+}


### PR DESCRIPTION
## Description

Adds a first-class `sync` action to the TUI: press `S` on the selected worktree
to run `gwm sync` (fetch + rebase onto upstream) without leaving the TUI. Runs
off-thread on the #231 async-task spine, then refreshes the list and reports the
outcome. Closes the last part of the original #231 `/goal` gap (`sync` had no TUI
surface to make non-blocking).

Closes #258

## Type of change

- [x] ✨ Feature (new TUI action; no breaking change)

## Changes

- **Spine** (`async_task`): `TaskKind::Sync` (single global op — a second `S`
  coalesces, never races a second rebase), `syncing…` label, `TaskMsg::Sync`.
- **Keymap**: `Sync => "sync"`, default `S`. NB: the issue assumed `s` was free
  but `s` is `ToggleSidebarMode` — so `S` (uppercase, alongside `F`/`R`);
  rebindable via `[tui.keys] sync`. Palette `:sync` entry for parity.
- **Handler**: `App::request_sync` resolves the selection, claims a generation,
  spawns a worker running the existing `sync::sync` (rebase) off-thread.
  `drain_task_results` applies it — `self.refresh()` then the outcome via the
  reused `cli::format_sync_report`, or the error. Dispatch gated `!picker_mode`.
- **Help overlay** + EN/FR keybindings docs + CHANGELOG.

## Reused, not re-implemented

`sync::sync` (the libgit2 inspection + `git` fetch/rebase shell-out) and
`cli::format_sync_report` are reused verbatim — the TUI only adds the action +
off-thread plumbing, per the issue.

## Tests

- [x] `cargo test` / `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
- [x] Env-minimal run green
- [x] New tests: spine coalescing/late-drop + label; keymap default `S` (+ the
  `s`-conflict guard); `request_sync` coalesce / no-selection; drain apply /
  failure / superseded-drop; **end-to-end** `sync_tests` case that runs a real
  fetch+rebase against a local upstream and asserts the post-sync re-list shows
  the rebased HEAD + the fetched ahead/behind.

## Notes for reviewers

- **`s` → `S` deviation**: the issue text said `s` was unbound; it isn't
  (`ToggleSidebarMode`). `S` is the consistent, conflict-free choice; the keymap
  test guards both bindings.
- **Staleness check**: I verified empirically (discriminating ahead/behind
  assertion) that `self.repo` is **not** stale after the worker's subprocess
  `git fetch`/`rebase` — libgit2 re-reads refs from disk — so the canonical
  `self.refresh()` is correct here; no fresh-repo workaround needed.
- **Off-thread `git` + prompts**: `run_git` uses `.output()` (no TTY), so a
  fetch needing SSH/HTTPS credentials can fail or prompt on the real tty under
  the alt-screen — same known behavior as the off-thread `gh` fetch.
- **No cross-action lock**: nothing blocks `d`/`b` on a worktree mid-rebase
  (same exposure as two terminals); a conscious deferral, out of scope for #258.
- Follow-up: a `sync --merge` variant (e.g. via the open-menu) is deferred.

## Linked issues / docs

- Issue: #258 · sibling #231 follow-ups: #256 (bootstrap off-thread), #257 (loader widget)