### PR TITLE
✨ feat(tui): add delete loader and working-tree count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- TUI now has a reusable dedicated-area `LoaderWidget`; the delete-worktree modal uses it as the first real consumer, showing both in-flight and failed delete states.
+- The sidebar `Working Tree` pane now renders the changed-file count in its bottom-right footer.
 - Project tooling now ships a Flippad-style colored `Makefile` plus Zed tasks for the local Rust workflow (`build`, `test`, `clippy`, `doctor`, `audit`, worktree bootstrap, and related shortcuts).
 
 ### Fixed
 
-- TUI quit now waits for in-flight mutating spine tasks (`sync` / `bootstrap`) to finish instead of abandoning them mid-operation.
+- Delete-worktree confirmation no longer blocks the TUI render loop while the removal runs; the async spine drives the deletion and quit waits for it like other mutating tasks.
+- TUI quit now waits for in-flight mutating spine tasks (`sync` / `bootstrap` / delete-worktree) to finish instead of abandoning them mid-operation.
 
 ## Past releases
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,9 +94,9 @@ If an issue still shows `open` on GitHub even though its work shipped, it's a tr
 
 Near-term TUI work, listed in **rough implementation order** — each item builds on the one above it. This is a dependency ordering, not a date commitment.
 
-The 0.9.0 async-task train (the spine #231, GitHub-fetch-on-spine #255, sync `S` #258, bootstrap `b` #256, Command Logs `3` #226, Configuration panel `4` #232, open-docs `.` #233) has shipped — see the Shipped highlights table above. The graceful-shutdown follow-up #267 has also landed on `dev` after v0.9.0 and is tracked in `CHANGELOG.md` under `[Unreleased]`. The near-term queue is now:
+The 0.9.0 async-task train (the spine #231, GitHub-fetch-on-spine #255, sync `S` #258, bootstrap `b` #256, Command Logs `3` #226, Configuration panel `4` #232, open-docs `.` #233) has shipped — see the Shipped highlights table above. The graceful-shutdown follow-up #267 has also landed on `dev` after v0.9.0 and is tracked in `CHANGELOG.md` under `[Unreleased]`. The standalone loader-widget follow-up #257 now has its first real consumer in the delete-worktree modal and is tracked in `CHANGELOG.md` under `[Unreleased]`.
 
-1. [#257](https://github.com/kbrdn1/gwm-cli/issues/257) — **Standalone loader widget** — *blocked*: its intended consumers (#226 Command Logs, #232 Configuration panel) shipped without a dedicated async loading area (both open instantly), so building it now would be dead code. Deferred until a panel with a genuinely slow, dedicated-area data source lands (e.g. #35 embedded lazygit PTY, #36 multi-repo listing).
+No small near-term TUI follow-up is queued right now; the next candidates are the larger Ambitious items below when demand warrants them.
 
 ## Ambitious
 

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -90,6 +90,9 @@ added: the text still shows the exact `git status --short` codes.
 
 Empty checkout renders as `✓ clean`.
 
+The bottom-right footer shows the number of files currently reported by
+`git status --short`; a clean checkout shows `0`.
+
 ## `Recent Commits` block
 
 A lazygit-style commit graph that fills the available height. Added by [#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72) and finished in [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).

--- a/docs/fr/2.tui/2.sidebar.md
+++ b/docs/fr/2.tui/2.sidebar.md
@@ -90,6 +90,9 @@ ajoutée : le texte affiche toujours les codes exacts de `git status --short`.
 
 Un checkout vide s'affiche comme `✓ clean`.
 
+Le footer en bas à droite affiche le nombre de fichiers actuellement remontés
+par `git status --short` ; un checkout propre affiche `0`.
+
 ## bloc `Recent Commits`
 
 Un graphe de commits à la lazygit qui remplit la hauteur disponible. Ajouté par [#71](https://github.com/kbrdn1/gwm-cli/issues/71) / [#72](https://github.com/kbrdn1/gwm-cli/pull/72) et finalisé dans [#73](https://github.com/kbrdn1/gwm-cli/issues/73) / [#74](https://github.com/kbrdn1/gwm-cli/pull/74).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -258,6 +258,11 @@ pub struct App {
   /// the status messages and call `worktree::remove`.
   pub confirm: ConfirmModal,
 
+  /// Last delete-worktree failure shown inside the confirm modal (issue
+  /// #257). Kept on `App`, not `ConfirmModal`, because it is the outcome of
+  /// the async worktree deletion side effect rather than countdown state.
+  pub delete_failure: Option<String>,
+
   /// Animated loader for overlays (issue #187). Advanced by the event
   /// loop's 200ms poll tick while the confirm countdown is armed and
   /// read by the renderer; pure state lives in
@@ -397,6 +402,7 @@ impl App {
       picker_should_exit: false,
       should_quit: false,
       confirm: ConfirmModal::new(),
+      delete_failure: None,
       spinner: Spinner::new(),
       github: GitHubFetch::new(),
       link_prompt: LinkPrompt::new(),
@@ -699,6 +705,32 @@ impl App {
           // refresh / sync arms use).
           refresh_applied = true;
         }
+        TaskMsg::DeleteWorktree(generation, name, label, result) => {
+          if !self.tasks.complete(TaskKind::DeleteWorktree, generation) {
+            // Late result — a newer run (or an invalidate) superseded it.
+            continue;
+          }
+          match result {
+            Ok(()) => {
+              self.delete_failure = None;
+              self.view = View::List;
+              self.confirm.reset();
+              let refresh_result = self.refresh();
+              self.status = match refresh_result {
+                Ok(()) => format!("removed {} ({})", name, label),
+                Err(e) => format!("removed {} ({}); refresh failed: {}", name, label, e),
+              };
+            }
+            Err(e) => {
+              self.delete_failure = Some(e.clone());
+              self.view = View::Confirm;
+              self.status = format!("delete failed: {}", e);
+            }
+          }
+          applied = true;
+          // Delete owns the status line this tick.
+          refresh_applied = true;
+        }
       }
     }
     // Once nothing GitHub-side is left loading, swap the "fetching…"
@@ -723,9 +755,14 @@ impl App {
     self.tasks.is_any_loading()
   }
 
+  /// `true` while the delete-worktree worker is in flight (issue #257).
+  pub fn is_delete_worktree_loading(&self) -> bool {
+    self.tasks.is_loading(TaskKind::DeleteWorktree)
+  }
+
   /// `true` when a requested quit can safely leave the event loop now.
   /// Mutating spine workers keep running until their result is drained so
-  /// `sync` / `bootstrap` are not abandoned mid-operation.
+  /// `sync` / `bootstrap` / delete-worktree are not abandoned mid-operation.
   pub fn can_quit_now(&self) -> bool {
     !self.should_quit || !self.tasks.has_mutating_task_in_flight()
   }
@@ -1476,6 +1513,7 @@ impl App {
     }
     self.view = View::Confirm;
     self.confirm.reset();
+    self.delete_failure = None;
     // Start the loader animation from a deterministic frame each time
     // the modal opens (#187).
     self.spinner.reset();
@@ -1486,11 +1524,38 @@ impl App {
       Some(s) => (s.name.clone(), s.path.display().to_string()),
       None => return Ok(()),
     };
-    worktree::remove(&self.repo, &name, self.delete_branch_on_remove)?;
-    self.status = format!("removed {} ({})", name, label);
-    self.view = View::List;
-    self.confirm.reset();
-    self.refresh()
+    if self.is_delete_worktree_loading() {
+      return Ok(());
+    }
+    if self.tasks.has_mutating_task_in_flight() {
+      if let Some(label) = self.tasks.mutating_loading_label() {
+        self.status = format!("finish {} before deleting worktree", label.trim_end_matches('…'));
+      } else {
+        self.status = "finish current task before deleting worktree".into();
+      }
+      return Ok(());
+    }
+    let Some(generation) = self.tasks.request(TaskKind::DeleteWorktree) else {
+      return Ok(());
+    };
+    let delete_branch = self.delete_branch_on_remove;
+    self.delete_failure = None;
+    self.confirm.dismiss();
+    self.spinner.reset();
+    self.status = TaskKind::DeleteWorktree.loading_label().into();
+    self.spawn_delete_worktree(generation, name, label, delete_branch);
+    Ok(())
+  }
+
+  fn spawn_delete_worktree(&self, generation: u64, name: String, label: String, delete_branch: bool) {
+    let tx = self.task_tx.clone();
+    let workdir = self.workdir.clone();
+    std::thread::spawn(move || {
+      let result = worktree::discover_repo(Some(&workdir))
+        .and_then(|repo| worktree::remove(&repo, &name, delete_branch))
+        .map_err(|e| e.to_string());
+      let _ = tx.send(TaskMsg::DeleteWorktree(generation, name, label, result));
+    });
   }
 
   // ---- Confirm-overlay safety countdown (issue #30, extracted per #125) ---
@@ -1540,7 +1605,12 @@ impl App {
   /// Handle the dismissal keys (`n` / `Esc`) inside the confirm overlay.
   /// Always disarms the countdown and returns to the list.
   pub fn confirm_dismiss(&mut self) {
+    if self.is_delete_worktree_loading() {
+      self.status = TaskKind::DeleteWorktree.loading_label().into();
+      return;
+    }
     self.confirm.dismiss();
+    self.delete_failure = None;
     self.view = View::List;
   }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -136,6 +136,10 @@ fn leave_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Resu
 /// countdown mode the first call arms (the loop ticks the bar), a second
 /// disarms; in classic mode it fires immediately.
 fn confirm_fire(app: &mut App) {
+  if app.is_delete_worktree_loading() {
+    app.status = TaskKind::DeleteWorktree.loading_label().into();
+    return;
+  }
   match app.confirm_press_y(Instant::now()) {
     ConfirmKeyAction::FireNow => {
       if let Err(e) = app.confirm_delete() {
@@ -196,7 +200,6 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         CountdownTickOutcome::ReadyToFire => {
           if let Err(e) = app.confirm_delete() {
             app.status = format!("delete failed: {}", e);
-            app.view = View::List;
           }
         }
         CountdownTickOutcome::Pending | CountdownTickOutcome::NotArmed => {}
@@ -337,6 +340,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         CreateKey::Cancel => app.view = View::List,
         CreateKey::Handled => {}
       },
+      View::Confirm if app.is_delete_worktree_loading() => {}
       View::Confirm => match key.code {
         // `y` confirms directly regardless of which button is focused
         // (unchanged muscle memory). `Enter` activates the *focused*

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -10,7 +10,7 @@
 //!
 //! Unlike [`super::github_fetch`] this is **not** a result cache. The
 //! GitHub layer caches `(target, number)` lookups and dedupes them; a
-//! refresh / sync / bootstrap is a one-shot "run it, give me a fresh
+//! refresh / sync / bootstrap / delete-worktree is a one-shot "run it, give me a fresh
 //! result" with nothing worth caching by key. So the spine keeps only
 //! two things from that design — *coalescing* and the *late-result
 //! drop* — and drops the per-key cache:
@@ -73,6 +73,11 @@ pub enum TaskKind {
   /// before the spawn; completion sets `App::report` and flips to
   /// `View::Report`.
   Bootstrap,
+  /// Off-thread delete of the selected worktree (issue #257):
+  /// `worktree::remove` can touch git admin files, remove the worktree
+  /// directory, and optionally delete the branch, so it must not block the
+  /// render loop while the confirm modal is open.
+  DeleteWorktree,
 }
 
 impl TaskKind {
@@ -85,6 +90,7 @@ impl TaskKind {
       TaskKind::GithubIssue(_) | TaskKind::GithubPr(_) => "fetching GitHub status…",
       TaskKind::Sync => "syncing…",
       TaskKind::Bootstrap => "bootstrapping…",
+      TaskKind::DeleteWorktree => "deleting worktree…",
     }
   }
 
@@ -100,7 +106,7 @@ impl TaskKind {
   /// `true` for workers that can leave repository / worktree state
   /// partially changed if the process exits before their result is drained.
   pub fn is_mutating(self) -> bool {
-    matches!(self, TaskKind::Sync | TaskKind::Bootstrap)
+    matches!(self, TaskKind::Sync | TaskKind::Bootstrap | TaskKind::DeleteWorktree)
   }
 }
 
@@ -129,6 +135,10 @@ pub enum TaskMsg {
   /// drain sets `App::report` and flips to `View::Report`; a superseded
   /// late result is dropped by [`TaskRunner::complete`].
   Bootstrap(u64, std::result::Result<BootstrapReport, String>),
+  /// A delete-worktree result (issue #257): the worker's generation, the
+  /// deleted worktree's display name + path label for the status line, and
+  /// the deletion outcome.
+  DeleteWorktree(u64, String, String, std::result::Result<(), String>),
 }
 
 /// Coalescing + late-drop spine for background tasks (issue #231).
@@ -222,7 +232,7 @@ impl TaskRunner {
   }
 
   /// `true` while a mutating worker is still in flight. Quit handling uses
-  /// this to keep `sync` / `bootstrap` from being abandoned mid-operation.
+  /// this to keep `sync` / `bootstrap` / delete-worktree from being abandoned mid-operation.
   pub fn has_mutating_task_in_flight(&self) -> bool {
     self.running.iter().any(|kind| kind.is_mutating())
   }
@@ -233,6 +243,8 @@ impl TaskRunner {
       Some(TaskKind::Sync.loading_label())
     } else if self.running.contains(&TaskKind::Bootstrap) {
       Some(TaskKind::Bootstrap.loading_label())
+    } else if self.running.contains(&TaskKind::DeleteWorktree) {
+      Some(TaskKind::DeleteWorktree.loading_label())
     } else {
       None
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,5 +1,6 @@
 use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::keymap::{Action, Keymap};
+use super::state::async_task::TaskKind;
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::Field;
 use super::state::sidebar::SidebarMode;
@@ -11,10 +12,11 @@ use crate::config::ConfigSource;
 use crate::github::{IssueState, LinkSource, PrState};
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
+  buffer::Buffer,
   layout::{Alignment, Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, Wrap},
+  widgets::{Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, Widget, Wrap},
   Frame,
 };
 use std::time::{Duration, Instant};
@@ -34,8 +36,100 @@ pub struct SidebarSections {
   pub worktree: Vec<Line<'static>>,
   /// `git status --short` lines, or `✓ clean`, or a load error.
   pub working_tree: Vec<Line<'static>>,
+  /// Number of changed files reported by `git status --short`.
+  pub working_tree_file_count: usize,
   /// Up to 10 oneline commits, or an empty / error notice.
   pub recent_commits: Vec<Line<'static>>,
+}
+
+/// Reusable one-line loader for dedicated panel/modal areas (issue #257).
+#[derive(Debug, Clone, Copy)]
+pub enum LoaderWidgetState<'a> {
+  Running {
+    glyph: &'a str,
+    label: &'a str,
+    detail: Option<&'a str>,
+  },
+  Failed {
+    message: &'a str,
+    detail: Option<&'a str>,
+  },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LoaderWidget<'a> {
+  state: LoaderWidgetState<'a>,
+  accent: Color,
+  text: Color,
+  muted: Color,
+  failed: Color,
+  alignment: Alignment,
+}
+
+impl<'a> LoaderWidget<'a> {
+  pub fn running(glyph: &'a str, label: &'a str, detail: Option<&'a str>, theme: &Theme) -> Self {
+    Self {
+      state: LoaderWidgetState::Running { glyph, label, detail },
+      accent: theme.accent,
+      text: theme.name,
+      muted: theme.muted,
+      failed: theme.prunable,
+      alignment: Alignment::Left,
+    }
+  }
+
+  pub fn failed(message: &'a str, detail: Option<&'a str>, theme: &Theme) -> Self {
+    Self {
+      state: LoaderWidgetState::Failed { message, detail },
+      accent: theme.accent,
+      text: theme.name,
+      muted: theme.muted,
+      failed: theme.prunable,
+      alignment: Alignment::Left,
+    }
+  }
+
+  pub fn alignment(mut self, alignment: Alignment) -> Self {
+    self.alignment = alignment;
+    self
+  }
+
+  fn line(self) -> Line<'static> {
+    let mut spans = match self.state {
+      LoaderWidgetState::Running { glyph, label, .. } => vec![
+        Span::styled(
+          format!("{glyph} "),
+          Style::default().fg(self.accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+          label.to_string(),
+          Style::default().fg(self.text).add_modifier(Modifier::BOLD),
+        ),
+      ],
+      LoaderWidgetState::Failed { message, .. } => vec![
+        Span::styled("! ", Style::default().fg(self.failed).add_modifier(Modifier::BOLD)),
+        Span::styled(
+          message.to_string(),
+          Style::default().fg(self.failed).add_modifier(Modifier::BOLD),
+        ),
+      ],
+    };
+
+    let detail = match self.state {
+      LoaderWidgetState::Running { detail, .. } | LoaderWidgetState::Failed { detail, .. } => detail,
+    };
+    if let Some(detail) = detail {
+      spans.push(Span::styled(" — ", Style::default().fg(self.muted)));
+      spans.push(Span::styled(detail.to_string(), Style::default().fg(self.muted)));
+    }
+    Line::from(spans)
+  }
+}
+
+impl Widget for LoaderWidget<'_> {
+  fn render(self, area: Rect, buf: &mut Buffer) {
+    Paragraph::new(self.line()).alignment(self.alignment).render(area, buf);
+  }
 }
 
 pub fn draw(f: &mut Frame, app: &mut App) {
@@ -531,12 +625,13 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   // Read the cached section lengths via a short immutable borrow so the
   // layout solver and scroll clamp can run before the render borrow. The
   // worktree section gains +1 row for the live header prefix.
-  let (worktree_len, working_tree_len, commits_len) = {
+  let (worktree_len, working_tree_len, working_tree_file_count, commits_len) = {
     let cache = app.sidebar.cache.as_ref();
     let s = cache.map(|(_, s)| s);
     (
       s.map(|s| s.worktree.len()).unwrap_or(0) + 1,
       s.map(|s| s.working_tree.len()).unwrap_or(0),
+      s.map(|s| s.working_tree_file_count).unwrap_or(0),
       s.map(|s| s.recent_commits.len()).unwrap_or(0) as u16,
     )
   };
@@ -602,6 +697,11 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   };
   let issue_pr_title = issue_pr_pane_title(&app.keymap);
   let working_tree_title = working_tree_pane_title(&app.keymap);
+  let working_tree_footer = if working_tree_len == 0 {
+    None
+  } else {
+    Some(format!(" {} ", working_tree_file_count))
+  };
 
   // The render borrow: cached sections are read by reference and never
   // cloned (issue #238). On a cache hit this copies zero commit text — the
@@ -639,7 +739,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
         SectionBody::new(&cache.working_tree),
         border_color,
         0,
-        None,
+        working_tree_footer,
       );
     }
     render_section(
@@ -791,13 +891,14 @@ pub fn build_sidebar_sections(
     // follow-up list; v1 ships `<ref>  <subject>` only.
     SidebarMode::Stashes => stash_lines(w, STASHES_DISPLAY_LIMIT, theme),
   };
-  let working_tree = match mode {
+  let (working_tree, working_tree_file_count) = match mode {
     SidebarMode::Commits => working_tree_lines(w, theme),
-    SidebarMode::Stashes => Vec::new(),
+    SidebarMode::Stashes => (Vec::new(), 0),
   };
   SidebarSections {
     worktree: worktree_identity_lines(w, theme),
     working_tree,
+    working_tree_file_count,
     recent_commits: body,
   }
 }
@@ -954,19 +1055,27 @@ fn badges_line(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
   Line::from(spans)
 }
 
-fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> Vec<Line<'static>> {
+fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, usize) {
   match worktree::git_status_short(&w.path) {
-    Ok(s) if s.trim().is_empty() => {
+    Ok(s) if s.trim().is_empty() => (
       vec![Line::from(Span::styled(
         "✓ clean".to_string(),
         Style::default().fg(theme.clean),
-      ))]
+      ))],
+      0,
+    ),
+    Ok(s) => {
+      let lines: Vec<Line<'static>> = s.lines().map(|line| working_tree_status_line(line, theme)).collect();
+      let count = lines.len();
+      (lines, count)
     }
-    Ok(s) => s.lines().map(|line| working_tree_status_line(line, theme)).collect(),
-    Err(e) => vec![Line::from(Span::styled(
-      format!("! {}", e),
-      Style::default().fg(theme.prunable),
-    ))],
+    Err(e) => (
+      vec![Line::from(Span::styled(
+        format!("! {}", e),
+        Style::default().fg(theme.prunable),
+      ))],
+      0,
+    ),
   }
 }
 
@@ -2677,8 +2786,24 @@ fn draw_confirm(f: &mut Frame, app: &App) {
 
   f.render_widget(Paragraph::new(content).wrap(Wrap { trim: false }), inner[0]);
 
-  // --- loader + countdown (only while the safety countdown is armed) ---
-  if app.confirm_is_countdown_mode() && app.confirm.is_armed() {
+  // --- loader + countdown ---
+  if app.is_delete_worktree_loading() {
+    f.render_widget(
+      LoaderWidget::running(
+        app.spinner.glyph(DOT_FRAMES),
+        TaskKind::DeleteWorktree.loading_label(),
+        None,
+        &app.theme,
+      )
+      .alignment(Alignment::Center),
+      inner[1],
+    );
+  } else if let Some(error) = app.delete_failure.as_deref() {
+    f.render_widget(
+      LoaderWidget::failed("delete failed", Some(error), &app.theme).alignment(Alignment::Center),
+      inner[1],
+    );
+  } else if app.confirm_is_countdown_mode() && app.confirm.is_armed() {
     let now = Instant::now();
     let mut spans = vec![Span::styled(
       format!("{} ", app.spinner.glyph(DOT_FRAMES)),
@@ -2695,20 +2820,22 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   }
 
   // --- buttons (focused one highlighted) ---
-  f.render_widget(
-    Paragraph::new(confirm_buttons_line(
-      app.confirm.focused_button(),
-      app.theme.accent,
-      muted,
-    ))
-    .alignment(Alignment::Center),
-    inner[2],
-  );
+  if !app.is_delete_worktree_loading() {
+    f.render_widget(
+      Paragraph::new(confirm_buttons_line(
+        app.confirm.focused_button(),
+        app.theme.accent,
+        muted,
+      ))
+      .alignment(Alignment::Center),
+      inner[2],
+    );
 
-  f.render_widget(
-    Paragraph::new(modal_hint_for_context(HintContext::Confirm, &app.keymap, &app.theme)),
-    inner[4],
-  );
+    f.render_widget(
+      Paragraph::new(modal_hint_for_context(HintContext::Confirm, &app.keymap, &app.theme)),
+      inner[4],
+    );
+  }
 }
 
 /// The ` Confirm ` ` Cancel ` button row (#187, restyled in #217). The

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4257,6 +4257,89 @@ fn drain_drops_a_superseded_sync_result() {
 }
 
 #[test]
+fn drain_delete_worktree_success_returns_to_list_and_reports_removed_target() {
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::DeleteWorktree).unwrap();
+  app.view = View::Confirm;
+  app.delete_failure = Some("old failure".into());
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::DeleteWorktree(
+      generation,
+      "alpha".into(),
+      "/tmp/alpha".into(),
+      Ok(()),
+    ))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "delete result should be applied");
+  assert!(!app.is_delete_worktree_loading(), "delete slot clears after success");
+  assert_eq!(app.view, View::List);
+  assert!(app.delete_failure.is_none(), "old failure is cleared after success");
+  assert!(
+    app.status.contains("removed alpha") && app.status.contains("/tmp/alpha"),
+    "status reports the removed target: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn drain_delete_worktree_failure_stays_in_confirm_and_records_failure() {
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::DeleteWorktree).unwrap();
+  app.view = View::Confirm;
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::DeleteWorktree(
+      generation,
+      "alpha".into(),
+      "/tmp/alpha".into(),
+      Err("permission denied".into()),
+    ))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "delete failure should still be applied");
+  assert!(!app.is_delete_worktree_loading(), "delete slot clears after failure");
+  assert_eq!(app.view, View::Confirm);
+  assert_eq!(app.delete_failure.as_deref(), Some("permission denied"));
+  assert!(
+    app.status.contains("delete failed") && app.status.contains("permission denied"),
+    "status reports the delete failure: {:?}",
+    app.status
+  );
+}
+
+#[test]
+fn drain_drops_a_superseded_delete_worktree_result() {
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let (_dir, mut app) = make_app();
+  let stale = app.tasks.request(TaskKind::DeleteWorktree).unwrap();
+  app.tasks.invalidate(TaskKind::DeleteWorktree);
+  app.view = View::Confirm;
+  app.status = "untouched".into();
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::DeleteWorktree(
+      stale,
+      "alpha".into(),
+      "/tmp/alpha".into(),
+      Ok(()),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(app.view, View::Confirm);
+  assert_eq!(app.status, "untouched");
+}
+
+#[test]
 fn request_sync_coalesces_onto_an_inflight_run() {
   // A second `S` press while a sync is already in flight must not spawn a
   // second rebase — `request_sync` coalesces and returns early (zero threads).
@@ -4327,6 +4410,19 @@ fn quit_waits_while_a_bootstrap_task_is_in_flight() {
   app.tasks.request(TaskKind::Bootstrap).unwrap();
 
   assert!(!app.can_quit_now());
+}
+
+#[test]
+fn quit_waits_while_a_delete_worktree_task_is_in_flight() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::DeleteWorktree).unwrap();
+
+  assert!(!app.can_quit_now());
+  app.defer_quit_for_mutating_task();
+  assert_eq!(app.status, "finishing deleting worktree before quit…");
 }
 
 #[test]

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -35,7 +35,7 @@ mod common;
 
 use common::init_repo;
 use gwm::bootstrap::{BootstrapReport, StepResult};
-use gwm::tui::{draw, App, LinkTarget, View};
+use gwm::tui::{draw, App, LinkTarget, TaskKind, View};
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::{backend::TestBackend, buffer::Buffer, Terminal};
 use std::path::PathBuf;
@@ -175,6 +175,35 @@ fn confirm_modal_renders_title_target_and_buttons() {
   // Confirm / Cancel buttons.
   assert_present(&buf, "Confirm", "confirm button");
   assert_present(&buf, "Cancel", "cancel button");
+}
+
+#[test]
+fn confirm_modal_renders_delete_loader_while_delete_is_in_flight() {
+  let (_dir, mut app) = make_app();
+  app.worktrees.push(deletable_worktree("feat-257-loader"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.view = View::Confirm;
+  app.tasks.request(TaskKind::DeleteWorktree).unwrap();
+
+  let buf = render(&mut app);
+
+  assert_present(&buf, "Delete Worktree", "confirm title");
+  assert_present(&buf, "deleting worktree", "delete loader label");
+}
+
+#[test]
+fn confirm_modal_renders_delete_failure_after_async_delete_fails() {
+  let (_dir, mut app) = make_app();
+  app.worktrees.push(deletable_worktree("feat-257-loader"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.view = View::Confirm;
+  app.delete_failure = Some("permission denied".into());
+
+  let buf = render(&mut app);
+
+  assert_present(&buf, "delete failed", "delete failure label");
+  assert_present(&buf, "permission denied", "delete failure detail");
+  assert_present(&buf, "Cancel", "cancel button after failure");
 }
 
 #[test]

--- a/tests/tui_sidebar_render_tests.rs
+++ b/tests/tui_sidebar_render_tests.rs
@@ -102,3 +102,27 @@ fn sidebar_warm_cache_render_is_stable_across_frames() {
     "two consecutive warm-cache draws must produce byte-identical sidebar buffers"
   );
 }
+
+#[test]
+fn working_tree_section_renders_file_count_footer() {
+  let dir = repo_with_commits(1);
+  for i in 0..11 {
+    std::fs::write(dir.path().join(format!("dirty-{i}.txt")), "dirty").unwrap();
+  }
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+
+  let text = buffer_text(&terminal);
+  assert!(
+    text.contains("Working Tree"),
+    "sidebar must render the Working Tree pane: {text}"
+  );
+  assert!(
+    text.contains(" 11 "),
+    "Working Tree footer must render the number of changed files: {text}"
+  );
+}

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -266,6 +266,19 @@ fn bootstrap_task_reports_the_bootstrapping_label() {
 }
 
 #[test]
+fn delete_worktree_task_reports_the_deleting_label_and_is_mutating() {
+  assert_eq!(TaskKind::DeleteWorktree.loading_label(), "deleting worktree…");
+  assert!(
+    !TaskKind::DeleteWorktree.is_github(),
+    "DeleteWorktree is not a GitHub kind"
+  );
+  assert!(
+    TaskKind::DeleteWorktree.is_mutating(),
+    "DeleteWorktree mutates disk/git state"
+  );
+}
+
+#[test]
 fn second_bootstrap_request_while_inflight_is_coalesced() {
   // Only one bootstrap runs at a time — a second `b` press while one is in
   // flight must not spawn a second concurrent run (file copies / hooks).


### PR DESCRIPTION
## Description

Adds the reusable dedicated-area loader widget from #257 with the delete-worktree modal as its first real consumer. The delete path now runs on the async task spine so the TUI can keep rendering the modal loader, surface a failed delete in-place, and defer quit until the mutating worker drains.

Closes #257

## Type of change

- [x] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Add `TaskKind::DeleteWorktree` / `TaskMsg::DeleteWorktree` on the TUI async spine and keep delete confirmation in `View::Confirm` while removal runs.
- Add a reusable `LoaderWidget` with running and failed states, then render it in the Delete Worktree modal.
- Show the changed-file count in the bottom-right footer of the sidebar `Working Tree` pane.
- Update changelog, roadmap, and EN/FR sidebar docs.

## Tests

- [x] `cargo test` passes locally (`make ci`)
- [x] `cargo fmt --check` passes (`make ci`)
- [x] `cargo clippy -- -D warnings` passes (`make ci`)
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Not captured; render-level `ratatui::backend::TestBackend` tests assert the modal loader, failed state, and Working Tree footer content.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (not applicable)
- [x] `examples/gwm.toml.example` updated if config schema changed (not applicable)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #257
- Related PR: #254

## Notes for reviewers

Focus on the delete flow transition from synchronous removal to the async task spine, and the modal behaviour while `TaskKind::DeleteWorktree` is in flight or fails.