### PR TITLE
✨ feat(tui): edit all keymaps from the Settings panel (Keys tab, live capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Edit every keymap from the Settings panel** (issue #294): the Settings
+  panel (`4`) gains a **Keys** tab that lists every rebindable binding — the
+  global list-view actions (`[global]`) and every modal verb grouped by
+  context (`[modal.<context>]`) — each with its current key(s) and a
+  `default`/`user`/`repo` source badge. Select a binding, press the activate
+  key, and **capture** a new key live: the key column becomes a `[ … ]` input
+  that records the actual keystroke(s) pressed. A multi-stroke global chord
+  commits on `Enter` (`Backspace` drops the last stroke); a single-stroke
+  modal verb auto-commits on the first key; `Esc` cancels.
+  - The capture writes a TOML array to the layer the panel targets
+    (`[tui.keys]` for a global action, `[tui.keys.modal.<context>]` for a
+    modal verb), honouring the project ↔ global layer toggle (`L`).
+  - The write is validated before it touches disk — a conflict /
+    prefix-collision aborts it, leaves the previous binding live, and reports
+    the error on the statusbar — then the keymap reloads so the new key works
+    immediately, no restart.
+  - An empty capture unbinds the action (global). `Esc`, `Enter`, `Backspace`
+    and `Ctrl+C` can't be assigned via capture by design — hand-edit
+    `.gwm.toml` for those.
+  - New `config_cli::set_array_at` array write-back backs the persistence.
 - **Rebindable modal keys with contextual actions** (issue #219): the
   modal/overlay keys that used to be hard-coded (create form, delete-confirm,
   link prompt, settings panel, command logs, help, open-menu, command palette,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are fully rebindable in `[tui.keys]`. Powered by `portable-pty 0.9` +
   `tui-term 0.3` (`tui_term::vt100` — bundled vt100 0.16).
 
+### Changed
+
+- **Worktree table: label the issue/PR badge column** (issue #294): the second
+  table column (the `●` / `●` issue / PR pastilles) now carries an `I/P` header
+  so the badges read self-explanatory next to the `Worktree` / `Branch` columns.
+
 ### Dependencies
 
 - Added `portable-pty 0.9` (cross-platform PTY pair) and `tui-term 0.3`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,13 +95,23 @@ If an issue still shows `open` on GitHub even though its work shipped, it's a tr
 
 Near-term TUI work, listed in **rough implementation order** — each item builds on the one above it. This is a dependency ordering, not a date commitment.
 
-The 0.10.0-rc.1 Settings-editability + TUI enrichment train has shipped to `dev` — see the Shipped highlights table above and [`changelogs/pre-releases/0.10.0-rc.1.md`](changelogs/pre-releases/0.10.0-rc.1.md) for the full delta. No small near-term TUI follow-up is queued right now; the next candidates are the larger Ambitious items below when demand warrants them.
+The 0.10.0-rc.1 Settings-editability + TUI enrichment train has shipped to `dev` — see the Shipped highlights table above and [`changelogs/pre-releases/0.10.0-rc.1.md`](changelogs/pre-releases/0.10.0-rc.1.md) for the full delta.
+
+A second post-rc.1 train has since landed on `dev`, queued for the next release (see [`CHANGELOG.md`](CHANGELOG.md) `[Unreleased]` for the delta):
+
+- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — embedded PTY overlay for lazygit / native terminal (`l` / `L` / `o` / `O`).
+- [#290](https://github.com/kbrdn1/gwm-cli/issues/290) — TUI keymap redesign (unified list-view bindings, `[tui.macro1]` / `[tui.macro2]`).
+- [#219](https://github.com/kbrdn1/gwm-cli/issues/219) — rebindable modal keys with contextual `[tui.keys.modal.<context>]` actions.
+- [#294](https://github.com/kbrdn1/gwm-cli/issues/294) — edit every keymap from the Settings panel (Keys tab, live keystroke capture, validated write-back).
+
+Queued near-term follow-up:
+
+- [#298](https://github.com/kbrdn1/gwm-cli/issues/298) — **Status-pane CI indicator + Working Tree file-explorer view** — surface the current PR's CI status in the Status pane when present (the `statusCheckRollup` is already fetched), and render the Working Tree pane as a true nerd-font file-explorer tree. Two independent surfaces → two PRs.
 
 ## Ambitious
 
 Larger investments with strategic payoff. Gated by user demand or a concrete first consumer.
 
-- [#35](https://github.com/kbrdn1/gwm-cli/issues/35) — **PTY-embedded lazygit overlay** — render lazygit live inside gwm (`portable-pty` + `tui-term`) as a **~90% fullscreen modal overlay** over the worktree list (not a beside / side pane), drawn like the other modals and outside the `Tab` focus cycle. Distinct from the existing `l` launcher: this one renders lazygit **inside** gwm rather than handing the alt-screen over.
 - [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — **Multi-repo workspace mode** — `gwm --workspace ~/Projects` shows worktrees across every child repo in one TUI.
 - [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks instead of the generic default.
 - [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC / gRPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -45,7 +45,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `1`         | focus the worktrees pane (rebindable action `focus_worktrees`)                                    |
 | `2`         | open (if hidden) and focus the status pane (rebindable action `focus_status`)                     |
 | `3`         | open the Command Logs overlay — scrollable transcript of the commands gwm ran (rebindable action `command_logs`) |
-| `4`         | open the Configuration panel — resolved `.gwm.toml` with a per-row source column (rebindable action `config_panel`) |
+| `4`         | open the [Settings panel](#settings-panel-4) — edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column (rebindable action `config_panel`) |
 | `/`         | open the [fuzzy filter](/tui/filter) bar (`Enter` confirms · `Esc` clears)                        |
 | `p`         | toggle "delete branch on remove"                                                                  |
 | `Enter`     | show selected path in status bar                                                                  |
@@ -81,6 +81,45 @@ progress bar as a live loader.
 | `Esc`                     | cancel                                                  |
 
 If the repo's `.gwm.toml` isn't trusted, `Enter` lands the form's status bar on a refuse message instead of running the bootstrap — the worktree directory is **not** created in that case, so you can fix the trust state in another terminal (`gwm bootstrap` from CLI, or set `GWM_ALLOW_BOOTSTRAP=1` and relaunch) and retry. See [Configuration → TOFU trust ledger](/configuration/trust-ledger#tui-behaviour) for the exact wording and full decision tree.
+
+## settings panel (`4`)
+
+`4` opens the in-TUI Settings panel. Tabs (`Tab` / `Shift+Tab`) split it into
+`Theme`, `Worktree`, `TUI`, `Keys` and the read-only `All` resolved-config
+view. `L` flips the edit layer between the project `.gwm.toml` and the
+user-global config; the layer selector decides which file an edit writes.
+
+| Key            | Action                                                              |
+|:---------------|:-------------------------------------------------------------------|
+| `Tab` / `BackTab` | next / previous tab                                             |
+| `↑` / `↓`      | select a field / binding (scrolls on the `All` tab)                |
+| `L`            | toggle the edit layer (project ↔ global)                           |
+| `Space` / `Enter` | activate: cycle a choice, edit a value, or **rebind a key**     |
+| `Esc` / `q`    | close                                                              |
+
+### Keys tab — live keymap editor
+
+The `Keys` tab lists **every** rebindable binding: the global list-view
+actions (`[global]`) and every modal verb grouped by context
+(`[modal.<context>]`), each with its current key(s) and a `default` / `user` /
+`repo` source badge. Select a binding and press the activate key (`Space` /
+`Enter`) to capture a new key — the key column becomes a `[ … ]` input:
+
+| Key             | Action                                                            |
+|:----------------|:-----------------------------------------------------------------|
+| any key         | record it into the binding                                       |
+| `Enter`         | commit a multi-stroke global chord (modal verbs auto-commit on the first key) |
+| `Backspace`     | drop the last captured stroke (global chord)                     |
+| `Esc`           | cancel the capture, leaving the binding unchanged                |
+
+The capture writes the binding as a TOML array to the targeted layer
+(`[tui.keys]` for a global action, `[tui.keys.modal.<context>]` for a modal
+verb), validates it (a conflict / prefix-collision aborts the write and leaves
+the previous binding live), and reloads the keymap so the new key works
+immediately. An empty capture (`Enter` with nothing recorded — global only)
+unbinds the action. `Esc`, `Enter`, `Backspace` and `Ctrl+C` can't themselves
+be assigned via capture — hand-edit `.gwm.toml` for those (see
+[`[tui.keys]`](/configuration/gwm-toml#tuikeys)).
 
 ## issue / PR link prompt (`L`)
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -46,7 +46,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `1`         | donner le focus au panneau des worktrees (action remappable `focus_worktrees`)                    |
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (action remappable `focus_status`)     |
 | `3`         | ouvrir l'overlay Command Logs — transcription scrollable des commandes lancées par gwm (action remappable `command_logs`) |
-| `4`         | ouvrir le panneau Configuration — `.gwm.toml` résolu avec une colonne de source par ligne (action remappable `config_panel`) |
+| `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) — éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne (action remappable `config_panel`) |
 | `/`         | ouvrir la barre de [filtre flou](/fr/tui/filter) (`Enter` confirme · `Esc` efface)                |
 | `p`         | basculer « supprimer la branche au retrait »                                                      |
 | `Enter`     | afficher le chemin sélectionné dans la barre de statut                                            |
@@ -82,6 +82,47 @@ barre de progression comme loader en direct.
 | `Esc`                     | annuler                                                 |
 
 Si le `.gwm.toml` du dépôt n'est pas approuvé, `Enter` place la barre de statut du formulaire sur un message de refus au lieu de lancer le bootstrap — le répertoire du worktree n'est **pas** créé dans ce cas, donc vous pouvez corriger l'état de confiance dans un autre terminal (`gwm bootstrap` depuis le CLI, ou définir `GWM_ALLOW_BOOTSTRAP=1` et relancer) puis réessayer. Voir [Configuration → registre de confiance TOFU](/fr/configuration/trust-ledger#comportement-de-la-tui) pour la formulation exacte et l'arbre de décision complet.
+
+## panneau Paramètres (`4`)
+
+`4` ouvre le panneau Paramètres dans la TUI. Les onglets (`Tab` / `Shift+Tab`)
+le découpent en `Theme`, `Worktree`, `TUI`, `Keys` et la vue `All` en lecture
+seule (config résolue). `L` bascule la couche d'édition entre le `.gwm.toml`
+du projet et la config globale utilisateur ; le sélecteur de couche décide dans
+quel fichier une édition est écrite.
+
+| Touche            | Action                                                            |
+|:------------------|:-----------------------------------------------------------------|
+| `Tab` / `BackTab` | onglet suivant / précédent                                       |
+| `↑` / `↓`         | sélectionner un champ / un binding (défile sur l'onglet `All`)   |
+| `L`               | basculer la couche d'édition (projet ↔ global)                   |
+| `Space` / `Enter` | activer : cycler un choix, éditer une valeur ou **remapper une touche** |
+| `Esc` / `q`       | fermer                                                           |
+
+### Onglet Keys — éditeur de keymaps en direct
+
+L'onglet `Keys` liste **tous** les bindings remappables : les actions globales
+de la vue liste (`[global]`) et chaque verbe modal groupé par contexte
+(`[modal.<contexte>]`), chacun avec sa ou ses touches courantes et une pastille
+de source `default` / `user` / `repo`. Sélectionnez un binding et appuyez sur la
+touche d'activation (`Space` / `Enter`) pour capturer une nouvelle touche — la
+colonne des touches devient un champ `[ … ]` :
+
+| Touche          | Action                                                            |
+|:----------------|:-----------------------------------------------------------------|
+| n'importe quelle touche | l'enregistrer dans le binding                            |
+| `Enter`         | valider un chord global multi-touches (les verbes modaux se valident à la première touche) |
+| `Backspace`     | retirer la dernière touche capturée (chord global)               |
+| `Esc`           | annuler la capture, binding inchangé                             |
+
+La capture écrit le binding sous forme de tableau TOML dans la couche ciblée
+(`[tui.keys]` pour une action globale, `[tui.keys.modal.<contexte>]` pour un
+verbe modal), le valide (un conflit / une collision de préfixe annule
+l'écriture et laisse le binding précédent actif) et recharge le keymap pour que
+la nouvelle touche fonctionne immédiatement. Une capture vide (`Enter` sans rien
+enregistrer — global uniquement) délie l'action. `Esc`, `Enter`, `Backspace` et
+`Ctrl+C` ne peuvent pas être assignés par capture — éditez `.gwm.toml` à la main
+pour ces cas (voir [`[tui.keys]`](/fr/configuration/gwm-toml#tuikeys)).
 
 ## invite de liaison issue / PR (`L`)
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -245,10 +245,13 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # [tui]
 # sidebar_position = "left"
 
-# --- TUI keymap: `[tui.keys]` (issues #87 / #219) ----------------------------
+# --- TUI keymap: `[tui.keys]` (issues #87 / #219 / #294) ---------------------
 # Remap any TUI key. An override REPLACES the default for that verb; an empty
 # array unbinds it. Run `gwm tui keys` for the full list of actions, contexts,
-# and verbs, and `gwm doctor` to validate overrides.
+# and verbs, and `gwm doctor` to validate overrides. You can also edit every
+# binding live from inside the TUI: open the Settings panel (`4`), tab to
+# `Keys`, select a binding and press the activate key to capture a new key —
+# it writes the same TOML shown below to the layer the panel targets (#294).
 #
 # Global list-view verbs are arrays keyed by action slug (multi-key chords
 # like "g g" allowed here):

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -83,6 +83,21 @@ pub fn set_array_at(path: &Path, key: &str, items: &[String]) -> Result<()> {
   set_item_at(path, key, value(arr))
 }
 
+/// Remove `key` from the TOML file at an explicit `path` (issue #294): the
+/// layer-aware sibling of [`unset`], used by the in-TUI Keys tab to strip a
+/// pre-#290 alias when the canonical slug is rewritten. Tolerant — an absent
+/// file or missing key is a no-op (nothing to remove), so callers can clear a
+/// possible alias unconditionally. Validate-before-write like the setters.
+pub fn unset_at(path: &Path, key: &str) -> Result<()> {
+  if !path.exists() {
+    return Ok(());
+  }
+  let mut doc = load_document(path)?;
+  let segments = parse_key(key)?;
+  remove_value(doc.as_table_mut(), &segments)?;
+  write_and_validate(path, &doc)
+}
+
 /// Shared write path: ensure the parent dir exists, set `key` to `item` in
 /// the surgically-edited document, and validate-before-write so an invalid
 /// edit can never overwrite a good file.

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -66,6 +66,23 @@ pub fn set_string_at(path: &Path, key: &str, raw_value: &str) -> Result<()> {
   set_item_at(path, key, value(raw_value))
 }
 
+/// Array variant of [`set_value_at`] for the in-TUI Keys tab (issue #294):
+/// write `key = ["a", "b", …]` as a TOML array of strings at an explicit
+/// `path`. Backs the keymap rebind surface — a global action's chord list
+/// under `[tui.keys]`, or a modal verb's single-stroke list under
+/// `[tui.keys.modal.<context>]`. An empty `items` writes `key = []`, the
+/// legitimate "unbind" value. Reuses the same parent-dir creation, surgical
+/// `toml_edit` edit and validate-before-write as the scalar writers, so a
+/// rebind that produces a conflicting / prefix-colliding keymap is rejected
+/// before it can clobber a good file.
+pub fn set_array_at(path: &Path, key: &str, items: &[String]) -> Result<()> {
+  let mut arr = toml_edit::Array::new();
+  for item in items {
+    arr.push(item.as_str());
+  }
+  set_item_at(path, key, value(arr))
+}
+
 /// Shared write path: ensure the parent dir exists, set `key` to `item` in
 /// the surgically-edited document, and validate-before-write so an invalid
 /// edit can never overwrite a good file.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1465,27 +1465,31 @@ impl App {
       .as_ref()
       .map(|c| c.single_only)
       .unwrap_or(false);
-    match self.resolve_modal(KeyContext::ConfigEdit, key) {
-      Some(ModalAction::ConfigEditCancel) => self.config_panel.cancel_capture(),
-      Some(ModalAction::ConfigEditSubmit) => {
-        // Enter commits an accumulated global chord; for a single-stroke modal
-        // capture it is a reserved control (ignored, not captured).
-        if !single {
-          self.commit_key_capture();
-        }
+    // Reserved capture controls. The *physical* Esc / Enter / Backspace are
+    // always controls (never captured) regardless of any `config.edit` rebind,
+    // so a custom `submit = ["Ctrl+s"]` can't make Enter assignable (Codex #297
+    // review). The resolved `config.edit` verbs are honoured *in addition*, so a
+    // custom key also cancels / commits.
+    let resolved = self.resolve_modal(KeyContext::ConfigEdit, key);
+    let is_cancel = key.code == KeyCode::Esc || resolved == Some(ModalAction::ConfigEditCancel);
+    let is_submit = key.code == KeyCode::Enter || resolved == Some(ModalAction::ConfigEditSubmit);
+    if is_cancel {
+      self.config_panel.cancel_capture();
+    } else if is_submit {
+      // Enter commits an accumulated global chord; a reserved control (ignored)
+      // for a single-stroke modal capture.
+      if !single {
+        self.commit_key_capture();
       }
-      _ if key.code == KeyCode::Backspace => {
-        // Backspace edits a global chord; reserved (ignored) while a
-        // single-stroke modal capture is armed.
-        if !single {
-          self.config_panel.capture_pop();
-        }
+    } else if key.code == KeyCode::Backspace {
+      // Backspace edits a global chord; reserved (ignored) for a modal capture.
+      if !single {
+        self.config_panel.capture_pop();
       }
-      _ => {
-        self.push_key_capture(key);
-        if single {
-          self.commit_key_capture();
-        }
+    } else {
+      self.push_key_capture(key);
+      if single {
+        self.commit_key_capture();
       }
     }
   }
@@ -1528,6 +1532,12 @@ impl App {
     let prior = std::fs::read(&path).ok();
 
     if let Err(e) = crate::config_cli::set_array_at(&path, &config_key, &items) {
+      // `write_and_validate` writes the edit *before* erroring when the file
+      // was already invalid on its own (the recovery path for #281 — here the
+      // target value can be shadowed by another layer so the app still
+      // loaded). Roll back so a rebind reported as failed never persists or
+      // takes effect on the next launch (Codex #297 review P2).
+      Self::restore_file(&path, prior);
       self.status = format!("keys: {}", e);
       return;
     }
@@ -1552,14 +1562,7 @@ impl App {
         // The single-file write validated but the layered merge is invalid —
         // roll the file back to its prior state so the config is never left
         // broken on disk, and keep the previous live keymaps.
-        match prior {
-          Some(bytes) => {
-            let _ = std::fs::write(&path, bytes);
-          }
-          None => {
-            let _ = std::fs::remove_file(&path);
-          }
-        }
+        Self::restore_file(&path, prior);
         self.status = format!("keys: rebind rejected — would break the merged config: {}", e);
         return;
       }
@@ -1599,6 +1602,20 @@ impl App {
       status.push_str(" — shadowed (a higher layer or legacy alias still binds it)");
     }
     self.status = status;
+  }
+
+  /// Restore a config file to a snapshot taken before a rebind write: rewrite
+  /// the prior bytes, or remove the file if it did not exist before. Used to
+  /// roll back a failed / merge-invalid Keys-tab write (issue #294).
+  fn restore_file(path: &std::path::Path, prior: Option<Vec<u8>>) {
+    match prior {
+      Some(bytes) => {
+        let _ = std::fs::write(path, bytes);
+      }
+      None => {
+        let _ = std::fs::remove_file(path);
+      }
+    }
   }
 
   /// Whether the just-committed capture is the *effective* state in the live

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1471,18 +1471,36 @@ impl App {
       },
     };
 
+    // Snapshot the target file first: `set_array_at` only validates the file
+    // it writes, not the layered merge, so a rebind that is valid in this file
+    // alone but collides with the *other* layer once merged (e.g. a prefix
+    // collision the global layer reveals) would slip past and brick the
+    // config for the next launch. Keep the prior bytes so we can roll back
+    // (Codex #297 review P2).
+    let prior = std::fs::read(&path).ok();
+
     if let Err(e) = crate::config_cli::set_array_at(&path, &config_key, &items) {
       self.status = format!("keys: {}", e);
       return;
     }
 
     // Reload the merged config and rebuild both keymaps so the new binding
-    // fires without a restart. The write already validated, so these resolve;
-    // route any error to the statusbar rather than panicking.
+    // fires without a restart.
     match Config::load_layered(&self.workdir, self.global_path.as_deref()) {
       Ok(cfg) => self.config = cfg,
       Err(e) => {
-        self.status = format!("keys saved, but reload failed: {}", e);
+        // The single-file write validated but the layered merge is invalid —
+        // roll the file back to its prior state so the config is never left
+        // broken on disk, and keep the previous live keymaps.
+        match prior {
+          Some(bytes) => {
+            let _ = std::fs::write(&path, bytes);
+          }
+          None => {
+            let _ = std::fs::remove_file(&path);
+          }
+        }
+        self.status = format!("keys: rebind rejected — would break the merged config: {}", e);
         return;
       }
     }
@@ -1510,7 +1528,22 @@ impl App {
     } else {
       items.join(" ")
     };
-    self.status = format!("set {} = {} ({})", config_key, desc, self.config_panel.layer.label());
+    let mut status = format!("set {} = {} ({})", config_key, desc, self.config_panel.layer.label());
+    // Surface a shadowed edit: a global rebind for a key the repo overrides
+    // leaves the effective binding unchanged (repo wins), so the new key won't
+    // fire. Mirror `apply_setting`'s guidance (Codex #297 review P3).
+    if self.config_panel.layer == SettingsLayer::Global
+      && self
+        .config_panel
+        .key_rows
+        .iter()
+        .find(|r| r.target.config_key() == config_key)
+        .map(|r| r.source == crate::config::ConfigSource::Repo)
+        .unwrap_or(false)
+    {
+      status.push_str(" — shadowed by .gwm.toml");
+    }
+    self.status = status;
   }
 
   // ── PTY overlay (issue #35) ────────────────────────────────────────────

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@ use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::palette::PaletteState;
 use super::state::async_task::{CreateWorktreeResult, EditWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 use super::state::command_logs::CommandLogs;
-use super::state::config_panel::{ConfigPanel, FieldKind, SettingField, SettingsLayer};
+use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
 use super::state::filter::{fuzzy_match_indices, FilterState};
@@ -1542,21 +1542,31 @@ impl App {
       items.join(" ")
     };
     let mut status = format!("set {} = {} ({})", config_key, desc, self.config_panel.layer.label());
-    // Surface a shadowed edit: a global rebind for a key the repo overrides
-    // leaves the effective binding unchanged (repo wins), so the new key won't
-    // fire. Mirror `apply_setting`'s guidance (Codex #297 review P3).
-    if self.config_panel.layer == SettingsLayer::Global
-      && self
-        .config_panel
-        .key_rows
-        .iter()
-        .find(|r| r.target.config_key() == config_key)
-        .map(|r| r.source == crate::config::ConfigSource::Repo)
-        .unwrap_or(false)
-    {
-      status.push_str(" — shadowed by .gwm.toml");
+    // Verify the capture actually took effect in the *merged* keymap: a
+    // higher-precedence layer, or a pre-#290 alias still declared in another
+    // layer (which we deliberately don't edit), can shadow the write so the new
+    // key never fires even though it persisted. Warn instead of reporting a
+    // clean success (Codex #297 review). An unbind has nothing to verify.
+    if !items.is_empty() && !self.capture_took_effect(target, &cap.pending) {
+      status.push_str(" — shadowed (a higher layer or legacy alias still binds it)");
     }
     self.status = status;
+  }
+
+  /// Whether `strokes` resolve to `target`'s action in the live (merged)
+  /// keymap — i.e. the just-committed rebind is the *effective* binding and not
+  /// shadowed by another layer / a lingering legacy alias. Issue #294 (Codex
+  /// #297 review).
+  fn capture_took_effect(&self, target: KeyTarget, strokes: &[KeyStroke]) -> bool {
+    match target {
+      KeyTarget::Global(action) => {
+        matches!(self.keymap.lookup(strokes), ChordResolution::Matched(a) if a == action)
+      }
+      KeyTarget::Modal(action) => strokes
+        .first()
+        .map(|s| self.modal_keymap.resolve(action.context(), s) == Some(action))
+        .unwrap_or(false),
+    }
   }
 
   // ── PTY overlay (issue #35) ────────────────────────────────────────────

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1443,6 +1443,53 @@ impl App {
     self.config_panel.capture_push(KeyStroke::from_event(&key));
   }
 
+  /// Drive a key through an armed Keys-tab capture (issue #294). The event loop
+  /// owns no logic — it just routes here when a capture is armed, mirroring
+  /// `handle_create_key` / `handle_link_prompt_key`. Controls (resolved through
+  /// the `config.edit` context so a rebind shows through):
+  ///
+  /// - `cancel` (def Esc) aborts the capture;
+  /// - `submit` (def Enter) commits a **multi-stroke global chord**;
+  /// - `Backspace` drops the last stroke of a global chord;
+  /// - any other key is captured — a **single-stroke modal** verb auto-commits
+  ///   on the first one, a global chord accumulates until `submit`.
+  ///
+  /// `Esc` / `Enter` / `Backspace` stay reserved controls in **both** modes and
+  /// are never themselves captured (a modal verb can't be bound to them via the
+  /// UI — hand-edit `.gwm.toml`), matching the documented capture controls and
+  /// the hard-coded escape-hatch policy.
+  pub fn handle_capture_key(&mut self, key: KeyEvent) {
+    let single = self
+      .config_panel
+      .capture
+      .as_ref()
+      .map(|c| c.single_only)
+      .unwrap_or(false);
+    match self.resolve_modal(KeyContext::ConfigEdit, key) {
+      Some(ModalAction::ConfigEditCancel) => self.config_panel.cancel_capture(),
+      Some(ModalAction::ConfigEditSubmit) => {
+        // Enter commits an accumulated global chord; for a single-stroke modal
+        // capture it is a reserved control (ignored, not captured).
+        if !single {
+          self.commit_key_capture();
+        }
+      }
+      _ if key.code == KeyCode::Backspace => {
+        // Backspace edits a global chord; reserved (ignored) while a
+        // single-stroke modal capture is armed.
+        if !single {
+          self.config_panel.capture_pop();
+        }
+      }
+      _ => {
+        self.push_key_capture(key);
+        if single {
+          self.commit_key_capture();
+        }
+      }
+    }
+  }
+
   /// Commit the in-progress Keys-tab capture (issue #294): write the captured
   /// chord as a TOML array to the selected target's `[tui.keys]` /
   /// `[tui.keys.modal.<context>]` key in the active layer, then reload the
@@ -1545,27 +1592,39 @@ impl App {
     // Verify the capture actually took effect in the *merged* keymap: a
     // higher-precedence layer, or a pre-#290 alias still declared in another
     // layer (which we deliberately don't edit), can shadow the write so the new
-    // key never fires even though it persisted. Warn instead of reporting a
-    // clean success (Codex #297 review). An unbind has nothing to verify.
-    if !items.is_empty() && !self.capture_took_effect(target, &cap.pending) {
+    // key never fires — or, for an unbind, keeps the action bound — even though
+    // it persisted. Warn instead of reporting a clean success (Codex #297
+    // review).
+    if !self.capture_took_effect(target, &cap.pending) {
       status.push_str(" — shadowed (a higher layer or legacy alias still binds it)");
     }
     self.status = status;
   }
 
-  /// Whether `strokes` resolve to `target`'s action in the live (merged)
-  /// keymap — i.e. the just-committed rebind is the *effective* binding and not
-  /// shadowed by another layer / a lingering legacy alias. Issue #294 (Codex
-  /// #297 review).
+  /// Whether the just-committed capture is the *effective* state in the live
+  /// (merged) keymap, i.e. not shadowed by another layer / a lingering legacy
+  /// alias. For a rebind (`strokes` non-empty) the captured chord must resolve
+  /// to the target's action; for an unbind (`strokes` empty) the action must
+  /// have no remaining binding. Issue #294 (Codex #297 review).
   fn capture_took_effect(&self, target: KeyTarget, strokes: &[KeyStroke]) -> bool {
     match target {
       KeyTarget::Global(action) => {
-        matches!(self.keymap.lookup(strokes), ChordResolution::Matched(a) if a == action)
+        if strokes.is_empty() {
+          self.keymap.keys_display(action).is_empty()
+        } else {
+          matches!(self.keymap.lookup(strokes), ChordResolution::Matched(a) if a == action)
+        }
       }
-      KeyTarget::Modal(action) => strokes
-        .first()
-        .map(|s| self.modal_keymap.resolve(action.context(), s) == Some(action))
-        .unwrap_or(false),
+      KeyTarget::Modal(action) => {
+        if strokes.is_empty() {
+          self.modal_keymap.keys_display(action).is_empty()
+        } else {
+          strokes
+            .first()
+            .map(|s| self.modal_keymap.resolve(action.context(), s) == Some(action))
+            .unwrap_or(false)
+        }
+      }
     }
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1416,8 +1416,101 @@ impl App {
         self.status = format!("error: {}", e);
       }
     }
+    self.refresh_key_rows();
     self.config_panel.reset();
     self.view = View::Config;
+  }
+
+  /// Rebuild the Keys-tab rows (issue #294) from the live keymaps, attributing
+  /// each binding's source via the resolved-row snapshot (the same layer
+  /// attribution the `All` tab shows). Called on panel open and after a
+  /// successful rebind so the displayed key(s) + badge track the edit.
+  fn refresh_key_rows(&mut self) {
+    let rows = self.config_panel.rows.clone();
+    let key_rows = super::state::config_panel::build_key_rows(&self.keymap, &self.modal_keymap, |key| {
+      rows
+        .iter()
+        .find(|r| r.key == key)
+        .map(|r| r.source)
+        .unwrap_or(crate::config::ConfigSource::Default)
+    });
+    self.config_panel.key_rows = key_rows;
+  }
+
+  /// Feed a raw key event into the in-progress Keys-tab capture (issue #294),
+  /// normalising it to a [`KeyStroke`] first. No-op when no capture is armed.
+  pub fn push_key_capture(&mut self, key: KeyEvent) {
+    self.config_panel.capture_push(KeyStroke::from_event(&key));
+  }
+
+  /// Commit the in-progress Keys-tab capture (issue #294): write the captured
+  /// chord as a TOML array to the selected target's `[tui.keys]` /
+  /// `[tui.keys.modal.<context>]` key in the active layer, then reload the
+  /// config + both keymaps so the rebind is live immediately. An empty capture
+  /// writes `[]` (unbind). Validation (conflict / prefix-collision) happens in
+  /// the writer's validate-before-write gate; on failure the file and the live
+  /// keymaps are left untouched and the error is surfaced on the statusbar.
+  pub fn commit_key_capture(&mut self) {
+    let Some(cap) = self.config_panel.take_capture() else {
+      return;
+    };
+    let config_key = match self.config_panel.key_rows.get(cap.row) {
+      Some(row) => row.target.config_key(),
+      None => return,
+    };
+    let items = cap.as_config_items();
+
+    let path = match self.config_panel.layer {
+      SettingsLayer::Project => self.workdir.join(crate::config::CONFIG_FILE),
+      SettingsLayer::Global => match self.global_path.clone() {
+        Some(p) => p,
+        None => {
+          self.status = "keys: no global config path (set $XDG_CONFIG_HOME or $HOME)".into();
+          return;
+        }
+      },
+    };
+
+    if let Err(e) = crate::config_cli::set_array_at(&path, &config_key, &items) {
+      self.status = format!("keys: {}", e);
+      return;
+    }
+
+    // Reload the merged config and rebuild both keymaps so the new binding
+    // fires without a restart. The write already validated, so these resolve;
+    // route any error to the statusbar rather than panicking.
+    match Config::load_layered(&self.workdir, self.global_path.as_deref()) {
+      Ok(cfg) => self.config = cfg,
+      Err(e) => {
+        self.status = format!("keys saved, but reload failed: {}", e);
+        return;
+      }
+    }
+    match self.config.tui.keys.resolved_keymap() {
+      Ok(km) => self.keymap = km,
+      Err(e) => {
+        self.status = format!("keys: {}", e);
+        return;
+      }
+    }
+    match self.config.tui.keys.resolved_modal_keymap() {
+      Ok(mk) => self.modal_keymap = mk,
+      Err(e) => {
+        self.status = format!("keys: {}", e);
+        return;
+      }
+    }
+    if let Ok(rows) = crate::config::resolved_rows(&self.workdir, self.global_path.as_deref()) {
+      self.config_panel.rows = rows;
+    }
+    self.refresh_key_rows();
+
+    let desc = if items.is_empty() {
+      "unbound".to_string()
+    } else {
+      items.join(" ")
+    };
+    self.status = format!("set {} = {} ({})", config_key, desc, self.config_panel.layer.label());
   }
 
   // ── PTY overlay (issue #35) ────────────────────────────────────────────

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1454,10 +1454,11 @@ impl App {
     let Some(cap) = self.config_panel.take_capture() else {
       return;
     };
-    let config_key = match self.config_panel.key_rows.get(cap.row) {
-      Some(row) => row.target.config_key(),
+    let target = match self.config_panel.key_rows.get(cap.row) {
+      Some(row) => row.target,
       None => return,
     };
+    let config_key = target.config_key();
     let items = cap.as_config_items();
 
     let path = match self.config_panel.layer {
@@ -1482,6 +1483,18 @@ impl App {
     if let Err(e) = crate::config_cli::set_array_at(&path, &config_key, &items) {
       self.status = format!("keys: {}", e);
       return;
+    }
+
+    // Strip any pre-#290 alias of this action from the same file: a legacy
+    // config that still carries e.g. `tui.keys.open_menu` would, on reload,
+    // re-apply the alias after the canonical `browse_links` in the sorted
+    // override walk and silently shadow the new binding (Codex #297 review).
+    // Best-effort: the canonical key is already written, so a cleanup error
+    // is surfaced but does not abort the rebind.
+    for alias_key in target.compat_alias_keys() {
+      if let Err(e) = crate::config_cli::unset_at(&path, &alias_key) {
+        self.status = format!("keys: {}", e);
+      }
     }
 
     // Reload the merged config and rebuild both keymaps so the new binding

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -161,20 +161,36 @@ impl Action {
     if let Some(a) = Self::from_slug(s) {
       return Some(a);
     }
-    // Compat aliases for slugs that were renamed in #290.
-    match s {
-      "git_tui" => Some(Action::LazyGitFullscreen),
-      "git_tui_overlay" => Some(Action::LazyGitPty),
-      "review" => Some(Action::ReviewFullscreen),
-      "review_overlay" => Some(Action::ReviewPty),
-      "yank" => Some(Action::YankPath),
-      "open" => Some(Action::TerminalFullscreen),
-      "open_terminal_overlay" => Some(Action::TerminalPty),
-      "open_menu" => Some(Action::BrowseLinks),
-      _ => None,
-    }
+    COMPAT_ALIASES.iter().find(|(slug, _)| *slug == s).map(|(_, a)| *a)
+  }
+
+  /// The pre-#290 alias slug(s) that resolve to this action, if any. Used by
+  /// the in-TUI keymap editor (issue #294) to strip a stale alias from a
+  /// legacy config when the canonical slug is (re)written — otherwise the
+  /// alias, applied later in the sorted override walk, would silently shadow
+  /// the new binding (Codex #297 review).
+  pub fn compat_alias_slugs(self) -> impl Iterator<Item = &'static str> {
+    COMPAT_ALIASES
+      .iter()
+      .filter(move |(_, a)| *a == self)
+      .map(|(slug, _)| *slug)
   }
 }
+
+/// Pre-#290 slug aliases, accepted by [`Action::from_slug_compat`] so existing
+/// `.gwm.toml` files keep working after the #290 rename. The canonical slug is
+/// always preferred; these only fire on a miss. Single source of truth for both
+/// directions (resolve + [`Action::compat_alias_slugs`]).
+const COMPAT_ALIASES: &[(&str, Action)] = &[
+  ("git_tui", Action::LazyGitFullscreen),
+  ("git_tui_overlay", Action::LazyGitPty),
+  ("review", Action::ReviewFullscreen),
+  ("review_overlay", Action::ReviewPty),
+  ("yank", Action::YankPath),
+  ("open", Action::TerminalFullscreen),
+  ("open_terminal_overlay", Action::TerminalPty),
+  ("open_menu", Action::BrowseLinks),
+];
 
 // ---------------------------------------------------------------------------
 // Key-string parser

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -656,6 +656,18 @@ impl Keymap {
       .and_then(|b| b.chords.first())
       .map(|chord| format_chord(chord))
   }
+
+  /// Every chord bound to `action`, comma-joined (`"j, Down"`) or empty when
+  /// unbound — the help-overlay / Keys-tab row form. Mirrors
+  /// [`crate::tui::modal_keymap::ModalKeymap::keys_display`].
+  pub fn keys_display(&self, action: Action) -> String {
+    self
+      .entries
+      .iter()
+      .find(|b| b.action == action)
+      .map(|b| b.chords.iter().map(|c| format_chord(c)).collect::<Vec<_>>().join(", "))
+      .unwrap_or_default()
+  }
 }
 
 /// Build a default `Binding` from a list of chord literals. Panics

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -388,6 +388,38 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // Esc / `q` / the bound `config_panel` key (default `4`) close.
       // #219: edit sub-mode keys resolve through the `config.edit` context;
       // anything else is literal input into the numeric edit buffer.
+      // Keys tab live capture (issue #294). While a capture is armed every
+      // keystroke is recorded into the binding rather than navigating: `cancel`
+      // (def Esc) aborts, and for a multi-stroke global chord `submit` (def
+      // Enter) commits while Backspace drops the last stroke. A modal verb is
+      // single-stroke, so the first non-cancel key is captured and committed
+      // immediately. Esc / Enter / Backspace therefore can't themselves be
+      // assigned via capture (hand-edit `.gwm.toml` for those rare cases) —
+      // the same hard-coded-escape-hatch trade-off as the rest of the keymap.
+      // The commit/cancel verbs resolve through `config.edit` so a rebind of
+      // `[tui.keys.modal.config.edit]` carries through here too (#219 review).
+      View::Config if app.config_panel.capture.is_some() => {
+        let single = app
+          .config_panel
+          .capture
+          .as_ref()
+          .map(|c| c.single_only)
+          .unwrap_or(false);
+        match app.resolve_modal(KeyContext::ConfigEdit, key) {
+          Some(ModalAction::ConfigEditCancel) => app.config_panel.cancel_capture(),
+          Some(ModalAction::ConfigEditSubmit) if !single => app.commit_key_capture(),
+          _ => {
+            if single {
+              app.push_key_capture(key);
+              app.commit_key_capture();
+            } else if key.code == KeyCode::Backspace {
+              app.config_panel.capture_pop();
+            } else {
+              app.push_key_capture(key);
+            }
+          }
+        }
+      }
       View::Config if app.config_panel.editing.is_some() => match app.resolve_modal(KeyContext::ConfigEdit, key) {
         Some(ModalAction::ConfigEditSubmit) => app.commit_settings_edit(),
         Some(ModalAction::ConfigEditCancel) => app.config_panel.cancel_edit(),
@@ -408,7 +440,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
           Some(ModalAction::ConfigNextTab) => app.config_panel.next_tab(),
           Some(ModalAction::ConfigPrevTab) => app.config_panel.prev_tab(),
           Some(ModalAction::ConfigToggleLayer) => app.config_panel.toggle_layer(),
-          Some(ModalAction::ConfigActivate) => app.activate_selected_setting(),
+          // On the Keys tab `activate` arms a live keystroke capture for the
+          // selected binding (issue #294); elsewhere it cycles a choice or
+          // opens the numeric/text edit buffer.
+          Some(ModalAction::ConfigActivate) => {
+            if app.config_panel.tab == SettingsTab::Keys {
+              app.config_panel.begin_capture();
+            } else {
+              app.activate_selected_setting();
+            }
+          }
           Some(ModalAction::ConfigSelectNext) => {
             if on_all {
               app.config_panel.scroll_down();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -390,37 +390,15 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // #219: edit sub-mode keys resolve through the `config.edit` context;
       // anything else is literal input into the numeric edit buffer.
       // Keys tab live capture (issue #294). While a capture is armed every
-      // keystroke is recorded into the binding rather than navigating: `cancel`
-      // (def Esc) aborts, and for a multi-stroke global chord `submit` (def
-      // Enter) commits while Backspace drops the last stroke. A modal verb is
-      // single-stroke, so the first non-cancel key is captured and committed
-      // immediately. Esc / Enter / Backspace therefore can't themselves be
-      // assigned via capture (hand-edit `.gwm.toml` for those rare cases) —
-      // the same hard-coded-escape-hatch trade-off as the rest of the keymap.
-      // The commit/cancel verbs resolve through `config.edit` so a rebind of
-      // `[tui.keys.modal.config.edit]` carries through here too (#219 review).
-      View::Config if app.config_panel.capture.is_some() => {
-        let single = app
-          .config_panel
-          .capture
-          .as_ref()
-          .map(|c| c.single_only)
-          .unwrap_or(false);
-        match app.resolve_modal(KeyContext::ConfigEdit, key) {
-          Some(ModalAction::ConfigEditCancel) => app.config_panel.cancel_capture(),
-          Some(ModalAction::ConfigEditSubmit) if !single => app.commit_key_capture(),
-          _ => {
-            if single {
-              app.push_key_capture(key);
-              app.commit_key_capture();
-            } else if key.code == KeyCode::Backspace {
-              app.config_panel.capture_pop();
-            } else {
-              app.push_key_capture(key);
-            }
-          }
-        }
-      }
+      // keystroke is recorded into the binding rather than navigating. The
+      // logic lives in a testable `App` method (mirrors `handle_create_key` /
+      // `handle_link_prompt_key`): `cancel` (def Esc) aborts, `submit` (def
+      // Enter) commits a multi-stroke global chord, Backspace drops its last
+      // stroke, a single-stroke modal verb auto-commits on the first key. Esc /
+      // Enter / Backspace stay reserved controls and can't be assigned via
+      // capture — hand-edit `.gwm.toml` for those (same hard-coded escape-hatch
+      // trade-off as the rest of the keymap).
+      View::Config if app.config_panel.capture.is_some() => app.handle_capture_key(key),
       View::Config if app.config_panel.editing.is_some() => match app.resolve_modal(KeyContext::ConfigEdit, key) {
         Some(ModalAction::ConfigEditSubmit) => app.commit_settings_edit(),
         Some(ModalAction::ConfigEditCancel) => app.config_panel.cancel_edit(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -61,18 +61,19 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, command_logs_footer_hints, config_edit_footer_hints,
-  config_nav_footer_hints, confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line,
-  delete_worktree_title, ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, format_status,
-  freshness_color, github_status_lines, header_line, help_body_section_color, help_entry_line, help_label_style,
-  help_lines, help_rows, help_section_style, hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title,
-  issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_keys, link_target_line,
-  modal_hint_line, palette_name_style, pane_counter, panel_border_color, pr_badge_color, pr_summary_line,
-  recent_commits_lines, recent_items_pane_title, rename_buttons_line, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, type_selector_line, working_tree_counts_footer, working_tree_pane_title,
-  working_tree_status_counts, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
-  HelpRow, HintContext, SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON,
-  RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
+  build_sidebar_sections, centered_abs, chip_style, command_logs_footer_hints, config_capture_footer_hints,
+  config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line, confirm_delete_branch_line,
+  confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line,
+  filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines, header_line,
+  help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
+  hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
+  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
+  panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
+  rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
+  working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts, working_tree_status_line,
+  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
+  WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON,
+  WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -29,7 +29,9 @@ use std::time::{Duration, Instant};
 pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
 pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
-pub use state::config_panel::{ConfigPanel, FieldKind, SettingField, SettingsLayer, SettingsTab};
+pub use state::config_panel::{
+  build_key_rows, ConfigPanel, FieldKind, KeyCapture, KeyRow, KeyTarget, SettingField, SettingsLayer, SettingsTab,
+};
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
 pub use state::filter::FilterState;

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -114,6 +114,17 @@ impl KeyTarget {
   pub fn single_only(self) -> bool {
     matches!(self, KeyTarget::Modal(_))
   }
+
+  /// Dotted `.gwm.toml` keys for any pre-#290 alias of a global action — to be
+  /// stripped from a legacy config when the canonical slug is (re)written so a
+  /// stale alias can't shadow the new binding (Codex #297 review). Empty for
+  /// modal verbs (they have no compat aliases).
+  pub fn compat_alias_keys(self) -> Vec<String> {
+    match self {
+      KeyTarget::Global(a) => a.compat_alias_slugs().map(|s| format!("tui.keys.{s}")).collect(),
+      KeyTarget::Modal(_) => Vec::new(),
+    }
+  }
 }
 
 /// One row of the Keys tab: a bindable target, its display scope/label, the

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -20,9 +20,12 @@
 //! the renderer each frame against the live viewport.
 
 use crate::config::{Config, ConfigRow, ConfigSource};
+use crate::tui::keymap::{Action, KeyStroke, Keymap};
+use crate::tui::modal_keymap::{ModalAction, ModalKeymap};
 
-/// The Settings categories, in tab order. `Theme` and `Tui` are editable;
-/// `All` is the read-only resolved-config view (the pre-#279 panel).
+/// The Settings categories, in tab order. `Theme`, `Worktree`, `Tui` and
+/// `Keys` are editable; `All` is the read-only resolved-config view (the
+/// pre-#279 panel).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SettingsTab {
   /// Theme preset selection (editable).
@@ -33,16 +36,21 @@ pub enum SettingsTab {
   /// TUI behaviour knobs: sidebar side, open mode + commands, confirm
   /// countdown.
   Tui,
+  /// Keymap editor (issue #294): every global action + modal verb, rebound
+  /// via live keystroke capture. Rows are dynamic ([`KeyRow`]), not the
+  /// `&'static [SettingField]` the other editable tabs use.
+  Keys,
   /// The full resolved config, read-only with source attribution.
   All,
 }
 
 impl SettingsTab {
   /// Tabs in display order — the navigation cycle.
-  pub const ALL: [SettingsTab; 4] = [
+  pub const ALL: [SettingsTab; 5] = [
     SettingsTab::Theme,
     SettingsTab::Worktree,
     SettingsTab::Tui,
+    SettingsTab::Keys,
     SettingsTab::All,
   ];
 
@@ -52,6 +60,7 @@ impl SettingsTab {
       SettingsTab::Theme => "Theme",
       SettingsTab::Worktree => "Worktree",
       SettingsTab::Tui => "TUI",
+      SettingsTab::Keys => "Keys",
       SettingsTab::All => "All",
     }
   }
@@ -74,8 +83,111 @@ impl SettingsTab {
         SettingField::OpenShellCmd,
         SettingField::OpenEditorCmd,
       ],
-      SettingsTab::All => &[],
+      // The Keys tab edits dynamic [`KeyRow`]s, not static fields, and `All`
+      // is read-only.
+      SettingsTab::Keys | SettingsTab::All => &[],
     }
+  }
+}
+
+/// What a [`KeyRow`] rebinds: a global `View::List` action ([`Action`], chords
+/// allowed) or a contextual modal verb ([`ModalAction`], single-stroke).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyTarget {
+  /// A global action under `[tui.keys]`.
+  Global(Action),
+  /// A modal verb under `[tui.keys.modal.<context>]`.
+  Modal(ModalAction),
+}
+
+impl KeyTarget {
+  /// The dotted `.gwm.toml` key the rebind writes (`config_cli::set_array_at`).
+  pub fn config_key(self) -> String {
+    match self {
+      KeyTarget::Global(a) => format!("tui.keys.{}", a.slug()),
+      KeyTarget::Modal(m) => format!("tui.keys.modal.{}.{}", m.context().config_path(), m.verb()),
+    }
+  }
+
+  /// Modal verbs are single-stroke (issue #219); global actions accept
+  /// multi-stroke chords. Drives the capture machine's accumulate-vs-commit.
+  pub fn single_only(self) -> bool {
+    matches!(self, KeyTarget::Modal(_))
+  }
+}
+
+/// One row of the Keys tab: a bindable target, its display scope/label, the
+/// current key(s), and the layer that sourced the binding. Built fresh on
+/// panel open by [`build_key_rows`] from the live keymaps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyRow {
+  /// What this row rebinds.
+  pub target: KeyTarget,
+  /// `"global"` or `"modal.<context-path>"`.
+  pub scope: String,
+  /// The action slug (global) or context-local verb (modal).
+  pub label: String,
+  /// Current key(s), comma-joined (`"j, Down"`); empty when unbound.
+  pub keys: String,
+  /// The layer the binding came from (repo / user / default).
+  pub source: ConfigSource,
+}
+
+/// Build the full Keys-tab row list: every global action (declaration order),
+/// then every modal verb grouped by its context (declaration order). `source_of`
+/// maps a dotted config key to its layer — the App passes the same resolved-row
+/// attribution the `All` tab uses, so a hand-edited or in-TUI-set binding shows
+/// the right `repo`/`user` badge and an untouched one reads `default`.
+pub fn build_key_rows(keymap: &Keymap, modal: &ModalKeymap, source_of: impl Fn(&str) -> ConfigSource) -> Vec<KeyRow> {
+  let mut rows = Vec::new();
+  for action in Action::all() {
+    let target = KeyTarget::Global(action);
+    rows.push(KeyRow {
+      target,
+      scope: "global".to_string(),
+      label: action.slug().to_string(),
+      keys: keymap.keys_display(action),
+      source: source_of(&target.config_key()),
+    });
+  }
+  for action in ModalAction::all() {
+    let target = KeyTarget::Modal(action);
+    rows.push(KeyRow {
+      target,
+      scope: format!("modal.{}", action.context().config_path()),
+      label: action.verb().to_string(),
+      keys: modal.keys_display(action),
+      source: source_of(&target.config_key()),
+    });
+  }
+  rows
+}
+
+/// In-progress live keystroke capture for the selected [`KeyRow`] (issue
+/// #294). Pure: the routing layer feeds strokes in, the App reads
+/// [`Self::as_config_items`] to persist. `single_only` mirrors the target's
+/// kind so the router knows whether to auto-commit (modal) or accumulate a
+/// chord until the user confirms (global).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyCapture {
+  /// Index into [`ConfigPanel::key_rows`] being rebound.
+  pub row: usize,
+  /// Modal verb → true (one stroke, auto-commit); global → false (chord).
+  pub single_only: bool,
+  /// The strokes captured so far, in order.
+  pub pending: Vec<KeyStroke>,
+}
+
+impl KeyCapture {
+  /// The TOML array elements to write: one chord, the captured strokes
+  /// space-joined (`"g g"`), or an empty list when nothing was captured (an
+  /// unbind). Live capture sets a single binding; alternatives stay a
+  /// hand-edit.
+  pub fn as_config_items(&self) -> Vec<String> {
+    if self.pending.is_empty() {
+      return Vec::new();
+    }
+    vec![self.pending.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(" ")]
   }
 }
 
@@ -281,6 +393,13 @@ pub struct ConfigPanel {
   /// When `Some`, the numeric-input edit buffer for the selected `Uint`
   /// field; keystrokes route here until commit (Enter) or cancel (Esc).
   pub editing: Option<String>,
+  /// Keys-tab rows (issue #294): every rebindable global action + modal verb
+  /// with its current binding + source. Rebuilt on panel open by the App from
+  /// the live keymaps; empty on the other tabs.
+  pub key_rows: Vec<KeyRow>,
+  /// When `Some`, a live keystroke capture is in progress on the Keys tab;
+  /// strokes route into it until commit / cancel.
+  pub capture: Option<KeyCapture>,
   /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
   pub scroll: u16,
   /// Maximum vertical scroll offset, republished by the renderer each
@@ -308,13 +427,33 @@ impl ConfigPanel {
     self.fields().get(self.selected).copied()
   }
 
+  /// The selected Keys-tab row, if the active tab is `Keys`.
+  pub fn selected_key_row(&self) -> Option<&KeyRow> {
+    if self.tab == SettingsTab::Keys {
+      self.key_rows.get(self.selected)
+    } else {
+      None
+    }
+  }
+
+  /// Number of selectable rows in the current tab: the static fields, or the
+  /// dynamic key rows on the Keys tab.
+  fn selectable_count(&self) -> usize {
+    if self.tab == SettingsTab::Keys {
+      self.key_rows.len()
+    } else {
+      self.fields().len()
+    }
+  }
+
   /// Move to the next tab, wrapping. Resets the field selection and any
-  /// in-progress edit so the new tab starts clean.
+  /// in-progress edit / capture so the new tab starts clean.
   pub fn next_tab(&mut self) {
     let idx = SettingsTab::ALL.iter().position(|t| *t == self.tab).unwrap_or(0);
     self.tab = SettingsTab::ALL[(idx + 1) % SettingsTab::ALL.len()];
     self.selected = 0;
     self.editing = None;
+    self.capture = None;
     self.scroll = 0;
   }
 
@@ -325,6 +464,7 @@ impl ConfigPanel {
     self.tab = SettingsTab::ALL[(idx + len - 1) % len];
     self.selected = 0;
     self.editing = None;
+    self.capture = None;
     self.scroll = 0;
   }
 
@@ -333,21 +473,21 @@ impl ConfigPanel {
     self.layer = self.layer.toggled();
   }
 
-  /// Select the previous field in the current tab (no-op while editing or on
-  /// a tab with no fields).
+  /// Select the previous field / key row in the current tab (no-op while
+  /// editing or capturing, or on a tab with no rows).
   pub fn select_prev(&mut self) {
-    if self.editing.is_some() {
+    if self.editing.is_some() || self.capture.is_some() {
       return;
     }
     self.selected = self.selected.saturating_sub(1);
   }
 
-  /// Select the next field in the current tab, clamped to the last field.
+  /// Select the next field / key row in the current tab, clamped to the last.
   pub fn select_next(&mut self) {
-    if self.editing.is_some() {
+    if self.editing.is_some() || self.capture.is_some() {
       return;
     }
-    let count = self.fields().len();
+    let count = self.selectable_count();
     if count > 0 {
       self.selected = (self.selected + 1).min(count - 1);
     }
@@ -410,6 +550,49 @@ impl ConfigPanel {
     self.rows.iter().find(|r| r.key == field.key_path()).map(|r| r.source)
   }
 
+  // ── Keys tab: live keystroke capture (issue #294) ──────────────────────
+
+  /// Arm a live capture for the selected Keys-tab row. No-op off the Keys tab
+  /// or with no row selected. The capture inherits the row's `single_only`
+  /// flag so the router auto-commits a modal verb but accumulates a global
+  /// chord.
+  pub fn begin_capture(&mut self) {
+    if self.tab != SettingsTab::Keys {
+      return;
+    }
+    if let Some(row) = self.key_rows.get(self.selected) {
+      self.capture = Some(KeyCapture {
+        row: self.selected,
+        single_only: row.target.single_only(),
+        pending: Vec::new(),
+      });
+    }
+  }
+
+  /// Append a captured stroke to the in-progress capture.
+  pub fn capture_push(&mut self, stroke: KeyStroke) {
+    if let Some(cap) = self.capture.as_mut() {
+      cap.pending.push(stroke);
+    }
+  }
+
+  /// Drop the last captured stroke (Backspace during a multi-stroke capture).
+  pub fn capture_pop(&mut self) {
+    if let Some(cap) = self.capture.as_mut() {
+      cap.pending.pop();
+    }
+  }
+
+  /// Cancel the in-progress capture, discarding pending strokes.
+  pub fn cancel_capture(&mut self) {
+    self.capture = None;
+  }
+
+  /// Commit the in-progress capture, returning it for the App to persist.
+  pub fn take_capture(&mut self) -> Option<KeyCapture> {
+    self.capture.take()
+  }
+
   /// Scroll down one row, never past the last line.
   pub fn scroll_down(&mut self) {
     self.scroll = (self.scroll + 1).min(self.max_scroll);
@@ -447,5 +630,6 @@ impl ConfigPanel {
     self.x_scroll = 0;
     self.selected = 0;
     self.editing = None;
+    self.capture = None;
   }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -463,7 +463,8 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
     // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
     // and a header would steal space from BRANCH on narrow terminals.
     Cell::from(""),
-    Cell::from(""),
+    // Issue / PR badge column (the `●/●` pastilles) — `I/P` fits its 3 cells.
+    Cell::from("I/P"),
     Cell::from("NAME"),
     Cell::from("BRANCH"),
     Cell::from("STATUS"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1990,7 +1990,9 @@ pub fn config_nav_footer_hints(
   if tab == SettingsTab::All {
     hints.push(("j/k".to_string(), "scroll".to_string()));
   } else {
-    let label = if selected_kind == Some(FieldKind::Choice) {
+    let label = if tab == SettingsTab::Keys {
+      "rebind"
+    } else if selected_kind == Some(FieldKind::Choice) {
       "cycle"
     } else {
       "edit"
@@ -2007,6 +2009,29 @@ pub fn config_nav_footer_hints(
     if let Some(k) = modal.primary_key(action) {
       hints.push((k, label.to_string()));
     }
+  }
+  hints
+}
+
+/// Settings-panel footer hints while a live keystroke capture is armed on the
+/// Keys tab (issue #294). `cancel` (and, for a multi-stroke global chord,
+/// `save`) resolve from the `ConfigEdit*` modal bindings so a rebind of
+/// `[tui.keys.modal.config.edit]` shows through. A single-stroke modal capture
+/// auto-commits on the first key, so it advertises that instead of a `save`
+/// verb; the multi-stroke global path adds the literal `Backspace` deletes-last
+/// affordance (no modal verb binds it).
+pub fn config_capture_footer_hints(modal: &ModalKeymap, single_only: bool) -> Vec<(String, String)> {
+  let mut hints: Vec<(String, String)> = Vec::new();
+  if single_only {
+    hints.push(("any key".to_string(), "bind".to_string()));
+  } else {
+    if let Some(k) = modal.primary_key(ModalAction::ConfigEditSubmit) {
+      hints.push((k, "save".to_string()));
+    }
+    hints.push(("Backspace".to_string(), "delete".to_string()));
+  }
+  if let Some(k) = modal.primary_key(ModalAction::ConfigEditCancel) {
+    hints.push((k, "cancel".to_string()));
   }
   hints
 }
@@ -2908,6 +2933,90 @@ fn settings_fields_lines(app: &App, fields: &[SettingField]) -> Vec<Line<'static
   lines
 }
 
+/// Build the Keys-tab body (issue #294): the rebindable bindings grouped by
+/// scope (`[global]`, `[modal.<context>]`), each row showing its source badge,
+/// label and current key(s). The selected row is marked; while a live capture
+/// is armed its key column becomes a `[ … ]` input echoing the captured
+/// strokes. Returns the line index of the selected row so the caller can keep
+/// it in view (this body is far taller than the viewport). Mirrors
+/// [`settings_all_lines`]'s section grouping + source colours.
+fn settings_keys_lines(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let label_style = help_label_style(&app.theme);
+  let muted_style = Style::default().fg(muted);
+  let panel = &app.config_panel;
+  let mut lines: Vec<Line<'static>> = Vec::new();
+  let mut selected_line: Option<usize> = None;
+
+  if panel.key_rows.is_empty() {
+    lines.push(Line::from(Span::styled("No bindings resolved.", muted_style)));
+    return (lines, None);
+  }
+
+  let mut current_scope: Option<String> = None;
+  for (i, row) in panel.key_rows.iter().enumerate() {
+    if current_scope.as_deref() != Some(row.scope.as_str()) {
+      if current_scope.is_some() {
+        lines.push(Line::from(String::new()));
+      }
+      lines.push(Line::from(Span::styled(
+        format!("[{}]", row.scope),
+        help_section_style(accent),
+      )));
+      current_scope = Some(row.scope.clone());
+    }
+
+    let selected = i == panel.selected;
+    if selected {
+      selected_line = Some(lines.len());
+    }
+    let capturing = selected && panel.capture.is_some();
+    let marker = if selected { "›" } else { " " };
+    let marker_style = Style::default().fg(accent).add_modifier(Modifier::BOLD);
+    let src_color = match row.source {
+      ConfigSource::Repo => app.theme.clean,
+      ConfigSource::User => app.theme.branch,
+      ConfigSource::Default => muted,
+    };
+
+    let key_span = if capturing {
+      let pending = panel
+        .capture
+        .as_ref()
+        .map(|c| c.pending.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(" "))
+        .unwrap_or_default();
+      Span::styled(
+        format!("[ {pending}_ ]"),
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+      )
+    } else {
+      let shown = if row.keys.is_empty() {
+        "(unbound)".to_string()
+      } else {
+        row.keys.clone()
+      };
+      let style = if row.keys.is_empty() {
+        muted_style
+      } else if selected {
+        Style::default().fg(accent).add_modifier(Modifier::BOLD)
+      } else {
+        Style::default().fg(Color::White)
+      };
+      Span::styled(shown, style)
+    };
+
+    lines.push(Line::from(vec![
+      Span::styled(format!(" {marker} "), marker_style),
+      Span::styled(format!("{:<7}", row.source.label()), Style::default().fg(src_color)),
+      Span::raw(" "),
+      Span::styled(format!("{:<24}", row.label), label_style),
+      key_span,
+    ]));
+  }
+  (lines, selected_line)
+}
+
 /// Render the Settings overlay (issue #232; editable in #279): same modal
 /// size as the Keybindings overlay, with a fixed header (title + the edit
 /// layer as a subtitle + category tabs), a scrollable body (the active
@@ -2943,17 +3052,29 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   }
   let header_lines = vec![title, subtitle, Line::from(String::new()), Line::from(tab_spans)];
 
-  // Body depends on the active tab.
+  // Body depends on the active tab. The Keys tab (issue #294) also reports the
+  // line index of the selected row so the renderer can scroll it into view (it
+  // has ~100 rows, unlike the short field tabs).
+  let mut keys_selected_line: Option<usize> = None;
   let body_lines = match tab {
     SettingsTab::All => settings_all_lines(app),
+    SettingsTab::Keys => {
+      let (lines, sel) = settings_keys_lines(app);
+      keys_selected_line = sel;
+      lines
+    }
     other => settings_fields_lines(app, other.fields()),
   };
 
   // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
-  // the current tab / edit mode. Both the edit and nav rows resolve their
-  // single-key verbs from the Config* modal bindings (#219 review) so a rebind
-  // of `[tui.keys.modal.config(.edit)]` shows through instead of literal keys.
-  let footer_owned = if editing {
+  // the current tab / edit / capture mode. The edit, capture and nav rows
+  // resolve their single-key verbs from the Config* modal bindings (#219
+  // review) so a rebind of `[tui.keys.modal.config(.edit)]` shows through
+  // instead of literal keys.
+  let capture_single = app.config_panel.capture.as_ref().map(|c| c.single_only);
+  let footer_owned = if let Some(single) = capture_single {
+    config_capture_footer_hints(&app.modal_keymap, single)
+  } else if editing {
     config_edit_footer_hints(&app.modal_keymap)
   } else {
     config_nav_footer_hints(&app.modal_keymap, tab, selected_kind)
@@ -2974,6 +3095,16 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   // Publish scroll bounds against the BODY viewport only (issue #279).
   let body_viewport = body_area.height as usize;
   app.config_panel.max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
+  // Keys tab (issue #294): follow the selected row so it stays on screen as
+  // selection moves (the field tabs are short enough to never need this).
+  if let Some(sel) = keys_selected_line {
+    let scroll = app.config_panel.scroll as usize;
+    if sel < scroll {
+      app.config_panel.scroll = sel as u16;
+    } else if body_viewport > 0 && sel >= scroll + body_viewport {
+      app.config_panel.scroll = (sel + 1 - body_viewport) as u16;
+    }
+  }
   app.config_panel.scroll = app.config_panel.scroll.min(app.config_panel.max_scroll);
   let scroll = app.config_panel.scroll;
   // Reserve the scrollbar column first, then bound the pan (review P3).

--- a/tests/config_set_at_tests.rs
+++ b/tests/config_set_at_tests.rs
@@ -8,7 +8,9 @@
 //! injected (tempdirs), never `$HOME`.
 
 use gwm::config::{Config, SidebarPosition, TuiOpenMode};
-use gwm::config_cli::{set_string_at, set_value_at};
+use gwm::config_cli::{set_array_at, set_string_at, set_value_at};
+use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+use gwm::tui::modal_keymap::{KeyContext, ModalAction};
 use std::path::Path;
 
 fn load(repo: &Path, global: Option<&Path>) -> Config {
@@ -118,6 +120,85 @@ fn editing_an_already_invalid_file_still_writes_the_change() {
     raw.contains("preset = \"gruvbox\""),
     "the unrelated edit must still be written to an already-invalid file: {raw}"
   );
+}
+
+// ── array write-back: keymaps (issue #294) ─────────────────────────────────
+
+#[test]
+fn set_array_at_writes_a_global_keymap_array_and_round_trips() {
+  // The in-TUI Keys tab rebinds a global action by writing its chord list as
+  // a TOML array under `[tui.keys]`. The write must round-trip through
+  // `resolved_keymap` so the new chord actually fires.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_array_at(&gwm_toml, "tui.keys.quit", &["Q".to_string()]).unwrap();
+
+  let raw = std::fs::read_to_string(&gwm_toml).unwrap();
+  assert!(raw.contains("quit = [\"Q\"]"), "must write a TOML array: {raw}");
+
+  let cfg = load(repo.path(), None);
+  let km = cfg.tui.keys.resolved_keymap().expect("keymap resolves");
+  let q = KeyStroke::new(
+    crossterm::event::KeyCode::Char('Q'),
+    crossterm::event::KeyModifiers::empty(),
+  );
+  assert_eq!(km.lookup(&[q]), ChordResolution::Matched(Action::Quit));
+}
+
+#[test]
+fn set_array_at_writes_a_modal_verb_into_its_nested_table() {
+  // A modal verb lives under `[tui.keys.modal.<context>]`; the dotted key must
+  // auto-vivify the `modal` -> context tables and round-trip through
+  // `resolved_modal_keymap`.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_array_at(&gwm_toml, "tui.keys.modal.confirm.confirm", &["o".to_string()]).unwrap();
+
+  let cfg = load(repo.path(), None);
+  let mk = cfg.tui.keys.resolved_modal_keymap().expect("modal keymap resolves");
+  let o = KeyStroke::new(
+    crossterm::event::KeyCode::Char('o'),
+    crossterm::event::KeyModifiers::empty(),
+  );
+  assert_eq!(mk.resolve(KeyContext::Confirm, &o), Some(ModalAction::ConfirmConfirm));
+}
+
+#[test]
+fn set_array_at_can_unbind_with_an_empty_array() {
+  // An empty capture writes `key = []` — a legitimate unbind. The file must
+  // round-trip (an unbound modal verb simply stops resolving).
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  set_array_at(&gwm_toml, "tui.keys.modal.confirm.confirm", &[]).unwrap();
+
+  let cfg = load(repo.path(), None);
+  let mk = cfg.tui.keys.resolved_modal_keymap().expect("modal keymap resolves");
+  let y = KeyStroke::new(
+    crossterm::event::KeyCode::Char('y'),
+    crossterm::event::KeyModifiers::empty(),
+  );
+  assert_eq!(
+    mk.resolve(KeyContext::Confirm, &y),
+    None,
+    "the default `y` is gone once `confirm` is unbound"
+  );
+}
+
+#[test]
+fn set_array_at_rejects_a_prefix_collision_and_leaves_the_file_untouched() {
+  // Binding `refresh = ["g"]` while `top` keeps its default `g g` chord is a
+  // prefix collision — refused at the validate-before-write gate so a good
+  // (here: absent) file is never clobbered with an invalid keymap.
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+
+  let result = set_array_at(&gwm_toml, "tui.keys.refresh", &["g".to_string()]);
+
+  assert!(result.is_err(), "a prefix collision must be rejected");
+  assert!(!gwm_toml.exists(), "a rejected write must not create the file");
 }
 
 #[test]

--- a/tests/config_set_at_tests.rs
+++ b/tests/config_set_at_tests.rs
@@ -8,7 +8,7 @@
 //! injected (tempdirs), never `$HOME`.
 
 use gwm::config::{Config, SidebarPosition, TuiOpenMode};
-use gwm::config_cli::{set_array_at, set_string_at, set_value_at};
+use gwm::config_cli::{set_array_at, set_string_at, set_value_at, unset_at};
 use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
 use gwm::tui::modal_keymap::{KeyContext, ModalAction};
 use std::path::Path;
@@ -199,6 +199,21 @@ fn set_array_at_rejects_a_prefix_collision_and_leaves_the_file_untouched() {
 
   assert!(result.is_err(), "a prefix collision must be rejected");
   assert!(!gwm_toml.exists(), "a rejected write must not create the file");
+}
+
+#[test]
+fn unset_at_removes_a_key_and_tolerates_absent_targets() {
+  let repo = tempfile::tempdir().unwrap();
+  let gwm_toml = repo.path().join(".gwm.toml");
+  set_array_at(&gwm_toml, "tui.keys.open_menu", &["B".to_string()]).unwrap();
+
+  unset_at(&gwm_toml, "tui.keys.open_menu").unwrap();
+  let raw = std::fs::read_to_string(&gwm_toml).unwrap();
+  assert!(!raw.contains("open_menu"), "key removed: {raw}");
+
+  // Removing a missing key (or from an absent file) is a no-op, not an error.
+  unset_at(&gwm_toml, "tui.keys.does_not_exist").unwrap();
+  unset_at(&repo.path().join("nope.toml"), "tui.keys.x").unwrap();
 }
 
 #[test]

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -569,6 +569,34 @@ fn from_slug_compat_accepts_pre_290_slugs() {
 }
 
 #[test]
+fn compat_alias_slugs_is_the_reverse_of_from_slug_compat() {
+  // Every alias `compat_alias_slugs` reports for an action must resolve back to
+  // that action; a canonical-only action reports none (issue #294 — the Keys
+  // tab strips these from a legacy config on rewrite).
+  assert_eq!(
+    Action::BrowseLinks.compat_alias_slugs().collect::<Vec<_>>(),
+    vec!["open_menu"]
+  );
+  assert_eq!(
+    Action::LazyGitFullscreen.compat_alias_slugs().collect::<Vec<_>>(),
+    vec!["git_tui"]
+  );
+  assert!(
+    Action::Down.compat_alias_slugs().next().is_none(),
+    "an action with no rename reports no alias"
+  );
+  for action in Action::all() {
+    for alias in action.compat_alias_slugs() {
+      assert_eq!(
+        Action::from_slug_compat(alias),
+        Some(action),
+        "alias {alias:?} must resolve back to {action:?}"
+      );
+    }
+  }
+}
+
+#[test]
 fn from_slug_compat_still_resolves_canonical_slugs() {
   // The compat wrapper must not break the canonical path.
   assert_eq!(

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -358,6 +358,132 @@ fn a_shadowed_global_key_rebind_warns() {
 }
 
 #[test]
+fn modal_capture_reserves_enter_and_backspace_as_controls() {
+  // Codex #297 review (P2): Enter / Backspace must stay reserved capture
+  // controls even for a single-stroke modal target — they can't be captured
+  // as a binding (hand-edit for those), matching the documented controls.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::{KeyContext, ModalAction};
+  use gwm::tui::{App, KeyTarget, SettingsTab};
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Modal(ModalAction::ConfirmConfirm))
+    .unwrap();
+  app.config_panel.selected = idx;
+  app.config_panel.begin_capture();
+
+  // Enter and Backspace are ignored — the capture stays armed, nothing bound.
+  app.handle_capture_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+  assert!(
+    app.config_panel.capture.is_some(),
+    "Enter must not capture a modal verb"
+  );
+  app.handle_capture_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+  assert!(
+    app.config_panel.capture.is_some(),
+    "Backspace must not capture a modal verb"
+  );
+  let enter = KeyStroke::new(KeyCode::Enter, KeyModifiers::NONE);
+  assert_ne!(
+    app.modal_keymap.resolve(KeyContext::Confirm, &enter),
+    Some(ModalAction::ConfirmConfirm),
+    "Enter must not have become the binding"
+  );
+
+  // A real key auto-commits the single-stroke modal capture.
+  app.handle_capture_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+  assert!(app.config_panel.capture.is_none(), "a real key commits the capture");
+  let o = KeyStroke::new(KeyCode::Char('o'), KeyModifiers::NONE);
+  assert_eq!(
+    app.modal_keymap.resolve(KeyContext::Confirm, &o),
+    Some(ModalAction::ConfirmConfirm)
+  );
+}
+
+#[test]
+fn global_capture_commits_on_enter_and_pops_on_backspace() {
+  // The global (multi-stroke) path: real keys accumulate, Backspace drops the
+  // last, Enter commits — all through the testable handler.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{App, KeyTarget, SettingsTab};
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Refresh))
+    .unwrap();
+  app.config_panel.selected = idx;
+  app.config_panel.begin_capture();
+
+  app.handle_capture_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+  app.handle_capture_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  assert!(
+    app.config_panel.capture.is_some(),
+    "global chord accumulates, no auto-commit"
+  );
+  app.handle_capture_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)); // drop 'z'
+  app.handle_capture_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // commit "x"
+
+  assert!(app.config_panel.capture.is_none(), "Enter commits the global chord");
+  let x = KeyStroke::new(KeyCode::Char('x'), KeyModifiers::NONE);
+  assert_eq!(app.keymap.lookup(&[x]), ChordResolution::Matched(Action::Refresh));
+}
+
+#[test]
+fn an_unbind_shadowed_by_another_layer_warns() {
+  // Codex #297 review (P2): an empty capture (unbind) on a low-precedence
+  // layer is shadowed when a higher layer still binds the action — warn rather
+  // than report a clean `unbound`.
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::Action;
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let home = tempfile::tempdir().unwrap();
+  let global = home.path().join("gwm").join("config.toml");
+  set_array_at(&repo.path().join(".gwm.toml"), "tui.keys.quit", &["x".to_string()]).unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), Some(&global)).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Global;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Quit))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  // Empty capture → unbind written to the global layer.
+  app.config_panel.begin_capture();
+  app.commit_key_capture();
+
+  assert!(
+    app.status.contains("unbound"),
+    "status reports the unbind: {}",
+    app.status
+  );
+  assert!(
+    app.status.contains("shadowed"),
+    "a shadowed unbind must warn: {}",
+    app.status
+  );
+}
+
+#[test]
 fn a_cross_layer_alias_shadow_is_detected_and_warned() {
   // Codex #297 review (P2, cross-layer): the legacy alias lives in the OTHER
   // layer (global `open_menu`) while the canonical `browse_links` is rebound in

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -358,6 +358,49 @@ fn a_shadowed_global_key_rebind_warns() {
 }
 
 #[test]
+fn a_cross_layer_alias_shadow_is_detected_and_warned() {
+  // Codex #297 review (P2, cross-layer): the legacy alias lives in the OTHER
+  // layer (global `open_menu`) while the canonical `browse_links` is rebound in
+  // the project layer. We don't edit the global file, so the alias survives the
+  // merge and shadows the new key — the commit must detect the ineffective
+  // rebind and warn rather than report a clean success.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let home = tempfile::tempdir().unwrap();
+  let global = home.path().join("gwm").join("config.toml");
+  set_array_at(&global, "tui.keys.open_menu", &["B".to_string()]).unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), Some(&global)).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Project;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::BrowseLinks))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  assert!(
+    app.status.contains("shadowed"),
+    "a cross-layer alias shadow must warn: {}",
+    app.status
+  );
+  // The new key really doesn't fire — the global alias `B` still wins.
+  let z = KeyStroke::new(KeyCode::Char('z'), KeyModifiers::NONE);
+  assert_ne!(app.keymap.lookup(&[z]), ChordResolution::Matched(Action::BrowseLinks));
+}
+
+#[test]
 fn rebinding_an_aliased_action_strips_the_legacy_alias() {
   // Codex #297 review (P2): a pre-#290 config carrying `tui.keys.open_menu`
   // (alias for `browse_links`) would, after a rebind writes the canonical

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -358,6 +358,45 @@ fn a_shadowed_global_key_rebind_warns() {
 }
 
 #[test]
+fn rebinding_an_aliased_action_strips_the_legacy_alias() {
+  // Codex #297 review (P2): a pre-#290 config carrying `tui.keys.open_menu`
+  // (alias for `browse_links`) would, after a rebind writes the canonical
+  // `browse_links`, re-apply the alias last in the sorted override walk and
+  // silently shadow the new key. The commit must strip the alias so the new
+  // binding actually wins.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let toml = repo.path().join(".gwm.toml");
+  set_array_at(&toml, "tui.keys.open_menu", &["B".to_string()]).unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Project;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::BrowseLinks))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  let raw = std::fs::read_to_string(&toml).unwrap();
+  assert!(!raw.contains("open_menu"), "the legacy alias was stripped: {raw}");
+  // The new key actually wins — the alias can no longer shadow it on reload.
+  let z = KeyStroke::new(KeyCode::Char('z'), KeyModifiers::NONE);
+  assert_eq!(app.keymap.lookup(&[z]), ChordResolution::Matched(Action::BrowseLinks));
+}
+
+#[test]
 fn hint_context_follows_focus() {
   // Issue #217: the statusbar chip + help subtitle read the live focus. The
   // worktrees pane is the default; focusing the sidebar switches to Status.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -358,6 +358,91 @@ fn a_shadowed_global_key_rebind_warns() {
 }
 
 #[test]
+fn physical_enter_stays_reserved_even_with_a_custom_config_edit_submit() {
+  // Codex #297 review (P2): rebinding `config.edit.submit` to e.g. Ctrl+s must
+  // not make the *physical* Enter assignable in capture — it stays a reserved
+  // control regardless of the config.edit lookup.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::{KeyContext, ModalAction};
+  use gwm::tui::{App, KeyTarget, SettingsTab};
+
+  let (repo, _) = init_repo();
+  set_array_at(
+    &repo.path().join(".gwm.toml"),
+    "tui.keys.modal.config.edit.submit",
+    &["Ctrl+s".to_string()],
+  )
+  .unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Modal(ModalAction::ConfirmConfirm))
+    .unwrap();
+  app.config_panel.selected = idx;
+  app.config_panel.begin_capture();
+
+  // Physical Enter is reserved: ignored, not captured — capture stays armed.
+  app.handle_capture_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+  assert!(app.config_panel.capture.is_some(), "physical Enter must stay reserved");
+  let enter = KeyStroke::new(KeyCode::Enter, KeyModifiers::NONE);
+  assert_ne!(
+    app.modal_keymap.resolve(KeyContext::Confirm, &enter),
+    Some(ModalAction::ConfirmConfirm),
+    "Enter must not have become the binding"
+  );
+}
+
+#[test]
+fn a_failed_write_to_an_already_invalid_shadowed_file_rolls_back() {
+  // Codex #297 review (P2): when the target file is invalid on its own but
+  // loaded because the bad value is shadowed by another layer,
+  // `write_and_validate` writes the edit then returns Err (recovery path). The
+  // commit must roll back so a rebind reported as failed never persists.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::Action;
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let home = tempfile::tempdir().unwrap();
+  let global = home.path().join("gwm").join("config.toml");
+  std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+  // Global is invalid on its own (non-numeric countdown)…
+  std::fs::write(&global, "[tui]\nconfirm_countdown_secs = \"abc\"\n").unwrap();
+  // …but the repo overrides it with a valid value, so the merged config loads.
+  std::fs::write(repo.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 4\n").unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), Some(&global)).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Global; // write the invalid file
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Quit))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('Q'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  assert!(app.status.starts_with("keys:"), "failure surfaced: {}", app.status);
+  let raw = std::fs::read_to_string(&global).unwrap();
+  assert!(
+    !raw.contains("quit"),
+    "a failed write must be rolled back, not persisted: {raw}"
+  );
+}
+
+#[test]
 fn modal_capture_reserves_enter_and_backspace_as_controls() {
   // Codex #297 review (P2): Enter / Backspace must stay reserved capture
   // controls even for a single-stroke modal target — they can't be captured

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -365,7 +365,7 @@ fn modal_capture_reserves_enter_and_backspace_as_controls() {
   use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   use gwm::tui::keymap::KeyStroke;
   use gwm::tui::modal_keymap::{KeyContext, ModalAction};
-  use gwm::tui::{App, KeyTarget, SettingsTab};
+  use gwm::tui::{KeyTarget, SettingsTab};
 
   let (_dir, mut app) = make_app();
   app.enter_config_panel();
@@ -413,7 +413,7 @@ fn global_capture_commits_on_enter_and_pops_on_backspace() {
   // last, Enter commits — all through the testable handler.
   use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
-  use gwm::tui::{App, KeyTarget, SettingsTab};
+  use gwm::tui::{KeyTarget, SettingsTab};
 
   let (_dir, mut app) = make_app();
   app.enter_config_panel();

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -138,6 +138,134 @@ fn enter_config_panel_opens_resolves_rows_and_resets_scroll() {
   assert_eq!(base.source, ConfigSource::Default);
 }
 
+// ── Keys tab: in-TUI keymap editor (issue #294) ────────────────────────────
+
+#[test]
+fn enter_config_panel_builds_the_keys_tab_rows() {
+  use gwm::tui::keymap::Action;
+  use gwm::tui::modal_keymap::ModalAction;
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+
+  let expected = Action::all().count() + ModalAction::all().count();
+  assert_eq!(
+    app.config_panel.key_rows.len(),
+    expected,
+    "opening the panel enumerates every global + modal binding"
+  );
+}
+
+#[test]
+fn capturing_a_global_chord_rebinds_it_live_and_writes_the_file() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{KeyTarget, SettingsTab};
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Quit))
+    .expect("quit row present");
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('Q'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  // The live keymap reflects the rebind without a restart.
+  let q = KeyStroke::new(KeyCode::Char('Q'), KeyModifiers::NONE);
+  assert_eq!(app.keymap.lookup(&[q]), ChordResolution::Matched(Action::Quit));
+
+  // …and it round-trips to disk under `[tui.keys]`.
+  let raw = std::fs::read_to_string(dir.path().join(".gwm.toml")).unwrap();
+  assert!(raw.contains("quit = [\"Q\"]"), "binding persisted: {raw}");
+}
+
+#[test]
+fn capturing_a_modal_verb_rebinds_it_live() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::{KeyContext, ModalAction};
+  use gwm::tui::{KeyTarget, SettingsTab};
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Modal(ModalAction::ConfirmConfirm))
+    .expect("confirm row present");
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  let o = KeyStroke::new(KeyCode::Char('o'), KeyModifiers::NONE);
+  assert_eq!(
+    app.modal_keymap.resolve(KeyContext::Confirm, &o),
+    Some(ModalAction::ConfirmConfirm),
+    "the modal verb fires on its new key immediately"
+  );
+}
+
+#[test]
+fn an_invalid_rebind_is_rejected_and_leaves_the_binding_live() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{KeyTarget, SettingsTab};
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Refresh))
+    .expect("refresh row present");
+  app.config_panel.selected = idx;
+
+  // `g` is a strict prefix of `top`'s default `g g` chord — a prefix
+  // collision the validate-before-write gate must reject.
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  assert!(app.status.starts_with("keys:"), "error surfaced: {}", app.status);
+  // The previous binding survives — `f` still refreshes.
+  let f = KeyStroke::new(KeyCode::Char('f'), KeyModifiers::NONE);
+  assert_eq!(app.keymap.lookup(&[f]), ChordResolution::Matched(Action::Refresh));
+}
+
+#[test]
+fn cancelling_a_capture_writes_nothing() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::SettingsTab;
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.selected = 0;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  app.config_panel.cancel_capture();
+
+  assert!(app.config_panel.capture.is_none(), "capture cleared on cancel");
+  assert!(
+    !dir.path().join(".gwm.toml").exists(),
+    "a cancelled capture must not write the file"
+  );
+}
+
 #[test]
 fn hint_context_follows_focus() {
   // Issue #217: the statusbar chip + help subtitle read the live focus. The

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -267,6 +267,97 @@ fn cancelling_a_capture_writes_nothing() {
 }
 
 #[test]
+fn a_cross_layer_conflict_rolls_back_and_does_not_brick_the_config() {
+  // Codex #297 review (P2): `set_array_at` validates only the file it writes.
+  // A rebind that is valid in the project file alone but collides with the
+  // global layer once merged must NOT be left on disk — otherwise the next
+  // launch's layered load fails and the repo config is bricked.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::config::Config;
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::{Action, ChordResolution, KeyStroke};
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let home = tempfile::tempdir().unwrap();
+  let global = home.path().join("gwm").join("config.toml");
+  // The global layer binds `top` to a two-stroke chord.
+  set_array_at(&global, "tui.keys.top", &["z z".to_string()]).unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), Some(&global)).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Project; // write the repo file
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Refresh))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  // `z` alone is a prefix of the global `z z` — valid in the repo file by
+  // itself, invalid once the layers merge.
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  assert!(app.status.starts_with("keys:"), "rejection surfaced: {}", app.status);
+  // The merged config still loads — nothing was left broken on disk.
+  assert!(
+    Config::load_layered(repo.path(), Some(&global)).is_ok(),
+    "the layered config must still load after a rolled-back rebind"
+  );
+  let repo_toml = repo.path().join(".gwm.toml");
+  if repo_toml.exists() {
+    let raw = std::fs::read_to_string(&repo_toml).unwrap();
+    assert!(!raw.contains("refresh"), "the rejected rebind was rolled back: {raw}");
+  }
+  // The previous binding survives — `f` still refreshes.
+  let f = KeyStroke::new(KeyCode::Char('f'), KeyModifiers::NONE);
+  assert_eq!(app.keymap.lookup(&[f]), ChordResolution::Matched(Action::Refresh));
+}
+
+#[test]
+fn a_shadowed_global_key_rebind_warns() {
+  // Codex #297 review (P3): editing the global layer for a key the repo
+  // overrides leaves the effective binding unchanged (repo wins). Mirror
+  // `apply_setting` and flag the shadow rather than reporting a clean set.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::config_cli::set_array_at;
+  use gwm::tui::keymap::Action;
+  use gwm::tui::{App, KeyTarget, SettingsLayer, SettingsTab};
+
+  let (repo, _) = init_repo();
+  let home = tempfile::tempdir().unwrap();
+  let global = home.path().join("gwm").join("config.toml");
+  // The repo pins `quit` to `x`, so a global rebind of `quit` is shadowed.
+  set_array_at(&repo.path().join(".gwm.toml"), "tui.keys.quit", &["x".to_string()]).unwrap();
+
+  let mut app = App::new_at_layered(Some(repo.path()), Some(&global)).unwrap();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Keys;
+  app.config_panel.layer = SettingsLayer::Global;
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Quit))
+    .unwrap();
+  app.config_panel.selected = idx;
+
+  app.config_panel.begin_capture();
+  app.push_key_capture(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
+  app.commit_key_capture();
+
+  assert!(
+    app.status.contains("shadowed"),
+    "a shadowed global rebind must warn: {}",
+    app.status
+  );
+}
+
+#[test]
 fn hint_context_follows_focus() {
   // Issue #217: the statusbar chip + help subtitle read the live focus. The
   // worktrees pane is the default; focusing the sidebar switches to Status.

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -423,6 +423,39 @@ fn settings_panel_all_tab_renders_title_section_and_source_column() {
 }
 
 #[test]
+fn settings_keys_tab_renders_scopes_bindings_and_capture_input() {
+  use gwm::config::ConfigSource;
+  use gwm::tui::keymap::{Action, Keymap};
+  use gwm::tui::modal_keymap::ModalKeymap;
+  use gwm::tui::{build_key_rows, KeyTarget, SettingsTab};
+
+  let (_dir, mut app) = make_app();
+  app.config_panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  app.config_panel.tab = SettingsTab::Keys;
+  app.view = View::Config;
+
+  let buf = render(&mut app);
+  assert_present(&buf, "Keys", "the Keys tab label in the strip");
+  assert_present(&buf, "[global]", "global scope heading");
+  // `down` is the first global action, so it sits in the initial viewport
+  // (later rows like `quit` need a scroll, exercised by the capture below).
+  assert_present(&buf, "down", "the first global action slug");
+
+  // Arm a capture on the `quit` row → selecting it scrolls it into view and
+  // its key column becomes a `[ … ]` input.
+  let idx = app
+    .config_panel
+    .key_rows
+    .iter()
+    .position(|r| r.target == KeyTarget::Global(Action::Quit))
+    .unwrap();
+  app.config_panel.selected = idx;
+  app.config_panel.begin_capture();
+  let buf = render(&mut app);
+  assert_present(&buf, "[ ", "capture input box rendered for the selected row");
+}
+
+#[test]
 fn settings_all_tab_horizontal_pan_reveals_the_last_column_past_the_scrollbar() {
   use gwm::config::{ConfigRow, ConfigSource};
   use gwm::tui::SettingsTab;

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -122,6 +122,18 @@ fn assert_present(buf: &Buffer, needle: &str, what: &str) {
 }
 
 #[test]
+fn worktrees_table_header_labels_the_issue_pr_badge_column() {
+  // The worktree table's badge column (the `●/●` issue/PR pastilles) now
+  // carries an `I/P` caption alongside the NAME / BRANCH / STATUS / PATH
+  // headers. Render the default list view (no modal) and assert it.
+  let (_dir, mut app) = make_app();
+  let buf = render(&mut app);
+  assert_present(&buf, "I/P", "issue/PR badge column header");
+  assert_present(&buf, "NAME", "name column header");
+  assert_present(&buf, "BRANCH", "branch column header");
+}
+
+#[test]
 fn help_modal_renders_title_and_close_hint() {
   let (_dir, mut app) = make_app();
   app.enter_help();

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -6,8 +6,11 @@
 //! the modal paints. Mirrors the Command Logs slice's clamp tests —
 //! ratatui-free, no terminal backend.
 
+use crossterm::event::{KeyCode, KeyModifiers};
 use gwm::config::{Config, ConfigRow, ConfigSource};
-use gwm::tui::{ConfigPanel, FieldKind, SettingField, SettingsLayer, SettingsTab};
+use gwm::tui::keymap::{Action, KeyStroke, Keymap};
+use gwm::tui::modal_keymap::{ModalAction, ModalKeymap};
+use gwm::tui::{build_key_rows, ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer, SettingsTab};
 
 fn sample_row() -> ConfigRow {
   ConfigRow {
@@ -99,13 +102,19 @@ fn new_panel_defaults_to_theme_tab_project_layer() {
 }
 
 #[test]
-fn next_tab_cycles_theme_worktree_tui_all_and_wraps() {
+fn next_tab_cycles_theme_worktree_tui_keys_all_and_wraps() {
   let mut panel = ConfigPanel::new();
   assert_eq!(panel.tab, SettingsTab::Theme);
   panel.next_tab();
   assert_eq!(panel.tab, SettingsTab::Worktree);
   panel.next_tab();
   assert_eq!(panel.tab, SettingsTab::Tui);
+  panel.next_tab();
+  assert_eq!(
+    panel.tab,
+    SettingsTab::Keys,
+    "Keys tab sits between TUI and All (issue #294)"
+  );
   panel.next_tab();
   assert_eq!(panel.tab, SettingsTab::All);
   panel.next_tab();
@@ -255,6 +264,164 @@ fn cancel_edit_discards_the_buffer() {
   panel.push_edit_char('2');
   panel.cancel_edit();
   assert!(panel.editing.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Keys tab (issue #294): the dynamic keymap-editor row model + the live
+// keystroke-capture state machine — all pure, ratatui-free.
+// ---------------------------------------------------------------------------
+
+fn ch(c: char) -> KeyStroke {
+  KeyStroke::new(KeyCode::Char(c), KeyModifiers::empty())
+}
+
+#[test]
+fn build_key_rows_enumerates_every_global_and_modal_binding() {
+  let rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  let expected = Action::all().count() + ModalAction::all().count();
+  assert_eq!(rows.len(), expected, "one row per global action + per modal verb");
+
+  // Global rows come first, in declaration order, scoped "global".
+  assert_eq!(rows[0].target, KeyTarget::Global(Action::all().next().unwrap()));
+  assert_eq!(rows[0].scope, "global");
+  // The modal block carries a context-qualified scope.
+  assert!(
+    rows.iter().any(|r| r.scope == "modal.confirm" && r.label == "confirm"),
+    "modal verbs are grouped by their context path"
+  );
+}
+
+#[test]
+fn key_rows_show_current_chords_and_source() {
+  let rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |key| {
+    if key == "tui.keys.quit" {
+      ConfigSource::Repo
+    } else {
+      ConfigSource::Default
+    }
+  });
+  let quit = rows
+    .iter()
+    .find(|r| r.target == KeyTarget::Global(Action::Quit))
+    .expect("quit row present");
+  assert_eq!(quit.keys, "q", "default quit chord shown");
+  assert_eq!(quit.source, ConfigSource::Repo, "source resolved via the lookup");
+}
+
+#[test]
+fn config_key_addresses_the_right_toml_table() {
+  assert_eq!(KeyTarget::Global(Action::Quit).config_key(), "tui.keys.quit");
+  assert_eq!(
+    KeyTarget::Modal(ModalAction::ConfirmConfirm).config_key(),
+    "tui.keys.modal.confirm.confirm"
+  );
+  // A staged (dotted) context keeps its dotted path.
+  assert_eq!(
+    KeyTarget::Modal(ModalAction::LinkChooseIssue).config_key(),
+    "tui.keys.modal.link.choose_target.issue"
+  );
+}
+
+#[test]
+fn modal_targets_are_single_only_globals_are_not() {
+  assert!(
+    !KeyTarget::Global(Action::Down).single_only(),
+    "global actions accept chords"
+  );
+  assert!(
+    KeyTarget::Modal(ModalAction::ConfirmConfirm).single_only(),
+    "modal verbs are single-stroke"
+  );
+}
+
+#[test]
+fn begin_capture_arms_only_on_the_keys_tab_with_a_selected_row() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+
+  // Not on the Keys tab → no-op.
+  panel.tab = SettingsTab::Theme;
+  panel.begin_capture();
+  assert!(panel.capture.is_none());
+
+  // On the Keys tab → arms with the row's single_only flag.
+  panel.tab = SettingsTab::Keys;
+  panel.selected = 0; // first global action
+  panel.begin_capture();
+  let cap = panel.capture.as_ref().expect("capture armed");
+  assert_eq!(cap.row, 0);
+  assert!(!cap.single_only, "first row is a global action");
+  assert!(cap.pending.is_empty());
+}
+
+#[test]
+fn capture_accumulates_strokes_and_pop_drops_the_last() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  panel.tab = SettingsTab::Keys;
+  panel.selected = 0;
+  panel.begin_capture();
+
+  panel.capture_push(ch('g'));
+  panel.capture_push(ch('g'));
+  assert_eq!(panel.capture.as_ref().unwrap().pending, vec![ch('g'), ch('g')]);
+  panel.capture_pop();
+  assert_eq!(panel.capture.as_ref().unwrap().pending, vec![ch('g')]);
+}
+
+#[test]
+fn cancel_capture_discards_pending() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  panel.tab = SettingsTab::Keys;
+  panel.begin_capture();
+  panel.capture_push(ch('x'));
+  panel.cancel_capture();
+  assert!(panel.capture.is_none());
+}
+
+#[test]
+fn capture_as_config_items_joins_a_chord_and_unbinds_when_empty() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  panel.tab = SettingsTab::Keys;
+  panel.selected = 0;
+  panel.begin_capture();
+
+  // A multi-stroke global chord serialises to one space-joined element.
+  panel.capture_push(ch('g'));
+  panel.capture_push(ch('g'));
+  assert_eq!(
+    panel.capture.as_ref().unwrap().as_config_items(),
+    vec!["g g".to_string()]
+  );
+
+  // Cleared pending → empty list (an unbind).
+  panel.capture_pop();
+  panel.capture_pop();
+  assert!(panel.capture.as_ref().unwrap().as_config_items().is_empty());
+}
+
+#[test]
+fn selection_clamps_to_key_rows_on_the_keys_tab() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  panel.tab = SettingsTab::Keys;
+  for _ in 0..(panel.key_rows.len() + 50) {
+    panel.select_next();
+  }
+  assert_eq!(panel.selected, panel.key_rows.len() - 1, "never past the last key row");
+}
+
+#[test]
+fn switching_tab_clears_an_armed_capture() {
+  let mut panel = ConfigPanel::new();
+  panel.key_rows = build_key_rows(&Keymap::defaults(), &ModalKeymap::defaults(), |_| ConfigSource::Default);
+  panel.tab = SettingsTab::Keys;
+  panel.begin_capture();
+  assert!(panel.capture.is_some());
+  panel.next_tab();
+  assert!(panel.capture.is_none(), "tab change cancels capture");
 }
 
 #[test]

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -620,6 +620,49 @@ fn config_nav_footer_hints_track_rebinding() {
     !rebound.iter().any(|(k, _)| k == "Tab" || k == "Esc"),
     "stale Tab / Esc must not linger after the rebind: {rebound:?}"
   );
+
+  // Keys tab (issue #294): `activate` advertises `rebind`, not `edit`/`cycle`.
+  let keys = config_nav_footer_hints(&ModalKeymap::defaults(), SettingsTab::Keys, None);
+  assert!(
+    keys.iter().any(|(_, l)| l == "rebind"),
+    "Keys tab footer advertises rebind: {keys:?}"
+  );
+}
+
+#[test]
+fn config_capture_footer_hints_differ_by_capture_kind() {
+  // Issue #294: while capturing, the footer resolves cancel (+ save for a
+  // multi-stroke global chord) from the ConfigEdit modal bindings; a
+  // single-stroke modal capture auto-commits, so it advertises the live
+  // prompt instead of a save verb.
+  use gwm::tui::config_capture_footer_hints;
+  use gwm::tui::modal_keymap::{parse_single, ModalAction, ModalKeymap};
+
+  let global = config_capture_footer_hints(&ModalKeymap::defaults(), false);
+  assert!(global.iter().any(|(k, l)| k == "Enter" && l == "save"), "{global:?}");
+  assert!(
+    global.iter().any(|(k, l)| k == "Backspace" && l == "delete"),
+    "{global:?}"
+  );
+  assert!(global.iter().any(|(k, l)| k == "Esc" && l == "cancel"), "{global:?}");
+
+  let modal = config_capture_footer_hints(&ModalKeymap::defaults(), true);
+  assert!(
+    modal.iter().any(|(_, l)| l == "bind"),
+    "single-stroke prompt: {modal:?}"
+  );
+  assert!(modal.iter().any(|(_, l)| l == "cancel"), "{modal:?}");
+  assert!(
+    !modal.iter().any(|(_, l)| l == "save"),
+    "a single-stroke capture auto-commits, no save verb: {modal:?}"
+  );
+
+  // A rebind of the config.edit cancel verb shows through.
+  let mut mk = ModalKeymap::defaults();
+  mk.apply_override(ModalAction::ConfigEditCancel, vec![parse_single("q").unwrap()])
+    .unwrap();
+  let rebound = config_capture_footer_hints(&mk, false);
+  assert!(rebound.iter().any(|(k, l)| k == "q" && l == "cancel"), "{rebound:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adds a **Keys** tab to the in-TUI Settings panel (`4`) that lets you rebind
**every** keymap — global list-view actions and modal verbs — with **live
keystroke capture**, layer-aware write-back, validation, and an in-memory
reload so the new binding is active immediately.

Closes #294

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `config_cli::set_array_at` — array write-back for keymap TOML (`[tui.keys]` /
  `[tui.keys.modal.<context>]`), reusing the existing validate-before-write
  gate; empty list = unbind.
- `SettingsTab::Keys` + `KeyTarget` / `KeyRow` / `build_key_rows` + `KeyCapture`
  — the dynamic row model (every `Action` + `ModalAction`, grouped by scope,
  with source attribution) and the pure live-capture state machine.
- App wiring: `enter_config_panel` builds the rows; `push_key_capture` /
  `commit_key_capture` persist the captured chord and reload both keymaps; a
  conflict / prefix-collision aborts the write and leaves the binding live.
- Routing: a `View::Config` capture branch (Esc cancels, Enter commits a global
  chord, Backspace drops the last stroke; modal verbs auto-commit on the first
  key); `activate` arms capture on the Keys tab.
- Render: `settings_keys_lines` (scopes, source badges, current key(s), `[ … ]`
  capture input, selection-follow scroll) + `config_capture_footer_hints`.
- Docs: CHANGELOG `[Unreleased]`, `examples/gwm.toml.example`, EN + FR
  keybindings docs.

## Tests

- [x] `cargo test` passes locally (full suite, minimal-PATH CI-like run)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD, red-first per concern):
  `config_set_at_tests` (array write-back + unbind + conflict-rejection),
  `tui_state_config_panel_tests` (row model + capture machine),
  `tui_app_tests` (rebind live + reload + conflict + cancel),
  `tui_modal_render_tests` (Keys tab + capture overlay),
  `tui_ui_helpers_tests` (capture/nav footer hints).

## Screenshots / TUI captures

_None — covered by the render net (`tui_modal_render_tests`)._

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [x] `examples/gwm.toml.example` updated
- [x] No `unwrap()` on user-facing paths (errors route to the statusbar)
- [x] No `println!` in TUI render code

## Notes for reviewers

- **Capture trade-off**: `Esc` / `Enter` / `Backspace` / `Ctrl+C` are capture
  controls, so they can't themselves be *assigned* via capture — hand-edit
  `.gwm.toml` for those rare cases. This mirrors the existing hard-coded
  escape-hatch policy (#219). The commit/cancel verbs resolve through
  `[tui.keys.modal.config.edit]`, so a rebind of those carries into capture.
- **Replace, not merge**: a capture sets one binding (the captured chord),
  replacing the prior chords for that action — adding *alternatives* stays a
  hand-edit. `gwm doctor` stays green (`43 global + 58 modal`).
- `gh issue create` first opened a duplicate (#296, now closed) before I found
  the existing canonical #294; this PR targets #294.

## Linked issues / docs

- Issue: #294
- Builds on: #87 (chords), #219 (modal keymap), #232 / #279 (Settings panel)