### PR TITLE
🐛 fix(config): don't block recovery edits on an already-invalid config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Settings free-text fields (worktree base/patterns, open shell/editor commands) persist as TOML strings, so a value like `123` or `true` is no longer coerced to a number/bool; config writes also validate before touching disk, so a rejected edit can never overwrite a good config file.
+- Settings free-text fields (worktree base/patterns, open shell/editor commands) persist as TOML strings, so a value like `123` or `true` is no longer coerced to a number/bool; config writes also validate before touching disk, so a rejected edit can never overwrite a good config file — while an edit to an already-invalid file is still written (then surfaces the error) so `gwm config set` can recover a broken config rather than refusing every edit.
 - Scrollable modal bodies (Keybindings, Command Logs, Settings) compute the horizontal-pan bound after reserving the scrollbar column, so the final cell of a long line stays reachable.
 - Delete-worktree confirmation no longer blocks the TUI render loop while the removal runs; the async spine drives the deletion and quit waits for it like other mutating tasks.
 - Create-worktree submission no longer blocks the TUI render loop while `worktree::add` and bootstrap run; the Create modal now shows a dedicated loader/failure row and the global statusline spinner stays active until completion.

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -176,13 +176,28 @@ fn load_document(path: &Path) -> Result<DocumentMut> {
 }
 
 fn write_and_validate(path: &Path, doc: &DocumentMut) -> Result<()> {
-  // Validate the rendered document BEFORE touching disk (issue #279 review
-  // P2): a write that would fail `Config` validation must not overwrite the
-  // existing good file and strand the next launch on an invalid config.
   let rendered = doc.to_string();
-  validate_rendered(path, &rendered)?;
-  std::fs::write(path, rendered)?;
-  Ok(())
+  match validate_rendered(path, &rendered) {
+    // The edit is valid — write it.
+    Ok(()) => {
+      std::fs::write(path, rendered)?;
+      Ok(())
+    }
+    // The edit would produce an invalid Config. Only refuse the write when
+    // the existing on-disk file is VALID (or absent) — i.e. this edit would
+    // clobber a good file with a broken one (issue #279 review P2). If the
+    // file is ALREADY invalid, keep the historical write-then-error
+    // behaviour so `gwm config set` can still edit a broken file toward a
+    // fixed state rather than refusing every edit until it is hand-repaired
+    // (issue #281 — the validate-before-write chicken-and-egg).
+    Err(e) => {
+      if validate_file(path).is_ok() {
+        return Err(e);
+      }
+      std::fs::write(path, rendered)?;
+      Err(e)
+    }
+  }
 }
 
 fn validate_file(path: &Path) -> Result<()> {

--- a/tests/config_set_at_tests.rs
+++ b/tests/config_set_at_tests.rs
@@ -100,6 +100,27 @@ fn an_invalid_write_does_not_clobber_the_existing_file() {
 }
 
 #[test]
+fn editing_an_already_invalid_file_still_writes_the_change() {
+  // Issue #281: validate-before-write (review P2) must not block recovery
+  // edits. A pre-existing invalid file (here a non-numeric countdown) plus
+  // an unrelated set still writes the change — the validation error is
+  // surfaced, but the edit is not refused, so `gwm config set` can be used
+  // to nudge a broken config back toward valid.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+  std::fs::write(&gwm_toml, "[tui]\nconfirm_countdown_secs = \"abc\"\n").unwrap();
+
+  let result = set_string_at(&gwm_toml, "theme.preset", "gruvbox");
+  assert!(result.is_err(), "the pre-existing invalid value is still surfaced");
+
+  let raw = std::fs::read_to_string(&gwm_toml).unwrap();
+  assert!(
+    raw.contains("preset = \"gruvbox\""),
+    "the unrelated edit must still be written to an already-invalid file: {raw}"
+  );
+}
+
+#[test]
 fn set_value_at_preserves_other_keys_in_the_file() {
   // Surgical edit: setting one key must not drop unrelated existing keys.
   let repo = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Description

Follow-up to PR #280. The validate-before-write guard (review P2) refused **every** `config set` while the on-disk `.gwm.toml` / global `config.toml` was invalid — a chicken-and-egg that made a broken config unrecoverable via `gwm config set`. Now the write is only refused when it would clobber a **valid** (or absent) file; on an already-invalid file the edit is written and the validation error is still surfaced (historical behaviour).

Closes #281

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `config_cli::write_and_validate`: on validation failure, only return early (no write) when `validate_file(path)` shows the existing file is valid/absent; otherwise write the edit then return the error.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New test: `editing_an_already_invalid_file_still_writes_the_change` (recovery edit lands); the P2 atomicity test (`an_invalid_write_does_not_clobber_the_existing_file`) still passes (valid file not clobbered).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #281
- Follow-up to: #280