### PR TITLE
✨ feat(tui): Issue/PR pastilles, persisted PR detection, pane badges + nerdfont icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TUI now has a reusable dedicated-area `LoaderWidget`; the delete-worktree modal uses it as the first real consumer, showing both in-flight and failed delete states.
 - The sidebar `Working Tree` pane now renders the changed-file count in its bottom-right footer.
 - Project tooling now ships a Flippad-style colored `Makefile` plus Zed tasks for the local Rust workflow (`build`, `test`, `clippy`, `doctor`, `audit`, worktree bootstrap, and related shortcuts).
+- The worktree table renders Issue/PR as two pastilles `●/●` (left = Issue, green when linked; right = PR, violet when linked; white for an empty slot; the main worktree keeps its `★`). The Issue/PR pane now leads each line with a nerdfont dev glyph and badges the link source (` auto ` / ` detected `) and GitHub state (` open ` / ` closed ` / ` draft ` / ` merged `) as version-style reverse-video chips.
 
 ### Changed
 
 - Statusbar and modal which-key hints drop the reverse-video badge for a flat "accent bind + muted action" treatment; action buttons keep their chip style. The Keybindings and Command Logs overlays now scroll their body only, keeping the title and footer hints pinned, with a herdr-style scrollbar. Command Logs separates entries with a full-width dashed rule, uses the flat footer hint, and copies the whole transcript to the clipboard with `y`.
+- An auto-detected PR (`gh pr list --head <branch>`) is now persisted to a dedicated `branch.<name>.gwm-pr-detected` git-config key on the `F` refresh, so the worktree table can colour its PR pastille on every row without a per-row `gh` shell-out. An explicit `gwm link --pr` still wins, and a vanished detection clears the stored key.
 
 ### Fixed
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -145,6 +145,13 @@ pub fn apply_detected_pr(link: &mut BranchLink, detected: Option<u64>) {
 /// echoing a stale stored number (Codex review #284). Only an explicit
 /// `gwm link --pr` short-circuits the probe.
 ///
+/// On a successful probe this also **reconciles the persisted cache**
+/// (`gwm-pr-detected`): it rewrites the stored number to the fresh result,
+/// or clears it when the PR vanished, so the no-fetch consumers (`read_link`,
+/// the TUI table at startup, `gwm open pr`) don't resurrect a stale number
+/// after this path saw it change (Codex review #284). The cache write is
+/// best-effort — a read-only repo must not turn `gwm status` into an error.
+///
 /// Detection is best-effort: a `gh` failure (not installed, no network)
 /// leaves the link untouched — a persisted detection survives the failed
 /// probe rather than being wiped — and the local link is still returned.
@@ -161,6 +168,15 @@ pub fn read_link_with_pr_detection(repo: &Repository, branch: &str, slug: &str) 
       link.pr_source = match detected {
         Some(_) => LinkSource::Detected,
         None => LinkSource::None,
+      };
+      // Reconcile the persisted cache (issue #283 / Codex review #284) so the
+      // no-fetch consumers (`read_link`, the TUI table at startup,
+      // `gwm open pr`) don't resurrect a stale number after this live path
+      // saw it change or vanish. Best-effort: a read-only repo must not turn
+      // `gwm status` into an error, so a write failure is discarded.
+      let _ = match detected {
+        Some(n) => persist_detected_pr(repo, branch, n),
+        None => clear_persisted_detected_pr(repo, branch),
       };
     }
   }

--- a/src/github.rs
+++ b/src/github.rs
@@ -134,20 +134,35 @@ pub fn apply_detected_pr(link: &mut BranchLink, detected: Option<u64>) {
   }
 }
 
-/// Resolve the link for `branch` and, when no PR is explicitly linked,
+/// Resolve the link for `branch` and, unless a PR is *explicitly* linked,
 /// auto-detect the branch's PR from GitHub via `gh` (issue #181). The
-/// detected PR is marked [`LinkSource::Detected`] and is never persisted.
+/// detected PR is marked [`LinkSource::Detected`].
 ///
-/// Detection is best-effort: a `gh` failure (not installed, no network,
-/// no PR for the branch) degrades silently to "no PR" rather than
-/// erroring — the local link is still returned. This shells out, so
-/// callers on hot paths (per-worktree listing) must opt in deliberately
-/// rather than route every read through here.
+/// A persisted auto-detection (`gwm-pr-detected`, issue #283) does NOT pin
+/// the result here: this is the live-detection path (`gwm status` /
+/// `gwm list --detect-pr`), so it re-runs `gh pr list` to reflect a PR that
+/// was opened / closed / replaced since the last detection, rather than
+/// echoing a stale stored number (Codex review #284). Only an explicit
+/// `gwm link --pr` short-circuits the probe.
+///
+/// Detection is best-effort: a `gh` failure (not installed, no network)
+/// leaves the link untouched — a persisted detection survives the failed
+/// probe rather than being wiped — and the local link is still returned.
+/// This shells out, so callers on hot paths (per-worktree listing) must opt
+/// in deliberately rather than route every read through here.
 pub fn read_link_with_pr_detection(repo: &Repository, branch: &str, slug: &str) -> Result<BranchLink> {
   let mut link = read_link(repo, branch)?;
-  if link.pr.is_none() {
-    let detected = find_pr_for_branch(slug, branch).ok().flatten();
-    apply_detected_pr(&mut link, detected);
+  if link.pr_source != LinkSource::Explicit {
+    // Re-resolve live. On success, the fresh result replaces any persisted
+    // detection (a vanished PR clears it); on a `gh` failure, keep whatever
+    // `read_link` already resolved (possibly a persisted detection).
+    if let Ok(detected) = find_pr_for_branch(slug, branch) {
+      link.pr = detected;
+      link.pr_source = match detected {
+        Some(_) => LinkSource::Detected,
+        None => LinkSource::None,
+      };
+    }
   }
   Ok(link)
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -26,6 +26,12 @@ static PR_URL_RE: LazyLock<regex::Regex> =
 
 const ISSUE_CONFIG_KEY: &str = "gwm-issue";
 const PR_CONFIG_KEY: &str = "gwm-pr";
+/// Persisted home of an auto-detected PR (issue #283). Kept distinct from
+/// the explicit [`PR_CONFIG_KEY`] so [`read_link`] can resolve it as
+/// [`LinkSource::Detected`] (not `Explicit`) — the pane needs that
+/// distinction for its `detected` badge, and the explicit override must
+/// still win.
+const DETECTED_PR_CONFIG_KEY: &str = "gwm-pr-detected";
 
 /// Where the issue or PR number came from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,9 +43,10 @@ pub enum LinkSource {
   /// Explicit override set via `gwm link …` (lives in git branch config).
   Explicit,
   /// Auto-detected from GitHub: a PR whose head ref is this branch was
-  /// found via `gh pr list --head <branch>` (issue #181). Ephemeral —
-  /// never written to the git config, so an explicit `gwm link --pr`
-  /// always wins on the next read.
+  /// found via `gh pr list --head <branch>` (issue #181). May be persisted
+  /// to the `gwm-pr-detected` branch-config key (issue #283) so the
+  /// no-fetch table read path surfaces it on every row; an explicit
+  /// `gwm link --pr` still always wins on the next read.
   Detected,
 }
 
@@ -87,9 +94,16 @@ pub fn read_link(repo: &Repository, branch: &str) -> Result<BranchLink> {
     },
   };
 
+  // PR resolution order (issue #283): an explicit `gwm link --pr` wins,
+  // then a persisted auto-detection (`gwm-pr-detected`), then nothing. The
+  // persisted-detected branch is what lets the no-fetch table read path
+  // colour the PR pastille on every row without a per-row `gh` shell-out.
   let (pr, pr_source) = match explicit_pr {
     Some(n) => (Some(n), LinkSource::Explicit),
-    None => (None, LinkSource::None),
+    None => match read_branch_u64(repo, branch, DETECTED_PR_CONFIG_KEY)? {
+      Some(n) => (Some(n), LinkSource::Detected),
+      None => (None, LinkSource::None),
+    },
   };
 
   Ok(BranchLink {
@@ -107,9 +121,10 @@ pub fn read_link(repo: &Repository, branch: &str) -> Result<BranchLink> {
 ///
 /// An explicit (or previously-detected) PR always wins: when `link.pr`
 /// is already `Some`, this is a no-op so a `gwm link --pr` override is
-/// never clobbered. The applied number is marked [`LinkSource::Detected`]
-/// and is *never* persisted to the git config by this function — it lives
-/// only on the in-memory [`BranchLink`].
+/// never clobbered. The applied number is marked [`LinkSource::Detected`].
+/// This function only mutates the in-memory [`BranchLink`]; call
+/// [`persist_detected_pr`] separately to write it to the git config so the
+/// table read path (issue #283) picks it up.
 pub fn apply_detected_pr(link: &mut BranchLink, detected: Option<u64>) {
   if link.pr.is_none() {
     if let Some(n) = detected {
@@ -151,6 +166,24 @@ pub fn unlink_issue(repo: &Repository, branch: &str) -> Result<()> {
 
 pub fn unlink_pr(repo: &Repository, branch: &str) -> Result<()> {
   remove_branch_key(repo, branch, PR_CONFIG_KEY)
+}
+
+/// Persist an auto-detected PR number to its own branch-config key
+/// (`gwm-pr-detected`, issue #283), distinct from the explicit `gwm-pr`.
+/// This lets the no-fetch table read path surface the detected PR on every
+/// row without a per-row `gh` shell-out, while keeping the
+/// detected/explicit distinction the pane badge needs. An explicit
+/// `gwm link --pr` still wins in [`read_link`]. Re-detection overwrites the
+/// stored value.
+pub fn persist_detected_pr(repo: &Repository, branch: &str, number: u64) -> Result<()> {
+  write_branch_u64(repo, branch, DETECTED_PR_CONFIG_KEY, number)
+}
+
+/// Drop a persisted auto-detection (issue #283). A no-op when no detected
+/// PR was stored. Used when a detection no longer holds (the branch's PR
+/// went away) so a stale number doesn't linger in the config.
+pub fn clear_persisted_detected_pr(repo: &Repository, branch: &str) -> Result<()> {
+  remove_branch_key(repo, branch, DETECTED_PR_CONFIG_KEY)
 }
 
 fn config_key(branch: &str, leaf: &str) -> String {

--- a/src/github.rs
+++ b/src/github.rs
@@ -165,7 +165,11 @@ pub fn unlink_issue(repo: &Repository, branch: &str) -> Result<()> {
 }
 
 pub fn unlink_pr(repo: &Repository, branch: &str) -> Result<()> {
-  remove_branch_key(repo, branch, PR_CONFIG_KEY)
+  // Drop both the explicit link and any persisted auto-detection (#283),
+  // otherwise unlinking would leave a stale `gwm-pr-detected` number that
+  // `read_link` would resurface as a `Detected` PR on the next read.
+  remove_branch_key(repo, branch, PR_CONFIG_KEY)?;
+  remove_branch_key(repo, branch, DETECTED_PR_CONFIG_KEY)
 }
 
 /// Persist an auto-detected PR number to its own branch-config key

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2077,6 +2077,26 @@ impl App {
     &self.github.link
   }
 
+  /// Mirror the live resolved `github.link` onto the selected worktree's
+  /// snapshot (issue #283 / Codex review #284). The table renders the PR/
+  /// issue pastilles from `self.worktrees[*].link`, captured at list time,
+  /// so a freshly persisted auto-detection would otherwise stay invisible on
+  /// the selected row until a full relist. Resolves the selection through
+  /// the same filter map as [`Self::selected`].
+  fn sync_selected_link_into_table(&mut self) {
+    let Some(i) = self.list_state.selected() else {
+      return;
+    };
+    let filtered = self.filter.snapshot_indices(&self.worktrees, fuzzy_match_indices);
+    let Some(&original) = filtered.get(i) else {
+      return;
+    };
+    let link = self.github.link.clone();
+    if let Some(w) = self.worktrees.get_mut(original) {
+      w.link = link;
+    }
+  }
+
   pub fn current_slug(&self) -> Option<&str> {
     self.github.link_slug.as_deref()
   }
@@ -2134,17 +2154,37 @@ impl App {
     // only fills an empty slot.
     if self.github.link.pr.is_none() {
       if let (Some(slug), Some(branch)) = (slug.as_deref(), self.selected_branch_name()) {
-        let detected = github::find_pr_for_branch(slug, &branch).ok().flatten();
-        self.github.apply_detected_pr(detected);
-        // Persist the detection (issue #283) so the no-fetch table read
-        // path colours the PR pastille on every row, not just the selected
-        // one. A vanished detection clears the stored key so it can't go
-        // stale. Best-effort: a git-config write failure must not break the
-        // refresh, so the result is intentionally discarded.
-        let _ = match detected {
-          Some(n) => github::persist_detected_pr(&self.repo, &branch, n),
-          None => github::clear_persisted_detected_pr(&self.repo, &branch),
-        };
+        match github::find_pr_for_branch(slug, &branch) {
+          Ok(detected) => {
+            self.github.apply_detected_pr(detected);
+            // Persist the detection (issue #283) so the no-fetch table read
+            // path colours the PR pastille on every row, not just the
+            // selected one. Only a *successful* probe is authoritative:
+            // store a hit, and clear the key only on a proven `Ok(None)`.
+            // Best-effort write — a git-config failure must not break the
+            // refresh, so the result is intentionally discarded.
+            let _ = match detected {
+              Some(n) => github::persist_detected_pr(&self.repo, &branch, n),
+              None => github::clear_persisted_detected_pr(&self.repo, &branch),
+            };
+          }
+          Err(_) => {
+            // The probe failed (gh missing / offline / rate limit). It did
+            // NOT prove the PR vanished, so keep any persisted detection
+            // rather than wiping it (Codex review #284), and restore it into
+            // memory so a failed `F` doesn't blank a still-valid PR.
+            if let Ok(stored) = github::read_link(&self.repo, &branch) {
+              if stored.pr_source == github::LinkSource::Detected {
+                self.github.apply_detected_pr(stored.pr);
+              }
+            }
+          }
+        }
+        // Mirror the resolved link onto the selected row's snapshot so the
+        // table pastille reflects the detection immediately, without waiting
+        // for a separate relist (Codex review #284). The table renders from
+        // `self.worktrees[*].link`, not the live `github.link`.
+        self.sync_selected_link_into_table();
       }
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2143,43 +2143,33 @@ impl App {
   pub fn refresh_github_status(&mut self) {
     let slug = self.github.link_slug.clone();
 
-    // Drop a prior auto-detection so this refresh re-resolves it live
-    // (issue #181): a detected PR must not stick across `F` presses if
-    // the branch's PR changed. Explicit / branch-name links stay pinned.
-    self.github.clear_detected_pr();
-
-    // Auto-detect the selected branch's PR when none is linked (issue
-    // #181). Synchronous (see method doc); needs a remote, so it's a no-op
-    // without a slug. An explicit `gwm link --pr` wins — `apply_detected_pr`
-    // only fills an empty slot.
-    if self.github.link.pr.is_none() {
+    // Re-resolve a non-explicit PR live on `F` (issue #181/#283): only an
+    // explicit `gwm link --pr` pins the PR; a branch-name / none / persisted-
+    // detected (#283) PR is re-probed so a number that changed since the last
+    // detection is refreshed. The in-memory detection is dropped *only* once
+    // we have a fresh successful result (the `Ok` arm), so a refresh that
+    // cannot probe — no origin slug, no resolvable branch, or a failed `gh`
+    // call — keeps the persisted detection visible instead of blanking the
+    // pane/table (Codex review #284). `apply_detected_pr` only fills an empty
+    // slot, hence the clear-then-apply to replace a stale detection.
+    if self.github.link.pr_source != github::LinkSource::Explicit {
       if let (Some(slug), Some(branch)) = (slug.as_deref(), self.selected_branch_name()) {
-        match github::find_pr_for_branch(slug, &branch) {
-          Ok(detected) => {
-            self.github.apply_detected_pr(detected);
-            // Persist the detection (issue #283) so the no-fetch table read
-            // path colours the PR pastille on every row, not just the
-            // selected one. Only a *successful* probe is authoritative:
-            // store a hit, and clear the key only on a proven `Ok(None)`.
-            // Best-effort write — a git-config failure must not break the
-            // refresh, so the result is intentionally discarded.
-            let _ = match detected {
-              Some(n) => github::persist_detected_pr(&self.repo, &branch, n),
-              None => github::clear_persisted_detected_pr(&self.repo, &branch),
-            };
-          }
-          Err(_) => {
-            // The probe failed (gh missing / offline / rate limit). It did
-            // NOT prove the PR vanished, so keep any persisted detection
-            // rather than wiping it (Codex review #284), and restore it into
-            // memory so a failed `F` doesn't blank a still-valid PR.
-            if let Ok(stored) = github::read_link(&self.repo, &branch) {
-              if stored.pr_source == github::LinkSource::Detected {
-                self.github.apply_detected_pr(stored.pr);
-              }
-            }
-          }
+        if let Ok(detected) = github::find_pr_for_branch(slug, &branch) {
+          self.github.clear_detected_pr();
+          self.github.apply_detected_pr(detected);
+          // Persist the detection (issue #283) so the no-fetch table read
+          // path colours the PR pastille on every row, not just the selected
+          // one. Only a successful probe is authoritative: store a hit, clear
+          // the key on a proven `Ok(None)`. Best-effort write — a git-config
+          // failure must not break the refresh, so the result is discarded.
+          let _ = match detected {
+            Some(n) => github::persist_detected_pr(&self.repo, &branch, n),
+            None => github::clear_persisted_detected_pr(&self.repo, &branch),
+          };
         }
+        // On a `gh` failure (Err) nothing was cleared, so the link keeps
+        // whatever `read_link` resolved (possibly a persisted detection).
+        //
         // Mirror the resolved link onto the selected row's snapshot so the
         // table pastille reflects the detection immediately, without waiting
         // for a separate relist (Codex review #284). The table renders from

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2136,6 +2136,15 @@ impl App {
       if let (Some(slug), Some(branch)) = (slug.as_deref(), self.selected_branch_name()) {
         let detected = github::find_pr_for_branch(slug, &branch).ok().flatten();
         self.github.apply_detected_pr(detected);
+        // Persist the detection (issue #283) so the no-fetch table read
+        // path colours the PR pastille on every row, not just the selected
+        // one. A vanished detection clears the stored key so it can't go
+        // stale. Best-effort: a git-config write failure must not break the
+        // refresh, so the result is intentionally discarded.
+        let _ = match detected {
+          Some(n) => github::persist_detected_pr(&self.repo, &branch, n),
+          None => github::clear_persisted_detected_pr(&self.repo, &branch),
+        };
       }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -65,7 +65,7 @@ pub use ui::{
   pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, status_line, status_pane_title,
   table_marker, tilde_compress_with_home, type_selector_line, working_tree_pane_title, working_tree_status_line,
   worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  COMMIT_HASH_DISPLAY_LEN, RECENT_COMMITS_LIMIT,
+  COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -178,7 +178,10 @@ impl GitHubFetch {
   /// here so the sidebar's `pr_fetch_state()` can resolve it. Delegates
   /// to [`github::apply_detected_pr`], so an explicit `gwm link --pr`
   /// (already on `link.pr`) always wins and the result is marked
-  /// `LinkSource::Detected` — never persisted.
+  /// `LinkSource::Detected`. This only mutates in-memory state; the `App`
+  /// separately persists the detection via
+  /// [`github::persist_detected_pr`] (issue #283) so the table read path
+  /// picks it up.
   pub fn apply_detected_pr(&mut self, detected: Option<u64>) {
     github::apply_detected_pr(&mut self.link, detected);
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3514,12 +3514,36 @@ pub fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   lines
 }
 
-fn source_marker(s: LinkSource) -> &'static str {
+/// Nerdfont glyph leading the pane's Issue line (issue #283):
+/// `nf-oct-issue_opened`.
+pub const ISSUE_ICON: &str = "\u{f41b}";
+/// Nerdfont glyph leading the pane's PR line (issue #283):
+/// `nf-oct-git_pull_request`.
+pub const PR_ICON: &str = "\u{f407}";
+
+/// The pane's source chip (issue #283): `auto` for a branch-name inference,
+/// `detected` for a live GitHub match. Explicit / none carry no chip — the
+/// number already speaks for an explicit link. Rendered version-badge style
+/// (reverse-video [`chip_style`]); `auto` stays muted, `detected` takes the
+/// accent so a freshly-found PR draws the eye.
+fn source_chip(s: LinkSource, theme: &Theme) -> Option<(&'static str, Color)> {
   match s {
-    LinkSource::None => "",
-    LinkSource::BranchName => " (auto)",
-    LinkSource::Explicit => "",
-    LinkSource::Detected => " (detected)",
+    LinkSource::BranchName => Some(("auto", theme.muted)),
+    LinkSource::Detected => Some(("detected", theme.accent)),
+    LinkSource::Explicit | LinkSource::None => None,
+  }
+}
+
+/// Collapse a multi-span line into a single truncated plain span when the
+/// styled spans together overflow `max_width`. Used by the pane's narrow
+/// fallback so the icon + chips never push the line past the block border
+/// (issue #283). Width is counted in display columns (`chars().count()`),
+/// matching the budget arithmetic in [`summary_line`].
+fn flatten_if_overflow(spans: &mut Vec<Span<'static>>, max_width: usize) {
+  let w: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+  if w > max_width {
+    let raw: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    *spans = vec![Span::raw(trunc(&raw, max_width))];
   }
 }
 
@@ -3555,28 +3579,67 @@ enum SummaryState<'a> {
   Error(&'a str),
 }
 
-/// Shared renderer behind [`issue_summary_line`] and [`pr_summary_line`].
-/// Both twins resolve their `head` ("Issue #…" vs "PR    #…"), badge, and
-/// `trailing` segment, then delegate here so the truncation budget, the
-/// narrow-fallback flatten, and the Idle/Loading/Error arms live in one
-/// place. The `trailing` param is what keeps the two byte-identical: issue
-/// passes "" → renders `] title`; PR passes ` · checks 1/2` → renders
-/// `]· checks 1/2 title`, exactly as the inlined versions did.
+/// Shared renderer behind [`issue_summary_line`] and [`pr_summary_line`]
+/// (issue #283). Both twins pass their leading nerdfont `icon`, their `head`
+/// identity ("Issue #…" / "PR    #…"), the link `source`, and — for `Loaded`
+/// — a state `badge` + optional `trailing` segment. Every line leads with
+/// `<icon> <head>`, then an optional version-badge-style source chip
+/// (`auto` / `detected`), then the state-specific tail.
+///
+/// `trailing` keeps the two twins identical past the badge: issue passes ""
+/// → renders ` badge  title`; PR passes ` · checks 1/2` → renders
+/// ` badge · checks 1/2 title`. Widths are counted in display columns (the
+/// `·` is U+00B7: 1 column) so the budget arithmetic holds.
 fn summary_line(
+  icon: &str,
   head: String,
+  source: LinkSource,
   state: SummaryState,
   max_width: usize,
   theme: &Theme,
   spinner: Option<&str>,
 ) -> Line<'static> {
-  // The `head` carries no status signal, only identity — it paints with
-  // the `name` role (issue #210; default `White`) while the badge colour
-  // tracks the GitHub state.
+  // `<icon> <head>` plus an optional source chip are common to every state.
+  // `prefix_w` tracks the visible width so the variable tail (title / error
+  // blob) can be trimmed to fit `max_width`.
+  let icon_seg = format!("{} ", icon); // glyph + space
+  let chip = source_chip(source, theme);
+  // Source chip segment = " " + " <label> " (a leading gap + the padded chip).
+  let source_seg_w = chip.map(|(l, _)| 1 + l.chars().count() + 2).unwrap_or(0);
+  let prefix_w = icon_seg.chars().count() + head.chars().count() + source_seg_w;
+
+  // The `head` carries no status signal, only identity — it paints with the
+  // `name` role (issue #210); the icon stays muted and the chips carry the
+  // state/source colour.
+  let build_prefix = |head_bold: bool| -> Vec<Span<'static>> {
+    let head_style = if head_bold {
+      Style::default().fg(theme.name).add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(theme.name)
+    };
+    let mut spans = vec![
+      Span::styled(icon_seg.clone(), Style::default().fg(theme.muted)),
+      Span::styled(head.clone(), head_style),
+    ];
+    if let Some((label, color)) = chip {
+      spans.push(Span::raw(" "));
+      spans.push(Span::styled(format!(" {} ", label), chip_style(color)));
+    }
+    spans
+  };
+
   match state {
-    SummaryState::Idle => Line::from(Span::styled(trunc(&head, max_width), Style::default().fg(theme.name))),
+    SummaryState::Idle => {
+      let mut spans = build_prefix(false);
+      flatten_if_overflow(&mut spans, max_width);
+      Line::from(spans)
+    }
     SummaryState::Loading => {
       let glyph = spinner.unwrap_or("…");
-      Line::from(trunc(&format!("{} {} loading", head, glyph), max_width))
+      let mut spans = build_prefix(false);
+      spans.push(Span::raw(format!(" {} loading", glyph)));
+      flatten_if_overflow(&mut spans, max_width);
+      Line::from(spans)
     }
     SummaryState::Loaded {
       badge,
@@ -3584,41 +3647,39 @@ fn summary_line(
       trailing,
       title,
     } => {
-      // Fixed prefix = "<head> [<badge>]<trailing> " — try to preserve in
-      // full and trim the title to whatever budget remains. If the prefix
-      // alone already exceeds the width budget (very narrow sidebar), fall
-      // back to flattening the line into a single styled string and
-      // truncating it — preserves no badge color but stays inside the
-      // block. `trailing` is empty for issues and ` · checks N/M` for PRs;
-      // count chars (the `·` is U+00B7: 2 bytes, 1 column) so the budget
-      // arithmetic matches the pre-dedup twins exactly.
-      let fixed = head.chars().count() + 3 + badge.chars().count() + trailing.chars().count() + 1; // " [" + badge + "]" + trailing + " "
+      // Tail fixed cost past the prefix = " " + " <badge> " + trailing + " ".
+      let badge_seg_w = 1 + badge.chars().count() + 2;
+      let fixed = prefix_w + badge_seg_w + trailing.chars().count() + 1;
       if fixed >= max_width {
-        let raw = format!("{} [{}]{} {}", head, badge, trailing, title);
-        return Line::from(trunc(&raw, max_width));
+        // Very narrow pane: keep the prefix + badge, drop the title, and
+        // flatten to fit rather than overflow the block border.
+        let mut spans = build_prefix(true);
+        spans.push(Span::raw(" "));
+        spans.push(Span::raw(format!(" {} ", badge)));
+        spans.push(Span::raw(trailing));
+        flatten_if_overflow(&mut spans, max_width);
+        return Line::from(spans);
       }
       let budget = max_width - fixed;
-      Line::from(vec![
-        Span::styled(head, Style::default().fg(theme.name).add_modifier(Modifier::BOLD)),
-        Span::raw(" ["),
-        Span::styled(
-          badge.to_string(),
-          Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("]"),
-        Span::raw(trailing),
-        Span::raw(" "),
-        Span::raw(trunc(title, budget)),
-      ])
+      let mut spans = build_prefix(true);
+      spans.push(Span::raw(" "));
+      spans.push(Span::styled(format!(" {} ", badge), chip_style(badge_color)));
+      spans.push(Span::raw(trailing));
+      spans.push(Span::raw(" "));
+      spans.push(Span::raw(trunc(title, budget)));
+      Line::from(spans)
     }
     SummaryState::Error(e) => {
-      let fixed = head.chars().count() + 2; // " " + "!"
+      let fixed = prefix_w + 2; // " " + "!"
       let budget = max_width.saturating_sub(fixed);
-      Line::from(vec![
-        Span::styled(head, Style::default().fg(theme.name)),
-        Span::raw(" "),
-        Span::styled(format!("!{}", trunc(e, budget)), Style::default().fg(theme.prunable)),
-      ])
+      let mut spans = build_prefix(false);
+      spans.push(Span::raw(" "));
+      spans.push(Span::styled(
+        format!("!{}", trunc(e, budget)),
+        Style::default().fg(theme.prunable),
+      ));
+      flatten_if_overflow(&mut spans, max_width);
+      Line::from(spans)
     }
   }
 }
@@ -3631,7 +3692,7 @@ fn issue_summary_line_with_spinner(
   theme: &Theme,
   spinner: Option<&str>,
 ) -> Line<'static> {
-  let head = format!("Issue #{}{}", n, source_marker(src));
+  let head = format!("Issue #{}", n);
   let resolved = match state {
     GitHubFetchState::Idle => SummaryState::Idle,
     GitHubFetchState::Loading => SummaryState::Loading,
@@ -3654,7 +3715,7 @@ fn issue_summary_line_with_spinner(
     }
     GitHubFetchState::Error(e) => SummaryState::Error(e),
   };
-  summary_line(head, resolved, max_width, theme, spinner)
+  summary_line(ISSUE_ICON, head, src, resolved, max_width, theme, spinner)
 }
 
 /// Render the Loaded / Idle / Loading / Error variants for a PR link
@@ -3679,7 +3740,7 @@ fn pr_summary_line_with_spinner(
   theme: &Theme,
   spinner: Option<&str>,
 ) -> Line<'static> {
-  let head = format!("PR    #{}{}", n, source_marker(src));
+  let head = format!("PR    #{}", n);
   let resolved = match state {
     GitHubFetchState::Idle => SummaryState::Idle,
     GitHubFetchState::Loading => SummaryState::Loading,
@@ -3709,7 +3770,7 @@ fn pr_summary_line_with_spinner(
     }
     GitHubFetchState::Error(e) => SummaryState::Error(e),
   };
-  summary_line(head, resolved, max_width, theme, spinner)
+  summary_line(PR_ICON, head, src, resolved, max_width, theme, spinner)
 }
 
 // ---- Issue #73: lazygit-style colour helpers -------------------------------
@@ -3805,7 +3866,11 @@ pub fn table_marker(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
   // An empty slot stays `name`-white so "no link" reads as a neutral
   // placeholder rather than borrowing a status colour that would claim the
   // row. A linked slot takes its accent: issue → `clean`, PR → `locked`.
-  let issue_color = if w.link.issue.is_some() { theme.clean } else { theme.name };
+  let issue_color = if w.link.issue.is_some() {
+    theme.clean
+  } else {
+    theme.name
+  };
   let pr_color = if w.link.pr.is_some() { theme.locked } else { theme.name };
   Line::from(vec![
     Span::styled("●", Style::default().fg(issue_color)),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -474,8 +474,8 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   // column rock-stable at 4 cells (the cost of losing the unit
   // letter to truncation — "22h" → "22" — is worse than name/branch
   // shrinking by a char or two). Strategy:
-  //   - `Length(4)` for age, `Length(2)` for marker, `Length(16)` for
-  //     status: hard-fixed lengths the solver must honour.
+  //   - `Length(4)` for age, `Length(3)` for marker (`●/●`), `Length(16)`
+  //     for status: hard-fixed lengths the solver must honour.
   //   - `Min(name_w)` / `Min(branch_w)`: these absorb the pressure
   //     when the terminal is narrow (they shrink down to 8) and grow
   //     to the original clamped width (or more) when there's room.
@@ -484,7 +484,7 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   // stays at 4 cells across every size.
   let widths = [
     Constraint::Length(4),
-    Constraint::Length(2),
+    Constraint::Length(3),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
@@ -1426,7 +1426,7 @@ pub fn help_label_style(theme: &Theme) -> Style {
 }
 
 fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16, theme: &Theme) -> Row<'static> {
-  let (marker_label, marker_color) = table_marker(w, theme);
+  let marker = table_marker(w, theme);
   let branch_text = w.branch.clone().unwrap_or_else(|| "-".into());
 
   // The worktree name is the row's primary identity text. It paints with
@@ -1458,7 +1458,7 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16, theme:
 
   Row::new(vec![
     age_cell,
-    Cell::from(marker_label).style(Style::default().fg(marker_color)),
+    Cell::from(marker),
     name_cell,
     branch_cell,
     status_cell,
@@ -3784,24 +3784,32 @@ pub fn issue_badge_color(state: IssueState, theme: &Theme) -> Color {
   }
 }
 
-/// Pick the marker glyph + colour for the table's first column. `★`
-/// for the main worktree (preserves the pre-#73 convention), `●` for
-/// any other worktree that carries an issue or PR link, blank space
-/// otherwise so unlinked rows don't read as "claimed". Colour stays
-/// neutral (Cyan) — the live PR / issue state isn't known at the
-/// table layer (only the selected worktree triggers a fetch), so the
-/// table dot signals "has link" rather than a specific status. The
-/// colour-coded `●` lives in the sidebar header where the fetch state
-/// is available.
-pub fn table_marker(w: &WorktreeInfo, theme: &Theme) -> (&'static str, Color) {
+/// Build the table's first-column marker (issue #283). The main worktree
+/// keeps its single `★` (painted with the `main` role, preserving the
+/// pre-#73 convention). Every other row renders two pastilles `●/●`:
+///
+/// - left = **Issue** — `clean` green when an issue is linked, else white.
+/// - right = **PR** — `locked` violet when a PR is linked, else white.
+/// - a `muted` `/` separates them.
+///
+/// The table is the no-fetch read path (only the selected worktree triggers
+/// a `gh` fetch), so the pastille colour signals link **presence / type**,
+/// not live open/closed state — that coloured-by-status dot lives in the
+/// sidebar header where the fetch result is known. A detected PR shows here
+/// on every row only because it is persisted to `gwm-pr-detected` (#283) and
+/// read back by [`crate::github::read_link`].
+pub fn table_marker(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
   if w.is_main {
-    return ("★", theme.main);
+    return Line::from(Span::styled("★", Style::default().fg(theme.main)));
   }
-  if w.link.issue.is_some() || w.link.pr.is_some() {
-    return ("●", theme.accent);
-  }
-  // No semantic role: an unlinked, non-main row carries no signal, so
-  // it stays on the terminal default rather than borrowing a theme
-  // colour that would read as "claimed".
-  (" ", Color::Reset)
+  // An empty slot stays `name`-white so "no link" reads as a neutral
+  // placeholder rather than borrowing a status colour that would claim the
+  // row. A linked slot takes its accent: issue → `clean`, PR → `locked`.
+  let issue_color = if w.link.issue.is_some() { theme.clean } else { theme.name };
+  let pr_color = if w.link.pr.is_some() { theme.locked } else { theme.name };
+  Line::from(vec![
+    Span::styled("●", Style::default().fg(issue_color)),
+    Span::styled("/", Style::default().fg(theme.muted)),
+    Span::styled("●", Style::default().fg(pr_color)),
+  ])
 }

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -147,6 +147,22 @@ fn persist_detected_pr_overwrites_a_previous_detection() {
 }
 
 #[test]
+fn unlink_pr_also_clears_a_persisted_detection() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  // A persisted detection plus an explicit link, then unlink: unlinking a PR
+  // must not resurface a stale auto-detection from the detected key.
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 77).unwrap();
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  github::unlink_pr(&repo, "feat/#42-tui-search").unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.pr, None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
+#[test]
 fn clear_persisted_detected_pr_removes_the_detected_link() {
   let (_dir, repo) = init_repo();
   make_branch(&repo, "feat/#42-tui-search");

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -100,6 +100,65 @@ fn unlink_pr_clears_the_pr_link_only() {
   assert_eq!(link.pr, None);
 }
 
+// --- Persisted PR detection (issue #283) ---------------------------------
+
+#[test]
+fn persist_detected_pr_is_read_back_as_detected_source() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  // The detected PR lives in its own key so the no-fetch table read path
+  // can surface it on every row while staying distinguishable from an
+  // explicit link.
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 77).unwrap();
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+
+  assert_eq!(link.pr, Some(77));
+  assert_eq!(link.pr_source, LinkSource::Detected);
+}
+
+#[test]
+fn explicit_pr_overrides_persisted_detected_pr() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  // Both keys set: the explicit `gwm link --pr` must win, and its source
+  // must read back as Explicit (not Detected) so the pane badge is right.
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 77).unwrap();
+  github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.pr, Some(61));
+  assert_eq!(link.pr_source, LinkSource::Explicit);
+}
+
+#[test]
+fn persist_detected_pr_overwrites_a_previous_detection() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  // Re-detection (the branch's PR changed) refreshes the stored value.
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 77).unwrap();
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 88).unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.pr, Some(88));
+  assert_eq!(link.pr_source, LinkSource::Detected);
+}
+
+#[test]
+fn clear_persisted_detected_pr_removes_the_detected_link() {
+  let (_dir, repo) = init_repo();
+  make_branch(&repo, "feat/#42-tui-search");
+
+  github::persist_detected_pr(&repo, "feat/#42-tui-search", 77).unwrap();
+  github::clear_persisted_detected_pr(&repo, "feat/#42-tui-search").unwrap();
+
+  let link = github::read_link(&repo, "feat/#42-tui-search").unwrap();
+  assert_eq!(link.pr, None);
+  assert_eq!(link.pr_source, LinkSource::None);
+}
+
 // --- Repo-slug extraction ------------------------------------------------
 
 fn set_origin(repo: &git2::Repository, url: &str) {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2055,6 +2055,67 @@ fn refresh_keeps_persisted_pr_when_gh_detection_fails() {
   );
 }
 
+#[cfg(unix)]
+#[test]
+fn read_link_with_pr_detection_refreshes_a_persisted_detection() {
+  use std::os::unix::fs::PermissionsExt;
+
+  // Codex review #284: a persisted detection (#283) must NOT make the live
+  // CLI detection path (`gwm status` / `gwm list --detect-pr`) authoritative.
+  // It must still re-run `gh pr list` so a PR that was replaced since the
+  // last TUI `F` is reflected — only an explicit `gwm link --pr` pins it.
+  let (dir, repo) = init_repo();
+  {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("detect-me", &head, false).unwrap();
+  }
+
+  // Stale persisted detection: #128.
+  gwm::github::persist_detected_pr(&repo, "detect-me", 128).unwrap();
+
+  // Live `gh` now reports #200 for the branch.
+  let gh = dir.path().join("fake-gh-200");
+  std::fs::write(
+    &gh,
+    "#!/bin/sh\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
+       printf '%s' '[{\"number\":200}]'\n\
+     fi\n",
+  )
+  .unwrap();
+  let mut perms = std::fs::metadata(&gh).unwrap().permissions();
+  perms.set_mode(0o755);
+  std::fs::set_permissions(&gh, perms).unwrap();
+
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+  let prior = std::env::var("GWM_GH").ok();
+  // SAFETY: env mutation guarded by `env_lock()`; GWM_GH restored below.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh);
+  }
+  let link = gwm::github::read_link_with_pr_detection(&repo, "detect-me", "kbrdn1/gwm-cli").unwrap();
+
+  // Explicit override still wins even over a live re-detection.
+  gwm::github::link_pr(&repo, "detect-me", 61).unwrap();
+  let explicit = gwm::github::read_link_with_pr_detection(&repo, "detect-me", "kbrdn1/gwm-cli").unwrap();
+
+  unsafe {
+    match prior {
+      Some(v) => std::env::set_var("GWM_GH", v),
+      None => std::env::remove_var("GWM_GH"),
+    }
+  }
+
+  assert_eq!(
+    link.pr,
+    Some(200),
+    "live detection must override the stale persisted #128"
+  );
+  assert_eq!(link.pr_source, LinkSource::Detected);
+  assert_eq!(explicit.pr, Some(61), "an explicit link still wins over live detection");
+  assert_eq!(explicit.pr_source, LinkSource::Explicit);
+}
+
 // ---- Configurable launchers (issue #75) --------------------------------
 //
 // The `R` key in the worktree-list view now triggers the [review]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2973,6 +2973,141 @@ fn issue_summary_line_truncates_error_state_to_budget() {
   assert!(width <= 30, "error line must fit in 30 cols, got {}", width);
 }
 
+// ---- Issue #283: pane icons + source / state chips ----------------------
+
+fn span_with<'a>(line: &'a ratatui::text::Line<'a>, needle: &str) -> Option<&'a ratatui::text::Span<'a>> {
+  line.spans.iter().find(|s| s.content.contains(needle))
+}
+
+#[test]
+fn issue_summary_line_leads_with_the_issue_icon() {
+  let line = issue_summary_line(
+    7,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Idle,
+    80,
+    &Theme::default(),
+  );
+  assert!(
+    line.spans[0].content.contains(gwm::tui::ISSUE_ICON),
+    "issue pane line must lead with the issue nerdfont glyph: {:?}",
+    line.spans[0].content
+  );
+}
+
+#[test]
+fn pr_summary_line_leads_with_the_pr_icon() {
+  let status = gwm::github::PrStatus {
+    number: 9,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    updated_at: String::new(),
+  };
+  let line = pr_summary_line(
+    9,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Loaded(status),
+    80,
+    &Theme::default(),
+  );
+  assert!(
+    line.spans[0].content.contains(gwm::tui::PR_ICON),
+    "pr pane line must lead with the pr nerdfont glyph: {:?}",
+    line.spans[0].content
+  );
+}
+
+#[test]
+fn pr_summary_line_renders_detected_source_as_a_reverse_video_chip() {
+  use ratatui::style::Modifier;
+  let status = gwm::github::PrStatus {
+    number: 9,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    updated_at: String::new(),
+  };
+  let line = pr_summary_line(
+    9,
+    gwm::github::LinkSource::Detected,
+    &GitHubFetchState::Loaded(status),
+    80,
+    &Theme::default(),
+  );
+  let chip = span_with(&line, "detected").expect("a 'detected' source chip span");
+  assert!(
+    chip.style.add_modifier.contains(Modifier::REVERSED),
+    "the source chip must use the version-badge reverse-video treatment"
+  );
+}
+
+#[test]
+fn issue_summary_line_renders_auto_source_as_a_reverse_video_chip() {
+  use ratatui::style::Modifier;
+  let line = issue_summary_line(
+    7,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Idle,
+    80,
+    &Theme::default(),
+  );
+  let chip = span_with(&line, "auto").expect("an 'auto' source chip span");
+  assert!(
+    chip.style.add_modifier.contains(Modifier::REVERSED),
+    "the source chip must use the version-badge reverse-video treatment"
+  );
+}
+
+#[test]
+fn explicit_link_renders_no_source_chip() {
+  let line = issue_summary_line(
+    7,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Idle,
+    80,
+    &Theme::default(),
+  );
+  let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    !text.contains("auto"),
+    "explicit link must not show an auto chip: {text}"
+  );
+  assert!(
+    !text.contains("detected"),
+    "explicit link must not show a detected chip: {text}"
+  );
+}
+
+#[test]
+fn issue_summary_line_state_badge_is_a_reverse_video_chip() {
+  use ratatui::style::Modifier;
+  let status = gwm::github::IssueStatus {
+    number: 7,
+    title: "x".into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+  };
+  let line = issue_summary_line(
+    7,
+    gwm::github::LinkSource::Explicit,
+    &GitHubFetchState::Loaded(status),
+    80,
+    &Theme::default(),
+  );
+  let chip = span_with(&line, "open").expect("an 'open' state chip span");
+  assert!(
+    chip.style.add_modifier.contains(Modifier::REVERSED),
+    "the state badge must use the version-badge reverse-video treatment"
+  );
+}
+
 // ---- Recent Commits panel: lazygit-style fill + clip (issue #71) ---------
 
 use gwm::tui::{recent_commits_lines, RECENT_COMMITS_LIMIT};

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1937,6 +1937,15 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
   app.refresh_github_status();
   assert_eq!(app.current_link().pr, Some(128));
   assert_eq!(app.current_link().pr_source, LinkSource::Detected);
+  // Table-snapshot sync (Codex review #284): the table renders from
+  // `self.worktrees[*].link`, not the live `github.link`, so a detection
+  // must be mirrored onto the selected row or its PR pastille stays white
+  // until a separate relist.
+  assert_eq!(
+    app.selected().map(|w| w.link.pr),
+    Some(Some(128)),
+    "the selected row snapshot must reflect the detected PR immediately"
+  );
 
   // The branch's PR changed (e.g. closed + reopened as #200). A detected
   // link is "resolved live", so a second refresh must re-detect rather
@@ -1974,6 +1983,76 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
     "the detected PR must be persisted so the table read path sees it"
   );
   assert_eq!(persisted.pr_source, LinkSource::Detected);
+}
+
+#[cfg(unix)]
+#[test]
+fn refresh_keeps_persisted_pr_when_gh_detection_fails() {
+  use std::os::unix::fs::PermissionsExt;
+
+  // Codex review #284: a transient `gh` failure (missing binary, offline,
+  // rate limit) must NOT wipe a previously persisted detection — pressing
+  // `F` offline should keep showing the PR, not blank it.
+  let (dir, repo, mut app) = make_app_on_branch("detect-me");
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  app.refresh_link();
+
+  // A `gh` that detects PR #128, then a `gh` that always fails (exit 1).
+  let gh_ok = dir.path().join("fake-gh-ok");
+  std::fs::write(
+    &gh_ok,
+    "#!/bin/sh\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
+       printf '%s' '[{\"number\":128}]'\n\
+     elif [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+       printf '%s' '{\"number\":128,\"title\":\"x\",\"state\":\"OPEN\",\"isDraft\":false,\"url\":\"https://example.test/pull/128\"}'\n\
+     fi\n",
+  )
+  .unwrap();
+  let gh_fail = dir.path().join("fake-gh-fail");
+  std::fs::write(&gh_fail, "#!/bin/sh\nexit 1\n").unwrap();
+  for p in [&gh_ok, &gh_fail] {
+    let mut perms = std::fs::metadata(p).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(p, perms).unwrap();
+  }
+
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+  let prior = std::env::var("GWM_GH").ok();
+  // SAFETY: env mutation guarded by `env_lock()`; GWM_GH restored below.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh_ok);
+  }
+  app.refresh_github_status();
+  assert_eq!(app.current_link().pr, Some(128), "first refresh detects #128");
+
+  // Now `gh` fails. The probe did not prove the PR vanished.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh_fail);
+  }
+  app.refresh_github_status();
+
+  unsafe {
+    match prior {
+      Some(v) => std::env::set_var("GWM_GH", v),
+      None => std::env::remove_var("GWM_GH"),
+    }
+  }
+
+  // The persisted key survives a failed probe...
+  let persisted = gwm::github::read_link(&repo, "detect-me").unwrap();
+  assert_eq!(
+    persisted.pr,
+    Some(128),
+    "a failed gh probe must not wipe the persisted detection"
+  );
+  assert_eq!(persisted.pr_source, LinkSource::Detected);
+  // ...and stays visible in memory rather than blanking the pane.
+  assert_eq!(
+    app.current_link().pr,
+    Some(128),
+    "the pane must keep the still-valid PR after a failed probe"
+  );
 }
 
 // ---- Configurable launchers (issue #75) --------------------------------

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1985,6 +1985,32 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
   assert_eq!(persisted.pr_source, LinkSource::Detected);
 }
 
+#[test]
+fn refresh_keeps_persisted_pr_when_no_remote_slug() {
+  // Codex review #284: pressing `F` when the probe cannot run at all (no
+  // origin remote → `link_slug` is None) must NOT blank a persisted
+  // detection. The unconditional `clear_detected_pr()` used to wipe the
+  // in-memory link before the skipped probe could restore it.
+  let (_dir, repo, mut app) = make_app_on_branch("detect-me");
+  // No origin remote is configured, so there is no slug to probe with.
+  gwm::github::persist_detected_pr(&repo, "detect-me", 128).unwrap();
+  app.refresh_link();
+  assert_eq!(
+    app.current_link().pr,
+    Some(128),
+    "precondition: the persisted detection loads into memory"
+  );
+
+  app.refresh_github_status();
+
+  assert_eq!(
+    app.current_link().pr,
+    Some(128),
+    "a refresh that cannot probe must keep the persisted detection"
+  );
+  assert_eq!(app.current_link().pr_source, LinkSource::Detected);
+}
+
 #[cfg(unix)]
 #[test]
 fn refresh_keeps_persisted_pr_when_gh_detection_fails() {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2120,6 +2120,10 @@ fn read_link_with_pr_detection_refreshes_a_persisted_detection() {
     std::env::set_var("GWM_GH", &gh);
   }
   let link = gwm::github::read_link_with_pr_detection(&repo, "detect-me", "kbrdn1/gwm-cli").unwrap();
+  // The live path must reconcile the persisted cache (#284), not just memory,
+  // so no-fetch consumers (table at startup, `gwm open pr`) don't resurrect
+  // the stale #128. Capture the stored value before the explicit link below.
+  let reconciled = gwm::github::read_link(&repo, "detect-me").unwrap();
 
   // Explicit override still wins even over a live re-detection.
   gwm::github::link_pr(&repo, "detect-me", 61).unwrap();
@@ -2138,8 +2142,64 @@ fn read_link_with_pr_detection_refreshes_a_persisted_detection() {
     "live detection must override the stale persisted #128"
   );
   assert_eq!(link.pr_source, LinkSource::Detected);
+  assert_eq!(
+    reconciled.pr,
+    Some(200),
+    "the live detection must rewrite the persisted cache to the fresh number"
+  );
   assert_eq!(explicit.pr, Some(61), "an explicit link still wins over live detection");
   assert_eq!(explicit.pr_source, LinkSource::Explicit);
+}
+
+#[cfg(unix)]
+#[test]
+fn read_link_with_pr_detection_clears_persisted_cache_when_pr_vanished() {
+  use std::os::unix::fs::PermissionsExt;
+
+  // Codex review #284: when the live probe proves the PR is gone (`Ok(None)`),
+  // the live CLI path must clear the persisted cache too, otherwise a no-fetch
+  // read (`read_link`) would resurrect the stale stored number.
+  let (dir, repo) = init_repo();
+  {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch("detect-me", &head, false).unwrap();
+  }
+  gwm::github::persist_detected_pr(&repo, "detect-me", 128).unwrap();
+
+  // Live `gh pr list` returns an empty array — the PR no longer exists.
+  let gh = dir.path().join("fake-gh-empty");
+  std::fs::write(
+    &gh,
+    "#!/bin/sh\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n\
+       printf '%s' '[]'\n\
+     fi\n",
+  )
+  .unwrap();
+  let mut perms = std::fs::metadata(&gh).unwrap().permissions();
+  perms.set_mode(0o755);
+  std::fs::set_permissions(&gh, perms).unwrap();
+
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+  let prior = std::env::var("GWM_GH").ok();
+  // SAFETY: env mutation guarded by `env_lock()`; GWM_GH restored below.
+  unsafe {
+    std::env::set_var("GWM_GH", &gh);
+  }
+  let link = gwm::github::read_link_with_pr_detection(&repo, "detect-me", "kbrdn1/gwm-cli").unwrap();
+  let stored = gwm::github::read_link(&repo, "detect-me").unwrap();
+  unsafe {
+    match prior {
+      Some(v) => std::env::set_var("GWM_GH", v),
+      None => std::env::remove_var("GWM_GH"),
+    }
+  }
+
+  assert_eq!(link.pr, None, "a vanished PR resolves to no PR live");
+  assert_eq!(
+    stored.pr, None,
+    "the persisted cache must be cleared so no-fetch reads don't resurrect it"
+  );
 }
 
 // ---- Configurable launchers (issue #75) --------------------------------

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2352,29 +2352,57 @@ fn yank_selected_path_returns_none_when_nothing_selected() {
   assert!(app.yank_selected_path().is_none());
 }
 
-// ---- Issue #73 (PR #74 follow-up): table marker pastille ------------------
-// The marker column (first cell) doubles as the lazygit-style status dot.
-// `★` still wins for main; non-main worktrees that carry a link (issue or
-// PR) get `●` so the row visually signals "this has GitHub context", even
-// when the sidebar is hidden (`<120` cols or `v` collapsed).
+// ---- Issue #283: table marker pastilles -----------------------------------
+// The marker column (first cell) renders two pastilles `●/●`: left = Issue
+// (green when linked), right = PR (violet when linked), white when the slot
+// is empty, muted `/` between. The main worktree keeps its `★`. The table is
+// the no-fetch read path, so the colour signals link **presence**, not live
+// open/closed state (that stays in the sidebar header where a fetch runs).
+
+/// Pull each span's `(content, fg)` out of a `table_marker` line so the
+/// pastille assertions read as a flat list.
+fn marker_cells(line: &ratatui::text::Line<'_>) -> Vec<(String, Option<Color>)> {
+  line
+    .spans
+    .iter()
+    .map(|s| (s.content.as_ref().to_string(), s.style.fg))
+    .collect()
+}
 
 #[test]
-fn table_marker_for_main_worktree_is_yellow_star() {
+fn table_marker_for_main_worktree_is_a_yellow_star() {
   use gwm::github::BranchLink;
   let mut w = worktree_fixture("main");
   w.is_main = true;
   w.link = BranchLink::empty();
-  let (label, color) = gwm::tui::table_marker(&w, &Theme::default());
-  assert_eq!(label, "★");
-  assert_eq!(color, Color::Yellow);
+  let line = gwm::tui::table_marker(&w, &Theme::default());
+  assert_eq!(marker_cells(&line), vec![("★".to_string(), Some(Color::Yellow))]);
 }
 
 #[test]
-fn table_marker_for_linked_non_main_is_neutral_dot() {
-  // No fetched state available at the table layer — colour stays neutral
-  // (Cyan) so the dot reads as "has link" without claiming a specific
-  // open/closed status. The coloured dot lives in the sidebar header where
-  // the live fetch state is known.
+fn table_marker_paints_green_issue_and_violet_pr_pastilles() {
+  use gwm::github::{BranchLink, LinkSource};
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink {
+    issue: Some(42),
+    pr: Some(43),
+    issue_source: LinkSource::BranchName,
+    pr_source: LinkSource::Detected,
+  };
+  let line = gwm::tui::table_marker(&w, &Theme::default());
+  assert_eq!(
+    marker_cells(&line),
+    vec![
+      ("●".to_string(), Some(Color::Green)),    // issue linked → clean role
+      ("/".to_string(), Some(Color::DarkGray)), // muted separator
+      ("●".to_string(), Some(Color::Magenta)),  // pr linked → locked role
+    ]
+  );
+}
+
+#[test]
+fn table_marker_issue_only_leaves_the_pr_pastille_white() {
   use gwm::github::{BranchLink, LinkSource};
   let mut w = worktree_fixture("feat-1");
   w.is_main = false;
@@ -2384,19 +2412,40 @@ fn table_marker_for_linked_non_main_is_neutral_dot() {
     issue_source: LinkSource::BranchName,
     pr_source: LinkSource::None,
   };
-  let (label, color) = gwm::tui::table_marker(&w, &Theme::default());
-  assert_eq!(label, "●");
-  assert_eq!(color, Color::Cyan);
+  let line = gwm::tui::table_marker(&w, &Theme::default());
+  let cells = marker_cells(&line);
+  assert_eq!(cells[0].1, Some(Color::Green), "issue dot green");
+  assert_eq!(cells[2].1, Some(Color::White), "empty pr dot white");
 }
 
 #[test]
-fn table_marker_for_unlinked_non_main_is_blank() {
+fn table_marker_pr_only_leaves_the_issue_pastille_white() {
+  use gwm::github::{BranchLink, LinkSource};
+  let mut w = worktree_fixture("feat-1");
+  w.is_main = false;
+  w.link = BranchLink {
+    issue: None,
+    pr: Some(43),
+    issue_source: LinkSource::None,
+    pr_source: LinkSource::Detected,
+  };
+  let line = gwm::tui::table_marker(&w, &Theme::default());
+  let cells = marker_cells(&line);
+  assert_eq!(cells[0].1, Some(Color::White), "empty issue dot white");
+  assert_eq!(cells[2].1, Some(Color::Magenta), "pr dot violet");
+}
+
+#[test]
+fn table_marker_unlinked_non_main_is_two_white_pastilles() {
   use gwm::github::BranchLink;
   let mut w = worktree_fixture("feat-1");
   w.is_main = false;
   w.link = BranchLink::empty();
-  let (label, _color) = gwm::tui::table_marker(&w, &Theme::default());
-  assert_eq!(label, " ", "unlinked non-main rows keep an empty marker cell");
+  let line = gwm::tui::table_marker(&w, &Theme::default());
+  let cells = marker_cells(&line);
+  assert_eq!(cells[0].1, Some(Color::White), "empty issue dot white");
+  assert_eq!(cells[1].0, "/", "muted separator between the pastilles");
+  assert_eq!(cells[2].1, Some(Color::White), "empty pr dot white");
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1961,6 +1961,19 @@ fn refresh_github_status_auto_detects_pr_for_unlinked_branch() {
     "a detected PR must re-resolve on refresh"
   );
   assert_eq!(app.current_link().pr_source, LinkSource::Detected);
+
+  // Wiring guard (issue #283): the detection must be PERSISTED to the git
+  // config, not just held in memory — that is what lets the no-fetch table
+  // read path colour the PR pastille on every row. Read the link straight
+  // from the repo (bypassing the in-memory `app.github.link`) so dropping
+  // `persist_detected_pr` from `refresh_github_status` turns this red.
+  let persisted = gwm::github::read_link(&repo, "detect-me").unwrap();
+  assert_eq!(
+    persisted.pr,
+    Some(200),
+    "the detected PR must be persisted so the table read path sees it"
+  );
+  assert_eq!(persisted.pr_source, LinkSource::Detected);
 }
 
 // ---- Configurable launchers (issue #75) --------------------------------

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -221,26 +221,41 @@ fn issue_badge_color_resolves_through_theme_roles() {
 }
 
 #[test]
-fn table_marker_resolves_through_theme_roles_but_keeps_neutral_default() {
+fn table_marker_resolves_through_theme_roles() {
   let t = audit_theme();
 
+  // Main keeps its single `★` painted with the `main` role.
   let mut main = base_worktree("main");
   main.is_main = true;
-  assert_eq!(table_marker(&main, &t).1, t.main, "main worktree marker → main role");
+  assert_eq!(table_marker(&main, &t).spans[0].style.fg, Some(t.main), "main marker → main role");
 
-  let mut linked = base_worktree("linked");
-  linked.link = BranchLink {
+  // Issue linked, PR empty: issue dot → `clean`, separator → `muted`, the
+  // empty PR dot → `name` (the neutral white slot).
+  let mut issue_only = base_worktree("issue");
+  issue_only.link = BranchLink {
     issue: Some(7),
     ..BranchLink::empty()
   };
-  assert_eq!(table_marker(&linked, &t).1, t.accent, "linked marker → accent role");
+  let line = table_marker(&issue_only, &t);
+  assert_eq!(line.spans[0].style.fg, Some(t.clean), "issue dot → clean role");
+  assert_eq!(line.spans[1].style.fg, Some(t.muted), "separator → muted role");
+  assert_eq!(line.spans[2].style.fg, Some(t.name), "empty pr dot → name role");
 
+  // PR linked, issue empty: mirror — empty issue dot → `name`, PR → `locked`.
+  let mut pr_only = base_worktree("pr");
+  pr_only.link = BranchLink {
+    pr: Some(8),
+    ..BranchLink::empty()
+  };
+  let line = table_marker(&pr_only, &t);
+  assert_eq!(line.spans[0].style.fg, Some(t.name), "empty issue dot → name role");
+  assert_eq!(line.spans[2].style.fg, Some(t.locked), "pr dot → locked role");
+
+  // Nothing linked: two `name`-white slots.
   let unlinked = base_worktree("plain");
-  assert_eq!(
-    table_marker(&unlinked, &t).1,
-    Color::Reset,
-    "unlinked, non-main marker carries no role and stays Reset"
-  );
+  let line = table_marker(&unlinked, &t);
+  assert_eq!(line.spans[0].style.fg, Some(t.name), "empty issue dot → name role");
+  assert_eq!(line.spans[2].style.fg, Some(t.name), "empty pr dot → name role");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -227,7 +227,11 @@ fn table_marker_resolves_through_theme_roles() {
   // Main keeps its single `★` painted with the `main` role.
   let mut main = base_worktree("main");
   main.is_main = true;
-  assert_eq!(table_marker(&main, &t).spans[0].style.fg, Some(t.main), "main marker → main role");
+  assert_eq!(
+    table_marker(&main, &t).spans[0].style.fg,
+    Some(t.main),
+    "main marker → main role"
+  );
 
   // Issue linked, PR empty: issue dot → `clean`, separator → `muted`, the
   // empty PR dot → `name` (the neutral white slot).


### PR DESCRIPTION
## Description

One feature with three faces (issue #283), built TDD:

- **Table pastilles** — the worktree table replaces its single neutral `●`
  with two pastilles `●/●`: left = Issue (green when linked), right = PR
  (violet when linked), white for an empty slot, muted `/` between. The main
  worktree keeps its `★`.
- **Persisted PR detection** — a PR auto-detected via `gh pr list --head`
  is now stored in a dedicated `branch.<name>.gwm-pr-detected` git-config
  key, so the no-fetch table read path colours the PR pastille on every row
  without a per-row `gh` shell-out. Explicit `gwm link --pr` still wins.
- **Pane badges + icons** — each Issue/PR pane line leads with a nerdfont dev
  glyph and renders the link source (` auto ` / ` detected `) and the GitHub
  state (` open ` / ` closed ` / ` draft ` / ` merged `) as version-style
  reverse-video chips.

Closes #283

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `github.rs`: new `gwm-pr-detected` key; `read_link` resolves PR as
  explicit → detected-persisted (`LinkSource::Detected`) → none;
  `persist_detected_pr` / `clear_persisted_detected_pr`; wired into the `F`
  refresh in `app.rs` (best-effort write). Corrected the now-false "never
  persisted" docs.
- `ui.rs`: `table_marker` now returns a multi-span `Line` (two theme-routed
  pastilles); marker column widened 2 → 3. `summary_line` gains an `icon` +
  `source` and renders source/state chips via the shared `chip_style`, with
  width budgeting + a narrow-pane flatten fallback. New `ISSUE_ICON` /
  `PR_ICON` consts.

## Tests

- [x] `cargo test` passes locally (61 test binaries green, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD)

New / updated tests: `github_tests.rs` (persistence round-trip: detected
read-back, explicit override, re-detection overwrite, clear);
`tui_app_tests.rs` (5 pastille cases + pane icon/source/state chip cases +
existing width budgets); `tui_theme_audit_tests.rs` (pastille colour routes,
badge colour routes preserved).

## Screenshots / TUI captures

Not captured in this run — the change is pinned by the state-machine /
helper tests above (pastille spans + colours, chip modifiers, width
budgets) rather than a terminal capture.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a —
  `gwm-pr-detected` is internal branch state, not user-facing `.gwm.toml`)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #283

## Notes for reviewers

- The detected/explicit distinction is load-bearing: persisting to a
  *separate* key (not `gwm-pr`) is what lets the pane keep showing the
  `detected` badge — writing to `gwm-pr` would read back as `Explicit`.
- The nerdfont glyphs (`nf-oct-issue_opened` U+F41B, `nf-oct-git_pull_request`
  U+F407) assume a nerdfont-patched terminal, as requested.
- Pastille colour signals link *presence/type*, not live open/closed state
  (the table is the no-fetch path); the status-coloured dot stays in the
  sidebar header.