### PR TITLE
🐛 fix(tui): wait for mutating tasks before quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Fixed
+
+- TUI quit now waits for in-flight mutating spine tasks (`sync` / `bootstrap`) to finish instead of abandoning them mid-operation.
 
 ## Past releases
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -723,6 +723,23 @@ impl App {
     self.tasks.is_any_loading()
   }
 
+  /// `true` when a requested quit can safely leave the event loop now.
+  /// Mutating spine workers keep running until their result is drained so
+  /// `sync` / `bootstrap` are not abandoned mid-operation.
+  pub fn can_quit_now(&self) -> bool {
+    !self.should_quit || !self.tasks.has_mutating_task_in_flight()
+  }
+
+  /// Surface why a requested quit is being held. The event loop keeps
+  /// ticking/draining while this status is visible.
+  pub fn defer_quit_for_mutating_task(&mut self) {
+    if let Some(label) = self.tasks.mutating_loading_label() {
+      self.status = format!("finishing {} before quit…", label.trim_end_matches('…'));
+    } else {
+      self.status = "finishing task before quit…".into();
+    }
+  }
+
   /// A clone of the task channel sender background workers report over
   /// (issue #231; GitHub fetch workers too since #255). Exposed so the
   /// async-apply path ([`Self::drain_task_results`]) can be driven

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -220,6 +220,9 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       app.defer_quit_for_mutating_task();
       continue;
     }
+    if app.should_quit {
+      continue;
+    }
 
     match app.view {
       // When the inline filter bar is open, capture every key as filter input

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -161,6 +161,13 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       app.spinner.tick();
     }
 
+    if app.should_quit {
+      if app.can_quit_now() {
+        break;
+      }
+      app.defer_quit_for_mutating_task();
+    }
+
     // Keep the Command Logs overlay live (issue #226): re-snapshot the
     // global log each tick while it is open so a command that finishes
     // off-thread (e.g. the GitHub fetch) appears without reopening. The
@@ -206,7 +213,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
 
     // Global keys
     if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-      break;
+      app.should_quit = true;
+      if app.can_quit_now() {
+        break;
+      }
+      app.defer_quit_for_mutating_task();
+      continue;
     }
 
     match app.view {
@@ -251,7 +263,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           if !app.filter.query().is_empty() {
             app.exit_filter_cancel();
           } else {
-            break;
+            app.should_quit = true;
           }
         } else if key.code == KeyCode::Enter {
           app.cancel_pending_motion();
@@ -266,9 +278,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
           // palette overlay (issue #32) and the key path stay
           // observationally identical: both call the same dispatch.
           if matches!(action, Action::Quit) {
-            break;
+            app.should_quit = true;
+          } else {
+            run_action(terminal, &mut app, action)?;
           }
-          run_action(terminal, &mut app, action)?;
         }
       }
       View::Help => match key.code {
@@ -422,13 +435,14 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
     if app.picker_should_exit {
       break;
     }
-    // Issue #32: `Action::Quit` fired from a non-keystroke path
-    // (the command palette accepting `:quit`) sets this flag via
-    // `run_action`. The keystroke path also breaks directly, so
-    // this branch only matters for palette / future-non-keystroke
-    // dispatchers.
+    // Issue #32/#267: every quit path raises this flag, then the loop
+    // exits only once in-flight mutating workers have reported back. Read-
+    // only workers may be abandoned immediately.
     if app.should_quit {
-      break;
+      if app.can_quit_now() {
+        break;
+      }
+      app.defer_quit_for_mutating_task();
     }
   }
   Ok(app.picker_result)
@@ -459,21 +473,13 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
 /// future feature wired into one would silently miss the other.
 ///
 /// `Action::Quit` raises `app.should_quit` so the event loop can
-/// honour it from any caller — the keystroke path can also just
-/// `break` directly, but the palette path delegates here and has
-/// no way to signal `break` through a `Result<()>`. The loop
-/// checks the flag at the top of every iteration (alongside
-/// `picker_should_exit`).
+/// honour it from any caller and defer the actual exit while a mutating
+/// worker is still in flight. The loop checks the flag at the top and
+/// bottom of every iteration.
 fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App, action: Action) -> Result<()> {
   match action {
-    // Issue #32: signal quit via `app.should_quit` so the palette
-    // path (which can't `break` from inside `run_action` →
-    // `accept_command_palette` → event-loop match) still exits the
-    // TUI when the user types `:quit`. The keystroke path also
-    // matches on `Action::Quit` and `break`s directly before
-    // calling `run_action`, so this branch is observationally a
-    // no-op for the `q` key — both paths converge on the loop
-    // exit.
+    // Issue #32/#267: signal quit via `app.should_quit` so palette
+    // and keymap paths share the same graceful-shutdown gate.
     Action::Quit => app.should_quit = true,
     Action::Down => app.next(),
     Action::Up => app.prev(),

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -229,11 +229,13 @@ impl TaskRunner {
 
   /// Loader label for a mutating in-flight task, if any.
   pub fn mutating_loading_label(&self) -> Option<&'static str> {
-    self
-      .running
-      .iter()
-      .find(|kind| kind.is_mutating())
-      .map(|kind| kind.loading_label())
+    if self.running.contains(&TaskKind::Sync) {
+      Some(TaskKind::Sync.loading_label())
+    } else if self.running.contains(&TaskKind::Bootstrap) {
+      Some(TaskKind::Bootstrap.loading_label())
+    } else {
+      None
+    }
   }
 
   /// The loader label for an in-flight task, if any. `None` when nothing

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -96,6 +96,12 @@ impl TaskKind {
   pub fn is_github(self) -> bool {
     matches!(self, TaskKind::GithubIssue(_) | TaskKind::GithubPr(_))
   }
+
+  /// `true` for workers that can leave repository / worktree state
+  /// partially changed if the process exits before their result is drained.
+  pub fn is_mutating(self) -> bool {
+    matches!(self, TaskKind::Sync | TaskKind::Bootstrap)
+  }
 }
 
 /// Result of an off-thread task, posted from a worker thread back to the
@@ -213,6 +219,21 @@ impl TaskRunner {
   /// alongside the GitHub fetch's own loading signal.
   pub fn is_any_loading(&self) -> bool {
     !self.running.is_empty()
+  }
+
+  /// `true` while a mutating worker is still in flight. Quit handling uses
+  /// this to keep `sync` / `bootstrap` from being abandoned mid-operation.
+  pub fn has_mutating_task_in_flight(&self) -> bool {
+    self.running.iter().any(|kind| kind.is_mutating())
+  }
+
+  /// Loader label for a mutating in-flight task, if any.
+  pub fn mutating_loading_label(&self) -> Option<&'static str> {
+    self
+      .running
+      .iter()
+      .find(|kind| kind.is_mutating())
+      .map(|kind| kind.loading_label())
   }
 
   /// The loader label for an in-flight task, if any. `None` when nothing

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1918,7 +1918,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     HelpRow::Section("Global".to_string()),
     HelpRow::Blank,
     entry(Action::Quit, "quit (Esc also quits when filter is clear)"),
-    fixed("Ctrl-C", "force quit (hard-coded escape hatch)"),
+    fixed("Ctrl-C", "quit (hard-coded escape hatch)"),
     HelpRow::Blank,
     HelpRow::Section("List View".to_string()),
     HelpRow::Blank,

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4308,6 +4308,55 @@ fn request_refresh_coalesces_onto_an_inflight_run() {
 }
 
 #[test]
+fn quit_waits_while_a_sync_task_is_in_flight() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::Sync).unwrap();
+
+  assert!(!app.can_quit_now());
+}
+
+#[test]
+fn quit_waits_while_a_bootstrap_task_is_in_flight() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::Bootstrap).unwrap();
+
+  assert!(!app.can_quit_now());
+}
+
+#[test]
+fn quit_does_not_wait_for_read_only_tasks() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  app.tasks.request(TaskKind::GithubIssue(42)).unwrap();
+  app.tasks.request(TaskKind::GithubPr(7)).unwrap();
+
+  assert!(app.can_quit_now());
+}
+
+#[test]
+fn quit_waiting_status_explains_the_deferred_exit() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::Bootstrap).unwrap();
+
+  assert!(!app.can_quit_now());
+  app.defer_quit_for_mutating_task();
+
+  assert_eq!(app.status, "finishing bootstrapping before quit…");
+}
+
+#[test]
 fn sync_refresh_invalidates_an_inflight_async_refresh() {
   // Issue #231 race guard: a synchronous `refresh()` (the create / delete /
   // report-close path) must bump the task generation so a still-in-flight

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -122,6 +122,48 @@ fn is_github_is_true_only_for_github_kinds() {
 }
 
 #[test]
+fn is_mutating_is_true_only_for_tasks_that_change_worktrees() {
+  assert!(TaskKind::Sync.is_mutating());
+  assert!(TaskKind::Bootstrap.is_mutating());
+  assert!(!TaskKind::RefreshWorktrees.is_mutating());
+  assert!(!TaskKind::GithubIssue(1).is_mutating());
+  assert!(!TaskKind::GithubPr(1).is_mutating());
+}
+
+#[test]
+fn runner_reports_when_a_mutating_task_is_in_flight() {
+  let mut runner = TaskRunner::new();
+  runner.request(TaskKind::RefreshWorktrees);
+  runner.request(TaskKind::GithubIssue(42));
+
+  assert!(runner.is_any_loading());
+  assert!(!runner.has_mutating_task_in_flight());
+
+  runner.request(TaskKind::Sync);
+  assert!(runner.has_mutating_task_in_flight());
+}
+
+#[test]
+fn mutating_loading_label_prefers_mutating_work_over_read_only_work() {
+  let mut runner = TaskRunner::new();
+  runner.request(TaskKind::RefreshWorktrees);
+  runner.request(TaskKind::GithubIssue(42));
+  runner.request(TaskKind::Sync);
+
+  assert_eq!(runner.mutating_loading_label(), Some("syncing…"));
+}
+
+#[test]
+fn runner_stops_reporting_mutating_work_once_it_completes() {
+  let mut runner = TaskRunner::new();
+  let generation = runner.request(TaskKind::Bootstrap).unwrap();
+
+  assert!(runner.has_mutating_task_in_flight());
+  assert!(runner.complete(TaskKind::Bootstrap, generation));
+  assert!(!runner.has_mutating_task_in_flight());
+}
+
+#[test]
 fn github_issue_and_pr_with_same_number_are_independent_slots() {
   // The (target, number) identity carries onto the spine: Issue(42) and
   // Pr(42) never coalesce or share a generation.

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -148,6 +148,7 @@ fn mutating_loading_label_prefers_mutating_work_over_read_only_work() {
   let mut runner = TaskRunner::new();
   runner.request(TaskKind::RefreshWorktrees);
   runner.request(TaskKind::GithubIssue(42));
+  runner.request(TaskKind::Bootstrap);
   runner.request(TaskKind::Sync);
 
   assert_eq!(runner.mutating_loading_label(), Some("syncing…"));


### PR DESCRIPTION
## Description

Gracefully defers TUI quit while an in-flight mutating async spine task is still running, so `sync` and `bootstrap` workers are not abandoned mid-operation. Read-only tasks still allow immediate exit.

Closes #267

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Add mutating-task classification for the async task spine.
- Gate TUI quit through `App::can_quit_now()` so `sync` / `bootstrap` finish before exit.
- Keep read-only refresh / GitHub tasks non-blocking on quit and update the help text for `Ctrl-C`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Not applicable; state-machine coverage verifies the quit gate without a terminal recording.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #267
- Related PR: #266

## Notes for reviewers

The shutdown gate intentionally waits only for mutating spine tasks (`Sync`, `Bootstrap`). Refresh and GitHub fetch workers remain safe to abandon on quit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TUI now gracefully waits for in-flight sync and bootstrap tasks to complete before quitting, preventing incomplete operations and data loss.

* **Documentation**
  * Updated help text for the global quit shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->