### PR TITLE
✨ feat(tui): run bootstrap (`b`) off-thread on the async-task spine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Changed
+
+- Off-thread bootstrap: pressing `b` to re-run bootstrap on the selected
+  worktree now runs `bootstrap::run` (file copies, guards, command hooks)
+  on the shared async-task spine instead of blocking the event loop, so a
+  slow bootstrap no longer freezes the TUI. The statusbar spinner animates
+  with a `bootstrapping…` label and `q` / `Esc` stay responsive while it
+  runs; the Report view opens when it finishes. The TOFU trust gate still
+  runs synchronously on the main thread before the worker spawns, and a
+  second `b` press while one is in flight coalesces (no double run).
+  ([#256](https://github.com/kbrdn1/gwm-cli/issues/256))
 
 ## Past releases
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -25,7 +25,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `G`         | jump to the last worktree                                                                         |
 | `n`         | new worktree (form: type → issue → description) · gated by the [TOFU trust ledger](/configuration/trust-ledger) — refuses with a status-bar hint on untrusted `.gwm.toml` |
 | `d`         | delete selected (confirm `y` · countdown when `p` is armed — see [confirm-overlay](/tui/confirm-countdown)) |
-| `b`         | re-run bootstrap on the selected worktree · same [trust gate](/configuration/trust-ledger) as `n` |
+| `b`         | re-run bootstrap on the selected worktree, off-thread (the statusbar spinner animates while it runs; the Report view opens when it finishes) · same [trust gate](/configuration/trust-ledger) as `n` |
 | `o`         | open the worktree per [`[tui.open]`](/tui/open-dispatch) — `shell` (default) / `editor` / `finder` |
 | `y`         | yank the selected worktree's path to the system clipboard (pbcopy / wl-copy / xclip / xsel / clip) |
 | `l`         | launch the configured [`[git_tui]`](/tui/launchers) command (default `lazygit -p {path}`, fullscreen) |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -26,7 +26,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `G`         | sauter au dernier worktree                                                                        |
 | `n`         | nouveau worktree (formulaire : type → issue → description) · protégé par le [registre de confiance TOFU](/fr/configuration/trust-ledger) — refuse avec une indication dans la barre de statut sur un `.gwm.toml` non approuvé |
 | `d`         | supprimer la sélection (confirmer `y` · compte à rebours quand `p` est armé — voir [surcouche de confirmation](/fr/tui/confirm-countdown)) |
-| `b`         | relancer le bootstrap sur le worktree sélectionné · même [barrière de confiance](/fr/configuration/trust-ledger) que `n` |
+| `b`         | relancer le bootstrap sur le worktree sélectionné, hors thread (le spinner de la barre de statut s'anime pendant l'exécution ; la vue Report s'ouvre à la fin) · même [barrière de confiance](/fr/configuration/trust-ledger) que `n` |
 | `o`         | ouvrir le worktree selon [`[tui.open]`](/fr/tui/open-dispatch) — `shell` (par défaut) / `editor` / `finder` |
 | `y`         | copier le chemin du worktree sélectionné dans le presse-papiers système (pbcopy / wl-copy / xclip / xsel / clip) |
 | `l`         | lancer la commande [`[git_tui]`](/fr/tui/launchers) configurée (par défaut `lazygit -p {path}`, plein écran) |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -672,6 +672,33 @@ impl App {
           // GitHub report from overwriting it (same guard the refresh uses).
           refresh_applied = true;
         }
+        TaskMsg::Bootstrap(generation, result) => {
+          if !self.tasks.complete(TaskKind::Bootstrap, generation) {
+            // Late result — a newer run (or an invalidate) superseded it, so
+            // it must not flip the view to a stale report.
+            continue;
+          }
+          match result {
+            Ok(report) => {
+              // Same outcome as the old synchronous path (issue #256): show
+              // the report and surface whether any step failed.
+              let any_failed = report.steps.iter().any(|s| s.status == StepStatus::Failed);
+              self.report = Some(report);
+              self.view = View::Report;
+              self.status = if any_failed {
+                "bootstrap had failures".into()
+              } else {
+                "bootstrap ok".into()
+              };
+            }
+            Err(e) => self.status = format!("bootstrap error: {}", e),
+          }
+          applied = true;
+          // The bootstrap owns the status line (and the view) this tick — keep
+          // the post-loop GitHub report from overwriting it (same guard the
+          // refresh / sync arms use).
+          refresh_applied = true;
+        }
       }
     }
     // Once nothing GitHub-side is left loading, swap the "fetching…"
@@ -1682,24 +1709,36 @@ impl App {
       }
     }
 
-    let ctx = BootstrapCtx {
-      main_repo: &self.workdir,
-      worktree: &path,
-      config: &self.config,
+    // Run off-thread on the async-task spine (issue #256): `bootstrap::run`
+    // (file copies, guards, command hooks) used to block the event loop. The
+    // TOFU gate above stays synchronous on the main thread; only the run
+    // itself moves to a worker, with the `View::Report` transition deferred
+    // to `drain_task_results`. A second `b` press while one is in flight
+    // coalesces (no `Some(generation)`), so two bootstraps never race.
+    let Some(generation) = self.tasks.request(TaskKind::Bootstrap) else {
+      return;
     };
-    match bootstrap::run(&ctx) {
-      Ok(r) => {
-        let any_failed = r.steps.iter().any(|s| s.status == StepStatus::Failed);
-        self.report = Some(r);
-        self.view = View::Report;
-        self.status = if any_failed {
-          "bootstrap had failures".into()
-        } else {
-          "bootstrap ok".into()
-        };
-      }
-      Err(e) => self.status = format!("bootstrap error: {}", e),
-    }
+    self.spinner.reset();
+    self.status = TaskKind::Bootstrap.loading_label().into();
+    self.spawn_bootstrap(generation, self.workdir.clone(), path, self.config.clone());
+  }
+
+  /// Spawn the off-thread bootstrap worker (issue #256). Only owned, `Send`
+  /// data crosses the thread boundary — the `main_repo` / `worktree` paths
+  /// and a clone of the resolved `Config` — so the worker rebuilds its own
+  /// `BootstrapCtx` rather than borrowing `self`. The result is posted back
+  /// over the task channel for `drain_task_results` to apply.
+  fn spawn_bootstrap(&self, generation: u64, main_repo: PathBuf, worktree: PathBuf, config: Config) {
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let ctx = BootstrapCtx {
+        main_repo: &main_repo,
+        worktree: &worktree,
+        config: &config,
+      };
+      let result = bootstrap::run(&ctx).map_err(|e| e.to_string());
+      let _ = tx.send(TaskMsg::Bootstrap(generation, result));
+    });
   }
 
   // ---- Issue/PR linking (issue #67) -------------------------------------

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -34,6 +34,7 @@
 //! module is pure state — no I/O, no `App` dependency — so the contract
 //! is pinned by `tests/tui_state_async_task_tests.rs`.
 
+use crate::bootstrap::BootstrapReport;
 use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
 use crate::worktree::WorktreeInfo;
@@ -64,6 +65,14 @@ pub enum TaskKind {
   /// [`Self::RefreshWorktrees`] — one sync in flight at a time, so a second
   /// `S` press while one runs coalesces instead of racing a second rebase.
   Sync,
+  /// Off-thread bootstrap of the selected worktree (issue #256 — the `b`
+  /// key): `bootstrap::run` (file copies, guards, command hooks) used to
+  /// block the event loop. A single global op like [`Self::Sync`] — one
+  /// bootstrap in flight at a time, so a second `b` press coalesces instead
+  /// of racing a second run. The TOFU trust gate stays on the main thread
+  /// before the spawn; completion sets `App::report` and flips to
+  /// `View::Report`.
+  Bootstrap,
 }
 
 impl TaskKind {
@@ -75,6 +84,7 @@ impl TaskKind {
       TaskKind::RefreshWorktrees => "refreshing worktrees…",
       TaskKind::GithubIssue(_) | TaskKind::GithubPr(_) => "fetching GitHub status…",
       TaskKind::Sync => "syncing…",
+      TaskKind::Bootstrap => "bootstrapping…",
     }
   }
 
@@ -108,6 +118,11 @@ pub enum TaskMsg {
   /// worktree's display `name` (for the status line), and the [`SyncReport`]
   /// (or a stringified error — dirty tree, no upstream, conflicts).
   Sync(u64, String, std::result::Result<SyncReport, String>),
+  /// A bootstrap result (issue #256): the worker's `generation` and the
+  /// [`BootstrapReport`] (or a stringified error). On a live generation the
+  /// drain sets `App::report` and flips to `View::Report`; a superseded
+  /// late result is dropped by [`TaskRunner::complete`].
+  Bootstrap(u64, std::result::Result<BootstrapReport, String>),
 }
 
 /// Coalescing + late-drop spine for background tasks (issue #231).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3741,6 +3741,156 @@ run  = "echo trapped"
   }
 }
 
+// ---- Issue #256: bootstrap on the async-task spine ----------------------
+//
+// `bootstrap_selected` claims a `TaskKind::Bootstrap` generation and spawns
+// a worker (after the synchronous TOFU gate above); the worker's
+// `TaskMsg::Bootstrap` is applied by `drain_task_results`. These tests pin
+// the drain side — the result handling and late-drop guard — without a real
+// OS thread, mirroring the GitHub / sync drain tests.
+
+#[test]
+fn bootstrap_selected_with_no_selection_reports_and_does_not_load() {
+  // The early guard runs before the trust gate and the spawn: with nothing
+  // selected there is no worktree to bootstrap, so no generation is claimed.
+  let (_dir, mut app) = make_app();
+  app.worktrees.clear();
+  app.bootstrap_selected();
+  assert_eq!(app.status, "nothing selected");
+  assert!(!app.is_task_loading(), "no worktree selected → no task claimed");
+}
+
+#[test]
+fn drain_applies_async_bootstrap_report_and_flips_to_report_view() {
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-x");
+
+  // Claim a generation exactly as `bootstrap_selected` would after the gate.
+  let generation = app
+    .tasks
+    .request(TaskKind::Bootstrap)
+    .expect("a cold bootstrap slot must hand out a generation");
+  assert!(app.is_task_loading(), "request must mark the app as loading");
+
+  let report = BootstrapReport {
+    steps: vec![StepResult::ok("copy .env"), StepResult::ok("post_create hook")],
+  };
+  app
+    .task_result_sender()
+    .send(TaskMsg::Bootstrap(generation, Ok(report)))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "a live bootstrap result must be applied");
+  assert_eq!(app.view, View::Report, "completion flips to the Report view");
+  assert!(app.report.is_some(), "the report is stored for the Report view");
+  assert_eq!(app.status, "bootstrap ok");
+  assert!(!app.is_task_loading(), "completion clears the in-flight slot");
+}
+
+#[test]
+fn drain_bootstrap_report_with_a_failed_step_says_had_failures() {
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-x");
+
+  let generation = app.tasks.request(TaskKind::Bootstrap).unwrap();
+  let report = BootstrapReport {
+    steps: vec![
+      StepResult::ok("copy .env"),
+      StepResult::failed("post_create hook", "exit 1"),
+    ],
+  };
+  app
+    .task_result_sender()
+    .send(TaskMsg::Bootstrap(generation, Ok(report)))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(app.view, View::Report, "a partial failure still shows the report");
+  assert_eq!(app.status, "bootstrap had failures");
+}
+
+#[test]
+fn a_late_bootstrap_result_is_dropped_and_keeps_the_list_view() {
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-x");
+
+  // A worker is in flight, then an invalidate bumps the generation (e.g. a
+  // second `b` press coalesced after an invalidate) — the stale worker's
+  // result must not flip the view to its now-superseded report.
+  let stale = app.tasks.request(TaskKind::Bootstrap).unwrap();
+  app.tasks.invalidate(TaskKind::Bootstrap);
+  app
+    .task_result_sender()
+    .send(TaskMsg::Bootstrap(
+      stale,
+      Ok(BootstrapReport {
+        steps: vec![StepResult::ok("stale")],
+      }),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(app.view, View::List, "a dropped late result must not flip the view");
+  assert!(app.report.is_none(), "a dropped late result must not store a report");
+}
+
+#[test]
+fn drain_bootstrap_error_reports_status_and_does_not_flip_to_report() {
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-x");
+
+  let generation = app.tasks.request(TaskKind::Bootstrap).unwrap();
+  app
+    .task_result_sender()
+    .send(TaskMsg::Bootstrap(generation, Err("disk full".into())))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(
+    app.view,
+    View::List,
+    "a failed bootstrap stays on the list, no Report to show"
+  );
+  assert!(app.report.is_none());
+  assert_eq!(app.status, "bootstrap error: disk full");
+}
+
+#[test]
+fn drain_bootstrap_report_flips_to_report_even_from_another_view() {
+  // The bootstrap is async now (issue #256): between the `b` press and the
+  // result, the user may have navigated elsewhere (e.g. opened the create
+  // form). A live result still flips to the Report view — the user asked for
+  // the bootstrap, so its outcome takes the screen. This pins the
+  // always-flip choice (vs only flipping from the list view); a behaviour
+  // change from the old synchronous path, which had no such window.
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{TaskKind, TaskMsg};
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-x");
+
+  let generation = app.tasks.request(TaskKind::Bootstrap).unwrap();
+  app.view = View::Create;
+  app
+    .task_result_sender()
+    .send(TaskMsg::Bootstrap(
+      generation,
+      Ok(BootstrapReport {
+        steps: vec![StepResult::ok("copy .env")],
+      }),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(
+    app.view,
+    View::Report,
+    "a live bootstrap result takes the screen even mid-create"
+  );
+}
+
 // ---- Issue #106: LinkTarget canonical location --------------------------
 //
 // The `LinkTarget` enum was duplicated between `cli.rs` and

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -213,3 +213,40 @@ fn a_late_sync_result_after_invalidate_is_dropped() {
     "a result from the invalidated generation must be dropped"
   );
 }
+
+// ---- Bootstrap task on the spine (issue #256) -----------------------------
+
+#[test]
+fn bootstrap_task_reports_the_bootstrapping_label() {
+  assert_eq!(TaskKind::Bootstrap.loading_label(), "bootstrapping…");
+  assert!(!TaskKind::Bootstrap.is_github(), "Bootstrap is not a GitHub kind");
+}
+
+#[test]
+fn second_bootstrap_request_while_inflight_is_coalesced() {
+  // Only one bootstrap runs at a time — a second `b` press while one is in
+  // flight must not spawn a second concurrent run (file copies / hooks).
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.request(TaskKind::Bootstrap), Some(1));
+  assert_eq!(
+    runner.request(TaskKind::Bootstrap),
+    None,
+    "a second bootstrap request while one is inflight must coalesce"
+  );
+  assert!(runner.is_loading(TaskKind::Bootstrap));
+}
+
+#[test]
+fn a_late_bootstrap_result_after_invalidate_is_dropped() {
+  // The generalised #138 guard for bootstrap: a worker whose generation was
+  // bumped by an intervening invalidate is dropped rather than flipping the
+  // view to a stale report.
+  let mut runner = TaskRunner::new();
+  let stale = runner.request(TaskKind::Bootstrap).unwrap();
+  runner.invalidate(TaskKind::Bootstrap);
+  assert!(!runner.is_loading(TaskKind::Bootstrap), "invalidate frees the slot");
+  assert!(
+    !runner.complete(TaskKind::Bootstrap, stale),
+    "a result from the invalidated generation must be dropped"
+  );
+}


### PR DESCRIPTION
## Description

Follow-up to #231. `bootstrap_selected` (the `b` key — re-run bootstrap on the selected worktree) ran `bootstrap::run` (file copies, guards, command hooks) **synchronously on the event loop**, freezing the TUI on a slow bootstrap. This moves it onto the shared `TaskRunner` spine, exactly like the worktree refresh (#231) and sync (#258).

Closes #256

## Type of change

- [x] ✨ Feature (non-blocking bootstrap; new `TaskKind`)

## Changes

- `src/tui/state/async_task.rs`: `TaskKind::Bootstrap` (single global op → coalesces; `bootstrapping…` label) + `TaskMsg::Bootstrap(generation, Result<BootstrapReport, String>)`.
- `src/tui/app.rs`: `bootstrap_selected` keeps the synchronous TOFU trust gate on the main thread, then claims a generation and spawns `spawn_bootstrap` (moves only owned `Send` data — the two paths + a `Config` clone — and rebuilds its own `BootstrapCtx`). The `View::Report` transition + ok/had-failures status move to `drain_task_results`, behind the generation late-drop guard.
- Tests + docs (EN/FR keybindings, CHANGELOG).

## Tests

- [x] `cargo test` passes locally (env-minimal PATH; 60 binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added (TDD red→green): spine contract (label / coalesce / late-drop) in `tui_state_async_task_tests.rs`; drain behaviour (Ok→Report, Failed→"had failures", Err→status no-flip, late-drop, always-flip-even-mid-create, no-selection guard) in `tui_app_tests.rs`. No real OS thread spawned in tests (results injected via `task_result_sender` + drain — the #248 trap avoided).

## Notes for reviewers

- **Intentional scope:** only the `b` re-run (`bootstrap_selected`) moves off-thread. The **create flow** (`n` → `submit_create`) still calls `bootstrap::run` synchronously — the issue names `bootstrap_selected` specifically, and migrating the create flow (which interleaves with the create modal's own state machine) is a separate, differently-sequenced change. Possible follow-up; deliberately **not** in this PR.
- **Behaviour change vs the old sync path:** because the run is now async, the user can navigate between the `b` press and the result. A live result **always flips to `View::Report`** — the user asked for the bootstrap, so its outcome takes the screen even if they opened the create form meanwhile (the create slice persists; only the modal context is lost on the next `Esc`). This is pinned by `drain_bootstrap_report_flips_to_report_even_from_another_view`. If we'd rather protect an open modal, the minimal guard (flip only from `View::List`) is a one-liner follow-up.
- TOFU trust gate unchanged (#95): still synchronous, still before the spawn — the existing `tui_bootstrap_selected_aborts_on_untrusted_config` stays green.

## Linked issues / docs

- Issue: #256
- Built on: #231 (async-task spine), mirrors #258 (sync)