### PR TITLE
📝 docs(roadmap): sync docs roadmap with v0.9 surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Docs roadmap pages now mirror the v0.9.0 stable surface, the v0.8.0 historical cycle, and the current `[Unreleased]` dev delta in both English and French.
 - TUI now has a reusable dedicated-area `LoaderWidget`; the delete-worktree modal uses it as the first real consumer, showing both in-flight and failed delete states.
 - The sidebar `Working Tree` pane now renders the changed-file count in its bottom-right footer.
 - Project tooling now ships a Flippad-style colored `Makefile` plus Zed tasks for the local Rust workflow (`build`, `test`, `clippy`, `doctor`, `audit`, worktree bootstrap, and related shortcuts).

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,44 +1,59 @@
 ---
 title: Roadmap
-description: What ships next — the merged-on-dev 0.8.0 RC series, post-v0.7.0 priorities, and the link to the issue tracker.
+description: What ships next — the v0.9.0 stable surface, the small Unreleased delta on dev, and the link to the issue tracker.
 ---
 
 # Roadmap
 
 The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
 
-## shipped in v0.7.0
+## current state — v0.9.0
 
-For reference — what made it into the current stable line:
+The current stable line is **v0.9.0**. It builds on the v0.8.0 configurability and personalisation cycle, then adds the 0.9.0 TUI train:
 
-- **Configurable branch types, declarative GitHub labels & milestones** ([#80](https://github.com/kbrdn1/gwm-cli/issues/80) / [#81](https://github.com/kbrdn1/gwm-cli/issues/81) / [#82](https://github.com/kbrdn1/gwm-cli/issues/82)) — drive `gwm`'s branch taxonomy and GitHub label/milestone set from `.gwm.toml`.
-- **Bootstrap hardening + TOFU trust ledger** ([#93](https://github.com/kbrdn1/gwm-cli/issues/93) / [#94](https://github.com/kbrdn1/gwm-cli/issues/94) / [#95](https://github.com/kbrdn1/gwm-cli/issues/95) / [#96](https://github.com/kbrdn1/gwm-cli/issues/96)) — `O_NOFOLLOW` write primitives, canonicalize + prefix-check on every resolved bootstrap path, and a `gwm trust list / revoke / show` ledger that closes the arbitrary-RCE primitive against hostile clones. See [TOFU trust ledger](/configuration/trust-ledger).
-- **TUI internals: `App` decomposed into focused `tui/state/` sub-structs** ([#102](https://github.com/kbrdn1/gwm-cli/issues/102) and the #123–#128 follow-ups) plus typed error variants and shared render helpers ([#105](https://github.com/kbrdn1/gwm-cli/issues/105) / [#106](https://github.com/kbrdn1/gwm-cli/issues/106)).
-- **Measured TUI sidebar performance** ([#107](https://github.com/kbrdn1/gwm-cli/issues/107) / [#108](https://github.com/kbrdn1/gwm-cli/issues/108)) — Recent Commits via a libgit2 revwalk cached by `(worktree path, head OID, limit)` (~99% off the 300-row benchmark) and a commit graph that carries `git2::Oid` values instead of heap-allocated hash strings (~47% off the graph render benchmark).
+- **Full theme-role coverage** ([#170](https://github.com/kbrdn1/gwm-cli/issues/170) / [#210](https://github.com/kbrdn1/gwm-cli/issues/210) / [#211](https://github.com/kbrdn1/gwm-cli/issues/211) / [#214](https://github.com/kbrdn1/gwm-cli/issues/214)) — the resolved `[theme]` is threaded through every TUI render site, with dedicated `name`, `path`, `staged`, `modified`, and `untracked` roles. Defaults are preserved and pinned by `tests/tui_theme_audit_tests.rs`.
+- **`git2` 0.21 source migration** ([#169](https://github.com/kbrdn1/gwm-cli/issues/169)) — the breaking accessor API change from the deferred v0.8.0 bump is now handled in source, pruning the old `url` transitive tree.
+- **TUI statusbar, layout, and modal polish** ([#217](https://github.com/kbrdn1/gwm-cli/issues/217) / [#220](https://github.com/kbrdn1/gwm-cli/issues/220) / [#222](https://github.com/kbrdn1/gwm-cli/issues/222) / [#224](https://github.com/kbrdn1/gwm-cli/issues/224)) — contextual statusbar, animated GitHub-fetch spinner, direct pane-focus keys (`1` / `2`), stacked-by-default sidebar, wider overlays, and refined create/link/delete/Issue-PR modals.
+- **Async-task spine** ([#231](https://github.com/kbrdn1/gwm-cli/issues/231) / [#255](https://github.com/kbrdn1/gwm-cli/issues/255) / [#258](https://github.com/kbrdn1/gwm-cli/issues/258) / [#256](https://github.com/kbrdn1/gwm-cli/issues/256)) — worktree refresh, GitHub fetch, `sync` (`S`), and bootstrap (`b`) now run off-thread with coalescing, late-result drop, and statusbar progress instead of freezing the event loop.
+- **Pane-key family `1` / `2` / `3` / `4`** ([#226](https://github.com/kbrdn1/gwm-cli/issues/226) / [#232](https://github.com/kbrdn1/gwm-cli/issues/232)) — direct focus for Worktrees / Status, a Command Logs overlay, and a Configuration panel showing the resolved config with repo / user / default source attribution.
+- **Docs key (`.`)** ([#233](https://github.com/kbrdn1/gwm-cli/issues/233)) — open the documentation from inside the TUI; rebindable as `open_docs`.
 
-The full v0.7.0 release notes (consolidating rc.1 → rc.3 plus the stable-only delta) live at [`changelogs/0.7.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.7.0.md). MSRV is **1.82**.
+The full v0.9.0 release notes live at [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). MSRV is **1.82**.
 
-## merged on dev since v0.7.0 (the 0.8.0 RC series)
+## previous stable cycle — v0.8.0
 
-Surface that has landed and soaked through the `0.8.0` release candidates but not yet been promoted to a stable tag. Per-RC notes live under [`changelogs/pre-releases/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs/pre-releases):
+For reference, **v0.8.0** promoted the large configurability and personalisation cycle:
 
-- **Release hardening + CLI aliases + gitmoji** (`v0.8.0-rc.1`, [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) / [#86](https://github.com/kbrdn1/gwm-cli/issues/86)) — `gh`-CLI publish + workflow token, the `[Unreleased]` dupe guard, Windows in the test matrix, `[aliases]` in `.gwm.toml`, and gitmoji mapping with `gwm commit-prefix` + an opt-in `commit-msg` hook.
-- **Safety daily** (`v0.8.0-rc.2`, [#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#31](https://github.com/kbrdn1/gwm-cli/issues/31)) — `--dry-run` on `gwm remove` / `gwm prune`, plus `gwm undo` + `gwm history` backed by an operation journal at `$XDG_DATA_HOME/gwm/history.toml`.
-- **Configurability + GitHub templates + TUI personalisation** (`v0.8.0-rc.3`, [#88](https://github.com/kbrdn1/gwm-cli/issues/88) / [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) / [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34)) — `gwm config get/set/unset/list/validate/path/edit`, `[hooks.*]` lifecycle hooks, `[issue_template]` + `gwm new`, `[pr_template]` + `gwm pr`, a remappable `[tui.keys]` keymap with chords, a `:` command palette, role-based `[theme]` presets, and a sidebar stashes mode (`s`).
-- **Quick wins** (`v0.8.0-rc.4`, [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27)) — `gwm sync [<pattern>] [--merge]` (fetch + rebase/merge onto upstream, conflict-safe) and `cargo-binstall` support via `[package.metadata.binstall]`. See [`gwm sync` in the CLI reference](/cli/reference) and the [install guide](/getting-started/install).
-- **Personalisation + polish** (`v0.8.0-rc.5`, [#190](https://github.com/kbrdn1/gwm-cli/issues/190) / [#188](https://github.com/kbrdn1/gwm-cli/issues/188) / [#185](https://github.com/kbrdn1/gwm-cli/issues/185) / [#187](https://github.com/kbrdn1/gwm-cli/issues/187) / [#180](https://github.com/kbrdn1/gwm-cli/issues/180) / [#179](https://github.com/kbrdn1/gwm-cli/issues/179) / [#181](https://github.com/kbrdn1/gwm-cli/issues/181) / [#175](https://github.com/kbrdn1/gwm-cli/issues/175)) — a user-level global config at `~/.config/gwm/config.toml` merged underneath each repo's `.gwm.toml` (#190); a responsive sidebar that stacks on narrow terminals with a `V` layout cycle and an `H`/`[tui] sidebar_position` left/right toggle (#188); a `claude-dark` theme preset and a reworked single-row header (#185); a full modal polish pass with selectable confirm buttons defaulting to Cancel (#187); a single-line statusline with badge chips and a flush-right log (#180); working-tree colourisation of the sidebar status block (#179); ephemeral PR auto-detection wired into `gwm status`, the TUI sidebar, and `gwm list --detect-pr` (#181); and `{repo_path}` / `{repo_parent}` config placeholders (#175). Plus a test-hermeticity fix so `cargo test` no longer reads the contributor's real global config ([#194](https://github.com/kbrdn1/gwm-cli/issues/194) / [#196](https://github.com/kbrdn1/gwm-cli/issues/196)).
+- **Release hardening, Windows CI, CLI aliases, and Gitmoji tooling** (`v0.8.0-rc.1`, [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) / [#86](https://github.com/kbrdn1/gwm-cli/issues/86)) — reliable release publishing, `[Unreleased]` duplicate guard, `windows-latest` in the test matrix, `[aliases]`, `gwm commit-prefix`, `gwm types --gitmoji`, and an opt-in `commit-msg` hook.
+- **Safety daily** (`v0.8.0-rc.2`, [#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#31](https://github.com/kbrdn1/gwm-cli/issues/31)) — `--dry-run` on `gwm remove` / `gwm prune`, plus `gwm undo` / `gwm history` backed by `$XDG_DATA_HOME/gwm/history.toml`.
+- **Config CLI, lifecycle hooks, GitHub templates, and TUI personalisation** (`v0.8.0-rc.3`, [#88](https://github.com/kbrdn1/gwm-cli/issues/88) / [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) / [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34)) — `gwm config`, `[hooks.*]`, `gwm new`, `gwm pr`, remappable `[tui.keys]`, the `:` command palette, role-based `[theme]` presets, and sidebar stashes mode.
+- **Quick wins** (`v0.8.0-rc.4`, [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27)) — `gwm sync [<pattern>] [--merge]` and `cargo-binstall` support.
+- **Global config and chrome polish** (`v0.8.0-rc.5`, [#190](https://github.com/kbrdn1/gwm-cli/issues/190) / [#188](https://github.com/kbrdn1/gwm-cli/issues/188) / [#185](https://github.com/kbrdn1/gwm-cli/issues/185) / [#187](https://github.com/kbrdn1/gwm-cli/issues/187) / [#180](https://github.com/kbrdn1/gwm-cli/issues/180) / [#179](https://github.com/kbrdn1/gwm-cli/issues/179) / [#181](https://github.com/kbrdn1/gwm-cli/issues/181) / [#175](https://github.com/kbrdn1/gwm-cli/issues/175)) — user-level `~/.config/gwm/config.toml`, responsive sidebar, `claude-dark`, modal polish, single-line statusline, working-tree colourisation, ephemeral PR auto-detection, and `{repo_path}` / `{repo_parent}` placeholders.
 
-The `git2` 0.20 → 0.21 bump is deferred — it is a breaking accessor-API migration tracked in [#169](https://github.com/kbrdn1/gwm-cli/issues/169). Track the full not-yet-shipped surface in [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) under `[Unreleased]` and the per-RC files.
+The full v0.8.0 notes live at [`changelogs/0.8.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.8.0.md).
+
+## merged on dev since v0.9.0
+
+`[Unreleased]` in the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) reflects what has accumulated on `dev` since the last stable release. Current small deltas include:
+
+- a reusable dedicated-area `LoaderWidget`, first consumed by the delete-worktree modal, including in-flight and failed delete states;
+- a bottom-right changed-file count in the sidebar `Working Tree` pane;
+- project-local Make / Zed task shortcuts for the Rust workflow.
 
 ## what's next
 
-Post-v0.7.0 priorities are tracked in the issue tracker. Pick by interest, comment on the issue if you intend to work on it (avoids parallel duplication), and open a PR targeting `dev`:
+No small near-term TUI follow-up is queued right now. The next candidates are larger items, gated by user demand or a concrete first consumer:
+
+- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — PTY-embedded lazygit overlay.
+- [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — multi-repo workspace mode.
+- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — configuration presets.
+- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — JSON-RPC / gRPC API and daemon mode.
+
+For fresh work, start from the issue tracker:
 
 - [Open issues — `enhancement`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aenhancement)
 - [Open issues — `good first issue`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
 - [Open issues — `roadmap`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aroadmap)
-
-`[Unreleased]` in the root [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) reflects what's accumulated on `dev` since the last release — check there for the merged-but-not-yet-shipped surface.
 
 ## how to contribute
 

--- a/docs/fr/7.roadmap.md
+++ b/docs/fr/7.roadmap.md
@@ -1,44 +1,59 @@
 ---
 title: Roadmap
-description: Ce qui arrive ensuite — la série de RC 0.8.0 mergée sur dev, les priorités post-v0.7.0 et le lien vers le tracker d'issues.
+description: Ce qui arrive ensuite — la surface stable v0.9.0, le petit delta Unreleased sur dev et le lien vers le tracker d'issues.
 ---
 
 # Roadmap
 
 La roadmap complète (avec les catégories groupées et les liens d'issues par item) vit dans [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) à la racine du repo. Le tracker d'issues est la source de vérité pour les détails de scope, les critères d'acceptation et les alternatives considérées.
 
-## livré en v0.7.0
+## état courant — v0.9.0
 
-Pour référence — ce qui a fait partie de la ligne stable courante :
+La ligne stable courante est **v0.9.0**. Elle s'appuie sur le cycle de configurabilité et de personnalisation v0.8.0, puis ajoute le train TUI 0.9.0 :
 
-- **Types de branches configurables, labels et milestones GitHub déclaratifs** ([#80](https://github.com/kbrdn1/gwm-cli/issues/80) / [#81](https://github.com/kbrdn1/gwm-cli/issues/81) / [#82](https://github.com/kbrdn1/gwm-cli/issues/82)) — piloter la taxonomie des branches de `gwm` et l'ensemble des labels/milestones GitHub depuis `.gwm.toml`.
-- **Durcissement du bootstrap + registre de confiance TOFU** ([#93](https://github.com/kbrdn1/gwm-cli/issues/93) / [#94](https://github.com/kbrdn1/gwm-cli/issues/94) / [#95](https://github.com/kbrdn1/gwm-cli/issues/95) / [#96](https://github.com/kbrdn1/gwm-cli/issues/96)) — primitives d'écriture `O_NOFOLLOW`, canonicalize + vérification de préfixe sur chaque chemin de bootstrap résolu, et un registre `gwm trust list / revoke / show` qui ferme la primitive de RCE arbitraire contre les clones hostiles. Voir [registre de confiance TOFU](/fr/configuration/trust-ledger).
-- **Internes de la TUI : `App` décomposé en sous-structs `tui/state/` ciblés** ([#102](https://github.com/kbrdn1/gwm-cli/issues/102) et les suivis #123–#128) plus des variantes d'erreur typées et des helpers de rendu partagés ([#105](https://github.com/kbrdn1/gwm-cli/issues/105) / [#106](https://github.com/kbrdn1/gwm-cli/issues/106)).
-- **Performance mesurée de la sidebar de la TUI** ([#107](https://github.com/kbrdn1/gwm-cli/issues/107) / [#108](https://github.com/kbrdn1/gwm-cli/issues/108)) — Recent Commits via un revwalk libgit2 mis en cache par `(worktree path, head OID, limit)` (~99 % de moins sur le benchmark de 300 lignes) et un graphe de commits qui porte des valeurs `git2::Oid` au lieu de chaînes de hash allouées sur le tas (~47 % de moins sur le benchmark de rendu du graphe).
+- **Couverture complète des rôles de thème** ([#170](https://github.com/kbrdn1/gwm-cli/issues/170) / [#210](https://github.com/kbrdn1/gwm-cli/issues/210) / [#211](https://github.com/kbrdn1/gwm-cli/issues/211) / [#214](https://github.com/kbrdn1/gwm-cli/issues/214)) — le `[theme]` résolu est propagé à tous les sites de rendu TUI, avec des rôles dédiés `name`, `path`, `staged`, `modified` et `untracked`. Les valeurs par défaut sont conservées et verrouillées par `tests/tui_theme_audit_tests.rs`.
+- **Migration source vers `git2` 0.21** ([#169](https://github.com/kbrdn1/gwm-cli/issues/169)) — le changement cassant d'API d'accesseurs, différé pendant v0.8.0, est maintenant absorbé dans le code source et l'ancien arbre transitif `url` disparaît.
+- **Polish de la statusbar, du layout et des modales TUI** ([#217](https://github.com/kbrdn1/gwm-cli/issues/217) / [#220](https://github.com/kbrdn1/gwm-cli/issues/220) / [#222](https://github.com/kbrdn1/gwm-cli/issues/222) / [#224](https://github.com/kbrdn1/gwm-cli/issues/224)) — statusbar contextuelle, spinner animé pendant le fetch GitHub, touches directes de focus (`1` / `2`), sidebar empilée par défaut, overlays plus larges et modales create/link/delete/Issue-PR affinées.
+- **Spine de tâches async** ([#231](https://github.com/kbrdn1/gwm-cli/issues/231) / [#255](https://github.com/kbrdn1/gwm-cli/issues/255) / [#258](https://github.com/kbrdn1/gwm-cli/issues/258) / [#256](https://github.com/kbrdn1/gwm-cli/issues/256)) — refresh des worktrees, fetch GitHub, `sync` (`S`) et bootstrap (`b`) tournent maintenant hors thread avec coalescing, abandon des résultats tardifs et progression dans la statusbar au lieu de figer la boucle d'événements.
+- **Famille de panes `1` / `2` / `3` / `4`** ([#226](https://github.com/kbrdn1/gwm-cli/issues/226) / [#232](https://github.com/kbrdn1/gwm-cli/issues/232)) — focus direct Worktrees / Status, overlay Command Logs et panneau Configuration affichant la config résolue avec attribution repo / user / default.
+- **Touche docs (`.`)** ([#233](https://github.com/kbrdn1/gwm-cli/issues/233)) — ouverture de la documentation depuis la TUI ; rebindable via `open_docs`.
 
-Les notes de release complètes de la v0.7.0 (consolidant rc.1 → rc.3 plus le delta stable-only) vivent dans [`changelogs/0.7.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.7.0.md). La MSRV est **1.82**.
+Les notes de release complètes de la v0.9.0 vivent dans [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). La MSRV est **1.82**.
 
-## mergé sur dev depuis la v0.7.0 (la série de RC 0.8.0)
+## cycle stable précédent — v0.8.0
 
-Surface qui a atterri et a maturé à travers les release candidates `0.8.0` mais n'a pas encore été promue à un tag stable. Les notes par-RC vivent sous [`changelogs/pre-releases/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs/pre-releases) :
+Pour référence, **v0.8.0** a promu le grand cycle configurabilité et personnalisation :
 
-- **Durcissement de release + alias CLI + gitmoji** (`v0.8.0-rc.1`, [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) / [#86](https://github.com/kbrdn1/gwm-cli/issues/86)) — publication via la CLI `gh` + token de workflow, le guard de doublons `[Unreleased]`, Windows dans la matrice de tests, `[aliases]` dans `.gwm.toml`, et le mapping gitmoji avec `gwm commit-prefix` + un hook `commit-msg` opt-in.
-- **Sécurité au quotidien** (`v0.8.0-rc.2`, [#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#31](https://github.com/kbrdn1/gwm-cli/issues/31)) — `--dry-run` sur `gwm remove` / `gwm prune`, plus `gwm undo` + `gwm history` adossés à un journal d'opérations dans `$XDG_DATA_HOME/gwm/history.toml`.
-- **Configurabilité + templates GitHub + personnalisation de la TUI** (`v0.8.0-rc.3`, [#88](https://github.com/kbrdn1/gwm-cli/issues/88) / [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) / [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34)) — `gwm config get/set/unset/list/validate/path/edit`, les hooks de cycle de vie `[hooks.*]`, `[issue_template]` + `gwm new`, `[pr_template]` + `gwm pr`, un keymap `[tui.keys]` remappable avec chords, une command palette `:`, des presets `[theme]` basés sur les rôles, et un mode stashes en sidebar (`s`).
-- **Quick wins** (`v0.8.0-rc.4`, [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27)) — `gwm sync [<pattern>] [--merge]` (fetch + rebase/merge sur upstream, conflict-safe) et le support de `cargo-binstall` via `[package.metadata.binstall]`. Voir [`gwm sync` dans la référence CLI](/fr/cli/reference) et le [guide d'installation](/fr/getting-started/install).
-- **Personnalisation + polish** (`v0.8.0-rc.5`, [#190](https://github.com/kbrdn1/gwm-cli/issues/190) / [#188](https://github.com/kbrdn1/gwm-cli/issues/188) / [#185](https://github.com/kbrdn1/gwm-cli/issues/185) / [#187](https://github.com/kbrdn1/gwm-cli/issues/187) / [#180](https://github.com/kbrdn1/gwm-cli/issues/180) / [#179](https://github.com/kbrdn1/gwm-cli/issues/179) / [#181](https://github.com/kbrdn1/gwm-cli/issues/181) / [#175](https://github.com/kbrdn1/gwm-cli/issues/175)) — une config globale au niveau utilisateur dans `~/.config/gwm/config.toml` fusionnée sous le `.gwm.toml` de chaque repo (#190) ; une sidebar responsive qui s'empile sur les terminaux étroits avec un cycle de layout `V` et un toggle gauche/droite `H`/`[tui] sidebar_position` (#188) ; un preset de thème `claude-dark` et un header sur une seule ligne retravaillé (#185) ; une passe complète de polish des modales avec des boutons de confirmation sélectionnables par défaut sur Cancel (#187) ; une statusline sur une seule ligne avec des badge chips et un log aligné à droite (#180) ; une colorisation working-tree du bloc de statut de la sidebar (#179) ; l'auto-détection des PR éphémères câblée dans `gwm status`, la sidebar de la TUI et `gwm list --detect-pr` (#181) ; et les placeholders de config `{repo_path}` / `{repo_parent}` (#175). Plus un correctif d'hermeticité des tests pour que `cargo test` ne lise plus la vraie config globale du contributeur ([#194](https://github.com/kbrdn1/gwm-cli/issues/194) / [#196](https://github.com/kbrdn1/gwm-cli/issues/196)).
+- **Durcissement de release, CI Windows, alias CLI et tooling Gitmoji** (`v0.8.0-rc.1`, [#146](https://github.com/kbrdn1/gwm-cli/issues/146) / [#147](https://github.com/kbrdn1/gwm-cli/issues/147) / [#112](https://github.com/kbrdn1/gwm-cli/issues/112) / [#85](https://github.com/kbrdn1/gwm-cli/issues/85) / [#86](https://github.com/kbrdn1/gwm-cli/issues/86)) — publication fiable, guard de doublons `[Unreleased]`, `windows-latest` dans la matrice, `[aliases]`, `gwm commit-prefix`, `gwm types --gitmoji` et hook `commit-msg` opt-in.
+- **Sécurité au quotidien** (`v0.8.0-rc.2`, [#29](https://github.com/kbrdn1/gwm-cli/issues/29) / [#31](https://github.com/kbrdn1/gwm-cli/issues/31)) — `--dry-run` sur `gwm remove` / `gwm prune`, plus `gwm undo` / `gwm history` adossés à `$XDG_DATA_HOME/gwm/history.toml`.
+- **Config CLI, hooks de cycle de vie, templates GitHub et personnalisation TUI** (`v0.8.0-rc.3`, [#88](https://github.com/kbrdn1/gwm-cli/issues/88) / [#89](https://github.com/kbrdn1/gwm-cli/issues/89) / [#83](https://github.com/kbrdn1/gwm-cli/issues/83) / [#84](https://github.com/kbrdn1/gwm-cli/issues/84) / [#87](https://github.com/kbrdn1/gwm-cli/issues/87) / [#32](https://github.com/kbrdn1/gwm-cli/issues/32) / [#33](https://github.com/kbrdn1/gwm-cli/issues/33) / [#34](https://github.com/kbrdn1/gwm-cli/issues/34)) — `gwm config`, `[hooks.*]`, `gwm new`, `gwm pr`, `[tui.keys]` remappable, palette `:`, presets `[theme]` par rôles et mode stashes en sidebar.
+- **Quick wins** (`v0.8.0-rc.4`, [#24](https://github.com/kbrdn1/gwm-cli/issues/24) / [#27](https://github.com/kbrdn1/gwm-cli/issues/27)) — `gwm sync [<pattern>] [--merge]` et support `cargo-binstall`.
+- **Config globale et polish du chrome** (`v0.8.0-rc.5`, [#190](https://github.com/kbrdn1/gwm-cli/issues/190) / [#188](https://github.com/kbrdn1/gwm-cli/issues/188) / [#185](https://github.com/kbrdn1/gwm-cli/issues/185) / [#187](https://github.com/kbrdn1/gwm-cli/issues/187) / [#180](https://github.com/kbrdn1/gwm-cli/issues/180) / [#179](https://github.com/kbrdn1/gwm-cli/issues/179) / [#181](https://github.com/kbrdn1/gwm-cli/issues/181) / [#175](https://github.com/kbrdn1/gwm-cli/issues/175)) — config utilisateur `~/.config/gwm/config.toml`, sidebar responsive, `claude-dark`, polish des modales, statusline sur une ligne, colorisation working-tree, auto-détection de PR éphémère et placeholders `{repo_path}` / `{repo_parent}`.
 
-Le bump `git2` 0.20 → 0.21 est différé — c'est une migration cassante de l'API d'accesseurs suivie dans [#169](https://github.com/kbrdn1/gwm-cli/issues/169). Suivez la surface complète pas-encore-livrée dans [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) sous `[Unreleased]` et les fichiers par-RC.
+Les notes complètes de la v0.8.0 vivent dans [`changelogs/0.8.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.8.0.md).
+
+## mergé sur dev depuis v0.9.0
+
+`[Unreleased]` dans le [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) racine reflète ce qui s'est accumulé sur `dev` depuis la dernière release stable. Les petits deltas actuels incluent :
+
+- un `LoaderWidget` réutilisable pour les zones dédiées, consommé d'abord par la modale delete-worktree avec états en cours et en échec ;
+- un compteur du nombre de fichiers modifiés en bas à droite du pane `Working Tree` de la sidebar ;
+- des raccourcis Make / Zed locaux pour le workflow Rust du projet.
 
 ## la suite
 
-Les priorités post-v0.7.0 sont suivies dans le tracker d'issues. Choisissez selon vos centres d'intérêt, commentez l'issue si vous comptez y travailler (évite la duplication en parallèle), et ouvrez une PR ciblant `dev` :
+Aucun petit suivi TUI court terme n'est en file pour l'instant. Les prochains candidats sont des items plus larges, déclenchés par la demande utilisateur ou par un premier consommateur concret :
+
+- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — overlay lazygit embarqué via PTY.
+- [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — mode workspace multi-repos.
+- [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — presets de configuration.
+- [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — API JSON-RPC / gRPC et mode daemon.
+
+Pour démarrer un nouveau travail, partez du tracker d'issues :
 
 - [Issues ouvertes — `enhancement`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aenhancement)
 - [Issues ouvertes — `good first issue`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
 - [Issues ouvertes — `roadmap`](https://github.com/kbrdn1/gwm-cli/issues?q=is%3Aopen+label%3Aroadmap)
-
-`[Unreleased]` dans le [`CHANGELOG.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CHANGELOG.md) racine reflète ce qui s'est accumulé sur `dev` depuis la dernière release — vérifiez-y la surface mergée-mais-pas-encore-livrée.
 
 ## comment contribuer
 


### PR DESCRIPTION
## Description

Sync the docs-site roadmap mirrors with the current root `ROADMAP.md` surface: v0.9.0 is now the stable line, v0.8.0 is historical context, and the current small `[Unreleased]` dev delta is called out.

Closes #228

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Reframes `docs/7.roadmap.md` around the v0.9.0 stable TUI train.
- Mirrors the same structure and translated content in `docs/fr/7.roadmap.md`.
- Adds a root `CHANGELOG.md` `[Unreleased]` entry for the docs roadmap sync.

## Tests

- [ ] `cargo test` passes locally
- [x] `cargo fmt --check` passes (`make fmt-check`)
- [ ] `cargo clippy -- -D warnings` passes
- [ ] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Docs-only change; no production behaviour changed, so no new tests were added.

Additional validation:

- [x] `git diff --check`
- [x] stale roadmap wording search for v0.7/v0.8 RC framing

## Screenshots / TUI captures

Not applicable — docs-only.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

README / config-schema checklist items are not applicable.

## Linked issues / docs

- Issue: #228
- Source of truth: `ROADMAP.md`

## Notes for reviewers

Focus on EN/FR parity and whether the docs-site roadmap now matches the root roadmap's v0.9.0 stable framing.