### PR TITLE
🐛 fix(tests): fix #248 flaky github-detect via distinct fake-gh scripts

### DIFF
--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1895,11 +1895,16 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
   // Re-resolve the slug now that the remote exists.
   app.refresh_link();
 
-  let gh = dir.path().join("fake-gh");
-  // Write a fake `gh` that detects PR `n` (both `pr list` and `pr view`).
-  let write_gh = |n: u64| {
+  // Write a fake `gh` (detecting PR `n` via both `pr list` and `pr view`)
+  // to its own path. Two distinct scripts — never one rewritten in place —
+  // because the first refresh spawns an off-thread `pr view` worker (issue
+  // #255) that may still be executing its script when the second refresh
+  // fires. Truncating a script mid-exec raced that worker (`ETXTBSY` on
+  // Linux → the re-detect's spawn fails → `None`): the #248 flake. Keeping
+  // every script write-once / exec-many removes the race on any OS.
+  let write_gh = |path: &std::path::Path, n: u64| {
     std::fs::write(
-      &gh,
+      path,
       format!(
         "#!/bin/sh\n\
          if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
@@ -1910,11 +1915,14 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
       ),
     )
     .unwrap();
-    let mut perms = std::fs::metadata(&gh).unwrap().permissions();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
     perms.set_mode(0o755);
-    std::fs::set_permissions(&gh, perms).unwrap();
+    std::fs::set_permissions(path, perms).unwrap();
   };
-  write_gh(128);
+  let gh_first = dir.path().join("fake-gh-128");
+  let gh_second = dir.path().join("fake-gh-200");
+  write_gh(&gh_first, 128);
+  write_gh(&gh_second, 200);
 
   // Serialise against the other env-mutating tests in this binary.
   let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
@@ -1922,7 +1930,7 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
   // SAFETY: env mutation is guarded by `env_lock()` above; GWM_GH is
   // restored at the end of the test, before returning.
   unsafe {
-    std::env::set_var("GWM_GH", &gh);
+    std::env::set_var("GWM_GH", &gh_first);
   }
 
   // First refresh: nothing linked → detect PR #128.
@@ -1932,8 +1940,12 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
 
   // The branch's PR changed (e.g. closed + reopened as #200). A detected
   // link is "resolved live", so a second refresh must re-detect rather
-  // than stick to #128 (issue #181 — Copilot review on PR #184).
-  write_gh(200);
+  // than stick to #128 (issue #181 — Copilot review on PR #184). Point at
+  // the second script — written once, never the file the first refresh's
+  // worker is still execing — so the re-detect can't race that exec.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh_second);
+  }
   app.refresh_github_status();
 
   unsafe {


### PR DESCRIPTION
## Description

Fix the intermittent CI failure of `tests/tui_app_tests.rs::refresh_github_status_auto_detects_pr_for_unlinked_branch` (observed on `ubuntu-latest`).

**Root cause** (differs from the issue's suspected env-var race): the test rewrote a *single* `fake-gh` script in place between its two refreshes. The first `refresh_github_status()` spawns a **real off-thread `pr view` worker** (issue #255) that may still be executing that script when the second refresh truncates and re-execs it. On Linux, `execve` on a file open for write returns `ETXTBSY` → the re-detect's spawn fails → `find_pr_for_branch` yields `None` → `left: None, right: Some(200)`. Under ubuntu-runner load the window widens. The env-var race in the issue is a red herring — every env mutator in this binary already takes `env_lock()`.

**Fix**: write two distinct scripts (`fake-gh-128` / `fake-gh-200`) and re-point `GWM_GH` at the second. Every script is now **write-once / exec-many**; no file is ever truncated while a worker is executing it, on any OS.

Closes #248

## Type of change

- [x] 🐛 Fix (bug fix) — test robustness; no production change

## Changes

- `tests/tui_app_tests.rs`: replace the single-rewritten `fake-gh` with two distinct scripts and re-point `GWM_GH` between refreshes; document the off-thread-worker write/exec race in comments.

## Tests

- [x] `cargo test` passes locally (`tui_app_tests`: 223/223)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] No new test added — this **is** the test fix; the change is purely test robustness (no prod behaviour). No skip / no `#[ignore]` (acceptance criterion).

## Notes for reviewers

- **TDD / RED caveat (argued exception):** the flake is **Linux-`ETXTBSY`-specific** and does **not** reproduce on darwin — 700+ CPU-loaded local runs stayed green both before and after the fix (`darwin` doesn't enforce text-busy on exec-while-open-for-write). So there's no local RED to show; the empirical proof is CI staying green across the matrix (acceptance criterion: green across 3 consecutive runs).
- The diagnosis is grounded in code: `spawn_github_fetch` does a real `std::thread::spawn` (`src/tui/app.rs`), and `find_pr_for_branch` → `run_gh` → `Command::new(program)` execs the `GWM_GH` script.
- Possible deeper follow-up (out of scope, would touch the shared `src/tui/app.rs`): make `spawn_github_fetch` threading injectable so TUI tests never spawn a real OS thread.

## Linked issues / docs

- Issue: #248
- Related: #255 (introduced the real off-thread github worker)