### PR TITLE
✨ feat(tui): Working Tree pane as a nerd-font file-explorer tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,8 +119,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `git status` scan is streamed and **stopped after 5000 records** (git is
     killed once the cap is hit, so its directory walk can't run away), and the
     tree then renders at most **500 file leaves** with the remainder shown as
-    a single `… N more` row — selecting such a worktree can neither stall the
-    scan nor flood the non-scrollable section.
+    a single `… N more` row (`… N+ more` when the scan itself was truncated,
+    since the true total is then unknown) — selecting such a worktree can
+    neither stall the scan nor flood the non-scrollable section. The scan
+    runs under `--no-optional-locks` so killing it at the cap can't leave a
+    stale `.git/index.lock`, and stderr is drained off-thread to avoid a pipe
+    deadlock.
+  - File and directory names are **sanitised** before rendering (control
+    characters → `?`), so a verbatim `-z` filename can't corrupt the sidebar
+    layout or inject terminal escape sequences.
   - `git_status_short` now reads `git status --porcelain -z
     --untracked-files=all`: `-uall` expands an untracked directory into its
     individual files (git-ignored paths stay excluded), and `--porcelain -z`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     only-new → green, only-deleted → red, mixed → neutral accent.
   - An **extra space** pads each nerd-font glyph (most render double-width in
     a single cell) so the following name isn't clipped.
-  - A pathological untracked directory is **capped at 500 file leaves**, with
-    the remainder shown as a single `… N more` row, so selecting such a
-    worktree can't flood the non-scrollable section.
+  - A pathological untracked directory is bounded at **two levels**: the
+    `git status` scan is streamed and **stopped after 5000 records** (git is
+    killed once the cap is hit, so its directory walk can't run away), and the
+    tree then renders at most **500 file leaves** with the remainder shown as
+    a single `… N more` row — selecting such a worktree can neither stall the
+    scan nor flood the non-scrollable section.
   - `git_status_short` now reads `git status --porcelain -z
     --untracked-files=all`: `-uall` expands an untracked directory into its
     individual files (git-ignored paths stay excluded), and `--porcelain -z`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   builder (flat status → tree model) is a pure, ratatui-free function with
   unit tests. `git_status_short` now passes `--untracked-files=all` so an
   untracked directory expands into its individual files (git-ignored paths
-  stay excluded).
+  stay excluded). Paths git C-quotes (non-ASCII names, embedded quotes) are
+  decoded back to their real UTF-8 name before nesting.
 - **Worktree table: label the issue/PR badge column** (issue #294): the second
   table column (the `●` / `●` issue / PR pastilles) now carries an `I/P` header
   so the badges read self-explanatory next to the `Worktree` / `Branch` columns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Working Tree pane as a file-explorer tree** (issue #300): the Status
+  pane's Working Tree section (`2`) now renders `git status` as a nested,
+  nerd-font file tree instead of a flat `XY PATH` list. Directories sort
+  before files (alphabetical within a level) and single-child directory
+  chains collapse (`src/tui/` then `ui.rs`); each file row carries an
+  extension-driven file-type icon plus its `M` / `A` / `D` / `?` status
+  badge, all painted in the file's change-category colour (so a row matches
+  the footer count it belongs to). The counts footer is unchanged. The tree
+  builder (flat status → tree model) is a pure, ratatui-free function with
+  unit tests. `git_status_short` now passes `--untracked-files=all` so an
+  untracked directory expands into its individual files (git-ignored paths
+  stay excluded).
 - **Worktree table: label the issue/PR badge column** (issue #294): the second
   table column (the `●` / `●` issue / PR pastilles) now carries an `I/P` header
   so the badges read self-explanatory next to the `Worktree` / `Branch` columns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,10 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   badge, all painted in the file's change-category colour (so a row matches
   the footer count it belongs to). The counts footer is unchanged. The tree
   builder (flat status → tree model) is a pure, ratatui-free function with
-  unit tests. `git_status_short` now passes `--untracked-files=all` so an
-  untracked directory expands into its individual files (git-ignored paths
-  stay excluded). Paths git C-quotes (non-ASCII names, embedded quotes) are
-  decoded back to their real UTF-8 name before nesting.
+  unit tests. `git_status_short` now reads `git status --porcelain -z
+  --untracked-files=all`: `-uall` expands an untracked directory into its
+  individual files (git-ignored paths stay excluded), and `--porcelain -z`
+  emits paths verbatim and NUL-delimited — so filenames with spaces,
+  arrows, quotes, or non-ASCII bytes (and rename source/destination) parse
+  unambiguously. The footer counts share the same `-z` parser, so a rename
+  counts once and the total always matches the rows rendered.
 - **Worktree table: label the issue/PR badge column** (issue #294): the second
   table column (the `●` / `●` issue / PR pastilles) now carries an `I/P` header
   so the badges read self-explanatory next to the `Worktree` / `Branch` columns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,13 +107,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   badge, all painted in the file's change-category colour (so a row matches
   the footer count it belongs to). The counts footer is unchanged. The tree
   builder (flat status → tree model) is a pure, ratatui-free function with
-  unit tests. `git_status_short` now reads `git status --porcelain -z
-  --untracked-files=all`: `-uall` expands an untracked directory into its
-  individual files (git-ignored paths stay excluded), and `--porcelain -z`
-  emits paths verbatim and NUL-delimited — so filenames with spaces,
-  arrows, quotes, or non-ASCII bytes (and rename source/destination) parse
-  unambiguously. The footer counts share the same `-z` parser, so a rename
-  counts once and the total always matches the rows rendered.
+  unit tests.
+  - **Tree connector lines** (`├─` / `└─` / `│`) draw the hierarchy like
+    `tree(1)`, in the muted role.
+  - **Directory rows are coloured retroactively by git**: a folder takes the
+    aggregate change-category of its subtree — only-modified → yellow,
+    only-new → green, only-deleted → red, mixed → neutral accent.
+  - An **extra space** pads each nerd-font glyph (most render double-width in
+    a single cell) so the following name isn't clipped.
+  - A pathological untracked directory is **capped at 500 file leaves**, with
+    the remainder shown as a single `… N more` row, so selecting such a
+    worktree can't flood the non-scrollable section.
+  - `git_status_short` now reads `git status --porcelain -z
+    --untracked-files=all`: `-uall` expands an untracked directory into its
+    individual files (git-ignored paths stay excluded), and `--porcelain -z`
+    emits paths verbatim and NUL-delimited — so filenames with spaces,
+    arrows, quotes, or non-ASCII bytes (and rename source/destination) parse
+    unambiguously. The footer counts share the same `-z` parser, so a rename
+    counts once and the total always matches the rows rendered.
 - **Worktree table: label the issue/PR badge column** (issue #294): the second
   table column (the `●` / `●` issue / PR pastilles) now carries an `I/P` header
   so the badges read self-explanatory next to the `Worktree` / `Branch` columns.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -12,6 +12,7 @@ pub mod palette;
 pub mod state;
 pub mod theme;
 mod ui;
+pub mod wt_tree;
 
 use crate::error::Result;
 use crate::tui::keymap::Action;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1185,7 +1185,10 @@ fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], prefix: String,
         };
         out.push(Line::from(vec![
           Span::styled(connector, Style::default().fg(theme.muted)),
-          Span::styled(format!("{}  {}", WT_DIR_OPEN_ICON, name), Style::default().fg(color)),
+          Span::styled(
+            format!("{}  {}", WT_DIR_OPEN_ICON, wt_tree::sanitize_name(name)),
+            Style::default().fg(color),
+          ),
         ]));
         let child_prefix = format!("{}{}", prefix, if is_last { "   " } else { "│  " });
         push_wt_nodes(out, children, child_prefix, theme);
@@ -1200,7 +1203,10 @@ fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], prefix: String,
         out.push(Line::from(vec![
           Span::styled(connector, Style::default().fg(theme.muted)),
           Span::styled(format!("{} ", badge), Style::default().fg(color)),
-          Span::styled(format!("{}  {}", icon, name), Style::default().fg(color)),
+          Span::styled(
+            format!("{}  {}", icon, wt_tree::sanitize_name(name)),
+            Style::default().fg(color),
+          ),
         ]));
       }
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1103,14 +1103,14 @@ fn badges_line(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
 
 fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, WorkingTreeCounts) {
   match worktree::git_status_short(&w.path) {
-    Ok(s) if s.trim().is_empty() => (
+    Ok((s, _)) if s.trim().is_empty() => (
       vec![Line::from(Span::styled(
         "✓ clean".to_string(),
         Style::default().fg(theme.clean),
       ))],
       WorkingTreeCounts::default(),
     ),
-    Ok(s) => {
+    Ok((s, scan_truncated)) => {
       let counts = working_tree_status_counts(&s);
       let records = wt_tree::parse_status_z(&s);
       // Cap the explorer for a pathological untracked-dir explosion (issue
@@ -1120,10 +1120,15 @@ fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, W
       let (tree, overflow) = wt_tree::build_capped_tree(&records, wt_tree::WT_TREE_MAX_FILES);
       let mut lines = working_tree_tree_lines(&tree, theme);
       if overflow > 0 {
-        lines.push(Line::from(Span::styled(
-          format!("… {} more", overflow),
-          Style::default().fg(theme.muted),
-        )));
+        // After a scan truncation the real remainder is unknown (git was
+        // killed at the cap), so `overflow` is only a lower bound — render
+        // `… N+ more` rather than claiming an exact count.
+        let label = if scan_truncated {
+          format!("… {}+ more", overflow)
+        } else {
+          format!("… {} more", overflow)
+        };
+        lines.push(Line::from(Span::styled(label, Style::default().fg(theme.muted))));
       }
       (lines, counts)
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -9,6 +9,7 @@ use super::state::pty_overlay::PtyKind;
 use super::state::sidebar::SidebarMode;
 use super::state::spinner::DOT_FRAMES;
 use super::theme::Theme;
+use super::wt_tree::{self, working_tree_category, WtCategory, WtNode, WT_DIR_OPEN_ICON};
 use crate::bootstrap::{BootstrapReport, StepStatus};
 use crate::command_log::CommandStatus;
 use crate::config::ConfigSource;
@@ -1111,7 +1112,7 @@ fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, W
     ),
     Ok(s) => {
       let counts = working_tree_status_counts(&s);
-      let lines: Vec<Line<'static>> = s.lines().map(|line| working_tree_status_line(line, theme)).collect();
+      let lines = working_tree_tree_lines(&wt_tree::build_tree(&s), theme);
       (lines, counts)
     }
     Err(e) => (
@@ -1121,6 +1122,52 @@ fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, W
       ))],
       WorkingTreeCounts::default(),
     ),
+  }
+}
+
+/// Render the Working Tree file-explorer model (issue #300) into styled
+/// sidebar rows. Directories are emitted before their children with a
+/// folder glyph in the `accent` role; files carry a category-coloured
+/// status badge + a nerd-font file-type icon + the leaf name, all painted
+/// in the file's change-category colour so a row's colour matches the
+/// footer count it belongs to (the #287 invariant, preserved). Two spaces
+/// of indentation per depth level give the tree its shape.
+fn working_tree_tree_lines(nodes: &[WtNode], theme: &Theme) -> Vec<Line<'static>> {
+  let mut out = Vec::new();
+  push_wt_nodes(&mut out, nodes, 0, theme);
+  out
+}
+
+/// Depth-first walk used by [`working_tree_tree_lines`]; recurses into each
+/// directory's children one indent level deeper.
+fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], depth: usize, theme: &Theme) {
+  let indent = "  ".repeat(depth);
+  for node in nodes {
+    match node {
+      WtNode::Dir { name, children } => {
+        out.push(Line::from(vec![
+          Span::raw(indent.clone()),
+          Span::styled(
+            format!("{} {}", WT_DIR_OPEN_ICON, name),
+            Style::default().fg(theme.accent),
+          ),
+        ]));
+        push_wt_nodes(out, children, depth + 1, theme);
+      }
+      WtNode::File {
+        name,
+        icon,
+        badge,
+        category,
+      } => {
+        let color = working_tree_category_color(*category, theme);
+        out.push(Line::from(vec![
+          Span::raw(indent.clone()),
+          Span::styled(format!("{} ", badge), Style::default().fg(color)),
+          Span::styled(format!("{} {}", icon, name), Style::default().fg(color)),
+        ]));
+      }
+    }
   }
 }
 
@@ -1152,34 +1199,6 @@ impl WorkingTreeCounts {
 pub const WT_CREATED_ICON: &str = "\u{eadc}";
 pub const WT_MODIFIED_ICON: &str = "\u{eadd}";
 pub const WT_DELETED_ICON: &str = "\u{eade}";
-
-/// The single change-category a `git status --short` `XY` pair falls into
-/// (issue #287). Shared by the Working-Tree footer counts and the per-row
-/// colouring so a file's row colour always equals the footer segment it's
-/// counted in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WtCategory {
-  Created,
-  Modified,
-  Deleted,
-}
-
-/// Classify a porcelain `XY` status pair into its dominant
-/// [`WtCategory`], with a deterministic precedence (created > deleted >
-/// modified) so each file maps to exactly one bucket:
-///
-/// - `??` (untracked) or an `A` in either column → **created**,
-/// - else a `D` in either column → **deleted**,
-/// - else anything changed (`M`, `R`, `C`, `T`, `U`, …) → **modified**.
-fn working_tree_category(x: char, y: char) -> WtCategory {
-  if (x == '?' && y == '?') || x == 'A' || y == 'A' {
-    WtCategory::Created
-  } else if x == 'D' || y == 'D' {
-    WtCategory::Deleted
-  } else {
-    WtCategory::Modified
-  }
-}
 
 /// Theme colour for a change category (issue #287): created → `untracked`
 /// (green), modified → `modified` (yellow), deleted → `prunable` (red).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1210,27 +1210,15 @@ fn working_tree_category_color(cat: WtCategory, theme: &Theme) -> Color {
   }
 }
 
-/// Tally `git status --short` porcelain output into per-category
-/// [`WorkingTreeCounts`] (issue #287) via [`working_tree_category`]. Lines
-/// too short to carry an `XY` pair, or an all-blank pair, are skipped —
-/// real porcelain output never produces them, but the helper is `pub` so a
-/// non-git caller could.
-pub fn working_tree_status_counts(status_short: &str) -> WorkingTreeCounts {
+/// Tally `git status --porcelain -z` output into per-category
+/// [`WorkingTreeCounts`] (issue #287) via [`working_tree_category`]. Shares
+/// the NUL-delimited parser ([`wt_tree::parse_status_z`]) with the file
+/// tree, so a rename counts once (its source token is dropped) and the
+/// footer total always matches the number of rows the tree renders.
+pub fn working_tree_status_counts(status_z: &str) -> WorkingTreeCounts {
   let mut c = WorkingTreeCounts::default();
-  for line in status_short.lines() {
-    let mut chars = line.chars();
-    let x = match chars.next() {
-      Some(ch) => ch,
-      None => continue,
-    };
-    let y = match chars.next() {
-      Some(ch) => ch,
-      None => continue,
-    };
-    if x == ' ' && y == ' ' {
-      continue;
-    }
-    match working_tree_category(x, y) {
+  for rec in wt_tree::parse_status_z(status_z) {
+    match working_tree_category(rec.x, rec.y) {
       WtCategory::Created => c.created += 1,
       WtCategory::Modified => c.modified += 1,
       WtCategory::Deleted => c.deleted += 1,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1112,7 +1112,19 @@ fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, W
     ),
     Ok(s) => {
       let counts = working_tree_status_counts(&s);
-      let lines = working_tree_tree_lines(&wt_tree::build_tree(&s), theme);
+      let records = wt_tree::parse_status_z(&s);
+      // Cap the explorer for a pathological untracked-dir explosion (issue
+      // #300): build at most WT_TREE_MAX_FILES leaves and surface the
+      // remainder as a single muted `… N more` row, so the non-scrollable
+      // section can't be sized from tens of thousands of files.
+      let (tree, overflow) = wt_tree::build_capped_tree(&records, wt_tree::WT_TREE_MAX_FILES);
+      let mut lines = working_tree_tree_lines(&tree, theme);
+      if overflow > 0 {
+        lines.push(Line::from(Span::styled(
+          format!("… {} more", overflow),
+          Style::default().fg(theme.muted),
+        )));
+      }
       (lines, counts)
     }
     Err(e) => (
@@ -1126,33 +1138,52 @@ fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, W
 }
 
 /// Render the Working Tree file-explorer model (issue #300) into styled
-/// sidebar rows. Directories are emitted before their children with a
-/// folder glyph in the `accent` role; files carry a category-coloured
-/// status badge + a nerd-font file-type icon + the leaf name, all painted
-/// in the file's change-category colour so a row's colour matches the
-/// footer count it belongs to (the #287 invariant, preserved). Two spaces
-/// of indentation per depth level give the tree its shape.
+/// sidebar rows.
+///
+/// - **Connector lines**: each row is prefixed with box-drawing branches
+///   (`├─ ` / `└─ ` with `│  ` / `   ` carried down from ancestors) in the
+///   muted role, so the hierarchy reads like `tree(1)`.
+/// - **Directory colour is retroactive**: a folder is painted by the
+///   aggregate git category of its subtree — only-modified → yellow,
+///   only-new → green, only-deleted → red, mixed (or none) → neutral
+///   `accent`.
+/// - **Files** carry a category-coloured status badge + a nerd-font
+///   file-type icon + the leaf name, painted in the file's change-category
+///   colour so a row's colour matches the footer count it belongs to (the
+///   #287 invariant, preserved).
+/// - An **extra space** follows each nerd-font glyph: most glyphs render
+///   double-width but occupy a single terminal cell, so the pad keeps the
+///   following text from being clipped.
 fn working_tree_tree_lines(nodes: &[WtNode], theme: &Theme) -> Vec<Line<'static>> {
   let mut out = Vec::new();
-  push_wt_nodes(&mut out, nodes, 0, theme);
+  push_wt_nodes(&mut out, nodes, String::new(), theme);
   out
 }
 
-/// Depth-first walk used by [`working_tree_tree_lines`]; recurses into each
-/// directory's children one indent level deeper.
-fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], depth: usize, theme: &Theme) {
-  let indent = "  ".repeat(depth);
-  for node in nodes {
+/// Depth-first walk used by [`working_tree_tree_lines`]. `prefix` is the
+/// accumulated ancestor connector string; each child appends `├─ `/`└─ `
+/// for its own row and `│  `/`   ` for its descendants.
+fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], prefix: String, theme: &Theme) {
+  let last = nodes.len().saturating_sub(1);
+  for (i, node) in nodes.iter().enumerate() {
+    let is_last = i == last;
+    let connector = format!("{}{}", prefix, if is_last { "└─ " } else { "├─ " });
     match node {
-      WtNode::Dir { name, children } => {
+      WtNode::Dir {
+        name,
+        children,
+        category,
+      } => {
+        let color = match category {
+          Some(c) => working_tree_category_color(*c, theme),
+          None => theme.accent,
+        };
         out.push(Line::from(vec![
-          Span::raw(indent.clone()),
-          Span::styled(
-            format!("{} {}", WT_DIR_OPEN_ICON, name),
-            Style::default().fg(theme.accent),
-          ),
+          Span::styled(connector, Style::default().fg(theme.muted)),
+          Span::styled(format!("{}  {}", WT_DIR_OPEN_ICON, name), Style::default().fg(color)),
         ]));
-        push_wt_nodes(out, children, depth + 1, theme);
+        let child_prefix = format!("{}{}", prefix, if is_last { "   " } else { "│  " });
+        push_wt_nodes(out, children, child_prefix, theme);
       }
       WtNode::File {
         name,
@@ -1162,9 +1193,9 @@ fn push_wt_nodes(out: &mut Vec<Line<'static>>, nodes: &[WtNode], depth: usize, t
       } => {
         let color = working_tree_category_color(*category, theme);
         out.push(Line::from(vec![
-          Span::raw(indent.clone()),
+          Span::styled(connector, Style::default().fg(theme.muted)),
           Span::styled(format!("{} ", badge), Style::default().fg(color)),
-          Span::styled(format!("{} {}", icon, name), Style::default().fg(color)),
+          Span::styled(format!("{}  {}", icon, name), Style::default().fg(color)),
         ]));
       }
     }

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -174,10 +174,17 @@ pub fn build_tree(status_short: &str) -> Vec<WtNode> {
       continue;
     }
     let rest: String = chars.collect();
-    // Take the rename destination (if any), then decode git's C-quoting —
-    // the ` -> ` separator is added outside the quotes, so splitting the raw
-    // token first is safe.
-    let path = decode_porcelain_path(rename_destination(rest.trim()));
+    let trimmed = rest.trim();
+    // ` -> ` is git's separator only on a rename/copy line (`R`/`C` in either
+    // status column); on any other status a literal ` -> ` is part of the
+    // filename and must be kept. Decode git's C-quoting afterwards — the
+    // separator is added outside the quotes, so splitting first is safe.
+    let token = if x == 'R' || x == 'C' || y == 'R' || y == 'C' {
+      rename_destination(trimmed)
+    } else {
+      trimmed
+    };
+    let path = decode_porcelain_path(token);
     if path.is_empty() {
       continue;
     }

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -129,6 +129,16 @@ pub fn file_icon(name: &str) -> &'static str {
   }
 }
 
+/// Make a path segment safe to render in the TUI: every control character
+/// (newline, tab, carriage return, ANSI escape, …) becomes `?`. `-z` emits
+/// filenames verbatim, so a name carrying embedded control bytes could
+/// otherwise break the sidebar layout or inject terminal escape sequences;
+/// the real bytes still live in git, this only guards what reaches the
+/// screen.
+pub fn sanitize_name(name: &str) -> String {
+  name.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
+}
+
 /// A node in the Working Tree file-explorer model. A `Dir` carries its
 /// (possibly collapsed) display name, ordered children, and the aggregate
 /// change-category of its subtree (issue #300: `Some(c)` when every

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -174,11 +174,14 @@ pub fn build_tree(status_short: &str) -> Vec<WtNode> {
       continue;
     }
     let rest: String = chars.collect();
-    let path = rename_destination(rest.trim());
+    // Take the rename destination (if any), then decode git's C-quoting —
+    // the ` -> ` separator is added outside the quotes, so splitting the raw
+    // token first is safe.
+    let path = decode_porcelain_path(rename_destination(rest.trim()));
     if path.is_empty() {
       continue;
     }
-    root.insert(path, x, y);
+    root.insert(&path, x, y);
   }
   root.into_nodes()
 }
@@ -190,6 +193,95 @@ fn rename_destination(path: &str) -> &str {
     Some((_, dest)) => dest,
     None => path,
   }
+}
+
+/// Decode a `git status --short` path token. When a path carries "unusual"
+/// bytes (non-ASCII under the default `core.quotePath`, a literal `"` or
+/// `\`, or a control char) git wraps it in double quotes and C-escapes the
+/// payload; this reverses that quoting back to the real name. An unquoted
+/// token is returned as-is.
+fn decode_porcelain_path(token: &str) -> String {
+  let bytes = token.as_bytes();
+  if bytes.len() >= 2 && bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
+    unquote_c(&token[1..token.len() - 1])
+  } else {
+    token.to_string()
+  }
+}
+
+/// Reverse git's C-style string quoting: the named escapes plus octal byte
+/// escapes (`\ooo`). Octal escapes are accumulated as raw bytes so a
+/// multi-byte UTF-8 codepoint (emitted as several `\ooo`) reassembles
+/// correctly; the byte buffer is then decoded lossily. An unrecognised
+/// escape keeps its backslash verbatim.
+fn unquote_c(s: &str) -> String {
+  let bytes = s.as_bytes();
+  let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+  let mut i = 0;
+  while i < bytes.len() {
+    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+      match bytes[i + 1] {
+        b'n' => {
+          out.push(b'\n');
+          i += 2;
+        }
+        b't' => {
+          out.push(b'\t');
+          i += 2;
+        }
+        b'r' => {
+          out.push(b'\r');
+          i += 2;
+        }
+        b'a' => {
+          out.push(0x07);
+          i += 2;
+        }
+        b'b' => {
+          out.push(0x08);
+          i += 2;
+        }
+        b'f' => {
+          out.push(0x0c);
+          i += 2;
+        }
+        b'v' => {
+          out.push(0x0b);
+          i += 2;
+        }
+        b'"' => {
+          out.push(b'"');
+          i += 2;
+        }
+        b'\\' => {
+          out.push(b'\\');
+          i += 2;
+        }
+        b'0'..=b'7' => {
+          let mut val: u32 = 0;
+          let mut digits = 0;
+          let mut j = i + 1;
+          while j < bytes.len() && digits < 3 && bytes[j].is_ascii_digit() && bytes[j] < b'8' {
+            val = val * 8 + u32::from(bytes[j] - b'0');
+            j += 1;
+            digits += 1;
+          }
+          out.push(val as u8);
+          i = j;
+        }
+        _ => {
+          // Unknown escape: keep the backslash and let the next byte be
+          // handled on the following iteration.
+          out.push(b'\\');
+          i += 1;
+        }
+      }
+    } else {
+      out.push(bytes[i]);
+      i += 1;
+    }
+  }
+  String::from_utf8_lossy(&out).into_owned()
 }
 
 // Intermediate mutable builder kept private; `BTreeMap` gives the

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -1,0 +1,262 @@
+//! Working Tree file-explorer model (issue #300).
+//!
+//! A **pure, ratatui-free** transform of `git status --short` porcelain
+//! output (`XY PATH` lines) into a nested directory tree, so the Status
+//! pane's Working Tree section can render like a real file explorer
+//! (nerd-font folder / file-type icons + a per-file change badge) instead
+//! of a flat list. The renderer in [`super::ui`] walks the [`WtNode`] tree
+//! and paints it with [`Theme`](super::theme::Theme) colours; everything in
+//! this module is deterministic and theme-free so it can be unit-tested
+//! without a terminal.
+//!
+//! Layout rules baked into [`build_tree`]:
+//!
+//! - **Nesting** by path segment (`src/tui/ui.rs` → `src` → `tui` → `ui.rs`).
+//! - **Directories before files**, alphabetical within each level.
+//! - **Single-child directory chains collapse** for compactness
+//!   (`src` → `tui` → `ui.rs` renders as `src/tui/` then `ui.rs`), matching
+//!   the way file explorers fold empty intermediate folders.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Nerd-font glyph for a closed directory (`nf-fa-folder`). Kept public so
+/// a future expand/collapse affordance (issue #300, deferred) can pick the
+/// closed variant; the MVP renders the full tree with [`WT_DIR_OPEN_ICON`].
+pub const WT_DIR_ICON: &str = "\u{f07b}";
+/// Nerd-font glyph for an open directory (`nf-fa-folder_open`). The MVP
+/// always shows children, so every directory row uses this.
+pub const WT_DIR_OPEN_ICON: &str = "\u{f07c}";
+/// Generic file glyph (`nf-fa-file`) — the fallback when no extension in
+/// [`file_icon`]'s table matches.
+pub const WT_FILE_ICON: &str = "\u{f15b}";
+
+/// `.rs` (`nf-dev-rust`).
+pub const WT_RUST_ICON: &str = "\u{e7a8}";
+/// `.md` / `.markdown` (`nf-oct-markdown`).
+pub const WT_MARKDOWN_ICON: &str = "\u{f48a}";
+/// `.toml` (`nf-seti-config`).
+pub const WT_TOML_ICON: &str = "\u{e615}";
+/// `.json` (`nf-seti-json`).
+pub const WT_JSON_ICON: &str = "\u{e60b}";
+/// `.js` / `.cjs` / `.mjs` (`nf-seti-javascript`).
+pub const WT_JS_ICON: &str = "\u{e74e}";
+/// `.ts` / `.tsx` (`nf-seti-typescript`).
+pub const WT_TS_ICON: &str = "\u{e628}";
+/// `.lock` (`nf-fa-lock`).
+pub const WT_LOCK_ICON: &str = "\u{f023}";
+/// `.yml` / `.yaml` (`nf-seti-yml`).
+pub const WT_YAML_ICON: &str = "\u{e6a8}";
+/// `.sh` / `.bash` / `.zsh` (`nf-oct-terminal`).
+pub const WT_SHELL_ICON: &str = "\u{f489}";
+/// `.txt` (`nf-fa-file_text`).
+pub const WT_TEXT_ICON: &str = "\u{f15c}";
+
+/// The single change-category a `git status --short` `XY` pair falls into
+/// (issue #287, relocated here in #300 to be the shared, ratatui-free
+/// source of truth). Drives both the Working-Tree footer counts and the
+/// per-row / per-badge colouring so a file's colour always equals the
+/// footer segment it's counted in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WtCategory {
+  Created,
+  Modified,
+  Deleted,
+}
+
+/// Classify a porcelain `XY` status pair into its dominant
+/// [`WtCategory`], with a deterministic precedence (created > deleted >
+/// modified) so each file maps to exactly one bucket:
+///
+/// - `??` (untracked) or an `A` in either column → **created**,
+/// - else a `D` in either column → **deleted**,
+/// - else anything changed (`M`, `R`, `C`, `T`, `U`, …) → **modified**.
+pub fn working_tree_category(x: char, y: char) -> WtCategory {
+  if (x == '?' && y == '?') || x == 'A' || y == 'A' {
+    WtCategory::Created
+  } else if x == 'D' || y == 'D' {
+    WtCategory::Deleted
+  } else {
+    WtCategory::Modified
+  }
+}
+
+/// Representative single-character status badge for a porcelain `XY` pair,
+/// shown at the start of a file row in the same colour as its
+/// [`WtCategory`]:
+///
+/// - `??` → `?` (untracked, created colour),
+/// - `A` in either column → `A` (added, created colour),
+/// - `D` in either column → `D` (deleted colour),
+/// - anything else → `M` (modified colour).
+///
+/// The precedence mirrors [`working_tree_category`] so badge and row colour
+/// never disagree.
+pub fn status_badge(x: char, y: char) -> char {
+  if x == '?' && y == '?' {
+    '?'
+  } else if x == 'A' || y == 'A' {
+    'A'
+  } else if x == 'D' || y == 'D' {
+    'D'
+  } else {
+    'M'
+  }
+}
+
+/// Pick a nerd-font glyph for a file by its extension, falling back to the
+/// generic [`WT_FILE_ICON`] for unknown or extension-less names (including
+/// dotfiles like `.gitignore`). The match is a single table so new types
+/// are a one-line addition.
+pub fn file_icon(name: &str) -> &'static str {
+  let ext = Path::new(name)
+    .extension()
+    .and_then(|e| e.to_str())
+    .unwrap_or("")
+    .to_ascii_lowercase();
+  match ext.as_str() {
+    "rs" => WT_RUST_ICON,
+    "md" | "markdown" => WT_MARKDOWN_ICON,
+    "toml" => WT_TOML_ICON,
+    "json" => WT_JSON_ICON,
+    "js" | "cjs" | "mjs" => WT_JS_ICON,
+    "ts" | "tsx" => WT_TS_ICON,
+    "lock" => WT_LOCK_ICON,
+    "yml" | "yaml" => WT_YAML_ICON,
+    "sh" | "bash" | "zsh" => WT_SHELL_ICON,
+    "txt" => WT_TEXT_ICON,
+    _ => WT_FILE_ICON,
+  }
+}
+
+/// A node in the Working Tree file-explorer model. A `Dir` carries its
+/// (possibly collapsed) display name and ordered children; a `File` carries
+/// its leaf name plus the precomputed icon, badge glyph, and change
+/// category the renderer needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WtNode {
+  Dir {
+    name: String,
+    children: Vec<WtNode>,
+  },
+  File {
+    name: String,
+    icon: &'static str,
+    badge: char,
+    category: WtCategory,
+  },
+}
+
+/// Build the nested Working Tree model from `git status --short` porcelain
+/// output. Each `XY PATH` line becomes a leaf at the end of its path
+/// segments; intermediate segments are directories. Renames
+/// (`R  old -> new`) key off the destination. The result is dir-first
+/// alphabetical at every level with single-child directory chains
+/// collapsed.
+///
+/// Lines too short to carry an `XY` pair, or whose path is empty, are
+/// skipped — real porcelain output never produces them, but the helper
+/// stays total for non-git callers.
+pub fn build_tree(status_short: &str) -> Vec<WtNode> {
+  let mut root = DirBuilder::default();
+  for line in status_short.lines() {
+    let mut chars = line.chars();
+    let x = match chars.next() {
+      Some(c) => c,
+      None => continue,
+    };
+    let y = match chars.next() {
+      Some(c) => c,
+      None => continue,
+    };
+    // Skip the separator char; the remainder (trimmed) is the path.
+    if chars.next().is_none() {
+      continue;
+    }
+    let rest: String = chars.collect();
+    let path = rename_destination(rest.trim());
+    if path.is_empty() {
+      continue;
+    }
+    root.insert(path, x, y);
+  }
+  root.into_nodes()
+}
+
+/// Porcelain renames render the path as `old -> new`; keep only the
+/// destination. A plain path is returned unchanged.
+fn rename_destination(path: &str) -> &str {
+  match path.rsplit_once(" -> ") {
+    Some((_, dest)) => dest,
+    None => path,
+  }
+}
+
+// Intermediate mutable builder kept private; `BTreeMap` gives the
+// alphabetical ordering for free, and emitting dirs before files yields the
+// dir-first rule.
+#[derive(Default)]
+struct DirBuilder {
+  dirs: BTreeMap<String, DirBuilder>,
+  files: BTreeMap<String, FileLeaf>,
+}
+
+struct FileLeaf {
+  icon: &'static str,
+  badge: char,
+  category: WtCategory,
+}
+
+impl DirBuilder {
+  /// Insert one `XY PATH` entry, splitting `path` on `/` into directory
+  /// segments plus a final file leaf. Empty segments (a trailing slash or
+  /// `//`) are ignored so a stray separator can't spawn a blank node.
+  fn insert(&mut self, path: &str, x: char, y: char) {
+    let mut segments = path.split('/').filter(|s| !s.is_empty()).peekable();
+    let mut node = self;
+    while let Some(seg) = segments.next() {
+      if segments.peek().is_none() {
+        // Last segment → the file leaf.
+        node.files.insert(
+          seg.to_string(),
+          FileLeaf {
+            icon: file_icon(seg),
+            badge: status_badge(x, y),
+            category: working_tree_category(x, y),
+          },
+        );
+        return;
+      }
+      node = node.dirs.entry(seg.to_string()).or_default();
+    }
+  }
+
+  /// Lower the mutable builder into the public [`WtNode`] tree: directories
+  /// first (alphabetical, courtesy of `BTreeMap`), then files. Single-child
+  /// directory chains (a dir holding exactly one subdir and no files) are
+  /// folded into a single `a/b/c` row for compactness.
+  fn into_nodes(self) -> Vec<WtNode> {
+    let mut out = Vec::with_capacity(self.dirs.len() + self.files.len());
+    for (mut name, mut dir) in self.dirs {
+      while dir.files.is_empty() && dir.dirs.len() == 1 {
+        let (child_name, child_dir) = dir.dirs.into_iter().next().unwrap();
+        name.push('/');
+        name.push_str(&child_name);
+        dir = child_dir;
+      }
+      out.push(WtNode::Dir {
+        name,
+        children: dir.into_nodes(),
+      });
+    }
+    for (name, leaf) in self.files {
+      out.push(WtNode::File {
+        name,
+        icon: leaf.icon,
+        badge: leaf.badge,
+        category: leaf.category,
+      });
+    }
+    out
+  }
+}

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -130,14 +130,18 @@ pub fn file_icon(name: &str) -> &'static str {
 }
 
 /// A node in the Working Tree file-explorer model. A `Dir` carries its
-/// (possibly collapsed) display name and ordered children; a `File` carries
-/// its leaf name plus the precomputed icon, badge glyph, and change
-/// category the renderer needs.
+/// (possibly collapsed) display name, ordered children, and the aggregate
+/// change-category of its subtree (issue #300: `Some(c)` when every
+/// descendant shares category `c`, `None` when the subtree mixes
+/// categories) so the directory row can be coloured by what it contains. A
+/// `File` carries its leaf name plus the precomputed icon, badge glyph, and
+/// change category the renderer needs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WtNode {
   Dir {
     name: String,
     children: Vec<WtNode>,
+    category: Option<WtCategory>,
   },
   File {
     name: String,
@@ -145,6 +149,30 @@ pub enum WtNode {
     badge: char,
     category: WtCategory,
   },
+}
+
+/// Aggregate change-category of a directory subtree (issue #300): `Some(c)`
+/// when every categorised descendant shares category `c`, `None` when they
+/// mix (or the subtree is empty). A child directory that is itself mixed
+/// (`None`) makes its parent mixed too. Drives the retroactive directory
+/// colouring — a folder of only-modified files reads yellow, only-new
+/// green, only-deleted red, and a mixed folder a neutral accent.
+fn aggregate_category(children: &[WtNode]) -> Option<WtCategory> {
+  let mut found: Option<WtCategory> = None;
+  for child in children {
+    let cat = match child {
+      WtNode::File { category, .. } => *category,
+      WtNode::Dir { category: Some(c), .. } => *c,
+      // A child subtree that is already mixed makes this directory mixed.
+      WtNode::Dir { category: None, .. } => return None,
+    };
+    match found {
+      None => found = Some(cat),
+      Some(f) if f == cat => {}
+      Some(_) => return None,
+    }
+  }
+  found
 }
 
 /// One parsed `git status --porcelain -z` record: the two status columns
@@ -212,11 +240,29 @@ pub fn parse_status_z(raw: &str) -> Vec<StatusRecord> {
 /// directories. The result is dir-first alphabetical at every level with
 /// single-child directory chains collapsed.
 pub fn build_tree(status_z: &str) -> Vec<WtNode> {
+  build_capped_tree(&parse_status_z(status_z), usize::MAX).0
+}
+
+/// Maximum file leaves the Working Tree explorer builds in one pass (issue
+/// #300). `--untracked-files=all` makes git enumerate every file inside an
+/// unignored generated/vendor directory; without a cap the sidebar would
+/// build and cache one `Line` per file and size its non-scrollable section
+/// from that full length, so selecting such a worktree could flood the TUI.
+/// Past the cap, [`build_capped_tree`] stops and reports the remainder for
+/// a single `… N more` row.
+pub const WT_TREE_MAX_FILES: usize = 500;
+
+/// Build the nested model from at most `max` of `records`, returning the
+/// node list plus the number of records dropped past the cap (`0` when
+/// nothing was capped). The kept records are the first `max` in the order
+/// git emitted them.
+pub fn build_capped_tree(records: &[StatusRecord], max: usize) -> (Vec<WtNode>, usize) {
+  let shown = records.len().min(max);
   let mut root = DirBuilder::default();
-  for rec in parse_status_z(status_z) {
+  for rec in &records[..shown] {
     root.insert(&rec.path, rec.x, rec.y);
   }
-  root.into_nodes()
+  (root.into_nodes(), records.len() - shown)
 }
 
 // Intermediate mutable builder kept private; `BTreeMap` gives the
@@ -271,9 +317,12 @@ impl DirBuilder {
         name.push_str(&child_name);
         dir = child_dir;
       }
+      let children = dir.into_nodes();
+      let category = aggregate_category(&children);
       out.push(WtNode::Dir {
         name,
-        children: dir.into_nodes(),
+        children,
+        category,
       });
     }
     for (name, leaf) in self.files {

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -147,20 +147,39 @@ pub enum WtNode {
   },
 }
 
-/// Build the nested Working Tree model from `git status --short` porcelain
-/// output. Each `XY PATH` line becomes a leaf at the end of its path
-/// segments; intermediate segments are directories. Renames
-/// (`R  old -> new`) key off the destination. The result is dir-first
-/// alphabetical at every level with single-child directory chains
-/// collapsed.
+/// One parsed `git status --porcelain -z` record: the two status columns
+/// and the working-tree path. For a rename/copy this is the **destination**
+/// (the source token is consumed and dropped during parsing), so every
+/// record is a live entry the tree can nest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusRecord {
+  pub x: char,
+  pub y: char,
+  pub path: String,
+}
+
+/// Parse `git status --porcelain -z` output into [`StatusRecord`]s.
 ///
-/// Lines too short to carry an `XY` pair, or whose path is empty, are
-/// skipped — real porcelain output never produces them, but the helper
-/// stays total for non-git callers.
-pub fn build_tree(status_short: &str) -> Vec<WtNode> {
-  let mut root = DirBuilder::default();
-  for line in status_short.lines() {
-    let mut chars = line.chars();
+/// The `-z` format is a run of **NUL-terminated** tokens, each `XY<space>PATH`;
+/// a rename/copy entry (`R`/`C` in either status column) is immediately
+/// *followed* by a second NUL-terminated token carrying its original path,
+/// which is skipped. Crucially, `-z` emits paths **verbatim** — no double-
+/// quoting, no C-escapes — and delimits on NUL, so a filename containing a
+/// space, a literal ` -> `, a quote, or non-ASCII bytes is unambiguous.
+/// This is why the file-explorer reads `-z` rather than the human `--short`
+/// format: it removes every textual-parsing edge case at the source.
+///
+/// Tokens too short to carry an `XY` pair, or with an empty path, are
+/// skipped; the trailing NUL's empty token is ignored. The helper is total
+/// for non-git callers.
+pub fn parse_status_z(raw: &str) -> Vec<StatusRecord> {
+  let mut records = Vec::new();
+  let mut tokens = raw.split('\0');
+  while let Some(tok) = tokens.next() {
+    if tok.is_empty() {
+      continue;
+    }
+    let mut chars = tok.chars();
     let x = match chars.next() {
       Some(c) => c,
       None => continue,
@@ -169,126 +188,35 @@ pub fn build_tree(status_short: &str) -> Vec<WtNode> {
       Some(c) => c,
       None => continue,
     };
-    // Skip the separator char; the remainder (trimmed) is the path.
+    // Skip the single separator space between the `XY` pair and the path.
     if chars.next().is_none() {
       continue;
     }
-    let rest: String = chars.collect();
-    let trimmed = rest.trim();
-    // ` -> ` is git's separator only on a rename/copy line (`R`/`C` in either
-    // status column); on any other status a literal ` -> ` is part of the
-    // filename and must be kept. Decode git's C-quoting afterwards — the
-    // separator is added outside the quotes, so splitting first is safe.
-    let token = if x == 'R' || x == 'C' || y == 'R' || y == 'C' {
-      rename_destination(trimmed)
-    } else {
-      trimmed
-    };
-    let path = decode_porcelain_path(token);
+    let path: String = chars.collect();
     if path.is_empty() {
       continue;
     }
-    root.insert(&path, x, y);
+    // A rename/copy entry is trailed by its source-path token — drop it so
+    // the source dir doesn't show up as a phantom entry.
+    if x == 'R' || x == 'C' || y == 'R' || y == 'C' {
+      tokens.next();
+    }
+    records.push(StatusRecord { x, y, path });
+  }
+  records
+}
+
+/// Build the nested Working Tree model from `git status --porcelain -z`
+/// output (via [`parse_status_z`]). Each record's path becomes a leaf at
+/// the end of its `/`-separated segments; intermediate segments are
+/// directories. The result is dir-first alphabetical at every level with
+/// single-child directory chains collapsed.
+pub fn build_tree(status_z: &str) -> Vec<WtNode> {
+  let mut root = DirBuilder::default();
+  for rec in parse_status_z(status_z) {
+    root.insert(&rec.path, rec.x, rec.y);
   }
   root.into_nodes()
-}
-
-/// Porcelain renames render the path as `old -> new`; keep only the
-/// destination. A plain path is returned unchanged.
-fn rename_destination(path: &str) -> &str {
-  match path.rsplit_once(" -> ") {
-    Some((_, dest)) => dest,
-    None => path,
-  }
-}
-
-/// Decode a `git status --short` path token. When a path carries "unusual"
-/// bytes (non-ASCII under the default `core.quotePath`, a literal `"` or
-/// `\`, or a control char) git wraps it in double quotes and C-escapes the
-/// payload; this reverses that quoting back to the real name. An unquoted
-/// token is returned as-is.
-fn decode_porcelain_path(token: &str) -> String {
-  let bytes = token.as_bytes();
-  if bytes.len() >= 2 && bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
-    unquote_c(&token[1..token.len() - 1])
-  } else {
-    token.to_string()
-  }
-}
-
-/// Reverse git's C-style string quoting: the named escapes plus octal byte
-/// escapes (`\ooo`). Octal escapes are accumulated as raw bytes so a
-/// multi-byte UTF-8 codepoint (emitted as several `\ooo`) reassembles
-/// correctly; the byte buffer is then decoded lossily. An unrecognised
-/// escape keeps its backslash verbatim.
-fn unquote_c(s: &str) -> String {
-  let bytes = s.as_bytes();
-  let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-  let mut i = 0;
-  while i < bytes.len() {
-    if bytes[i] == b'\\' && i + 1 < bytes.len() {
-      match bytes[i + 1] {
-        b'n' => {
-          out.push(b'\n');
-          i += 2;
-        }
-        b't' => {
-          out.push(b'\t');
-          i += 2;
-        }
-        b'r' => {
-          out.push(b'\r');
-          i += 2;
-        }
-        b'a' => {
-          out.push(0x07);
-          i += 2;
-        }
-        b'b' => {
-          out.push(0x08);
-          i += 2;
-        }
-        b'f' => {
-          out.push(0x0c);
-          i += 2;
-        }
-        b'v' => {
-          out.push(0x0b);
-          i += 2;
-        }
-        b'"' => {
-          out.push(b'"');
-          i += 2;
-        }
-        b'\\' => {
-          out.push(b'\\');
-          i += 2;
-        }
-        b'0'..=b'7' => {
-          let mut val: u32 = 0;
-          let mut digits = 0;
-          let mut j = i + 1;
-          while j < bytes.len() && digits < 3 && bytes[j].is_ascii_digit() && bytes[j] < b'8' {
-            val = val * 8 + u32::from(bytes[j] - b'0');
-            j += 1;
-            digits += 1;
-          }
-          out.push(val as u8);
-          i = j;
-        }
-        _ => {
-          // Unknown escape: keep the backslash and let the next byte be
-          // handled on the following iteration.
-          out.push(b'\\');
-          i += 1;
-        }
-      }
-    } else {
-      out.push(bytes[i]);
-      i += 1;
-    }
-  }
-  String::from_utf8_lossy(&out).into_owned()
 }
 
 // Intermediate mutable builder kept private; `BTreeMap` gives the

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1136,10 +1136,17 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   Ok(entries)
 }
 
-/// Shell out to `git status --short` inside `path` and return raw stdout.
-/// Used by the TUI sidebar to preview the working-tree state.
+/// Shell out to `git status --short --untracked-files=all` inside `path`
+/// and return raw stdout. Used by the TUI sidebar to preview the working-
+/// tree state.
+///
+/// `--untracked-files=all` (issue #300) expands an entirely-untracked
+/// directory into its individual files (`src/app/mod.rs`) instead of git's
+/// default single collapsed `src/` row, so the Working Tree file-explorer
+/// can nest them. Git-ignored paths (e.g. `target/`) stay excluded, so this
+/// never floods the pane with build artefacts.
 pub fn git_status_short(path: &Path) -> Result<String> {
-  run_git(path, &["status", "--short"])
+  run_git(path, &["status", "--short", "--untracked-files=all"])
 }
 
 /// Time elapsed since the *oldest* commit on `branch` that's not also on a

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1179,7 +1179,13 @@ pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<(String, bool)
   use std::io::{BufRead, BufReader};
   use std::process::{Command, Stdio};
 
+  // `--no-optional-locks` keeps git from taking the index lock for its
+  // opportunistic stat-cache refresh (the flag git ships for status pollers
+  // like IDEs / watchman). Without it, killing the child at the cap could
+  // leave a stale `.git/index.lock` behind and break the next git command in
+  // that worktree.
   let mut child = Command::new("git")
+    .arg("--no-optional-locks")
     .arg("-C")
     .arg(path)
     .args(["status", "--porcelain", "-z", "--untracked-files=all"])

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1136,9 +1136,19 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   Ok(entries)
 }
 
-/// Shell out to `git status --porcelain -z --untracked-files=all` inside
-/// `path` and return raw stdout. Used by the TUI sidebar to preview the
-/// working-tree state.
+/// Hard cap on the number of NUL-terminated `git status -z` records read
+/// before the scan is abandoned (issue #300). `--untracked-files=all` makes
+/// git recurse into unignored generated/vendor directories; streaming the
+/// output and stopping here bounds **both** git's directory walk (the child
+/// is killed once the cap is hit) and our own parse / allocation, so a
+/// pathological worktree can't stall the TUI. Set well above any realistic
+/// change set; the file tree itself renders at most
+/// [`crate::tui::wt_tree::WT_TREE_MAX_FILES`].
+pub const STATUS_SCAN_CAP: usize = 5000;
+
+/// Stream `git status --porcelain -z --untracked-files=all` inside `path`
+/// and return raw stdout, capped at [`STATUS_SCAN_CAP`] records. Used by the
+/// TUI sidebar to preview the working-tree state.
 ///
 /// Two flags matter for the Working Tree file-explorer (issue #300):
 ///
@@ -1155,7 +1165,82 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
 ///   without guesswork. The footer counts (issue #287) parse the same
 ///   stream.
 pub fn git_status_short(path: &Path) -> Result<String> {
-  run_git(path, &["status", "--porcelain", "-z", "--untracked-files=all"])
+  git_status_short_capped(path, STATUS_SCAN_CAP)
+}
+
+/// Cap-injectable core of [`git_status_short`]. Spawns git with a piped
+/// stdout, reads NUL-terminated records until `cap` is reached (then kills
+/// the child so git stops walking the tree), and returns the bytes gathered
+/// so far. Exposed so integration tests can exercise truncation with a small
+/// `cap` instead of creating thousands of files.
+pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<String> {
+  use std::io::{BufRead, BufReader};
+  use std::process::{Command, Stdio};
+
+  let mut child = Command::new("git")
+    .arg("-C")
+    .arg(path)
+    .args(["status", "--porcelain", "-z", "--untracked-files=all"])
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .map_err(|e| GwmError::CommandFailed(format!("git status failed to spawn: {}", e)))?;
+
+  let stdout = child
+    .stdout
+    .take()
+    .ok_or_else(|| GwmError::CommandFailed("git status: stdout pipe missing".to_string()))?;
+  let mut reader = BufReader::new(stdout);
+  let mut collected: Vec<u8> = Vec::new();
+  let mut segment: Vec<u8> = Vec::new();
+  let mut records = 0usize;
+  let mut truncated = false;
+  loop {
+    if records >= cap {
+      truncated = true;
+      break;
+    }
+    segment.clear();
+    let n = reader
+      .read_until(0u8, &mut segment)
+      .map_err(|e| GwmError::CommandFailed(format!("git status: read failed: {}", e)))?;
+    if n == 0 {
+      break; // EOF — git produced fewer than `cap` records.
+    }
+    collected.extend_from_slice(&segment);
+    // A trailing NUL marks a complete record; a final unterminated chunk
+    // (only at true EOF) is kept verbatim and just isn't counted.
+    if segment.last() == Some(&0) {
+      records += 1;
+    }
+  }
+
+  if truncated {
+    // We have enough to render — stop git's directory walk. The kill is
+    // best-effort: the child may have already exited on a small tree.
+    let _ = child.kill();
+  }
+  let status = child
+    .wait()
+    .map_err(|e| GwmError::CommandFailed(format!("git status: wait failed: {}", e)))?;
+
+  // A non-truncated, unsuccessful run is a real failure (e.g. not a repo) —
+  // surface git's stderr. A truncated run was killed on purpose, so its
+  // non-zero status is expected and ignored.
+  if !truncated && !status.success() {
+    let mut err = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+      use std::io::Read;
+      let _ = stderr.read_to_string(&mut err);
+    }
+    return Err(GwmError::CommandFailed(format!(
+      "git status exited {}: {}",
+      status,
+      err.trim()
+    )));
+  }
+
+  Ok(String::from_utf8_lossy(&collected).into_owned())
 }
 
 /// Time elapsed since the *oldest* commit on `branch` that's not also on a

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1164,16 +1164,18 @@ pub const STATUS_SCAN_CAP: usize = 5000;
 ///   parse filenames containing spaces, arrows, quotes, or UTF-8 bytes
 ///   without guesswork. The footer counts (issue #287) parse the same
 ///   stream.
-pub fn git_status_short(path: &Path) -> Result<String> {
+pub fn git_status_short(path: &Path) -> Result<(String, bool)> {
   git_status_short_capped(path, STATUS_SCAN_CAP)
 }
 
 /// Cap-injectable core of [`git_status_short`]. Spawns git with a piped
 /// stdout, reads NUL-terminated records until `cap` is reached (then kills
-/// the child so git stops walking the tree), and returns the bytes gathered
-/// so far. Exposed so integration tests can exercise truncation with a small
-/// `cap` instead of creating thousands of files.
-pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<String> {
+/// the child so git stops walking the tree), and returns `(bytes, truncated)`
+/// — the raw stdout gathered so far plus whether the cap was hit (so the
+/// caller reports a lower bound rather than an exact total). Exposed so
+/// integration tests can exercise truncation with a small `cap` instead of
+/// creating thousands of files.
+pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<(String, bool)> {
   use std::io::{BufRead, BufReader};
   use std::process::{Command, Stdio};
 
@@ -1190,6 +1192,17 @@ pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<String> {
     .stdout
     .take()
     .ok_or_else(|| GwmError::CommandFailed("git status: stdout pipe missing".to_string()))?;
+  // Drain stderr on its own thread so a chatty git (advisory warnings under
+  // `-uall`) can't fill the stderr pipe and deadlock against our stdout read.
+  let stderr_reader = child.stderr.take().map(|mut stderr| {
+    std::thread::spawn(move || {
+      use std::io::Read;
+      let mut buf = String::new();
+      let _ = stderr.read_to_string(&mut buf);
+      buf
+    })
+  });
+
   let mut reader = BufReader::new(stdout);
   let mut collected: Vec<u8> = Vec::new();
   let mut segment: Vec<u8> = Vec::new();
@@ -1223,24 +1236,21 @@ pub fn git_status_short_capped(path: &Path, cap: usize) -> Result<String> {
   let status = child
     .wait()
     .map_err(|e| GwmError::CommandFailed(format!("git status: wait failed: {}", e)))?;
+  // Joining the drainer also closes our end of the stderr pipe.
+  let stderr = stderr_reader.and_then(|h| h.join().ok()).unwrap_or_default();
 
   // A non-truncated, unsuccessful run is a real failure (e.g. not a repo) —
   // surface git's stderr. A truncated run was killed on purpose, so its
   // non-zero status is expected and ignored.
   if !truncated && !status.success() {
-    let mut err = String::new();
-    if let Some(mut stderr) = child.stderr.take() {
-      use std::io::Read;
-      let _ = stderr.read_to_string(&mut err);
-    }
     return Err(GwmError::CommandFailed(format!(
       "git status exited {}: {}",
       status,
-      err.trim()
+      stderr.trim()
     )));
   }
 
-  Ok(String::from_utf8_lossy(&collected).into_owned())
+  Ok((String::from_utf8_lossy(&collected).into_owned(), truncated))
 }
 
 /// Time elapsed since the *oldest* commit on `branch` that's not also on a

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1136,17 +1136,26 @@ pub fn git_stash_list(path: &Path, limit: usize) -> Result<Vec<StashEntry>> {
   Ok(entries)
 }
 
-/// Shell out to `git status --short --untracked-files=all` inside `path`
-/// and return raw stdout. Used by the TUI sidebar to preview the working-
-/// tree state.
+/// Shell out to `git status --porcelain -z --untracked-files=all` inside
+/// `path` and return raw stdout. Used by the TUI sidebar to preview the
+/// working-tree state.
 ///
-/// `--untracked-files=all` (issue #300) expands an entirely-untracked
-/// directory into its individual files (`src/app/mod.rs`) instead of git's
-/// default single collapsed `src/` row, so the Working Tree file-explorer
-/// can nest them. Git-ignored paths (e.g. `target/`) stay excluded, so this
-/// never floods the pane with build artefacts.
+/// Two flags matter for the Working Tree file-explorer (issue #300):
+///
+/// - `--untracked-files=all` expands an entirely-untracked directory into
+///   its individual files (`src/app/mod.rs`) instead of git's default
+///   collapsed `src/` row, so the tree can nest them. Git-ignored paths
+///   (e.g. `target/`) stay excluded, so the pane never floods with build
+///   artefacts.
+/// - `--porcelain -z` emits paths **verbatim**, NUL-terminated — no double-
+///   quoting of non-ASCII / special-character names, and renames carry the
+///   source path as a separate NUL field instead of an ambiguous
+///   `old -> new` text join. This lets [`crate::tui::wt_tree::parse_status_z`]
+///   parse filenames containing spaces, arrows, quotes, or UTF-8 bytes
+///   without guesswork. The footer counts (issue #287) parse the same
+///   stream.
 pub fn git_status_short(path: &Path) -> Result<String> {
-  run_git(path, &["status", "--short", "--untracked-files=all"])
+  run_git(path, &["status", "--porcelain", "-z", "--untracked-files=all"])
 }
 
 /// Time elapsed since the *oldest* commit on `branch` that's not also on a

--- a/tests/tui_sidebar_render_tests.rs
+++ b/tests/tui_sidebar_render_tests.rs
@@ -160,6 +160,10 @@ fn working_tree_section_renders_file_tree_with_icons() {
     text.contains(gwm::tui::wt_tree::WT_RUST_ICON),
     "the .rs leaf carries the Rust file-type glyph: {text}"
   );
+  assert!(
+    text.contains('└') || text.contains('├'),
+    "rows are drawn with tree connector lines: {text}"
+  );
 }
 
 /// Run a `git` CLI command in `dir`, asserting success. Lets a render test

--- a/tests/tui_sidebar_render_tests.rs
+++ b/tests/tui_sidebar_render_tests.rs
@@ -131,6 +131,37 @@ fn working_tree_section_renders_colored_status_counts_footer() {
   assert!(text.contains("11"), "footer must render the created-file count: {text}");
 }
 
+#[test]
+fn working_tree_section_renders_file_tree_with_icons() {
+  // A nested untracked file must render as an explorer tree (issue #300):
+  // the collapsed `src/app` directory row with a folder glyph, then the
+  // `mod.rs` leaf with the Rust file-type glyph — not a flat `?? src/app/mod.rs`.
+  let dir = repo_with_commits(1);
+  std::fs::create_dir_all(dir.path().join("src/app")).unwrap();
+  std::fs::write(dir.path().join("src/app/mod.rs"), "fn x() {}").unwrap();
+
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+
+  let text = buffer_text(&terminal);
+  assert!(
+    text.contains("src/app"),
+    "single-child dir chain renders collapsed: {text}"
+  );
+  assert!(text.contains("mod.rs"), "the leaf file name renders: {text}");
+  assert!(
+    text.contains(gwm::tui::wt_tree::WT_DIR_OPEN_ICON),
+    "directory row carries a folder glyph: {text}"
+  );
+  assert!(
+    text.contains(gwm::tui::wt_tree::WT_RUST_ICON),
+    "the .rs leaf carries the Rust file-type glyph: {text}"
+  );
+}
+
 /// Run a `git` CLI command in `dir`, asserting success. Lets a render test
 /// build a feature branch with a deterministic diff against `main`.
 fn git_in(dir: &std::path::Path, args: &[&str]) {

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -895,16 +895,11 @@ fn centered_abs_caps_height_taller_than_the_area() {
 
 #[test]
 fn working_tree_status_counts_buckets_each_file_once() {
-  // One line per porcelain family; created wins over deleted wins over
-  // modified so every line increments exactly one counter.
-  let status = "\
-?? new.rs
- M mod.rs
- D del.rs
-A  added.rs
-AM both.rs
-R  renamed.rs
-";
+  // One NUL-delimited (`-z`) record per porcelain family; created wins over
+  // deleted wins over modified so every record increments exactly one
+  // counter. The rename (`R`) carries a trailing source field (`orig.rs`)
+  // that the shared parser drops, so it still counts once.
+  let status = "?? new.rs\0 M mod.rs\0 D del.rs\0A  added.rs\0AM both.rs\0R  renamed.rs\0orig.rs\0";
   let c = working_tree_status_counts(status);
   assert_eq!(c.created, 3, "?? + A + AM → created: {c:?}");
   assert_eq!(c.modified, 2, " M + R → modified: {c:?}");

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -1,0 +1,150 @@
+//! Pure-state tests for the Working Tree file-explorer model (issue #300).
+//!
+//! Ratatui-free and Theme-free: they pin the flat `XY PATH` → nested tree
+//! transform — nesting, dir-first alphabetical sort, single-child directory
+//! collapse, the extension→icon table, and the per-file status badge /
+//! category — without ever rasterizing a buffer. The render-level
+//! counterpart lives in `tui_sidebar_render_tests.rs`.
+
+use gwm::tui::wt_tree::{
+  build_tree, file_icon, status_badge, working_tree_category, WtCategory, WtNode, WT_FILE_ICON, WT_JSON_ICON,
+  WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
+};
+
+/// Find a direct `Dir` child by name in a node slice.
+fn dir<'a>(nodes: &'a [WtNode], name: &str) -> &'a WtNode {
+  nodes
+    .iter()
+    .find(|n| matches!(n, WtNode::Dir { name: n, .. } if n == name))
+    .unwrap_or_else(|| panic!("no Dir named {name:?} in {nodes:?}"))
+}
+
+/// Borrow a `Dir`'s children.
+fn children(node: &WtNode) -> &[WtNode] {
+  match node {
+    WtNode::Dir { children, .. } => children,
+    other => panic!("expected a Dir, got {other:?}"),
+  }
+}
+
+#[test]
+fn build_tree_empty_status_is_empty() {
+  assert!(build_tree("").is_empty());
+  assert!(build_tree("\n  \n").is_empty(), "blank lines yield no nodes");
+}
+
+#[test]
+fn build_tree_collapses_single_child_directory_chain() {
+  // `src` → `tui` → `ui.rs`: the two single-child dirs fold into one
+  // `src/tui` row, and `ui.rs` stays its own child (issue #300 example).
+  let tree = build_tree("?? src/tui/ui.rs\n");
+  assert_eq!(tree.len(), 1, "one top-level node: {tree:?}");
+  let top = dir(&tree, "src/tui");
+  let kids = children(top);
+  assert_eq!(kids.len(), 1, "the collapsed dir holds just the file: {kids:?}");
+  assert!(
+    matches!(&kids[0], WtNode::File { name, .. } if name == "ui.rs"),
+    "leaf file kept separate from the collapsed chain: {:?}",
+    kids[0]
+  );
+}
+
+#[test]
+fn build_tree_does_not_collapse_a_dir_with_a_file_sibling() {
+  // `src` has both a file (`lib.rs`) and a subdir (`tui`), so it must NOT
+  // fold into its child — only single-*child* dir chains collapse.
+  let tree = build_tree("?? src/lib.rs\n?? src/tui/ui.rs\n");
+  let src = dir(&tree, "src");
+  let kids = children(src);
+  assert_eq!(kids.len(), 2, "src keeps both children: {kids:?}");
+  // Directory sorts before the file.
+  assert!(matches!(&kids[0], WtNode::Dir { name, .. } if name == "tui"));
+  assert!(matches!(&kids[1], WtNode::File { name, .. } if name == "lib.rs"));
+}
+
+#[test]
+fn build_tree_sorts_dirs_before_files_alphabetically() {
+  let tree = build_tree(
+    "?? zebra.txt\n\
+     ?? alpha.txt\n\
+     ?? lib/mod.rs\n\
+     ?? abc/x.rs\n",
+  );
+  let names: Vec<&str> = tree
+    .iter()
+    .map(|n| match n {
+      WtNode::Dir { name, .. } => name.as_str(),
+      WtNode::File { name, .. } => name.as_str(),
+    })
+    .collect();
+  // dirs (alphabetical) before files (alphabetical).
+  assert_eq!(names, vec!["abc", "lib", "alpha.txt", "zebra.txt"], "got {names:?}");
+}
+
+#[test]
+fn build_tree_file_carries_extension_icon_badge_and_category() {
+  let tree = build_tree(" M src/main.rs\n");
+  let kids = children(dir(&tree, "src"));
+  match &kids[0] {
+    WtNode::File {
+      name,
+      icon,
+      badge,
+      category,
+    } => {
+      assert_eq!(name, "main.rs");
+      assert_eq!(*icon, WT_RUST_ICON, "extension drives the icon");
+      assert_eq!(*badge, 'M', "tracked-modified badge");
+      assert_eq!(*category, WtCategory::Modified);
+    }
+    other => panic!("expected a File, got {other:?}"),
+  }
+}
+
+#[test]
+fn build_tree_takes_destination_of_a_rename() {
+  // Porcelain renames render `R  old -> new`; the tree must key off the
+  // destination path and drop the source.
+  let tree = build_tree("R  old/a.rs -> new/b.rs\n");
+  assert_eq!(tree.len(), 1, "only the destination dir survives: {tree:?}");
+  let kids = children(dir(&tree, "new"));
+  assert!(
+    matches!(&kids[0], WtNode::File { name, badge, .. } if name == "b.rs" && *badge == 'M'),
+    "rename keyed to destination, badge M (modified): {:?}",
+    kids[0]
+  );
+}
+
+#[test]
+fn status_badge_maps_each_porcelain_family() {
+  assert_eq!(status_badge('?', '?'), '?', "untracked");
+  assert_eq!(status_badge('A', ' '), 'A', "staged add");
+  assert_eq!(status_badge(' ', 'A'), 'A', "add in worktree column");
+  assert_eq!(status_badge('D', ' '), 'D', "deleted");
+  assert_eq!(status_badge(' ', 'M'), 'M', "worktree-modified");
+  assert_eq!(status_badge('R', ' '), 'M', "rename → modified");
+  // Created precedence: an add wins over a delete in the other column.
+  assert_eq!(status_badge('A', 'D'), 'A');
+}
+
+#[test]
+fn working_tree_category_matches_badge_families() {
+  assert_eq!(working_tree_category('?', '?'), WtCategory::Created);
+  assert_eq!(working_tree_category('A', ' '), WtCategory::Created);
+  assert_eq!(working_tree_category('D', ' '), WtCategory::Deleted);
+  assert_eq!(working_tree_category(' ', 'M'), WtCategory::Modified);
+  assert_eq!(working_tree_category('R', ' '), WtCategory::Modified);
+}
+
+#[test]
+fn file_icon_maps_known_extensions_and_falls_back() {
+  assert_eq!(file_icon("main.rs"), WT_RUST_ICON);
+  assert_eq!(file_icon("README.md"), WT_MARKDOWN_ICON);
+  assert_eq!(file_icon("Cargo.toml"), WT_TOML_ICON);
+  assert_eq!(file_icon("pkg.json"), WT_JSON_ICON);
+  // Case-insensitive on the extension.
+  assert_eq!(file_icon("MAIN.RS"), WT_RUST_ICON);
+  // No extension, and dotfiles, fall back to the generic glyph.
+  assert_eq!(file_icon("Makefile"), WT_FILE_ICON);
+  assert_eq!(file_icon(".gitignore"), WT_FILE_ICON);
+}

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -7,8 +7,8 @@
 //! counterpart lives in `tui_sidebar_render_tests.rs`.
 
 use gwm::tui::wt_tree::{
-  build_capped_tree, build_tree, file_icon, parse_status_z, status_badge, working_tree_category, StatusRecord,
-  WtCategory, WtNode, WT_FILE_ICON, WT_JSON_ICON, WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
+  build_capped_tree, build_tree, file_icon, parse_status_z, sanitize_name, status_badge, working_tree_category,
+  StatusRecord, WtCategory, WtNode, WT_FILE_ICON, WT_JSON_ICON, WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
 };
 
 /// Find a direct `Dir` child by name in a node slice.
@@ -189,6 +189,14 @@ fn working_tree_category_matches_badge_families() {
   assert_eq!(working_tree_category('D', ' '), WtCategory::Deleted);
   assert_eq!(working_tree_category(' ', 'M'), WtCategory::Modified);
   assert_eq!(working_tree_category('R', ' '), WtCategory::Modified);
+}
+
+#[test]
+fn sanitize_name_replaces_control_characters() {
+  assert_eq!(sanitize_name("normal.rs"), "normal.rs", "plain names pass through");
+  assert_eq!(sanitize_name("a\nb\t.rs"), "a?b?.rs", "newline and tab neutralised");
+  // An embedded ANSI escape can't reach the terminal as a control sequence.
+  assert_eq!(sanitize_name("x\u{1b}[2J.rs"), "x?[2J.rs");
 }
 
 #[test]

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -7,8 +7,8 @@
 //! counterpart lives in `tui_sidebar_render_tests.rs`.
 
 use gwm::tui::wt_tree::{
-  build_tree, file_icon, status_badge, working_tree_category, WtCategory, WtNode, WT_FILE_ICON, WT_JSON_ICON,
-  WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
+  build_tree, file_icon, parse_status_z, status_badge, working_tree_category, WtCategory, WtNode, WT_FILE_ICON,
+  WT_JSON_ICON, WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
 };
 
 /// Find a direct `Dir` child by name in a node slice.
@@ -30,14 +30,14 @@ fn children(node: &WtNode) -> &[WtNode] {
 #[test]
 fn build_tree_empty_status_is_empty() {
   assert!(build_tree("").is_empty());
-  assert!(build_tree("\n  \n").is_empty(), "blank lines yield no nodes");
+  assert!(build_tree("\0").is_empty(), "a lone trailing NUL yields no nodes");
 }
 
 #[test]
 fn build_tree_collapses_single_child_directory_chain() {
   // `src` → `tui` → `ui.rs`: the two single-child dirs fold into one
   // `src/tui` row, and `ui.rs` stays its own child (issue #300 example).
-  let tree = build_tree("?? src/tui/ui.rs\n");
+  let tree = build_tree("?? src/tui/ui.rs\0");
   assert_eq!(tree.len(), 1, "one top-level node: {tree:?}");
   let top = dir(&tree, "src/tui");
   let kids = children(top);
@@ -53,7 +53,7 @@ fn build_tree_collapses_single_child_directory_chain() {
 fn build_tree_does_not_collapse_a_dir_with_a_file_sibling() {
   // `src` has both a file (`lib.rs`) and a subdir (`tui`), so it must NOT
   // fold into its child — only single-*child* dir chains collapse.
-  let tree = build_tree("?? src/lib.rs\n?? src/tui/ui.rs\n");
+  let tree = build_tree("?? src/lib.rs\0?? src/tui/ui.rs\0");
   let src = dir(&tree, "src");
   let kids = children(src);
   assert_eq!(kids.len(), 2, "src keeps both children: {kids:?}");
@@ -64,12 +64,7 @@ fn build_tree_does_not_collapse_a_dir_with_a_file_sibling() {
 
 #[test]
 fn build_tree_sorts_dirs_before_files_alphabetically() {
-  let tree = build_tree(
-    "?? zebra.txt\n\
-     ?? alpha.txt\n\
-     ?? lib/mod.rs\n\
-     ?? abc/x.rs\n",
-  );
+  let tree = build_tree("?? zebra.txt\0?? alpha.txt\0?? lib/mod.rs\0?? abc/x.rs\0");
   let names: Vec<&str> = tree
     .iter()
     .map(|n| match n {
@@ -83,7 +78,7 @@ fn build_tree_sorts_dirs_before_files_alphabetically() {
 
 #[test]
 fn build_tree_file_carries_extension_icon_badge_and_category() {
-  let tree = build_tree(" M src/main.rs\n");
+  let tree = build_tree(" M src/main.rs\0");
   let kids = children(dir(&tree, "src"));
   match &kids[0] {
     WtNode::File {
@@ -103,9 +98,10 @@ fn build_tree_file_carries_extension_icon_badge_and_category() {
 
 #[test]
 fn build_tree_takes_destination_of_a_rename() {
-  // Porcelain renames render `R  old -> new`; the tree must key off the
-  // destination path and drop the source.
-  let tree = build_tree("R  old/a.rs -> new/b.rs\n");
+  // In `-z` porcelain a rename is `XY <dest>\0<source>\0`: the destination
+  // comes first, the source in the trailing NUL field. The tree keys off the
+  // destination and drops the source.
+  let tree = build_tree("R  new/b.rs\0old/a.rs\0");
   assert_eq!(tree.len(), 1, "only the destination dir survives: {tree:?}");
   let kids = children(dir(&tree, "new"));
   assert!(
@@ -116,52 +112,29 @@ fn build_tree_takes_destination_of_a_rename() {
 }
 
 #[test]
-fn build_tree_decodes_c_quoted_non_ascii_path() {
-  // `git status --short` wraps a path with non-ASCII bytes in double quotes
-  // with octal C-escapes (`core.quotePath` default). The builder must decode
-  // it back to the real UTF-8 name rather than nest the escaped literal.
-  let tree = build_tree("?? \"caf\\303\\251.rs\"\n");
-  assert_eq!(tree.len(), 1, "one decoded file: {tree:?}");
+fn build_tree_keeps_special_chars_in_names_verbatim() {
+  // `-z` emits paths verbatim — no quoting. A filename with a space, a
+  // literal ` -> `, and non-ASCII bytes nests with its real name intact (the
+  // edge cases that textual `--short` parsing would mangle).
+  let tree = build_tree("?? a -> café b.txt\0");
   assert!(
-    matches!(&tree[0], WtNode::File { name, icon, .. } if name == "café.rs" && *icon == WT_RUST_ICON),
-    "quoted path decoded to café.rs with the rust icon: {:?}",
+    matches!(&tree[0], WtNode::File { name, .. } if name == "a -> café b.txt"),
+    "special chars preserved verbatim: {:?}",
     tree[0]
   );
 }
 
 #[test]
-fn build_tree_decodes_c_quoted_escaped_quote() {
-  // An embedded double quote is escaped as `\"`; decoding restores it.
-  let tree = build_tree("?? \"a\\\"b.txt\"\n");
-  assert!(
-    matches!(&tree[0], WtNode::File { name, .. } if name == "a\"b.txt"),
-    "escaped quote decoded: {:?}",
-    tree[0]
-  );
-}
-
-#[test]
-fn build_tree_decodes_quoted_rename_destination() {
-  // A rename whose destination is quoted: decode the destination after the
-  // ` -> ` split.
-  let tree = build_tree("R  a.rs -> \"b\\303\\251.rs\"\n");
-  assert!(
-    matches!(&tree[0], WtNode::File { name, badge, .. } if name == "bé.rs" && *badge == 'M'),
-    "quoted rename destination decoded: {:?}",
-    tree[0]
-  );
-}
-
-#[test]
-fn build_tree_keeps_arrow_in_a_plain_untracked_filename() {
-  // ` -> ` is git's separator only on a rename/copy (`R`/`C`) status line;
-  // an untracked file literally named `a -> b.txt` must keep its name, not
-  // be truncated to the bogus "destination".
-  let tree = build_tree("?? a -> b.txt\n");
-  assert!(
-    matches!(&tree[0], WtNode::File { name, .. } if name == "a -> b.txt"),
-    "arrow kept verbatim in a non-rename filename: {:?}",
-    tree[0]
+fn parse_status_z_drops_rename_source_and_preserves_paths() {
+  // NUL-delimited records; the rename destination (`dst.rs`) is kept and its
+  // trailing source field (`src.rs`) dropped, while spaces in plain names
+  // survive untouched.
+  let recs = parse_status_z("?? a b.rs\0R  dst.rs\0src.rs\0 M c.rs\0");
+  let got: Vec<(char, char, &str)> = recs.iter().map(|r| (r.x, r.y, r.path.as_str())).collect();
+  assert_eq!(
+    got,
+    vec![('?', '?', "a b.rs"), ('R', ' ', "dst.rs"), (' ', 'M', "c.rs")],
+    "rename source dropped, paths verbatim: {got:?}"
   );
 }
 

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -116,6 +116,43 @@ fn build_tree_takes_destination_of_a_rename() {
 }
 
 #[test]
+fn build_tree_decodes_c_quoted_non_ascii_path() {
+  // `git status --short` wraps a path with non-ASCII bytes in double quotes
+  // with octal C-escapes (`core.quotePath` default). The builder must decode
+  // it back to the real UTF-8 name rather than nest the escaped literal.
+  let tree = build_tree("?? \"caf\\303\\251.rs\"\n");
+  assert_eq!(tree.len(), 1, "one decoded file: {tree:?}");
+  assert!(
+    matches!(&tree[0], WtNode::File { name, icon, .. } if name == "café.rs" && *icon == WT_RUST_ICON),
+    "quoted path decoded to café.rs with the rust icon: {:?}",
+    tree[0]
+  );
+}
+
+#[test]
+fn build_tree_decodes_c_quoted_escaped_quote() {
+  // An embedded double quote is escaped as `\"`; decoding restores it.
+  let tree = build_tree("?? \"a\\\"b.txt\"\n");
+  assert!(
+    matches!(&tree[0], WtNode::File { name, .. } if name == "a\"b.txt"),
+    "escaped quote decoded: {:?}",
+    tree[0]
+  );
+}
+
+#[test]
+fn build_tree_decodes_quoted_rename_destination() {
+  // A rename whose destination is quoted: decode the destination after the
+  // ` -> ` split.
+  let tree = build_tree("R  a.rs -> \"b\\303\\251.rs\"\n");
+  assert!(
+    matches!(&tree[0], WtNode::File { name, badge, .. } if name == "bé.rs" && *badge == 'M'),
+    "quoted rename destination decoded: {:?}",
+    tree[0]
+  );
+}
+
+#[test]
 fn status_badge_maps_each_porcelain_family() {
   assert_eq!(status_badge('?', '?'), '?', "untracked");
   assert_eq!(status_badge('A', ' '), 'A', "staged add");

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -7,8 +7,8 @@
 //! counterpart lives in `tui_sidebar_render_tests.rs`.
 
 use gwm::tui::wt_tree::{
-  build_tree, file_icon, parse_status_z, status_badge, working_tree_category, WtCategory, WtNode, WT_FILE_ICON,
-  WT_JSON_ICON, WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
+  build_capped_tree, build_tree, file_icon, parse_status_z, status_badge, working_tree_category, StatusRecord,
+  WtCategory, WtNode, WT_FILE_ICON, WT_JSON_ICON, WT_MARKDOWN_ICON, WT_RUST_ICON, WT_TOML_ICON,
 };
 
 /// Find a direct `Dir` child by name in a node slice.
@@ -122,6 +122,38 @@ fn build_tree_keeps_special_chars_in_names_verbatim() {
     "special chars preserved verbatim: {:?}",
     tree[0]
   );
+}
+
+#[test]
+fn build_tree_directory_category_is_uniform_or_mixed() {
+  // A directory whose descendants are all one category carries `Some(c)`;
+  // mixing categories flips it to `None` (the neutral / mixed colour).
+  let uniform = build_tree(" M app/a.rs\0 M app/sub/b.rs\0");
+  match dir(&uniform, "app") {
+    WtNode::Dir { category, .. } => assert_eq!(*category, Some(WtCategory::Modified), "all modified"),
+    other => panic!("expected a Dir, got {other:?}"),
+  }
+  let mixed = build_tree(" M app/a.rs\0?? app/c.rs\0");
+  match dir(&mixed, "app") {
+    WtNode::Dir { category, .. } => assert_eq!(*category, None, "modified + created → mixed"),
+    other => panic!("expected a Dir, got {other:?}"),
+  }
+}
+
+#[test]
+fn build_capped_tree_stops_at_max_and_reports_overflow() {
+  let recs: Vec<StatusRecord> = (0..10)
+    .map(|i| StatusRecord {
+      x: '?',
+      y: '?',
+      path: format!("f{i:02}.txt"),
+    })
+    .collect();
+  let (tree, overflow) = build_capped_tree(&recs, 4);
+  assert_eq!(overflow, 6, "10 records, cap 4 → 6 dropped");
+  let files = tree.iter().filter(|n| matches!(n, WtNode::File { .. })).count();
+  assert_eq!(files, 4, "only the first 4 records built into leaves");
+  assert_eq!(build_capped_tree(&recs, 100).1, 0, "cap above the count → no overflow");
 }
 
 #[test]

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -153,6 +153,19 @@ fn build_tree_decodes_quoted_rename_destination() {
 }
 
 #[test]
+fn build_tree_keeps_arrow_in_a_plain_untracked_filename() {
+  // ` -> ` is git's separator only on a rename/copy (`R`/`C`) status line;
+  // an untracked file literally named `a -> b.txt` must keep its name, not
+  // be truncated to the bogus "destination".
+  let tree = build_tree("?? a -> b.txt\n");
+  assert!(
+    matches!(&tree[0], WtNode::File { name, .. } if name == "a -> b.txt"),
+    "arrow kept verbatim in a non-rename filename: {:?}",
+    tree[0]
+  );
+}
+
+#[test]
 fn status_badge_maps_each_porcelain_family() {
   assert_eq!(status_badge('?', '?'), '?', "untracked");
   assert_eq!(status_badge('A', ' '), 'A', "staged add");

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -318,6 +318,22 @@ fn git_status_short_lists_untracked_file() {
 }
 
 #[test]
+fn git_status_short_expands_untracked_directory_into_files() {
+  // For the Working Tree file-explorer (issue #300) the porcelain must list
+  // individual files inside an untracked directory rather than collapsing
+  // it to a single `src/` row, so the tree builder can nest them.
+  let (dir, _) = init_repo();
+  std::fs::create_dir_all(dir.path().join("src/app")).unwrap();
+  std::fs::write(dir.path().join("src/app/mod.rs"), "fn x() {}").unwrap();
+  let out = worktree::git_status_short(dir.path()).unwrap();
+  assert!(
+    out.contains("src/app/mod.rs"),
+    "untracked dir must be expanded to its files, got: {:?}",
+    out
+  );
+}
+
+#[test]
 fn git_log_oneline_errors_outside_repo() {
   let empty = TempDir::new().unwrap();
   let err = worktree::git_log_oneline(empty.path(), 5);

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -297,19 +297,20 @@ fn git_log_oneline_respects_limit() {
 #[test]
 fn git_status_short_empty_on_clean_repo() {
   let (dir, _) = init_repo();
-  let out = worktree::git_status_short(dir.path()).unwrap();
+  let (out, truncated) = worktree::git_status_short(dir.path()).unwrap();
   assert!(
     out.trim().is_empty(),
     "clean repo should produce empty status, got: {:?}",
     out
   );
+  assert!(!truncated, "a clean repo is never truncated");
 }
 
 #[test]
 fn git_status_short_lists_untracked_file() {
   let (dir, _) = init_repo();
   std::fs::write(dir.path().join("new.txt"), "hello").unwrap();
-  let out = worktree::git_status_short(dir.path()).unwrap();
+  let (out, _) = worktree::git_status_short(dir.path()).unwrap();
   assert!(
     out.contains("new.txt"),
     "expected untracked new.txt in status, got: {:?}",
@@ -325,7 +326,7 @@ fn git_status_short_expands_untracked_directory_into_files() {
   let (dir, _) = init_repo();
   std::fs::create_dir_all(dir.path().join("src/app")).unwrap();
   std::fs::write(dir.path().join("src/app/mod.rs"), "fn x() {}").unwrap();
-  let out = worktree::git_status_short(dir.path()).unwrap();
+  let (out, _) = worktree::git_status_short(dir.path()).unwrap();
   assert!(
     out.contains("src/app/mod.rs"),
     "untracked dir must be expanded to its files, got: {:?}",
@@ -337,15 +338,17 @@ fn git_status_short_expands_untracked_directory_into_files() {
 fn git_status_short_caps_the_scan() {
   // The streaming scan must stop after `cap` NUL-terminated records (issue
   // #300) so an unignored directory with thousands of untracked files can't
-  // stall the TUI — git is killed once the cap is hit.
+  // stall the TUI — git is killed once the cap is hit, and the truncation is
+  // reported so the caller doesn't claim an exact total.
   let (dir, _) = init_repo();
   for i in 0..6 {
     std::fs::write(dir.path().join(format!("f{i}.txt")), "x").unwrap();
   }
-  let out = worktree::git_status_short_capped(dir.path(), 3).unwrap();
+  let (out, truncated) = worktree::git_status_short_capped(dir.path(), 3).unwrap();
   let tokens = out.matches('\0').count();
   assert!(tokens <= 3, "scan capped at 3 records, got {tokens}: {out:?}");
   assert!(!out.is_empty(), "the first records are still returned: {out:?}");
+  assert!(truncated, "hitting the cap must report truncation");
 }
 
 #[test]
@@ -355,8 +358,9 @@ fn git_status_short_returns_full_output_below_the_cap() {
   for i in 0..4 {
     std::fs::write(dir.path().join(format!("g{i}.txt")), "x").unwrap();
   }
-  let out = worktree::git_status_short_capped(dir.path(), 1000).unwrap();
+  let (out, truncated) = worktree::git_status_short_capped(dir.path(), 1000).unwrap();
   assert_eq!(out.matches('\0').count(), 4, "all 4 records returned: {out:?}");
+  assert!(!truncated, "below the cap → not truncated");
 }
 
 #[test]

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -334,6 +334,32 @@ fn git_status_short_expands_untracked_directory_into_files() {
 }
 
 #[test]
+fn git_status_short_caps_the_scan() {
+  // The streaming scan must stop after `cap` NUL-terminated records (issue
+  // #300) so an unignored directory with thousands of untracked files can't
+  // stall the TUI — git is killed once the cap is hit.
+  let (dir, _) = init_repo();
+  for i in 0..6 {
+    std::fs::write(dir.path().join(format!("f{i}.txt")), "x").unwrap();
+  }
+  let out = worktree::git_status_short_capped(dir.path(), 3).unwrap();
+  let tokens = out.matches('\0').count();
+  assert!(tokens <= 3, "scan capped at 3 records, got {tokens}: {out:?}");
+  assert!(!out.is_empty(), "the first records are still returned: {out:?}");
+}
+
+#[test]
+fn git_status_short_returns_full_output_below_the_cap() {
+  // A normal change set (well under the cap) comes back in full, untruncated.
+  let (dir, _) = init_repo();
+  for i in 0..4 {
+    std::fs::write(dir.path().join(format!("g{i}.txt")), "x").unwrap();
+  }
+  let out = worktree::git_status_short_capped(dir.path(), 1000).unwrap();
+  assert_eq!(out.matches('\0').count(), 4, "all 4 records returned: {out:?}");
+}
+
+#[test]
 fn git_log_oneline_errors_outside_repo() {
   let empty = TempDir::new().unwrap();
   let err = worktree::git_log_oneline(empty.path(), 5);


### PR DESCRIPTION
## Description

Renders the Status pane's **Working Tree** section (`2`) as a nested,
nerd-font **file-explorer tree** instead of a flat `XY PATH` list — matching
the lazygit-style polish the rest of the TUI already has.

Closes #300

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- New pure, ratatui-free `tui::wt_tree` module: `build_tree` folds the flat
  `git status --short` porcelain into a nested `WtNode` tree — **dirs before
  files** (alphabetical within a level), **single-child dir chains collapse**
  (`src/tui/` then `ui.rs`), each file leaf carrying an extension-driven
  nerd-font icon, an `M`/`A`/`D`/`?` status badge, and its change category.
  The extension→icon table is a single `match`, easy to extend.
- `WtCategory` / `working_tree_category` moved out of `ui.rs` into the pure
  module as the shared source of truth for the footer counts and per-row
  colouring.
- `ui.rs` walks the tree into styled rows: folder rows in the `accent` role,
  file rows painted in their change-category colour so a row's colour still
  matches the footer segment it's counted in (the #287 invariant). Counts
  footer unchanged; a clean tree still shows `✓ clean`.
- `git_status_short` now passes `--untracked-files=all` so an untracked
  directory expands into its individual files (git-ignored paths stay
  excluded — no build-artefact flooding).

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: red → green throughout)
  - `tests/tui_wt_tree_tests.rs` — pure model: nesting, dir-first sort,
    single-child collapse, extension→icon map, badge/category, rename
    destination.
  - `tests/tui_sidebar_render_tests.rs` — rendered Working Tree section shows
    the collapsed dir + folder glyph + `.rs` file glyph for a nested dirty
    file.
  - `tests/worktree_integration.rs` — `git_status_short` expands an untracked
    directory into its files.

## Screenshots / TUI captures

_Not captured — render asserted via `TestBackend` buffer text in the new
sidebar render test._

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed _(no CLI surface change)_
- [ ] `examples/gwm.toml.example` updated if config schema changed _(no schema change)_
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

- **Behaviour change to watch**: `git_status_short` gaining `-uall` makes the
  #287 footer counts file-accurate (an untracked dir now counts as N files,
  not 1). Intentional and consistent with a file explorer.
- `working_tree_status_line` is kept as a public primitive (its tests in
  `tui_app_tests.rs` / `tui_theme_audit_tests.rs` still pin it); the pane just
  no longer routes through it.
- Expand/collapse of directories is deliberately deferred (issue notes it as
  optional follow-up); the MVP renders the full tree.

## Linked issues / docs

- Issue: #300