### PR TITLE
✨ feat(tui): current-PR CI status indicator in the Status pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Current-PR CI status indicator in the Status pane** (issue #299): the
+  Issue / PR section (`2`) now renders an overall CI state for the linked PR
+  instead of a bare ` · checks N/M`. A coloured nerd-font indicator
+  (` CI passing 9/9` green, ` CI failing 7/9` red, ` CI running 8/9` yellow)
+  is derived from the `statusCheckRollup` already fetched — no extra GitHub
+  request. The state follows **failing > running > passing** so a red check is
+  never hidden behind an in-flight one; a PR with no checks renders nothing.
+
 - **Edit every keymap from the Settings panel** (issue #294): the Settings
   panel (`4`) gains a **Keys** tab that lists every rebindable binding — the
   global list-view actions (`[global]`) and every modal verb grouped by

--- a/src/github.rs
+++ b/src/github.rs
@@ -516,6 +516,24 @@ pub enum PrState {
   Merged,
 }
 
+/// Overall CI outcome derived from a PR's `statusCheckRollup` (issue #299).
+/// A single ordered signal so the sidebar can render pass/fail/running at a
+/// glance instead of a bare `N/M` count. Priority is **failing > running >
+/// passing**: the most actionable state always wins, so a red check is never
+/// hidden behind an in-flight one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiState {
+  /// The PR has no checks at all — render nothing.
+  None,
+  /// Every check completed successfully (counting `NEUTRAL` / `SKIPPED`).
+  Passing,
+  /// At least one check is still in flight and none has failed.
+  Running,
+  /// At least one check completed with a failing conclusion
+  /// (`FAILURE` / `CANCELLED` / `TIMED_OUT` / `ACTION_REQUIRED`).
+  Failing,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrStatus {
   pub number: u64,
@@ -525,6 +543,9 @@ pub struct PrStatus {
   pub updated_at: String,
   pub checks_passed: u32,
   pub checks_total: u32,
+  /// Overall CI state derived from the same rollup that feeds
+  /// `checks_passed` / `checks_total` — no extra GitHub request.
+  pub ci: CiState,
 }
 
 #[derive(Deserialize)]
@@ -607,6 +628,7 @@ pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
           .is_some_and(|s| s.eq_ignore_ascii_case("SUCCESS"))
     })
     .count() as u32;
+  let ci = derive_ci_state(&raw.status_check_rollup);
   Ok(PrStatus {
     number: raw.number,
     title: raw.title,
@@ -615,7 +637,44 @@ pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
     updated_at: raw.updated_at,
     checks_passed,
     checks_total,
+    ci,
   })
+}
+
+/// Collapse a `statusCheckRollup` into a single [`CiState`] with the
+/// priority **failing > running > passing** (issue #299). A completed check
+/// whose conclusion is one of the failing terminals wins immediately; any
+/// still-pending check downgrades an otherwise-green rollup to `Running`;
+/// an empty rollup is `None`.
+fn derive_ci_state(checks: &[RawCheck]) -> CiState {
+  if checks.is_empty() {
+    return CiState::None;
+  }
+  let mut any_running = false;
+  for c in checks {
+    if c.status.eq_ignore_ascii_case("COMPLETED") {
+      if c.conclusion.as_deref().is_some_and(is_failing_conclusion) {
+        // Failing outranks everything — short-circuit so a red check is
+        // never masked by a later in-flight one.
+        return CiState::Failing;
+      }
+    } else {
+      any_running = true;
+    }
+  }
+  if any_running {
+    CiState::Running
+  } else {
+    CiState::Passing
+  }
+}
+
+/// GitHub check conclusions that read as a failure for CI-state purposes.
+fn is_failing_conclusion(conclusion: &str) -> bool {
+  matches!(
+    conclusion.to_ascii_uppercase().as_str(),
+    "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED"
+  )
 }
 
 // ---- gh CLI invocation ---------------------------------------------------

--- a/src/github.rs
+++ b/src/github.rs
@@ -579,12 +579,18 @@ struct RawPr {
   status_check_rollup: Vec<RawCheck>,
 }
 
+/// One `statusCheckRollup` entry. GitHub returns two shapes here: a
+/// `CheckRun` (the Checks API — carries `status` + `conclusion`) and a
+/// legacy `StatusContext` (the commit-status API — carries `state`). We
+/// deserialize all three so both shapes classify correctly.
 #[derive(Deserialize)]
 struct RawCheck {
   #[serde(default)]
   status: String,
   #[serde(default)]
   conclusion: Option<String>,
+  #[serde(default)]
+  state: String,
 }
 
 pub fn parse_issue_json(s: &str) -> Result<IssueStatus> {
@@ -617,16 +623,14 @@ pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
     (other, _) => return Err(GwmError::Other(format!("unknown PR state '{}'", other))),
   };
   let checks_total = raw.status_check_rollup.len() as u32;
+  // Count the same "accepted" terminals the CI state treats as green, so the
+  // `N/M` shown next to the indicator stays consistent with its label — a
+  // rollup of SUCCESS + NEUTRAL + SKIPPED reads "passing 3/3", not "1/3"
+  // (Codex review #302).
   let checks_passed = raw
     .status_check_rollup
     .iter()
-    .filter(|c| {
-      c.status.eq_ignore_ascii_case("COMPLETED")
-        && c
-          .conclusion
-          .as_deref()
-          .is_some_and(|s| s.eq_ignore_ascii_case("SUCCESS"))
-    })
+    .filter(|c| matches!(classify_check(c), CheckOutcome::Passing))
     .count() as u32;
   let ci = derive_ci_state(&raw.status_check_rollup);
   Ok(PrStatus {
@@ -641,25 +645,68 @@ pub fn parse_pr_json(s: &str) -> Result<PrStatus> {
   })
 }
 
+/// The outcome of a single rollup entry, before the per-PR aggregation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckOutcome {
+  Passing,
+  Running,
+  Failing,
+}
+
+/// Classify one rollup entry, handling both the `CheckRun` shape
+/// (`status` + `conclusion`) and the legacy `StatusContext` shape
+/// (`state`). A `CheckRun` is only green for an *accepted* terminal
+/// conclusion (SUCCESS / NEUTRAL / SKIPPED, or a completed check with no
+/// conclusion); every other terminal conclusion — FAILURE, CANCELLED,
+/// TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE, STALE, … — reads as failing
+/// rather than silently falling through to green (Codex review #302).
+fn classify_check(c: &RawCheck) -> CheckOutcome {
+  // `CheckRun`: `status` is populated (QUEUED / IN_PROGRESS / COMPLETED).
+  if !c.status.is_empty() {
+    if !c.status.eq_ignore_ascii_case("COMPLETED") {
+      return CheckOutcome::Running;
+    }
+    return match c.conclusion.as_deref() {
+      Some(s) if is_accepted_conclusion(s) => CheckOutcome::Passing,
+      // A completed check with no conclusion is treated leniently (green) so
+      // missing data never paints a false red.
+      None => CheckOutcome::Passing,
+      Some(_) => CheckOutcome::Failing,
+    };
+  }
+  // Legacy `StatusContext`: classify by `state`.
+  match c.state.to_ascii_uppercase().as_str() {
+    "SUCCESS" => CheckOutcome::Passing,
+    "FAILURE" | "ERROR" => CheckOutcome::Failing,
+    // PENDING / EXPECTED / unknown — not yet conclusive.
+    _ => CheckOutcome::Running,
+  }
+}
+
+/// Terminal `CheckRun` conclusions that count as green.
+fn is_accepted_conclusion(conclusion: &str) -> bool {
+  matches!(
+    conclusion.to_ascii_uppercase().as_str(),
+    "SUCCESS" | "NEUTRAL" | "SKIPPED"
+  )
+}
+
 /// Collapse a `statusCheckRollup` into a single [`CiState`] with the
-/// priority **failing > running > passing** (issue #299). A completed check
-/// whose conclusion is one of the failing terminals wins immediately; any
-/// still-pending check downgrades an otherwise-green rollup to `Running`;
-/// an empty rollup is `None`.
+/// priority **failing > running > passing** (issue #299). A failing check
+/// wins immediately; any still-pending check downgrades an otherwise-green
+/// rollup to `Running`; an empty rollup is `None`.
 fn derive_ci_state(checks: &[RawCheck]) -> CiState {
   if checks.is_empty() {
     return CiState::None;
   }
   let mut any_running = false;
   for c in checks {
-    if c.status.eq_ignore_ascii_case("COMPLETED") {
-      if c.conclusion.as_deref().is_some_and(is_failing_conclusion) {
-        // Failing outranks everything — short-circuit so a red check is
-        // never masked by a later in-flight one.
-        return CiState::Failing;
-      }
-    } else {
-      any_running = true;
+    match classify_check(c) {
+      // Failing outranks everything — short-circuit so a red check is never
+      // masked by a later in-flight one.
+      CheckOutcome::Failing => return CiState::Failing,
+      CheckOutcome::Running => any_running = true,
+      CheckOutcome::Passing => {}
     }
   }
   if any_running {
@@ -667,14 +714,6 @@ fn derive_ci_state(checks: &[RawCheck]) -> CiState {
   } else {
     CiState::Passing
   }
-}
-
-/// GitHub check conclusions that read as a failure for CI-state purposes.
-fn is_failing_conclusion(conclusion: &str) -> bool {
-  matches!(
-    conclusion.to_ascii_uppercase().as_str(),
-    "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED"
-  )
 }
 
 // ---- gh CLI invocation ---------------------------------------------------

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -61,11 +61,11 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, command_logs_footer_hints, config_capture_footer_hints,
-  config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line, confirm_delete_branch_line,
-  confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle, field_input_line,
-  filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines, header_line,
-  help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
+  build_sidebar_sections, centered_abs, chip_style, ci_indicator, command_logs_footer_hints,
+  config_capture_footer_hints, config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line,
+  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
+  field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,
+  header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
   hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
   link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
   panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -12,7 +12,7 @@ use super::theme::Theme;
 use crate::bootstrap::{BootstrapReport, StepStatus};
 use crate::command_log::CommandStatus;
 use crate::config::ConfigSource;
-use crate::github::{IssueState, LinkSource, PrState};
+use crate::github::{CiState, IssueState, LinkSource, PrState};
 use crate::worktree::{self, BranchStatus, WorktreeInfo};
 use ratatui::{
   buffer::Buffer,
@@ -4270,6 +4270,12 @@ pub const ISSUE_ICON: &str = "\u{f41b}";
 /// `nf-oct-git_pull_request`.
 pub const PR_ICON: &str = "\u{f407}";
 
+/// Nerdfont glyphs for the per-PR CI indicator (issue #299):
+/// `nf-oct-check` (passing), `nf-oct-x` (failing), `nf-oct-sync` (running).
+pub const CI_PASSING_ICON: &str = "\u{f42e}";
+pub const CI_FAILING_ICON: &str = "\u{f467}";
+pub const CI_RUNNING_ICON: &str = "\u{f46a}";
+
 /// The pane's source chip (issue #283): `auto` for a branch-name inference,
 /// `detected` for a live GitHub match. Explicit / none carry no chip — the
 /// number already speaks for an explicit link. Rendered version-badge style
@@ -4340,6 +4346,9 @@ enum SummaryState<'a> {
     badge: &'a str,
     badge_color: Color,
     trailing: String,
+    /// Colour for the `trailing` segment, e.g. the CI indicator
+    /// (issue #299). `None` paints it with the default foreground.
+    trailing_color: Option<Color>,
     title: &'a str,
   },
   Loading,
@@ -4347,6 +4356,8 @@ enum SummaryState<'a> {
     badge: &'a str,
     badge_color: Color,
     trailing: String,
+    /// See [`SummaryState::CachedStatus::trailing_color`].
+    trailing_color: Option<Color>,
     title: &'a str,
   },
   Error(&'a str),
@@ -4363,6 +4374,16 @@ enum SummaryState<'a> {
 /// → renders ` badge  title`; PR passes ` · checks 1/2` → renders
 /// ` badge · checks 1/2 title`. Widths are counted in display columns (the
 /// `·` is U+00B7: 1 column) so the budget arithmetic holds.
+/// Render a `trailing` segment, styling it with `color` when present
+/// (the CI indicator, issue #299) and falling back to the default
+/// foreground otherwise (the legacy uncoloured `· checks N/M`).
+fn trailing_span(trailing: String, color: Option<Color>) -> Span<'static> {
+  match color {
+    Some(c) => Span::styled(trailing, Style::default().fg(c)),
+    None => Span::raw(trailing),
+  }
+}
+
 fn summary_line(
   icon: &str,
   head: String,
@@ -4426,6 +4447,7 @@ fn summary_line(
       badge,
       badge_color,
       trailing,
+      trailing_color,
       title,
     } => {
       let badge_seg_w = 1 + badge.chars().count() + 2;
@@ -4434,7 +4456,7 @@ fn summary_line(
         let mut spans = build_prefix(true);
         spans.push(Span::raw(" "));
         spans.push(Span::raw(format!(" {} ", badge)));
-        spans.push(Span::raw(trailing));
+        spans.push(trailing_span(trailing, trailing_color));
         flatten_if_overflow(&mut spans, max_width);
         return Line::from(spans);
       }
@@ -4442,7 +4464,7 @@ fn summary_line(
       let mut spans = build_prefix(true);
       spans.push(Span::raw(" "));
       spans.push(Span::styled(format!(" {} ", badge), chip_style(badge_color)));
-      spans.push(Span::raw(trailing));
+      spans.push(trailing_span(trailing, trailing_color));
       spans.push(Span::raw(" "));
       spans.push(Span::raw(trunc(title, budget)));
       Line::from(spans)
@@ -4458,6 +4480,7 @@ fn summary_line(
       badge,
       badge_color,
       trailing,
+      trailing_color,
       title,
     } => {
       // Tail fixed cost past the prefix = " " + " <badge> " + trailing + " ".
@@ -4469,7 +4492,7 @@ fn summary_line(
         let mut spans = build_prefix(true);
         spans.push(Span::raw(" "));
         spans.push(Span::raw(format!(" {} ", badge)));
-        spans.push(Span::raw(trailing));
+        spans.push(trailing_span(trailing, trailing_color));
         flatten_if_overflow(&mut spans, max_width);
         return Line::from(spans);
       }
@@ -4477,7 +4500,7 @@ fn summary_line(
       let mut spans = build_prefix(true);
       spans.push(Span::raw(" "));
       spans.push(Span::styled(format!(" {} ", badge), chip_style(badge_color)));
-      spans.push(Span::raw(trailing));
+      spans.push(trailing_span(trailing, trailing_color));
       spans.push(Span::raw(" "));
       spans.push(Span::raw(trunc(title, budget)));
       Line::from(spans)
@@ -4518,6 +4541,7 @@ fn issue_summary_line_with_spinner(
           badge,
           badge_color: issue_badge_color(state, theme),
           trailing: String::new(),
+          trailing_color: None,
           title: persisted.title.unwrap_or(""),
         }
       }
@@ -4536,6 +4560,7 @@ fn issue_summary_line_with_spinner(
           badge,
           badge_color: issue_badge_color(state, theme),
           trailing: format!(" · {} loading", spinner.unwrap_or("…")),
+          trailing_color: None,
           title: persisted.title.unwrap_or(""),
         }
       }
@@ -4555,6 +4580,7 @@ fn issue_summary_line_with_spinner(
         badge,
         badge_color: issue_badge_color(s.state, theme),
         trailing: String::new(),
+        trailing_color: None,
         title: &s.title,
       }
     }
@@ -4565,8 +4591,9 @@ fn issue_summary_line_with_spinner(
 
 /// Render the Loaded / Idle / Loading / Error variants for a PR link
 /// row in the sidebar. See [`issue_summary_line`] for the `max_width`
-/// contract — same idea, with a `checks N/M` segment squeezed in between
-/// badge and title when the rollup is non-zero.
+/// contract — same idea, with a coloured CI indicator ([`ci_indicator`],
+/// issue #299) squeezed in between badge and title when the rollup is
+/// non-empty.
 pub fn pr_summary_line(
   n: u64,
   src: LinkSource,
@@ -4600,6 +4627,7 @@ fn pr_summary_line_with_spinner(
           badge,
           badge_color: pr_badge_color(state, theme),
           trailing: String::new(),
+          trailing_color: None,
           title: persisted.title.unwrap_or(""),
         }
       }
@@ -4620,6 +4648,7 @@ fn pr_summary_line_with_spinner(
           badge,
           badge_color: pr_badge_color(state, theme),
           trailing: format!(" · {} loading", spinner.unwrap_or("…")),
+          trailing_color: None,
           title: persisted.title.unwrap_or(""),
         }
       }
@@ -4637,15 +4666,18 @@ fn pr_summary_line_with_spinner(
         PrState::Closed => "closed",
         PrState::Merged => "merged",
       };
-      let trailing = if s.checks_total > 0 {
-        format!(" · checks {}/{}", s.checks_passed, s.checks_total)
-      } else {
-        String::new()
+      // Issue #299: surface the derived CI state (icon + label + N/M, coloured)
+      // instead of the bare ` · checks N/M`, so pass / fail / running reads at a
+      // glance. `ci_indicator` returns `None` when the PR has no checks.
+      let (trailing, trailing_color) = match ci_indicator(s.ci, s.checks_passed, s.checks_total, theme) {
+        Some((text, color)) => (text, Some(color)),
+        None => (String::new(), None),
       };
       SummaryState::Loaded {
         badge,
         badge_color: pr_badge_color(s.state, theme),
         trailing,
+        trailing_color,
         title: &s.title,
       }
     }
@@ -4714,6 +4746,23 @@ pub fn pr_badge_color(state: PrState, theme: &Theme) -> Color {
     PrState::Merged => theme.locked,
     PrState::Closed => theme.prunable,
   }
+}
+
+/// Build the CI indicator segment for a loaded PR (issue #299): a nerd-font
+/// glyph + short label + `passed/total` count, plus the theme colour it
+/// paints with. Returns `None` for [`CiState::None`] so a PR with no checks
+/// renders nothing. Colours reuse the status-dot roles already used elsewhere
+/// in the sidebar: passing → `clean` (green), failing → `prunable` (red),
+/// running → `dirty` (yellow). The leading space keeps it flush against the
+/// preceding badge, mirroring the old ` · checks N/M` trailing.
+pub fn ci_indicator(ci: CiState, passed: u32, total: u32, theme: &Theme) -> Option<(String, Color)> {
+  let (icon, label, color) = match ci {
+    CiState::None => return None,
+    CiState::Passing => (CI_PASSING_ICON, "passing", theme.clean),
+    CiState::Failing => (CI_FAILING_ICON, "failing", theme.prunable),
+    CiState::Running => (CI_RUNNING_ICON, "running", theme.dirty),
+  };
+  Some((format!(" {} CI {} {}/{}", icon, label, passed, total), color))
 }
 
 /// Same idea as [`pr_badge_color`] but for a linked issue. Closed maps

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use common::init_repo;
-use gwm::github::{self, parse_issue_json, parse_pr_json, BranchLink, IssueState, LinkSource, PrState};
+use gwm::github::{self, parse_issue_json, parse_pr_json, BranchLink, CiState, IssueState, LinkSource, PrState};
 
 fn make_branch(repo: &git2::Repository, name: &str) {
   let head = repo.head().unwrap().peel_to_commit().unwrap();
@@ -543,6 +543,104 @@ fn parse_pr_json_handles_missing_status_check_rollup() {
   assert_eq!(pr.checks_total, 0);
   assert_eq!(pr.checks_passed, 0);
   assert_eq!(pr.state, PrState::Open);
+}
+
+// --- CI state derivation (issue #299) -----------------------------------
+
+/// Build a minimal PR JSON body with the given `statusCheckRollup` array
+/// literal so the CI-state tests stay focused on the rollup.
+fn pr_json_with_rollup(rollup: &str) -> String {
+  format!(
+    r#"{{
+      "number": 7,
+      "title": "x",
+      "state": "OPEN",
+      "isDraft": false,
+      "url": "https://github.com/x/y/pull/7",
+      "statusCheckRollup": {rollup},
+      "updatedAt": "2026-06-15T10:00:00Z"
+    }}"#
+  )
+}
+
+#[test]
+fn ci_state_is_passing_when_all_checks_succeed() {
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"}
+    ]"#,
+  );
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::Passing);
+}
+
+#[test]
+fn ci_state_treats_neutral_and_skipped_as_passing() {
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "optional", "status": "COMPLETED", "conclusion": "NEUTRAL"},
+      {"name": "deploy", "status": "COMPLETED", "conclusion": "SKIPPED"}
+    ]"#,
+  );
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::Passing);
+}
+
+#[test]
+fn ci_state_is_running_when_a_check_is_in_flight() {
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "fmt", "status": "IN_PROGRESS", "conclusion": null}
+    ]"#,
+  );
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::Running);
+}
+
+#[test]
+fn ci_state_treats_queued_and_pending_as_running() {
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "queued", "status": "QUEUED", "conclusion": null},
+      {"name": "pending", "status": "PENDING", "conclusion": null}
+    ]"#,
+  );
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::Running);
+}
+
+#[test]
+fn ci_state_is_failing_on_any_failed_conclusion() {
+  for conclusion in ["FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"] {
+    let json = pr_json_with_rollup(&format!(
+      r#"[
+        {{"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"}},
+        {{"name": "broken", "status": "COMPLETED", "conclusion": "{conclusion}"}}
+      ]"#
+    ));
+    assert_eq!(
+      parse_pr_json(&json).unwrap().ci,
+      CiState::Failing,
+      "conclusion {conclusion} must read as Failing"
+    );
+  }
+}
+
+#[test]
+fn ci_state_failing_outranks_running() {
+  // A red check must never hide behind a still-running one.
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "still-going", "status": "IN_PROGRESS", "conclusion": null},
+      {"name": "broken", "status": "COMPLETED", "conclusion": "FAILURE"}
+    ]"#,
+  );
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::Failing);
+}
+
+#[test]
+fn ci_state_is_none_when_there_are_no_checks() {
+  let json = pr_json_with_rollup("[]");
+  assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::None);
 }
 
 // --- Labels: gh label list --json contract (issue #81) ------------------

--- a/tests/github_tests.rs
+++ b/tests/github_tests.rs
@@ -643,6 +643,58 @@ fn ci_state_is_none_when_there_are_no_checks() {
   assert_eq!(parse_pr_json(&json).unwrap().ci, CiState::None);
 }
 
+#[test]
+fn ci_state_classifies_legacy_status_context_state() {
+  // A `StatusContext` (legacy commit-status API) carries `state`, not
+  // `status` / `conclusion`. A failed external CI status must read red, not
+  // be mistaken for a still-running check (Codex review #302).
+  let failing = pr_json_with_rollup(r#"[{"context": "ci/ext", "state": "FAILURE"}]"#);
+  assert_eq!(parse_pr_json(&failing).unwrap().ci, CiState::Failing);
+
+  let error = pr_json_with_rollup(r#"[{"context": "ci/ext", "state": "ERROR"}]"#);
+  assert_eq!(parse_pr_json(&error).unwrap().ci, CiState::Failing);
+
+  let success = pr_json_with_rollup(r#"[{"context": "ci/ext", "state": "SUCCESS"}]"#);
+  assert_eq!(parse_pr_json(&success).unwrap().ci, CiState::Passing);
+
+  let pending = pr_json_with_rollup(r#"[{"context": "ci/ext", "state": "PENDING"}]"#);
+  assert_eq!(parse_pr_json(&pending).unwrap().ci, CiState::Running);
+}
+
+#[test]
+fn ci_state_treats_non_success_terminal_conclusions_as_failing() {
+  // A completed check whose conclusion is a terminal failure GitHub doesn't
+  // list among the "common" four (e.g. STARTUP_FAILURE, STALE) must still
+  // read red rather than fall through to green (Codex review #302).
+  for conclusion in ["STARTUP_FAILURE", "STALE"] {
+    let json = pr_json_with_rollup(&format!(
+      r#"[{{"name": "broken", "status": "COMPLETED", "conclusion": "{conclusion}"}}]"#
+    ));
+    assert_eq!(
+      parse_pr_json(&json).unwrap().ci,
+      CiState::Failing,
+      "conclusion {conclusion} must read as Failing"
+    );
+  }
+}
+
+#[test]
+fn checks_passed_counts_accepted_terminals_so_count_matches_ci_label() {
+  // The N/M shown next to the CI label must use the same accepted terminals
+  // as the state, else a green rollup renders "passing 1/3" (Codex review #302).
+  let json = pr_json_with_rollup(
+    r#"[
+      {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"name": "optional", "status": "COMPLETED", "conclusion": "NEUTRAL"},
+      {"name": "deploy", "status": "COMPLETED", "conclusion": "SKIPPED"}
+    ]"#,
+  );
+  let pr = parse_pr_json(&json).unwrap();
+  assert_eq!(pr.ci, CiState::Passing);
+  assert_eq!(pr.checks_passed, 3);
+  assert_eq!(pr.checks_total, 3);
+}
+
 // --- Labels: gh label list --json contract (issue #81) ------------------
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1783,7 +1783,7 @@ fn filled_cells_floors_partial_progress() {
 
 // ---- Issue / PR linking (issue #67) -------------------------------------
 
-use gwm::github::{IssueState, IssueStatus, LinkSource, PrState, PrStatus};
+use gwm::github::{CiState, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use gwm::tui::{GitHubFetchState, LinkPromptStage, LinkTarget};
 
 fn make_app_on_branch(name: &str) -> (tempfile::TempDir, git2::Repository, App) {
@@ -2113,6 +2113,7 @@ fn apply_fetch_results_loads_issue_and_pr_state() {
     updated_at: "2026-05-19T00:00:00Z".into(),
     checks_passed: 2,
     checks_total: 3,
+    ci: CiState::Running,
   };
   app.apply_issue_fetch_result(Ok(issue.clone()));
   app.apply_pr_fetch_result(Ok(pr.clone()));
@@ -2161,6 +2162,7 @@ fn loaded_explicit_pr_status_persists_title_for_no_fetch_startup() {
     updated_at: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   }));
 
   let link = gwm::github::read_link(&repo, "feat/#42-tui-search").unwrap();
@@ -2182,6 +2184,7 @@ fn loaded_detected_pr_status_persists_detected_title_for_no_fetch_startup() {
     updated_at: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   }));
 
   let link = gwm::github::read_link(&repo, "feat/#42-tui-search").unwrap();
@@ -2730,6 +2733,7 @@ fn refresh_github_status_message_reflects_partial_failure() {
     updated_at: "".into(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   };
   app.apply_pr_fetch_result(Ok(pr));
   // Now call the same status-rendering logic the refresh would have run.
@@ -3634,6 +3638,7 @@ fn table_marker_pr_pastille_uses_loaded_closed_pr_state() {
     updated_at: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   }));
 
   let theme = Theme::default();
@@ -4306,6 +4311,7 @@ fn pr_summary_line_truncates_loaded_state_to_budget() {
     url: String::new(),
     checks_passed: 3,
     checks_total: 3,
+    ci: CiState::Passing,
     updated_at: String::new(),
   };
   let line = pr_summary_line(
@@ -4459,6 +4465,7 @@ fn pr_summary_line_leads_with_the_pr_icon() {
     url: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
     updated_at: String::new(),
   };
   let line = pr_summary_line(
@@ -4500,6 +4507,7 @@ fn pr_summary_line_loaded_icon_uses_pr_state_color() {
     url: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
     updated_at: String::new(),
   };
   let theme = Theme::default();
@@ -4518,6 +4526,85 @@ fn pr_summary_line_loaded_icon_uses_pr_state_color() {
 }
 
 #[test]
+fn pr_summary_line_loaded_renders_ci_indicator_when_checks_present() {
+  // Issue #299: a PR with a failing rollup must surface a coloured CI
+  // indicator (icon + label + N/M), not just the bare count.
+  let status = gwm::github::PrStatus {
+    number: 9,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 1,
+    checks_total: 2,
+    ci: gwm::github::CiState::Failing,
+    updated_at: String::new(),
+  };
+  let theme = Theme::default();
+  let line = pr_summary_line(
+    9,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    80,
+    &theme,
+  );
+  let ci = span_with(&line, "CI").expect("a CI indicator span");
+  assert!(
+    ci.content.contains("failing") && ci.content.contains("1/2"),
+    "CI indicator must carry the failing label and count, got {:?}",
+    ci.content
+  );
+  assert_eq!(
+    ci.style.fg,
+    Some(theme.prunable),
+    "a failing CI indicator must paint with the prunable (red) role"
+  );
+}
+
+#[test]
+fn pr_summary_line_loaded_omits_ci_indicator_when_no_checks() {
+  let status = gwm::github::PrStatus {
+    number: 9,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    ci: gwm::github::CiState::None,
+    updated_at: String::new(),
+  };
+  let line = pr_summary_line(
+    9,
+    gwm::github::LinkSource::BranchName,
+    &GitHubFetchState::Loaded(status),
+    80,
+    &Theme::default(),
+  );
+  let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+  assert!(
+    !joined.contains("CI"),
+    "a PR with no checks must not render any CI indicator: {}",
+    joined
+  );
+}
+
+#[test]
+fn ci_indicator_maps_states_to_status_roles() {
+  let theme = Theme::default();
+  // None renders nothing.
+  assert!(gwm::tui::ci_indicator(gwm::github::CiState::None, 0, 0, &theme).is_none());
+  // Passing → clean (green), failing → prunable (red), running → dirty (yellow).
+  let (txt, col) = gwm::tui::ci_indicator(gwm::github::CiState::Passing, 9, 9, &theme).unwrap();
+  assert!(txt.contains("passing") && txt.contains("9/9"));
+  assert_eq!(col, theme.clean);
+  let (txt, col) = gwm::tui::ci_indicator(gwm::github::CiState::Failing, 7, 9, &theme).unwrap();
+  assert!(txt.contains("failing") && txt.contains("7/9"));
+  assert_eq!(col, theme.prunable);
+  let (txt, col) = gwm::tui::ci_indicator(gwm::github::CiState::Running, 8, 9, &theme).unwrap();
+  assert!(txt.contains("running") && txt.contains("8/9"));
+  assert_eq!(col, theme.dirty);
+}
+
+#[test]
 fn pr_summary_line_renders_detected_source_as_a_reverse_video_chip() {
   use ratatui::style::Modifier;
   let status = gwm::github::PrStatus {
@@ -4527,6 +4614,7 @@ fn pr_summary_line_renders_detected_source_as_a_reverse_video_chip() {
     url: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
     updated_at: String::new(),
   };
   let line = pr_summary_line(

--- a/tests/tui_state_github_fetch_tests.rs
+++ b/tests/tui_state_github_fetch_tests.rs
@@ -18,7 +18,7 @@
 //!   `Pr(42)`, and `Issue(43)` are all independent (the #138 keying).
 //! - `invalidate()` clears the cache.
 
-use gwm::github::{IssueState, IssueStatus, PrState, PrStatus};
+use gwm::github::{CiState, IssueState, IssueStatus, PrState, PrStatus};
 use gwm::tui::state::github_fetch::{FetchKey, GitHubFetch, GitHubFetchState};
 
 fn sample_issue(n: u64) -> IssueStatus {
@@ -41,6 +41,7 @@ fn sample_pr(n: u64) -> PrStatus {
     updated_at: "2026-01-01T00:00:00Z".into(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   }
 }
 

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -33,7 +33,7 @@
 mod common;
 
 use common::init_repo;
-use gwm::github::{BranchLink, IssueState, PrState};
+use gwm::github::{BranchLink, CiState, IssueState, PrState};
 use gwm::tui::commit_graph::{render_pipe_set, test_row, Pipe, PipeKind};
 use gwm::tui::state::sidebar::SidebarMode;
 use gwm::tui::theme::Theme;
@@ -423,6 +423,7 @@ fn pr_summary_line_merged_badge_routes_through_pr_badge_color() {
     url: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
     updated_at: String::new(),
   };
   let line = gwm::tui::pr_summary_line(
@@ -570,6 +571,7 @@ fn summary_line_loaded_icons_resolve_through_state_roles() {
     updated_at: String::new(),
     checks_passed: 0,
     checks_total: 0,
+    ci: CiState::None,
   };
   let pr = gwm::tui::pr_summary_line(
     9,


### PR DESCRIPTION
## Description

The Issue / PR section (Status pane, key `2`) showed a bare ` · checks N/M` on
the linked PR — which doesn't tell you the **outcome** (is the last check
running, failed, or skipped?). This derives an overall **CI state** from the
`statusCheckRollup` already fetched and surfaces it as a coloured nerd-font
indicator, no extra GitHub request.

Closes #299

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `github`: new `CiState` enum (`None` / `Passing` / `Running` / `Failing`) +
  pure `derive_ci_state` over the rollup, stored on `PrStatus.ci`. Priority is
  **failing > running > passing** so a red check is never hidden behind an
  in-flight one; an empty rollup is `None`. Failing conclusions = `FAILURE` /
  `CANCELLED` / `TIMED_OUT` / `ACTION_REQUIRED`; `NEUTRAL` / `SKIPPED` count as
  passing.
- `tui`: `ci_indicator(ci, passed, total, theme)` builds a coloured segment
  (icon + label + `N/M`) reusing the status-dot roles — passing → `clean`
  (green), failing → `prunable` (red), running → `dirty` (yellow). It replaces
  the old ` · checks N/M` trailing; `summary_line` gains a `trailing_color` so
  the segment is painted. A PR with no checks renders nothing.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: tests written red-first)

`tests/github_tests.rs`: rollup fixtures → `CiState` (all-success,
neutral/skipped, in-flight, queued/pending, each failing conclusion,
failing-outranks-running, empty). `tests/tui_app_tests.rs`: the PR summary line
renders the indicator (label + count + red role) when checks exist and omits it
when they don't; `ci_indicator` state → role mapping.

## Screenshots / TUI captures

<!-- Derivation + render are pinned by the unit/render tests above; no live
capture attached. -->

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — no new CLI surface)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #299 (split out of #298, part A)

## Notes for reviewers

The derivation discards no information the count already needed — it reads the
same `RawCheck { status, conclusion }` list. `trailing_color` is `Option<Color>`
so the legacy uncoloured cached/loading trailings are untouched (only the loaded
PR path passes a colour).