### PR TITLE
✨ feat(tui): rebindable modal keys with contextual actions (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rebindable modal keys with contextual actions** (issue #219): the
   modal/overlay keys that used to be hard-coded (create form, delete-confirm,
   link prompt, settings panel, command logs, help, open-menu, command palette,
-  bootstrap report) are now remappable under nested `[tui.keys.<context>]`
-  sub-tables in `.gwm.toml`. Each context owns typed verbs, so the same
-  physical key can mean different things in different modals (`Enter` is
-  `submit` in the create form but `activate` in the delete-confirm modal).
+  bootstrap report) are now remappable under nested
+  `[tui.keys.modal.<context>]` sub-tables in `.gwm.toml`. Each context owns
+  typed verbs, so the same physical key can mean different things in different
+  modals (`Enter` is `submit` in the create form but `activate` in the
+  delete-confirm modal). The dedicated `modal` namespace keeps a context from
+  colliding with a same-named global action (`create`/`help`/`command_logs`/
+  `link`): a global `create` array and a modal `[tui.keys.modal.create]` table
+  coexist across config layers.
   - Modal bindings are single keystrokes only (no chord timeout); a
     multi-stroke chord is rejected at load time.
-  - Two-stage surfaces use a dotted path — `[tui.keys.link.choose_target]`,
-    `[tui.keys.link.input_number]`, `[tui.keys.config.edit]`.
+  - Two-stage surfaces use a dotted path —
+    `[tui.keys.modal.link.choose_target]`,
+    `[tui.keys.modal.link.input_number]`, `[tui.keys.modal.config.edit]`.
   - `gwm tui keys` lists every context and verb; `gwm doctor` validates the
-    contextual bindings and reports per-context conflicts.
+    contextual bindings (re-reading the on-disk config) and reports
+    per-context conflicts.
   - The Keybindings help overlay and the statusbar footer hints now resolve
     modal keys from the override layer instead of fixed strings.
   - `Ctrl+C`, the list view's contextual `Esc`/`Enter`, and the PTY overlay's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rebindable modal keys with contextual actions** (issue #219): the
+  modal/overlay keys that used to be hard-coded (create form, delete-confirm,
+  link prompt, settings panel, command logs, help, open-menu, command palette,
+  bootstrap report) are now remappable under nested `[tui.keys.<context>]`
+  sub-tables in `.gwm.toml`. Each context owns typed verbs, so the same
+  physical key can mean different things in different modals (`Enter` is
+  `submit` in the create form but `activate` in the delete-confirm modal).
+  - Modal bindings are single keystrokes only (no chord timeout); a
+    multi-stroke chord is rejected at load time.
+  - Two-stage surfaces use a dotted path — `[tui.keys.link.choose_target]`,
+    `[tui.keys.link.input_number]`, `[tui.keys.config.edit]`.
+  - `gwm tui keys` lists every context and verb; `gwm doctor` validates the
+    contextual bindings and reports per-context conflicts.
+  - The Keybindings help overlay and the statusbar footer hints now resolve
+    modal keys from the override layer instead of fixed strings.
+  - `Ctrl+C`, the list view's contextual `Esc`/`Enter`, and the PTY overlay's
+    emergency `Esc` stay hard-coded by design.
 - **TUI keymap redesign** (issue #290): unified, consistent key bindings across
   the worktree list. New actions and default bindings:
   - `p` → `pull` — git pull on the selected worktree's branch (async,

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -245,6 +245,52 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # [tui]
 # sidebar_position = "left"
 
+# --- TUI keymap: `[tui.keys]` (issues #87 / #219) ----------------------------
+# Remap any TUI key. An override REPLACES the default for that verb; an empty
+# array unbinds it. Run `gwm tui keys` for the full list of actions, contexts,
+# and verbs, and `gwm doctor` to validate overrides.
+#
+# Global list-view verbs are arrays keyed by action slug (multi-key chords
+# like "g g" allowed here):
+# [tui.keys]
+# quit = ["q", "Esc"]
+# down = ["j", "Down"]
+# top  = ["g g"]
+#
+# Modal / overlay verbs are nested sub-tables keyed by context (issue #219).
+# These are SINGLE keystrokes only — modals have no chord timeout. The same
+# physical key can mean different verbs in different contexts:
+# [tui.keys.create]
+# next_field = ["Tab"]
+# prev_field = ["BackTab"]
+# submit     = ["Enter"]
+# cancel     = ["Esc"]
+#
+# [tui.keys.confirm]
+# confirm       = ["y"]
+# cancel        = ["n", "Esc"]
+# focus_confirm = ["Left", "h"]
+# focus_cancel  = ["Right", "l"]
+# activate      = ["Enter"]
+#
+# The link prompt and the settings editor are two-stage, addressed with a
+# dotted context path:
+# [tui.keys.link.choose_target]
+# issue  = ["i"]
+# pr     = ["p"]
+# next   = ["j", "Down"]
+# prev   = ["k", "Up"]
+# accept = ["Enter"]
+# cancel = ["Esc"]
+#
+# [tui.keys.link.input_number]
+# submit = ["Enter"]
+# cancel = ["Esc"]
+#
+# [tui.keys.config.edit]
+# submit = ["Enter"]
+# cancel = ["Esc"]
+
 # --- TUI launcher: `l` (git_tui) keybinding (issue #75) ----------------------
 # The `l` key suspends the gwm TUI and launches a git TUI on the selected
 # worktree. Placeholders: {path}. Default (no section) → `lazygit -p {path}`

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -257,16 +257,20 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # down = ["j", "Down"]
 # top  = ["g g"]
 #
-# Modal / overlay verbs are nested sub-tables keyed by context (issue #219).
-# These are SINGLE keystrokes only — modals have no chord timeout. The same
-# physical key can mean different verbs in different contexts:
-# [tui.keys.create]
+# Modal / overlay verbs are nested under the dedicated `[tui.keys.modal]`
+# namespace, keyed by context (issue #219). The separate namespace keeps a
+# modal context from colliding with a same-named global action (create / help /
+# command_logs / link are both): a global `create` array and a modal
+# `[tui.keys.modal.create]` table can coexist. These are SINGLE keystrokes
+# only — modals have no chord timeout. The same physical key can mean different
+# verbs in different contexts:
+# [tui.keys.modal.create]
 # next_field = ["Tab"]
 # prev_field = ["BackTab"]
 # submit     = ["Enter"]
 # cancel     = ["Esc"]
 #
-# [tui.keys.confirm]
+# [tui.keys.modal.confirm]
 # confirm       = ["y"]
 # cancel        = ["n", "Esc"]
 # focus_confirm = ["Left", "h"]
@@ -275,7 +279,7 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # The link prompt and the settings editor are two-stage, addressed with a
 # dotted context path:
-# [tui.keys.link.choose_target]
+# [tui.keys.modal.link.choose_target]
 # issue  = ["i"]
 # pr     = ["p"]
 # next   = ["j", "Down"]
@@ -283,11 +287,11 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # accept = ["Enter"]
 # cancel = ["Esc"]
 #
-# [tui.keys.link.input_number]
+# [tui.keys.modal.link.input_number]
 # submit = ["Enter"]
 # cancel = ["Esc"]
 #
-# [tui.keys.config.edit]
+# [tui.keys.modal.config.edit]
 # submit = ["Enter"]
 # cancel = ["Esc"]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1713,10 +1713,15 @@ fn cmd_prune(dry_run: bool) -> Result<()> {
 fn cmd_doctor() -> Result<()> {
   let RepoContext { repo, workdir, config } = repo_context_lenient(None)?;
 
+  // Thread the real global layer so the keymap check re-reads exactly what the
+  // TUI loads, while keeping the ambient read out of `doctor::run` itself
+  // (issue #219 review — injected contexts stay deterministic).
+  let global = crate::config::global_config_path();
   let ctx = DoctorCtx {
     repo_workdir: &workdir,
     repo: &repo,
     config: &config,
+    global_config_path: global.as_deref(),
   };
   let report = doctor::run(&ctx)?;
   print_doctor_report(&report);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -899,22 +899,23 @@ fn cmd_theme_show(name: &str) -> Result<()> {
 /// validation pass, so the column contents stay in sync.
 fn cmd_tui_keys() -> Result<()> {
   use crate::tui::keymap::{Keymap, Source};
+  use crate::tui::modal_keymap::{KeyContext, ModalKeymap};
 
-  // Build the resolved keymap. Outside a repo, OR inside a bare
+  // Build the resolved keymaps. Outside a repo, OR inside a bare
   // repo (no workdir to read `.gwm.toml` from), fall back to
   // defaults so the command stays useful for new users discovering
   // the binary. Same fallback path either way — surfacing
   // `NotInGitRepo` on a bare repo would be misleading because the
   // command itself is repo-agnostic.
-  let keymap = match worktree::discover_repo(None) {
+  let (keymap, modal) = match worktree::discover_repo(None) {
     Ok(repo) => match repo.workdir() {
       Some(workdir) => {
         let cfg = Config::load_for_repo(workdir)?;
-        cfg.tui.keys.resolved_keymap()?
+        (cfg.tui.keys.resolved_keymap()?, cfg.tui.keys.resolved_modal_keymap()?)
       }
-      None => Keymap::defaults(),
+      None => (Keymap::defaults(), ModalKeymap::defaults()),
     },
-    Err(_) => Keymap::defaults(),
+    Err(_) => (Keymap::defaults(), ModalKeymap::defaults()),
   };
 
   let rows = keymap.list();
@@ -960,6 +961,47 @@ fn cmd_tui_keys() -> Result<()> {
       aw = action_w,
       kw = keys_w
     );
+  }
+
+  // Issue #219: contextual modal / overlay bindings, grouped by context.
+  // Printed under their `[tui.keys.<context>]` heading so the user can copy
+  // a heading straight into `.gwm.toml` to start an override.
+  let fmt_keys = |keys: &[crate::tui::keymap::KeyStroke]| -> String {
+    keys.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(", ")
+  };
+  for ctx in KeyContext::all() {
+    let bindings = modal.bindings_for(*ctx);
+    if bindings.is_empty() {
+      continue;
+    }
+    println!("\n[tui.keys.{}]", ctx.config_path());
+    let verb_w = bindings
+      .iter()
+      .map(|b| b.action.verb().len())
+      .max()
+      .unwrap_or(0)
+      .max("verb".len());
+    let keys_w = bindings
+      .iter()
+      .map(|b| fmt_keys(&b.keys).len())
+      .max()
+      .unwrap_or(0)
+      .max("keys".len());
+    println!("{:<vw$}  {:<kw$}  source", "verb", "keys", vw = verb_w, kw = keys_w);
+    for binding in bindings {
+      let source = match binding.source {
+        Source::Default => "default",
+        Source::UserConfig => ".gwm.toml",
+      };
+      println!(
+        "{:<vw$}  {:<kw$}  {}",
+        binding.action.verb(),
+        fmt_keys(&binding.keys),
+        source,
+        vw = verb_w,
+        kw = keys_w
+      );
+    }
   }
   Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -964,7 +964,7 @@ fn cmd_tui_keys() -> Result<()> {
   }
 
   // Issue #219: contextual modal / overlay bindings, grouped by context.
-  // Printed under their `[tui.keys.<context>]` heading so the user can copy
+  // Printed under their `[tui.keys.modal.<context>]` heading so the user can copy
   // a heading straight into `.gwm.toml` to start an override.
   let fmt_keys = |keys: &[crate::tui::keymap::KeyStroke]| -> String {
     keys.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(", ")
@@ -974,7 +974,7 @@ fn cmd_tui_keys() -> Result<()> {
     if bindings.is_empty() {
       continue;
     }
-    println!("\n[tui.keys.{}]", ctx.config_path());
+    println!("\n[tui.keys.modal.{}]", ctx.config_path());
     let verb_w = bindings
       .iter()
       .map(|b| b.action.verb().len())

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,7 +548,7 @@ impl Default for TuiConfig {
 ///   Resolved by [`Self::resolved_keymap`] into a
 ///   [`crate::tui::keymap::Keymap`].
 /// - **table value** → a *contextual* modal sub-table, e.g.
-///   `[tui.keys.confirm]` or `[tui.keys.link.choose_target]`. Resolved by
+///   `[tui.keys.modal.confirm]` or `[tui.keys.modal.link.choose_target]`. Resolved by
 ///   [`Self::resolved_modal_keymap`] into a
 ///   [`crate::tui::modal_keymap::ModalKeymap`].
 ///
@@ -569,20 +569,28 @@ pub struct TuiKeysConfig {
 
 impl TuiKeysConfig {
   /// Resolve the **global** `View::List` keymap: the top-level array
-  /// entries of `[tui.keys]`. Table entries (modal contexts) are skipped
-  /// here and handled by [`Self::resolved_modal_keymap`].
+  /// entries of `[tui.keys]`. The `[tui.keys.modal]` sub-table (modal
+  /// contexts) is skipped here and handled by [`Self::resolved_modal_keymap`].
   pub fn resolved_keymap(&self) -> Result<crate::tui::keymap::Keymap> {
     use crate::tui::keymap::{Action, KeyStroke, Keymap};
 
     let mut km = Keymap::defaults();
     for (action_slug, value) in &self.raw {
+      // Modal contexts live under `[tui.keys.modal.<context>]` and are
+      // resolved by `resolved_modal_keymap`. The dedicated namespace (issue
+      // #219 review) keeps a global action and a same-named modal context
+      // (`create` / `help` / `command_logs` / `link`) from colliding at the
+      // `tui.keys.<name>` path during the layered merge — which previously
+      // replaced the global array with the modal table and silently dropped
+      // the user's global override.
+      if action_slug == TUI_KEYS_MODAL_NAMESPACE {
+        continue;
+      }
       let chord_strings = match value {
         toml::Value::Array(_) => as_chord_list(action_slug, value)?,
-        // A table is a contextual modal block — resolved elsewhere.
-        toml::Value::Table(_) => continue,
         other => {
           return Err(GwmError::Config(format!(
-            "tui.keys.{}: expected an array of chords or a context table, got {}",
+            "tui.keys.{}: expected an array of chords; modal contexts go under [tui.keys.modal.<context>], got {}",
             action_slug,
             other.type_str()
           )))
@@ -605,22 +613,32 @@ impl TuiKeysConfig {
     Ok(km)
   }
 
-  /// Resolve the **contextual** modal keymap: the top-level table entries
-  /// of `[tui.keys]`, recursed into stages (`link.choose_target`,
-  /// `config.edit`). Array entries (global actions) are skipped here.
+  /// Resolve the **contextual** modal keymap from the `[tui.keys.modal]`
+  /// sub-table, recursing into stages (`link.choose_target`, `config.edit`).
+  /// A missing `[tui.keys.modal]` table means no overrides — the built-in
+  /// defaults stand. The dedicated namespace (issue #219 review) keeps modal
+  /// contexts from colliding with same-named global actions during the
+  /// layered merge.
   pub fn resolved_modal_keymap(&self) -> Result<crate::tui::modal_keymap::ModalKeymap> {
     use crate::tui::modal_keymap::ModalKeymap;
 
     let mut mk = ModalKeymap::defaults();
-    for (key, value) in &self.raw {
+    let Some(modal_val) = self.raw.get(TUI_KEYS_MODAL_NAMESPACE) else {
+      return Ok(mk);
+    };
+    let table = modal_val.as_table().ok_or_else(|| {
+      GwmError::Config(format!(
+        "tui.keys.modal: expected a table of modal contexts, got {}",
+        modal_val.type_str()
+      ))
+    })?;
+    for (ctx_key, value) in table {
       match value {
-        toml::Value::Table(table) => walk_modal_context(key, table, &mut mk)?,
-        // An array is a global action — resolved by `resolved_keymap`.
-        toml::Value::Array(_) => continue,
+        toml::Value::Table(sub) => walk_modal_context(ctx_key, sub, &mut mk)?,
         other => {
           return Err(GwmError::Config(format!(
-            "tui.keys.{}: expected an array of chords or a context table, got {}",
-            key,
+            "tui.keys.modal.{}: expected a context table, got {}",
+            ctx_key,
             other.type_str()
           )))
         }
@@ -629,6 +647,10 @@ impl TuiKeysConfig {
     Ok(mk)
   }
 }
+
+/// Sub-table key under `[tui.keys]` that holds the contextual modal bindings
+/// (`[tui.keys.modal.<context>]`). See [`TuiKeysConfig::resolved_modal_keymap`].
+const TUI_KEYS_MODAL_NAMESPACE: &str = "modal";
 
 /// Extract a `["a", "b"]` chord list from a TOML array value, erroring on a
 /// non-string element. `coord` is the dotted `tui.keys.…` path for messages.
@@ -660,7 +682,7 @@ fn is_modal_context_group(path: &str) -> bool {
     .any(|c| c.config_path().starts_with(&prefix))
 }
 
-/// Walk one `[tui.keys.<ctx_path>]` sub-table, applying every `verb = [keys]`
+/// Walk one `[tui.keys.modal.<ctx_path>]` sub-table, applying every `verb = [keys]`
 /// entry to `mk` and recursing into nested stage sub-tables.
 fn walk_modal_context(
   ctx_path: &str,
@@ -672,7 +694,7 @@ fn walk_modal_context(
   let ctx = KeyContext::from_config_path(ctx_path);
   if ctx.is_none() && !is_modal_context_group(ctx_path) {
     return Err(GwmError::Config(format!(
-      "tui.keys.{}: unknown modal context (run `gwm tui keys` for the list)",
+      "tui.keys.modal.{}: unknown modal context (run `gwm tui keys` for the list)",
       ctx_path
     )));
   }
@@ -682,15 +704,15 @@ fn walk_modal_context(
       toml::Value::Array(_) => {
         let ctx = ctx.ok_or_else(|| {
           GwmError::Config(format!(
-            "tui.keys.{path}: {path:?} is a context group, not a leaf — bind under a stage (e.g. {path}.<stage>)",
+            "tui.keys.modal.{path}: {path:?} is a context group, not a leaf — bind under a stage (e.g. {path}.<stage>)",
             path = ctx_path
           ))
         })?;
-        let coord = format!("{}.{}", ctx_path, key);
+        let coord = format!("modal.{}.{}", ctx_path, key);
         let chords = as_chord_list(&coord, value)?;
         let action = ModalAction::from_context_verb(ctx, key).ok_or_else(|| {
           GwmError::Config(format!(
-            "tui.keys.{}: unknown verb {:?} (run `gwm tui keys` for the list)",
+            "tui.keys.modal.{}: unknown verb {:?} (run `gwm tui keys` for the list)",
             ctx_path, key
           ))
         })?;
@@ -699,7 +721,7 @@ fn walk_modal_context(
           parsed.push(parse_single(s).map_err(|e| rewrap(&coord, e))?);
         }
         mk.apply_override(action, parsed)
-          .map_err(|e| rewrap(&format!("tui.keys.{}", ctx_path), e))?;
+          .map_err(|e| rewrap(&format!("tui.keys.modal.{}", ctx_path), e))?;
       }
       toml::Value::Table(sub) => {
         let child = format!("{}.{}", ctx_path, key);
@@ -707,7 +729,7 @@ fn walk_modal_context(
       }
       other => {
         return Err(GwmError::Config(format!(
-          "tui.keys.{}.{}: expected an array of keys or a sub-table, got {}",
+          "tui.keys.modal.{}.{}: expected an array of keys or a sub-table, got {}",
           ctx_path,
           key,
           other.type_str()

--- a/src/config.rs
+++ b/src/config.rs
@@ -540,30 +540,54 @@ impl Default for TuiConfig {
 }
 
 /// `[tui.keys]` — user-facing override table for the TUI keymap.
-/// Stored as `action-slug -> [chord, …]` so the TOML stays declarative
-/// and copy-pastable across machines.
 ///
-/// Resolution / validation happens in [`Self::resolved_keymap`], which
-/// is called from `Config::load_for_repo` so a malformed override is
-/// surfaced at load time (action name typos, parse errors, chord
-/// conflicts, prefix collisions) rather than as a silent no-op in the
-/// TUI. The raw map is preserved on `Self` so `gwm tui keys` can show
-/// both the user's source and the resolved bindings.
+/// Two kinds of entry live side by side, disambiguated by value type
+/// (issue #219):
+///
+/// - **array value** → a *global* `View::List` verb, e.g. `quit = ["q"]`.
+///   Resolved by [`Self::resolved_keymap`] into a
+///   [`crate::tui::keymap::Keymap`].
+/// - **table value** → a *contextual* modal sub-table, e.g.
+///   `[tui.keys.confirm]` or `[tui.keys.link.choose_target]`. Resolved by
+///   [`Self::resolved_modal_keymap`] into a
+///   [`crate::tui::modal_keymap::ModalKeymap`].
+///
+/// A few names exist in both worlds (`create`, `help`, `command_logs`,
+/// `link` are global actions *and* modal contexts). TOML forbids defining
+/// the same key twice, so a user picks one per file; the value type is
+/// what the walkers below key off. Resolution / validation runs at
+/// `Config::load_for_repo` time via [`Config::validate_tui_keys`] so a
+/// malformed override (unknown action / context / verb, parse error,
+/// per-context conflict, multi-stroke modal chord) is surfaced at load
+/// rather than as a silent no-op in the TUI. The raw table is preserved so
+/// `gwm tui keys` can show both the user's source and the resolved set.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TuiKeysConfig {
-  pub bindings: std::collections::BTreeMap<String, Vec<String>>,
+  pub raw: toml::Table,
 }
 
 impl TuiKeysConfig {
-  /// Apply this user override layer on top of the built-in defaults.
-  /// Returns a fully-resolved [`crate::tui::keymap::Keymap`] ready to
-  /// hand to the TUI event loop.
+  /// Resolve the **global** `View::List` keymap: the top-level array
+  /// entries of `[tui.keys]`. Table entries (modal contexts) are skipped
+  /// here and handled by [`Self::resolved_modal_keymap`].
   pub fn resolved_keymap(&self) -> Result<crate::tui::keymap::Keymap> {
     use crate::tui::keymap::{Action, KeyStroke, Keymap};
 
     let mut km = Keymap::defaults();
-    for (action_slug, chord_strings) in &self.bindings {
+    for (action_slug, value) in &self.raw {
+      let chord_strings = match value {
+        toml::Value::Array(_) => as_chord_list(action_slug, value)?,
+        // A table is a contextual modal block — resolved elsewhere.
+        toml::Value::Table(_) => continue,
+        other => {
+          return Err(GwmError::Config(format!(
+            "tui.keys.{}: expected an array of chords or a context table, got {}",
+            action_slug,
+            other.type_str()
+          )))
+        }
+      };
       let action = Action::from_slug_compat(action_slug).ok_or_else(|| {
         GwmError::Config(format!(
           "tui.keys: unknown action {:?} (run `gwm tui keys` for the full list)",
@@ -571,29 +595,137 @@ impl TuiKeysConfig {
         ))
       })?;
       let mut parsed = Vec::with_capacity(chord_strings.len());
-      for chord_str in chord_strings {
-        let chord = KeyStroke::parse_chord(chord_str).map_err(|e| {
-          // Re-wrap so the user sees `tui.keys.<action>` as the
-          // coordinate rather than the bare "keymap:" prefix from
-          // the parser.
-          let inner = match e {
-            GwmError::Config(msg) => msg,
-            other => other.to_string(),
-          };
-          GwmError::Config(format!("tui.keys.{}: {}", action_slug, inner))
-        })?;
+      for chord_str in &chord_strings {
+        let chord = KeyStroke::parse_chord(chord_str).map_err(|e| rewrap(&format!("tui.keys.{}", action_slug), e))?;
         parsed.push(chord);
       }
-      km.apply_override(action, parsed).map_err(|e| {
-        let inner = match e {
-          GwmError::Config(msg) => msg,
-          other => other.to_string(),
-        };
-        GwmError::Config(format!("tui.keys.{}: {}", action_slug, inner))
-      })?;
+      km.apply_override(action, parsed)
+        .map_err(|e| rewrap(&format!("tui.keys.{}", action_slug), e))?;
     }
     Ok(km)
   }
+
+  /// Resolve the **contextual** modal keymap: the top-level table entries
+  /// of `[tui.keys]`, recursed into stages (`link.choose_target`,
+  /// `config.edit`). Array entries (global actions) are skipped here.
+  pub fn resolved_modal_keymap(&self) -> Result<crate::tui::modal_keymap::ModalKeymap> {
+    use crate::tui::modal_keymap::ModalKeymap;
+
+    let mut mk = ModalKeymap::defaults();
+    for (key, value) in &self.raw {
+      match value {
+        toml::Value::Table(table) => walk_modal_context(key, table, &mut mk)?,
+        // An array is a global action — resolved by `resolved_keymap`.
+        toml::Value::Array(_) => continue,
+        other => {
+          return Err(GwmError::Config(format!(
+            "tui.keys.{}: expected an array of chords or a context table, got {}",
+            key,
+            other.type_str()
+          )))
+        }
+      }
+    }
+    Ok(mk)
+  }
+}
+
+/// Extract a `["a", "b"]` chord list from a TOML array value, erroring on a
+/// non-string element. `coord` is the dotted `tui.keys.…` path for messages.
+fn as_chord_list(coord: &str, value: &toml::Value) -> Result<Vec<String>> {
+  let arr = value
+    .as_array()
+    .expect("as_chord_list called on a non-array — caller must match Value::Array first");
+  let mut out = Vec::with_capacity(arr.len());
+  for v in arr {
+    let s = v.as_str().ok_or_else(|| {
+      GwmError::Config(format!(
+        "tui.keys.{}: chord list must contain strings, got {}",
+        coord,
+        v.type_str()
+      ))
+    })?;
+    out.push(s.to_string());
+  }
+  Ok(out)
+}
+
+/// `true` when `path` is a non-leaf context *group* — i.e. some real
+/// context nests below it (`link` → `link.choose_target`). Used to give a
+/// precise "bind under a stage" error instead of "unknown context".
+fn is_modal_context_group(path: &str) -> bool {
+  let prefix = format!("{}.", path);
+  crate::tui::modal_keymap::KeyContext::all()
+    .iter()
+    .any(|c| c.config_path().starts_with(&prefix))
+}
+
+/// Walk one `[tui.keys.<ctx_path>]` sub-table, applying every `verb = [keys]`
+/// entry to `mk` and recursing into nested stage sub-tables.
+fn walk_modal_context(
+  ctx_path: &str,
+  table: &toml::Table,
+  mk: &mut crate::tui::modal_keymap::ModalKeymap,
+) -> Result<()> {
+  use crate::tui::modal_keymap::{parse_single, KeyContext, ModalAction};
+
+  let ctx = KeyContext::from_config_path(ctx_path);
+  if ctx.is_none() && !is_modal_context_group(ctx_path) {
+    return Err(GwmError::Config(format!(
+      "tui.keys.{}: unknown modal context (run `gwm tui keys` for the list)",
+      ctx_path
+    )));
+  }
+
+  for (key, value) in table {
+    match value {
+      toml::Value::Array(_) => {
+        let ctx = ctx.ok_or_else(|| {
+          GwmError::Config(format!(
+            "tui.keys.{path}: {path:?} is a context group, not a leaf — bind under a stage (e.g. {path}.<stage>)",
+            path = ctx_path
+          ))
+        })?;
+        let coord = format!("{}.{}", ctx_path, key);
+        let chords = as_chord_list(&coord, value)?;
+        let action = ModalAction::from_context_verb(ctx, key).ok_or_else(|| {
+          GwmError::Config(format!(
+            "tui.keys.{}: unknown verb {:?} (run `gwm tui keys` for the list)",
+            ctx_path, key
+          ))
+        })?;
+        let mut parsed = Vec::with_capacity(chords.len());
+        for s in &chords {
+          parsed.push(parse_single(s).map_err(|e| rewrap(&coord, e))?);
+        }
+        mk.apply_override(action, parsed)
+          .map_err(|e| rewrap(&format!("tui.keys.{}", ctx_path), e))?;
+      }
+      toml::Value::Table(sub) => {
+        let child = format!("{}.{}", ctx_path, key);
+        walk_modal_context(&child, sub, mk)?;
+      }
+      other => {
+        return Err(GwmError::Config(format!(
+          "tui.keys.{}.{}: expected an array of keys or a sub-table, got {}",
+          ctx_path,
+          key,
+          other.type_str()
+        )))
+      }
+    }
+  }
+  Ok(())
+}
+
+/// Re-wrap a parser / keymap error so the user sees the `tui.keys.<coord>`
+/// coordinate rather than the bare `keymap:` prefix from the inner layer.
+fn rewrap(coord: &str, e: GwmError) -> GwmError {
+  let inner = match e {
+    GwmError::Config(msg) => msg,
+    other => other.to_string(),
+  };
+  GwmError::Config(format!("{}: {}", coord, inner))
 }
 
 /// `[theme]` block (issue #33) — role-based TUI colour scheme.
@@ -986,7 +1118,11 @@ impl Config {
   /// (it's rebuilt by the TUI at startup); the call is only kept for
   /// its error side-effects.
   pub(crate) fn validate_tui_keys(&self) -> Result<()> {
-    self.tui.keys.resolved_keymap().map(|_| ())
+    // Global verbs (array entries) and contextual modal verbs (table
+    // entries) are validated in one pass each; the resolved keymaps are
+    // discarded — they're rebuilt by the TUI at startup.
+    self.tui.keys.resolved_keymap().map(|_| ())?;
+    self.tui.keys.resolved_modal_keymap().map(|_| ())
   }
 
   /// Reject `[theme]` entries that name an unknown preset, unknown

--- a/src/config.rs
+++ b/src/config.rs
@@ -1144,13 +1144,6 @@ impl Config {
     })
   }
 
-  /// Effective merged config from disk for `repo_root`, layering the global
-  /// config under the repo's `.gwm.toml` exactly as [`Self::load_for_repo`]
-  /// does, but **unvalidated** — see [`Self::merge_layered`].
-  pub(crate) fn merge_for_repo_unvalidated(repo_root: &Path) -> Result<Self> {
-    Self::merge_layered(repo_root, global_config_path().as_deref())
-  }
-
   /// Reject `[tui.keys]` entries that name an unknown action, list a
   /// chord that does not parse, or create a conflict / prefix
   /// collision with another binding (issue #87). Delegates to

--- a/src/config.rs
+++ b/src/config.rs
@@ -1082,6 +1082,27 @@ impl Config {
   /// the merge contract can be pinned by a test without touching the
   /// runner's real `$HOME` / `$XDG_CONFIG_HOME`.
   pub fn load_layered(repo_root: &Path, global_path: Option<&Path>) -> Result<Self> {
+    let cfg = Self::merge_layered(repo_root, global_path)?;
+    cfg.validate_branch_types()?;
+    cfg.validate_bootstrap_paths()?;
+    cfg.validate_bootstrap_guards()?;
+    cfg.validate_labels()?;
+    cfg.validate_aliases()?;
+    cfg.validate_tui_keys()?;
+    cfg.validate_theme()?;
+    Ok(cfg)
+  }
+
+  /// Build the effective (deep-merged) config from disk **without** running
+  /// the semantic validators. Same merge rule as [`Self::load_layered`]; only
+  /// the TOML structure must be sound (a parse / shape error still fails).
+  ///
+  /// `gwm doctor` uses this to re-check one section against the real on-disk
+  /// config even when the lenient `repo_context_lenient` defaulted the whole
+  /// config away after `load_for_repo` rejected it — otherwise a check would
+  /// validate the default and mask the very error it promises to surface
+  /// (issue #219 review).
+  pub(crate) fn merge_layered(repo_root: &Path, global_path: Option<&Path>) -> Result<Self> {
     let repo_path = repo_root.join(CONFIG_FILE);
     let global_val = match global_path {
       Some(p) if p.exists() => Some(read_config_value(p)?),
@@ -1093,21 +1114,19 @@ impl Config {
       None
     };
 
-    let cfg: Config = match (global_val, repo_val) {
-      (None, None) => return Ok(Self::default()),
+    Ok(match (global_val, repo_val) {
+      (None, None) => Self::default(),
       (Some(g), None) => g.try_into()?,
       (None, Some(r)) => r.try_into()?,
       (Some(g), Some(r)) => merge_toml(g, r).try_into()?,
-    };
+    })
+  }
 
-    cfg.validate_branch_types()?;
-    cfg.validate_bootstrap_paths()?;
-    cfg.validate_bootstrap_guards()?;
-    cfg.validate_labels()?;
-    cfg.validate_aliases()?;
-    cfg.validate_tui_keys()?;
-    cfg.validate_theme()?;
-    Ok(cfg)
+  /// Effective merged config from disk for `repo_root`, layering the global
+  /// config under the repo's `.gwm.toml` exactly as [`Self::load_for_repo`]
+  /// does, but **unvalidated** — see [`Self::merge_layered`].
+  pub(crate) fn merge_for_repo_unvalidated(repo_root: &Path) -> Result<Self> {
+    Self::merge_layered(repo_root, global_config_path().as_deref())
   }
 
   /// Reject `[tui.keys]` entries that name an unknown action, list a

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -219,6 +219,13 @@ fn validate_rendered(path: &Path, raw: &str) -> Result<()> {
   cfg.validate_bootstrap_guards()?;
   cfg.validate_labels()?;
   cfg.validate_aliases()?;
+  // `[tui.keys]` / `[theme]` deserialize into raw tables resolved lazily, so a
+  // malformed keymap or theme passes `toml::from_str` cleanly. Run the same
+  // validators `Config::load_for_repo` does (issue #219 review) — otherwise
+  // `gwm config validate` / validate-before-write greenlights a config the
+  // loader will later reject.
+  cfg.validate_tui_keys()?;
+  cfg.validate_theme()?;
   Ok(())
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -157,7 +157,18 @@ pub fn run(ctx: &DoctorCtx<'_>) -> Result<DoctorReport> {
 fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   let name = "[tui.keys] keymap resolves";
 
-  let keymap = match ctx.config.tui.keys.resolved_keymap() {
+  // Re-derive `[tui.keys]` from the on-disk config (#219 review): the lenient
+  // `repo_context_lenient` returns `Config::default()` when `load_for_repo`
+  // rejects the user's file, so validating `ctx.config` here would silently
+  // OK a config that actually refuses to start the TUI. Fall back to
+  // `ctx.config` only when the *merge* fails — that is a parse / shape error
+  // already surfaced by `check_config_parses`.
+  let keys = match Config::merge_for_repo_unvalidated(ctx.repo_workdir) {
+    Ok(cfg) => cfg.tui.keys,
+    Err(_) => ctx.config.tui.keys.clone(),
+  };
+
+  let keymap = match keys.resolved_keymap() {
     Ok(km) => km,
     Err(e) => {
       return Check::failed(name, format!("{}", e))
@@ -197,7 +208,7 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   // validated the same way — an unknown context / verb, a multi-stroke
   // chord, or a per-context conflict surfaces here with the offending
   // coordinate so `gwm doctor` flags it before the user hits it live.
-  let modal = match ctx.config.tui.keys.resolved_modal_keymap() {
+  let modal = match keys.resolved_modal_keymap() {
     Ok(mk) => mk,
     Err(e) => {
       return Check::failed(name, format!("{}", e)).with_hint(

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -192,7 +192,24 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   // `gwm doctor` output and misleading the user about how many
   // actions are actually reachable.
   let bound_count = bindings.iter().filter(|b| !b.chords.is_empty()).count();
-  Check::ok(name, format!("{} action(s) bound", bound_count))
+
+  // Issue #219: the contextual modal keymap (`[tui.keys.<context>]`) is
+  // validated the same way — an unknown context / verb, a multi-stroke
+  // chord, or a per-context conflict surfaces here with the offending
+  // coordinate so `gwm doctor` flags it before the user hits it live.
+  let modal = match ctx.config.tui.keys.resolved_modal_keymap() {
+    Ok(mk) => mk,
+    Err(e) => {
+      return Check::failed(name, format!("{}", e)).with_hint(
+        "fix the `[tui.keys.<context>]` entry called out above; `gwm tui keys` lists every context and verb",
+      );
+    }
+  };
+  let modal_bound = modal.list().iter().filter(|b| !b.keys.is_empty()).count();
+  Check::ok(
+    name,
+    format!("{} global + {} modal binding(s) bound", bound_count, modal_bound),
+  )
 }
 
 /// Check #1: `.gwm.toml` parses cleanly. Missing config is fine — defaults

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -176,7 +176,7 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
     }
   };
 
-  // Issue #219: the contextual modal keymap (`[tui.keys.<context>]`) is
+  // Issue #219: the contextual modal keymap (`[tui.keys.modal.<context>]`) is
   // validated the same way — an unknown context / verb, a multi-stroke
   // chord, or a per-context conflict surfaces here with the offending
   // coordinate so `gwm doctor` flags it before the user hits it live.
@@ -187,7 +187,7 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
     Ok(mk) => mk,
     Err(e) => {
       return Check::failed(name, format!("{}", e)).with_hint(
-        "fix the `[tui.keys.<context>]` entry called out above; `gwm tui keys` lists every context and verb",
+        "fix the `[tui.keys.modal.<context>]` entry called out above; `gwm tui keys` lists every context and verb",
       );
     }
   };

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -107,6 +107,13 @@ pub struct DoctorCtx<'a> {
   pub repo_workdir: &'a Path,
   pub repo: &'a git2::Repository,
   pub config: &'a Config,
+  /// Global config layer to merge under the repo `.gwm.toml` when a check
+  /// re-reads the on-disk config (the `[tui.keys]` keymap check). Threaded
+  /// explicitly — rather than read ambiently via `global_config_path()` — so
+  /// `doctor::run` stays deterministic for embedders and unit tests that
+  /// inject an isolated context (issue #219 review). `None` skips the global
+  /// layer entirely.
+  pub global_config_path: Option<&'a Path>,
 }
 
 pub fn run(ctx: &DoctorCtx<'_>) -> Result<DoctorReport> {
@@ -160,10 +167,12 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   // Re-derive `[tui.keys]` from the on-disk config (#219 review): the lenient
   // `repo_context_lenient` returns `Config::default()` when `load_for_repo`
   // rejects the user's file, so validating `ctx.config` here would silently
-  // OK a config that actually refuses to start the TUI. Fall back to
-  // `ctx.config` only when the *merge* fails — that is a parse / shape error
-  // already surfaced by `check_config_parses`.
-  let keys = match Config::merge_for_repo_unvalidated(ctx.repo_workdir) {
+  // OK a config that actually refuses to start the TUI. The global layer is
+  // the one threaded into the context (not an ambient `global_config_path()`
+  // read) so the check stays deterministic for injected contexts. Fall back to
+  // `ctx.config` only when the *merge* fails — a parse / shape error already
+  // surfaced by `check_config_parses`.
+  let keys = match Config::merge_layered(ctx.repo_workdir, ctx.global_config_path) {
     Ok(cfg) => cfg.tui.keys,
     Err(_) => ctx.config.tui.keys.clone(),
   };

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -176,6 +176,22 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
     }
   };
 
+  // Issue #219: the contextual modal keymap (`[tui.keys.<context>]`) is
+  // validated the same way — an unknown context / verb, a multi-stroke
+  // chord, or a per-context conflict surfaces here with the offending
+  // coordinate so `gwm doctor` flags it before the user hits it live.
+  // #219 review (P2): resolve it *before* the quit warning so a hard modal
+  // error (Failed) is never downgraded to the `quit` Warning when a config
+  // carries both an unbound `quit` and an invalid modal binding.
+  let modal = match keys.resolved_modal_keymap() {
+    Ok(mk) => mk,
+    Err(e) => {
+      return Check::failed(name, format!("{}", e)).with_hint(
+        "fix the `[tui.keys.<context>]` entry called out above; `gwm tui keys` lists every context and verb",
+      );
+    }
+  };
+
   // Snapshot once. The pre-review version called `keymap.list()`
   // twice — both `quit_has_user_binding` and the success count
   // cloned the bindings vector. One snapshot reused below.
@@ -203,19 +219,6 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   // `gwm doctor` output and misleading the user about how many
   // actions are actually reachable.
   let bound_count = bindings.iter().filter(|b| !b.chords.is_empty()).count();
-
-  // Issue #219: the contextual modal keymap (`[tui.keys.<context>]`) is
-  // validated the same way — an unknown context / verb, a multi-stroke
-  // chord, or a per-context conflict surfaces here with the offending
-  // coordinate so `gwm doctor` flags it before the user hits it live.
-  let modal = match keys.resolved_modal_keymap() {
-    Ok(mk) => mk,
-    Err(e) => {
-      return Check::failed(name, format!("{}", e)).with_hint(
-        "fix the `[tui.keys.<context>]` entry called out above; `gwm tui keys` lists every context and verb",
-      );
-    }
-  };
   let modal_bound = modal.list().iter().filter(|b| !b.keys.is_empty()).count();
   Check::ok(
     name,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2338,29 +2338,30 @@ impl App {
       ConfirmKeyAction::FireNow => {}
       ConfirmKeyAction::Disarmed => {
         let secs = total.as_secs();
-        let confirm = self.confirm_key_hint(ModalAction::ConfirmConfirm, "y");
-        self.status = format!("countdown cancelled — press {confirm} to re-arm ({secs}s safety delay)");
+        // #219 review: name the live confirm key, and drop the clause entirely
+        // when it is unbound — never advertise a key that no longer re-arms.
+        self.status = match self.modal_keymap.primary_key(ModalAction::ConfirmConfirm) {
+          Some(c) => format!("countdown cancelled — press {c} to re-arm ({secs}s safety delay)"),
+          None => format!("countdown cancelled ({secs}s safety delay)"),
+        };
       }
       ConfirmKeyAction::Armed => {
         let secs = total.as_secs();
-        // #219 review: name the live confirm / cancel keys, not the defaults —
-        // they are rebindable via `[tui.keys.modal.confirm]`.
-        let confirm = self.confirm_key_hint(ModalAction::ConfirmConfirm, "y");
-        let cancel = self.confirm_key_hint(ModalAction::ConfirmCancel, "Esc");
-        self.status = format!("armed — auto-fires in {secs}s · press {confirm} again or {cancel} to cancel");
+        // #219 review: name the live confirm / cancel keys (rebindable via
+        // `[tui.keys.modal.confirm]`), dropping either clause when its verb is
+        // unbound rather than advertising a phantom key while the timer runs.
+        let confirm = self.modal_keymap.primary_key(ModalAction::ConfirmConfirm);
+        let cancel = self.modal_keymap.primary_key(ModalAction::ConfirmCancel);
+        let tail = match (confirm, cancel) {
+          (Some(c), Some(x)) => format!(" · press {c} again or {x} to cancel"),
+          (Some(c), None) => format!(" · press {c} again to disarm"),
+          (None, Some(x)) => format!(" · press {x} to cancel"),
+          (None, None) => String::new(),
+        };
+        self.status = format!("armed — auto-fires in {secs}s{tail}");
       }
     }
     action
-  }
-
-  /// The live primary key bound to a confirm-modal verb, for inline status
-  /// copy (#219 review). Falls back to the historical literal when the verb is
-  /// unbound so the destructive-modal instructions never go blank.
-  fn confirm_key_hint(&self, action: ModalAction, fallback: &str) -> String {
-    self
-      .modal_keymap
-      .primary_key(action)
-      .unwrap_or_else(|| fallback.to_string())
   }
 
   /// Handle the dismissal keys (`n` / `Esc`) inside the confirm overlay.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2122,26 +2122,30 @@ impl App {
       return CreateKey::Handled;
     }
     let on_type = self.create_form.field == Field::Type;
-    match key.code {
-      KeyCode::Esc => return CreateKey::Cancel,
-      KeyCode::Tab => self.create_next_field(),
-      KeyCode::BackTab => self.create_prev_field(),
-      KeyCode::Enter => {
+    // #219: verbs resolve through the `create` context. The type-cycling
+    // verbs (`prev_type` / `next_type`, def arrows + h/l) only fire on the
+    // Type field; on a text field their keys fall through to literal input
+    // so `h` / `l` are never swallowed while typing a description.
+    match self.resolve_modal(KeyContext::Create, key) {
+      Some(ModalAction::CreateCancel) => return CreateKey::Cancel,
+      Some(ModalAction::CreateNextField) => self.create_next_field(),
+      Some(ModalAction::CreatePrevField) => self.create_prev_field(),
+      Some(ModalAction::CreateSubmit) => {
         if self.create_form.field == Field::Desc {
           return CreateKey::Submit;
         }
         self.create_next_field();
       }
-      KeyCode::Up | KeyCode::Left if on_type => self.create_prev_type(),
-      KeyCode::Down | KeyCode::Right if on_type => self.create_next_type(),
-      KeyCode::Char('h') if on_type => self.create_prev_type(),
-      KeyCode::Char('l') if on_type => self.create_next_type(),
-      KeyCode::Char(c) if self.create_form.field == Field::Issue && !c.is_ascii_digit() => {
-        self.status = "issue accepts digits only".into();
-      }
-      KeyCode::Char(c) if !on_type => self.create_push_char(c),
-      KeyCode::Backspace if !on_type => self.create_pop_char(),
-      _ => {}
+      Some(ModalAction::CreatePrevType) if on_type => self.create_prev_type(),
+      Some(ModalAction::CreateNextType) if on_type => self.create_next_type(),
+      _ => match key.code {
+        KeyCode::Char(c) if self.create_form.field == Field::Issue && !c.is_ascii_digit() => {
+          self.status = "issue accepts digits only".into();
+        }
+        KeyCode::Char(c) if !on_type => self.create_push_char(c),
+        KeyCode::Backspace if !on_type => self.create_pop_char(),
+        _ => {}
+      },
     }
     CreateKey::Handled
   }
@@ -3076,26 +3080,32 @@ impl App {
     if self.key_matches_action(key, Action::FetchGithub) {
       return LinkPromptKey::Refresh;
     }
-    match (self.link_prompt.stage, key.code) {
-      (_, KeyCode::Esc) => return LinkPromptKey::Cancel,
-      // ChooseTarget: a vertical selectable list. j/k (and arrows) move the
-      // highlight, Enter links the highlighted row, i/p stay direct picks.
-      // With exactly two targets, up and down land on the same other row, so
-      // a single flip serves j/k/Up/Down alike.
-      (LinkPromptStage::ChooseTarget, KeyCode::Char('j') | KeyCode::Char('k') | KeyCode::Down | KeyCode::Up) => {
-        self.link_prompt.toggle_selection()
-      }
-      (LinkPromptStage::ChooseTarget, KeyCode::Char('i')) => self.link_prompt_choose(LinkTarget::Issue),
-      (LinkPromptStage::ChooseTarget, KeyCode::Char('p')) => self.link_prompt_choose(LinkTarget::Pr),
-      (LinkPromptStage::ChooseTarget, KeyCode::Enter) => {
-        let target = self.link_prompt.selected;
-        self.link_prompt_choose(target);
-      }
-      // InputNumber: type the digits, Enter submits, Backspace deletes.
-      (LinkPromptStage::InputNumber, KeyCode::Enter) => return LinkPromptKey::Submit,
-      (LinkPromptStage::InputNumber, KeyCode::Char(c)) => self.link_prompt_push_char(c),
-      (LinkPromptStage::InputNumber, KeyCode::Backspace) => self.link_prompt_pop_char(),
-      _ => {}
+    // #219: each stage is its own modal context. ChooseTarget is a vertical
+    // two-row picker — `next` / `prev` both flip the highlight (a single
+    // flip serves j/k/Up/Down alike), while `issue` / `pr` are direct picks.
+    // InputNumber routes `submit` / `cancel` through the context and treats
+    // everything else as digit input.
+    match self.link_prompt.stage {
+      LinkPromptStage::ChooseTarget => match self.resolve_modal(KeyContext::LinkChooseTarget, key) {
+        Some(ModalAction::LinkChooseCancel) => return LinkPromptKey::Cancel,
+        Some(ModalAction::LinkChooseNext) | Some(ModalAction::LinkChoosePrev) => self.link_prompt.toggle_selection(),
+        Some(ModalAction::LinkChooseIssue) => self.link_prompt_choose(LinkTarget::Issue),
+        Some(ModalAction::LinkChoosePr) => self.link_prompt_choose(LinkTarget::Pr),
+        Some(ModalAction::LinkChooseAccept) => {
+          let target = self.link_prompt.selected;
+          self.link_prompt_choose(target);
+        }
+        _ => {}
+      },
+      LinkPromptStage::InputNumber => match self.resolve_modal(KeyContext::LinkInputNumber, key) {
+        Some(ModalAction::LinkInputCancel) => return LinkPromptKey::Cancel,
+        Some(ModalAction::LinkInputSubmit) => return LinkPromptKey::Submit,
+        _ => match key.code {
+          KeyCode::Char(c) => self.link_prompt_push_char(c),
+          KeyCode::Backspace => self.link_prompt_pop_char(),
+          _ => {}
+        },
+      },
     }
     LinkPromptKey::Handled
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2338,14 +2338,29 @@ impl App {
       ConfirmKeyAction::FireNow => {}
       ConfirmKeyAction::Disarmed => {
         let secs = total.as_secs();
-        self.status = format!("countdown cancelled — press y to re-arm ({secs}s safety delay)");
+        let confirm = self.confirm_key_hint(ModalAction::ConfirmConfirm, "y");
+        self.status = format!("countdown cancelled — press {confirm} to re-arm ({secs}s safety delay)");
       }
       ConfirmKeyAction::Armed => {
         let secs = total.as_secs();
-        self.status = format!("armed — auto-fires in {secs}s · press y again or Esc to cancel");
+        // #219 review: name the live confirm / cancel keys, not the defaults —
+        // they are rebindable via `[tui.keys.confirm]`.
+        let confirm = self.confirm_key_hint(ModalAction::ConfirmConfirm, "y");
+        let cancel = self.confirm_key_hint(ModalAction::ConfirmCancel, "Esc");
+        self.status = format!("armed — auto-fires in {secs}s · press {confirm} again or {cancel} to cancel");
       }
     }
     action
+  }
+
+  /// The live primary key bound to a confirm-modal verb, for inline status
+  /// copy (#219 review). Falls back to the historical literal when the verb is
+  /// unbound so the destructive-modal instructions never go blank.
+  fn confirm_key_hint(&self, action: ModalAction, fallback: &str) -> String {
+    self
+      .modal_keymap
+      .primary_key(action)
+      .unwrap_or_else(|| fallback.to_string())
   }
 
   /// Handle the dismissal keys (`n` / `Esc`) inside the confirm overlay.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -233,7 +233,7 @@ pub struct App {
   pub keymap: Keymap,
 
   /// Resolved contextual keymap for modals / overlays (issue #219).
-  /// Built from the `[tui.keys.<context>]` sub-tables at construction
+  /// Built from the `[tui.keys.modal.<context>]` sub-tables at construction
   /// time alongside [`Self::keymap`]; consulted by the modal routing in
   /// `src/tui/mod.rs` to turn a keystroke into a typed [`ModalAction`].
   pub modal_keymap: ModalKeymap,
@@ -2344,7 +2344,7 @@ impl App {
       ConfirmKeyAction::Armed => {
         let secs = total.as_secs();
         // #219 review: name the live confirm / cancel keys, not the defaults —
-        // they are rebindable via `[tui.keys.confirm]`.
+        // they are rebindable via `[tui.keys.modal.confirm]`.
         let confirm = self.confirm_key_hint(ModalAction::ConfirmConfirm, "y");
         let cancel = self.confirm_key_hint(ModalAction::ConfirmCancel, "Esc");
         self.status = format!("armed — auto-fires in {secs}s · press {confirm} again or {cancel} to cancel");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,5 @@
 use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
+use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::palette::PaletteState;
 use super::state::async_task::{CreateWorktreeResult, EditWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 use super::state::command_logs::CommandLogs;
@@ -231,6 +232,12 @@ pub struct App {
   /// change, mirroring how every other knob in `[tui]` behaves.
   pub keymap: Keymap,
 
+  /// Resolved contextual keymap for modals / overlays (issue #219).
+  /// Built from the `[tui.keys.<context>]` sub-tables at construction
+  /// time alongside [`Self::keymap`]; consulted by the modal routing in
+  /// `src/tui/mod.rs` to turn a keystroke into a typed [`ModalAction`].
+  pub modal_keymap: ModalKeymap,
+
   /// Resolved colour theme for this TUI session (issue #33). Built
   /// from `[theme]` in `.gwm.toml` at construction time. Threaded
   /// through `draw_*` calls so user overrides reach every visual
@@ -404,6 +411,9 @@ impl App {
     // fresh error — but we re-`?` it rather than `.expect()` so a
     // future hot-reload path could exercise the same call.
     let keymap = config.tui.keys.resolved_keymap()?;
+    // Issue #219: resolve the contextual modal keymap once, same lifecycle
+    // as the global keymap above. Pre-validated by `Config::load_for_repo`.
+    let modal_keymap = config.tui.keys.resolved_modal_keymap()?;
     // Issue #33: resolve the colour theme once at construction.
     // Validated by `Config::load_for_repo` already, so this can
     // only surface a fresh error if the loader pre-validation is
@@ -439,6 +449,7 @@ impl App {
       pending_g: false,
       pending_chord: Vec::new(),
       keymap,
+      modal_keymap,
       theme,
       filter: FilterState::new(),
       picker_mode: false,
@@ -1175,6 +1186,14 @@ impl App {
       self.keymap.lookup(&[KeyStroke::from_event(&key)]),
       ChordResolution::Matched(found) if found == action
     )
+  }
+
+  /// Resolve a keystroke against the contextual modal keymap (issue #219).
+  /// Returns the [`ModalAction`] bound to `key` in `ctx`, or `None` when
+  /// nothing in that context binds it — the modal routing then applies its
+  /// text-input / default fallback (digits, free-text, sub-state guards).
+  pub fn resolve_modal(&self, ctx: KeyContext, key: KeyEvent) -> Option<ModalAction> {
+    self.modal_keymap.resolve(ctx, &KeyStroke::from_event(&key))
   }
 
   /// Mirror the new `pending_chord` buffer into the legacy

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3086,14 +3086,13 @@ impl App {
   /// (submit shell-out, view transition).
   pub fn handle_link_prompt_key(&mut self, key: KeyEvent) -> LinkPromptKey {
     use crate::tui::state::link_prompt::LinkPromptStage;
-    if self.key_matches_action(key, Action::FetchGithub) {
-      return LinkPromptKey::Refresh;
-    }
     // #219: each stage is its own modal context. ChooseTarget is a vertical
     // two-row picker — `next` / `prev` both flip the highlight (a single
     // flip serves j/k/Up/Down alike), while `issue` / `pr` are direct picks.
     // InputNumber routes `submit` / `cancel` through the context and treats
-    // everything else as digit input.
+    // everything else as digit input. The global `fetch_github` key is a
+    // FALLBACK after the stage context, so a contextual binding on that key
+    // (e.g. `submit = ["F"]`) wins over the fetch shortcut (#293 review).
     match self.link_prompt.stage {
       LinkPromptStage::ChooseTarget => match self.resolve_modal(KeyContext::LinkChooseTarget, key) {
         Some(ModalAction::LinkChooseCancel) => return LinkPromptKey::Cancel,
@@ -3104,11 +3103,13 @@ impl App {
           let target = self.link_prompt.selected;
           self.link_prompt_choose(target);
         }
+        _ if self.key_matches_action(key, Action::FetchGithub) => return LinkPromptKey::Refresh,
         _ => {}
       },
       LinkPromptStage::InputNumber => match self.resolve_modal(KeyContext::LinkInputNumber, key) {
         Some(ModalAction::LinkInputCancel) => return LinkPromptKey::Cancel,
         Some(ModalAction::LinkInputSubmit) => return LinkPromptKey::Submit,
+        _ if self.key_matches_action(key, Action::FetchGithub) => return LinkPromptKey::Refresh,
         _ => match key.code {
           KeyCode::Char(c) => self.link_prompt_push_char(c),
           KeyCode::Backspace => self.link_prompt_pop_char(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1327,7 +1327,16 @@ impl App {
       View::Create => HintContext::Create,
       View::Confirm => HintContext::Confirm,
       View::OpenMenu => HintContext::OpenMenu,
-      View::LinkPrompt => HintContext::LinkPrompt,
+      // #219: the two link-prompt stages advertise different keys — the
+      // choose-target picker vs the number-input submit/cancel — so the
+      // statusbar tracks whichever stage is live.
+      View::LinkPrompt => {
+        if self.link_prompt_stage() == crate::tui::state::link_prompt::LinkPromptStage::InputNumber {
+          HintContext::LinkInputNumber
+        } else {
+          HintContext::LinkPrompt
+        }
+      }
       View::CommandPalette => HintContext::CommandPalette,
       View::Report => HintContext::Report,
       View::Help => HintContext::Help,

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -221,12 +221,23 @@ impl KeyStroke {
   /// modifier) matches every variant. Without this, the bound chord and
   /// the runtime event compared unequal on SHIFT-reporting terminals and
   /// every uppercase binding (`G`, `R`, `V`, `H`, …) silently did nothing
-  /// (PR #192). Non-`Char` codes (e.g. `Shift+Tab` → `BackTab`) keep their
-  /// SHIFT bit untouched.
+  /// (PR #192).
+  ///
+  /// `BackTab` gets the same treatment for the same reason: it *is* the
+  /// shifted Tab, but terminals disagree on whether they additionally set
+  /// the `SHIFT` bit (some send bare `BackTab`, others `BackTab` + `SHIFT`,
+  /// kitty `BackTab` + `SHIFT`). We canonicalise to bare `BackTab` so a
+  /// binding written `"BackTab"` matches every variant. Without this the
+  /// modal `prev_field` / `prev_tab` defaults silently stopped firing on
+  /// SHIFT-reporting terminals once they routed through the keymap instead
+  /// of a modifier-blind `match KeyCode::BackTab` (issue #219 review).
   fn normalize(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
     match code {
       KeyCode::Char(c) if modifiers.contains(KeyModifiers::SHIFT) => {
         (KeyCode::Char(c.to_ascii_uppercase()), modifiers - KeyModifiers::SHIFT)
+      }
+      KeyCode::BackTab if modifiers.contains(KeyModifiers::SHIFT) => {
+        (KeyCode::BackTab, modifiers - KeyModifiers::SHIFT)
       }
       _ => (code, modifiers),
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,18 +59,18 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, confirm_buttons_line, confirm_delete_branch_line,
-  confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line,
-  filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines, header_line,
-  help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
+  build_sidebar_sections, centered_abs, chip_style, config_edit_footer_hints, confirm_buttons_line,
+  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
+  field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,
+  header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
   hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
-  link_prompt_modal_width, link_target_line, modal_hint_line, palette_name_style, pane_counter, panel_border_color,
-  pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, rename_buttons_line, status_line,
-  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_counts_footer,
-  working_tree_pane_title, working_tree_status_counts, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, WorkingTreeCounts,
-  COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON,
-  WT_MODIFIED_ICON,
+  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
+  panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
+  rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
+  working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON,
+  WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,6 +15,7 @@ mod ui;
 
 use crate::error::Result;
 use crate::tui::keymap::Action;
+use crate::tui::modal_keymap::{KeyContext, ModalAction};
 use crossterm::{
   event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers},
   execute,
@@ -346,30 +347,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
           }
         }
       }
-      View::Help => match key.code {
-        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => app.view = View::List,
-        // Scroll the Keybindings overlay when it outgrows the modal (#217).
-        KeyCode::Down | KeyCode::Char('j') => app.help_scroll_down(),
-        KeyCode::Up | KeyCode::Char('k') => app.help_scroll_up(),
-        KeyCode::Right | KeyCode::Char('l') => app.help_scroll_right(),
-        KeyCode::Left | KeyCode::Char('h') => app.help_scroll_left(),
-        KeyCode::Home | KeyCode::Char('g') => app.help_scroll = 0,
-        KeyCode::End | KeyCode::Char('G') => app.help_scroll = app.help_max_scroll,
+      // #219: keys resolved through the `help` modal context. Scroll the
+      // Keybindings overlay when it outgrows the modal (#217).
+      View::Help => match app.resolve_modal(KeyContext::Help, key) {
+        Some(ModalAction::HelpClose) => app.view = View::List,
+        Some(ModalAction::HelpScrollDown) => app.help_scroll_down(),
+        Some(ModalAction::HelpScrollUp) => app.help_scroll_up(),
+        Some(ModalAction::HelpScrollRight) => app.help_scroll_right(),
+        Some(ModalAction::HelpScrollLeft) => app.help_scroll_left(),
+        Some(ModalAction::HelpScrollTop) => app.help_scroll = 0,
+        Some(ModalAction::HelpScrollBottom) => app.help_scroll = app.help_max_scroll,
         _ => {}
       },
       // Command Logs overlay (issue #226). Scrolls like the help overlay;
       // closes on Esc / `q` or the bound `command_logs` key (default `3`)
       // so the open key toggles it shut even when rebound.
-      View::CommandLogs => match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
+      // #219: keys resolved through the `command_logs` modal context. The
+      // bound global `command_logs` key still toggles the overlay shut.
+      View::CommandLogs => match app.resolve_modal(KeyContext::CommandLogs, key) {
+        Some(ModalAction::CommandLogsClose) => app.view = View::List,
         // `y` copies the whole transcript to the clipboard (issue #279).
-        KeyCode::Char('y') => copy_command_logs_to_clipboard(&mut app),
-        KeyCode::Down | KeyCode::Char('j') => app.command_logs.scroll_down(),
-        KeyCode::Up | KeyCode::Char('k') => app.command_logs.scroll_up(),
-        KeyCode::Right | KeyCode::Char('l') => app.command_logs.scroll_right(),
-        KeyCode::Left | KeyCode::Char('h') => app.command_logs.scroll_left(),
-        KeyCode::Home | KeyCode::Char('g') => app.command_logs.scroll_to_top(),
-        KeyCode::End | KeyCode::Char('G') => app.command_logs.scroll_to_bottom(),
+        Some(ModalAction::CommandLogsCopy) => copy_command_logs_to_clipboard(&mut app),
+        Some(ModalAction::CommandLogsScrollDown) => app.command_logs.scroll_down(),
+        Some(ModalAction::CommandLogsScrollUp) => app.command_logs.scroll_up(),
+        Some(ModalAction::CommandLogsScrollRight) => app.command_logs.scroll_right(),
+        Some(ModalAction::CommandLogsScrollLeft) => app.command_logs.scroll_left(),
+        Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
+        Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
         _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
         _ => {}
       },
@@ -380,49 +384,51 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // edit layer, Up/Down select fields (or scroll on the read-only `All`
       // tab), Space/Enter cycle a choice or open the numeric input, and
       // Esc / `q` / the bound `config_panel` key (default `4`) close.
-      View::Config if app.config_panel.editing.is_some() => match key.code {
-        KeyCode::Enter => app.commit_settings_edit(),
-        KeyCode::Esc => app.config_panel.cancel_edit(),
-        KeyCode::Backspace => app.config_panel.pop_edit_char(),
-        KeyCode::Char(c) => app.config_panel.push_edit_char(c),
-        _ => {}
+      // #219: edit sub-mode keys resolve through the `config.edit` context;
+      // anything else is literal input into the numeric edit buffer.
+      View::Config if app.config_panel.editing.is_some() => match app.resolve_modal(KeyContext::ConfigEdit, key) {
+        Some(ModalAction::ConfigEditSubmit) => app.commit_settings_edit(),
+        Some(ModalAction::ConfigEditCancel) => app.config_panel.cancel_edit(),
+        _ => match key.code {
+          KeyCode::Backspace => app.config_panel.pop_edit_char(),
+          KeyCode::Char(c) => app.config_panel.push_edit_char(c),
+          _ => {}
+        },
       },
-      View::Config => match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => app.view = View::List,
-        KeyCode::Tab => app.config_panel.next_tab(),
-        KeyCode::BackTab => app.config_panel.prev_tab(),
-        KeyCode::Char('L') => app.config_panel.toggle_layer(),
-        KeyCode::Char(' ') | KeyCode::Enter => app.activate_selected_setting(),
-        KeyCode::Down | KeyCode::Char('j') => {
-          if app.config_panel.tab == SettingsTab::All {
-            app.config_panel.scroll_down();
-          } else {
-            app.config_panel.select_next();
+      // #219: nav keys resolve through the `config` context. Select vs scroll
+      // and the horizontal pan / jump verbs stay gated on the read-only `All`
+      // tab exactly as before; the bound global `config_panel` key still
+      // toggles the overlay shut.
+      View::Config => {
+        let on_all = app.config_panel.tab == SettingsTab::All;
+        match app.resolve_modal(KeyContext::Config, key) {
+          Some(ModalAction::ConfigClose) => app.view = View::List,
+          Some(ModalAction::ConfigNextTab) => app.config_panel.next_tab(),
+          Some(ModalAction::ConfigPrevTab) => app.config_panel.prev_tab(),
+          Some(ModalAction::ConfigToggleLayer) => app.config_panel.toggle_layer(),
+          Some(ModalAction::ConfigActivate) => app.activate_selected_setting(),
+          Some(ModalAction::ConfigSelectNext) => {
+            if on_all {
+              app.config_panel.scroll_down();
+            } else {
+              app.config_panel.select_next();
+            }
           }
-        }
-        KeyCode::Up | KeyCode::Char('k') => {
-          if app.config_panel.tab == SettingsTab::All {
-            app.config_panel.scroll_up();
-          } else {
-            app.config_panel.select_prev();
+          Some(ModalAction::ConfigSelectPrev) => {
+            if on_all {
+              app.config_panel.scroll_up();
+            } else {
+              app.config_panel.select_prev();
+            }
           }
+          Some(ModalAction::ConfigScrollRight) if on_all => app.config_panel.scroll_right(),
+          Some(ModalAction::ConfigScrollLeft) if on_all => app.config_panel.scroll_left(),
+          Some(ModalAction::ConfigScrollTop) if on_all => app.config_panel.scroll_to_top(),
+          Some(ModalAction::ConfigScrollBottom) if on_all => app.config_panel.scroll_to_bottom(),
+          _ if app.key_matches_action(key, Action::ConfigPanel) => app.view = View::List,
+          _ => {}
         }
-        // Horizontal pan + jump only matter on the long read-only `All` tab.
-        KeyCode::Right | KeyCode::Char('l') if app.config_panel.tab == SettingsTab::All => {
-          app.config_panel.scroll_right()
-        }
-        KeyCode::Left | KeyCode::Char('h') if app.config_panel.tab == SettingsTab::All => {
-          app.config_panel.scroll_left()
-        }
-        KeyCode::Home | KeyCode::Char('g') if app.config_panel.tab == SettingsTab::All => {
-          app.config_panel.scroll_to_top()
-        }
-        KeyCode::End | KeyCode::Char('G') if app.config_panel.tab == SettingsTab::All => {
-          app.config_panel.scroll_to_bottom()
-        }
-        _ if app.key_matches_action(key, Action::ConfigPanel) => app.view = View::List,
-        _ => {}
-      },
+      }
       // Create-overlay keys live in a testable `App` method (issue #217);
       // the loop only owns the two side effects (submit / close). While the
       // async create worker is in flight (#276), keep the modal locked so a
@@ -438,46 +444,50 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         CreateKey::Handled => {}
       },
       View::Confirm if app.is_delete_worktree_loading() => {}
-      View::Confirm => match key.code {
-        // `y` confirms directly regardless of which button is focused
-        // (unchanged muscle memory). `Enter` activates the *focused*
-        // button — and focus defaults to Cancel (#187), so a stray
-        // Enter on a freshly-opened modal cancels rather than deletes.
-        KeyCode::Char('y') => confirm_fire(&mut app),
-        KeyCode::Enter => match app.confirm.focused_button() {
+      // #219: keys resolve through the `confirm` context. `confirm` (def `y`)
+      // fires regardless of focus (unchanged muscle memory); `activate` (def
+      // Enter) acts on the *focused* button — focus defaults to Cancel (#187),
+      // so a stray Enter on a freshly-opened modal cancels rather than
+      // deletes. The bound global `delete_branch` key still toggles the
+      // branch-deletion checkbox. Focus nav (#187): `focus_confirm` (←/h),
+      // `focus_cancel` (→/l), `toggle_focus` (Tab).
+      View::Confirm => match app.resolve_modal(KeyContext::Confirm, key) {
+        Some(ModalAction::ConfirmConfirm) => confirm_fire(&mut app),
+        Some(ModalAction::ConfirmActivate) => match app.confirm.focused_button() {
           ConfirmButton::Confirm => confirm_fire(&mut app),
           ConfirmButton::Cancel => app.confirm_dismiss(),
         },
-        KeyCode::Char('n') | KeyCode::Esc => app.confirm_dismiss(),
+        Some(ModalAction::ConfirmCancel) => app.confirm_dismiss(),
+        Some(ModalAction::ConfirmFocusConfirm) => app.confirm.focus_confirm(),
+        Some(ModalAction::ConfirmFocusCancel) => app.confirm.focus_cancel(),
+        Some(ModalAction::ConfirmToggleFocus) => app.confirm.toggle_focus(),
         _ if app.key_matches_action(key, Action::ToggleDeleteBranch) => app.toggle_delete_branch(),
-        // Button focus navigation (#187). `←` / `h` → Confirm,
-        // `→` / `l` → Cancel, `Tab` toggles.
-        KeyCode::Left | KeyCode::Char('h') => app.confirm.focus_confirm(),
-        KeyCode::Right | KeyCode::Char('l') => app.confirm.focus_cancel(),
-        KeyCode::Tab => app.confirm.toggle_focus(),
         _ => {}
       },
-      View::Report => match key.code {
-        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter => {
+      // #219: the bootstrap-report overlay closes (and refreshes) on the
+      // `report` context's `close` verb (def Esc / q / Enter).
+      View::Report => {
+        if let Some(ModalAction::ReportClose) = app.resolve_modal(KeyContext::Report, key) {
           app.view = View::List;
           app.refresh()?;
         }
-        _ => {}
-      },
-      View::OpenMenu => match key.code {
-        KeyCode::Esc | KeyCode::Char('q') => app.exit_open_menu(),
-        KeyCode::Char('j') | KeyCode::Char('k') | KeyCode::Down | KeyCode::Up => app.open_menu_toggle_selection(),
-        KeyCode::Enter => {
+      }
+      // #219: keys resolve through the `open_menu` context. The bound global
+      // `fetch_github` key still refreshes the GitHub status in place.
+      View::OpenMenu => match app.resolve_modal(KeyContext::OpenMenu, key) {
+        Some(ModalAction::OpenMenuClose) => app.exit_open_menu(),
+        Some(ModalAction::OpenMenuToggle) => app.open_menu_toggle_selection(),
+        Some(ModalAction::OpenMenuAccept) => {
           if let Some(url) = app.open_menu_pick(app.open_menu_selected) {
             open_url(&url, &mut app);
           }
         }
-        KeyCode::Char('i') => {
+        Some(ModalAction::OpenMenuIssue) => {
           if let Some(url) = app.open_menu_pick(LinkTarget::Issue) {
             open_url(&url, &mut app);
           }
         }
-        KeyCode::Char('p') => {
+        Some(ModalAction::OpenMenuPr) => {
           if let Some(url) = app.open_menu_pick(LinkTarget::Pr) {
             open_url(&url, &mut app);
           }
@@ -503,6 +513,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // overlay so the user can exit even if the program does not respond to
       // `q`. Process death (natural exit via lazygit's `q`) is detected by
       // the pre-draw `is_alive()` check above and also closes the overlay.
+      //
+      // #219: this `Esc` stays hard-coded by design — it is an *emergency*
+      // detach, and routing it through a rebindable context would silently
+      // steal a keystroke from the child program. See the `modal_keymap`
+      // module note ("What stays hard-coded").
       View::Pty => match key.code {
         KeyCode::Esc => app.close_pty_overlay(),
         _ => {
@@ -535,26 +550,30 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // search) that share the input bar don't inherit a "swallow
       // everything" contract by accident. Esc / Enter / arrows /
       // Tab still exit or navigate; Backspace edits.
-      View::CommandPalette => match key.code {
-        KeyCode::Esc => app.close_command_palette(),
-        KeyCode::Enter => {
+      // #219: close / accept / prev / next resolve through the `palette`
+      // context; every other key is literal input into the fuzzy buffer.
+      View::CommandPalette => match app.resolve_modal(KeyContext::CommandPalette, key) {
+        Some(ModalAction::CommandPaletteClose) => app.close_command_palette(),
+        Some(ModalAction::CommandPaletteAccept) => {
           if let Some(action) = app.accept_command_palette() {
             run_palette_action(terminal, &mut app, action)?;
           }
         }
-        KeyCode::Up => app.palette_cycle_up(),
-        KeyCode::Down | KeyCode::Tab => app.palette_cycle_down(),
-        KeyCode::Backspace => app.palette_pop_char(),
-        KeyCode::Char(c) if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-' => {
-          app.palette_push_char(c);
-        }
-        // Any other char (including the palette trigger `:`, the
-        // help glyph `?`, uppercase letters) is dropped — there is
-        // no palette entry name that could match it. Silently
-        // ignoring is friendlier than appending and producing zero
-        // matches with no explanation.
-        KeyCode::Char(_) => {}
-        _ => {}
+        Some(ModalAction::CommandPalettePrev) => app.palette_cycle_up(),
+        Some(ModalAction::CommandPaletteNext) => app.palette_cycle_down(),
+        _ => match key.code {
+          KeyCode::Backspace => app.palette_pop_char(),
+          KeyCode::Char(c) if c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-' => {
+            app.palette_push_char(c);
+          }
+          // Any other char (including the palette trigger `:`, the
+          // help glyph `?`, uppercase letters) is dropped — there is
+          // no palette entry name that could match it. Silently
+          // ignoring is friendlier than appending and producing zero
+          // matches with no explanation.
+          KeyCode::Char(_) => {}
+          _ => {}
+        },
       },
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,7 @@ mod app;
 #[doc(hidden)]
 pub mod commit_graph;
 pub mod keymap;
+pub mod modal_keymap;
 pub mod palette;
 pub mod state;
 pub mod theme;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,18 +59,18 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, config_edit_footer_hints, confirm_buttons_line,
-  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
-  field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,
-  header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
-  hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
-  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
-  panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
-  rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
-  working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts, working_tree_status_line,
-  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON,
-  WT_DELETED_ICON, WT_MODIFIED_ICON,
+  build_sidebar_sections, centered_abs, chip_style, command_logs_footer_hints, config_edit_footer_hints,
+  config_nav_footer_hints, confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line,
+  delete_worktree_title, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, format_status,
+  freshness_color, github_status_lines, header_line, help_body_section_color, help_entry_line, help_label_style,
+  help_lines, help_rows, help_section_style, hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title,
+  issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_keys, link_target_line,
+  modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
+  recent_commits_lines, recent_items_pane_title, rename_buttons_line, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, type_selector_line, working_tree_counts_footer, working_tree_pane_title,
+  working_tree_status_counts, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
+  HelpRow, HintContext, SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON,
+  RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -413,6 +413,31 @@ impl ModalKeymap {
   pub fn list(&self) -> &[ModalBinding] {
     &self.entries
   }
+
+  /// The first key bound to `action`, rendered for an inline hint (the
+  /// statusbar chip / help-overlay footer). `None` when the verb is
+  /// unbound — the caller drops it rather than advertise a phantom key.
+  /// Mirrors [`crate::tui::keymap::Keymap::primary_chord`].
+  pub fn primary_key(&self, action: ModalAction) -> Option<String> {
+    self
+      .entries
+      .iter()
+      .find(|b| b.action == action)
+      .and_then(|b| b.keys.first())
+      .map(|k| k.to_string())
+  }
+
+  /// Every key bound to `action`, comma-joined (`"n, Esc"`) or empty when
+  /// unbound — the help-overlay row form, matching the global keymap's
+  /// `keys_for` rendering.
+  pub fn keys_display(&self, action: ModalAction) -> String {
+    self
+      .entries
+      .iter()
+      .find(|b| b.action == action)
+      .map(|b| b.keys.iter().map(|k| k.to_string()).collect::<Vec<_>>().join(", "))
+      .unwrap_or_default()
+  }
 }
 
 impl Default for ModalKeymap {

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -1,0 +1,422 @@
+//! Contextual modal / overlay keymap (issue #219).
+//!
+//! The global keymap in [`crate::tui::keymap`] resolves the `View::List`
+//! verbs (`j`, `g g`, `o`, `R`, …) and, deliberately, *only* those: its
+//! module note explains why `Esc` / `Enter` were kept hard-coded — their
+//! meaning depends on the active view, and a single global table cannot
+//! express "Enter submits in the create modal but activates the focused
+//! button in the confirm modal".
+//!
+//! This module lifts that limitation for the modals/overlays. Every modal
+//! is a [`KeyContext`]; each context owns a small set of typed verbs
+//! ([`ModalAction`]); the same physical key can map to different verbs in
+//! different contexts without any global conflict, because resolution is
+//! always scoped to the **active** context.
+//!
+//! ## Single-stroke only
+//!
+//! Unlike the global keymap, modal bindings are **single keystrokes** —
+//! no chords, no prefixes, no pending buffer. Modals are short-lived and
+//! the project refuses a Vim-style runtime timeout (see the global
+//! keymap's chord/prefix note). A user override that supplies a
+//! multi-stroke chord (`"g g"`) is rejected at load time with a precise
+//! message rather than silently never firing.
+//!
+//! ## What stays hard-coded
+//!
+//! - `Ctrl+C` — the emergency quit in `run_app`, ahead of every lookup.
+//! - `View::List`'s `Esc` / `Enter` — still contextual on filter / picker
+//!   / sticky-filter state, which the config language cannot express.
+//! - The PTY overlay's `Esc` — it is an *emergency* detach from a child
+//!   that otherwise receives every keystroke; making it rebindable would
+//!   silently steal a key from lazygit / the shell. Documented in the
+//!   `View::Pty` branch.
+//!
+//! ## Config surface
+//!
+//! Bindings live under `[tui.keys.<context-path>]` in `.gwm.toml`, nested
+//! below the existing global `[tui.keys]` table:
+//!
+//! ```toml
+//! [tui.keys]            # global verbs — unchanged
+//! quit = ["q"]
+//!
+//! [tui.keys.confirm]    # contextual verbs — new
+//! confirm = ["y"]
+//! cancel  = ["n", "Esc"]
+//!
+//! [tui.keys.link.choose_target]
+//! issue = ["i"]
+//! pr    = ["p"]
+//! ```
+//!
+//! The walker that turns that TOML into a [`ModalKeymap`] lives in
+//! [`crate::config`]; this module owns the typed model, the defaults, the
+//! per-context conflict validation, and the single-stroke resolver.
+
+use crate::error::{GwmError, Result};
+use crate::tui::keymap::{KeyStroke, Source};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// KeyContext
+// ---------------------------------------------------------------------------
+
+/// One modal / overlay surface whose keys are independently rebindable.
+///
+/// `config_path` is the dotted key under `[tui.keys]` that addresses the
+/// context's sub-table (`confirm`, `link.choose_target`, `config.edit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum KeyContext {
+  /// Create-worktree modal (also reused by the rename / `View::Edit` modal).
+  Create,
+  /// Delete-confirmation modal.
+  Confirm,
+  /// Keybindings / help overlay (scroll-only).
+  Help,
+  /// Command-logs overlay (issue #226, scroll-only + copy).
+  CommandLogs,
+  /// Settings panel navigation (issue #232).
+  Config,
+  /// Settings panel while a numeric field is being edited (sub-mode of
+  /// [`KeyContext::Config`]; a separate context because `Enter` means
+  /// *commit* here but *activate* in nav).
+  ConfigEdit,
+  /// Bootstrap-report overlay (scroll-only / close).
+  Report,
+  /// Browse-links menu (issue #224 / #290).
+  OpenMenu,
+  /// Command palette overlay (issue #32).
+  CommandPalette,
+  /// Link prompt, stage 1 — choose issue vs PR.
+  LinkChooseTarget,
+  /// Link prompt, stage 2 — type the issue / PR number.
+  LinkInputNumber,
+}
+
+impl KeyContext {
+  /// Dotted key under `[tui.keys]` addressing this context's sub-table.
+  pub fn config_path(self) -> &'static str {
+    match self {
+      KeyContext::Create => "create",
+      KeyContext::Confirm => "confirm",
+      KeyContext::Help => "help",
+      KeyContext::CommandLogs => "command_logs",
+      KeyContext::Config => "config",
+      KeyContext::ConfigEdit => "config.edit",
+      KeyContext::Report => "report",
+      KeyContext::OpenMenu => "open_menu",
+      KeyContext::CommandPalette => "palette",
+      KeyContext::LinkChooseTarget => "link.choose_target",
+      KeyContext::LinkInputNumber => "link.input_number",
+    }
+  }
+
+  /// Inverse of [`Self::config_path`] — used by the config walker to map a
+  /// `[tui.keys.<path>]` sub-table back to a typed context.
+  pub fn from_config_path(path: &str) -> Option<Self> {
+    Self::all().iter().copied().find(|c| c.config_path() == path)
+  }
+
+  /// Every context, in declaration order (the order `gwm tui keys` lists).
+  pub fn all() -> &'static [KeyContext] {
+    use KeyContext::*;
+    &[
+      Create,
+      Confirm,
+      Help,
+      CommandLogs,
+      Config,
+      ConfigEdit,
+      Report,
+      OpenMenu,
+      CommandPalette,
+      LinkChooseTarget,
+      LinkInputNumber,
+    ]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ModalAction + defaults table
+// ---------------------------------------------------------------------------
+
+/// Declarative definition of every modal verb, grouped by context, with its
+/// local verb slug and built-in default keystrokes. One ordered list keeps
+/// the enum, the `context`/`verb`/`default` accessors, and `all()` in sync.
+macro_rules! define_modal_actions {
+  ( $( $ctx:ident { $( $variant:ident => $verb:literal [ $( $chord:literal ),* $(,)? ] ),* $(,)? } )* ) => {
+    /// A context-qualified modal verb. Variant names are
+    /// `<Context><Verb>` so the flat enum stays unambiguous; the
+    /// `(context, verb)` pair is what the config surface addresses.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub enum ModalAction {
+      $( $( $variant, )* )*
+    }
+
+    impl ModalAction {
+      /// The context this verb belongs to.
+      pub fn context(self) -> KeyContext {
+        match self { $( $( ModalAction::$variant => KeyContext::$ctx, )* )* }
+      }
+
+      /// The context-local verb slug used under `[tui.keys.<context>]`.
+      pub fn verb(self) -> &'static str {
+        match self { $( $( ModalAction::$variant => $verb, )* )* }
+      }
+
+      /// Built-in default keystroke literals (each a single stroke).
+      fn default_chord_strs(self) -> &'static [&'static str] {
+        match self { $( $( ModalAction::$variant => &[ $( $chord, )* ], )* )* }
+      }
+
+      /// Every verb, in declaration order.
+      pub fn all() -> impl Iterator<Item = Self> {
+        [ $( $( ModalAction::$variant, )* )* ].into_iter()
+      }
+    }
+  };
+}
+
+define_modal_actions! {
+  Create {
+    CreateCancel    => "cancel"     [ "Esc" ],
+    CreateNextField => "next_field" [ "Tab" ],
+    CreatePrevField => "prev_field" [ "BackTab" ],
+    CreateSubmit    => "submit"     [ "Enter" ],
+    CreatePrevType  => "prev_type"  [ "Up", "Left", "h" ],
+    CreateNextType  => "next_type"  [ "Down", "Right", "l" ],
+  }
+  Confirm {
+    ConfirmConfirm      => "confirm"       [ "y" ],
+    ConfirmActivate     => "activate"      [ "Enter" ],
+    ConfirmCancel       => "cancel"        [ "n", "Esc" ],
+    ConfirmFocusConfirm => "focus_confirm" [ "Left", "h" ],
+    ConfirmFocusCancel  => "focus_cancel"  [ "Right", "l" ],
+    ConfirmToggleFocus  => "toggle_focus"  [ "Tab" ],
+  }
+  Help {
+    HelpClose        => "close"         [ "Esc", "q", "?" ],
+    HelpScrollDown   => "scroll_down"   [ "Down", "j" ],
+    HelpScrollUp     => "scroll_up"     [ "Up", "k" ],
+    HelpScrollRight  => "scroll_right"  [ "Right", "l" ],
+    HelpScrollLeft   => "scroll_left"   [ "Left", "h" ],
+    HelpScrollTop    => "scroll_top"    [ "Home", "g" ],
+    HelpScrollBottom => "scroll_bottom" [ "End", "G" ],
+  }
+  CommandLogs {
+    CommandLogsClose        => "close"         [ "Esc", "q" ],
+    CommandLogsCopy         => "copy"          [ "y" ],
+    CommandLogsScrollDown   => "scroll_down"   [ "Down", "j" ],
+    CommandLogsScrollUp     => "scroll_up"     [ "Up", "k" ],
+    CommandLogsScrollRight  => "scroll_right"  [ "Right", "l" ],
+    CommandLogsScrollLeft   => "scroll_left"   [ "Left", "h" ],
+    CommandLogsScrollTop    => "scroll_top"    [ "Home", "g" ],
+    CommandLogsScrollBottom => "scroll_bottom" [ "End", "G" ],
+  }
+  Config {
+    ConfigClose        => "close"         [ "Esc", "q" ],
+    ConfigNextTab      => "next_tab"      [ "Tab" ],
+    ConfigPrevTab      => "prev_tab"      [ "BackTab" ],
+    ConfigToggleLayer  => "toggle_layer"  [ "L" ],
+    ConfigActivate     => "activate"      [ "Space", "Enter" ],
+    ConfigSelectNext   => "select_next"   [ "Down", "j" ],
+    ConfigSelectPrev   => "select_prev"   [ "Up", "k" ],
+    ConfigScrollRight  => "scroll_right"  [ "Right", "l" ],
+    ConfigScrollLeft   => "scroll_left"   [ "Left", "h" ],
+    ConfigScrollTop    => "scroll_top"    [ "Home", "g" ],
+    ConfigScrollBottom => "scroll_bottom" [ "End", "G" ],
+  }
+  ConfigEdit {
+    ConfigEditSubmit => "submit" [ "Enter" ],
+    ConfigEditCancel => "cancel" [ "Esc" ],
+  }
+  Report {
+    ReportClose => "close" [ "Esc", "q", "Enter" ],
+  }
+  OpenMenu {
+    OpenMenuClose  => "close"  [ "Esc", "q" ],
+    OpenMenuToggle => "toggle" [ "j", "k", "Down", "Up" ],
+    OpenMenuAccept => "accept" [ "Enter" ],
+    OpenMenuIssue  => "issue"  [ "i" ],
+    OpenMenuPr     => "pr"     [ "p" ],
+  }
+  CommandPalette {
+    CommandPaletteClose  => "close"  [ "Esc" ],
+    CommandPaletteAccept => "accept" [ "Enter" ],
+    CommandPalettePrev   => "prev"   [ "Up" ],
+    CommandPaletteNext   => "next"   [ "Down", "Tab" ],
+  }
+  LinkChooseTarget {
+    LinkChooseNext   => "next"   [ "j", "Down" ],
+    LinkChoosePrev   => "prev"   [ "k", "Up" ],
+    LinkChooseIssue  => "issue"  [ "i" ],
+    LinkChoosePr     => "pr"     [ "p" ],
+    LinkChooseAccept => "accept" [ "Enter" ],
+    LinkChooseCancel => "cancel" [ "Esc" ],
+  }
+  LinkInputNumber {
+    LinkInputSubmit => "submit" [ "Enter" ],
+    LinkInputCancel => "cancel" [ "Esc" ],
+  }
+}
+
+impl ModalAction {
+  /// Resolve a `(context, verb-slug)` pair to a typed verb. Used by the
+  /// config walker to translate `[tui.keys.<context>].<verb>` keys.
+  pub fn from_context_verb(ctx: KeyContext, verb: &str) -> Option<Self> {
+    Self::all().find(|a| a.context() == ctx && a.verb() == verb)
+  }
+
+  /// Default keystrokes for this verb, parsed. Panics on a malformed
+  /// literal — that is a programmer error in the table above, never user
+  /// input (same contract as the global keymap's `def`).
+  fn default_keys(self) -> Vec<KeyStroke> {
+    self
+      .default_chord_strs()
+      .iter()
+      .map(|s| {
+        parse_single(s)
+          .unwrap_or_else(|e| panic!("default modal binding {:?} for {:?} failed to parse: {}", s, self, e))
+      })
+      .collect()
+  }
+}
+
+/// Parse a binding string that must resolve to exactly one keystroke.
+/// Modal bindings have no chord machinery, so a multi-stroke string is a
+/// hard error (returned to the user verbatim by the config walker).
+pub fn parse_single(s: &str) -> Result<KeyStroke> {
+  let strokes = KeyStroke::parse_chord(s)?;
+  match strokes.into_iter().collect::<Vec<_>>().as_slice() {
+    [one] => Ok(one.clone()),
+    _ => Err(GwmError::Config(format!(
+      "modal bindings must be a single keystroke, got chord {:?} (modals have no chord timeout)",
+      s
+    ))),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ModalKeymap
+// ---------------------------------------------------------------------------
+
+/// One resolved binding: a verb, the single-strokes that fire it (any one
+/// match suffices), and the layer it came from.
+#[derive(Debug, Clone)]
+pub struct ModalBinding {
+  pub action: ModalAction,
+  pub keys: Vec<KeyStroke>,
+  pub source: Source,
+}
+
+/// The resolved contextual keymap: every modal verb with its keys. Built
+/// from [`ModalKeymap::defaults`] then layered with user overrides via
+/// [`ModalKeymap::apply_override`].
+#[derive(Debug, Clone)]
+pub struct ModalKeymap {
+  entries: Vec<ModalBinding>,
+}
+
+impl ModalKeymap {
+  /// Built-in defaults — mirror the historical hard-coded modal routing in
+  /// `src/tui/mod.rs` before issue #219.
+  pub fn defaults() -> Self {
+    let entries = ModalAction::all()
+      .map(|action| ModalBinding {
+        action,
+        keys: action.default_keys(),
+        source: Source::Default,
+      })
+      .collect();
+    Self { entries }
+  }
+
+  /// Replace the keys bound to `action` with `keys` and re-validate the
+  /// action's **context**. An empty `Vec` unbinds the verb.
+  ///
+  /// Validation rejects the same stroke wired to two different verbs *in
+  /// the same context* (cross-context reuse is fine — that is the whole
+  /// point). A default binding in the same context silently vacates any
+  /// stroke the override claims, mirroring the global keymap: explicit
+  /// user intent wins over a shipped default.
+  pub fn apply_override(&mut self, action: ModalAction, keys: Vec<KeyStroke>) -> Result<()> {
+    let ctx = action.context();
+    let claimed: Vec<&KeyStroke> = keys.iter().collect();
+
+    // Build the post-override key→action map for this context (excluding the
+    // action being replaced), vacating claimed strokes from defaults.
+    let mut map: HashMap<KeyStroke, ModalAction> = HashMap::new();
+    for b in &self.entries {
+      if b.action.context() != ctx || b.action == action {
+        continue;
+      }
+      for k in &b.keys {
+        if b.source == Source::Default && claimed.contains(&k) {
+          continue;
+        }
+        map.insert(k.clone(), b.action);
+      }
+    }
+    for k in &keys {
+      if let Some(prev) = map.get(k) {
+        return Err(GwmError::Config(format!(
+          "tui.keys.{}: key {} bound to both {:?} and {:?} — conflict",
+          ctx.config_path(),
+          k,
+          prev.verb(),
+          action.verb()
+        )));
+      }
+    }
+
+    // Commit: vacate claimed strokes from same-context defaults, then
+    // replace the target verb's binding.
+    let claimed_owned: Vec<KeyStroke> = keys.clone();
+    for entry in self.entries.iter_mut() {
+      if entry.action.context() == ctx && entry.action != action && entry.source == Source::Default {
+        entry.keys.retain(|k| !claimed_owned.contains(k));
+      }
+    }
+    if let Some(entry) = self.entries.iter_mut().find(|b| b.action == action) {
+      entry.keys = keys;
+      entry.source = Source::UserConfig;
+    } else {
+      self.entries.push(ModalBinding {
+        action,
+        keys,
+        source: Source::UserConfig,
+      });
+    }
+    Ok(())
+  }
+
+  /// Resolve a single keystroke against the bindings of `ctx`. Returns the
+  /// matched verb, or `None` when nothing in this context binds the stroke
+  /// (the caller then applies the context's text-input / default fallback).
+  pub fn resolve(&self, ctx: KeyContext, stroke: &KeyStroke) -> Option<ModalAction> {
+    self
+      .entries
+      .iter()
+      .filter(|b| b.action.context() == ctx)
+      .find(|b| b.keys.iter().any(|k| k == stroke))
+      .map(|b| b.action)
+  }
+
+  /// Every binding whose verb lives in `ctx`, in declaration order.
+  pub fn bindings_for(&self, ctx: KeyContext) -> Vec<&ModalBinding> {
+    self.entries.iter().filter(|b| b.action.context() == ctx).collect()
+  }
+
+  /// Snapshot of every binding, declaration order, for `gwm tui keys` /
+  /// the help overlay / `gwm doctor`.
+  pub fn list(&self) -> &[ModalBinding] {
+    &self.entries
+  }
+}
+
+impl Default for ModalKeymap {
+  fn default() -> Self {
+    Self::defaults()
+  }
+}

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -62,6 +62,7 @@
 
 use crate::error::{GwmError, Result};
 use crate::tui::keymap::{KeyStroke, Source};
+use crossterm::event::{KeyCode, KeyModifiers};
 use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
@@ -294,13 +295,27 @@ impl ModalAction {
 /// hard error (returned to the user verbatim by the config walker).
 pub fn parse_single(s: &str) -> Result<KeyStroke> {
   let strokes = KeyStroke::parse_chord(s)?;
-  match strokes.into_iter().collect::<Vec<_>>().as_slice() {
-    [one] => Ok(one.clone()),
-    _ => Err(GwmError::Config(format!(
-      "modal bindings must be a single keystroke, got chord {:?} (modals have no chord timeout)",
+  let stroke = match strokes.into_iter().collect::<Vec<_>>().as_slice() {
+    [one] => one.clone(),
+    _ => {
+      return Err(GwmError::Config(format!(
+        "modal bindings must be a single keystroke, got chord {:?} (modals have no chord timeout)",
+        s
+      )))
+    }
+  };
+  // Ctrl+C is the emergency quit handled in `run_app` ahead of every lookup,
+  // so a modal binding to it would never fire — reject it rather than let
+  // `gwm tui keys` / footer hints advertise an unreachable action (#219 review).
+  if stroke.modifiers.contains(KeyModifiers::CONTROL)
+    && matches!(stroke.code, KeyCode::Char(c) if c.eq_ignore_ascii_case(&'c'))
+  {
+    return Err(GwmError::Config(format!(
+      "modal bindings cannot use {:?}: Ctrl+C is the reserved emergency quit (handled before any modal lookup)",
       s
-    ))),
+    )));
   }
+  Ok(stroke)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -34,18 +34,24 @@
 //!
 //! ## Config surface
 //!
-//! Bindings live under `[tui.keys.<context-path>]` in `.gwm.toml`, nested
-//! below the existing global `[tui.keys]` table:
+//! Bindings live under `[tui.keys.modal.<context-path>]` in `.gwm.toml`,
+//! nested below a dedicated `modal` namespace inside the global `[tui.keys]`
+//! table. The separate namespace keeps a modal context from colliding with a
+//! same-named global action (`create` / `help` / `command_logs` / `link` are
+//! both) at the `tui.keys.<name>` path — a collision the layered merge would
+//! otherwise resolve by silently dropping the global override (issue #219
+//! review):
 //!
 //! ```toml
-//! [tui.keys]            # global verbs — unchanged
-//! quit = ["q"]
+//! [tui.keys]                  # global verbs — arrays, unchanged
+//! quit   = ["q"]
+//! create = ["c"]              # global action; coexists with the modal below
 //!
-//! [tui.keys.confirm]    # contextual verbs — new
+//! [tui.keys.modal.confirm]    # contextual verbs — single strokes
 //! confirm = ["y"]
 //! cancel  = ["n", "Esc"]
 //!
-//! [tui.keys.link.choose_target]
+//! [tui.keys.modal.link.choose_target]
 //! issue = ["i"]
 //! pr    = ["p"]
 //! ```
@@ -64,8 +70,8 @@ use std::collections::HashMap;
 
 /// One modal / overlay surface whose keys are independently rebindable.
 ///
-/// `config_path` is the dotted key under `[tui.keys]` that addresses the
-/// context's sub-table (`confirm`, `link.choose_target`, `config.edit`).
+/// `config_path` is the dotted key under `[tui.keys.modal]` that addresses
+/// the context's sub-table (`confirm`, `link.choose_target`, `config.edit`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum KeyContext {
   /// Create-worktree modal (also reused by the rename / `View::Edit` modal).
@@ -95,7 +101,7 @@ pub enum KeyContext {
 }
 
 impl KeyContext {
-  /// Dotted key under `[tui.keys]` addressing this context's sub-table.
+  /// Dotted key under `[tui.keys.modal]` addressing this context's sub-table.
   pub fn config_path(self) -> &'static str {
     match self {
       KeyContext::Create => "create",
@@ -113,7 +119,7 @@ impl KeyContext {
   }
 
   /// Inverse of [`Self::config_path`] — used by the config walker to map a
-  /// `[tui.keys.<path>]` sub-table back to a typed context.
+  /// `[tui.keys.modal.<path>]` sub-table back to a typed context.
   pub fn from_config_path(path: &str) -> Option<Self> {
     Self::all().iter().copied().find(|c| c.config_path() == path)
   }
@@ -160,7 +166,7 @@ macro_rules! define_modal_actions {
         match self { $( $( ModalAction::$variant => KeyContext::$ctx, )* )* }
       }
 
-      /// The context-local verb slug used under `[tui.keys.<context>]`.
+      /// The context-local verb slug used under `[tui.keys.modal.<context>]`.
       pub fn verb(self) -> &'static str {
         match self { $( $( ModalAction::$variant => $verb, )* )* }
       }
@@ -263,7 +269,7 @@ define_modal_actions! {
 
 impl ModalAction {
   /// Resolve a `(context, verb-slug)` pair to a typed verb. Used by the
-  /// config walker to translate `[tui.keys.<context>].<verb>` keys.
+  /// config walker to translate `[tui.keys.modal.<context>].<verb>` keys.
   pub fn from_context_verb(ctx: KeyContext, verb: &str) -> Option<Self> {
     Self::all().find(|a| a.context() == ctx && a.verb() == verb)
   }
@@ -361,7 +367,7 @@ impl ModalKeymap {
     for k in &keys {
       if let Some(prev) = map.get(k) {
         return Err(GwmError::Config(format!(
-          "tui.keys.{}: key {} bound to both {:?} and {:?} — conflict",
+          "context {}: key {} bound to both {:?} and {:?} — conflict",
           ctx.config_path(),
           k,
           prev.verb(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,6 +1,6 @@
 use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::keymap::{Action, Keymap};
-use super::modal_keymap::{ModalAction, ModalKeymap};
+use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::state::async_task::TaskKind;
 use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
@@ -1874,11 +1874,47 @@ impl HintContext {
       .hint_specs()
       .iter()
       .filter_map(|h| match h {
-        Hint::Key(action, label) => keymap.primary_chord(*action).map(|k| (k, label.to_string())),
+        // #219: a global verb whose key is claimed by a modal binding in the
+        // active context is resolved as that modal verb first — the event loop
+        // never reaches the global action. Drop the hint rather than advertise
+        // a duplicate key for an unreachable action.
+        Hint::Key(action, label) => keymap
+          .primary_chord(*action)
+          .filter(|k| !self.key_shadowed_by_modal(k, modal))
+          .map(|k| (k, label.to_string())),
         Hint::Modal(action, label) => modal.primary_key(*action).map(|k| (k, label.to_string())),
         Hint::Lit(key, label) => Some((key.to_string(), label.to_string())),
       })
       .collect()
+  }
+
+  /// The modal [`KeyContext`] this hint context renders, when it is a modal /
+  /// overlay surface (the global panes have none). Used to detect a global
+  /// hint key shadowed by a modal binding in the same context.
+  fn modal_context(self) -> Option<KeyContext> {
+    Some(match self {
+      HintContext::Create | HintContext::Rename => KeyContext::Create,
+      HintContext::Confirm => KeyContext::Confirm,
+      HintContext::OpenMenu => KeyContext::OpenMenu,
+      HintContext::LinkPrompt => KeyContext::LinkChooseTarget,
+      HintContext::LinkInputNumber => KeyContext::LinkInputNumber,
+      HintContext::CommandPalette => KeyContext::CommandPalette,
+      HintContext::Report => KeyContext::Report,
+      HintContext::Help => KeyContext::Help,
+      HintContext::Worktrees | HintContext::Status | HintContext::Picker | HintContext::Pty => return None,
+    })
+  }
+
+  /// `true` when `key` is bound to a modal verb in this context — i.e. the
+  /// modal keymap intercepts it before any global action with the same key.
+  fn key_shadowed_by_modal(self, key: &str, modal: &ModalKeymap) -> bool {
+    match self.modal_context() {
+      Some(ctx) => modal
+        .bindings_for(ctx)
+        .iter()
+        .any(|b| b.keys.iter().any(|ks| ks.to_string() == key)),
+      None => false,
+    }
   }
 }
 
@@ -1936,6 +1972,63 @@ pub fn config_edit_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
   .into_iter()
   .filter_map(|(action, label)| modal.primary_key(action).map(|k| (k, label.to_string())))
   .collect()
+}
+
+/// Settings-panel footer hints in *navigation* mode (#219 review): the
+/// single-key verbs (`section` / `layer` / `close`, plus `cycle` / `edit` via
+/// `activate`) resolve from the `Config*` modal bindings so a rebind of
+/// `[tui.keys.config]` shows through. The `j/k` scroll pair stays literal —
+/// no single resolved key captures a movement pair (same rule as Help). The
+/// leading verb depends on the active tab / field kind, mirroring the historic
+/// hard-coded branches.
+pub fn config_nav_footer_hints(
+  modal: &ModalKeymap,
+  tab: SettingsTab,
+  selected_kind: Option<FieldKind>,
+) -> Vec<(String, String)> {
+  let mut hints: Vec<(String, String)> = Vec::new();
+  if tab == SettingsTab::All {
+    hints.push(("j/k".to_string(), "scroll".to_string()));
+  } else {
+    let label = if selected_kind == Some(FieldKind::Choice) {
+      "cycle"
+    } else {
+      "edit"
+    };
+    if let Some(k) = modal.primary_key(ModalAction::ConfigActivate) {
+      hints.push((k, label.to_string()));
+    }
+  }
+  for (action, label) in [
+    (ModalAction::ConfigNextTab, "section"),
+    (ModalAction::ConfigToggleLayer, "layer"),
+    (ModalAction::ConfigClose, "close"),
+  ] {
+    if let Some(k) = modal.primary_key(action) {
+      hints.push((k, label.to_string()));
+    }
+  }
+  hints
+}
+
+/// Command Logs overlay footer hints (#219 review): `copy` / `close` resolve
+/// from the `CommandLogs*` modal bindings so a rebind of
+/// `[tui.keys.command_logs]` shows through; the scroll / top-bottom movement
+/// pairs stay literal (no single resolved key captures `j/k` / `g/G`).
+pub fn command_logs_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
+  let mut hints: Vec<(String, String)> = vec![
+    ("j/k".to_string(), "scroll".to_string()),
+    ("g/G".to_string(), "top/bottom".to_string()),
+  ];
+  for (action, label) in [
+    (ModalAction::CommandLogsCopy, "copy"),
+    (ModalAction::CommandLogsClose, "close"),
+  ] {
+    if let Some(k) = modal.primary_key(action) {
+      hints.push((k, label.to_string()));
+    }
+  }
+  hints
 }
 
 fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKeymap, theme: &Theme) -> Line<'static> {
@@ -2650,18 +2743,11 @@ fn draw_command_logs(f: &mut Frame, app: &mut App) {
   app.command_logs.x_scroll = app.command_logs.x_scroll.min(app.command_logs.max_x_scroll);
   let x_scroll = app.command_logs.x_scroll;
   f.render_widget(Paragraph::new(lines).scroll((scroll, x_scroll)), text_area);
-  f.render_widget(
-    modal_hint_line(
-      &[
-        ("j/k", "scroll"),
-        ("g/G", "top/bottom"),
-        ("y", "copy"),
-        ("Esc", "close"),
-      ],
-      &app.theme,
-    ),
-    footer_area,
-  );
+  // #219 review: copy / close resolve from the command_logs modal bindings so
+  // a rebind shows through; the scroll / top-bottom pairs stay literal.
+  let footer_owned = command_logs_footer_hints(&app.modal_keymap);
+  let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+  f.render_widget(modal_hint_line(&footer_hints, &app.theme), footer_area);
 }
 
 /// Render a vertical scrollbar on the right edge of `area` when the content
@@ -2827,19 +2913,15 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   };
 
   // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
-  // the current tab / edit mode. While editing, save/cancel resolve from the
-  // ConfigEdit* modal bindings (#219 review) so a rebind of
-  // `[tui.keys.config.edit]` shows through instead of the literal Enter/Esc.
-  let edit_footer = editing.then(|| config_edit_footer_hints(&app.modal_keymap));
-  let footer_hints: Vec<(&str, &str)> = if let Some(hints) = &edit_footer {
-    hints.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect()
-  } else if tab == SettingsTab::All {
-    vec![("j/k", "scroll"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
-  } else if selected_kind == Some(FieldKind::Choice) {
-    vec![("Space", "cycle"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+  // the current tab / edit mode. Both the edit and nav rows resolve their
+  // single-key verbs from the Config* modal bindings (#219 review) so a rebind
+  // of `[tui.keys.config(.edit)]` shows through instead of literal keys.
+  let footer_owned = if editing {
+    config_edit_footer_hints(&app.modal_keymap)
   } else {
-    vec![("Enter", "edit"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
+    config_nav_footer_hints(&app.modal_keymap, tab, selected_kind)
   };
+  let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
 
   let block = overlay_block(accent);
   let inner = block.inner(area);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1671,7 +1671,7 @@ enum Hint {
   /// Resolve the displayed key from the global keymap (honours `[tui.keys]`).
   Key(super::keymap::Action, &'static str),
   /// Resolve the displayed key from the contextual modal keymap (honours
-  /// `[tui.keys.<context>]`, issue #219). Used for modal verbs whose hint
+  /// `[tui.keys.modal.<context>]`, issue #219). Used for modal verbs whose hint
   /// is a single rebindable key (cancel / submit / confirm / issue / pr).
   Modal(ModalAction, &'static str),
   /// A fixed key + label for a non-rebindable keystroke or a multi-key
@@ -1702,7 +1702,7 @@ pub enum HintContext {
   /// Issue/PR link prompt, stage 1 — choose issue vs PR.
   LinkPrompt,
   /// Issue/PR link prompt, stage 2 — typing the number (#219): submit /
-  /// cancel resolve from `[tui.keys.link.input_number]`, not the choose
+  /// cancel resolve from `[tui.keys.modal.link.input_number]`, not the choose
   /// stage's keys.
   LinkInputNumber,
   /// Command palette overlay.
@@ -1961,7 +1961,7 @@ pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
 
 /// Settings-panel footer hints shown while a field is being edited (#219
 /// review): `save` / `cancel` resolve from the `ConfigEdit*` modal bindings so
-/// a rebind of `[tui.keys.config.edit]` shows through instead of the literal
+/// a rebind of `[tui.keys.modal.config.edit]` shows through instead of the literal
 /// `Enter` / `Esc`. An unbound verb is dropped rather than advertised with a
 /// phantom key, mirroring the statusbar's `HintContext::resolve`.
 pub fn config_edit_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
@@ -1977,7 +1977,7 @@ pub fn config_edit_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
 /// Settings-panel footer hints in *navigation* mode (#219 review): the
 /// single-key verbs (`section` / `layer` / `close`, plus `cycle` / `edit` via
 /// `activate`) resolve from the `Config*` modal bindings so a rebind of
-/// `[tui.keys.config]` shows through. The `j/k` scroll pair stays literal —
+/// `[tui.keys.modal.config]` shows through. The `j/k` scroll pair stays literal —
 /// no single resolved key captures a movement pair (same rule as Help). The
 /// leading verb depends on the active tab / field kind, mirroring the historic
 /// hard-coded branches.
@@ -2013,7 +2013,7 @@ pub fn config_nav_footer_hints(
 
 /// Command Logs overlay footer hints (#219 review): `copy` / `close` resolve
 /// from the `CommandLogs*` modal bindings so a rebind of
-/// `[tui.keys.command_logs]` shows through; the scroll / top-bottom movement
+/// `[tui.keys.modal.command_logs]` shows through; the scroll / top-bottom movement
 /// pairs stay literal (no single resolved key captures `j/k` / `g/G`).
 pub fn command_logs_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
   let mut hints: Vec<(String, String)> = vec![
@@ -2358,7 +2358,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   };
   // A rebindable modal entry: keys resolved from the contextual keymap
   // (issue #219) so the create-form / delete-confirm rows track
-  // `[tui.keys.<context>]` overrides instead of a frozen literal.
+  // `[tui.keys.modal.<context>]` overrides instead of a frozen literal.
   let modal_entry = |action: ModalAction, label: &str| -> HelpRow {
     HelpRow::Entry {
       keys: modal.keys_display(action),
@@ -2449,10 +2449,28 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
     rows.push(HelpRow::Blank);
     rows.push(HelpRow::Section("Issue / PR".to_string()));
     rows.push(HelpRow::Blank);
-    rows.push(entry(Action::BrowseLinks, "open menu — i=issue · p=pull request"));
+    // #219 review: the direct-pick keys named in these descriptions are the
+    // OpenMenu / LinkChooseTarget modal verbs — resolve them so a rebind shows
+    // through instead of the stale literal i / p / j / k.
+    let mkey = |action: ModalAction, fallback: &str| modal.primary_key(action).unwrap_or_else(|| fallback.to_string());
+    rows.push(entry(
+      Action::BrowseLinks,
+      &format!(
+        "open menu — {}=issue · {}=pull request",
+        mkey(ModalAction::OpenMenuIssue, "i"),
+        mkey(ModalAction::OpenMenuPr, "p"),
+      ),
+    ));
     rows.push(entry(
       Action::LinkPrompt,
-      "link prompt — j/k + enter, or i/p, then digits",
+      &format!(
+        "link prompt — {}/{} + {}, or {}/{}, then digits",
+        mkey(ModalAction::LinkChooseNext, "j"),
+        mkey(ModalAction::LinkChoosePrev, "k"),
+        mkey(ModalAction::LinkChooseAccept, "enter"),
+        mkey(ModalAction::LinkChooseIssue, "i"),
+        mkey(ModalAction::LinkChoosePr, "p"),
+      ),
     ));
   }
   rows.push(entry(Action::Help, "this help"));
@@ -2915,7 +2933,7 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
   // the current tab / edit mode. Both the edit and nav rows resolve their
   // single-key verbs from the Config* modal bindings (#219 review) so a rebind
-  // of `[tui.keys.config(.edit)]` shows through instead of literal keys.
+  // of `[tui.keys.modal.config(.edit)]` shows through instead of literal keys.
   let footer_owned = if editing {
     config_edit_footer_hints(&app.modal_keymap)
   } else {
@@ -3257,7 +3275,7 @@ pub fn help_body_section_color(theme: &Theme) -> Color {
 
 /// Direct-pick keys (`issue`, `pr`) for the link / open-menu target chips,
 /// resolved from the active context's modal bindings (#219 review) so a
-/// rebind of `[tui.keys.link.choose_target]` / `[tui.keys.open_menu]` shows
+/// rebind of `[tui.keys.modal.link.choose_target]` / `[tui.keys.modal.open_menu]` shows
 /// through instead of the literal `i` / `p`. An unbound verb yields an empty
 /// string — the chip then renders label-only rather than a phantom key.
 pub fn link_target_keys(ctx: HintContext, modal: &ModalKeymap) -> (String, String) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2451,26 +2451,45 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
     rows.push(HelpRow::Blank);
     // #219 review: the direct-pick keys named in these descriptions are the
     // OpenMenu / LinkChooseTarget modal verbs — resolve them so a rebind shows
-    // through instead of the stale literal i / p / j / k.
-    let mkey = |action: ModalAction, fallback: &str| modal.primary_key(action).unwrap_or_else(|| fallback.to_string());
-    rows.push(entry(
-      Action::BrowseLinks,
-      &format!(
-        "open menu — {}=issue · {}=pull request",
-        mkey(ModalAction::OpenMenuIssue, "i"),
-        mkey(ModalAction::OpenMenuPr, "p"),
-      ),
-    ));
+    // through, and DROP any verb the user explicitly unbound rather than
+    // advertise a phantom literal (matching every other modal hint).
+    let open_picks: Vec<String> = [
+      (ModalAction::OpenMenuIssue, "issue"),
+      (ModalAction::OpenMenuPr, "pull request"),
+    ]
+    .into_iter()
+    .filter_map(|(a, l)| modal.primary_key(a).map(|k| format!("{k}={l}")))
+    .collect();
+    let open_desc = if open_picks.is_empty() {
+      "open menu".to_string()
+    } else {
+      format!("open menu — {}", open_picks.join(" · "))
+    };
+    rows.push(entry(Action::BrowseLinks, &open_desc));
+
+    let key = |a: ModalAction| modal.primary_key(a);
+    let nav: Vec<String> = [ModalAction::LinkChooseNext, ModalAction::LinkChoosePrev]
+      .into_iter()
+      .filter_map(key)
+      .collect();
+    let picks: Vec<String> = [ModalAction::LinkChooseIssue, ModalAction::LinkChoosePr]
+      .into_iter()
+      .filter_map(key)
+      .collect();
+    let mut parts: Vec<String> = Vec::new();
+    match (nav.is_empty(), key(ModalAction::LinkChooseAccept)) {
+      (false, Some(a)) => parts.push(format!("{} + {a}", nav.join("/"))),
+      (false, None) => parts.push(nav.join("/")),
+      (true, Some(a)) => parts.push(a),
+      (true, None) => {}
+    }
+    if !picks.is_empty() {
+      parts.push(format!("or {}", picks.join("/")));
+    }
+    parts.push("then digits".to_string());
     rows.push(entry(
       Action::LinkPrompt,
-      &format!(
-        "link prompt — {}/{} + {}, or {}/{}, then digits",
-        mkey(ModalAction::LinkChooseNext, "j"),
-        mkey(ModalAction::LinkChoosePrev, "k"),
-        mkey(ModalAction::LinkChooseAccept, "enter"),
-        mkey(ModalAction::LinkChooseIssue, "i"),
-        mkey(ModalAction::LinkChoosePr, "p"),
-      ),
+      &format!("link prompt — {}", parts.join(", ")),
     ));
   }
   rows.push(entry(Action::Help, "this help"));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1843,11 +1843,14 @@ impl HintContext {
         Hint::Modal(ModalAction::CommandPaletteAccept, "run"),
         Hint::Modal(ModalAction::CommandPaletteClose, "cancel"),
       ],
-      HintContext::Report => &[Hint::Lit("Enter/Esc", "close")],
+      // #219: `close` is a single rebindable verb, so it resolves through the
+      // modal keymap; the scroll/pan pairs stay literal (no single resolved
+      // key captures `j/k` / `h/l`, matching the Create/Confirm convention).
+      HintContext::Report => &[Hint::Modal(ModalAction::ReportClose, "close")],
       HintContext::Help => &[
         Hint::Lit("j/k", "scroll"),
         Hint::Lit("h/l", "pan"),
-        Hint::Lit("Esc/q", "close"),
+        Hint::Modal(ModalAction::HelpClose, "close"),
       ],
       HintContext::Pty => &[Hint::Lit("Esc", "close")],
       // Rename reuses the create-form input handler, hence the `create`
@@ -1918,6 +1921,21 @@ pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
     spans.push(Span::styled(format!(" {}", label), label_style));
   }
   Line::from(spans).centered()
+}
+
+/// Settings-panel footer hints shown while a field is being edited (#219
+/// review): `save` / `cancel` resolve from the `ConfigEdit*` modal bindings so
+/// a rebind of `[tui.keys.config.edit]` shows through instead of the literal
+/// `Enter` / `Esc`. An unbound verb is dropped rather than advertised with a
+/// phantom key, mirroring the statusbar's `HintContext::resolve`.
+pub fn config_edit_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
+  [
+    (ModalAction::ConfigEditSubmit, "save"),
+    (ModalAction::ConfigEditCancel, "cancel"),
+  ]
+  .into_iter()
+  .filter_map(|(action, label)| modal.primary_key(action).map(|k| (k, label.to_string())))
+  .collect()
 }
 
 fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKeymap, theme: &Theme) -> Line<'static> {
@@ -2809,9 +2827,12 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   };
 
   // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
-  // the current tab / edit mode.
-  let footer_hints: Vec<(&str, &str)> = if editing {
-    vec![("Enter", "save"), ("Esc", "cancel")]
+  // the current tab / edit mode. While editing, save/cancel resolve from the
+  // ConfigEdit* modal bindings (#219 review) so a rebind of
+  // `[tui.keys.config.edit]` shows through instead of the literal Enter/Esc.
+  let edit_footer = editing.then(|| config_edit_footer_hints(&app.modal_keymap));
+  let footer_hints: Vec<(&str, &str)> = if let Some(hints) = &edit_footer {
+    hints.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect()
   } else if tab == SettingsTab::All {
     vec![("j/k", "scroll"), ("Tab", "section"), ("L", "layer"), ("Esc", "close")]
   } else if selected_kind == Some(FieldKind::Choice) {
@@ -3152,19 +3173,38 @@ pub fn help_body_section_color(theme: &Theme) -> Color {
   theme.locked
 }
 
+/// Direct-pick keys (`issue`, `pr`) for the link / open-menu target chips,
+/// resolved from the active context's modal bindings (#219 review) so a
+/// rebind of `[tui.keys.link.choose_target]` / `[tui.keys.open_menu]` shows
+/// through instead of the literal `i` / `p`. An unbound verb yields an empty
+/// string — the chip then renders label-only rather than a phantom key.
+pub fn link_target_keys(ctx: HintContext, modal: &ModalKeymap) -> (String, String) {
+  let (issue, pr) = match ctx {
+    HintContext::OpenMenu => (ModalAction::OpenMenuIssue, ModalAction::OpenMenuPr),
+    _ => (ModalAction::LinkChooseIssue, ModalAction::LinkChoosePr),
+  };
+  (
+    modal.primary_key(issue).unwrap_or_default(),
+    modal.primary_key(pr).unwrap_or_default(),
+  )
+}
+
 pub fn link_open_modal_lines(app: &App, title: &str, selected: Option<LinkTarget>) -> Vec<Line<'static>> {
   let accent = app.theme.accent;
   let muted = app.theme.muted;
-  let mut lines = overlay_title_lines(title, accent);
-  lines.extend(github_status_lines(app, 56));
-  lines.push(Line::from(""));
-  lines.push(link_target_line("i", "Issue", selected == Some(LinkTarget::Issue), accent, muted).centered());
-  lines.push(link_target_line("p", "Pull Request", selected == Some(LinkTarget::Pr), accent, muted).centered());
   let ctx = if title == "Link" {
     HintContext::LinkPrompt
   } else {
     HintContext::OpenMenu
   };
+  // #219: the direct-pick chips track the active context's issue/pr bindings
+  // (like the footer below) so a rebind shows through instead of `i` / `p`.
+  let (issue_key, pr_key) = link_target_keys(ctx, &app.modal_keymap);
+  let mut lines = overlay_title_lines(title, accent);
+  lines.extend(github_status_lines(app, 56));
+  lines.push(Line::from(""));
+  lines.push(link_target_line(&issue_key, "Issue", selected == Some(LinkTarget::Issue), accent, muted).centered());
+  lines.push(link_target_line(&pr_key, "Pull Request", selected == Some(LinkTarget::Pr), accent, muted).centered());
   push_modal_hint(&mut lines, ctx, &app.keymap, &app.modal_keymap, &app.theme);
   lines
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1699,8 +1699,12 @@ pub enum HintContext {
   Confirm,
   /// Open issue/PR URL menu.
   OpenMenu,
-  /// Two-stage issue/PR link prompt.
+  /// Issue/PR link prompt, stage 1 — choose issue vs PR.
   LinkPrompt,
+  /// Issue/PR link prompt, stage 2 — typing the number (#219): submit /
+  /// cancel resolve from `[tui.keys.link.input_number]`, not the choose
+  /// stage's keys.
+  LinkInputNumber,
   /// Command palette overlay.
   CommandPalette,
   /// Bootstrap report overlay.
@@ -1726,6 +1730,7 @@ impl HintContext {
       HintContext::Confirm => "confirm",
       HintContext::OpenMenu => "open",
       HintContext::LinkPrompt => "link",
+      HintContext::LinkInputNumber => "link",
       HintContext::CommandPalette => "command",
       HintContext::Report => "report",
       HintContext::Help => "help",
@@ -1822,6 +1827,14 @@ impl HintContext {
         Hint::Modal(ModalAction::LinkChooseAccept, "link"),
         Hint::Key(FetchGithub, "fetch"),
         Hint::Modal(ModalAction::LinkChooseCancel, "cancel"),
+      ],
+      // #219: while typing the number, submit / cancel come from the
+      // input-number context — not the choose-target keys above.
+      HintContext::LinkInputNumber => &[
+        Hint::Lit("0-9", "number"),
+        Hint::Modal(ModalAction::LinkInputSubmit, "submit"),
+        Hint::Key(FetchGithub, "fetch"),
+        Hint::Modal(ModalAction::LinkInputCancel, "cancel"),
       ],
       HintContext::CommandPalette => &[
         Hint::Lit("↑/↓", "move"),
@@ -3646,7 +3659,7 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
       lines.push(Line::from(format!("  {}{}_", label, app.link_prompt_number_input())));
       push_modal_hint(
         &mut lines,
-        HintContext::LinkPrompt,
+        HintContext::LinkInputNumber,
         &app.keymap,
         &app.modal_keymap,
         &app.theme,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,5 +1,6 @@
 use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::keymap::{Action, Keymap};
+use super::modal_keymap::{ModalAction, ModalKeymap};
 use super::state::async_task::TaskKind;
 use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
@@ -1667,9 +1668,14 @@ pub fn format_status(s: &BranchStatus, width: usize, theme: &Theme) -> (String, 
 /// rebound.
 #[derive(Debug, Clone, Copy)]
 enum Hint {
-  /// Resolve the displayed key from the keymap (honours `[tui.keys]`).
+  /// Resolve the displayed key from the global keymap (honours `[tui.keys]`).
   Key(super::keymap::Action, &'static str),
-  /// A fixed key + label for a non-rebindable contextual keystroke.
+  /// Resolve the displayed key from the contextual modal keymap (honours
+  /// `[tui.keys.<context>]`, issue #219). Used for modal verbs whose hint
+  /// is a single rebindable key (cancel / submit / confirm / issue / pr).
+  Modal(ModalAction, &'static str),
+  /// A fixed key + label for a non-rebindable keystroke or a multi-key
+  /// movement pair (`↑/↓`, `j/k`) that no single resolved key captures.
   Lit(&'static str, &'static str),
 }
 
@@ -1729,9 +1735,12 @@ impl HintContext {
   }
 
   /// Static hint specs for this context. List-view contexts use rebindable
-  /// [`Hint::Key`] verbs (resolved live by [`Self::resolve`]); modal /
-  /// overlay contexts use [`Hint::Lit`] because their keys are hard-coded
-  /// contextual escape hatches (Esc / Enter / digits), not keymap actions.
+  /// [`Hint::Key`] verbs (resolved against the global keymap); modal /
+  /// overlay contexts use [`Hint::Modal`] for their single-key rebindable
+  /// verbs (resolved against the contextual keymap, issue #219) and
+  /// [`Hint::Lit`] only for movement pairs (`↑/↓`, `j/k`) and the genuinely
+  /// hard-coded escape hatches (the PTY overlay's `Esc`). All resolved live
+  /// by [`Self::resolve`].
   fn hint_specs(self) -> &'static [Hint] {
     use super::keymap::Action::*;
     match self {
@@ -1785,36 +1794,39 @@ impl HintContext {
         Hint::Key(Help, "help"),
         Hint::Key(Quit, "quit"),
       ],
+      // #219: single-key modal verbs use Hint::Modal so a rebind shows
+      // through; multi-key movement pairs (↑/↓, j/k, ←/→) stay literal
+      // because no single resolved key captures them.
       HintContext::Create => &[
-        Hint::Lit("Tab", "field"),
+        Hint::Modal(ModalAction::CreateNextField, "field"),
         Hint::Lit("↑/↓", "type"),
-        Hint::Lit("Enter", "submit"),
-        Hint::Lit("Esc", "cancel"),
+        Hint::Modal(ModalAction::CreateSubmit, "submit"),
+        Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
       HintContext::Confirm => &[
-        Hint::Lit("y", "confirm"),
+        Hint::Modal(ModalAction::ConfirmConfirm, "confirm"),
         Hint::Key(ToggleDeleteBranch, "branch"),
         Hint::Lit("←/→", "move"),
-        Hint::Lit("Enter", "activate"),
-        Hint::Lit("Esc", "cancel"),
+        Hint::Modal(ModalAction::ConfirmActivate, "activate"),
+        Hint::Modal(ModalAction::ConfirmCancel, "cancel"),
       ],
       HintContext::OpenMenu => &[
-        Hint::Lit("i", "issue"),
-        Hint::Lit("p", "pr"),
+        Hint::Modal(ModalAction::OpenMenuIssue, "issue"),
+        Hint::Modal(ModalAction::OpenMenuPr, "pr"),
         Hint::Key(FetchGithub, "fetch"),
-        Hint::Lit("Esc", "close"),
+        Hint::Modal(ModalAction::OpenMenuClose, "close"),
       ],
       HintContext::LinkPrompt => &[
         Hint::Lit("j/k", "move"),
         Hint::Lit("i/p", "kind"),
-        Hint::Lit("Enter", "link"),
+        Hint::Modal(ModalAction::LinkChooseAccept, "link"),
         Hint::Key(FetchGithub, "fetch"),
-        Hint::Lit("Esc", "cancel"),
+        Hint::Modal(ModalAction::LinkChooseCancel, "cancel"),
       ],
       HintContext::CommandPalette => &[
         Hint::Lit("↑/↓", "move"),
-        Hint::Lit("Enter", "run"),
-        Hint::Lit("Esc", "cancel"),
+        Hint::Modal(ModalAction::CommandPaletteAccept, "run"),
+        Hint::Modal(ModalAction::CommandPaletteClose, "cancel"),
       ],
       HintContext::Report => &[Hint::Lit("Enter/Esc", "close")],
       HintContext::Help => &[
@@ -1823,11 +1835,13 @@ impl HintContext {
         Hint::Lit("Esc/q", "close"),
       ],
       HintContext::Pty => &[Hint::Lit("Esc", "close")],
+      // Rename reuses the create-form input handler, hence the `create`
+      // context's verbs (#290 / #219).
       HintContext::Rename => &[
-        Hint::Lit("Tab", "field"),
+        Hint::Modal(ModalAction::CreateNextField, "field"),
         Hint::Lit("↑/↓", "type"),
-        Hint::Lit("Enter", "submit"),
-        Hint::Lit("Esc", "cancel"),
+        Hint::Modal(ModalAction::CreateSubmit, "submit"),
+        Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
     }
   }
@@ -1837,12 +1851,13 @@ impl HintContext {
   /// binding (issue #217 review) — the same `primary_chord` source the help
   /// overlay and the Issue/PR prompt use. An unbound action is dropped from
   /// the row rather than advertised with a phantom key.
-  pub fn resolve(self, keymap: &super::keymap::Keymap) -> Vec<(String, String)> {
+  pub fn resolve(self, keymap: &super::keymap::Keymap, modal: &ModalKeymap) -> Vec<(String, String)> {
     self
       .hint_specs()
       .iter()
       .filter_map(|h| match h {
         Hint::Key(action, label) => keymap.primary_chord(*action).map(|k| (k, label.to_string())),
+        Hint::Modal(action, label) => modal.primary_key(*action).map(|k| (k, label.to_string())),
         Hint::Lit(key, label) => Some((key.to_string(), label.to_string())),
       })
       .collect()
@@ -1890,15 +1905,21 @@ pub fn modal_hint_line(hints: &[(&str, &str)], theme: &Theme) -> Line<'static> {
   Line::from(spans).centered()
 }
 
-fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, theme: &Theme) -> Line<'static> {
-  let resolved = ctx.resolve(keymap);
+fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKeymap, theme: &Theme) -> Line<'static> {
+  let resolved = ctx.resolve(keymap, modal);
   let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
   modal_hint_line(&hints, theme)
 }
 
-fn push_modal_hint(lines: &mut Vec<Line<'static>>, ctx: HintContext, keymap: &Keymap, theme: &Theme) {
+fn push_modal_hint(
+  lines: &mut Vec<Line<'static>>,
+  ctx: HintContext,
+  keymap: &Keymap,
+  modal: &ModalKeymap,
+  theme: &Theme,
+) {
   lines.push(Line::from(String::new()));
-  lines.push(modal_hint_for_context(ctx, keymap, theme));
+  lines.push(modal_hint_for_context(ctx, keymap, modal, theme));
 }
 
 /// Build the single-line statusline (issue #180).
@@ -2110,7 +2131,7 @@ fn draw_footer(f: &mut Frame, area: Rect, app: &App) {
   // Resolve the rebindable hint keys against the live keymap (issue #217
   // review) so a user override shows through, then borrow into the slice
   // `status_line` expects.
-  let resolved = ctx.resolve(&app.keymap);
+  let resolved = ctx.resolve(&app.keymap, &app.modal_keymap);
   let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
   let line = status_line(
     ctx.label(),
@@ -2166,7 +2187,7 @@ pub enum HelpRow {
 /// picker-only / non-picker sections render. `HintContext::Picker` is the
 /// `gwm switch` overlay; `Worktrees` / `Status` are the two list-view panes
 /// (same body, the subtitle just names the focused pane).
-pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
+pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintContext) -> Vec<HelpRow> {
   use super::keymap::Action;
 
   let picker_mode = matches!(ctx, HintContext::Picker);
@@ -2202,10 +2223,19 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
     }
   };
   // A fixed entry: a non-rebindable surface documented with a literal
-  // key string (Ctrl-C, contextual Enter, create-form / confirm keys).
+  // key string (Ctrl-C, contextual Enter, the picker's hard-coded Enter).
   let fixed = |keys: &str, label: &str| -> HelpRow {
     HelpRow::Entry {
       keys: keys.to_string(),
+      label: label.to_string(),
+    }
+  };
+  // A rebindable modal entry: keys resolved from the contextual keymap
+  // (issue #219) so the create-form / delete-confirm rows track
+  // `[tui.keys.<context>]` overrides instead of a frozen literal.
+  let modal_entry = |action: ModalAction, label: &str| -> HelpRow {
+    HelpRow::Entry {
+      keys: modal.keys_display(action),
       label: label.to_string(),
     }
   };
@@ -2308,17 +2338,24 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
       HelpRow::Blank,
       HelpRow::Section("Create Form".to_string()),
       HelpRow::Blank,
-      fixed("←/→ ↑/↓", "change branch type"),
-      fixed("Tab/Shift-Tab", "next/prev field"),
-      fixed("Enter (desc)", "submit"),
-      fixed("Esc", "cancel"),
+      modal_entry(ModalAction::CreatePrevType, "previous branch type"),
+      modal_entry(ModalAction::CreateNextType, "next branch type"),
+      modal_entry(ModalAction::CreateNextField, "next field"),
+      modal_entry(ModalAction::CreatePrevField, "previous field"),
+      modal_entry(ModalAction::CreateSubmit, "submit (on description) / next field"),
+      modal_entry(ModalAction::CreateCancel, "cancel"),
       HelpRow::Blank,
       HelpRow::Section("Delete Worktree".to_string()),
       HelpRow::Blank,
-      fixed("←/→ Tab", "move focus between Confirm / Cancel"),
-      fixed("Enter", "activate the focused button (defaults to Cancel)"),
-      fixed("y", "confirm"),
-      fixed("n / Esc", "cancel"),
+      modal_entry(ModalAction::ConfirmFocusConfirm, "focus the Confirm button"),
+      modal_entry(ModalAction::ConfirmFocusCancel, "focus the Cancel button"),
+      modal_entry(ModalAction::ConfirmToggleFocus, "toggle the focused button"),
+      modal_entry(
+        ModalAction::ConfirmActivate,
+        "activate the focused button (defaults to Cancel)",
+      ),
+      modal_entry(ModalAction::ConfirmConfirm, "confirm"),
+      modal_entry(ModalAction::ConfirmCancel, "cancel"),
     ]);
   }
   rows
@@ -2329,7 +2366,7 @@ pub fn help_rows(km: &super::keymap::Keymap, ctx: HintContext) -> Vec<HelpRow> {
 /// `tests/tui_chord_tests.rs` asserts against: every entry renders as
 /// `  {keys:<13} {label}`, sections / title as their bare text, blanks
 /// as empty strings. The width 13 is wide enough for `Ctrl+Shift+Tab`.
-pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> {
+pub fn help_lines(km: &super::keymap::Keymap, modal: &ModalKeymap, picker_mode: bool) -> Vec<String> {
   // The bool signature is kept for `gwm tui keys` and the chord tests; map
   // it to the context enum (issue #217). The list-view help body is the same
   // for either pane, so `Worktrees` stands in for the non-picker case.
@@ -2338,7 +2375,7 @@ pub fn help_lines(km: &super::keymap::Keymap, picker_mode: bool) -> Vec<String> 
   } else {
     HintContext::Worktrees
   };
-  help_rows(km, ctx)
+  help_rows(km, modal, ctx)
     .into_iter()
     .map(|row| match row {
       HelpRow::Title(s) | HelpRow::Subtitle(s) | HelpRow::Section(s) => s,
@@ -2399,7 +2436,7 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   // Use the underlying pane context, not the view-priority `hint_context`
   // (which would be `Help` while this overlay is up) — `?` documents the
   // pane you opened it from, and the picker gating depends on it.
-  let rows = help_rows(&app.keymap, app.pane_hint_context());
+  let rows = help_rows(&app.keymap, &app.modal_keymap, app.pane_hint_context());
 
   // Theme-driven colours so the overlay tracks `[theme]` like the rest
   // of the TUI (pre-#187 it was hard-coded `Cyan` + plain text).
@@ -2477,7 +2514,7 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   let x_scroll = app.help_x_scroll;
   f.render_widget(Paragraph::new(body_lines).scroll((scroll, x_scroll)), text_area);
   f.render_widget(
-    modal_hint_for_context(HintContext::Help, &app.keymap, &app.theme),
+    modal_hint_for_context(HintContext::Help, &app.keymap, &app.modal_keymap, &app.theme),
     footer_area,
   );
 }
@@ -2910,7 +2947,12 @@ fn draw_create(f: &mut Frame, app: &App) {
       inner[2],
     );
     f.render_widget(
-      Paragraph::new(modal_hint_for_context(HintContext::Create, &app.keymap, &app.theme)),
+      Paragraph::new(modal_hint_for_context(
+        HintContext::Create,
+        &app.keymap,
+        &app.modal_keymap,
+        &app.theme,
+      )),
       inner[4],
     );
   }
@@ -3108,7 +3150,7 @@ pub fn link_open_modal_lines(app: &App, title: &str, selected: Option<LinkTarget
   } else {
     HintContext::OpenMenu
   };
-  push_modal_hint(&mut lines, ctx, &app.keymap, &app.theme);
+  push_modal_hint(&mut lines, ctx, &app.keymap, &app.modal_keymap, &app.theme);
   lines
 }
 
@@ -3254,7 +3296,12 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     );
 
     f.render_widget(
-      Paragraph::new(modal_hint_for_context(HintContext::Confirm, &app.keymap, &app.theme)),
+      Paragraph::new(modal_hint_for_context(
+        HintContext::Confirm,
+        &app.keymap,
+        &app.modal_keymap,
+        &app.theme,
+      )),
       inner[4],
     );
   }
@@ -3405,7 +3452,12 @@ fn draw_report(f: &mut Frame, app: &App) {
   );
   render_section(f, layout[2], " Logs ", SectionBody::new(&logs), accent, 0, None);
   f.render_widget(
-    Paragraph::new(modal_hint_for_context(HintContext::Report, &app.keymap, &app.theme)),
+    Paragraph::new(modal_hint_for_context(
+      HintContext::Report,
+      &app.keymap,
+      &app.modal_keymap,
+      &app.theme,
+    )),
     layout[4],
   );
 }
@@ -3592,7 +3644,13 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
         accent,
       );
       lines.push(Line::from(format!("  {}{}_", label, app.link_prompt_number_input())));
-      push_modal_hint(&mut lines, HintContext::LinkPrompt, &app.keymap, &app.theme);
+      push_modal_hint(
+        &mut lines,
+        HintContext::LinkPrompt,
+        &app.keymap,
+        &app.modal_keymap,
+        &app.theme,
+      );
       lines
     }
   };
@@ -3738,7 +3796,12 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
       inner[2],
     );
     f.render_widget(
-      Paragraph::new(modal_hint_for_context(HintContext::Rename, &app.keymap, &app.theme)),
+      Paragraph::new(modal_hint_for_context(
+        HintContext::Rename,
+        &app.keymap,
+        &app.modal_keymap,
+        &app.theme,
+      )),
       inner[4],
     );
   }
@@ -3832,6 +3895,7 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
     Paragraph::new(modal_hint_for_context(
       HintContext::CommandPalette,
       &app.keymap,
+      &app.modal_keymap,
       &app.theme,
     )),
     layout[6],

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1822,8 +1822,10 @@ impl HintContext {
         Hint::Modal(ModalAction::OpenMenuClose, "close"),
       ],
       HintContext::LinkPrompt => &[
-        Hint::Lit("j/k", "move"),
-        Hint::Lit("i/p", "kind"),
+        Hint::Modal(ModalAction::LinkChoosePrev, "prev"),
+        Hint::Modal(ModalAction::LinkChooseNext, "next"),
+        Hint::Modal(ModalAction::LinkChooseIssue, "issue"),
+        Hint::Modal(ModalAction::LinkChoosePr, "pr"),
         Hint::Modal(ModalAction::LinkChooseAccept, "link"),
         Hint::Key(FetchGithub, "fetch"),
         Hint::Modal(ModalAction::LinkChooseCancel, "cancel"),

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4203,7 +4203,7 @@ fn theme_show_output_round_trips_through_gwm_toml() {
 #[test]
 fn tui_keys_lists_modal_contexts() {
   // Issue #219: the listing prints the contextual modal bindings under
-  // their `[tui.keys.<context>]` headings, including nested link stages.
+  // their `[tui.keys.modal.<context>]` headings, including nested link stages.
   let (dir, _) = init_repo();
   Command::cargo_bin("gwm")
     .unwrap()
@@ -4211,7 +4211,7 @@ fn tui_keys_lists_modal_contexts() {
     .args(["tui", "keys"])
     .assert()
     .success()
-    .stdout(predicate::str::contains("[tui.keys.confirm]"))
+    .stdout(predicate::str::contains("[tui.keys.modal.confirm]"))
     .stdout(predicate::str::contains("focus_confirm"))
-    .stdout(predicate::str::contains("[tui.keys.link.choose_target]"));
+    .stdout(predicate::str::contains("[tui.keys.modal.link.choose_target]"));
 }

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4199,3 +4199,19 @@ fn theme_show_output_round_trips_through_gwm_toml() {
     .stderr(predicate::str::contains("invalid TOML").not())
     .stderr(predicate::str::contains("config error").not());
 }
+
+#[test]
+fn tui_keys_lists_modal_contexts() {
+  // Issue #219: the listing prints the contextual modal bindings under
+  // their `[tui.keys.<context>]` headings, including nested link stages.
+  let (dir, _) = init_repo();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["tui", "keys"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("[tui.keys.confirm]"))
+    .stdout(predicate::str::contains("focus_confirm"))
+    .stdout(predicate::str::contains("[tui.keys.link.choose_target]"));
+}

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -309,6 +309,29 @@ fn config_validate_rejects_unknown_schema_keys_with_hint() {
 }
 
 #[test]
+fn config_validate_rejects_malformed_keymap() {
+  // #219 review (P2): `[tui.keys]` deserializes into a raw `toml::Table`, so a
+  // malformed keymap no longer fails `toml::from_str::<Config>`. The validate /
+  // validate-before-write path must run the keymap validators too — otherwise
+  // `gwm config validate` greenlights a config that `load_for_repo` later
+  // rejects.
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "[tui.keys.modal.confirm]\nconfirm = [\"g g\"]\n",
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("single keystroke"));
+}
+
+#[test]
 fn config_edit_opens_editor_on_config_path() {
   let (dir, _repo) = init_repo();
   fs::write(dir.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 3\n").unwrap();

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1963,7 +1963,7 @@ command = "lazygit"
   assert_eq!(m1.open_in, MacroOpenMode::Pty);
 }
 
-// --- [tui.keys.<context>] contextual modal bindings (issue #219) ---------
+// --- [tui.keys.modal.<context>] contextual modal bindings (issue #219) ---
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use gwm::tui::keymap::KeyStroke;
@@ -1982,7 +1982,7 @@ fn modal_keys_nested_context_resolves() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.confirm]
+[tui.keys.modal.confirm]
 confirm = ["o"]
 cancel  = ["n", "Esc"]
 "#,
@@ -2004,10 +2004,10 @@ fn modal_keys_link_stage_uses_dotted_table() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.link.choose_target]
+[tui.keys.modal.link.choose_target]
 issue = ["x"]
 
-[tui.keys.link.input_number]
+[tui.keys.modal.link.input_number]
 submit = ["Right"]
 "#,
   )
@@ -2030,10 +2030,10 @@ fn modal_keys_config_edit_substage_resolves() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.config]
+[tui.keys.modal.config]
 close = ["q"]
 
-[tui.keys.config.edit]
+[tui.keys.modal.config.edit]
 cancel = ["Backspace"]
 "#,
   )
@@ -2056,7 +2056,7 @@ fn modal_keys_global_and_contextual_coexist() {
 [tui.keys]
 quit = ["Q"]
 
-[tui.keys.confirm]
+[tui.keys.modal.confirm]
 confirm = ["o"]
 "#,
   )
@@ -2074,12 +2074,49 @@ confirm = ["o"]
 }
 
 #[test]
+fn modal_namespace_does_not_collide_with_a_same_named_global_action() {
+  // #219 review (P2): before the dedicated `[tui.keys.modal]` namespace, a
+  // global `[tui.keys] create = ["c"]` and a modal `[tui.keys.create]` shared
+  // the `tui.keys.create` path. The layered merge saw array-vs-table at the
+  // same path, replaced the global array with the modal table, and silently
+  // dropped the user's global override (`resolved_keymap` then skipped the
+  // table). With the disjoint namespace the two live at different paths
+  // (`tui.keys.create` vs `tui.keys.modal.create`) and both survive the merge.
+  let global = TempDir::new().unwrap();
+  let global_path = global.path().join("global.toml");
+  std::fs::write(&global_path, "[tui.keys]\ncreate = [\"c\"]\n").unwrap();
+  let repo = TempDir::new().unwrap();
+  std::fs::write(
+    repo.path().join(CONFIG_FILE),
+    "[tui.keys.modal.create]\ncancel = [\"x\"]\n",
+  )
+  .unwrap();
+
+  let cfg = Config::load_layered(repo.path(), Some(&global_path)).unwrap();
+
+  // The global `create` override survives the merge (was silently lost before).
+  let km = cfg.tui.keys.resolved_keymap().unwrap();
+  assert_eq!(
+    km.primary_chord(gwm::tui::keymap::Action::Create).as_deref(),
+    Some("c"),
+    "the global create override must survive a same-named modal context"
+  );
+
+  // ...and the modal `create.cancel` override resolves independently.
+  let mk = cfg.tui.keys.resolved_modal_keymap().unwrap();
+  assert_eq!(
+    mk.resolve(KeyContext::Create, &kc('x')),
+    Some(ModalAction::CreateCancel)
+  );
+}
+
+#[test]
 fn modal_keys_reject_unknown_context() {
   let dir = TempDir::new().unwrap();
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.confrm]
+[tui.keys.modal.confrm]
 confirm = ["y"]
 "#,
   )
@@ -2094,7 +2131,7 @@ fn modal_keys_reject_unknown_verb() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.confirm]
+[tui.keys.modal.confirm]
 gallop = ["y"]
 "#,
   )
@@ -2109,7 +2146,7 @@ fn modal_keys_reject_multistroke_chord() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.confirm]
+[tui.keys.modal.confirm]
 confirm = ["g g"]
 "#,
   )
@@ -2124,7 +2161,7 @@ fn modal_keys_reject_in_context_conflict() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.confirm]
+[tui.keys.modal.confirm]
 confirm = ["x"]
 cancel  = ["x"]
 "#,
@@ -2140,7 +2177,7 @@ fn modal_keys_reject_array_directly_under_group() {
   std::fs::write(
     dir.path().join(CONFIG_FILE),
     r#"
-[tui.keys.link]
+[tui.keys.modal.link]
 issue = ["i"]
 "#,
   )

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1578,7 +1578,7 @@ fn tui_keys_default_is_empty_map() {
   // layer then keeps every built-in default. Mirrors the `labels` /
   // `milestones` "no override declared" contract.
   let cfg = Config::default();
-  assert!(cfg.tui.keys.bindings.is_empty());
+  assert!(cfg.tui.keys.raw.is_empty());
 }
 
 #[test]
@@ -1596,18 +1596,22 @@ top  = ["g g"]
   .unwrap();
 
   let cfg = Config::load_layered(dir.path(), None).unwrap();
-  assert_eq!(
-    cfg.tui.keys.bindings.get("down").map(Vec::as_slice),
-    Some(["j".to_string(), "Ctrl+n".to_string()].as_slice())
-  );
-  assert_eq!(
-    cfg.tui.keys.bindings.get("up").map(Vec::as_slice),
-    Some(["k".to_string(), "Ctrl+p".to_string()].as_slice())
-  );
-  assert_eq!(
-    cfg.tui.keys.bindings.get("top").map(Vec::as_slice),
-    Some(["g g".to_string()].as_slice())
-  );
+  // The raw `[tui.keys]` table preserves the user's source verbatim
+  // (issue #219 stores it as a `toml::Table` to also carry contextual
+  // sub-tables); pull each chord list back out as strings.
+  let chords = |slug: &str| -> Vec<String> {
+    cfg
+      .tui
+      .keys
+      .raw
+      .get(slug)
+      .and_then(|v| v.as_array())
+      .map(|a| a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect())
+      .unwrap_or_default()
+  };
+  assert_eq!(chords("down"), vec!["j".to_string(), "Ctrl+n".to_string()]);
+  assert_eq!(chords("up"), vec!["k".to_string(), "Ctrl+p".to_string()]);
+  assert_eq!(chords("top"), vec!["g g".to_string()]);
 }
 
 #[test]
@@ -1957,4 +1961,190 @@ command = "lazygit"
   let cfg = Config::load_layered(dir.path(), None).unwrap();
   let m1 = cfg.tui.macro1.expect("macro1 must parse");
   assert_eq!(m1.open_in, MacroOpenMode::Pty);
+}
+
+// --- [tui.keys.<context>] contextual modal bindings (issue #219) ---------
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use gwm::tui::keymap::KeyStroke;
+use gwm::tui::modal_keymap::{KeyContext, ModalAction};
+
+fn ks(code: KeyCode) -> KeyStroke {
+  KeyStroke::new(code, KeyModifiers::empty())
+}
+fn kc(c: char) -> KeyStroke {
+  KeyStroke::new(KeyCode::Char(c), KeyModifiers::empty())
+}
+
+#[test]
+fn modal_keys_nested_context_resolves() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.confirm]
+confirm = ["o"]
+cancel  = ["n", "Esc"]
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  let mk = cfg.tui.keys.resolved_modal_keymap().unwrap();
+  // new key fires, old default `y` is gone
+  assert_eq!(
+    mk.resolve(KeyContext::Confirm, &kc('o')),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  assert_eq!(mk.resolve(KeyContext::Confirm, &kc('y')), None);
+}
+
+#[test]
+fn modal_keys_link_stage_uses_dotted_table() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.link.choose_target]
+issue = ["x"]
+
+[tui.keys.link.input_number]
+submit = ["Right"]
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  let mk = cfg.tui.keys.resolved_modal_keymap().unwrap();
+  assert_eq!(
+    mk.resolve(KeyContext::LinkChooseTarget, &kc('x')),
+    Some(ModalAction::LinkChooseIssue)
+  );
+  assert_eq!(
+    mk.resolve(KeyContext::LinkInputNumber, &ks(KeyCode::Right)),
+    Some(ModalAction::LinkInputSubmit)
+  );
+}
+
+#[test]
+fn modal_keys_config_edit_substage_resolves() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.config]
+close = ["q"]
+
+[tui.keys.config.edit]
+cancel = ["Backspace"]
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  let mk = cfg.tui.keys.resolved_modal_keymap().unwrap();
+  assert_eq!(mk.resolve(KeyContext::Config, &kc('q')), Some(ModalAction::ConfigClose));
+  assert_eq!(
+    mk.resolve(KeyContext::ConfigEdit, &ks(KeyCode::Backspace)),
+    Some(ModalAction::ConfigEditCancel)
+  );
+}
+
+#[test]
+fn modal_keys_global_and_contextual_coexist() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys]
+quit = ["Q"]
+
+[tui.keys.confirm]
+confirm = ["o"]
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  // global path sees the array entry
+  let km = cfg.tui.keys.resolved_keymap().unwrap();
+  assert_eq!(km.primary_chord(gwm::tui::keymap::Action::Quit).as_deref(), Some("Q"));
+  // contextual path sees the table entry
+  let mk = cfg.tui.keys.resolved_modal_keymap().unwrap();
+  assert_eq!(
+    mk.resolve(KeyContext::Confirm, &kc('o')),
+    Some(ModalAction::ConfirmConfirm)
+  );
+}
+
+#[test]
+fn modal_keys_reject_unknown_context() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.confrm]
+confirm = ["y"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("typo'd context must reject");
+  assert!(err.to_string().contains("unknown modal context"), "{err}");
+}
+
+#[test]
+fn modal_keys_reject_unknown_verb() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.confirm]
+gallop = ["y"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("unknown verb must reject");
+  assert!(err.to_string().contains("unknown verb"), "{err}");
+}
+
+#[test]
+fn modal_keys_reject_multistroke_chord() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.confirm]
+confirm = ["g g"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("modal chords must be single strokes");
+  assert!(err.to_string().contains("single keystroke"), "{err}");
+}
+
+#[test]
+fn modal_keys_reject_in_context_conflict() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.confirm]
+confirm = ["x"]
+cancel  = ["x"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("two verbs sharing a key must conflict");
+  assert!(err.to_string().contains("conflict"), "{err}");
+}
+
+#[test]
+fn modal_keys_reject_array_directly_under_group() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui.keys.link]
+issue = ["i"]
+"#,
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("link needs a stage");
+  assert!(err.to_string().contains("context group"), "{err}");
 }

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -873,19 +873,16 @@ fn doctor_reports_modal_binding_count_on_default_keymap() {
 #[test]
 fn doctor_fails_on_in_context_modal_conflict() {
   // A `[tui.keys.confirm]` block binding two verbs to the same key is a
-  // per-context conflict. Inject it past load-time validation (which would
-  // otherwise reject it) to prove `gwm doctor` independently catches it.
+  // per-context conflict. Written to disk (load-time validation rejects it, so
+  // the lenient doctor context defaults ctx.config away) to prove `gwm doctor`
+  // re-reads the file and independently catches it.
   let (dir, repo) = init_repo();
-  let mut config = Config::default();
-  let mut confirm = toml::Table::new();
-  confirm.insert("confirm".into(), toml::Value::Array(vec!["x".into()]));
-  confirm.insert("cancel".into(), toml::Value::Array(vec!["x".into()]));
-  config
-    .tui
-    .keys
-    .raw
-    .insert("confirm".into(), toml::Value::Table(confirm));
-
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[tui.keys.confirm]\nconfirm = [\"x\"]\ncancel = [\"x\"]\n",
+  )
+  .unwrap();
+  let config = Config::default();
   let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
   let c = report
     .checks
@@ -896,6 +893,46 @@ fn doctor_fails_on_in_context_modal_conflict() {
   assert!(
     c.detail.contains("conflict"),
     "detail must explain the conflict, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn doctor_fails_on_disk_modal_error_even_when_context_defaulted() {
+  // #219 review (P2): `repo_context_lenient` returns `Config::default()` when
+  // `load_for_repo` rejects the user's `.gwm.toml` (here a multi-stroke modal
+  // chord, which load-time validation refuses). If doctor only re-validated
+  // that defaulted ctx.config it would report OK for a config that actually
+  // refuses to start the TUI — so the keymap check must re-read the on-disk
+  // file. This reproduces the real lenient path (the existing conflict test
+  // injects straight into ctx.config and never exercises the default-away).
+  let (dir, repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[tui.keys.confirm]\nconfirm = [\"g g\"]\n",
+  )
+  .unwrap();
+  // The file must be load-invalid (so the lenient loader would default it).
+  assert!(
+    Config::load_layered(dir.path(), None).is_err(),
+    "the on-disk modal chord must be rejected at load time for this regression"
+  );
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check");
+  assert_eq!(
+    c.status,
+    CheckStatus::Failed,
+    "doctor must flag the on-disk modal error, not the defaulted ctx.config: {}",
+    c.detail
+  );
+  assert!(
+    c.detail.contains("single keystroke"),
+    "detail must explain the multi-stroke modal chord rejection, got: {}",
     c.detail
   );
 }

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -849,3 +849,53 @@ quit = []
     c.detail
   );
 }
+
+#[test]
+fn doctor_reports_modal_binding_count_on_default_keymap() {
+  // Issue #219: the keymap check now also resolves the contextual modal
+  // keymap and folds its bound count into the detail line.
+  let (dir, repo) = init_repo();
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check");
+  assert_eq!(c.status, CheckStatus::Ok);
+  assert!(
+    c.detail.contains("modal"),
+    "detail must mention the modal binding count, got: {}",
+    c.detail
+  );
+}
+
+#[test]
+fn doctor_fails_on_in_context_modal_conflict() {
+  // A `[tui.keys.confirm]` block binding two verbs to the same key is a
+  // per-context conflict. Inject it past load-time validation (which would
+  // otherwise reject it) to prove `gwm doctor` independently catches it.
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  let mut confirm = toml::Table::new();
+  confirm.insert("confirm".into(), toml::Value::Array(vec!["x".into()]));
+  confirm.insert("cancel".into(), toml::Value::Array(vec!["x".into()]));
+  config
+    .tui
+    .keys
+    .raw
+    .insert("confirm".into(), toml::Value::Table(confirm));
+
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check");
+  assert_eq!(c.status, CheckStatus::Failed);
+  assert!(
+    c.detail.contains("conflict"),
+    "detail must explain the conflict, got: {}",
+    c.detail
+  );
+}

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -898,6 +898,37 @@ fn doctor_fails_on_in_context_modal_conflict() {
 }
 
 #[test]
+fn doctor_modal_error_outranks_the_quit_warning() {
+  // #219 review (P2): an invalid modal binding is a hard Failed. When the same
+  // config also unbinds `quit` (a Warning), the modal error must still win —
+  // otherwise the quit-warning early return hides the actionable modal error.
+  let (dir, repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[tui.keys]\nquit = []\n\n[tui.keys.confirm]\nconfirm = [\"g g\"]\n",
+  )
+  .unwrap();
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+  let c = report
+    .checks
+    .iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("expected a TUI keymap check");
+  assert_eq!(
+    c.status,
+    CheckStatus::Failed,
+    "the modal error must outrank the quit warning, got: {}",
+    c.detail
+  );
+  assert!(
+    c.detail.contains("single keystroke"),
+    "detail must be the modal error, not the quit warning, got: {}",
+    c.detail
+  );
+}
+
+#[test]
 fn doctor_fails_on_disk_modal_error_even_when_context_defaulted() {
   // #219 review (P2): `repo_context_lenient` returns `Config::default()` when
   // `load_for_repo` rejects the user's `.gwm.toml` (here a multi-stroke modal

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -872,14 +872,14 @@ fn doctor_reports_modal_binding_count_on_default_keymap() {
 
 #[test]
 fn doctor_fails_on_in_context_modal_conflict() {
-  // A `[tui.keys.confirm]` block binding two verbs to the same key is a
+  // A `[tui.keys.modal.confirm]` block binding two verbs to the same key is a
   // per-context conflict. Written to disk (load-time validation rejects it, so
   // the lenient doctor context defaults ctx.config away) to prove `gwm doctor`
   // re-reads the file and independently catches it.
   let (dir, repo) = init_repo();
   std::fs::write(
     dir.path().join(".gwm.toml"),
-    "[tui.keys.confirm]\nconfirm = [\"x\"]\ncancel = [\"x\"]\n",
+    "[tui.keys.modal.confirm]\nconfirm = [\"x\"]\ncancel = [\"x\"]\n",
   )
   .unwrap();
   let config = Config::default();
@@ -905,7 +905,7 @@ fn doctor_modal_error_outranks_the_quit_warning() {
   let (dir, repo) = init_repo();
   std::fs::write(
     dir.path().join(".gwm.toml"),
-    "[tui.keys]\nquit = []\n\n[tui.keys.confirm]\nconfirm = [\"g g\"]\n",
+    "[tui.keys]\nquit = []\n\n[tui.keys.modal.confirm]\nconfirm = [\"g g\"]\n",
   )
   .unwrap();
   let config = Config::default();
@@ -940,7 +940,7 @@ fn doctor_fails_on_disk_modal_error_even_when_context_defaulted() {
   let (dir, repo) = init_repo();
   std::fs::write(
     dir.path().join(".gwm.toml"),
-    "[tui.keys.confirm]\nconfirm = [\"g g\"]\n",
+    "[tui.keys.modal.confirm]\nconfirm = [\"g g\"]\n",
   )
   .unwrap();
   // The file must be load-invalid (so the lenient loader would default it).

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -11,6 +11,8 @@ fn ctx_for<'a>(repo: &'a git2::Repository, workdir: &'a std::path::Path, config:
     repo_workdir: workdir,
     repo,
     config,
+    // Isolated by default: no global layer is read for injected test contexts.
+    global_config_path: None,
   }
 }
 
@@ -894,6 +896,58 @@ fn doctor_fails_on_in_context_modal_conflict() {
     c.detail.contains("conflict"),
     "detail must explain the conflict, got: {}",
     c.detail
+  );
+}
+
+#[test]
+fn doctor_keymap_check_reads_only_the_threaded_global_layer() {
+  // #219 review (P2): the keymap check must merge the global layer that was
+  // *threaded into the context*, never an ambient `global_config_path()` read —
+  // otherwise a developer's real `~/.config/gwm` would make an isolated temp
+  // repo's check flap. A bad global is seen only when explicitly threaded.
+  let (dir, repo) = init_repo();
+  let global = dir.path().join("global.toml");
+  std::fs::write(&global, "[tui.keys.modal.confirm]\nconfirm = [\"g g\"]\n").unwrap();
+  let config = Config::default();
+
+  // Threaded → the bad global keymap surfaces.
+  let with = DoctorCtx {
+    repo_workdir: dir.path(),
+    repo: &repo,
+    config: &config,
+    global_config_path: Some(global.as_path()),
+  };
+  let c = doctor::run(&with)
+    .unwrap()
+    .checks
+    .into_iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("keymap check");
+  assert_eq!(
+    c.status,
+    CheckStatus::Failed,
+    "a threaded bad global must fail the check: {}",
+    c.detail
+  );
+
+  // Not threaded (None) → the very same file is ignored; the check is clean.
+  let without = DoctorCtx {
+    repo_workdir: dir.path(),
+    repo: &repo,
+    config: &config,
+    global_config_path: None,
+  };
+  let c2 = doctor::run(&without)
+    .unwrap()
+    .checks
+    .into_iter()
+    .find(|c| c.name.to_lowercase().contains("keymap"))
+    .expect("keymap check");
+  assert_eq!(
+    c2.status,
+    CheckStatus::Ok,
+    "an un-threaded global config must be ignored: {}",
+    c2.detail
   );
 }
 

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -249,6 +249,21 @@ fn parse_single_accepts_one_stroke_rejects_chords() {
   );
 }
 
+#[test]
+fn parse_single_rejects_the_reserved_ctrl_c() {
+  // #219 review (P2): Ctrl+C is the emergency quit handled in `run_app` before
+  // any modal lookup, so a modal binding to it would never fire. Reject it at
+  // parse time rather than advertise an unreachable action in `gwm tui keys`.
+  use gwm::tui::modal_keymap::parse_single;
+  for s in ["Ctrl+c", "Ctrl+C"] {
+    let err = parse_single(s).expect_err("Ctrl+C must be rejected as reserved");
+    assert!(
+      err.to_string().contains("Ctrl+C") || err.to_string().to_lowercase().contains("reserved"),
+      "message should explain the reserved key: {err}"
+    );
+  }
+}
+
 // ── listing ────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -3,7 +3,7 @@
 //! Ratatui-free: every assertion drives the pure [`ModalKeymap`] model so
 //! the routing contract is pinned without spawning a terminal.
 
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use gwm::tui::keymap::{KeyStroke, Source};
 use gwm::tui::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 
@@ -258,4 +258,26 @@ fn bindings_for_returns_only_that_contexts_verbs() {
   assert!(confirm.iter().all(|b| b.action.context() == KeyContext::Confirm));
   // confirm has six verbs
   assert_eq!(confirm.len(), 6);
+}
+
+// ── BackTab / Shift-Tab terminal disagreement (issue #219 review) ──────────
+
+#[test]
+fn backtab_with_shift_modifier_resolves_like_plain_backtab() {
+  // Some terminals report Shift-Tab as `KeyCode::BackTab` WITH a SHIFT
+  // modifier; others as bare `BackTab`. Both mean the same keystroke, so the
+  // modal resolver must fire the prev-field / prev-tab verb bound to the
+  // modifier-less `"BackTab"` default in either case. Without normalisation
+  // the shifted variant compared unequal and the default silently did
+  // nothing — a regression vs the old hard-coded `KeyCode::BackTab` branch.
+  let km = ModalKeymap::defaults();
+  let shifted = KeyStroke::from_event(&KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+  assert_eq!(
+    km.resolve(KeyContext::Create, &shifted),
+    Some(ModalAction::CreatePrevField)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Config, &shifted),
+    Some(ModalAction::ConfigPrevTab)
+  );
 }

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -1,0 +1,261 @@
+//! Contract tests for the contextual modal keymap (issue #219).
+//!
+//! Ratatui-free: every assertion drives the pure [`ModalKeymap`] model so
+//! the routing contract is pinned without spawning a terminal.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use gwm::tui::keymap::{KeyStroke, Source};
+use gwm::tui::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
+
+fn stroke(code: KeyCode) -> KeyStroke {
+  KeyStroke::new(code, KeyModifiers::empty())
+}
+
+fn ch(c: char) -> KeyStroke {
+  KeyStroke::new(KeyCode::Char(c), KeyModifiers::empty())
+}
+
+// ── context / verb roundtrip ───────────────────────────────────────────────
+
+#[test]
+fn config_path_roundtrips_through_from_config_path() {
+  for ctx in KeyContext::all() {
+    assert_eq!(
+      KeyContext::from_config_path(ctx.config_path()),
+      Some(*ctx),
+      "config_path {:?} must roundtrip",
+      ctx.config_path()
+    );
+  }
+}
+
+#[test]
+fn link_stages_use_dotted_config_paths() {
+  assert_eq!(KeyContext::LinkChooseTarget.config_path(), "link.choose_target");
+  assert_eq!(KeyContext::LinkInputNumber.config_path(), "link.input_number");
+  assert_eq!(KeyContext::ConfigEdit.config_path(), "config.edit");
+}
+
+#[test]
+fn from_context_verb_resolves_known_verbs_and_rejects_unknown() {
+  assert_eq!(
+    ModalAction::from_context_verb(KeyContext::Confirm, "confirm"),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  assert_eq!(
+    ModalAction::from_context_verb(KeyContext::Create, "submit"),
+    Some(ModalAction::CreateSubmit)
+  );
+  // A verb that exists in another context must not leak across.
+  assert_eq!(ModalAction::from_context_verb(KeyContext::Confirm, "submit"), None);
+  assert_eq!(ModalAction::from_context_verb(KeyContext::Create, "confirm"), None);
+}
+
+#[test]
+fn every_action_reports_its_owning_context() {
+  for action in ModalAction::all() {
+    let ctx = action.context();
+    assert_eq!(
+      ModalAction::from_context_verb(ctx, action.verb()),
+      Some(action),
+      "{:?} must resolve from its own (context, verb)",
+      action
+    );
+  }
+}
+
+// ── defaults resolution ────────────────────────────────────────────────────
+
+#[test]
+fn defaults_resolve_the_historical_keys() {
+  let km = ModalKeymap::defaults();
+
+  // confirm: y / Enter / n / Esc / h / l / Tab
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('y')),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &stroke(KeyCode::Enter)),
+    Some(ModalAction::ConfirmActivate)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('n')),
+    Some(ModalAction::ConfirmCancel)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &stroke(KeyCode::Esc)),
+    Some(ModalAction::ConfirmCancel)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('h')),
+    Some(ModalAction::ConfirmFocusConfirm)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &stroke(KeyCode::Tab)),
+    Some(ModalAction::ConfirmToggleFocus)
+  );
+
+  // create: Tab / BackTab / Enter / Esc, and h/l type cycling
+  assert_eq!(
+    km.resolve(KeyContext::Create, &stroke(KeyCode::Tab)),
+    Some(ModalAction::CreateNextField)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Create, &stroke(KeyCode::BackTab)),
+    Some(ModalAction::CreatePrevField)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Create, &ch('l')),
+    Some(ModalAction::CreateNextType)
+  );
+
+  // link stages
+  assert_eq!(
+    km.resolve(KeyContext::LinkChooseTarget, &ch('i')),
+    Some(ModalAction::LinkChooseIssue)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::LinkInputNumber, &stroke(KeyCode::Enter)),
+    Some(ModalAction::LinkInputSubmit)
+  );
+}
+
+#[test]
+fn unbound_stroke_resolves_to_none() {
+  let km = ModalKeymap::defaults();
+  // `z` is bound in no modal context.
+  assert_eq!(km.resolve(KeyContext::Confirm, &ch('z')), None);
+  // digits are free text in link.input_number, not a verb.
+  assert_eq!(km.resolve(KeyContext::LinkInputNumber, &ch('4')), None);
+}
+
+#[test]
+fn same_key_means_different_verbs_in_different_contexts() {
+  let km = ModalKeymap::defaults();
+  // Enter is `submit` in create but `activate` in confirm — the whole point.
+  assert_eq!(
+    km.resolve(KeyContext::Create, &stroke(KeyCode::Enter)),
+    Some(ModalAction::CreateSubmit)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &stroke(KeyCode::Enter)),
+    Some(ModalAction::ConfirmActivate)
+  );
+  // `i` is `issue` in both link.choose_target and open_menu — independent.
+  assert_eq!(
+    km.resolve(KeyContext::LinkChooseTarget, &ch('i')),
+    Some(ModalAction::LinkChooseIssue)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::OpenMenu, &ch('i')),
+    Some(ModalAction::OpenMenuIssue)
+  );
+}
+
+// ── overrides ──────────────────────────────────────────────────────────────
+
+#[test]
+fn override_replaces_keys_for_a_verb() {
+  let mut km = ModalKeymap::defaults();
+  km.apply_override(ModalAction::ConfirmConfirm, vec![ch('o')]).unwrap();
+  // new key fires
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('o')),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  // old default `y` no longer fires
+  assert_eq!(km.resolve(KeyContext::Confirm, &ch('y')), None);
+}
+
+#[test]
+fn override_can_unbind_with_empty_vec() {
+  let mut km = ModalKeymap::defaults();
+  km.apply_override(ModalAction::ConfirmConfirm, vec![]).unwrap();
+  assert_eq!(km.resolve(KeyContext::Confirm, &ch('y')), None);
+}
+
+#[test]
+fn user_override_wins_over_a_default_in_the_same_context() {
+  // Bind confirm's `cancel` to `y` — which defaults to `confirm`. The
+  // default `confirm` binding must silently vacate `y`; no conflict.
+  let mut km = ModalKeymap::defaults();
+  km.apply_override(ModalAction::ConfirmCancel, vec![ch('y'), stroke(KeyCode::Esc)])
+    .unwrap();
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('y')),
+    Some(ModalAction::ConfirmCancel)
+  );
+}
+
+#[test]
+fn user_vs_user_conflict_in_same_context_is_rejected() {
+  let mut km = ModalKeymap::defaults();
+  km.apply_override(ModalAction::ConfirmConfirm, vec![ch('x')]).unwrap();
+  let err = km
+    .apply_override(ModalAction::ConfirmCancel, vec![ch('x')])
+    .expect_err("same key for two verbs in one context must conflict");
+  let msg = err.to_string();
+  assert!(msg.contains("conflict"), "message should mention conflict: {msg}");
+  assert!(msg.contains("confirm"), "message should name the context: {msg}");
+}
+
+#[test]
+fn cross_context_reuse_is_not_a_conflict() {
+  let mut km = ModalKeymap::defaults();
+  // Bind `x` in confirm and in create — different contexts, both fine.
+  km.apply_override(ModalAction::ConfirmConfirm, vec![ch('x')]).unwrap();
+  km.apply_override(ModalAction::CreateSubmit, vec![ch('x')]).unwrap();
+  assert_eq!(
+    km.resolve(KeyContext::Confirm, &ch('x')),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::Create, &ch('x')),
+    Some(ModalAction::CreateSubmit)
+  );
+}
+
+#[test]
+fn override_marks_source_as_user_config() {
+  let mut km = ModalKeymap::defaults();
+  km.apply_override(ModalAction::ConfirmConfirm, vec![ch('o')]).unwrap();
+  let binding = km
+    .list()
+    .iter()
+    .find(|b| b.action == ModalAction::ConfirmConfirm)
+    .unwrap();
+  assert_eq!(binding.source, Source::UserConfig);
+  // an untouched verb stays Default
+  let other = km
+    .list()
+    .iter()
+    .find(|b| b.action == ModalAction::ConfirmCancel)
+    .unwrap();
+  assert_eq!(other.source, Source::Default);
+}
+
+// ── single-stroke contract ─────────────────────────────────────────────────
+
+#[test]
+fn parse_single_accepts_one_stroke_rejects_chords() {
+  use gwm::tui::modal_keymap::parse_single;
+  assert!(parse_single("Enter").is_ok());
+  assert!(parse_single("Ctrl+s").is_ok());
+  let err = parse_single("g g").expect_err("multi-stroke chord must be rejected for modals");
+  assert!(
+    err.to_string().contains("single keystroke"),
+    "message should explain the single-stroke rule: {err}"
+  );
+}
+
+// ── listing ────────────────────────────────────────────────────────────────
+
+#[test]
+fn bindings_for_returns_only_that_contexts_verbs() {
+  let km = ModalKeymap::defaults();
+  let confirm = km.bindings_for(KeyContext::Confirm);
+  assert!(confirm.iter().all(|b| b.action.context() == KeyContext::Confirm));
+  // confirm has six verbs
+  assert_eq!(confirm.len(), 6);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6570,3 +6570,43 @@ fn resolve_modal_reflects_a_confirm_rebind() {
     None
   );
 }
+
+#[test]
+fn link_input_number_context_advertises_its_own_hints() {
+  // #219 review: while typing the number, the hints must resolve submit /
+  // cancel from `[tui.keys.link.input_number]` (including a rebind), not the
+  // choose-target keys.
+  use crossterm::event::{KeyCode, KeyModifiers};
+  use gwm::tui::keymap::{KeyStroke, Keymap};
+  use gwm::tui::modal_keymap::{ModalAction, ModalKeymap};
+  use gwm::tui::HintContext;
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(
+      ModalAction::LinkInputSubmit,
+      vec![KeyStroke::new(KeyCode::Char('x'), KeyModifiers::empty())],
+    )
+    .unwrap();
+  let resolved = HintContext::LinkInputNumber.resolve(&Keymap::defaults(), &modal);
+  assert!(
+    resolved.iter().any(|(k, l)| l == "submit" && k == "x"),
+    "submit hint must show the rebound key, got {resolved:?}"
+  );
+  assert!(
+    !resolved.iter().any(|(_, l)| l == "kind" || l == "move"),
+    "the input-number stage must not advertise choose-target hints: {resolved:?}"
+  );
+}
+
+#[test]
+fn hint_context_switches_to_link_input_number_while_typing() {
+  use gwm::tui::HintContext;
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app.enter_link_prompt();
+  assert_eq!(app.hint_context(), HintContext::LinkPrompt, "choose-target stage");
+  // Commit a target → InputNumber stage; the statusbar context must follow.
+  app.link_prompt_choose(LinkTarget::Issue);
+  assert_eq!(app.link_prompt_stage(), LinkPromptStage::InputNumber);
+  assert_eq!(app.hint_context(), HintContext::LinkInputNumber, "number-input stage");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6608,7 +6608,7 @@ fn resolve_modal_reflects_a_confirm_rebind() {
 #[test]
 fn link_input_number_context_advertises_its_own_hints() {
   // #219 review: while typing the number, the hints must resolve submit /
-  // cancel from `[tui.keys.link.input_number]` (including a rebind), not the
+  // cancel from `[tui.keys.modal.link.input_number]` (including a rebind), not the
   // choose-target keys.
   use crossterm::event::{KeyCode, KeyModifiers};
   use gwm::tui::keymap::{KeyStroke, Keymap};

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1119,6 +1119,32 @@ fn countdown_status_uses_rebound_confirm_keys() {
 }
 
 #[test]
+fn countdown_status_omits_an_unbound_cancel_key() {
+  // #219 review (P2): with `[tui.keys.modal.confirm] cancel = []`, Esc no
+  // longer cancels — the armed status must not advertise a phantom cancel key
+  // (it would tell the user to press a key that does nothing while the delete
+  // timer runs). Drop it instead of falling back to the literal.
+  use gwm::tui::modal_keymap::ModalAction;
+  let (_dir, mut app) = make_app();
+  app
+    .modal_keymap
+    .apply_override(ModalAction::ConfirmCancel, vec![])
+    .unwrap();
+  app.toggle_delete_branch();
+  app.confirm_press_y(Instant::now()); // arms
+  assert!(
+    !app.status.contains("Esc") && !app.status.contains("to cancel"),
+    "armed status must not advertise an unbound cancel key: {}",
+    app.status
+  );
+  assert!(
+    app.status.contains("press y again"),
+    "the still-bound confirm key must remain in the copy: {}",
+    app.status
+  );
+}
+
+#[test]
 fn confirm_dismiss_resets_timer_and_returns_to_list() {
   let (_dir, mut app) = make_app();
   app.toggle_delete_branch();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6476,3 +6476,97 @@ fn request_sync_refuses_while_another_mutation_runs() {
     app.status
   );
 }
+
+// --- contextual modal rebinding (issue #219) -----------------------------
+
+#[test]
+fn create_modal_honours_a_rebound_submit_key() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::ModalAction;
+  use gwm::tui::CreateKey;
+
+  let (_dir, mut app) = make_app();
+  // Rebind create.submit from Enter to F2.
+  app
+    .modal_keymap
+    .apply_override(
+      ModalAction::CreateSubmit,
+      vec![KeyStroke::new(KeyCode::F(2), KeyModifiers::empty())],
+    )
+    .unwrap();
+
+  // Advance Type -> Issue -> Desc using the default `next_field` (Tab).
+  app.handle_create_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+  app.handle_create_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+  assert_eq!(app.create_form.field, Field::Desc);
+
+  // The rebound key submits…
+  assert_eq!(
+    app.handle_create_key(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE)),
+    CreateKey::Submit
+  );
+  // …and the old default Enter no longer submits (it is unbound now).
+  assert_eq!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    CreateKey::Handled
+  );
+}
+
+#[test]
+fn create_modal_type_cycle_keys_stay_literal_on_text_fields() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::CreateKey;
+
+  let (_dir, mut app) = make_app();
+  // On the Desc field, `l` is literal text — it must NOT cycle the type
+  // (the default next_type binding includes `l`, gated on the Type field).
+  app.handle_create_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)); // Issue
+  app.handle_create_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)); // Desc
+  assert_eq!(app.create_form.field, Field::Desc);
+  let before = app.create_form.type_index;
+  assert_eq!(
+    app.handle_create_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)),
+    CreateKey::Handled
+  );
+  assert_eq!(
+    app.create_form.type_index, before,
+    "type must not cycle while typing a description"
+  );
+  assert!(
+    app.create_form.desc.contains('l'),
+    "`l` must reach the description buffer as literal text"
+  );
+}
+
+#[test]
+fn resolve_modal_reflects_a_confirm_rebind() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::{KeyContext, ModalAction};
+
+  let (_dir, mut app) = make_app();
+  app
+    .modal_keymap
+    .apply_override(
+      ModalAction::ConfirmConfirm,
+      vec![KeyStroke::new(KeyCode::Char('o'), KeyModifiers::empty())],
+    )
+    .unwrap();
+  // The inline confirm routing resolves through App::resolve_modal, so a
+  // rebind is observable there: `o` now means confirm, `y` no longer does.
+  assert_eq!(
+    app.resolve_modal(
+      KeyContext::Confirm,
+      KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)
+    ),
+    Some(ModalAction::ConfirmConfirm)
+  );
+  assert_eq!(
+    app.resolve_modal(
+      KeyContext::Confirm,
+      KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE)
+    ),
+    None
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6610,3 +6610,33 @@ fn hint_context_switches_to_link_input_number_while_typing() {
   assert_eq!(app.link_prompt_stage(), LinkPromptStage::InputNumber);
   assert_eq!(app.hint_context(), HintContext::LinkInputNumber, "number-input stage");
 }
+
+#[test]
+fn link_modal_binding_on_fetch_key_wins_over_fetch_fallback() {
+  // #293 review: the global fetch shortcut is a FALLBACK after the stage
+  // context, so a contextual binding on that key is reachable. Rebinding the
+  // number-input submit onto `F` (also the default fetch key) must submit,
+  // not refresh.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::ModalAction;
+  use gwm::tui::LinkPromptKey;
+
+  let (_dir, _repo, mut app) = make_app_on_branch("random-branch");
+  app
+    .modal_keymap
+    .apply_override(
+      ModalAction::LinkInputSubmit,
+      vec![KeyStroke::new(KeyCode::Char('F'), KeyModifiers::empty())],
+    )
+    .unwrap();
+  app.enter_link_prompt();
+  app.link_prompt_choose(LinkTarget::Issue); // → InputNumber stage
+  assert!(
+    matches!(
+      app.handle_link_prompt_key(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::NONE)),
+      LinkPromptKey::Submit
+    ),
+    "a contextual binding on the fetch key must win over the fetch fallback"
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1085,6 +1085,40 @@ fn confirm_press_y_a_second_time_disarms_the_timer() {
 }
 
 #[test]
+fn countdown_status_uses_rebound_confirm_keys() {
+  // #219 review (P3): the armed/disarmed countdown status copy hard-coded
+  // `y` / `Esc`. When the confirm context's confirm/cancel verbs are rebound,
+  // the instructions must name the live keys, not the defaults.
+  use gwm::tui::modal_keymap::{parse_single, ModalAction};
+  let (_dir, mut app) = make_app();
+  app
+    .modal_keymap
+    .apply_override(ModalAction::ConfirmConfirm, vec![parse_single("c").unwrap()])
+    .unwrap();
+  app
+    .modal_keymap
+    .apply_override(ModalAction::ConfirmCancel, vec![parse_single("x").unwrap()])
+    .unwrap();
+  app.toggle_delete_branch();
+
+  let t0 = Instant::now();
+  app.confirm_press_y(t0); // arms
+  assert!(
+    app.status.contains("press c again or x to cancel"),
+    "armed copy must use the rebound confirm/cancel keys: {}",
+    app.status
+  );
+
+  let action = app.confirm_press_y(t0 + Duration::from_millis(500)); // disarms
+  assert_eq!(action, ConfirmKeyAction::Disarmed);
+  assert!(
+    app.status.contains("press c to re-arm"),
+    "disarmed copy must use the rebound confirm key: {}",
+    app.status
+  );
+}
+
+#[test]
 fn confirm_dismiss_resets_timer_and_returns_to_list() {
   let (_dir, mut app) = make_app();
   app.toggle_delete_branch();

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -186,7 +186,7 @@ fn help_overlay_lists_pane_focus_bindings() {
   use gwm::tui::keymap::Keymap;
 
   let km = Keymap::defaults();
-  let lines = help_lines(&km, false);
+  let lines = help_lines(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), false);
   assert!(
     lines.iter().any(|l| l.starts_with("  1 ")),
     "expected the default `1` focus binding in the help overlay:\n{}",
@@ -215,7 +215,7 @@ fn help_overlay_lists_sync() {
   use gwm::tui::keymap::Keymap;
 
   let km = Keymap::defaults();
-  let lines = help_lines(&km, false);
+  let lines = help_lines(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), false);
   let row = lines
     .iter()
     .find(|l| l.contains("sync") || l.contains("pull") || l.contains("fetch"))
@@ -243,7 +243,7 @@ fn help_overlay_reflects_user_keymap_override() {
   )
   .unwrap();
 
-  let lines = help_lines(&km, false);
+  let lines = help_lines(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), false);
   let next_line = lines
     .iter()
     .find(|l| l.contains("next"))
@@ -297,7 +297,11 @@ fn help_rows_structures_title_sections_and_entries() {
   use gwm::tui::{HelpRow, HintContext};
 
   let km = Keymap::defaults();
-  let rows = help_rows(&km, HintContext::Worktrees);
+  let rows = help_rows(
+    &km,
+    &gwm::tui::modal_keymap::ModalKeymap::defaults(),
+    HintContext::Worktrees,
+  );
 
   // Issue #217: the overlay title is now "Keybindings", followed by a
   // context subtitle reflecting the focused pane.
@@ -381,7 +385,7 @@ fn help_lines_is_help_rows_flattened() {
     } else {
       HintContext::Worktrees
     };
-    let expected: Vec<String> = help_rows(&km, ctx)
+    let expected: Vec<String> = help_rows(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), ctx)
       .into_iter()
       .map(|row| match row {
         HelpRow::Title(s) | HelpRow::Subtitle(s) | HelpRow::Section(s) => s,
@@ -392,7 +396,11 @@ fn help_lines_is_help_rows_flattened() {
         }
       })
       .collect();
-    assert_eq!(help_lines(&km, picker_mode), expected, "picker_mode={picker_mode}");
+    assert_eq!(
+      help_lines(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), picker_mode),
+      expected,
+      "picker_mode={picker_mode}"
+    );
   }
 }
 
@@ -410,10 +418,47 @@ fn help_subtitle_tracks_the_pane_context() {
     (HintContext::Status, "status"),
     (HintContext::Picker, "switch"),
   ] {
-    let rows = help_rows(&km, ctx);
+    let rows = help_rows(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults(), ctx);
     assert!(
       rows.iter().any(|r| matches!(r, HelpRow::Subtitle(s) if s == want)),
       "expected `{want}` subtitle for {want} context"
     );
   }
+}
+
+#[test]
+fn help_overlay_reflects_a_modal_rebind() {
+  // #219: the Create Form / Delete Worktree help rows resolve from the
+  // contextual modal keymap, so `[tui.keys.confirm] confirm = ["o"]` shows
+  // `o` next to the "confirm" row instead of the default `y`.
+  use gwm::tui::help_lines;
+  use gwm::tui::keymap::{KeyStroke, Keymap};
+  use gwm::tui::modal_keymap::{ModalAction, ModalKeymap};
+
+  let km = Keymap::defaults();
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(
+      ModalAction::ConfirmConfirm,
+      vec![KeyStroke::new(KeyCode::Char('o'), KeyModifiers::empty())],
+    )
+    .unwrap();
+
+  let lines = help_lines(&km, &modal, false);
+  let row = lines
+    .iter()
+    .find(|l| l.trim_end().ends_with("confirm") && !l.contains("Confirm"))
+    .unwrap_or_else(|| panic!("expected a `confirm` row in:\n{}", lines.join("\n")));
+  assert!(
+    row.starts_with("  o "),
+    "expected the confirm row to show the rebound `o`, got: {row}"
+  );
+  // The default `y` row for confirm must be gone.
+  assert!(
+    !lines
+      .iter()
+      .any(|l| l.starts_with("  y ") && l.trim_end().ends_with("confirm")),
+    "the default `y` binding must not remain after the modal rebind:\n{}",
+    lines.join("\n")
+  );
 }

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -370,6 +370,49 @@ fn help_rows_structures_title_sections_and_entries() {
 }
 
 #[test]
+fn help_rows_link_descriptions_track_modal_rebindings() {
+  // #219 review (P3): the help table's `open menu` / `link prompt` rows hard-
+  // coded `i=issue · p=pull request` and `j/k + enter, or i/p`. Those keys are
+  // the OpenMenu / LinkChooseTarget modal verbs, so a rebind must show through
+  // instead of advertising keys that no longer work.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::OpenMenuIssue, vec![parse_single("x").unwrap()])
+    .unwrap();
+  modal
+    .apply_override(ModalAction::LinkChooseIssue, vec![parse_single("z").unwrap()])
+    .unwrap();
+  let rows = help_rows(&km, &modal, HintContext::Worktrees);
+
+  let label_of = |needle: &str| -> String {
+    rows
+      .iter()
+      .find_map(|r| match r {
+        HelpRow::Entry { label, .. } if label.contains(needle) => Some(label.clone()),
+        _ => None,
+      })
+      .unwrap_or_else(|| panic!("no help entry containing {needle:?}: {rows:?}"))
+  };
+
+  let open_menu = label_of("open menu");
+  assert!(
+    open_menu.contains("x=issue") && !open_menu.contains("i=issue"),
+    "open-menu help must use the rebound issue key: {open_menu:?}"
+  );
+  let link_prompt = label_of("link prompt");
+  assert!(
+    link_prompt.contains('z'),
+    "link-prompt help must use the rebound choose-target issue key: {link_prompt:?}"
+  );
+}
+
+#[test]
 fn help_lines_is_help_rows_flattened() {
   // #187: `help_lines` must stay a pure flattening of `help_rows` so the
   // legacy `  {keys:<13} {label}` string contract (asserted elsewhere in
@@ -429,7 +472,7 @@ fn help_subtitle_tracks_the_pane_context() {
 #[test]
 fn help_overlay_reflects_a_modal_rebind() {
   // #219: the Create Form / Delete Worktree help rows resolve from the
-  // contextual modal keymap, so `[tui.keys.confirm] confirm = ["o"]` shows
+  // contextual modal keymap, so `[tui.keys.modal.confirm] confirm = ["o"]` shows
   // `o` next to the "confirm" row instead of the default `y`.
   use gwm::tui::help_lines;
   use gwm::tui::keymap::{KeyStroke, Keymap};

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -413,6 +413,47 @@ fn help_rows_link_descriptions_track_modal_rebindings() {
 }
 
 #[test]
+fn help_rows_link_descriptions_drop_unbound_keys() {
+  // #219 review (P3): when a direct-pick verb is explicitly unbound, the help
+  // description must not fall back to the literal `i` / `enter` — drop the
+  // clause like every other modal hint instead of advertising a dead key.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::{ModalAction, ModalKeymap};
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  let mut modal = ModalKeymap::defaults();
+  modal.apply_override(ModalAction::OpenMenuIssue, vec![]).unwrap();
+  modal.apply_override(ModalAction::LinkChooseIssue, vec![]).unwrap();
+  let rows = help_rows(&km, &modal, HintContext::Worktrees);
+  let label_of = |needle: &str| -> String {
+    rows
+      .iter()
+      .find_map(|r| match r {
+        HelpRow::Entry { label, .. } if label.contains(needle) => Some(label.clone()),
+        _ => None,
+      })
+      .unwrap_or_else(|| panic!("no help entry containing {needle:?}"))
+  };
+
+  let open_menu = label_of("open menu");
+  assert!(
+    !open_menu.contains("=issue"),
+    "an unbound open-menu issue pick must drop from the help text: {open_menu:?}"
+  );
+  assert!(
+    open_menu.contains("pull request"),
+    "the still-bound pr pick must remain: {open_menu:?}"
+  );
+  let link_prompt = label_of("link prompt");
+  assert!(
+    !link_prompt.contains("i/p"),
+    "the unbound link issue pick must drop (no `i/p`): {link_prompt:?}"
+  );
+}
+
+#[test]
 fn help_lines_is_help_rows_flattened() {
   // #187: `help_lines` must stay a pure flattening of `help_rows` so the
   // legacy `  {keys:<13} {label}` string contract (asserted elsewhere in

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -420,6 +420,38 @@ fn report_close_hint_resolves_user_rebinding() {
 }
 
 #[test]
+fn link_input_number_drops_fetch_hint_when_shadowed() {
+  // #219 review (P3): in the number-input stage the footer advertises the
+  // global `F fetch` fallback, but if a modal verb is rebound onto `F` the
+  // event loop resolves `F` as that verb first, leaving the fetch hint
+  // pointing at an unreachable action. The footer must drop a global hint
+  // whose key is shadowed by a modal binding in the active context.
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  let km = Keymap::defaults();
+
+  let default = HintContext::LinkInputNumber.resolve(&km, &ModalKeymap::defaults());
+  assert!(
+    default.iter().any(|(k, l)| k == "F" && l == "fetch"),
+    "by default `F fetch` is reachable during number input: {default:?}"
+  );
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::LinkInputSubmit, vec![parse_single("F").unwrap()])
+    .unwrap();
+  let resolved = HintContext::LinkInputNumber.resolve(&km, &modal);
+  assert!(
+    !resolved.iter().any(|(_, l)| l == "fetch"),
+    "the shadowed `F fetch` hint must be dropped: {resolved:?}"
+  );
+  assert!(
+    resolved.iter().any(|(k, l)| k == "F" && l == "submit"),
+    "F now resolves as submit and must show through: {resolved:?}"
+  );
+}
+
+#[test]
 fn help_close_hint_resolves_user_rebinding() {
   // #219 review (P3): same staleness on the Keybindings overlay — rebinding
   // `[tui.keys.help] close` must show through the footer (scroll/pan pairs

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -392,7 +392,7 @@ fn confirm_hints_include_delete_branch_toggle_binding() {
 #[test]
 fn report_close_hint_resolves_user_rebinding() {
   // #219 review (P3): the report overlay footer advertised a literal
-  // `Enter/Esc` even after `[tui.keys.report] close` was rebound — the event
+  // `Enter/Esc` even after `[tui.keys.modal.report] close` was rebound — the event
   // loop already routes close through the modal keymap, so the footer must
   // follow it instead of printing a stale key.
   use gwm::tui::keymap::Keymap;
@@ -454,7 +454,7 @@ fn link_input_number_drops_fetch_hint_when_shadowed() {
 #[test]
 fn help_close_hint_resolves_user_rebinding() {
   // #219 review (P3): same staleness on the Keybindings overlay — rebinding
-  // `[tui.keys.help] close` must show through the footer (scroll/pan pairs
+  // `[tui.keys.modal.help] close` must show through the footer (scroll/pan pairs
   // stay literal because no single resolved key captures `j/k` / `h/l`).
   use gwm::tui::keymap::Keymap;
   use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -230,7 +230,7 @@ fn status_line_keeps_context_and_log_when_narrow_dropping_hints() {
 fn link_prompt_status_line_keeps_short_log_at_80_cols() {
   use gwm::tui::keymap::Keymap;
   let km = Keymap::defaults();
-  let resolved = HintContext::LinkPrompt.resolve(&km);
+  let resolved = HintContext::LinkPrompt.resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults());
   let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
 
   let line = status_line("link", &hints, "pick", None, 80, &Theme::default());
@@ -261,7 +261,9 @@ fn hint_context_exposes_label_and_hints() {
     HintContext::CommandPalette,
   ] {
     assert!(
-      !ctx.resolve(&km).is_empty(),
+      !ctx
+        .resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults())
+        .is_empty(),
       "context {:?} must advertise hints",
       ctx.label()
     );
@@ -275,7 +277,7 @@ fn worktrees_and_status_hints_advertise_the_command_logs_key() {
   use gwm::tui::keymap::Keymap;
   let km = Keymap::defaults();
   for ctx in [HintContext::Worktrees, HintContext::Status] {
-    let resolved = ctx.resolve(&km);
+    let resolved = ctx.resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults());
     assert!(
       resolved.iter().any(|(k, l)| k == "3" && l == "logs"),
       "context {:?} must advertise the `3 logs` hint: {resolved:?}",
@@ -292,7 +294,7 @@ fn worktrees_and_status_hints_advertise_the_settings_panel_key() {
   use gwm::tui::keymap::Keymap;
   let km = Keymap::defaults();
   for ctx in [HintContext::Worktrees, HintContext::Status] {
-    let resolved = ctx.resolve(&km);
+    let resolved = ctx.resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults());
     assert!(
       resolved.iter().any(|(k, l)| k == "4" && l == "settings"),
       "context {:?} must advertise the `4 settings` hint: {resolved:?}",
@@ -308,7 +310,7 @@ fn status_hints_resolve_user_rebindings() {
   // `F` by default; rebind it and the resolved hint follows.
   use gwm::tui::keymap::{Action, KeyStroke, Keymap};
   let mut km = Keymap::defaults();
-  let default = HintContext::Status.resolve(&km);
+  let default = HintContext::Status.resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults());
   assert!(
     default.iter().any(|(k, l)| k == "F" && l == "fetch"),
     "default status hints should advertise the `F` fetch binding: {default:?}"
@@ -316,7 +318,7 @@ fn status_hints_resolve_user_rebindings() {
 
   km.apply_override(Action::FetchGithub, vec![KeyStroke::parse_chord("Ctrl+g").unwrap()])
     .unwrap();
-  let resolved = HintContext::Status.resolve(&km);
+  let resolved = HintContext::Status.resolve(&km, &gwm::tui::modal_keymap::ModalKeymap::defaults());
   assert!(
     resolved.iter().any(|(k, l)| k == "Ctrl+g" && l == "fetch"),
     "rebinding fetch_github must change the statusbar hint key: {resolved:?}"
@@ -335,7 +337,7 @@ fn worktrees_hints_are_grouped_lifecycle_then_act_then_navigate_then_global() {
   // verb of each family first.
   use gwm::tui::keymap::Keymap;
   let labels: Vec<String> = HintContext::Worktrees
-    .resolve(&Keymap::defaults())
+    .resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults())
     .into_iter()
     .map(|(_, l)| l)
     .collect();
@@ -355,7 +357,7 @@ fn worktrees_hints_are_grouped_lifecycle_then_act_then_navigate_then_global() {
 fn status_hints_are_grouped_read_then_sidebar_then_navigate_then_global() {
   use gwm::tui::keymap::Keymap;
   let labels: Vec<String> = HintContext::Status
-    .resolve(&Keymap::defaults())
+    .resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults())
     .into_iter()
     .map(|(_, l)| l)
     .collect();
@@ -380,7 +382,7 @@ fn status_hints_are_grouped_read_then_sidebar_then_navigate_then_global() {
 #[test]
 fn confirm_hints_include_delete_branch_toggle_binding() {
   use gwm::tui::keymap::Keymap;
-  let resolved = HintContext::Confirm.resolve(&Keymap::defaults());
+  let resolved = HintContext::Confirm.resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults());
   assert!(
     resolved.iter().any(|(k, l)| k == "D" && l == "branch"),
     "Delete Worktree hints should advertise the branch toggle binding: {resolved:?}"

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -388,3 +388,62 @@ fn confirm_hints_include_delete_branch_toggle_binding() {
     "Delete Worktree hints should advertise the branch toggle binding: {resolved:?}"
   );
 }
+
+#[test]
+fn report_close_hint_resolves_user_rebinding() {
+  // #219 review (P3): the report overlay footer advertised a literal
+  // `Enter/Esc` even after `[tui.keys.report] close` was rebound — the event
+  // loop already routes close through the modal keymap, so the footer must
+  // follow it instead of printing a stale key.
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  let km = Keymap::defaults();
+  let default = HintContext::Report.resolve(&km, &ModalKeymap::defaults());
+  assert!(
+    default.iter().any(|(k, l)| k == "Esc" && l == "close"),
+    "default report footer must advertise the primary `Esc` close: {default:?}"
+  );
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::ReportClose, vec![parse_single("x").unwrap()])
+    .unwrap();
+  let resolved = HintContext::Report.resolve(&km, &modal);
+  assert!(
+    resolved.iter().any(|(k, l)| k == "x" && l == "close"),
+    "rebinding report close must change the footer hint: {resolved:?}"
+  );
+  assert!(
+    !resolved.iter().any(|(k, _)| k == "Enter/Esc"),
+    "the stale literal `Enter/Esc` must not linger after the rebind: {resolved:?}"
+  );
+}
+
+#[test]
+fn help_close_hint_resolves_user_rebinding() {
+  // #219 review (P3): same staleness on the Keybindings overlay — rebinding
+  // `[tui.keys.help] close` must show through the footer (scroll/pan pairs
+  // stay literal because no single resolved key captures `j/k` / `h/l`).
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  let km = Keymap::defaults();
+  let default = HintContext::Help.resolve(&km, &ModalKeymap::defaults());
+  assert!(
+    default.iter().any(|(k, l)| k == "Esc" && l == "close"),
+    "default help footer must advertise the primary `Esc` close: {default:?}"
+  );
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::HelpClose, vec![parse_single("x").unwrap()])
+    .unwrap();
+  let resolved = HintContext::Help.resolve(&km, &modal);
+  assert!(
+    resolved.iter().any(|(k, l)| k == "x" && l == "close"),
+    "rebinding help close must change the footer hint: {resolved:?}"
+  );
+  assert!(
+    !resolved.iter().any(|(k, _)| k == "Esc/q"),
+    "the stale literal `Esc/q` must not linger after the rebind: {resolved:?}"
+  );
+}

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -491,6 +491,83 @@ fn link_target_line_highlights_the_selected_row() {
 }
 
 #[test]
+fn link_target_keys_track_rebinding_per_context() {
+  // #219 review (P3): the Issue / PR direct-pick chips hard-coded `i` / `p`.
+  // They must resolve from the active context's modal bindings so a rebind of
+  // `[tui.keys.link.choose_target]` (or `[tui.keys.open_menu]`) shows through,
+  // and the two contexts stay independent (the whole point of #219).
+  use gwm::tui::link_target_keys;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  use gwm::tui::HintContext;
+
+  assert_eq!(
+    link_target_keys(HintContext::LinkPrompt, &ModalKeymap::defaults()),
+    ("i".to_string(), "p".to_string()),
+    "defaults must keep the historical i / p direct-pick keys"
+  );
+  assert_eq!(
+    link_target_keys(HintContext::OpenMenu, &ModalKeymap::defaults()),
+    ("i".to_string(), "p".to_string()),
+  );
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::LinkChooseIssue, vec![parse_single("x").unwrap()])
+    .unwrap();
+  assert_eq!(
+    link_target_keys(HintContext::LinkPrompt, &modal),
+    ("x".to_string(), "p".to_string()),
+    "rebinding the link choose-target issue key must show through the chip"
+  );
+  assert_eq!(
+    link_target_keys(HintContext::OpenMenu, &modal),
+    ("i".to_string(), "p".to_string()),
+    "the open-menu chips are an independent context and must not change"
+  );
+}
+
+#[test]
+fn config_edit_footer_hints_track_rebinding() {
+  // #219 review (P2): the Settings panel edit footer printed a fixed
+  // `Enter save / Esc cancel`. Once `[tui.keys.config.edit]` is rebound the
+  // handler stops treating Enter/Esc as save/cancel, so the footer must
+  // resolve those hints from the ConfigEdit* modal bindings too.
+  use gwm::tui::config_edit_footer_hints;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+
+  assert_eq!(
+    config_edit_footer_hints(&ModalKeymap::defaults()),
+    vec![
+      ("Enter".to_string(), "save".to_string()),
+      ("Esc".to_string(), "cancel".to_string()),
+    ],
+    "default settings edit footer must read Enter save / Esc cancel"
+  );
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::ConfigEditSubmit, vec![parse_single("Ctrl+s").unwrap()])
+    .unwrap();
+  assert_eq!(
+    config_edit_footer_hints(&modal),
+    vec![
+      ("Ctrl+s".to_string(), "save".to_string()),
+      ("Esc".to_string(), "cancel".to_string()),
+    ],
+    "rebinding config.edit submit must change the save hint"
+  );
+
+  // Unbinding a verb drops it rather than advertising a phantom key.
+  let mut unbound = ModalKeymap::defaults();
+  unbound.apply_override(ModalAction::ConfigEditCancel, vec![]).unwrap();
+  let hints = config_edit_footer_hints(&unbound);
+  assert!(
+    !hints.iter().any(|(_, l)| l == "cancel"),
+    "an unbound cancel must drop from the settings edit footer: {hints:?}"
+  );
+}
+
+#[test]
 fn link_prompt_width_stays_compact_on_wide_terminals() {
   assert_eq!(link_prompt_modal_width(80), 64);
   assert_eq!(

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -494,7 +494,7 @@ fn link_target_line_highlights_the_selected_row() {
 fn link_target_keys_track_rebinding_per_context() {
   // #219 review (P3): the Issue / PR direct-pick chips hard-coded `i` / `p`.
   // They must resolve from the active context's modal bindings so a rebind of
-  // `[tui.keys.link.choose_target]` (or `[tui.keys.open_menu]`) shows through,
+  // `[tui.keys.modal.link.choose_target]` (or `[tui.keys.modal.open_menu]`) shows through,
   // and the two contexts stay independent (the whole point of #219).
   use gwm::tui::link_target_keys;
   use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
@@ -529,7 +529,7 @@ fn link_target_keys_track_rebinding_per_context() {
 #[test]
 fn config_edit_footer_hints_track_rebinding() {
   // #219 review (P2): the Settings panel edit footer printed a fixed
-  // `Enter save / Esc cancel`. Once `[tui.keys.config.edit]` is rebound the
+  // `Enter save / Esc cancel`. Once `[tui.keys.modal.config.edit]` is rebound the
   // handler stops treating Enter/Esc as save/cancel, so the footer must
   // resolve those hints from the ConfigEdit* modal bindings too.
   use gwm::tui::config_edit_footer_hints;

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -568,6 +568,97 @@ fn config_edit_footer_hints_track_rebinding() {
 }
 
 #[test]
+fn config_nav_footer_hints_track_rebinding() {
+  // #219 review (P3): the Settings panel *nav* footer (non-edit) still printed
+  // hard-coded Tab / L / Esc / Enter / Space. Resolve the single-key verbs
+  // (section / layer / close / activate) from the Config modal bindings; the
+  // j/k scroll pair stays literal (no single resolved key captures it).
+  use gwm::tui::config_nav_footer_hints;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+  use gwm::tui::{FieldKind, SettingsTab};
+
+  let all = config_nav_footer_hints(&ModalKeymap::defaults(), SettingsTab::All, None);
+  assert_eq!(
+    all[0],
+    ("j/k".to_string(), "scroll".to_string()),
+    "All tab leads with the literal scroll pair"
+  );
+  assert!(all.iter().any(|(k, l)| k == "Tab" && l == "section"));
+  assert!(all.iter().any(|(k, l)| k == "L" && l == "layer"));
+  assert!(all.iter().any(|(k, l)| k == "Esc" && l == "close"));
+
+  // An editable field advertises `edit`; a Choice field advertises `cycle`.
+  let editable = config_nav_footer_hints(&ModalKeymap::defaults(), SettingsTab::Tui, Some(FieldKind::Text));
+  assert!(
+    editable.iter().any(|(_, l)| l == "edit"),
+    "editable field footer: {editable:?}"
+  );
+  let choice = config_nav_footer_hints(&ModalKeymap::defaults(), SettingsTab::Tui, Some(FieldKind::Choice));
+  assert!(
+    choice.iter().any(|(_, l)| l == "cycle"),
+    "choice field footer: {choice:?}"
+  );
+
+  // Rebinding close + next_tab shows through.
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::ConfigClose, vec![parse_single("x").unwrap()])
+    .unwrap();
+  modal
+    .apply_override(ModalAction::ConfigNextTab, vec![parse_single("n").unwrap()])
+    .unwrap();
+  let rebound = config_nav_footer_hints(&modal, SettingsTab::All, None);
+  assert!(
+    rebound.iter().any(|(k, l)| k == "x" && l == "close"),
+    "rebound close: {rebound:?}"
+  );
+  assert!(
+    rebound.iter().any(|(k, l)| k == "n" && l == "section"),
+    "rebound section: {rebound:?}"
+  );
+  assert!(
+    !rebound.iter().any(|(k, _)| k == "Tab" || k == "Esc"),
+    "stale Tab / Esc must not linger after the rebind: {rebound:?}"
+  );
+}
+
+#[test]
+fn command_logs_footer_hints_track_rebinding() {
+  // #219 review (P3): the Command Logs overlay footer hard-coded j/k, g/G, y,
+  // Esc. Resolve copy / close from the CommandLogs modal bindings (movement
+  // pairs stay literal, as on Help).
+  use gwm::tui::command_logs_footer_hints;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+
+  let default = command_logs_footer_hints(&ModalKeymap::defaults());
+  assert!(default.iter().any(|(k, l)| k == "j/k" && l == "scroll"));
+  assert!(default.iter().any(|(k, l)| k == "g/G" && l == "top/bottom"));
+  assert!(default.iter().any(|(k, l)| k == "y" && l == "copy"));
+  assert!(default.iter().any(|(k, l)| k == "Esc" && l == "close"));
+
+  let mut modal = ModalKeymap::defaults();
+  modal
+    .apply_override(ModalAction::CommandLogsCopy, vec![parse_single("c").unwrap()])
+    .unwrap();
+  modal
+    .apply_override(ModalAction::CommandLogsClose, vec![parse_single("x").unwrap()])
+    .unwrap();
+  let rebound = command_logs_footer_hints(&modal);
+  assert!(
+    rebound.iter().any(|(k, l)| k == "c" && l == "copy"),
+    "rebound copy: {rebound:?}"
+  );
+  assert!(
+    rebound.iter().any(|(k, l)| k == "x" && l == "close"),
+    "rebound close: {rebound:?}"
+  );
+  assert!(
+    !rebound.iter().any(|(k, l)| k == "y" && l == "copy"),
+    "stale `y copy` must not linger after the rebind: {rebound:?}"
+  );
+}
+
+#[test]
 fn link_prompt_width_stays_compact_on_wide_terminals() {
   assert_eq!(link_prompt_modal_width(80), 64);
   assert_eq!(


### PR DESCRIPTION
## Description

Make the TUI modal / overlay keys rebindable through nested
`[tui.keys.<context>]` sub-tables in `.gwm.toml`, instead of the hard-coded
`match key.code` that lived in each `View::*` branch. Each modal is a typed
`KeyContext` owning its own verbs, so the same physical key can mean
different things in different modals (`Enter` is `submit` in the create form
but `activate` in the delete-confirm modal) without any global conflict.

Closes #219

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **New `src/tui/modal_keymap.rs`** — `KeyContext` (create / confirm / help /
  command_logs / config / config.edit / report / open_menu / palette /
  link.choose_target / link.input_number) + `ModalAction` (context-qualified
  verbs) + single-stroke `ModalKeymap` with per-context conflict validation
  and user-wins-over-default override semantics.
- **Config** — `TuiKeysConfig` now stores the raw `[tui.keys]` table; global
  verbs (array values) and contextual modal verbs (table values) coexist,
  keyed off value type. Recursive walker handles dotted stages
  (`link.choose_target`, `config.edit`) with precise per-coordinate errors.
  Both layers validated at load.
- **Event loop** — every modal branch in `src/tui/mod.rs` plus the create /
  link-prompt `App` handlers resolve keys via `App::resolve_modal` against
  the active context. Behaviour preserved verbatim (sub-state gating,
  text-input fallbacks, global toggle keys).
- **Discovery** — `gwm tui keys` lists each `[tui.keys.<context>]` block;
  `gwm doctor` validates contextual bindings and reports per-context
  conflicts; the help overlay and footer hints resolve modal keys live.
- **Docs** — CHANGELOG `[Unreleased]` + a worked `[tui.keys]` block in
  `examples/gwm.toml.example`.

### Hard-coded by design (documented)

`Ctrl+C` (emergency quit), the list view's contextual `Esc`/`Enter`, and the
PTY overlay's emergency `Esc` stay hard-coded — folding them into a
rebindable context would either need modal state the config can't express or
silently steal a key from the PTY child.

## Tests

- [x] `cargo test` passes locally (full suite green; also re-run under a
  stripped CI-like `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: model contract, config parsing +
  every error path, app-level rebind dispatch, doctor conflict, `gwm tui
  keys` listing, help-overlay modal rebind)

TDD-first: `tests/modal_keymap_tests.rs` (15) pinned the model before the
production code; config / doctor / cli / app / help tests were added with
each surface.

## Screenshots / TUI captures

n/a — no new visual surface; existing modal renders are unchanged
(`tests/tui_modal_render_tests.rs` stays green). Behaviour change is the
binding source, not the layout.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (6 atomic commits:
  model → config → routing → cli/doctor → help/footer → docs)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no new command; `gwm tui keys`
  gains a modal section, documented in the example config)
- [x] `examples/gwm.toml.example` updated (config schema changed)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #219
- Follow-up extracted from #217 / #218

## Notes for reviewers

- **Schema choice**: contexts nest under `[tui.keys.<context>]` (the issue's
  proposed direction). Because four global action slugs collide by name with
  context names (`create`, `help`, `command_logs`, `link`), the walker
  disambiguates by **value type** — an array is a global action, a table is a
  context. TOML forbids defining the same key twice, so a user picks one per
  file. Documented in the `modal_keymap` module note + `TuiKeysConfig`.
- **Single-stroke only** for modals (no chord timeout, per the project's
  no-runtime-timeout policy); a multi-stroke modal chord is rejected at load.
- Worth a close look: the per-context conflict validation in
  `ModalKeymap::apply_override` and the recursive walker in `config.rs`.