### PR TITLE
✨ feat(tui): herdr-style polish — badge-free hints, scrollable modals, editable Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Settings free-text fields (worktree base/patterns, open shell/editor commands) persist as TOML strings, so a value like `123` or `true` is no longer coerced to a number/bool; config writes also validate before touching disk, so a rejected edit can never overwrite a good config file.
+- Scrollable modal bodies (Keybindings, Command Logs, Settings) compute the horizontal-pan bound after reserving the scrollbar column, so the final cell of a long line stays reachable.
 - Delete-worktree confirmation no longer blocks the TUI render loop while the removal runs; the async spine drives the deletion and quit waits for it like other mutating tasks.
 - Create-worktree submission no longer blocks the TUI render loop while `worktree::add` and bootstrap run; the Create modal now shows a dedicated loader/failure row and the global statusline spinner stays active until completion.
 - TUI quit now waits for in-flight mutating spine tasks (`sync` / `bootstrap` / delete-worktree) to finish instead of abandoning them mid-operation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The Settings panel (`4`, renamed from Configuration) is now editable: category tabs (Theme / TUI / All), a per-project ↔ global edit-layer selector (`L`), real toggles/choices (theme preset, sidebar position, open mode) and a numeric input (confirm countdown). Edits persist into the chosen layer's TOML and apply live; a global edit shadowed by a `.gwm.toml` override is surfaced rather than silently dropped.
+- Scrollable modal bodies (Keybindings, Settings) now render a herdr-style scrollbar.
 - Docs roadmap pages now mirror the v0.9.0 stable surface, the v0.8.0 historical cycle, and the current `[Unreleased]` dev delta in both English and French.
 - TUI now has a reusable dedicated-area `LoaderWidget`; the delete-worktree modal uses it as the first real consumer, showing both in-flight and failed delete states.
 - The sidebar `Working Tree` pane now renders the changed-file count in its bottom-right footer.
 - Project tooling now ships a Flippad-style colored `Makefile` plus Zed tasks for the local Rust workflow (`build`, `test`, `clippy`, `doctor`, `audit`, worktree bootstrap, and related shortcuts).
+
+### Changed
+
+- Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings overlay now scrolls its body only, keeping the title and footer hints pinned.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The Settings panel (`4`, renamed from Configuration) is now editable: category tabs (Theme / TUI / All), a per-project ↔ global edit-layer selector (`L`), real toggles/choices (theme preset, sidebar position, open mode) and a numeric input (confirm countdown). Edits persist into the chosen layer's TOML and apply live; a global edit shadowed by a `.gwm.toml` override is surfaced rather than silently dropped.
+- The Settings panel (`4`, renamed from Configuration) is now editable: category tabs (Theme / Worktree / TUI / All) with the edit layer shown as a subtitle, a per-project ↔ global edit-layer selector (`L`), real toggles/choices (theme preset, sidebar position, open mode), numeric input (confirm countdown) and text inputs (worktree base + patterns, open shell/editor commands). Edits persist into the chosen layer's TOML and apply live; a global edit shadowed by a `.gwm.toml` override is surfaced rather than silently dropped. The read-only resolved config lives under the `All` tab.
 - Scrollable modal bodies (Keybindings, Settings) now render a herdr-style scrollbar.
 - Docs roadmap pages now mirror the v0.9.0 stable surface, the v0.8.0 historical cycle, and the current `[Unreleased]` dev delta in both English and French.
 - TUI now has a reusable dedicated-area `LoaderWidget`; the delete-worktree modal uses it as the first real consumer, showing both in-flight and failed delete states.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings and Command Logs overlays now scroll their body only, keeping the title and footer hints pinned, with a herdr-style scrollbar. Command Logs separates entries with a full-width dashed rule and uses the flat footer hint.
+- Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings and Command Logs overlays now scroll their body only, keeping the title and footer hints pinned, with a herdr-style scrollbar. Command Logs separates entries with a full-width dashed rule, uses the flat footer hint, and copies the whole transcript to the clipboard with `y`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings overlay now scrolls its body only, keeping the title and footer hints pinned.
+- Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings and Command Logs overlays now scroll their body only, keeping the title and footer hints pinned, with a herdr-style scrollbar. Command Logs separates entries with a full-width dashed rule and uses the flat footer hint.
 
 ### Fixed
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -49,7 +49,27 @@ pub fn set(key: &str, raw_value: Option<&str>) -> Result<()> {
 ///
 /// Creates the parent directory when missing so the user-global file can be
 /// written on its first use (the `~/.config/gwm/` dir may not exist yet).
+///
+/// `raw_value` is coerced with the same scalar heuristic as `gwm config set`
+/// (`123` → int, `true` → bool, else string). Use [`set_string_at`] for
+/// free-text settings that must stay strings regardless of their content.
 pub fn set_value_at(path: &Path, key: &str, raw_value: &str) -> Result<()> {
+  set_item_at(path, key, parse_scalar(raw_value))
+}
+
+/// String-forced variant of [`set_value_at`] for free-text Settings fields
+/// (issue #279 review P2): always writes the value as a TOML string, so a
+/// shell/editor command or worktree value like `123` / `true` is preserved
+/// as text rather than coerced to a number/bool by `parse_scalar` (which
+/// would then fail `Config` validation and, pre-fix, leave the file invalid).
+pub fn set_string_at(path: &Path, key: &str, raw_value: &str) -> Result<()> {
+  set_item_at(path, key, value(raw_value))
+}
+
+/// Shared write path: ensure the parent dir exists, set `key` to `item` in
+/// the surgically-edited document, and validate-before-write so an invalid
+/// edit can never overwrite a good file.
+fn set_item_at(path: &Path, key: &str, item: Item) -> Result<()> {
   if let Some(parent) = path.parent() {
     if !parent.as_os_str().is_empty() {
       std::fs::create_dir_all(parent)?;
@@ -57,7 +77,6 @@ pub fn set_value_at(path: &Path, key: &str, raw_value: &str) -> Result<()> {
   }
   let mut doc = load_document(path)?;
   let segments = parse_key(key)?;
-  let item = parse_scalar(raw_value);
   set_value(doc.as_table_mut(), &segments, item)?;
   write_and_validate(path, &doc)
 }
@@ -157,8 +176,13 @@ fn load_document(path: &Path) -> Result<DocumentMut> {
 }
 
 fn write_and_validate(path: &Path, doc: &DocumentMut) -> Result<()> {
-  std::fs::write(path, doc.to_string())?;
-  validate_file(path)
+  // Validate the rendered document BEFORE touching disk (issue #279 review
+  // P2): a write that would fail `Config` validation must not overwrite the
+  // existing good file and strand the next launch on an invalid config.
+  let rendered = doc.to_string();
+  validate_rendered(path, &rendered)?;
+  std::fs::write(path, rendered)?;
+  Ok(())
 }
 
 fn validate_file(path: &Path) -> Result<()> {
@@ -166,7 +190,15 @@ fn validate_file(path: &Path) -> Result<()> {
     return Ok(());
   }
   let raw = std::fs::read_to_string(path)?;
-  let cfg = toml::from_str::<Config>(&raw).map_err(|e| config_de_error(path, &raw, e))?;
+  validate_rendered(path, &raw)
+}
+
+/// Validate `raw` as a complete `Config` (deserialization + the semantic
+/// checks `gwm config validate` runs). `path` is only used for error
+/// coordinates. Shared by [`validate_file`] (on-disk) and the
+/// validate-before-write path in [`write_and_validate`].
+fn validate_rendered(path: &Path, raw: &str) -> Result<()> {
+  let cfg = toml::from_str::<Config>(raw).map_err(|e| config_de_error(path, raw, e))?;
   cfg.validate_branch_types()?;
   cfg.validate_bootstrap_paths()?;
   cfg.validate_bootstrap_guards()?;

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -39,6 +39,29 @@ pub fn set(key: &str, raw_value: Option<&str>) -> Result<()> {
   Ok(())
 }
 
+/// Layer-aware, silent variant of [`set`] for the in-TUI Settings panel
+/// (issue #279): set `key = value` in the TOML file at an EXPLICIT `path`
+/// (the repo `.gwm.toml` OR the user-global `config.toml`) rather than the
+/// discovered repo root, and return without printing so the TUI owns the
+/// feedback. Reuses the exact key-path parser, scalar coercion, surgical
+/// `toml_edit` write and post-write `Config` validation as `gwm config set`,
+/// so a write that round-trips through `gwm config` round-trips here too.
+///
+/// Creates the parent directory when missing so the user-global file can be
+/// written on its first use (the `~/.config/gwm/` dir may not exist yet).
+pub fn set_value_at(path: &Path, key: &str, raw_value: &str) -> Result<()> {
+  if let Some(parent) = path.parent() {
+    if !parent.as_os_str().is_empty() {
+      std::fs::create_dir_all(parent)?;
+    }
+  }
+  let mut doc = load_document(path)?;
+  let segments = parse_key(key)?;
+  let item = parse_scalar(raw_value);
+  set_value(doc.as_table_mut(), &segments, item)?;
+  write_and_validate(path, &doc)
+}
+
 fn split_set_args(key: &str, raw_value: Option<&str>) -> Result<(String, String)> {
   match (key.split_once('='), raw_value) {
     (Some((key, value)), None) if !key.is_empty() => Ok((key.to_string(), value.to_string())),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1307,6 +1307,32 @@ impl App {
     self.status = status;
   }
 
+  /// Render the Command Logs transcript as plain text for the clipboard
+  /// (issue #279, `y`): newest-first, mirroring the overlay's layout
+  /// (`$ argv`, the outcome line, then the full captured output — not the
+  /// tail-capped view), entries separated by a blank line. Pure + owned so
+  /// the format is unit-testable without a clipboard. Empty when no commands
+  /// have run.
+  pub fn command_logs_transcript(&self) -> String {
+    use crate::command_log::CommandStatus;
+    let mut out = String::new();
+    for entry in self.command_logs.entries.iter().rev() {
+      out.push_str(&format!("$ {}\n", entry.command));
+      let detail = match &entry.status {
+        CommandStatus::Exited(Some(0)) => format!("→ exit 0 ({} ms)", entry.duration.as_millis()),
+        CommandStatus::Exited(Some(code)) => format!("→ exit {} ({} ms)", code, entry.duration.as_millis()),
+        CommandStatus::Exited(None) => format!("→ terminated ({} ms)", entry.duration.as_millis()),
+        CommandStatus::Spawn => "✗ failed to spawn".to_string(),
+      };
+      out.push_str(&format!("  {}\n", detail));
+      for line in entry.output.lines() {
+        out.push_str(&format!("    {}\n", line));
+      }
+      out.push('\n');
+    }
+    out.trim_end().to_string()
+  }
+
   /// Scroll the help overlay down one row, clamped to the renderer-published
   /// `help_max_scroll` so it never scrolls past the last line.
   pub fn help_scroll_down(&mut self) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1222,7 +1222,7 @@ impl App {
           self.apply_setting(field, &next);
         }
       }
-      FieldKind::Uint => {
+      FieldKind::Uint | FieldKind::Text => {
         let current = field.current(&self.config);
         self.config_panel.begin_edit(&current);
       }
@@ -1238,6 +1238,13 @@ impl App {
       return;
     };
     if let Some(value) = self.config_panel.take_edit() {
+      // A cleared numeric input is a valid zero; a cleared text input is a
+      // legitimate empty / unset value.
+      let value = if field.kind() == FieldKind::Uint && value.is_empty() {
+        "0".to_string()
+      } else {
+        value
+      };
       self.apply_setting(field, &value);
     }
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1268,7 +1268,14 @@ impl App {
       },
     };
 
-    if let Err(e) = crate::config_cli::set_value_at(&path, field.key_path(), value) {
+    // Numeric fields write a TOML integer; choices and free text write a
+    // TOML string, so a value like `123` / `true` in a shell command or
+    // worktree pattern is preserved as text rather than coerced (review P2).
+    let write = match field.kind() {
+      FieldKind::Uint => crate::config_cli::set_value_at(&path, field.key_path(), value),
+      FieldKind::Choice | FieldKind::Text => crate::config_cli::set_string_at(&path, field.key_path(), value),
+    };
+    if let Err(e) = write {
       self.status = format!("settings: {}", e);
       return;
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,7 +2,7 @@ use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::palette::PaletteState;
 use super::state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 use super::state::command_logs::CommandLogs;
-use super::state::config_panel::ConfigPanel;
+use super::state::config_panel::{ConfigPanel, FieldKind, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -1207,6 +1207,97 @@ impl App {
     }
     self.config_panel.reset();
     self.view = View::Config;
+  }
+
+  /// Activate the selected Settings field (issue #279): cycle a choice field
+  /// to its next value (writing + applying live), or arm the numeric input
+  /// buffer for a `Uint` field. No-op on the read-only `All` tab.
+  pub fn activate_selected_setting(&mut self) {
+    let Some(field) = self.config_panel.selected_field() else {
+      return;
+    };
+    match field.kind() {
+      FieldKind::Choice => {
+        if let Some(next) = field.next_choice(&self.config) {
+          self.apply_setting(field, &next);
+        }
+      }
+      FieldKind::Uint => {
+        let current = field.current(&self.config);
+        self.config_panel.begin_edit(&current);
+      }
+    }
+  }
+
+  /// Commit the in-progress numeric edit (issue #279): write the buffered
+  /// value to the selected field and apply it live. Clearing the buffer
+  /// reads as `0` (see [`ConfigPanel::take_edit`]).
+  pub fn commit_settings_edit(&mut self) {
+    let Some(field) = self.config_panel.selected_field() else {
+      self.config_panel.cancel_edit();
+      return;
+    };
+    if let Some(value) = self.config_panel.take_edit() {
+      self.apply_setting(field, &value);
+    }
+  }
+
+  /// Persist `field = value` into the active layer's TOML file and apply the
+  /// change live (issue #279). The write targets the per-project `.gwm.toml`
+  /// or the user-global `config.toml` per the panel's layer selector; on
+  /// success the config is reloaded, the theme re-resolved, the sidebar
+  /// position re-seeded and the resolved-rows snapshot refreshed so the
+  /// `All` tab and the source attribution track the edit. Every fallible
+  /// step routes its error to the status line — no `unwrap` on this path.
+  pub fn apply_setting(&mut self, field: SettingField, value: &str) {
+    let path = match self.config_panel.layer {
+      SettingsLayer::Project => self.workdir.join(crate::config::CONFIG_FILE),
+      SettingsLayer::Global => match self.global_path.clone() {
+        Some(p) => p,
+        None => {
+          self.status = "settings: no global config path (set $XDG_CONFIG_HOME or $HOME)".into();
+          return;
+        }
+      },
+    };
+
+    if let Err(e) = crate::config_cli::set_value_at(&path, field.key_path(), value) {
+      self.status = format!("settings: {}", e);
+      return;
+    }
+
+    // Reload the merged config so every live read (open mode, confirm
+    // countdown) and the re-seeded state below reflect the edit.
+    match Config::load_layered(&self.workdir, self.global_path.as_deref()) {
+      Ok(cfg) => self.config = cfg,
+      Err(e) => {
+        self.status = format!("settings saved, but reload failed: {}", e);
+        return;
+      }
+    }
+    match self.config.theme.resolve() {
+      Ok(theme) => self.theme = theme,
+      Err(e) => self.status = format!("theme: {}", e),
+    }
+    self.sidebar.position = self.config.tui.sidebar_position;
+    if let Ok(rows) = crate::config::resolved_rows(&self.workdir, self.global_path.as_deref()) {
+      self.config_panel.rows = rows;
+    }
+
+    let mut status = format!(
+      "set {} = {} ({})",
+      field.key_path(),
+      value,
+      self.config_panel.layer.label()
+    );
+    // Surface a shadowed edit: writing global for a key the repo overrides
+    // leaves the effective value unchanged (repo wins).
+    if self.config_panel.layer == SettingsLayer::Global
+      && self.config_panel.field_source(field) == Some(crate::config::ConfigSource::Repo)
+    {
+      status.push_str(" — shadowed by .gwm.toml");
+    }
+    self.status = status;
   }
 
   /// Scroll the help overlay down one row, clamped to the renderer-published

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -315,17 +315,53 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
         _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
         _ => {}
       },
-      // Configuration panel (issue #232). Scrolls like the help / Command
-      // Logs overlays; closes on Esc / `q` or the bound `config_panel` key
-      // (default `4`) so the open key toggles it shut even when rebound.
+      // Settings panel (issue #232; editable in #279). While a numeric input
+      // is armed, keystrokes route to the edit buffer and only Enter / Esc
+      // escape — so `q` / `j` / Tab while typing a countdown never quit or
+      // navigate. Otherwise: Tab/BackTab switch category tabs, `L` flips the
+      // edit layer, Up/Down select fields (or scroll on the read-only `All`
+      // tab), Space/Enter cycle a choice or open the numeric input, and
+      // Esc / `q` / the bound `config_panel` key (default `4`) close.
+      View::Config if app.config_panel.editing.is_some() => match key.code {
+        KeyCode::Enter => app.commit_settings_edit(),
+        KeyCode::Esc => app.config_panel.cancel_edit(),
+        KeyCode::Backspace => app.config_panel.pop_edit_char(),
+        KeyCode::Char(c) => app.config_panel.push_edit_char(c),
+        _ => {}
+      },
       View::Config => match key.code {
         KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
-        KeyCode::Down | KeyCode::Char('j') => app.config_panel.scroll_down(),
-        KeyCode::Up | KeyCode::Char('k') => app.config_panel.scroll_up(),
-        KeyCode::Right | KeyCode::Char('l') => app.config_panel.scroll_right(),
-        KeyCode::Left | KeyCode::Char('h') => app.config_panel.scroll_left(),
-        KeyCode::Home | KeyCode::Char('g') => app.config_panel.scroll_to_top(),
-        KeyCode::End | KeyCode::Char('G') => app.config_panel.scroll_to_bottom(),
+        KeyCode::Tab => app.config_panel.next_tab(),
+        KeyCode::BackTab => app.config_panel.prev_tab(),
+        KeyCode::Char('L') => app.config_panel.toggle_layer(),
+        KeyCode::Char(' ') | KeyCode::Enter => app.activate_selected_setting(),
+        KeyCode::Down | KeyCode::Char('j') => {
+          if app.config_panel.tab == SettingsTab::All {
+            app.config_panel.scroll_down();
+          } else {
+            app.config_panel.select_next();
+          }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+          if app.config_panel.tab == SettingsTab::All {
+            app.config_panel.scroll_up();
+          } else {
+            app.config_panel.select_prev();
+          }
+        }
+        // Horizontal pan + jump only matter on the long read-only `All` tab.
+        KeyCode::Right | KeyCode::Char('l') if app.config_panel.tab == SettingsTab::All => {
+          app.config_panel.scroll_right()
+        }
+        KeyCode::Left | KeyCode::Char('h') if app.config_panel.tab == SettingsTab::All => {
+          app.config_panel.scroll_left()
+        }
+        KeyCode::Home | KeyCode::Char('g') if app.config_panel.tab == SettingsTab::All => {
+          app.config_panel.scroll_to_top()
+        }
+        KeyCode::End | KeyCode::Char('G') if app.config_panel.tab == SettingsTab::All => {
+          app.config_panel.scroll_to_bottom()
+        }
         _ if app.key_matches_action(key, Action::ConfigPanel) => app.view = View::List,
         _ => {}
       },

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
-pub use state::config_panel::ConfigPanel;
+pub use state::config_panel::{ConfigPanel, FieldKind, SettingField, SettingsLayer, SettingsTab};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -306,6 +306,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, mut app: App) 
       // so the open key toggles it shut even when rebound.
       View::CommandLogs => match key.code {
         KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
+        // `y` copies the whole transcript to the clipboard (issue #279).
+        KeyCode::Char('y') => copy_command_logs_to_clipboard(&mut app),
         KeyCode::Down | KeyCode::Char('j') => app.command_logs.scroll_down(),
         KeyCode::Up | KeyCode::Char('k') => app.command_logs.scroll_up(),
         KeyCode::Right | KeyCode::Char('l') => app.command_logs.scroll_right(),
@@ -743,12 +745,34 @@ fn run_subshell(
 /// its stdin. Failures and "no tool found" both surface in the status
 /// bar — no propagation, the TUI must never die on a clipboard miss.
 fn yank_selected_path_to_clipboard(app: &mut App) {
-  use std::io::Write;
   let Some(path) = app.yank_selected_path() else {
     app.status = "nothing selected".into();
     return;
   };
   let text = path.display().to_string();
+  copy_text_to_clipboard(app, &text, "yanked path");
+}
+
+/// Copy the Command Logs transcript to the clipboard (issue #279, `y`).
+/// Builds the plain-text transcript from owned state, then hands it to the
+/// shared clipboard helper. Empty transcript → a status note, no spawn.
+fn copy_command_logs_to_clipboard(app: &mut App) {
+  let text = app.command_logs_transcript();
+  if text.is_empty() {
+    app.status = "no commands to copy".into();
+    return;
+  }
+  copy_text_to_clipboard(app, &text, "copied command logs");
+}
+
+/// Feed `text` to the first available clipboard tool from
+/// [`clipboard_candidates`]. Walks the candidates in order, uses the first
+/// one whose binary is on `$PATH`, and feeds the text through its stdin.
+/// `success` is the status-bar label on a clean copy. Failures and "no tool
+/// found" both surface in the status bar — the TUI must never die on a
+/// clipboard miss.
+fn copy_text_to_clipboard(app: &mut App, text: &str, success: &str) {
+  use std::io::Write;
   for (cmd, args) in clipboard_candidates() {
     if which::which(cmd).is_err() {
       continue;
@@ -766,7 +790,7 @@ fn yank_selected_path_to_clipboard(app: &mut App) {
         }
         match c.wait() {
           Ok(s) if s.success() => {
-            app.status = format!("yanked path ({})", cmd);
+            app.status = format!("{} ({})", success, cmd);
             return;
           }
           Ok(s) => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,13 +59,13 @@ pub use ui::{
   build_sidebar_sections, centered_abs, chip_style, confirm_buttons_line, confirm_delete_branch_line,
   confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line,
   filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines, header_line,
-  help_body_section_color, help_label_style, help_lines, help_rows, help_section_style, issue_badge_color,
-  issue_pr_pane_title, issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_line,
-  modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
-  recent_commits_lines, recent_items_pane_title, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, COMMIT_HASH_DISPLAY_LEN,
-  RECENT_COMMITS_LIMIT,
+  help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
+  hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
+  link_prompt_modal_width, link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color,
+  pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title,
+  table_marker, tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -28,7 +28,10 @@ pub enum SettingsTab {
   /// Theme preset selection (editable).
   #[default]
   Theme,
-  /// TUI behaviour knobs: sidebar side, open mode, confirm countdown.
+  /// Worktree naming knobs: base dir + path / branch patterns.
+  Worktree,
+  /// TUI behaviour knobs: sidebar side, open mode + commands, confirm
+  /// countdown.
   Tui,
   /// The full resolved config, read-only with source attribution.
   All,
@@ -36,12 +39,18 @@ pub enum SettingsTab {
 
 impl SettingsTab {
   /// Tabs in display order — the navigation cycle.
-  pub const ALL: [SettingsTab; 3] = [SettingsTab::Theme, SettingsTab::Tui, SettingsTab::All];
+  pub const ALL: [SettingsTab; 4] = [
+    SettingsTab::Theme,
+    SettingsTab::Worktree,
+    SettingsTab::Tui,
+    SettingsTab::All,
+  ];
 
   /// Short tab label shown in the header strip.
   pub fn label(self) -> &'static str {
     match self {
       SettingsTab::Theme => "Theme",
+      SettingsTab::Worktree => "Worktree",
       SettingsTab::Tui => "TUI",
       SettingsTab::All => "All",
     }
@@ -52,10 +61,17 @@ impl SettingsTab {
   pub fn fields(self) -> &'static [SettingField] {
     match self {
       SettingsTab::Theme => &[SettingField::ThemePreset],
+      SettingsTab::Worktree => &[
+        SettingField::WorktreeBase,
+        SettingField::WorktreePathPattern,
+        SettingField::WorktreeBranchPattern,
+      ],
       SettingsTab::Tui => &[
         SettingField::SidebarPosition,
         SettingField::OpenMode,
         SettingField::ConfirmCountdown,
+        SettingField::OpenShellCmd,
+        SettingField::OpenEditorCmd,
       ],
       SettingsTab::All => &[],
     }
@@ -109,6 +125,8 @@ pub enum FieldKind {
   Choice,
   /// A numeric (`u32`) value edited character-by-character in a buffer.
   Uint,
+  /// A free-text value edited character-by-character in a buffer.
+  Text,
 }
 
 const SIDEBAR_CHOICES: &[&str] = &["right", "left"];
@@ -119,12 +137,22 @@ const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
 pub enum SettingField {
   /// `theme.preset` — cycle the built-in palettes.
   ThemePreset,
+  /// `worktree.base` — the worktree base directory (text).
+  WorktreeBase,
+  /// `worktree.path_pattern` — the worktree dir-name pattern (text).
+  WorktreePathPattern,
+  /// `worktree.branch_pattern` — the branch-name pattern (text).
+  WorktreeBranchPattern,
   /// `tui.sidebar_position` — left / right.
   SidebarPosition,
   /// `tui.open.mode` — shell / editor / finder.
   OpenMode,
   /// `tui.confirm_countdown_secs` — numeric input.
   ConfirmCountdown,
+  /// `tui.open.shell_cmd` — `$SHELL` override (text).
+  OpenShellCmd,
+  /// `tui.open.editor_cmd` — `$EDITOR` override (text).
+  OpenEditorCmd,
 }
 
 impl SettingField {
@@ -132,9 +160,14 @@ impl SettingField {
   pub fn label(self) -> &'static str {
     match self {
       SettingField::ThemePreset => "theme preset",
+      SettingField::WorktreeBase => "base directory",
+      SettingField::WorktreePathPattern => "path pattern",
+      SettingField::WorktreeBranchPattern => "branch pattern",
       SettingField::SidebarPosition => "sidebar position",
       SettingField::OpenMode => "open mode",
       SettingField::ConfirmCountdown => "confirm countdown (s)",
+      SettingField::OpenShellCmd => "open shell cmd",
+      SettingField::OpenEditorCmd => "open editor cmd",
     }
   }
 
@@ -142,28 +175,38 @@ impl SettingField {
   pub fn key_path(self) -> &'static str {
     match self {
       SettingField::ThemePreset => "theme.preset",
+      SettingField::WorktreeBase => "worktree.base",
+      SettingField::WorktreePathPattern => "worktree.path_pattern",
+      SettingField::WorktreeBranchPattern => "worktree.branch_pattern",
       SettingField::SidebarPosition => "tui.sidebar_position",
       SettingField::OpenMode => "tui.open.mode",
       SettingField::ConfirmCountdown => "tui.confirm_countdown_secs",
+      SettingField::OpenShellCmd => "tui.open.shell_cmd",
+      SettingField::OpenEditorCmd => "tui.open.editor_cmd",
     }
   }
 
-  /// Whether the field is a cyclable choice or a numeric input.
+  /// Whether the field is a cyclable choice, a numeric input, or free text.
   pub fn kind(self) -> FieldKind {
     match self {
+      SettingField::ThemePreset | SettingField::SidebarPosition | SettingField::OpenMode => FieldKind::Choice,
       SettingField::ConfirmCountdown => FieldKind::Uint,
-      _ => FieldKind::Choice,
+      SettingField::WorktreeBase
+      | SettingField::WorktreePathPattern
+      | SettingField::WorktreeBranchPattern
+      | SettingField::OpenShellCmd
+      | SettingField::OpenEditorCmd => FieldKind::Text,
     }
   }
 
   /// The fixed choice set for a `Choice` field. Theme presets come from the
-  /// theme registry; the rest are static. Empty for `Uint` fields.
+  /// theme registry; the rest are static. Empty for non-choice fields.
   pub fn choices(self) -> &'static [&'static str] {
     match self {
       SettingField::ThemePreset => crate::tui::theme::preset_names(),
       SettingField::SidebarPosition => SIDEBAR_CHOICES,
       SettingField::OpenMode => OPEN_MODE_CHOICES,
-      SettingField::ConfirmCountdown => &[],
+      _ => &[],
     }
   }
 
@@ -171,6 +214,9 @@ impl SettingField {
   pub fn current(self, cfg: &Config) -> String {
     match self {
       SettingField::ThemePreset => cfg.theme.preset.clone().unwrap_or_else(|| "default".into()),
+      SettingField::WorktreeBase => cfg.worktree.base.clone(),
+      SettingField::WorktreePathPattern => cfg.worktree.path_pattern.clone(),
+      SettingField::WorktreeBranchPattern => cfg.worktree.branch_pattern.clone(),
       SettingField::SidebarPosition => cfg.tui.sidebar_position.label().into(),
       SettingField::OpenMode => match cfg.tui.open.mode {
         crate::config::TuiOpenMode::Shell => "shell".into(),
@@ -178,6 +224,8 @@ impl SettingField {
         crate::config::TuiOpenMode::Finder => "finder".into(),
       },
       SettingField::ConfirmCountdown => cfg.tui.confirm_countdown_secs.to_string(),
+      SettingField::OpenShellCmd => cfg.tui.open.shell_cmd.clone().unwrap_or_default(),
+      SettingField::OpenEditorCmd => cfg.tui.open.editor_cmd.clone().unwrap_or_default(),
     }
   }
 
@@ -291,20 +339,29 @@ impl ConfigPanel {
     }
   }
 
-  /// Begin editing the selected `Uint` field, seeding the buffer with its
-  /// current value. No-op if the selected field is not a `Uint` input.
+  /// Begin editing the selected input field (`Uint` or `Text`), seeding the
+  /// buffer with its current value. No-op if the selected field is a
+  /// `Choice` (those cycle, they are not text-edited).
   pub fn begin_edit(&mut self, current: &str) {
-    if matches!(self.selected_field().map(SettingField::kind), Some(FieldKind::Uint)) {
+    if matches!(
+      self.selected_field().map(SettingField::kind),
+      Some(FieldKind::Uint | FieldKind::Text)
+    ) {
       self.editing = Some(current.to_string());
     }
   }
 
-  /// Append a digit to the edit buffer (ignores non-digits and overlong
-  /// input — the confirm countdown clamps to a single digit's worth of
-  /// seconds anyway, but we allow up to 3 chars for round-tripping).
+  /// Append a character to the edit buffer. `Uint` fields take ASCII digits
+  /// only (capped at 3 chars — the countdown clamps to single seconds
+  /// anyway); `Text` fields take any printable character (capped at 256).
   pub fn push_edit_char(&mut self, c: char) {
+    let uint = matches!(self.selected_field().map(SettingField::kind), Some(FieldKind::Uint));
     if let Some(buf) = self.editing.as_mut() {
-      if c.is_ascii_digit() && buf.len() < 3 {
+      if uint {
+        if c.is_ascii_digit() && buf.len() < 3 {
+          buf.push(c);
+        }
+      } else if !c.is_control() && buf.len() < 256 {
         buf.push(c);
       }
     }
@@ -322,10 +379,11 @@ impl ConfigPanel {
     self.editing = None;
   }
 
-  /// Commit the in-progress edit, returning the buffer (empty buffer reads
-  /// as `"0"` so a cleared input is a valid zero, not a parse error).
+  /// Commit the in-progress edit, returning the raw buffer (the caller
+  /// coerces an empty numeric buffer to `"0"`; an empty text buffer is a
+  /// legitimate "unset" value).
   pub fn take_edit(&mut self) -> Option<String> {
-    self.editing.take().map(|b| if b.is_empty() { "0".into() } else { b })
+    self.editing.take()
   }
 
   /// The source layer that currently provides `field`'s value, looked up in

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -1,28 +1,224 @@
-//! Configuration panel modal state (issue #232).
+//! Settings panel modal state (issue #232; editable in #279).
 //!
-//! The scroll cursor for the ~90% fullscreen Configuration overlay plus
-//! the owned, already-resolved [`crate::config::ConfigRow`] snapshot the
-//! renderer paints. Unlike the Command Logs slice there is no `sync`:
-//! the `App` resolves the rows once on open (cheap local TOML reads via
-//! [`crate::config::resolved_rows`]) and assigns them here, so the panel
-//! renders from owned state with no I/O on the render path.
+//! Started life as a read-only Configuration overlay (issue #232): the
+//! scroll cursor plus the owned, already-resolved [`crate::config::ConfigRow`]
+//! snapshot the renderer paints. Issue #279 turns it into an editable
+//! **Settings** panel — herdr-style — without dropping that read-only view:
 //!
-//! Scroll mirrors the help / Command Logs overlays: the cursor lives
-//! here, but `max_scroll` / `max_x_scroll` are republished by the
-//! renderer each frame against the live viewport, since only the renderer
-//! knows both the content length and the inner modal height. The scroll
-//! methods clamp against whatever bound the last frame published.
+//! - **Tabs** ([`SettingsTab`]) split the surface into the editable `Theme`
+//!   and `Tui` categories plus the read-only `All` resolved-config view.
+//! - **A layer selector** ([`SettingsLayer`]) chooses whether an edit lands
+//!   in the per-project `.gwm.toml` or the user-global `config.toml`.
+//! - **Fields** ([`SettingField`]) are real toggles / choices / numeric
+//!   inputs, resolved live against the loaded [`crate::config::Config`].
+//!
+//! The state here stays pure (no I/O): navigation, selection and the input
+//! edit buffer live here and are unit-tested ratatui-free; the actual write
+//! (`config_cli::set_value_at`) and the apply-live reload are orchestrated
+//! by [`crate::tui::App`]. Scroll mirrors the help / Command Logs overlays:
+//! the cursor lives here, `max_scroll` / `max_x_scroll` are republished by
+//! the renderer each frame against the live viewport.
 
-use crate::config::ConfigRow;
+use crate::config::{Config, ConfigRow, ConfigSource};
 
-/// Owned state for the Configuration overlay: the resolved rows and the
-/// (vertical + horizontal) scroll cursor with its renderer-published
+/// The Settings categories, in tab order. `Theme` and `Tui` are editable;
+/// `All` is the read-only resolved-config view (the pre-#279 panel).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SettingsTab {
+  /// Theme preset selection (editable).
+  #[default]
+  Theme,
+  /// TUI behaviour knobs: sidebar side, open mode, confirm countdown.
+  Tui,
+  /// The full resolved config, read-only with source attribution.
+  All,
+}
+
+impl SettingsTab {
+  /// Tabs in display order — the navigation cycle.
+  pub const ALL: [SettingsTab; 3] = [SettingsTab::Theme, SettingsTab::Tui, SettingsTab::All];
+
+  /// Short tab label shown in the header strip.
+  pub fn label(self) -> &'static str {
+    match self {
+      SettingsTab::Theme => "Theme",
+      SettingsTab::Tui => "TUI",
+      SettingsTab::All => "All",
+    }
+  }
+
+  /// The editable fields under this tab, in display order. `All` has none
+  /// (it is the read-only resolved view).
+  pub fn fields(self) -> &'static [SettingField] {
+    match self {
+      SettingsTab::Theme => &[SettingField::ThemePreset],
+      SettingsTab::Tui => &[
+        SettingField::SidebarPosition,
+        SettingField::OpenMode,
+        SettingField::ConfirmCountdown,
+      ],
+      SettingsTab::All => &[],
+    }
+  }
+}
+
+/// Which config layer an edit targets. Both are editable (issue #279):
+/// `Project` writes the repo `.gwm.toml`, `Global` writes the user-level
+/// `~/.config/gwm/config.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SettingsLayer {
+  /// The repo-local `.gwm.toml` — the default (matches `gwm config set`).
+  #[default]
+  Project,
+  /// The user-global `~/.config/gwm/config.toml`.
+  Global,
+}
+
+impl SettingsLayer {
+  /// Label for the header indicator.
+  pub fn label(self) -> &'static str {
+    match self {
+      SettingsLayer::Project => "project (.gwm.toml)",
+      SettingsLayer::Global => "global (~/.config/gwm)",
+    }
+  }
+
+  /// The [`ConfigSource`] an edit on this layer writes — used to decide
+  /// whether the edit will actually take effect or be shadowed by a
+  /// higher-precedence layer.
+  pub fn source(self) -> ConfigSource {
+    match self {
+      SettingsLayer::Project => ConfigSource::Repo,
+      SettingsLayer::Global => ConfigSource::User,
+    }
+  }
+
+  /// Flip to the other layer.
+  pub fn toggled(self) -> Self {
+    match self {
+      SettingsLayer::Project => SettingsLayer::Global,
+      SettingsLayer::Global => SettingsLayer::Project,
+    }
+  }
+}
+
+/// How a [`SettingField`] is edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+  /// Cycle through a fixed set of values (Space / Enter advances).
+  Choice,
+  /// A numeric (`u32`) value edited character-by-character in a buffer.
+  Uint,
+}
+
+const SIDEBAR_CHOICES: &[&str] = &["right", "left"];
+const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
+
+/// One editable setting, resolved live against the loaded [`Config`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingField {
+  /// `theme.preset` — cycle the built-in palettes.
+  ThemePreset,
+  /// `tui.sidebar_position` — left / right.
+  SidebarPosition,
+  /// `tui.open.mode` — shell / editor / finder.
+  OpenMode,
+  /// `tui.confirm_countdown_secs` — numeric input.
+  ConfirmCountdown,
+}
+
+impl SettingField {
+  /// Human label shown in the panel.
+  pub fn label(self) -> &'static str {
+    match self {
+      SettingField::ThemePreset => "theme preset",
+      SettingField::SidebarPosition => "sidebar position",
+      SettingField::OpenMode => "open mode",
+      SettingField::ConfirmCountdown => "confirm countdown (s)",
+    }
+  }
+
+  /// Dotted config key path the edit writes (`config_cli::set_value_at`).
+  pub fn key_path(self) -> &'static str {
+    match self {
+      SettingField::ThemePreset => "theme.preset",
+      SettingField::SidebarPosition => "tui.sidebar_position",
+      SettingField::OpenMode => "tui.open.mode",
+      SettingField::ConfirmCountdown => "tui.confirm_countdown_secs",
+    }
+  }
+
+  /// Whether the field is a cyclable choice or a numeric input.
+  pub fn kind(self) -> FieldKind {
+    match self {
+      SettingField::ConfirmCountdown => FieldKind::Uint,
+      _ => FieldKind::Choice,
+    }
+  }
+
+  /// The fixed choice set for a `Choice` field. Theme presets come from the
+  /// theme registry; the rest are static. Empty for `Uint` fields.
+  pub fn choices(self) -> &'static [&'static str] {
+    match self {
+      SettingField::ThemePreset => crate::tui::theme::preset_names(),
+      SettingField::SidebarPosition => SIDEBAR_CHOICES,
+      SettingField::OpenMode => OPEN_MODE_CHOICES,
+      SettingField::ConfirmCountdown => &[],
+    }
+  }
+
+  /// The current value as a display string, read from the resolved config.
+  pub fn current(self, cfg: &Config) -> String {
+    match self {
+      SettingField::ThemePreset => cfg.theme.preset.clone().unwrap_or_else(|| "default".into()),
+      SettingField::SidebarPosition => cfg.tui.sidebar_position.label().into(),
+      SettingField::OpenMode => match cfg.tui.open.mode {
+        crate::config::TuiOpenMode::Shell => "shell".into(),
+        crate::config::TuiOpenMode::Editor => "editor".into(),
+        crate::config::TuiOpenMode::Finder => "finder".into(),
+      },
+      SettingField::ConfirmCountdown => cfg.tui.confirm_countdown_secs.to_string(),
+    }
+  }
+
+  /// The next value for a `Choice` field, wrapping. If the current value is
+  /// not one of the choices (e.g. theme preset is `None`/"default"), the
+  /// first choice is returned. `None` for `Uint` fields.
+  pub fn next_choice(self, cfg: &Config) -> Option<String> {
+    let choices = self.choices();
+    if choices.is_empty() {
+      return None;
+    }
+    let current = self.current(cfg);
+    let idx = choices.iter().position(|c| *c == current);
+    let next = match idx {
+      Some(i) => choices[(i + 1) % choices.len()],
+      None => choices[0],
+    };
+    Some(next.to_string())
+  }
+}
+
+/// Owned state for the Settings overlay: the read-only resolved rows, the
+/// active tab / layer / selection, the optional numeric-input edit buffer,
+/// and the (vertical + horizontal) scroll cursor with renderer-published
 /// bounds.
 #[derive(Debug, Default)]
 pub struct ConfigPanel {
-  /// Resolved config rows (key, value, source), grouped section-first by
-  /// the renderer. Assigned by [`crate::tui::App::enter_config_panel`].
+  /// Resolved config rows (key, value, source) for the read-only `All` tab,
+  /// grouped section-first by the renderer. Also the source-attribution
+  /// lookup behind the editable tabs. Assigned by
+  /// [`crate::tui::App::enter_config_panel`].
   pub rows: Vec<ConfigRow>,
+  /// Active settings tab (issue #279).
+  pub tab: SettingsTab,
+  /// Which config layer edits target (issue #279).
+  pub layer: SettingsLayer,
+  /// Selected field index within the current editable tab.
+  pub selected: usize,
+  /// When `Some`, the numeric-input edit buffer for the selected `Uint`
+  /// field; keystrokes route here until commit (Enter) or cancel (Esc).
+  pub editing: Option<String>,
   /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
   pub scroll: u16,
   /// Maximum vertical scroll offset, republished by the renderer each
@@ -38,6 +234,106 @@ impl ConfigPanel {
   /// An empty overlay at the origin.
   pub fn new() -> Self {
     Self::default()
+  }
+
+  /// The editable fields under the active tab (empty on the `All` tab).
+  pub fn fields(&self) -> &'static [SettingField] {
+    self.tab.fields()
+  }
+
+  /// The selected field, if the active tab has any.
+  pub fn selected_field(&self) -> Option<SettingField> {
+    self.fields().get(self.selected).copied()
+  }
+
+  /// Move to the next tab, wrapping. Resets the field selection and any
+  /// in-progress edit so the new tab starts clean.
+  pub fn next_tab(&mut self) {
+    let idx = SettingsTab::ALL.iter().position(|t| *t == self.tab).unwrap_or(0);
+    self.tab = SettingsTab::ALL[(idx + 1) % SettingsTab::ALL.len()];
+    self.selected = 0;
+    self.editing = None;
+    self.scroll = 0;
+  }
+
+  /// Move to the previous tab, wrapping. Same reset as [`Self::next_tab`].
+  pub fn prev_tab(&mut self) {
+    let idx = SettingsTab::ALL.iter().position(|t| *t == self.tab).unwrap_or(0);
+    let len = SettingsTab::ALL.len();
+    self.tab = SettingsTab::ALL[(idx + len - 1) % len];
+    self.selected = 0;
+    self.editing = None;
+    self.scroll = 0;
+  }
+
+  /// Flip the edit target layer (project ↔ global).
+  pub fn toggle_layer(&mut self) {
+    self.layer = self.layer.toggled();
+  }
+
+  /// Select the previous field in the current tab (no-op while editing or on
+  /// a tab with no fields).
+  pub fn select_prev(&mut self) {
+    if self.editing.is_some() {
+      return;
+    }
+    self.selected = self.selected.saturating_sub(1);
+  }
+
+  /// Select the next field in the current tab, clamped to the last field.
+  pub fn select_next(&mut self) {
+    if self.editing.is_some() {
+      return;
+    }
+    let count = self.fields().len();
+    if count > 0 {
+      self.selected = (self.selected + 1).min(count - 1);
+    }
+  }
+
+  /// Begin editing the selected `Uint` field, seeding the buffer with its
+  /// current value. No-op if the selected field is not a `Uint` input.
+  pub fn begin_edit(&mut self, current: &str) {
+    if matches!(self.selected_field().map(SettingField::kind), Some(FieldKind::Uint)) {
+      self.editing = Some(current.to_string());
+    }
+  }
+
+  /// Append a digit to the edit buffer (ignores non-digits and overlong
+  /// input — the confirm countdown clamps to a single digit's worth of
+  /// seconds anyway, but we allow up to 3 chars for round-tripping).
+  pub fn push_edit_char(&mut self, c: char) {
+    if let Some(buf) = self.editing.as_mut() {
+      if c.is_ascii_digit() && buf.len() < 3 {
+        buf.push(c);
+      }
+    }
+  }
+
+  /// Delete the last character of the edit buffer.
+  pub fn pop_edit_char(&mut self) {
+    if let Some(buf) = self.editing.as_mut() {
+      buf.pop();
+    }
+  }
+
+  /// Cancel the in-progress edit, discarding the buffer.
+  pub fn cancel_edit(&mut self) {
+    self.editing = None;
+  }
+
+  /// Commit the in-progress edit, returning the buffer (empty buffer reads
+  /// as `"0"` so a cleared input is a valid zero, not a parse error).
+  pub fn take_edit(&mut self) -> Option<String> {
+    self.editing.take().map(|b| if b.is_empty() { "0".into() } else { b })
+  }
+
+  /// The source layer that currently provides `field`'s value, looked up in
+  /// the resolved rows. Drives the "shadowed edit" guidance: editing the
+  /// global layer for a field the repo overrides won't change the effective
+  /// value (repo wins).
+  pub fn field_source(&self, field: SettingField) -> Option<ConfigSource> {
+    self.rows.iter().find(|r| r.key == field.key_path()).map(|r| r.source)
   }
 
   /// Scroll down one row, never past the last line.
@@ -70,10 +366,12 @@ impl ConfigPanel {
     self.scroll = self.max_scroll;
   }
 
-  /// Reset the scroll cursor to the origin, keeping the resolved rows.
-  /// Called when the overlay opens.
+  /// Reset the cursor + selection + edit buffer to the origin, keeping the
+  /// resolved rows and the active tab/layer. Called when the overlay opens.
   pub fn reset(&mut self) {
     self.scroll = 0;
     self.x_scroll = 0;
+    self.selected = 0;
+    self.editing = None;
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2163,12 +2163,40 @@ pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> 
 /// so the labels line up regardless of how many chords a row binds.
 pub fn badge_group_width(keys: &str) -> usize {
   if keys.is_empty() || keys == "(unbound)" {
-    return "(unbound)".chars().count() + 2;
+    return "(unbound)".chars().count();
   }
   let chords: Vec<&str> = keys.split(", ").collect();
-  let badges: usize = chords.iter().map(|c| c.chars().count() + 2).sum();
-  // One space between adjacent badges.
-  badges + chords.len().saturating_sub(1)
+  // Flat accent-bold glyphs now (issue #279), no `` key `` padding box: a
+  // group is the sum of bare chord widths plus one space between adjacent
+  // chords.
+  let glyphs: usize = chords.iter().map(|c| c.chars().count()).sum();
+  glyphs + chords.len().saturating_sub(1)
+}
+
+/// One documented-binding row for the Keybindings overlay (issue #279):
+/// the chord(s) as flat accent-bold glyphs (no reverse-video badge),
+/// padded to `max_group_w` so every label lines up in one column, then the
+/// human label. An unbound action reads as a muted `(unbound)` placeholder.
+/// Extracted as a pure builder so the de-badged treatment is pinned by
+/// `tests/tui_ui_helpers_tests.rs` without a ratatui backend.
+pub fn help_entry_line(keys: &str, label: &str, max_group_w: usize, theme: &Theme) -> Line<'static> {
+  let key_style = hint_key_style(theme);
+  let muted_style = Style::default().fg(theme.muted);
+  let mut spans: Vec<Span<'static>> = vec![Span::raw("  ")];
+  if keys.is_empty() || keys == "(unbound)" {
+    spans.push(Span::styled("(unbound)", muted_style));
+  } else {
+    for (i, chord) in keys.split(", ").enumerate() {
+      if i > 0 {
+        spans.push(Span::raw(" "));
+      }
+      spans.push(Span::styled(chord.to_string(), key_style));
+    }
+  }
+  let pad = max_group_w.saturating_sub(badge_group_width(keys)) + 1;
+  spans.push(Span::raw(" ".repeat(pad)));
+  spans.push(Span::styled(label.to_string(), help_label_style(theme)));
+  Line::from(spans)
 }
 
 fn draw_help(f: &mut Frame, app: &mut App) {
@@ -2181,20 +2209,15 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   // Theme-driven colours so the overlay tracks `[theme]` like the rest
   // of the TUI (pre-#187 it was hard-coded `Cyan` + plain text).
   let accent = app.theme.accent;
-  let muted = app.theme.muted;
 
-  // Key *badges* mirror the bottom statusline's chip style
-  // (`footer_line`): a reversed-bold accent block. Section headers and
-  // the title share the bold-accent heading style. Labels stay white
-  // for contrast; an `(unbound)` action renders muted instead of a chip
-  // so it reads as "no binding" rather than a live key.
-  let chip_style = chip_style(accent);
   let heading_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
-  let label_style = help_label_style(&app.theme);
-  let muted_style = Style::default().fg(muted);
+  // Subtitle reads in a distinct accent hue (the theme's branch colour) +
+  // italic, so the context name is clearly a different colour from both the
+  // bold title and the muted key labels (issue #217 follow-up).
+  let subtitle_style = Style::default().fg(app.theme.branch).add_modifier(Modifier::ITALIC);
 
-  // Align every label to the same column: pad each badge *group* out to
-  // the widest one so the descriptions line up under one another.
+  // Align every label to the same column: pad each chord *group* out to the
+  // widest one so the descriptions line up under one another.
   let max_group_w = rows
     .iter()
     .filter_map(|r| match r {
@@ -2204,70 +2227,63 @@ fn draw_help(f: &mut Frame, app: &mut App) {
     .max()
     .unwrap_or(0);
 
-  // Subtitle reads in a distinct accent hue (the theme's branch colour) +
-  // italic, so the context name is clearly a different colour from both the
-  // bold title and the muted key labels (issue #217 follow-up).
-  let subtitle_style = Style::default().fg(app.theme.branch).add_modifier(Modifier::ITALIC);
-
-  let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows.len());
+  // Issue #279: split the overlay into a FIXED header (title + subtitle), a
+  // SCROLLABLE body (sections + entries), and a FIXED footer hint. Pre-#279
+  // the whole content scrolled in one `Paragraph`, so the title and the
+  // close hint rolled off the top/bottom as soon as the body outgrew the
+  // modal. Title/subtitle are the leading rows; everything else is body.
+  let mut header_lines: Vec<Line<'static>> = Vec::new();
+  let mut body_lines: Vec<Line<'static>> = Vec::new();
   for row in rows {
     match row {
-      // Title + subtitle are centred (issue #217); section headers stay
-      // left-aligned so they anchor their groups lazygit-style.
-      HelpRow::Title(t) => {
-        lines.push(Line::from(Span::styled(t, heading_style)).centered());
-      }
-      HelpRow::Subtitle(t) => {
-        lines.push(Line::from(Span::styled(t, subtitle_style)).centered());
-      }
-      HelpRow::Section(t) => {
-        lines.push(Line::from(Span::styled(
-          t,
-          help_section_style(help_body_section_color(&app.theme)),
-        )));
-      }
-      HelpRow::Blank => lines.push(Line::from(String::new())),
+      // Title + subtitle are centred (issue #217) and pinned in the header.
+      HelpRow::Title(t) => header_lines.push(Line::from(Span::styled(t, heading_style)).centered()),
+      HelpRow::Subtitle(t) => header_lines.push(Line::from(Span::styled(t, subtitle_style)).centered()),
+      // Section headers stay left-aligned so they anchor their groups
+      // lazygit-style.
+      HelpRow::Section(t) => body_lines.push(Line::from(Span::styled(
+        t,
+        help_section_style(help_body_section_color(&app.theme)),
+      ))),
+      HelpRow::Blank => body_lines.push(Line::from(String::new())),
       HelpRow::Entry { keys, label } => {
-        // One badge per chord, separated by a space (#187 review: the
-        // comma-joined `j, Down` now reads as `[ j ] [ Down ]`).
-        let mut spans: Vec<Span<'static>> = vec![Span::raw("  ")];
-        if keys.is_empty() || keys == "(unbound)" {
-          spans.push(Span::styled(" (unbound) ", muted_style));
-        } else {
-          for (i, chord) in keys.split(", ").enumerate() {
-            if i > 0 {
-              spans.push(Span::raw(" "));
-            }
-            spans.push(Span::styled(format!(" {} ", chord), chip_style));
-          }
-        }
-        let pad = max_group_w.saturating_sub(badge_group_width(&keys)) + 1;
-        spans.push(Span::raw(" ".repeat(pad)));
-        spans.push(Span::styled(label, label_style));
-        lines.push(Line::from(spans));
+        body_lines.push(help_entry_line(&keys, &label, max_group_w, &app.theme));
       }
     }
   }
-  push_modal_hint(&mut lines, HintContext::Help, &app.keymap, &app.theme);
 
-  // Publish the scroll bound against the actual viewport so the Keybindings
-  // overlay can scroll when it outgrows the modal (#217). The renderer is
-  // the only place that knows both the content length and the inner height,
-  // so it clamps the offset here too.
   let block = overlay_block(accent);
   let inner_area = block.inner(area);
-  let viewport = inner_area.height as usize;
-  app.help_max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  f.render_widget(Clear, area);
+  f.render_widget(block, area);
+
+  // header (fixed) | body (scrollable) | footer hint (fixed). The header is
+  // exactly as tall as its line count; the footer is one row; the body
+  // takes the rest.
+  let header_h = header_lines.len() as u16;
+  let [header_area, body_area, footer_area] =
+    Layout::vertical([Constraint::Length(header_h), Constraint::Min(1), Constraint::Length(1)]).areas(inner_area);
+
+  f.render_widget(Paragraph::new(header_lines), header_area);
+
+  // Publish the scroll bounds against the BODY viewport only (issue #279) —
+  // not the whole inner height — so the clamp matches what actually scrolls
+  // and the last body rows stay reachable.
+  let body_viewport = body_area.height as usize;
+  app.help_max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
   app.help_scroll = app.help_scroll.min(app.help_max_scroll);
-  let viewport_width = inner_area.width as usize;
-  let content_width = lines.iter().map(Line::width).max().unwrap_or(0);
-  app.help_max_x_scroll = content_width.saturating_sub(viewport_width) as u16;
+  let body_viewport_w = body_area.width as usize;
+  let content_width = body_lines.iter().map(Line::width).max().unwrap_or(0);
+  app.help_max_x_scroll = content_width.saturating_sub(body_viewport_w) as u16;
   app.help_x_scroll = app.help_x_scroll.min(app.help_max_x_scroll);
   let scroll = app.help_scroll;
   let x_scroll = app.help_x_scroll;
 
-  f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
+  f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), body_area);
+  f.render_widget(
+    modal_hint_for_context(HintContext::Help, &app.keymap, &app.theme),
+    footer_area,
+  );
 }
 
 /// Render the Command Logs overlay (issue #226): a ~90% fullscreen modal

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2276,14 +2276,14 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   let body_viewport = body_area.height as usize;
   app.help_max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
   app.help_scroll = app.help_scroll.min(app.help_max_scroll);
-  let body_viewport_w = body_area.width as usize;
-  let content_width = body_lines.iter().map(Line::width).max().unwrap_or(0);
-  app.help_max_x_scroll = content_width.saturating_sub(body_viewport_w) as u16;
-  app.help_x_scroll = app.help_x_scroll.min(app.help_max_x_scroll);
   let scroll = app.help_scroll;
-  let x_scroll = app.help_x_scroll;
-
+  // Reserve the scrollbar column FIRST, then bound the horizontal pan against
+  // the reduced text width so the final cell stays reachable (review P3).
   let text_area = scrollable_body_area(f, body_area, scroll, body_lines.len(), &app.theme);
+  let content_width = body_lines.iter().map(Line::width).max().unwrap_or(0);
+  app.help_max_x_scroll = content_width.saturating_sub(text_area.width as usize) as u16;
+  app.help_x_scroll = app.help_x_scroll.min(app.help_max_x_scroll);
+  let x_scroll = app.help_x_scroll;
   f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(
     modal_hint_for_context(HintContext::Help, &app.keymap, &app.theme),
@@ -2381,13 +2381,13 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let body_viewport = body_area.height as usize;
   app.command_logs.max_scroll = (lines.len().saturating_sub(body_viewport)) as u16;
   app.command_logs.scroll = app.command_logs.scroll.min(app.command_logs.max_scroll);
-  let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
-  app.command_logs.max_x_scroll = content_w.saturating_sub(body_area.width as usize) as u16;
-  app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
   let scroll = app.command_logs.scroll;
-  let x_scroll = app.command_logs.x_scroll;
-
+  // Reserve the scrollbar column first, then bound the pan (review P3).
   let text_area = scrollable_body_area(f, body_area, scroll, lines.len(), &app.theme);
+  let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
+  app.command_logs.max_x_scroll = content_w.saturating_sub(text_area.width as usize) as u16;
+  app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
+  let x_scroll = app.command_logs.x_scroll;
   f.render_widget(Paragraph::new(lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(
     modal_hint_line(
@@ -2592,13 +2592,13 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   let body_viewport = body_area.height as usize;
   app.config_panel.max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
   app.config_panel.scroll = app.config_panel.scroll.min(app.config_panel.max_scroll);
-  let content_w = body_lines.iter().map(Line::width).max().unwrap_or(0);
-  app.config_panel.max_x_scroll = content_w.saturating_sub(body_area.width as usize) as u16;
-  app.config_panel.x_scroll = app.config_panel.x_scroll.min(app.config_panel.max_x_scroll);
   let scroll = app.config_panel.scroll;
-  let x_scroll = app.config_panel.x_scroll;
-
+  // Reserve the scrollbar column first, then bound the pan (review P3).
   let text_area = scrollable_body_area(f, body_area, scroll, body_lines.len(), &app.theme);
+  let content_w = body_lines.iter().map(Line::width).max().unwrap_or(0);
+  app.config_panel.max_x_scroll = content_w.saturating_sub(text_area.width as usize) as u16;
+  app.config_panel.x_scroll = app.config_panel.x_scroll.min(app.config_panel.max_x_scroll);
+  let x_scroll = app.config_panel.x_scroll;
   f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(modal_hint_line(&footer_hints, &app.theme), footer_area);
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2390,7 +2390,13 @@ fn scrollable_body_area(f: &mut Frame, area: Rect, offset: u16, content_len: usi
   if content_len <= viewport || area.width < 2 {
     return area;
   }
-  let mut state = ScrollbarState::new(content_len)
+  // ratatui maps the thumb over `content_length - 1`, but our scroll offset
+  // is clamped to `content_len - viewport` (the last page stays full). Pass
+  // `content_length = max_scroll + 1` with the real viewport length so the
+  // thumb size stays proportional AND reaches the bottom at full scroll
+  // (issue #279 follow-up: the thumb used to top out early).
+  let max_scroll = content_len - viewport;
+  let mut state = ScrollbarState::new(max_scroll + 1)
     .position(offset as usize)
     .viewport_content_length(viewport);
   let bar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -2495,25 +2501,33 @@ fn settings_fields_lines(app: &App, fields: &[SettingField]) -> Vec<Line<'static
   lines
 }
 
-/// Render the Settings overlay (issue #232; editable in #279): a ~90%
-/// fullscreen modal with a fixed header (title + category tabs + the edit
-/// layer indicator), a scrollable body (the active tab's fields, or the
-/// read-only resolved config on the `All` tab) with a herdr-style
-/// scrollbar, and a fixed footer hint. The renderer republishes
+/// Render the Settings overlay (issue #232; editable in #279): same modal
+/// size as the Keybindings overlay, with a fixed header (title + the edit
+/// layer as a subtitle + category tabs), a scrollable body (the active
+/// tab's fields, or the read-only resolved config on the `All` tab) with a
+/// herdr-style scrollbar, and a fixed footer hint. The renderer republishes
 /// `config_panel.max_scroll` against the live body viewport.
 fn draw_config_panel(f: &mut Frame, app: &mut App) {
-  let area = centered(90, 85, f.area());
+  let area = centered(60, 60, f.area());
   let accent = app.theme.accent;
   let muted = app.theme.muted;
   let muted_style = Style::default().fg(muted);
   let heading_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
+  // Subtitle reads in the branch hue + italic, mirroring the Keybindings
+  // overlay's context subtitle.
+  let subtitle_style = Style::default().fg(app.theme.branch).add_modifier(Modifier::ITALIC);
 
   let tab = app.config_panel.tab;
   let editing = app.config_panel.editing.is_some();
   let selected_kind = app.config_panel.selected_field().map(SettingField::kind);
 
-  // Header: title + tab strip + layer indicator (all fixed).
+  // Header: title + the active edit layer as a subtitle + tab strip (fixed).
   let title = Line::from(Span::styled("Settings", heading_style)).centered();
+  let subtitle = Line::from(Span::styled(
+    format!("{}  ·  L to switch layer", app.config_panel.layer.label()),
+    subtitle_style,
+  ))
+  .centered();
   let mut tab_spans: Vec<Span<'static>> = vec![Span::raw(" ")];
   for (i, t) in SettingsTab::ALL.iter().enumerate() {
     if i > 0 {
@@ -2522,16 +2536,7 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
     let style = if *t == tab { chip_style(accent) } else { muted_style };
     tab_spans.push(Span::styled(format!(" {} ", t.label()), style));
   }
-  let tabs_line = Line::from(tab_spans);
-  let layer_line = Line::from(vec![
-    Span::styled("  layer: ", muted_style),
-    Span::styled(
-      app.config_panel.layer.label(),
-      Style::default().fg(accent).add_modifier(Modifier::BOLD),
-    ),
-    Span::styled("   (L to switch)", muted_style),
-  ]);
-  let header_lines = vec![title, tabs_line, layer_line];
+  let header_lines = vec![title, subtitle, Line::from(tab_spans)];
 
   // Body depends on the active tab.
   let body_lines = match tab {
@@ -2545,10 +2550,10 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
     vec![("Enter", "save"), ("Esc", "cancel")]
   } else if tab == SettingsTab::All {
     vec![("j/k", "scroll"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
-  } else if selected_kind == Some(FieldKind::Uint) {
-    vec![("Enter", "edit"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
-  } else {
+  } else if selected_kind == Some(FieldKind::Choice) {
     vec![("Space", "cycle"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+  } else {
+    vec![("Enter", "edit"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
   };
 
   let block = overlay_block(accent);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2306,15 +2306,39 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let err_color = app.theme.prunable;
   let label_style = help_label_style(&app.theme);
   let muted_style = Style::default().fg(muted);
+  let heading_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
 
-  let mut lines: Vec<Line<'static>> = overlay_title_lines("Command Logs", accent);
+  // Fixed header (title) / scrollable body / fixed footer hint (issue #279) —
+  // the title and the close hint stay pinned while the transcript scrolls.
+  let block = overlay_block(accent);
+  let inner = block.inner(area);
+  f.render_widget(Clear, area);
+  f.render_widget(block, area);
+
+  let [header_area, body_area, footer_area] =
+    Layout::vertical([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+  f.render_widget(
+    Paragraph::new(Line::from(Span::styled("Command Logs", heading_style)).centered()),
+    header_area,
+  );
+
+  // A full-width `-` rule, padded by a blank line above and below, separates
+  // adjacent log entries (issue #279 follow-up).
+  let rule = "-".repeat(body_area.width as usize);
+  let mut lines: Vec<Line<'static>> = Vec::new();
 
   if app.command_logs.entries.is_empty() {
     lines.push(Line::from(Span::styled("No commands run yet.", muted_style)));
   } else {
     // Newest-first: the most recent command is what the user opened the
     // overlay to see, so it sits at the top without scrolling.
-    for entry in app.command_logs.entries.iter().rev() {
+    for (i, entry) in app.command_logs.entries.iter().rev().enumerate() {
+      if i > 0 {
+        lines.push(Line::from(String::new()));
+        lines.push(Line::from(Span::styled(rule.clone(), muted_style)));
+        lines.push(Line::from(String::new()));
+      }
       // The resolved argv, prefixed lazygit-style with `$`.
       lines.push(Line::from(vec![
         Span::styled("$ ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
@@ -2350,34 +2374,28 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
           lines.push(Line::from(Span::styled(format!("    {}", l), muted_style)));
         }
       }
-      lines.push(Line::from(String::new()));
     }
   }
 
-  // Footer hint: scroll + close. A plain muted line (not `push_modal_hint`,
-  // whose contexts are pane-specific) keeps the overlay self-documenting.
-  lines.push(Line::from(Span::styled(
-    "j/k scroll · g/G top/bottom · esc close",
-    muted_style.add_modifier(Modifier::ITALIC),
-  )));
-
-  // Publish the scroll bounds against the live viewport (mirrors
-  // `draw_help`): the renderer is the only place that knows both the
-  // content length and the inner modal height, so it clamps here.
-  let block = overlay_block(accent);
-  let inner = block.inner(area);
-  let viewport = inner.height as usize;
-  app.command_logs.max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  // Publish the scroll bounds against the BODY viewport only (issue #279).
+  let body_viewport = body_area.height as usize;
+  app.command_logs.max_scroll = (lines.len().saturating_sub(body_viewport)) as u16;
   app.command_logs.scroll = app.command_logs.scroll.min(app.command_logs.max_scroll);
-  let viewport_w = inner.width as usize;
   let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
-  app.command_logs.max_x_scroll = content_w.saturating_sub(viewport_w) as u16;
+  app.command_logs.max_x_scroll = content_w.saturating_sub(body_area.width as usize) as u16;
   app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
   let scroll = app.command_logs.scroll;
   let x_scroll = app.command_logs.x_scroll;
 
-  f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
+  let text_area = scrollable_body_area(f, body_area, scroll, lines.len(), &app.theme);
+  f.render_widget(Paragraph::new(lines).scroll((scroll, x_scroll)), text_area);
+  f.render_widget(
+    modal_hint_line(
+      &[("j/k", "scroll"), ("g/G", "top/bottom"), ("Esc", "close")],
+      &app.theme,
+    ),
+    footer_area,
+  );
 }
 
 /// Render a vertical scrollbar on the right edge of `area` when the content

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,6 +1,7 @@
 use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::keymap::{Action, Keymap};
 use super::state::async_task::TaskKind;
+use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::Field;
 use super::state::sidebar::SidebarMode;
@@ -16,7 +17,10 @@ use ratatui::{
   layout::{Alignment, Constraint, Direction, Layout, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
-  widgets::{Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Table, Widget, Wrap},
+  widgets::{
+    Block, BorderType, Borders, Cell, Clear, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
+    Table, Widget, Wrap,
+  },
   Frame,
 };
 use std::time::{Duration, Instant};
@@ -1600,7 +1604,7 @@ impl HintContext {
         Hint::Key(Review, "review"),
         Hint::Key(FocusStatus, "status"),
         Hint::Key(CommandLogs, "logs"),
-        Hint::Key(ConfigPanel, "config"),
+        Hint::Key(ConfigPanel, "settings"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -1612,7 +1616,7 @@ impl HintContext {
         Hint::Key(FetchGithub, "fetch"),
         Hint::Key(FocusWorktrees, "worktrees"),
         Hint::Key(CommandLogs, "logs"),
-        Hint::Key(ConfigPanel, "config"),
+        Hint::Key(ConfigPanel, "settings"),
         Hint::Key(Filter, "filter"),
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
@@ -2279,7 +2283,8 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   let scroll = app.help_scroll;
   let x_scroll = app.help_x_scroll;
 
-  f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), body_area);
+  let text_area = scrollable_body_area(f, body_area, scroll, body_lines.len(), &app.theme);
+  f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(
     modal_hint_for_context(HintContext::Help, &app.keymap, &app.theme),
     footer_area,
@@ -2375,83 +2380,201 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
 }
 
-/// Render the Configuration panel overlay (issue #232): a ~90% fullscreen
-/// modal listing the resolved config (user-level global merged under the
-/// repo `.gwm.toml`) grouped by top-level section, each row carrying a
-/// leading colour-coded source column (repo / user / default). Scrolls
-/// like the help / Command Logs overlays — the renderer republishes
-/// `config_panel.max_scroll` / `max_x_scroll` against the live viewport.
+/// Render a vertical scrollbar on the right edge of `area` when the content
+/// overflows the viewport (issue #279, herdr-style), and return the text
+/// area shrunk by one column to make room. When everything fits, the area
+/// is returned unchanged and no scrollbar is drawn. The thumb tracks the
+/// theme `accent`; the track reads `muted`.
+fn scrollable_body_area(f: &mut Frame, area: Rect, offset: u16, content_len: usize, theme: &Theme) -> Rect {
+  let viewport = area.height as usize;
+  if content_len <= viewport || area.width < 2 {
+    return area;
+  }
+  let mut state = ScrollbarState::new(content_len)
+    .position(offset as usize)
+    .viewport_content_length(viewport);
+  let bar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+    .begin_symbol(None)
+    .end_symbol(None)
+    .thumb_style(Style::default().fg(theme.accent))
+    .track_style(Style::default().fg(theme.muted));
+  f.render_stateful_widget(bar, area, &mut state);
+  Rect {
+    width: area.width.saturating_sub(1),
+    ..area
+  }
+}
+
+/// Build the read-only `All`-tab body: the resolved config grouped by
+/// top-level section with a colour-coded source column (repo / user /
+/// default). The pre-#279 Configuration view, now one tab of the Settings
+/// overlay.
+fn settings_all_lines(app: &App) -> Vec<Line<'static>> {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let label_style = help_label_style(&app.theme);
+  let muted_style = Style::default().fg(muted);
+  let mut lines: Vec<Line<'static>> = Vec::new();
+
+  if app.config_panel.rows.is_empty() {
+    lines.push(Line::from(Span::styled("No configuration resolved.", muted_style)));
+    return lines;
+  }
+  let mut current_section: Option<String> = None;
+  for row in &app.config_panel.rows {
+    let section = row.key.split(['.', '[']).next().unwrap_or("").to_string();
+    if current_section.as_deref() != Some(section.as_str()) {
+      if current_section.is_some() {
+        lines.push(Line::from(String::new()));
+      }
+      lines.push(Line::from(Span::styled(
+        format!("[{section}]"),
+        help_section_style(accent),
+      )));
+      current_section = Some(section);
+    }
+    let src_color = match row.source {
+      ConfigSource::Repo => app.theme.clean,
+      ConfigSource::User => app.theme.branch,
+      ConfigSource::Default => muted,
+    };
+    lines.push(Line::from(vec![
+      Span::raw("  "),
+      Span::styled(format!("{:<7}", row.source.label()), Style::default().fg(src_color)),
+      Span::raw("  "),
+      Span::styled(row.key.clone(), label_style),
+      Span::styled(" = ", muted_style),
+      Span::styled(row.value.clone(), Style::default().fg(Color::White)),
+    ]));
+  }
+  lines
+}
+
+/// Build an editable-tab body: one row per [`SettingField`], the selected
+/// row marked and its value in the accent. The `Uint` field under edit
+/// shows its live buffer with a cursor; a field whose effective value is
+/// shadowed by a higher-precedence layer carries an inline guidance note
+/// (issue #279 — honours "edit both layers" without a silent dead edit).
+fn settings_fields_lines(app: &App, fields: &[SettingField]) -> Vec<Line<'static>> {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let label_style = help_label_style(&app.theme);
+  let muted_style = Style::default().fg(muted);
+  let panel = &app.config_panel;
+  let mut lines: Vec<Line<'static>> = Vec::new();
+
+  for (i, field) in fields.iter().enumerate() {
+    let selected = i == panel.selected;
+    let editing = selected && panel.editing.is_some();
+    let value = if editing {
+      format!("{}_", panel.editing.as_deref().unwrap_or(""))
+    } else {
+      field.current(&app.config)
+    };
+    let marker = if selected { "›" } else { " " };
+    let marker_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
+    let value_style = if selected {
+      Style::default().fg(accent).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(Color::White)
+    };
+    let mut spans = vec![
+      Span::styled(format!(" {marker} "), marker_style),
+      Span::styled(format!("{:<24}", field.label()), label_style),
+      Span::styled(value, value_style),
+    ];
+    // Shadow guidance: editing the Global layer for a field the repo
+    // overrides won't change the effective value (repo wins). Surface it
+    // rather than silently no-op or hard-disable the field.
+    if selected && panel.layer.source() == ConfigSource::User && panel.field_source(*field) == Some(ConfigSource::Repo)
+    {
+      spans.push(Span::styled("  — set in .gwm.toml; switch to Project", muted_style));
+    }
+    lines.push(Line::from(spans));
+  }
+  lines
+}
+
+/// Render the Settings overlay (issue #232; editable in #279): a ~90%
+/// fullscreen modal with a fixed header (title + category tabs + the edit
+/// layer indicator), a scrollable body (the active tab's fields, or the
+/// read-only resolved config on the `All` tab) with a herdr-style
+/// scrollbar, and a fixed footer hint. The renderer republishes
+/// `config_panel.max_scroll` against the live body viewport.
 fn draw_config_panel(f: &mut Frame, app: &mut App) {
   let area = centered(90, 85, f.area());
   let accent = app.theme.accent;
   let muted = app.theme.muted;
-  let repo_color = app.theme.clean;
-  let user_color = app.theme.branch;
-  let label_style = help_label_style(&app.theme);
   let muted_style = Style::default().fg(muted);
+  let heading_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
 
-  let mut lines: Vec<Line<'static>> = overlay_title_lines("Configuration", accent);
+  let tab = app.config_panel.tab;
+  let editing = app.config_panel.editing.is_some();
+  let selected_kind = app.config_panel.selected_field().map(SettingField::kind);
 
-  if app.config_panel.rows.is_empty() {
-    lines.push(Line::from(Span::styled("No configuration resolved.", muted_style)));
-  } else {
-    // Rows arrive sorted (the flatten walks a `BTreeMap`), so each
-    // top-level section is contiguous — emit a `[section]` heading when it
-    // changes, mirroring `gwm config list`'s grouping.
-    let mut current_section: Option<String> = None;
-    for row in &app.config_panel.rows {
-      let section = row.key.split(['.', '[']).next().unwrap_or("").to_string();
-      if current_section.as_deref() != Some(section.as_str()) {
-        if current_section.is_some() {
-          lines.push(Line::from(String::new()));
-        }
-        lines.push(Line::from(Span::styled(
-          format!("[{section}]"),
-          help_section_style(accent),
-        )));
-        current_section = Some(section);
-      }
-      // Leading source column, colour-coded and padded so keys align: repo
-      // overrides read strongest, user next, defaults muted.
-      let src_color = match row.source {
-        ConfigSource::Repo => repo_color,
-        ConfigSource::User => user_color,
-        ConfigSource::Default => muted,
-      };
-      lines.push(Line::from(vec![
-        Span::raw("  "),
-        Span::styled(format!("{:<7}", row.source.label()), Style::default().fg(src_color)),
-        Span::raw("  "),
-        Span::styled(row.key.clone(), label_style),
-        Span::styled(" = ", muted_style),
-        Span::styled(row.value.clone(), Style::default().fg(Color::White)),
-      ]));
+  // Header: title + tab strip + layer indicator (all fixed).
+  let title = Line::from(Span::styled("Settings", heading_style)).centered();
+  let mut tab_spans: Vec<Span<'static>> = vec![Span::raw(" ")];
+  for (i, t) in SettingsTab::ALL.iter().enumerate() {
+    if i > 0 {
+      tab_spans.push(Span::raw("  "));
     }
+    let style = if *t == tab { chip_style(accent) } else { muted_style };
+    tab_spans.push(Span::styled(format!(" {} ", t.label()), style));
   }
+  let tabs_line = Line::from(tab_spans);
+  let layer_line = Line::from(vec![
+    Span::styled("  layer: ", muted_style),
+    Span::styled(
+      app.config_panel.layer.label(),
+      Style::default().fg(accent).add_modifier(Modifier::BOLD),
+    ),
+    Span::styled("   (L to switch)", muted_style),
+  ]);
+  let header_lines = vec![title, tabs_line, layer_line];
 
-  // Footer hint: scroll + close, matching the Command Logs overlay.
-  lines.push(Line::from(String::new()));
-  lines.push(Line::from(Span::styled(
-    "j/k scroll · g/G top/bottom · esc close",
-    muted_style.add_modifier(Modifier::ITALIC),
-  )));
+  // Body depends on the active tab.
+  let body_lines = match tab {
+    SettingsTab::All => settings_all_lines(app),
+    other => settings_fields_lines(app, other.fields()),
+  };
 
-  // Publish the scroll bounds against the live viewport (mirrors
-  // `draw_command_logs` / `draw_help`).
+  // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
+  // the current tab / edit mode.
+  let footer_hints: Vec<(&str, &str)> = if editing {
+    vec![("Enter", "save"), ("Esc", "cancel")]
+  } else if tab == SettingsTab::All {
+    vec![("j/k", "scroll"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+  } else if selected_kind == Some(FieldKind::Uint) {
+    vec![("Enter", "edit"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+  } else {
+    vec![("Space", "cycle"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+  };
+
   let block = overlay_block(accent);
   let inner = block.inner(area);
-  let viewport = inner.height as usize;
-  app.config_panel.max_scroll = (lines.len().saturating_sub(viewport)) as u16;
+  f.render_widget(Clear, area);
+  f.render_widget(block, area);
+
+  let header_h = header_lines.len() as u16;
+  let [header_area, body_area, footer_area] =
+    Layout::vertical([Constraint::Length(header_h), Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+  f.render_widget(Paragraph::new(header_lines), header_area);
+
+  // Publish scroll bounds against the BODY viewport only (issue #279).
+  let body_viewport = body_area.height as usize;
+  app.config_panel.max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
   app.config_panel.scroll = app.config_panel.scroll.min(app.config_panel.max_scroll);
-  let viewport_w = inner.width as usize;
-  let content_w = lines.iter().map(Line::width).max().unwrap_or(0);
-  app.config_panel.max_x_scroll = content_w.saturating_sub(viewport_w) as u16;
+  let content_w = body_lines.iter().map(Line::width).max().unwrap_or(0);
+  app.config_panel.max_x_scroll = content_w.saturating_sub(body_area.width as usize) as u16;
   app.config_panel.x_scroll = app.config_panel.x_scroll.min(app.config_panel.max_x_scroll);
   let scroll = app.config_panel.scroll;
   let x_scroll = app.config_panel.x_scroll;
 
-  f.render_widget(Clear, area);
-  f.render_widget(Paragraph::new(lines).block(block).scroll((scroll, x_scroll)), area);
+  let text_area = scrollable_body_area(f, body_area, scroll, body_lines.len(), &app.theme);
+  f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), text_area);
+  f.render_widget(modal_hint_line(&footer_hints, &app.theme), footer_area);
 }
 
 fn draw_create(f: &mut Frame, app: &App) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2391,7 +2391,12 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   f.render_widget(Paragraph::new(lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(
     modal_hint_line(
-      &[("j/k", "scroll"), ("g/G", "top/bottom"), ("Esc", "close")],
+      &[
+        ("j/k", "scroll"),
+        ("g/G", "top/bottom"),
+        ("y", "copy"),
+        ("Esc", "close"),
+      ],
       &app.theme,
     ),
     footer_area,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2539,13 +2539,11 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   let editing = app.config_panel.editing.is_some();
   let selected_kind = app.config_panel.selected_field().map(SettingField::kind);
 
-  // Header: title + the active edit layer as a subtitle + tab strip (fixed).
+  // Header: title + the active edit layer as a subtitle + a blank spacer +
+  // the tab strip (all fixed). The layer-switch key lives in the footer
+  // hints, so the subtitle stays a plain context label.
   let title = Line::from(Span::styled("Settings", heading_style)).centered();
-  let subtitle = Line::from(Span::styled(
-    format!("{}  ·  L to switch layer", app.config_panel.layer.label()),
-    subtitle_style,
-  ))
-  .centered();
+  let subtitle = Line::from(Span::styled(app.config_panel.layer.label(), subtitle_style)).centered();
   let mut tab_spans: Vec<Span<'static>> = vec![Span::raw(" ")];
   for (i, t) in SettingsTab::ALL.iter().enumerate() {
     if i > 0 {
@@ -2554,7 +2552,7 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
     let style = if *t == tab { chip_style(accent) } else { muted_style };
     tab_spans.push(Span::styled(format!(" {} ", t.label()), style));
   }
-  let header_lines = vec![title, subtitle, Line::from(tab_spans)];
+  let header_lines = vec![title, subtitle, Line::from(String::new()), Line::from(tab_spans)];
 
   // Body depends on the active tab.
   let body_lines = match tab {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1385,6 +1385,23 @@ pub fn chip_style(color: Color) -> Style {
     .add_modifier(Modifier::REVERSED | Modifier::BOLD)
 }
 
+/// The hint *bind* style (issue #279): the accent-coloured, **bold** key
+/// glyph that leads every statusbar / modal hint. This replaces the
+/// pre-#279 reverse-video [`chip_style`] badge with a flat herdr-style
+/// "accent bind + space + muted action" treatment — no box around the key.
+/// Action *buttons* (Create / confirm / type selector) and the statusbar
+/// context anchor keep [`chip_style`]; only the which-key hints are flat.
+pub fn hint_key_style(theme: &Theme) -> Style {
+  Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+}
+
+/// The hint *action* style (issue #279): the muted description trailing a
+/// [`hint_key_style`] bind. Routed through the `muted` role so a theme
+/// override recolours it with the rest of the dim chrome.
+pub fn hint_label_style(theme: &Theme) -> Style {
+  Style::default().fg(theme.muted)
+}
+
 /// Style for a *non-highlighted* command name in the command palette
 /// (issue #210 follow-up). Routes through the `name` role (default
 /// `White`) so a `[theme]` override / light preset recolours it, instead
@@ -1687,14 +1704,16 @@ pub fn recent_items_pane_title(mode: SidebarMode, keymap: &Keymap) -> String {
 }
 
 pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
-  let chip_style = chip_style(theme.accent);
-  let label_style = Style::default().fg(theme.muted);
+  let key_style = hint_key_style(theme);
+  let label_style = hint_label_style(theme);
   let mut spans: Vec<Span<'static>> = Vec::new();
   for (i, (key, label)) in hints.iter().enumerate() {
     if i > 0 {
-      spans.push(Span::raw(" "));
+      // Two spaces between hint pairs keep `key action` groups visually
+      // distinct now that the badge box is gone (issue #279).
+      spans.push(Span::raw("  "));
     }
-    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled((*key).to_string(), key_style));
     spans.push(Span::styled(format!(" {}", label), label_style));
   }
   Line::from(spans).centered()
@@ -1732,8 +1751,8 @@ fn push_modal_hint(lines: &mut Vec<Line<'static>>, ctx: HintContext, keymap: &Ke
 /// are measured with `chars().count()` to match the rest of `ui.rs` (keys,
 /// labels and the bracketed status are ASCII / single-width in practice).
 pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &Theme) -> Line<'static> {
-  let chip_style = chip_style(theme.accent);
-  let label_style = Style::default().fg(theme.muted);
+  let key_style = hint_key_style(theme);
+  let label_style = hint_label_style(theme);
   let status_style = Style::default().fg(theme.dirty);
 
   // A zero-width row can hold nothing — return an empty line rather than let
@@ -1764,21 +1783,21 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &T
   let hint_budget = (width - status_w - 1).saturating_sub(1);
 
   let mut spans: Vec<Span<'static>> = Vec::new();
-  let mut used = 0usize; // display columns consumed by hint badges so far
+  let mut used = 0usize; // display columns consumed by hint groups so far
   let mut truncated = false;
   for (i, (key, label)) in hints.iter().enumerate() {
-    let sep = usize::from(i > 0); // single space between badges
-                                  // chip ` key ` (key + 2 pad) + ` label` (label + 1 leading space)
-    let badge_w = key.chars().count() + 2 + 1 + label.chars().count();
+    let sep = if i > 0 { 2 } else { 0 }; // two spaces between hint groups (#279)
+                                         // flat bind `key` + ` label` (label + 1 leading space)
+    let badge_w = key.chars().count() + 1 + label.chars().count();
     if used + sep + badge_w > hint_budget {
       truncated = true;
       break;
     }
-    if sep == 1 {
-      spans.push(Span::raw(" "));
-      used += 1;
+    if sep > 0 {
+      spans.push(Span::raw(" ".repeat(sep)));
+      used += sep;
     }
-    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled((*key).to_string(), key_style));
     spans.push(Span::styled(format!(" {}", label), label_style));
     used += badge_w;
   }
@@ -1824,8 +1843,8 @@ pub fn status_line(
   theme: &Theme,
 ) -> Line<'static> {
   let context_style = chip_style(theme.focus);
-  let chip_style = chip_style(theme.accent);
-  let label_style = Style::default().fg(theme.muted);
+  let key_style = hint_key_style(theme);
+  let label_style = hint_label_style(theme);
   let status_style = Style::default().fg(theme.dirty);
   let spinner_style = Style::default().fg(theme.accent).add_modifier(Modifier::BOLD);
 
@@ -1871,19 +1890,19 @@ pub fn status_line(
   let mut truncated = false;
   let mut hint_used = 0usize;
   for (i, (key, label)) in hints.iter().enumerate() {
-    // A separating space before every badge except the very first one when
-    // there is no left cluster.
-    let sep = usize::from(i > 0 || used > 0);
-    let badge_w = key.chars().count() + 2 + 1 + label.chars().count();
+    // Two spaces between hint groups (#279); a single space after the left
+    // cluster (context chip / spinner) before the first hint.
+    let sep = if i > 0 { 2 } else { usize::from(used > 0) };
+    let badge_w = key.chars().count() + 1 + label.chars().count();
     if hint_used + sep + badge_w > hint_budget {
       truncated = true;
       break;
     }
-    if sep == 1 {
-      spans.push(Span::raw(" "));
-      hint_used += 1;
+    if sep > 0 {
+      spans.push(Span::raw(" ".repeat(sep)));
+      hint_used += sep;
     }
-    spans.push(Span::styled(format!(" {} ", key), chip_style));
+    spans.push(Span::styled((*key).to_string(), key_style));
     spans.push(Span::styled(format!(" {}", label), label_style));
     hint_used += badge_w;
   }

--- a/tests/config_set_at_tests.rs
+++ b/tests/config_set_at_tests.rs
@@ -1,0 +1,80 @@
+//! Layer-aware config writer (`config_cli::set_value_at`) — the persistence
+//! behind the in-TUI Settings panel (issue #279).
+//!
+//! The contract is round-trip THROUGH `Config::load_layered`: a value the
+//! writer sets must come back as the typed Rust value after a real load, so
+//! a serde case-mismatch (e.g. writing `"Left"` when the deserializer wants
+//! `"left"`) shows up as a dead edit here rather than in the TUI. Paths are
+//! injected (tempdirs), never `$HOME`.
+
+use gwm::config::{Config, SidebarPosition, TuiOpenMode};
+use gwm::config_cli::set_value_at;
+use std::path::Path;
+
+fn load(repo: &Path, global: Option<&Path>) -> Config {
+  Config::load_layered(repo, global).expect("config should load")
+}
+
+#[test]
+fn set_value_at_persists_repo_layer_and_round_trips_typed() {
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_value_at(&gwm_toml, "theme.preset", "gruvbox").unwrap();
+  set_value_at(&gwm_toml, "tui.sidebar_position", "left").unwrap();
+
+  let cfg = load(repo.path(), None);
+  assert_eq!(cfg.theme.preset.as_deref(), Some("gruvbox"));
+  assert_eq!(cfg.tui.sidebar_position, SidebarPosition::Left);
+}
+
+#[test]
+fn set_value_at_creates_nested_tables_from_an_empty_file() {
+  // `tui.open.mode` into a fresh file: toml_edit must auto-vivify the
+  // `[tui]` then `[tui.open]` tables, and the value must deserialize as the
+  // typed enum (lowercase serde).
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_value_at(&gwm_toml, "tui.open.mode", "editor").unwrap();
+
+  let cfg = load(repo.path(), None);
+  assert_eq!(cfg.tui.open.mode, TuiOpenMode::Editor);
+}
+
+#[test]
+fn set_value_at_writes_global_layer_and_creates_parent_dir() {
+  // The user-global file lives under a `gwm/` dir that may not exist yet on
+  // first write — the writer must create it. Round-trip through the layered
+  // load with the global injected (repo declares nothing).
+  let repo = tempfile::tempdir().unwrap();
+  let home = tempfile::tempdir().unwrap();
+  // Parent dir intentionally absent until the writer creates it.
+  let global = home.path().join("gwm").join("config.toml");
+  assert!(!global.parent().unwrap().exists());
+
+  set_value_at(&global, "tui.confirm_countdown_secs", "3").unwrap();
+
+  assert!(global.exists(), "writer must create the global file + its parent dir");
+  let cfg = load(repo.path(), Some(&global));
+  assert_eq!(cfg.tui.confirm_countdown_secs, 3);
+}
+
+#[test]
+fn set_value_at_preserves_other_keys_in_the_file() {
+  // Surgical edit: setting one key must not drop unrelated existing keys.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+  std::fs::write(
+    &gwm_toml,
+    "[worktree]\nbase = \"/tmp/keepme\"\n\n[tui]\nconfirm_countdown_secs = 4\n",
+  )
+  .unwrap();
+
+  set_value_at(&gwm_toml, "tui.sidebar_position", "left").unwrap();
+
+  let cfg = load(repo.path(), None);
+  assert_eq!(cfg.tui.sidebar_position, SidebarPosition::Left);
+  assert_eq!(cfg.tui.confirm_countdown_secs, 4, "untouched key must survive");
+  assert_eq!(cfg.worktree.base, "/tmp/keepme", "untouched table must survive");
+}

--- a/tests/config_set_at_tests.rs
+++ b/tests/config_set_at_tests.rs
@@ -8,7 +8,7 @@
 //! injected (tempdirs), never `$HOME`.
 
 use gwm::config::{Config, SidebarPosition, TuiOpenMode};
-use gwm::config_cli::set_value_at;
+use gwm::config_cli::{set_string_at, set_value_at};
 use std::path::Path;
 
 fn load(repo: &Path, global: Option<&Path>) -> Config {
@@ -58,6 +58,45 @@ fn set_value_at_writes_global_layer_and_creates_parent_dir() {
   assert!(global.exists(), "writer must create the global file + its parent dir");
   let cfg = load(repo.path(), Some(&global));
   assert_eq!(cfg.tui.confirm_countdown_secs, 3);
+}
+
+#[test]
+fn set_string_at_preserves_numeric_looking_text_as_a_string() {
+  // Review P2: a free-text value that looks like a scalar (`123`, `true`)
+  // must persist as a TOML string, not be coerced — otherwise a worktree
+  // base / shell command of that form writes an int/bool and breaks the
+  // typed load.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_string_at(&gwm_toml, "worktree.base", "123").unwrap();
+
+  let raw = std::fs::read_to_string(&gwm_toml).unwrap();
+  assert!(
+    raw.contains("base = \"123\""),
+    "value must be quoted as a string: {raw}"
+  );
+  let cfg = load(repo.path(), None);
+  assert_eq!(cfg.worktree.base, "123");
+}
+
+#[test]
+fn an_invalid_write_does_not_clobber_the_existing_file() {
+  // Review P2: validation happens BEFORE the file is written, so an edit
+  // that would produce an invalid Config (here a non-numeric string into a
+  // u32 field) errors and leaves the previous good file untouched.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+  std::fs::write(&gwm_toml, "[tui]\nconfirm_countdown_secs = 4\n").unwrap();
+
+  let result = set_string_at(&gwm_toml, "tui.confirm_countdown_secs", "abc");
+  assert!(result.is_err(), "writing a non-numeric value to a u32 field must fail");
+
+  let cfg = load(repo.path(), None);
+  assert_eq!(
+    cfg.tui.confirm_countdown_secs, 4,
+    "the prior valid file must survive a rejected write"
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4729,6 +4729,27 @@ fn committing_text_input_persists_a_worktree_pattern() {
 }
 
 #[test]
+fn committing_numeric_looking_text_persists_as_a_string() {
+  // Review P2: a Text field whose value looks like a number must round-trip
+  // as a string through the typed load, not be coerced to an int.
+  use gwm::config::Config;
+  use gwm::tui::SettingsTab;
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Worktree;
+  app.config_panel.selected = 0; // base directory (Text input)
+
+  app.activate_selected_setting();
+  app.config_panel.editing = Some("404".into());
+  app.commit_settings_edit();
+
+  assert_eq!(app.config.worktree.base, "404", "live config keeps the text value");
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.worktree.base, "404", "numeric-looking text persisted as a string");
+}
+
+#[test]
 fn command_logs_transcript_is_newest_first_and_empty_when_blank() {
   use gwm::command_log::{CommandLogEntry, CommandStatus};
   use std::time::Duration;

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4729,6 +4729,46 @@ fn committing_text_input_persists_a_worktree_pattern() {
 }
 
 #[test]
+fn command_logs_transcript_is_newest_first_and_empty_when_blank() {
+  use gwm::command_log::{CommandLogEntry, CommandStatus};
+  use std::time::Duration;
+
+  let (_dir, mut app) = make_app();
+  // Empty transcript when nothing has run.
+  assert!(app.command_logs_transcript().is_empty());
+
+  app.command_logs.entries = vec![
+    CommandLogEntry {
+      command: "first cmd".into(),
+      duration: Duration::from_millis(10),
+      status: CommandStatus::Exited(Some(0)),
+      output: "ok".into(),
+    },
+    CommandLogEntry {
+      command: "second cmd".into(),
+      duration: Duration::from_millis(20),
+      status: CommandStatus::Exited(Some(2)),
+      output: "boom".into(),
+    },
+  ];
+  let t = app.command_logs_transcript();
+  assert!(
+    t.contains("$ first cmd") && t.contains("$ second cmd"),
+    "both argv present: {t}"
+  );
+  // Newest-first: the last-pushed entry leads the transcript.
+  assert!(
+    t.find("second cmd").unwrap() < t.find("first cmd").unwrap(),
+    "newest entry must come first: {t}"
+  );
+  assert!(t.contains("→ exit 2"), "non-zero exit is recorded: {t}");
+  assert!(
+    t.contains("boom") && t.contains("ok"),
+    "captured output is included: {t}"
+  );
+}
+
+#[test]
 fn activate_is_a_noop_on_the_read_only_all_tab() {
   use gwm::tui::SettingsTab;
   let (dir, mut app) = make_app();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4703,6 +4703,32 @@ fn committing_numeric_input_persists_the_typed_value() {
 }
 
 #[test]
+fn committing_text_input_persists_a_worktree_pattern() {
+  use gwm::config::Config;
+  use gwm::tui::SettingsTab;
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Worktree;
+  app.config_panel.selected = 0; // base directory (Text input)
+
+  app.activate_selected_setting();
+  assert!(
+    app.config_panel.editing.is_some(),
+    "Enter on a Text field opens the input"
+  );
+  app.config_panel.editing = Some("{home}/custom-wt/{repo}".into());
+  app.commit_settings_edit();
+
+  assert_eq!(
+    app.config.worktree.base, "{home}/custom-wt/{repo}",
+    "live config updated"
+  );
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.worktree.base, "{home}/custom-wt/{repo}", "text value persisted");
+}
+
+#[test]
 fn activate_is_a_noop_on_the_read_only_all_tab() {
   use gwm::tui::SettingsTab;
   let (dir, mut app) = make_app();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4633,3 +4633,85 @@ fn sync_refresh_invalidates_an_inflight_async_refresh() {
     "the dropped result's payload must never reach the list"
   );
 }
+
+// ---------------------------------------------------------------------------
+// Editable Settings panel — apply-live + persistence (issue #279)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn activate_choice_setting_persists_project_layer_and_applies_live() {
+  use gwm::config::{Config, SidebarPosition};
+  use gwm::tui::SettingsTab;
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Tui;
+  app.config_panel.selected = 0; // sidebar position
+  assert_eq!(app.config.tui.sidebar_position, SidebarPosition::Right);
+
+  // Cycle the choice: right → left, written to the project `.gwm.toml` and
+  // applied live.
+  app.activate_selected_setting();
+
+  assert_eq!(
+    app.config.tui.sidebar_position,
+    SidebarPosition::Left,
+    "live config updated"
+  );
+  assert_eq!(
+    app.sidebar.position,
+    SidebarPosition::Left,
+    "live sidebar position re-seeded"
+  );
+
+  let written = std::fs::read_to_string(dir.path().join(".gwm.toml")).unwrap();
+  assert!(
+    written.contains("sidebar_position"),
+    "edit persisted to .gwm.toml: {written}"
+  );
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(
+    cfg.tui.sidebar_position,
+    SidebarPosition::Left,
+    "edit round-trips through a fresh layered load"
+  );
+}
+
+#[test]
+fn committing_numeric_input_persists_the_typed_value() {
+  use gwm::config::Config;
+  use gwm::tui::SettingsTab;
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Tui;
+  app.config_panel.selected = 2; // confirm countdown (Uint input)
+
+  // Arm the input, retype "5", commit.
+  app.activate_selected_setting();
+  assert!(
+    app.config_panel.editing.is_some(),
+    "Enter on a Uint field opens the input"
+  );
+  app.config_panel.editing = Some("5".into());
+  app.commit_settings_edit();
+
+  assert!(app.config_panel.editing.is_none(), "commit closes the input");
+  assert_eq!(app.config.tui.confirm_countdown_secs, 5, "live config updated");
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.confirm_countdown_secs, 5, "typed value persisted");
+}
+
+#[test]
+fn activate_is_a_noop_on_the_read_only_all_tab() {
+  use gwm::tui::SettingsTab;
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::All;
+  app.activate_selected_setting();
+  // Nothing written: the All tab has no editable field.
+  assert!(
+    !dir.path().join(".gwm.toml").exists(),
+    "the read-only All tab must not write anything"
+  );
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -87,21 +87,37 @@ fn status_has_absolute_priority_when_space_is_tiny() {
 }
 
 #[test]
-fn keys_render_as_reverse_video_chips_on_the_accent_colour() {
+fn keys_render_as_accent_bold_binds_not_badges() {
+  // Issue #279: the footer hints drop the reverse-video badge for a
+  // herdr-style "accent bind + muted action" treatment. The key reads in
+  // the accent colour + BOLD with no REVERSED box.
   let line = footer_line(
     HINTS,
     "ready",
     120,
     &Theme {
       accent: Color::Magenta,
+      muted: Color::Gray,
       ..Theme::default()
     },
   );
-  // At least one span is a chip: reverse-video, accent-coloured, carrying a key.
-  let has_chip = line.spans.iter().any(|s| {
-    s.style.add_modifier.contains(Modifier::REVERSED) && s.style.fg == Some(Color::Magenta) && s.content.contains('n')
-  });
-  assert!(has_chip, "no reverse-video accent chip found in footer spans");
+  // A bind span: accent-coloured, bold, NOT reversed, carrying the key.
+  let bind = line
+    .spans
+    .iter()
+    .find(|s| s.style.fg == Some(Color::Magenta) && s.content.as_ref() == "n")
+    .expect("a bare accent 'n' bind span");
+  assert!(
+    bind.style.add_modifier.contains(Modifier::BOLD),
+    "bind is bold: {bind:?}"
+  );
+  assert!(
+    !line
+      .spans
+      .iter()
+      .any(|s| s.style.add_modifier.contains(Modifier::REVERSED)),
+    "no hint span should be a reverse-video badge anymore"
+  );
   // Labels are still present so the row stays self-documenting.
   assert!(plain(&line).contains("new"));
 }
@@ -158,20 +174,23 @@ fn status_line_shows_context_chip_at_the_left() {
     text.trim_start().starts_with("worktrees") || text.contains("worktrees"),
     "context chip missing at the left: {text:?}"
   );
-  // …and it is a reversed accent chip, like the hint badges.
+  // …and the context label stays a reversed focus chip — it's a "where am
+  // I" anchor, not a hint, so it keeps the badge treatment (issue #279).
   let has_ctx_chip = line.spans.iter().any(|s| {
     s.style.add_modifier.contains(Modifier::REVERSED)
       && s.style.fg == Some(Color::Green)
       && s.content.contains("worktrees")
   });
   assert!(has_ctx_chip, "context label is not a reversed focus chip: {text:?}");
+  // Hint binds, by contrast, are now flat accent-bold glyphs (no badge).
   assert!(
-    line
-      .spans
-      .iter()
-      .filter(|s| s.style.add_modifier.contains(Modifier::REVERSED))
-      .any(|s| s.style.fg == Some(Color::Magenta) && s.content.contains(" n ")),
-    "hint key badges should keep the accent colour while context uses focus: {text:?}"
+    line.spans.iter().any(|s| {
+      !s.style.add_modifier.contains(Modifier::REVERSED)
+        && s.style.fg == Some(Color::Magenta)
+        && s.style.add_modifier.contains(Modifier::BOLD)
+        && s.content.as_ref() == "n"
+    }),
+    "hint binds should be flat accent-bold glyphs while context uses a focus chip: {text:?}"
   );
 }
 

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -285,16 +285,17 @@ fn worktrees_and_status_hints_advertise_the_command_logs_key() {
 }
 
 #[test]
-fn worktrees_and_status_hints_advertise_the_config_panel_key() {
-  // Issue #232: the statusbar which-key must advertise `4 config` so the
-  // Configuration panel is discoverable, alongside the `1`/`2`/`3` pane keys.
+fn worktrees_and_status_hints_advertise_the_settings_panel_key() {
+  // Issue #232 / #279: the statusbar which-key must advertise `4 settings`
+  // so the Settings panel is discoverable, alongside the `1`/`2`/`3` pane
+  // keys (renamed from `config` when the panel became editable).
   use gwm::tui::keymap::Keymap;
   let km = Keymap::defaults();
   for ctx in [HintContext::Worktrees, HintContext::Status] {
     let resolved = ctx.resolve(&km);
     assert!(
-      resolved.iter().any(|(k, l)| k == "4" && l == "config"),
-      "context {:?} must advertise the `4 config` hint: {resolved:?}",
+      resolved.iter().any(|(k, l)| k == "4" && l == "settings"),
+      "context {:?} must advertise the `4 settings` hint: {resolved:?}",
       ctx.label()
     );
   }

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -306,6 +306,62 @@ fn command_logs_modal_renders_empty_placeholder() {
 }
 
 #[test]
+fn command_logs_modal_keeps_title_and_footer_fixed_while_body_scrolls() {
+  use gwm::command_log::{CommandLogEntry, CommandStatus};
+  use std::time::Duration;
+
+  // Issue #279: the Command Logs overlay scrolls its body only — title and
+  // footer hint stay pinned. Many entries + a short terminal force overflow;
+  // scrolling to the bottom must keep both on screen.
+  let (_dir, mut app) = make_app();
+  app.command_logs.entries = (0..12)
+    .map(|i| CommandLogEntry {
+      command: format!("command number {i}"),
+      duration: Duration::from_millis(10),
+      status: CommandStatus::Exited(Some(0)),
+      output: "some output".into(),
+    })
+    .collect();
+  app.view = View::CommandLogs;
+  app.command_logs.scroll = u16::MAX; // clamps to the bottom on render
+
+  let backend = TestBackend::new(100, 16);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  let buf = terminal.backend().buffer().clone();
+
+  assert_present(&buf, "Command Logs", "title stays fixed at the top");
+  assert_present(&buf, "scroll", "footer hint stays fixed at the bottom");
+}
+
+#[test]
+fn command_logs_modal_separates_entries_with_a_dashed_rule() {
+  use gwm::command_log::{CommandLogEntry, CommandStatus};
+  use std::time::Duration;
+
+  // Issue #279: adjacent log entries are separated by a full-width `-` rule
+  // (padded by a blank line above and below).
+  let (_dir, mut app) = make_app();
+  app.command_logs.entries = vec![
+    CommandLogEntry {
+      command: "first".into(),
+      duration: Duration::from_millis(1),
+      status: CommandStatus::Exited(Some(0)),
+      output: String::new(),
+    },
+    CommandLogEntry {
+      command: "second".into(),
+      duration: Duration::from_millis(1),
+      status: CommandStatus::Exited(Some(0)),
+      output: String::new(),
+    },
+  ];
+  app.view = View::CommandLogs;
+  let buf = render(&mut app);
+  assert_present(&buf, "----------", "a dashed rule separates the two entries");
+}
+
+#[test]
 fn settings_panel_all_tab_renders_title_section_and_source_column() {
   use gwm::config::{ConfigRow, ConfigSource};
   use gwm::tui::SettingsTab;

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -293,6 +293,8 @@ fn command_logs_modal_renders_title_and_entry_argv() {
   let buf = render(&mut app);
   assert_present(&buf, "Command Logs", "command logs title");
   assert_present(&buf, "gh issue view 226", "logged command argv");
+  // The footer advertises the `y` copy bind (issue #279).
+  assert_present(&buf, "copy", "command logs copy hint");
 }
 
 #[test]

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -347,9 +347,10 @@ fn settings_panel_theme_tab_renders_tabs_layer_and_editable_field() {
   assert_present(&buf, "Settings", "settings panel title");
   // Tab strip.
   assert_present(&buf, "Theme", "Theme tab label");
+  assert_present(&buf, "Worktree", "Worktree tab label");
   assert_present(&buf, "TUI", "TUI tab label");
-  // Layer indicator + the editable field row.
-  assert_present(&buf, "layer", "edit-layer indicator");
+  // Layer is now a subtitle ("… · L to switch layer").
+  assert_present(&buf, "L to switch layer", "edit-layer subtitle");
   assert_present(&buf, "theme preset", "editable theme-preset field label");
 }
 

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -306,8 +306,9 @@ fn command_logs_modal_renders_empty_placeholder() {
 }
 
 #[test]
-fn config_panel_modal_renders_title_section_and_source_column() {
+fn settings_panel_all_tab_renders_title_section_and_source_column() {
   use gwm::config::{ConfigRow, ConfigSource};
+  use gwm::tui::SettingsTab;
 
   let (_dir, mut app) = make_app();
   // Inject rows directly so the render is deterministic (the event loop is
@@ -324,13 +325,32 @@ fn config_panel_modal_renders_title_section_and_source_column() {
       source: ConfigSource::Default,
     },
   ];
+  // The read-only resolved config now lives under the `All` tab.
+  app.config_panel.tab = SettingsTab::All;
   app.view = View::Config;
   let buf = render(&mut app);
-  assert_present(&buf, "Configuration", "config panel title");
+  assert_present(&buf, "Settings", "settings panel title (renamed from Configuration)");
   assert_present(&buf, "[worktree]", "grouped section heading");
   assert_present(&buf, "worktree.base", "resolved config key");
   assert_present(&buf, "repo", "source column marker");
   assert_present(&buf, "default", "default source marker");
+}
+
+#[test]
+fn settings_panel_theme_tab_renders_tabs_layer_and_editable_field() {
+  // Issue #279: the default Theme tab shows the category tab strip, the
+  // edit-layer indicator, and the editable theme-preset field with its
+  // current value.
+  let (_dir, mut app) = make_app();
+  app.view = View::Config;
+  let buf = render(&mut app);
+  assert_present(&buf, "Settings", "settings panel title");
+  // Tab strip.
+  assert_present(&buf, "Theme", "Theme tab label");
+  assert_present(&buf, "TUI", "TUI tab label");
+  // Layer indicator + the editable field row.
+  assert_present(&buf, "layer", "edit-layer indicator");
+  assert_present(&buf, "theme preset", "editable theme-preset field label");
 }
 
 #[test]

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -395,6 +395,42 @@ fn settings_panel_all_tab_renders_title_section_and_source_column() {
 }
 
 #[test]
+fn settings_all_tab_horizontal_pan_reveals_the_last_column_past_the_scrollbar() {
+  use gwm::config::{ConfigRow, ConfigSource};
+  use gwm::tui::SettingsTab;
+
+  // Review P3: when a vertical scrollbar reserves the rightmost column, the
+  // horizontal pan bound must account for the narrower text area so the
+  // final cell of a long line is still reachable. A long first row (ending
+  // in a unique marker) plus many filler rows forces both a vertical
+  // scrollbar and a horizontal overflow.
+  let (_dir, mut app) = make_app();
+  let mut rows = vec![ConfigRow {
+    key: "tui.long".into(),
+    value: format!("{}ZEND", "v".repeat(120)),
+    source: ConfigSource::Repo,
+  }];
+  for i in 0..40 {
+    rows.push(ConfigRow {
+      key: format!("tui.k{i}"),
+      value: "x".into(),
+      source: ConfigSource::Default,
+    });
+  }
+  app.config_panel.rows = rows;
+  app.config_panel.tab = SettingsTab::All;
+  app.view = View::Config;
+  app.config_panel.x_scroll = u16::MAX; // clamps to max_x_scroll on render
+
+  let buf = render(&mut app);
+  assert_present(
+    &buf,
+    "ZEND",
+    "horizontal pan must reveal the final cell even with the scrollbar column reserved",
+  );
+}
+
+#[test]
 fn settings_panel_theme_tab_renders_tabs_layer_and_editable_field() {
   // Issue #279: the default Theme tab shows the category tab strip, the
   // edit-layer indicator, and the editable theme-preset field with its

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -135,6 +135,31 @@ fn help_modal_renders_title_and_close_hint() {
 }
 
 #[test]
+fn help_modal_keeps_title_and_footer_fixed_while_body_scrolls() {
+  // Issue #279: the Keybindings overlay scrolls its BODY only — the title
+  // and the footer hint stay pinned. Render into a short terminal (so the
+  // body definitely overflows), scroll to the bottom, and assert that both
+  // the title and the footer hint are still on screen. Pre-#279 the whole
+  // content scrolled in one Paragraph, so at max scroll the title rolled
+  // off the top — this test would have gone red.
+  let (_dir, mut app) = make_app();
+  app.enter_help();
+  // Drive the scroll cursor past the end; the renderer clamps it to the
+  // body's max-scroll, i.e. "scrolled to the bottom".
+  app.help_scroll = u16::MAX;
+
+  let backend = TestBackend::new(100, 18);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  let buf = terminal.backend().buffer().clone();
+
+  assert_present(&buf, "Keybindings", "help title stays fixed at the top");
+  // The footer advertises the close hint — pinned at the bottom, visible
+  // even at max scroll.
+  assert_present(&buf, "close", "help footer hint stays fixed at the bottom");
+}
+
+#[test]
 fn create_modal_renders_title_fields_and_buttons() {
   let (_dir, mut app) = make_app();
   app.enter_create();

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -405,8 +405,9 @@ fn settings_panel_theme_tab_renders_tabs_layer_and_editable_field() {
   assert_present(&buf, "Theme", "Theme tab label");
   assert_present(&buf, "Worktree", "Worktree tab label");
   assert_present(&buf, "TUI", "TUI tab label");
-  // Layer is now a subtitle ("… · L to switch layer").
-  assert_present(&buf, "L to switch layer", "edit-layer subtitle");
+  // The active layer reads as a plain subtitle (the switch key lives in the
+  // footer hints, not the subtitle).
+  assert_present(&buf, "project (.gwm.toml)", "edit-layer subtitle");
   assert_present(&buf, "theme preset", "editable theme-preset field label");
 }
 

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -6,8 +6,8 @@
 //! the modal paints. Mirrors the Command Logs slice's clamp tests —
 //! ratatui-free, no terminal backend.
 
-use gwm::config::{ConfigRow, ConfigSource};
-use gwm::tui::ConfigPanel;
+use gwm::config::{Config, ConfigRow, ConfigSource};
+use gwm::tui::{ConfigPanel, FieldKind, SettingField, SettingsLayer, SettingsTab};
 
 fn sample_row() -> ConfigRow {
   ConfigRow {
@@ -82,4 +82,199 @@ fn reset_zeroes_the_cursor_but_keeps_rows() {
   assert_eq!(panel.scroll, 0);
   assert_eq!(panel.x_scroll, 0);
   assert_eq!(panel.rows.len(), 1, "reset clears the cursor, not the data");
+}
+
+// ---------------------------------------------------------------------------
+// Editable Settings panel (issue #279): tabs, layer selector, field
+// selection, and the numeric-input edit buffer — all pure state.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_panel_defaults_to_theme_tab_project_layer() {
+  let panel = ConfigPanel::new();
+  assert_eq!(panel.tab, SettingsTab::Theme);
+  assert_eq!(panel.layer, SettingsLayer::Project);
+  assert_eq!(panel.selected, 0);
+  assert!(panel.editing.is_none());
+}
+
+#[test]
+fn next_tab_cycles_theme_tui_all_and_wraps() {
+  let mut panel = ConfigPanel::new();
+  assert_eq!(panel.tab, SettingsTab::Theme);
+  panel.next_tab();
+  assert_eq!(panel.tab, SettingsTab::Tui);
+  panel.next_tab();
+  assert_eq!(panel.tab, SettingsTab::All);
+  panel.next_tab();
+  assert_eq!(panel.tab, SettingsTab::Theme, "wraps back to the first tab");
+}
+
+#[test]
+fn prev_tab_wraps_backwards() {
+  let mut panel = ConfigPanel::new();
+  panel.prev_tab();
+  assert_eq!(panel.tab, SettingsTab::All, "prev from the first tab wraps to the last");
+}
+
+#[test]
+fn switching_tab_resets_selection_and_edit_buffer() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  panel.editing = Some("4".into());
+  panel.next_tab();
+  assert_eq!(panel.selected, 0, "selection resets on tab change");
+  assert!(panel.editing.is_none(), "edit buffer clears on tab change");
+}
+
+#[test]
+fn selected_field_follows_the_tab() {
+  let mut panel = ConfigPanel::new();
+  // Theme tab → theme preset.
+  assert_eq!(panel.selected_field(), Some(SettingField::ThemePreset));
+  // Tui tab → sidebar / open / countdown in order.
+  panel.tab = SettingsTab::Tui;
+  assert_eq!(panel.selected_field(), Some(SettingField::SidebarPosition));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::OpenMode));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::ConfirmCountdown));
+  // All tab is read-only → no editable field.
+  panel.tab = SettingsTab::All;
+  panel.selected = 0;
+  assert_eq!(panel.selected_field(), None);
+}
+
+#[test]
+fn select_next_clamps_to_the_last_field() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui; // 3 fields
+  for _ in 0..10 {
+    panel.select_next();
+  }
+  assert_eq!(panel.selected, 2, "never selects past the last field");
+}
+
+#[test]
+fn toggle_layer_flips_project_and_global_with_matching_source() {
+  let mut panel = ConfigPanel::new();
+  assert_eq!(panel.layer, SettingsLayer::Project);
+  assert_eq!(panel.layer.source(), ConfigSource::Repo);
+  panel.toggle_layer();
+  assert_eq!(panel.layer, SettingsLayer::Global);
+  assert_eq!(panel.layer.source(), ConfigSource::User);
+  panel.toggle_layer();
+  assert_eq!(panel.layer, SettingsLayer::Project);
+}
+
+#[test]
+fn begin_edit_only_arms_for_a_uint_field() {
+  let mut panel = ConfigPanel::new();
+  // Theme preset is a Choice → begin_edit is a no-op.
+  panel.begin_edit("catppuccin");
+  assert!(panel.editing.is_none(), "choice fields are not text-edited");
+  // Confirm countdown is a Uint → arms the buffer.
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  assert_eq!(panel.selected_field().map(SettingField::kind), Some(FieldKind::Uint));
+  panel.begin_edit("4");
+  assert_eq!(panel.editing.as_deref(), Some("4"));
+}
+
+#[test]
+fn edit_buffer_takes_digits_only_and_commits() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  panel.begin_edit("");
+  panel.push_edit_char('3');
+  panel.push_edit_char('x'); // ignored — not a digit
+  panel.push_edit_char('0');
+  assert_eq!(panel.editing.as_deref(), Some("30"));
+  panel.pop_edit_char();
+  assert_eq!(panel.editing.as_deref(), Some("3"));
+  assert_eq!(panel.take_edit().as_deref(), Some("3"));
+  assert!(panel.editing.is_none(), "commit clears the buffer");
+}
+
+#[test]
+fn taking_an_empty_edit_reads_as_zero() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  panel.begin_edit("");
+  assert_eq!(
+    panel.take_edit().as_deref(),
+    Some("0"),
+    "a cleared input is a valid zero"
+  );
+}
+
+#[test]
+fn cancel_edit_discards_the_buffer() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  panel.begin_edit("4");
+  panel.push_edit_char('2');
+  panel.cancel_edit();
+  assert!(panel.editing.is_none());
+}
+
+#[test]
+fn select_is_inert_while_editing() {
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Tui;
+  panel.selected = 2;
+  panel.begin_edit("4");
+  panel.select_prev();
+  assert_eq!(panel.selected, 2, "navigation is suppressed while typing");
+}
+
+#[test]
+fn setting_field_current_reads_the_resolved_config() {
+  let cfg = Config::default();
+  // Defaults: theme preset unset → "default"; sidebar right; open shell.
+  assert_eq!(SettingField::ThemePreset.current(&cfg), "default");
+  assert_eq!(SettingField::SidebarPosition.current(&cfg), "right");
+  assert_eq!(SettingField::OpenMode.current(&cfg), "shell");
+}
+
+#[test]
+fn choice_fields_cycle_and_wrap_uint_fields_do_not() {
+  let cfg = Config::default();
+  // sidebar: right → left.
+  assert_eq!(SettingField::SidebarPosition.next_choice(&cfg).as_deref(), Some("left"));
+  // open mode: shell → editor.
+  assert_eq!(SettingField::OpenMode.next_choice(&cfg).as_deref(), Some("editor"));
+  // theme preset currently "default" (not a choice) → falls back to the first preset.
+  let first = gwm::tui::theme::preset_names()[0];
+  assert_eq!(SettingField::ThemePreset.next_choice(&cfg).as_deref(), Some(first));
+  // confirm countdown is a Uint → no choice cycle.
+  assert_eq!(SettingField::ConfirmCountdown.next_choice(&cfg), None);
+}
+
+#[test]
+fn field_source_is_looked_up_from_the_resolved_rows() {
+  let mut panel = ConfigPanel::new();
+  panel.rows = vec![
+    ConfigRow {
+      key: "tui.sidebar_position".into(),
+      value: "left".into(),
+      source: ConfigSource::Repo,
+    },
+    ConfigRow {
+      key: "theme.preset".into(),
+      value: "\"gruvbox\"".into(),
+      source: ConfigSource::User,
+    },
+  ];
+  assert_eq!(
+    panel.field_source(SettingField::SidebarPosition),
+    Some(ConfigSource::Repo)
+  );
+  assert_eq!(panel.field_source(SettingField::ThemePreset), Some(ConfigSource::User));
+  // A field absent from the rows resolves to no source.
+  assert_eq!(panel.field_source(SettingField::OpenMode), None);
 }

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -99,9 +99,11 @@ fn new_panel_defaults_to_theme_tab_project_layer() {
 }
 
 #[test]
-fn next_tab_cycles_theme_tui_all_and_wraps() {
+fn next_tab_cycles_theme_worktree_tui_all_and_wraps() {
   let mut panel = ConfigPanel::new();
   assert_eq!(panel.tab, SettingsTab::Theme);
+  panel.next_tab();
+  assert_eq!(panel.tab, SettingsTab::Worktree);
   panel.next_tab();
   assert_eq!(panel.tab, SettingsTab::Tui);
   panel.next_tab();
@@ -149,11 +151,11 @@ fn selected_field_follows_the_tab() {
 #[test]
 fn select_next_clamps_to_the_last_field() {
   let mut panel = ConfigPanel::new();
-  panel.tab = SettingsTab::Tui; // 3 fields
+  panel.tab = SettingsTab::Tui; // 5 fields
   for _ in 0..10 {
     panel.select_next();
   }
-  assert_eq!(panel.selected, 2, "never selects past the last field");
+  assert_eq!(panel.selected, 4, "never selects past the last field");
 }
 
 #[test]
@@ -199,16 +201,33 @@ fn edit_buffer_takes_digits_only_and_commits() {
 }
 
 #[test]
-fn taking_an_empty_edit_reads_as_zero() {
+fn take_edit_returns_the_raw_buffer() {
+  // The state layer returns the raw buffer; the App commit path coerces an
+  // empty numeric buffer to "0" (an empty text buffer stays empty).
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
   panel.selected = 2;
   panel.begin_edit("");
   assert_eq!(
     panel.take_edit().as_deref(),
-    Some("0"),
-    "a cleared input is a valid zero"
+    Some(""),
+    "empty buffer round-trips verbatim"
   );
+}
+
+#[test]
+fn text_fields_accept_non_digit_characters() {
+  // Issue #279 follow-up: Worktree patterns are free-text inputs, so the
+  // buffer must take letters / punctuation, not digits only.
+  let mut panel = ConfigPanel::new();
+  panel.tab = SettingsTab::Worktree;
+  panel.selected = 0; // base directory (Text)
+  assert_eq!(panel.selected_field().map(SettingField::kind), Some(FieldKind::Text));
+  panel.begin_edit("");
+  for c in "{home}/wt".chars() {
+    panel.push_edit_char(c);
+  }
+  assert_eq!(panel.editing.as_deref(), Some("{home}/wt"));
 }
 
 #[test]

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -14,8 +14,8 @@ use gwm::tui::{
   status_pane_title, type_selector_line, working_tree_pane_title, worktrees_pane_title,
 };
 use gwm::tui::{
-  confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_section_style,
-  issue_pr_pane_title,
+  confirm_delete_branch_line, confirm_detail_line, delete_worktree_title, help_body_section_color, help_entry_line,
+  help_section_style, issue_pr_pane_title,
 };
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
@@ -58,28 +58,57 @@ fn ellipsize_middle_counts_chars_not_bytes() {
 }
 
 #[test]
-fn badge_group_width_single_chord_is_chord_plus_two_pad() {
-  // ` q ` → 1 + 2.
-  assert_eq!(badge_group_width("q"), 3);
-  // ` Ctrl-C ` → 6 + 2.
-  assert_eq!(badge_group_width("Ctrl-C"), 8);
+fn badge_group_width_single_chord_is_the_bare_chord_width() {
+  // Issue #279: chords are flat accent-bold glyphs now, no `` key `` box —
+  // so a group's width is the bare chord width, not chord + 2 pad.
+  assert_eq!(badge_group_width("q"), 1);
+  assert_eq!(badge_group_width("Ctrl-C"), 6);
 }
 
 #[test]
-fn badge_group_width_splits_comma_chords_into_separate_badges() {
-  // `j, Down` renders as `[ j ] [ Down ]`:
-  //   ` j ` = 3, one separator space, ` Down ` = 6  → 10.
-  assert_eq!(badge_group_width("j, Down"), 3 + 1 + 6);
-  // `g g` is a *single* sequential chord (space inside, no comma) → one
-  // badge ` g g ` = 5.
-  assert_eq!(badge_group_width("g g"), 5);
+fn badge_group_width_splits_comma_chords_with_a_single_space() {
+  // `j, Down` renders as `j Down` (flat): 1 + one separator space + 4 → 6.
+  assert_eq!(badge_group_width("j, Down"), 1 + 1 + 4);
+  // `g g` is a *single* sequential chord (space inside, no comma) → `g g` = 3.
+  assert_eq!(badge_group_width("g g"), 3);
 }
 
 #[test]
-fn badge_group_width_unbound_renders_one_muted_badge() {
-  let expected = "(unbound)".chars().count() + 2;
+fn badge_group_width_unbound_is_the_bare_placeholder_width() {
+  let expected = "(unbound)".chars().count();
   assert_eq!(badge_group_width("(unbound)"), expected);
   assert_eq!(badge_group_width(""), expected);
+}
+
+#[test]
+fn help_entry_line_renders_flat_accent_chords_not_badges() {
+  // Issue #279: the keybindings body drops the reverse-video chord badge
+  // for flat accent-bold glyphs (herdr-style). The label stays readable.
+  let theme = Theme {
+    accent: Color::Magenta,
+    ..Theme::default()
+  };
+  let line = help_entry_line("j, Down", "next", 10, &theme);
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(text.contains("next"), "label missing: {text:?}");
+  // The first chord renders as a bare `j` accent-bold span — no padding box.
+  let chord = line
+    .spans
+    .iter()
+    .find(|s| s.content.as_ref() == "j")
+    .expect("a bare 'j' chord span");
+  assert_eq!(chord.style.fg, Some(Color::Magenta), "chord wears the accent");
+  assert!(
+    chord.style.add_modifier.contains(Modifier::BOLD),
+    "chord is bold: {chord:?}"
+  );
+  assert!(
+    !line
+      .spans
+      .iter()
+      .any(|s| s.style.add_modifier.contains(Modifier::REVERSED)),
+    "no chord span should be a reverse-video badge anymore"
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -224,19 +224,40 @@ fn confirm_buttons_render_as_chips_without_brackets() {
 }
 
 #[test]
-fn modal_hint_line_uses_statusbar_badge_treatment() {
-  let line = modal_hint_line(&[("F", "fetch"), ("Esc", "close")], &Theme::default());
+fn modal_hint_line_renders_accent_bind_then_muted_action() {
+  // Issue #279: hints drop the reverse-video badge for a herdr-style
+  // "accent bind + space + muted action" treatment. The key span carries
+  // the accent colour + BOLD (no REVERSED box); the label reads muted.
+  let theme = Theme {
+    accent: Color::Magenta,
+    muted: Color::Gray,
+    ..Theme::default()
+  };
+  let line = modal_hint_line(&[("F", "fetch"), ("Esc", "close")], &theme);
   let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
   assert!(text.contains("fetch"), "hint label missing: {text:?}");
-  let fetch = line
+  // The bind is the bare key glyph — no surrounding padding box.
+  let key = line
     .spans
     .iter()
-    .find(|s| s.content.contains("F"))
-    .expect("fetch key badge");
+    .find(|s| s.content.as_ref() == "F")
+    .expect("a bare 'F' bind span (no badge padding)");
+  assert_eq!(key.style.fg, Some(Color::Magenta), "bind wears the accent");
   assert!(
-    fetch.style.add_modifier.contains(Modifier::REVERSED),
-    "modal key hints should use statusbar-like badges"
+    key.style.add_modifier.contains(Modifier::BOLD),
+    "bind is bold for emphasis"
   );
+  assert!(
+    !key.style.add_modifier.contains(Modifier::REVERSED),
+    "hints no longer use a reverse-video badge: {key:?}"
+  );
+  // The action reads in the muted role.
+  let label = line
+    .spans
+    .iter()
+    .find(|s| s.content.contains("fetch"))
+    .expect("a fetch label span");
+  assert_eq!(label.style.fg, Some(Color::Gray), "action reads muted");
 }
 
 #[test]


### PR DESCRIPTION
## Description

TUI polish pass integrating herdr's UX while keeping gwm's current design (theme roles, not herdr's palette). Three grouped concerns, atomic commits.

Closes #279

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **Hints without badges** — statusbar + every modal footer drop the reverse-video `chip_style` badge for a flat "accent bind + space + muted action" treatment (`hint_key_style` / `hint_label_style`). Action buttons (Create / confirm / type selector) and the statusbar context anchor keep their chip.
- **Keybindings modal: body-only scroll** — fixed header (title + context subtitle) / scrollable body / fixed footer hint; `help_max_scroll` computed against the body viewport only. Chord entries de-badged via the extracted `help_entry_line`. A herdr-style scrollbar renders when the body overflows.
- **"Configuration" → editable "Settings"** — category tabs (Theme / TUI / All), a per-project ↔ global layer selector (`L`), real toggles/choices (theme preset, sidebar position, open mode) and a numeric input (confirm countdown). Edits persist via the new layer-aware `config_cli::set_value_at` (surgical `toml_edit` write, creates the global file/dir on first use), then reload + re-resolve theme + re-seed sidebar + refresh rows so the change is live. The read-only resolved config moves under the `All` tab. A global edit shadowed by a `.gwm.toml` override is surfaced inline + on the status line, not silently dropped. While a numeric input is armed, keystrokes route to the buffer and only Enter/Esc escape.

## Tests

- [x] `cargo test` passes locally (full suite + minimal-PATH run)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD, red-first where assertion-visible):
  - `config_set_at_tests.rs` — writer round-trip through `Config::load_layered` (typed values, nested-from-empty, global dir creation, key preservation)
  - `tui_state_config_panel_tests.rs` — tabs / layer / field selection / input buffer (pure state)
  - `tui_app_tests.rs` — apply-live: choice cycle + numeric commit persist to `.gwm.toml` and update live state; All tab is a no-op
  - `tui_modal_render_tests.rs` — body-only scroll keeps title+footer pinned; Settings tabs/layer/field render; All-tab rename
  - `tui_footer_tests.rs` / `tui_ui_helpers_tests.rs` — flat accent-bind hint spans (no REVERSED), flat `badge_group_width`

## Screenshots / TUI captures

Verified via `TestBackend` buffer dumps (title/tabs/layer/fields/footer present; scrollbar `█`/`║` visible in the Keybindings body; statusbar hints flat). Not yet captured as a live recording.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a — schema unchanged; writes existing keys)
- [x] No `unwrap()` on user-facing paths (apply-live routes every error to the status line)
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #279
- Reference UX: https://github.com/ogulcancelik/herdr (`src/ui/status.rs`, `src/ui/keybind_help.rs`, `src/ui/settings.rs`)

## Notes for reviewers

- Internal names `View::Config` / `ConfigPanel` are kept; only the user-visible surface is renamed to "Settings" (modal title + `4 settings` hint).
- The layer selector resolves the precedence trap raised in design: writing global for a repo-overridden key still writes (both layers editable) but is flagged as shadowed rather than appearing as a dead edit.
- Theme-preset cycling covers the built-in presets only (no "default"/unset path) — a follow-up could add unset.