### PR TITLE
✨ feat(tui): run create flow through async loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Delete-worktree confirmation no longer blocks the TUI render loop while the removal runs; the async spine drives the deletion and quit waits for it like other mutating tasks.
+- Create-worktree submission no longer blocks the TUI render loop while `worktree::add` and bootstrap run; the Create modal now shows a dedicated loader/failure row and the global statusline spinner stays active until completion.
 - TUI quit now waits for in-flight mutating spine tasks (`sync` / `bootstrap` / delete-worktree) to finish instead of abandoning them mid-operation.
 
 ## Past releases

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,6 @@
 use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
-use super::state::async_task::{TaskKind, TaskMsg, TaskRunner};
+use super::state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 use super::state::command_logs::CommandLogs;
 use super::state::config_panel::ConfigPanel;
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
@@ -161,6 +161,8 @@ pub struct App {
   /// Create-worktree overlay state (extracted per #123). Holds field
   /// focus, type index, and the issue/slug input buffers.
   pub create_form: CreateForm,
+  /// Last asynchronous create failure shown inside the Create modal.
+  pub create_failure: Option<String>,
   /// Branch types displayed in the create-form picker. Resolved once at
   /// startup from [`Config::resolved_branch_types`] so the picker
   /// honours any `[[branch_types]]` override in `.gwm.toml` without
@@ -385,6 +387,7 @@ impl App {
       delete_branch_on_remove: false,
       open_menu_selected: LinkTarget::Issue,
       create_form: CreateForm::new(),
+      create_failure: None,
       branch_types,
       report: None,
       help_scroll: 0,
@@ -620,6 +623,37 @@ impl App {
     let mut refresh_applied = false;
     while let Ok(msg) = self.task_rx.try_recv() {
       match msg {
+        TaskMsg::CreateWorktree(generation, result) => {
+          if !self.tasks.complete(TaskKind::CreateWorktree, generation) {
+            // Late result — a newer run (or an invalidate) superseded it.
+            continue;
+          }
+          match result {
+            Ok(result) => {
+              self.create_failure = None;
+              self.report = Some(result.report);
+              self.view = View::Report;
+              let refresh_result = self.refresh();
+              self.status = match refresh_result {
+                Ok(()) => format!("created {} @ {}", result.branch, result.created.display()),
+                Err(e) => format!(
+                  "created {} @ {}; refresh failed: {}",
+                  result.branch,
+                  result.created.display(),
+                  e
+                ),
+              };
+            }
+            Err(e) => {
+              self.create_failure = Some(e.clone());
+              self.view = View::Create;
+              self.status = format!("create failed: {}", e);
+            }
+          }
+          applied = true;
+          // Create owns the status line this tick.
+          refresh_applied = true;
+        }
         TaskMsg::RefreshWorktrees(generation, result) => {
           if !self.tasks.complete(TaskKind::RefreshWorktrees, generation) {
             // Late result — a newer run (or an invalidate) superseded it.
@@ -753,6 +787,11 @@ impl App {
   /// the statusbar spinner alongside [`Self::is_github_loading`].
   pub fn is_task_loading(&self) -> bool {
     self.tasks.is_any_loading()
+  }
+
+  /// `true` while the create-worktree worker is in flight (issue #276).
+  pub fn is_create_worktree_loading(&self) -> bool {
+    self.tasks.is_loading(TaskKind::CreateWorktree)
   }
 
   /// `true` while the delete-worktree worker is in flight (issue #257).
@@ -1390,6 +1429,7 @@ impl App {
   pub fn enter_create(&mut self) {
     self.view = View::Create;
     self.create_form.reset();
+    self.create_failure = None;
     // Open focused on Issue rather than the cycle-only Type field (#217 UX):
     // the first keypress then edits text instead of being a silent no-op on
     // Type. The type keeps its `reset()` default and stays reachable via
@@ -1431,6 +1471,9 @@ impl App {
   /// when the Type field is focused; on a text field they are literal input
   /// so the letters are never swallowed.
   pub fn handle_create_key(&mut self, key: KeyEvent) -> CreateKey {
+    if self.is_create_worktree_loading() {
+      return CreateKey::Handled;
+    }
     let on_type = self.create_form.field == Field::Type;
     match key.code {
       KeyCode::Esc => return CreateKey::Cancel,
@@ -1485,19 +1528,60 @@ impl App {
       return Ok(());
     }
 
-    let created = worktree::add(&self.repo, &dirname, &target, &branch, false)?;
-
-    let ctx = BootstrapCtx {
-      main_repo: &self.workdir,
-      worktree: &created,
-      config: &self.config,
+    if self.tasks.has_mutating_task_in_flight() {
+      if let Some(label) = self.tasks.mutating_loading_label() {
+        self.status = format!("finish {} before creating worktree", label.trim_end_matches('…'));
+      } else {
+        self.status = "finish current task before creating worktree".into();
+      }
+      return Ok(());
+    }
+    let Some(generation) = self.tasks.request(TaskKind::CreateWorktree) else {
+      return Ok(());
     };
-    let report = bootstrap::run(&ctx)?;
-    self.report = Some(report);
-    self.view = View::Report;
-    self.refresh()?;
-    self.status = format!("created {} @ {}", branch, created.display());
+    self.create_failure = None;
+    self.spinner.reset();
+    self.status = TaskKind::CreateWorktree.loading_label().into();
+    self.spawn_create_worktree(
+      generation,
+      dirname,
+      target,
+      branch,
+      self.workdir.clone(),
+      self.config.clone(),
+    );
     Ok(())
+  }
+
+  fn spawn_create_worktree(
+    &self,
+    generation: u64,
+    dirname: String,
+    target: PathBuf,
+    branch: String,
+    workdir: PathBuf,
+    config: Config,
+  ) {
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let result = (|| -> Result<CreateWorktreeResult> {
+        let repo = worktree::discover_repo(Some(&workdir))?;
+        let created = worktree::add(&repo, &dirname, &target, &branch, false)?;
+        let ctx = BootstrapCtx {
+          main_repo: &workdir,
+          worktree: &created,
+          config: &config,
+        };
+        let report = bootstrap::run(&ctx)?;
+        Ok(CreateWorktreeResult {
+          branch,
+          created,
+          report,
+        })
+      })()
+      .map_err(|e| e.to_string());
+      let _ = tx.send(TaskMsg::CreateWorktree(generation, result));
+    });
   }
 
   // ---- Delete flow ---------------------------------------------------------

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
-pub use state::async_task::{TaskKind, TaskMsg, TaskRunner};
+pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
 pub use state::config_panel::ConfigPanel;
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
@@ -330,7 +330,10 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         _ => {}
       },
       // Create-overlay keys live in a testable `App` method (issue #217);
-      // the loop only owns the two side effects (submit / close).
+      // the loop only owns the two side effects (submit / close). While the
+      // async create worker is in flight (#276), keep the modal locked so a
+      // second submit/cancel does not race the mutating operation.
+      View::Create if app.is_create_worktree_loading() => {}
       View::Create => match app.handle_create_key(key) {
         CreateKey::Submit => {
           if let Err(e) = app.submit_create() {

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -1,8 +1,8 @@
 //! Generic background-task spine for the TUI (issue #231).
 //!
 //! Generalises the off-thread pattern introduced for the GitHub fetch
-//! (#217) so any slow, one-shot operation — currently the worktree list
-//! refresh (`f` / `r`), with bootstrap / launcher-prep to follow — runs
+//! (#217) so any slow, one-shot operation — worktree list refresh, create,
+//! sync, bootstrap, delete, and GitHub fetches — runs
 //! on a worker thread and posts its result back to the event loop rather
 //! than blocking it. The event loop keeps rendering (the statusbar
 //! spinner animates, `q` / `Esc` stay responsive); a result whose run
@@ -10,8 +10,8 @@
 //!
 //! Unlike [`super::github_fetch`] this is **not** a result cache. The
 //! GitHub layer caches `(target, number)` lookups and dedupes them; a
-//! refresh / sync / bootstrap / delete-worktree is a one-shot "run it, give me a fresh
-//! result" with nothing worth caching by key. So the spine keeps only
+//! create / refresh / sync / bootstrap / delete-worktree is a one-shot "run
+//! it, give me a fresh result" with nothing worth caching by key. So the spine keeps only
 //! two things from that design — *coalescing* and the *late-result
 //! drop* — and drops the per-key cache:
 //!
@@ -39,12 +39,17 @@ use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
 use crate::worktree::WorktreeInfo;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 /// Identity of a background task — the coalescing key and the source of
-/// the loader label. One variant per migrated op; bootstrap / sync /
-/// launcher-prep join here as their call sites move off-thread.
+/// the loader label. One variant per migrated op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TaskKind {
+  /// Off-thread create flow from the Create modal (issue #276):
+  /// `worktree::add` plus bootstrap can touch disk, refs, copies and hooks, so
+  /// the modal must stay renderable while it runs. A single global op like
+  /// [`Self::Bootstrap`] — one create in flight at a time.
+  CreateWorktree,
   /// Off-thread worktree list refresh (the `f` / `r` key path). The
   /// synchronous `App::refresh` stays for internal post-mutation callers
   /// (create / delete / report-close) that need the list fresh before the
@@ -86,6 +91,7 @@ impl TaskKind {
   /// reads consistently.
   pub fn loading_label(self) -> &'static str {
     match self {
+      TaskKind::CreateWorktree => "creating worktree…",
       TaskKind::RefreshWorktrees => "refreshing worktrees…",
       TaskKind::GithubIssue(_) | TaskKind::GithubPr(_) => "fetching GitHub status…",
       TaskKind::Sync => "syncing…",
@@ -106,8 +112,18 @@ impl TaskKind {
   /// `true` for workers that can leave repository / worktree state
   /// partially changed if the process exits before their result is drained.
   pub fn is_mutating(self) -> bool {
-    matches!(self, TaskKind::Sync | TaskKind::Bootstrap | TaskKind::DeleteWorktree)
+    matches!(
+      self,
+      TaskKind::CreateWorktree | TaskKind::Sync | TaskKind::Bootstrap | TaskKind::DeleteWorktree
+    )
   }
+}
+
+/// Successful result of a Create-modal worker (issue #276).
+pub struct CreateWorktreeResult {
+  pub branch: String,
+  pub created: PathBuf,
+  pub report: BootstrapReport,
 }
 
 /// Result of an off-thread task, posted from a worker thread back to the
@@ -116,6 +132,10 @@ impl TaskKind {
 /// plus the `generation` the worker was spawned with, so
 /// [`TaskRunner::complete`] can drop a superseded late result.
 pub enum TaskMsg {
+  /// A create-worktree result (issue #276): the worker's `generation` and the
+  /// created worktree + bootstrap report, or a stringified failure from naming,
+  /// libgit2 worktree creation, or bootstrap.
+  CreateWorktree(u64, std::result::Result<CreateWorktreeResult, String>),
   /// A worktree list refresh result: the freshly-listed worktrees, or a
   /// stringified error from the off-thread `discover_repo` + `list`.
   RefreshWorktrees(u64, std::result::Result<Vec<WorktreeInfo>, String>),
@@ -239,7 +259,9 @@ impl TaskRunner {
 
   /// Loader label for a mutating in-flight task, if any.
   pub fn mutating_loading_label(&self) -> Option<&'static str> {
-    if self.running.contains(&TaskKind::Sync) {
+    if self.running.contains(&TaskKind::CreateWorktree) {
+      Some(TaskKind::CreateWorktree.loading_label())
+    } else if self.running.contains(&TaskKind::Sync) {
       Some(TaskKind::Sync.loading_label())
     } else if self.running.contains(&TaskKind::Bootstrap) {
       Some(TaskKind::Bootstrap.loading_label())

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -5,7 +5,8 @@
 //! index + issue number buffer + slug buffer) and exposes the rotation /
 //! push-pop / reset primitives. The `App` orchestrator owns the side
 //! effects in `submit_create` (it composes `BranchSpec` from the form's
-//! values, then drives `worktree::add` + `bootstrap::run`).
+//! values, then dispatches `worktree::add` + `bootstrap::run` on the async
+//! task spine).
 
 /// Max digits accepted in the issue-number field. Seven digits covers any
 /// realistic GitHub issue/PR number (up to 9,999,999) while keeping the

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2077,7 +2077,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     rows.push(entry(Action::ToggleDeleteBranch, "toggle 'delete branch on remove'"));
     rows.push(fixed("enter", "show path in status bar"));
     rows.push(HelpRow::Blank);
-    rows.push(HelpRow::Section("Issue / PR (#67)".to_string()));
+    rows.push(HelpRow::Section("Issue / PR".to_string()));
     rows.push(HelpRow::Blank);
     rows.push(entry(Action::OpenMenu, "open menu — i=issue · p=pull request"));
     rows.push(entry(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2431,17 +2431,10 @@ fn draw_create(f: &mut Frame, app: &App) {
     .map(|t| (t.name.as_str(), t.description.as_str()))
     .unwrap_or(("", "(no branch types configured)"));
 
-  // The modal is a single Paragraph of per-line-aligned rows (the title /
-  // buttons / hint centre themselves, the fields stay left) — no manual
-  // Layout split, the rounded frame's `Padding` owns the breathing room
-  // (issue #217). Height is the fixed row count plus the border + padding
-  // rows, so the box hugs its content; the width is capped so the input
-  // surfaces don't span a wide terminal.
-  const ROWS: u16 = 14; // title(2) + type + gap + 2 preview + gap + issue + gap + desc + gap + buttons + gap + hint
-  let height = ROWS + 2 /* border */ + 2 /* vertical padding */;
-  let area = centered_box(70, 72, height, f.area());
   let block = overlay_block(clean);
-  let inner_w = block.inner(area).width as usize;
+  let term = f.area();
+  let outer = centered_box(70, 72, 1, term);
+  let inner_w = block.inner(outer).width as usize;
 
   // Width of the background-filled value field: the inner width minus the
   // `  label  ` gutter (2 indent + label column + 2 gap).
@@ -2500,12 +2493,52 @@ fn draw_create(f: &mut Frame, app: &App) {
     muted,
     surface,
   ));
-  lines.push(Line::from(String::new()));
-  lines.push(create_buttons_line(accent, muted).centered());
-  push_modal_hint(&mut lines, HintContext::Create, &app.keymap, &app.theme);
+
+  let height = lines.len() as u16 + 4 + 2 /* border */ + 2 /* vertical padding */;
+  let area = centered_box(70, 72, height, term);
+  let inner = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([
+      Constraint::Min(1),    // title + form fields
+      Constraint::Length(1), // loader / failure
+      Constraint::Length(1), // buttons
+      Constraint::Length(1), // hint gap
+      Constraint::Length(1), // hint
+    ])
+    .split(block.inner(area));
 
   f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(block), area);
+  f.render_widget(block, area);
+  f.render_widget(Paragraph::new(lines), inner[0]);
+
+  if app.is_create_worktree_loading() {
+    f.render_widget(
+      LoaderWidget::running(
+        app.spinner.glyph(DOT_FRAMES),
+        TaskKind::CreateWorktree.loading_label(),
+        None,
+        &app.theme,
+      )
+      .alignment(Alignment::Center),
+      inner[1],
+    );
+  } else if let Some(error) = app.create_failure.as_deref() {
+    f.render_widget(
+      LoaderWidget::failed("create failed", Some(error), &app.theme).alignment(Alignment::Center),
+      inner[1],
+    );
+  }
+
+  if !app.is_create_worktree_loading() {
+    f.render_widget(
+      Paragraph::new(create_buttons_line(accent, muted)).alignment(Alignment::Center),
+      inner[2],
+    );
+    f.render_widget(
+      Paragraph::new(modal_hint_for_context(HintContext::Create, &app.keymap, &app.theme)),
+      inner[4],
+    );
+  }
 }
 
 /// The create overlay's ` Create ` / ` Cancel ` button row (issue #217).

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3692,6 +3692,145 @@ run  = "echo would-have-run"
   let _ = BRANCH_TYPES; // keep the import live; the indirect lookup above relies on the default list.
 }
 
+// ---- Issue #276: create worktree on the async-task spine ------------------
+
+fn fill_create_form(app: &mut App, issue: &str, desc: &str) {
+  let feat_idx = app
+    .branch_types
+    .iter()
+    .position(|t| t.name == "feat")
+    .expect("`feat` is in branch types");
+  app.create_form.type_index = feat_idx;
+  app.create_form.issue = issue.into();
+  app.create_form.desc = desc.into();
+}
+
+#[test]
+fn submit_create_starts_async_create_and_keeps_create_modal_open() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let base_dir = tempfile::TempDir::new().unwrap();
+  let body = format!(
+    r#"[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+"#,
+    base = toml_basic_string(base_dir.path()),
+  );
+  let (_dir, mut app) = app_with_config(&body);
+  app.view = View::Create;
+  fill_create_form(&mut app, "276", "async-create");
+
+  app
+    .submit_create()
+    .expect("submit_create must only enqueue async create");
+
+  assert_eq!(app.view, View::Create, "the modal stays open while create runs");
+  assert!(
+    app.tasks.is_loading(TaskKind::CreateWorktree),
+    "create must claim an async loading slot"
+  );
+  assert_eq!(app.status, TaskKind::CreateWorktree.loading_label());
+
+  for _ in 0..50 {
+    if app.drain_task_results() {
+      break;
+    }
+    std::thread::sleep(Duration::from_millis(10));
+  }
+  assert!(
+    !app.tasks.is_loading(TaskKind::CreateWorktree),
+    "background create should drain before temp dirs are dropped"
+  );
+}
+
+#[test]
+fn drain_applies_async_create_result_and_flips_to_report_view() {
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{CreateWorktreeResult, TaskKind, TaskMsg};
+
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::CreateWorktree).unwrap();
+  app.view = View::Create;
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::CreateWorktree(
+      generation,
+      Ok(CreateWorktreeResult {
+        branch: "feat/#276-async-create".into(),
+        created: PathBuf::from("/tmp/gwm-created"),
+        report: BootstrapReport {
+          steps: vec![StepResult::ok("post_create hook")],
+        },
+      }),
+    ))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "a live create result must be applied");
+  assert_eq!(app.view, View::Report);
+  assert!(app.report.is_some(), "create report is shown in the Report view");
+  assert!(
+    app.status.contains("created feat/#276-async-create @ /tmp/gwm-created"),
+    "status reports the created branch and path: {:?}",
+    app.status
+  );
+  assert!(!app.tasks.is_loading(TaskKind::CreateWorktree));
+}
+
+#[test]
+fn drain_create_failure_stays_in_create_and_reports_status() {
+  use gwm::tui::{TaskKind, TaskMsg};
+
+  let (_dir, mut app) = make_app();
+  let generation = app.tasks.request(TaskKind::CreateWorktree).unwrap();
+  app.view = View::Create;
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::CreateWorktree(generation, Err("branch already exists".into())))
+    .unwrap();
+  let applied = app.drain_task_results();
+
+  assert!(applied, "a create failure still clears the live slot");
+  assert_eq!(app.view, View::Create);
+  assert_eq!(app.status, "create failed: branch already exists");
+  assert!(!app.tasks.is_loading(TaskKind::CreateWorktree));
+}
+
+#[test]
+fn drain_drops_a_superseded_create_result() {
+  use gwm::bootstrap::{BootstrapReport, StepResult};
+  use gwm::tui::{CreateWorktreeResult, TaskKind, TaskMsg};
+
+  let (_dir, mut app) = make_app();
+  let stale = app.tasks.request(TaskKind::CreateWorktree).unwrap();
+  app.tasks.invalidate(TaskKind::CreateWorktree);
+  app.view = View::Create;
+  app.status = "untouched".into();
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::CreateWorktree(
+      stale,
+      Ok(CreateWorktreeResult {
+        branch: "feat/#276-stale".into(),
+        created: PathBuf::from("/tmp/stale"),
+        report: BootstrapReport {
+          steps: vec![StepResult::ok("stale")],
+        },
+      }),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  assert_eq!(app.view, View::Create);
+  assert_eq!(app.status, "untouched");
+  assert!(app.report.is_none());
+}
+
 #[test]
 fn tui_bootstrap_selected_aborts_on_untrusted_config() {
   // Counterpart of the submit_create test — the `b` keybinding
@@ -4399,6 +4538,19 @@ fn quit_waits_while_a_sync_task_is_in_flight() {
   app.tasks.request(TaskKind::Sync).unwrap();
 
   assert!(!app.can_quit_now());
+}
+
+#[test]
+fn quit_waits_while_a_create_worktree_task_is_in_flight() {
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  app.should_quit = true;
+  app.tasks.request(TaskKind::CreateWorktree).unwrap();
+
+  assert!(!app.can_quit_now());
+  app.defer_quit_for_mutating_task();
+  assert_eq!(app.status, "finishing creating worktree before quit…");
 }
 
 #[test]

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -336,6 +336,18 @@ fn help_rows_structures_title_sections_and_entries() {
       .any(|r| matches!(r, HelpRow::Section(s) if s == "Delete Worktree")),
     "expected a `Delete Worktree` section header"
   );
+  assert!(
+    rows
+      .iter()
+      .any(|r| matches!(r, HelpRow::Section(s) if s == "Issue / PR")),
+    "expected a clean `Issue / PR` section header"
+  );
+  assert!(
+    !rows
+      .iter()
+      .any(|r| matches!(r, HelpRow::Section(s) if s.contains("(#67)"))),
+    "Which Key section headers must not expose internal issue references"
+  );
   for pair in rows.windows(2) {
     if matches!(pair[0], HelpRow::Section(_)) {
       assert!(

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -152,6 +152,31 @@ fn create_modal_renders_title_fields_and_buttons() {
 }
 
 #[test]
+fn create_modal_renders_loader_while_create_is_in_flight() {
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  app.tasks.request(TaskKind::CreateWorktree).unwrap();
+
+  let buf = render(&mut app);
+
+  assert_present(&buf, "New Worktree", "create title");
+  assert_present(&buf, "creating worktree", "create loader label");
+}
+
+#[test]
+fn create_modal_renders_create_failure_after_async_create_fails() {
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  app.create_failure = Some("branch already exists".into());
+
+  let buf = render(&mut app);
+
+  assert_present(&buf, "create failed", "create failure label");
+  assert_present(&buf, "branch already exists", "create failure detail");
+  assert_present(&buf, "Cancel", "cancel button after failure");
+}
+
+#[test]
 fn confirm_modal_renders_title_target_and_buttons() {
   let (_dir, mut app) = make_app();
   // Inject a deletable worktree and select it so the modal renders its

--- a/tests/tui_state_async_task_tests.rs
+++ b/tests/tui_state_async_task_tests.rs
@@ -123,6 +123,7 @@ fn is_github_is_true_only_for_github_kinds() {
 
 #[test]
 fn is_mutating_is_true_only_for_tasks_that_change_worktrees() {
+  assert!(TaskKind::CreateWorktree.is_mutating());
   assert!(TaskKind::Sync.is_mutating());
   assert!(TaskKind::Bootstrap.is_mutating());
   assert!(!TaskKind::RefreshWorktrees.is_mutating());
@@ -227,6 +228,31 @@ fn a_stale_github_worker_loses_to_a_newer_generation_after_invalidate() {
 fn sync_task_reports_the_syncing_label() {
   assert_eq!(TaskKind::Sync.loading_label(), "syncing…");
   assert!(!TaskKind::Sync.is_github(), "Sync is not a GitHub kind");
+}
+
+#[test]
+fn create_worktree_task_reports_the_creating_label_and_is_mutating() {
+  assert_eq!(TaskKind::CreateWorktree.loading_label(), "creating worktree…");
+  assert!(
+    !TaskKind::CreateWorktree.is_github(),
+    "CreateWorktree is not a GitHub kind"
+  );
+  assert!(
+    TaskKind::CreateWorktree.is_mutating(),
+    "CreateWorktree mutates disk/git state"
+  );
+}
+
+#[test]
+fn second_create_worktree_request_while_inflight_is_coalesced() {
+  let mut runner = TaskRunner::new();
+  assert_eq!(runner.request(TaskKind::CreateWorktree), Some(1));
+  assert_eq!(
+    runner.request(TaskKind::CreateWorktree),
+    None,
+    "a second create request while one is inflight must coalesce"
+  );
+  assert!(runner.is_loading(TaskKind::CreateWorktree));
 }
 
 #[test]

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -4,7 +4,8 @@
 //! / `type_index` / `issue` / `desc`, exposes focus rotation, type
 //! cycling, character push/pop. The `App` orchestrator owns the
 //! side-effecting `submit_create` which wires the form's resolved values
-//! into `BranchSpec` + `worktree::add` + `bootstrap::run`.
+//! into `BranchSpec` and dispatches `worktree::add` + `bootstrap::run` on
+//! the async task spine.
 
 use gwm::tui::state::create_form::{CreateForm, Field, MAX_DESC_LEN, MAX_ISSUE_LEN};
 


### PR DESCRIPTION
## Description

Run the TUI Create modal worktree creation path on the shared async task spine instead of blocking the event loop in `submit_create()`.

Closes #276

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Added `TaskKind::CreateWorktree` and `TaskMsg::CreateWorktree` with generation/coalescing semantics on the shared async spine.
- Moved the Create modal `worktree::add` + `bootstrap::run` work onto a background worker and drain result.
- Rendered Create modal running/failure states with `LoaderWidget`; the global statusline spinner is driven through the existing `is_task_loading()` path.
- Locked Create modal input while create is in flight and made quit wait for the mutating create worker.
- Updated `[Unreleased]` changelog and stale create-form comments.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Additional local checks run:

```bash
cargo test --test tui_state_async_task_tests
cargo test --test tui_modal_render_tests create
cargo test --test tui_app_tests create
cargo clippy --all-targets -- -D warnings
git diff --check
```

## Screenshots / TUI captures

Not captured; render coverage is pinned with `ratatui::backend::TestBackend` modal tests.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [x] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #276
- Related PR: #

## Notes for reviewers

The create worker uses owned `Send` data only and re-opens the repo from `workdir`, matching the existing refresh/bootstrap/delete async-task pattern.
