### PR TITLE
✨ feat(tui): multi-repo workspace mode (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-repo workspace mode** (issue #36): operate across every git repo one
+  level below a root directory instead of a single repo. Two entry points:
+  - `gwm --workspace ~/Projects` opens the TUI over every direct-child repo,
+    and `gwm list --workspace ~/Projects` prints the merged worktree table.
+    Both accept the flag before or after the subcommand (`global = true`).
+  - Bare `gwm` in a directory that is *not* itself a git repo but holds
+    child repos prompts `No git repo here. Open <dir> as a workspace? [Y/n]`
+    (declined silently when stdin is not a terminal, so pipes / CI keep the
+    old single-repo behaviour).
+  - The CLI table and the TUI list gain a leading **REPO** column naming each
+    row's repo. In the TUI the active repo follows the selection, so every
+    selection-driven action (lazygit, terminal, sync, delete, link, open, …)
+    operates on the highlighted worktree's own repo.
+  - `gwm create` in workspace mode requires `--repo <name>` to disambiguate
+    which child repo gets the new worktree; an absent or unknown name lists
+    the candidates.
+  - `.gwm.toml` stays per-repo — each row inherits its own repo's config.
+    There is no workspace-level config in this version; the keymap and theme
+    resolve once from the first repo, matching the single-repo "resolved once,
+    relaunch to change" contract.
 - **Current-PR CI status indicator in the Status pane** (issue #299): the
   Issue / PR section (`2`) now renders an overall CI state for the linked PR
   instead of a bare ` · checks N/M`. A coloured nerd-font indicator

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Step-by-step walkthrough: [`docs/getting-started/first-worktree.md`](docs/1.gett
 
 - **Native worktree ops** via vendored `libgit2` — `git worktree add/list/remove/prune` without shelling out.
 - **CLI + ratatui TUI** — `gwm <subcommand>` for scripts, bare `gwm` opens the interactive interface.
+- **Multi-repo workspace mode** ([#36](https://github.com/kbrdn1/gwm-cli/issues/36)) — `gwm --workspace ~/Projects` opens the TUI across every git repo one level below a root (a REPO column tags each row; the active repo follows the selection); `gwm list --workspace ~/Projects` prints the merged table; `gwm create --repo <name>` picks the target. Bare `gwm` in a repo-free dir that holds child repos offers to open it as a workspace.
 - **Per-repo `.gwm.toml` + user-level global config** — branch / path conventions, file copies, regex guards, no-symlink invariants. A `~/.config/gwm/config.toml` deep-merges underneath each repo's `.gwm.toml`. Edit it git-config-style with `gwm config get / set / list / validate`.
 - **Lifecycle hooks `[hooks.*]`** — `pre_create` / `post_create` / `pre_bootstrap` / `post_bootstrap` / `pre_remove` / `post_remove` phases, each with `when:` predicates and per-step `on_fail = abort|warn|ignore`.
 - **CLI aliases + Gitmoji convention** — `[aliases]` expand `gwm <alias>` to argv before parsing; `gwm commit-prefix`, `gwm types --gitmoji`, and an opt-in `gwm hooks install commit-msg` hook enforce the repo's Gitmoji + Conventional Commits style.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,6 +103,7 @@ A second post-rc.1 train has since landed on `dev`, queued for the next release 
 - [#290](https://github.com/kbrdn1/gwm-cli/issues/290) — TUI keymap redesign (unified list-view bindings, `[tui.macro1]` / `[tui.macro2]`).
 - [#219](https://github.com/kbrdn1/gwm-cli/issues/219) — rebindable modal keys with contextual `[tui.keys.modal.<context>]` actions.
 - [#294](https://github.com/kbrdn1/gwm-cli/issues/294) — edit every keymap from the Settings panel (Keys tab, live keystroke capture, validated write-back).
+- [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — **Multi-repo workspace mode** — `gwm --workspace ~/Projects` (and bare-`gwm` auto-detect) opens the TUI across every child repo with a REPO column; `gwm list --workspace` prints the merged table; `gwm create --repo <name>` disambiguates the target.
 
 Queued near-term follow-up:
 
@@ -112,7 +113,6 @@ Queued near-term follow-up:
 
 Larger investments with strategic payoff. Gated by user demand or a concrete first consumer.
 
-- [#36](https://github.com/kbrdn1/gwm-cli/issues/36) — **Multi-repo workspace mode** — `gwm --workspace ~/Projects` shows worktrees across every child repo in one TUI.
 - [#37](https://github.com/kbrdn1/gwm-cli/issues/37) — **Configuration presets** — `gwm init --preset laravel / nuxt / rust / go / python-uv` seeds an opinionated `.gwm.toml` for known stacks instead of the generic default.
 - [#38](https://github.com/kbrdn1/gwm-cli/issues/38) — **JSON-RPC / gRPC API + daemon mode** — `--format=json` on key commands, then a long-running daemon over `$XDG_RUNTIME_DIR/gwm.sock` for editor / statusbar integration.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,7 @@ use crate::naming::{parse_branch, BranchSpec};
 use crate::pr_templates::{self, PrTemplateContext};
 use crate::sync::{self, SyncAction, SyncReport, SyncStrategy};
 use crate::trust::{self, TrustLedger, TrustMode, TrustOutcome};
+use crate::workspace;
 use crate::worktree;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
@@ -44,6 +45,18 @@ pub struct Cli {
   /// execution path even if the ledger says trusted.
   #[arg(long, global = true, conflicts_with = "allow_bootstrap")]
   pub deny_bootstrap: bool,
+
+  /// Operate across every git repo one level below <DIR> (issue #36).
+  ///
+  /// Workspace mode is an orthogonal dimension on top of single-repo
+  /// mode: `gwm --workspace ~/Projects` opens the TUI over every
+  /// direct-child repo, and `gwm list --workspace ~/Projects` prints
+  /// the merged worktree table with a leading `REPO` column.
+  /// `.gwm.toml` stays per-repo — there is no workspace-level config.
+  /// `global = true` so the flag is accepted before or after the
+  /// subcommand.
+  #[arg(long, global = true, value_name = "DIR")]
+  pub workspace: Option<PathBuf>,
 
   #[command(subcommand)]
   pub command: Option<Command>,
@@ -738,7 +751,10 @@ pub fn run(cli: Cli) -> Result<()> {
 
   match cmd {
     Command::Init => cmd_init(),
-    Command::List { format, detect_pr } => cmd_list(format, detect_pr),
+    Command::List { format, detect_pr } => match cli.workspace {
+      Some(root) => cmd_list_workspace(&root, format, detect_pr),
+      None => cmd_list(format, detect_pr),
+    },
     Command::Create {
       branch_type,
       issue,
@@ -1110,6 +1126,125 @@ fn cmd_list(format: ListFormat, detect_pr: bool) -> Result<()> {
         branch,
         status,
         w.path.display(),
+        nw = name_w,
+        bw = branch_w,
+        sw = status_w,
+      );
+    }
+  }
+  Ok(())
+}
+
+/// `gwm list --workspace <root>`: the merged, repo-tagged table across every
+/// git repo one level below `root` (issue #36). Mirrors [`cmd_list`]'s columns
+/// but prepends a `REPO` column; `--detect-pr` is honoured per row against the
+/// owning repo. `--format names` qualifies each worktree as `<repo>/<name>`
+/// (including the main worktree, which in workspace mode is the primary `cd`
+/// target) so a completion candidate is unambiguous across repos.
+fn cmd_list_workspace(root: &Path, format: ListFormat, detect_pr: bool) -> Result<()> {
+  let ws = workspace::discover(root)?;
+  if ws.is_empty() {
+    return Err(GwmError::EmptyWorkspace {
+      root: root.display().to_string(),
+    });
+  }
+  let rows = workspace::merge_worktrees(&ws)?;
+
+  if format == ListFormat::Names {
+    for row in &rows {
+      println!("{}/{}", row.repo_name, row.info.name);
+    }
+    return Ok(());
+  }
+
+  // PR auto-detection (issue #181) resolved per row against its own repo.
+  let detected_prs: Vec<Option<u64>> = if detect_pr {
+    rows
+      .iter()
+      .map(|row| {
+        let repo = Repository::open(&row.repo_path).ok()?;
+        let branch = row.info.branch.as_deref()?;
+        let slug = github::repo_slug(&repo).ok()?;
+        github::read_link_with_pr_detection(&repo, branch, &slug)
+          .ok()
+          .and_then(|l| l.pr)
+      })
+      .collect()
+  } else {
+    Vec::new()
+  };
+
+  let repo_w = rows.iter().map(|r| r.repo_name.len()).max().unwrap_or(4).clamp(4, 30);
+  let name_w = rows.iter().map(|r| r.info.name.len()).max().unwrap_or(4).clamp(4, 40);
+  let branch_w = rows
+    .iter()
+    .map(|r| r.info.branch.as_deref().unwrap_or("-").len())
+    .max()
+    .unwrap_or(6)
+    .clamp(6, 40);
+  let status_w = 14;
+  let pr_w = 6;
+
+  if detect_pr {
+    println!(
+      "  {:<rw$}  {:<nw$}  {:<bw$}  {:<sw$}  {:<pw$}  PATH",
+      "REPO",
+      "NAME",
+      "BRANCH",
+      "STATUS",
+      "PR",
+      rw = repo_w,
+      nw = name_w,
+      bw = branch_w,
+      sw = status_w,
+      pw = pr_w,
+    );
+  } else {
+    println!(
+      "  {:<rw$}  {:<nw$}  {:<bw$}  {:<sw$}  PATH",
+      "REPO",
+      "NAME",
+      "BRANCH",
+      "STATUS",
+      rw = repo_w,
+      nw = name_w,
+      bw = branch_w,
+      sw = status_w,
+    );
+  }
+  for (i, row) in rows.iter().enumerate() {
+    let w = &row.info;
+    let mark = if w.is_main { "*" } else { " " };
+    let branch = w.branch.clone().unwrap_or_else(|| "-".into());
+    let status = format_status_text(w);
+    if detect_pr {
+      let pr = detected_prs.get(i).copied().flatten();
+      let pr_cell = pr.map(|n| format!("#{n}")).unwrap_or_else(|| "-".into());
+      println!(
+        "{} {:<rw$}  {:<nw$}  {:<bw$}  {:<sw$}  {:<pw$}  {}",
+        mark,
+        row.repo_name,
+        w.name,
+        branch,
+        status,
+        pr_cell,
+        w.path.display(),
+        rw = repo_w,
+        nw = name_w,
+        bw = branch_w,
+        sw = status_w,
+        pw = pr_w,
+      );
+    } else {
+      println!(
+        "{} {:<rw$}  {:<nw$}  {:<bw$}  {:<sw$}  {}",
+        mark,
+        row.repo_name,
+        w.name,
+        branch,
+        status,
+        w.path.display(),
+        rw = repo_w,
         nw = name_w,
         bw = branch_w,
         sw = status_w,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -765,6 +765,14 @@ pub fn run(cli: Cli) -> Result<()> {
     return crate::tui::run(mode);
   };
 
+  // `--workspace` is global (clap accepts it everywhere) but only `list`,
+  // `create` and the bare TUI implement it. Reject it on any other subcommand
+  // rather than silently ignoring it and acting on the current single repo — a
+  // wrong-target footgun for destructive commands (Codex review #303 P2).
+  if cli.workspace.is_some() && !matches!(cmd, Command::List { .. } | Command::Create { .. }) {
+    return Err(GwmError::WorkspaceUnsupportedCommand);
+  }
+
   match cmd {
     Command::Init => cmd_init(),
     Command::List { format, detect_pr } => match cli.workspace {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,12 @@ pub enum Command {
     /// Skip lifecycle hooks for comma-separated phases (e.g. pre_create,post_create).
     #[arg(long, value_name = "PHASES")]
     skip_hooks: Option<String>,
+    /// In workspace mode (`--workspace <dir>`), which child repo gets the
+    /// new worktree (issue #36). Required there to disambiguate; ignored
+    /// in single-repo mode, where the worktree always lands in the
+    /// discovered repo.
+    #[arg(long, value_name = "NAME")]
+    repo: Option<String>,
   },
   /// Render the PR body from `[pr_template]` (issue #84), then
   /// `gh pr create` unless `--render` is passed.
@@ -762,7 +768,23 @@ pub fn run(cli: Cli) -> Result<()> {
       no_bootstrap,
       reuse_branch,
       skip_hooks,
-    } => cmd_create(branch_type, issue, desc, no_bootstrap, reuse_branch, skip_hooks, mode),
+      repo,
+    } => {
+      let start = match &cli.workspace {
+        Some(root) => Some(resolve_workspace_create_repo(root, repo)?),
+        None => None,
+      };
+      cmd_create(
+        branch_type,
+        issue,
+        desc,
+        no_bootstrap,
+        reuse_branch,
+        skip_hooks,
+        mode,
+        start.as_deref(),
+      )
+    }
     Command::New {
       branch_type,
       desc,
@@ -1324,6 +1346,28 @@ pub fn repo_context_lenient(start: Option<&Path>) -> Result<RepoContext> {
   Ok(RepoContext { repo, workdir, config })
 }
 
+/// Resolve which child repo a workspace-mode `gwm create` targets (issue #36).
+/// `--repo` is required there to disambiguate; an absent flag lists the
+/// candidates, an unknown name lists them too. Returns the chosen repo's path
+/// so [`cmd_create`] can discover from it instead of the current directory.
+fn resolve_workspace_create_repo(root: &Path, repo: Option<String>) -> Result<PathBuf> {
+  let ws = workspace::discover(root)?;
+  if ws.is_empty() {
+    return Err(GwmError::EmptyWorkspace {
+      root: root.display().to_string(),
+    });
+  }
+  let available = ws.repos.iter().map(|r| r.name.as_str()).collect::<Vec<_>>().join(", ");
+  let name = repo.ok_or_else(|| GwmError::WorkspaceRepoRequired {
+    available: available.clone(),
+  })?;
+  ws.repos
+    .iter()
+    .find(|r| r.name == name)
+    .map(|r| r.path.clone())
+    .ok_or(GwmError::WorkspaceRepoNotFound { name, available })
+}
+
 fn cmd_create(
   branch_type: String,
   issue: String,
@@ -1332,8 +1376,9 @@ fn cmd_create(
   reuse_branch: bool,
   skip_hooks: Option<String>,
   trust_mode: TrustMode,
+  start: Option<&Path>,
 ) -> Result<()> {
-  let RepoContext { repo, workdir, config } = repo_context(None)?;
+  let RepoContext { repo, workdir, config } = repo_context(start)?;
   let repo_name = worktree::repo_name(&repo);
 
   let resolved_types = config.resolved_branch_types();
@@ -1439,6 +1484,7 @@ fn cmd_new(
     reuse_branch,
     skip_hooks,
     trust_mode,
+    None,
   )
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -752,6 +752,16 @@ pub fn run(cli: Cli) -> Result<()> {
   // sites (`submit_create`, `bootstrap_selected`) take the same
   // trust decision as `gwm create` / `gwm bootstrap`.
   let Some(cmd) = cli.command else {
+    // Explicit workspace mode (issue #36): `gwm --workspace <root>` opens the
+    // TUI across every child repo.
+    if let Some(root) = cli.workspace {
+      return crate::tui::run_workspace(&root, mode);
+    }
+    // Auto-detect: bare `gwm` in a repo-free directory that holds child repos
+    // offers to open it as a workspace.
+    if let Some(root) = autodetect_workspace_prompt()? {
+      return crate::tui::run_workspace(&root, mode);
+    }
     return crate::tui::run(mode);
   };
 
@@ -834,6 +844,39 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Undo { bootstrap } => cmd_undo(bootstrap),
     Command::Tui { action } => cmd_tui(action),
     Command::Theme { action } => cmd_theme(action),
+  }
+}
+
+/// Auto-detect prompt for bare `gwm` (issue #36): when the cwd is not inside a
+/// git repo but holds direct-child repos, ask whether to open it as a
+/// workspace. Returns the chosen root on a yes (`Enter` / `y`), else `None` so
+/// the caller falls through to single-repo discovery (which then surfaces
+/// `NotInGitRepo`). Declines silently when stdin is not a terminal (pipes / CI)
+/// so non-interactive `gwm` behaves exactly as before — never blocking on a
+/// prompt nobody can answer.
+fn autodetect_workspace_prompt() -> Result<Option<PathBuf>> {
+  use std::io::{IsTerminal, Write};
+
+  let cwd = std::env::current_dir()?;
+  let Some(ws) = workspace::autodetect(&cwd) else {
+    return Ok(None);
+  };
+  if !io::stdin().is_terminal() {
+    return Ok(None);
+  }
+  eprint!(
+    "No git repo here. Open {} as a workspace ({} repos)? [Y/n] ",
+    cwd.display(),
+    ws.repos.len()
+  );
+  io::stderr().flush().ok();
+  let mut answer = String::new();
+  io::stdin().read_line(&mut answer)?;
+  let a = answer.trim().to_ascii_lowercase();
+  if a.is_empty() || a == "y" || a == "yes" {
+    Ok(Some(ws.root))
+  } else {
+    Ok(None)
   }
 }
 
@@ -1368,6 +1411,12 @@ fn resolve_workspace_create_repo(root: &Path, repo: Option<String>) -> Result<Pa
     .ok_or(GwmError::WorkspaceRepoNotFound { name, available })
 }
 
+// `cmd_create` mirrors the `Create` subcommand's independent CLI args 1:1
+// (three positionals + three flags + the resolved trust mode), and #36 adds
+// the workspace `start` path. Bundling them into a struct would only add an
+// indirection that obscures the direct subcommand → handler mapping the rest
+// of this dispatcher follows, so the arg count is deliberate here.
+#[allow(clippy::too_many_arguments)]
 fn cmd_create(
   branch_type: String,
   issue: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,16 @@ pub enum GwmError {
   #[error("no git repos found directly under workspace root '{root}'")]
   EmptyWorkspace { root: String },
 
+  /// Issue #36: `gwm create` in workspace mode is ambiguous without an
+  /// explicit target repo — list the candidates so the user can pick one.
+  #[error("workspace mode: `gwm create` requires --repo <name> (one of: {available})")]
+  WorkspaceRepoRequired { available: String },
+
+  /// Issue #36: `--repo <name>` named a repo that is not present directly
+  /// under the workspace root.
+  #[error("repo '{name}' not found in workspace (available: {available})")]
+  WorkspaceRepoNotFound { name: String, available: String },
+
   #[error("{0}")]
   Other(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,6 +134,14 @@ pub enum GwmError {
   #[error("repo '{name}' not found in workspace (available: {available})")]
   WorkspaceRepoNotFound { name: String, available: String },
 
+  /// Issue #36: `--workspace` is a global flag, so clap accepts it for every
+  /// subcommand, but only `list`, `create` and bare `gwm` (the TUI) implement
+  /// it. Reject it elsewhere rather than silently ignoring it and acting on
+  /// the current single repo — a wrong-target footgun for destructive
+  /// commands like `gwm remove` (Codex review #303 P2).
+  #[error("--workspace is only supported with `gwm list`, `gwm create`, or bare `gwm` (the TUI) — refusing to run this subcommand against a single repo")]
+  WorkspaceUnsupportedCommand,
+
   #[error("{0}")]
   Other(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -118,6 +118,12 @@ pub enum GwmError {
   #[error("no {kind} linked to branch '{branch}'")]
   LinkMissing { kind: LinkKind, branch: String },
 
+  /// Issue #36: `--workspace <dir>` pointed at a directory that holds no
+  /// git repos directly below it. Surfaced rather than opening an empty
+  /// table / TUI so the user can tell a wrong path from an empty root.
+  #[error("no git repos found directly under workspace root '{root}'")]
+  EmptyWorkspace { root: String },
+
   #[error("{0}")]
   Other(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,4 +27,5 @@ pub mod sync;
 pub mod templating;
 pub mod trust;
 pub mod tui;
+pub mod workspace;
 pub mod worktree;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -200,6 +200,12 @@ pub struct App {
   pub config: Config,
   /// Workspace-mode state (issue #36); `None` in single-repo mode.
   pub workspace: Option<WorkspaceState>,
+  /// Set when the selected row's repo could not be activated in workspace mode
+  /// (moved / deleted / corrupt since listing). While true, `repo`/`workdir`/
+  /// `config` still point at the previously active repo, so repo-mutating
+  /// actions are blocked to avoid a wrong-target write (#304). Always `false`
+  /// in single-repo mode and once a selection activates cleanly.
+  pub workspace_active_stale: bool,
   pub worktrees: Vec<WorktreeInfo>,
   pub list_state: TableState,
   pub view: View,
@@ -467,6 +473,7 @@ impl App {
       workdir,
       config,
       workspace: None,
+      workspace_active_stale: false,
       worktrees,
       list_state: state,
       view: View::List,
@@ -628,6 +635,9 @@ impl App {
       return;
     };
     if target == ws.active {
+      // The selection is on the live, already-activated repo — clear any stale
+      // flag left over from a previous unreachable selection.
+      self.workspace_active_stale = false;
       return;
     }
     let Some(meta) = ws.repos.get(target).cloned() else {
@@ -639,6 +649,7 @@ impl App {
         self.repo_name = meta.name;
         self.workdir = meta.workdir;
         self.config = meta.config;
+        self.workspace_active_stale = false;
         // The branch types drive the create form; re-resolve them from the
         // newly-active repo's config so a per-repo `[[branch_types]]` override
         // applies to the row being acted on (Codex review #303 P2).
@@ -655,7 +666,14 @@ impl App {
         self.refresh_link();
       }
       Err(e) => {
-        self.status = format!("workspace: failed to open repo '{}': {}", meta.name, e);
+        // Keep the previously active repo live but mark the selection stale so
+        // repo-mutating actions are blocked until the user moves to a
+        // reachable row (or a refresh drops the dead repo) — #304.
+        self.workspace_active_stale = true;
+        self.status = format!(
+          "workspace: repo '{}' is unavailable ({}) — press r to refresh",
+          meta.name, e
+        );
       }
     }
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -675,6 +675,35 @@ impl App {
     }
   }
 
+  /// Reload every workspace repo's cached config from disk (issue #36). Called
+  /// after a Global-layer settings edit, which changes the deep-merged config
+  /// for *all* repos — without this, navigating to a non-active repo would
+  /// restore the config it was loaded with at startup, reverting the edit for
+  /// that repo until relaunch (Codex review #303 P2). The active repo's live
+  /// `self.config` is already current (set by `set_active_config`); this
+  /// re-syncs its cached meta too, so it stays the single source of truth.
+  fn reload_workspace_repo_configs(&mut self) {
+    let Some(ws) = self.workspace.as_ref() else {
+      return;
+    };
+    let global = self.global_path.clone();
+    let targets: Vec<(usize, PathBuf)> = ws
+      .repos
+      .iter()
+      .enumerate()
+      .map(|(i, m)| (i, m.workdir.clone()))
+      .collect();
+    for (i, workdir) in targets {
+      if let Ok(cfg) = Config::load_layered(&workdir, global.as_deref()) {
+        if let Some(ws) = self.workspace.as_mut() {
+          if let Some(meta) = ws.repos.get_mut(i) {
+            meta.config = cfg;
+          }
+        }
+      }
+    }
+  }
+
   /// Per-row mask of whether each `worktrees` row belongs to the currently
   /// active repo. `None` in single-repo mode (every row qualifies). Issue/PR
   /// numbers are only unique *within* a repo, so the number-keyed GitHub state
@@ -2007,6 +2036,14 @@ impl App {
         self.status = format!("settings saved, but reload failed: {}", e);
         return;
       }
+    }
+    // A Global-layer edit changes config for *every* repo, not just the active
+    // one — refresh each cached `RepoMeta.config` so navigating to another repo
+    // doesn't restore the pre-edit global value (Codex review #303 P2). A
+    // Project-layer edit only touched the active repo's `.gwm.toml`, already
+    // handled by `set_active_config`.
+    if self.config_panel.layer == SettingsLayer::Global {
+      self.reload_workspace_repo_configs();
     }
     match self.config.theme.resolve() {
       Ok(theme) => self.theme = theme,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -560,13 +560,21 @@ impl App {
     // branch types, and sets up the task channels exactly as single-repo mode.
     let mut app = Self::new_at_layered(Some(&repos[0].workdir), global_path)?;
 
-    // Replace the single-repo list with the merged, repo-tagged one.
-    let name_to_idx: HashMap<&str, usize> = repos.iter().enumerate().map(|(i, m)| (m.name.as_str(), i)).collect();
+    // Replace the single-repo list with the merged, repo-tagged one. Map each
+    // row to its repo by the repo's *workdir path*, not its display name —
+    // names can collide (a linked worktree resolving to an owner outside the
+    // root, symlinks), and a name-keyed map would then point rows at the wrong
+    // repo handle/config (Codex review #303 round-2 P2).
+    let path_to_idx: HashMap<&Path, usize> = repos
+      .iter()
+      .enumerate()
+      .map(|(i, m)| (m.workdir.as_path(), i))
+      .collect();
     let rows = crate::workspace::merge_worktrees(&ws)?;
     let mut worktrees = Vec::with_capacity(rows.len());
     let mut row_repo = Vec::with_capacity(rows.len());
     for row in &rows {
-      let idx = name_to_idx.get(row.repo_name.as_str()).copied().unwrap_or(0);
+      let idx = path_to_idx.get(row.repo_path.as_path()).copied().unwrap_or(0);
       worktrees.push(row.info.clone());
       row_repo.push(idx);
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -660,6 +660,32 @@ impl App {
     }
   }
 
+  /// Set the active config, keeping the workspace cache coherent. In
+  /// workspace mode the per-repo `RepoMeta.config` is the source of truth that
+  /// `sync_active_repo` restores on activation, so a settings/keymap reload
+  /// that only updated `self.config` would be reverted the next time the user
+  /// navigated away and back (Codex review #303 P3). Write the reloaded config
+  /// through to the active repo's cached meta too.
+  fn set_active_config(&mut self, cfg: Config) {
+    self.config = cfg;
+    if let Some(ws) = self.workspace.as_mut() {
+      if let Some(meta) = ws.repos.get_mut(ws.active) {
+        meta.config = self.config.clone();
+      }
+    }
+  }
+
+  /// Per-row mask of whether each `worktrees` row belongs to the currently
+  /// active repo. `None` in single-repo mode (every row qualifies). Issue/PR
+  /// numbers are only unique *within* a repo, so the number-keyed GitHub state
+  /// stamping must be scoped to the active repo's rows in workspace mode —
+  /// otherwise a fetch for repo A's `#1` would stamp (and persist to the wrong
+  /// repo) every other repo's `#1` row (Codex review #303 P2).
+  fn active_repo_row_mask(&self) -> Option<Vec<bool>> {
+    let ws = self.workspace.as_ref()?;
+    Some(ws.row_repo.iter().map(|&r| r == ws.active).collect())
+  }
+
   /// Re-list every repo in the workspace and rebuild the merged table +
   /// row→repo map (issue #36). The single-repo async refresh would clobber the
   /// merged list with one repo's worktrees, so workspace refresh runs
@@ -804,26 +830,33 @@ impl App {
   /// the synchronous [`Self::refresh`] and by the off-thread drain in
   /// [`Self::drain_task_results`].
   fn apply_refreshed_worktrees(&mut self, mut worktrees: Vec<WorktreeInfo>) {
-    let issue_states: HashMap<u64, IssueState> = self
-      .worktrees
-      .iter()
-      .filter_map(|w| Some((w.link.issue?, w.issue_state?)))
-      .collect();
-    let pr_states = self
-      .worktrees
-      .iter()
-      .filter_map(|w| Some((w.link.pr?, w.pr_state?)))
-      .collect::<HashMap<_, _>>();
+    // The carry-over preserves this session's in-memory fetched issue/PR state
+    // across a re-list, keyed by number. In workspace mode that key collides
+    // across repos (two repos can both own `#1`), so skip it: the freshly
+    // listed rows already carry each repo's own *persisted* state from
+    // `read_link`, which is per-repo-correct (Codex review #303 P2).
+    if !self.is_workspace() {
+      let issue_states: HashMap<u64, IssueState> = self
+        .worktrees
+        .iter()
+        .filter_map(|w| Some((w.link.issue?, w.issue_state?)))
+        .collect();
+      let pr_states = self
+        .worktrees
+        .iter()
+        .filter_map(|w| Some((w.link.pr?, w.pr_state?)))
+        .collect::<HashMap<_, _>>();
 
-    for w in &mut worktrees {
-      if let Some(issue) = w.link.issue {
-        if let Some(state) = issue_states.get(&issue).copied() {
-          w.issue_state = Some(state);
+      for w in &mut worktrees {
+        if let Some(issue) = w.link.issue {
+          if let Some(state) = issue_states.get(&issue).copied() {
+            w.issue_state = Some(state);
+          }
         }
-      }
-      if let Some(pr) = w.link.pr {
-        if let Some(state) = pr_states.get(&pr).copied() {
-          w.pr_state = Some(state);
+        if let Some(pr) = w.link.pr {
+          if let Some(state) = pr_states.get(&pr).copied() {
+            w.pr_state = Some(state);
+          }
         }
       }
     }
@@ -1787,7 +1820,7 @@ impl App {
     // Reload the merged config and rebuild both keymaps so the new binding
     // fires without a restart.
     match Config::load_layered(&self.workdir, self.global_path.as_deref()) {
-      Ok(cfg) => self.config = cfg,
+      Ok(cfg) => self.set_active_config(cfg),
       Err(e) => {
         // The single-file write validated but the layered merge is invalid —
         // roll the file back to its prior state so the config is never left
@@ -1969,7 +2002,7 @@ impl App {
     // Reload the merged config so every live read (open mode, confirm
     // countdown) and the re-seeded state below reflect the edit.
     match Config::load_layered(&self.workdir, self.global_path.as_deref()) {
-      Ok(cfg) => self.config = cfg,
+      Ok(cfg) => self.set_active_config(cfg),
       Err(e) => {
         self.status = format!("settings saved, but reload failed: {}", e);
         return;
@@ -3144,7 +3177,15 @@ impl App {
         let _ = github::persist_issue_state(&self.repo, &branch, status.state);
       }
     }
-    for w in &mut self.worktrees {
+    // In workspace mode the fetch was for the active repo's selected issue, so
+    // only stamp/persist rows belonging to that repo — a number-only match
+    // would otherwise carry repo A's state onto repo B's same-numbered row and
+    // persist it through the wrong repo handle (Codex review #303 P2).
+    let mask = self.active_repo_row_mask();
+    for (i, w) in self.worktrees.iter_mut().enumerate() {
+      if mask.as_ref().is_some_and(|m| !m[i]) {
+        continue;
+      }
       if w.link.issue != Some(status.number) {
         continue;
       }
@@ -3172,7 +3213,13 @@ impl App {
         };
       }
     }
-    for w in &mut self.worktrees {
+    // Scope to the active repo's rows in workspace mode — see the matching
+    // note in `sync_issue_status_into_table` (Codex review #303 P2).
+    let mask = self.active_repo_row_mask();
+    for (i, w) in self.worktrees.iter_mut().enumerate() {
+      if mask.as_ref().is_some_and(|m| !m[i]) {
+        continue;
+      }
       if w.link.pr != Some(status.number) {
         continue;
       }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -637,9 +637,15 @@ impl App {
       return;
     };
     let Some(raw) = self.selected_raw_index() else {
+      // No visible/selected row (e.g. the filter hides everything): there is no
+      // active repo the selection points at, so writes must not fall through to
+      // the previously active repo — mark stale to block them (#304). Reached
+      // only in workspace mode (the `ws` guard above returns in single-repo).
+      self.workspace_active_stale = true;
       return;
     };
     let Some(&target) = ws.row_repo.get(raw) else {
+      self.workspace_active_stale = true;
       return;
     };
     if target == ws.active {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1836,6 +1836,13 @@ impl App {
     let config_key = target.config_key();
     let items = cap.as_config_items();
 
+    // A Project-layer write targets `self.workdir/.gwm.toml`. In workspace mode
+    // with a stale selection that path is the *previously* active repo, so
+    // refuse rather than rebind keys in the wrong repo (#304).
+    if self.workspace_active_stale && self.config_panel.layer == SettingsLayer::Project {
+      self.status = "workspace: selected repo is unavailable — can't edit its project keymap".into();
+      return;
+    }
     let path = match self.config_panel.layer {
       SettingsLayer::Project => self.workdir.join(crate::config::CONFIG_FILE),
       SettingsLayer::Global => match self.global_path.clone() {
@@ -2037,6 +2044,14 @@ impl App {
   /// `All` tab and the source attribution track the edit. Every fallible
   /// step routes its error to the status line — no `unwrap` on this path.
   pub fn apply_setting(&mut self, field: SettingField, value: &str) {
+    // A Project-layer write targets `self.workdir/.gwm.toml`. In workspace mode
+    // with a stale selection that path is the *previously* active repo, so
+    // refuse rather than write settings into the wrong repo (#304). Global-layer
+    // edits are repo-independent and stay allowed.
+    if self.workspace_active_stale && self.config_panel.layer == SettingsLayer::Project {
+      self.status = "workspace: selected repo is unavailable — can't edit its project config".into();
+      return;
+    }
     let path = match self.config_panel.layer {
       SettingsLayer::Project => self.workdir.join(crate::config::CONFIG_FILE),
       SettingsLayer::Global => match self.global_path.clone() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -575,9 +575,10 @@ impl App {
     });
     app.filter.invalidate();
     app.list_state.select(if wt_count == 0 { None } else { Some(0) });
-    // Resolve GitHub statuses across the full merged set (construction only
-    // refreshed the anchor repo's rows).
-    app.refresh_linked_github_statuses_for_worktrees();
+    // Resolve the initially-selected row's GitHub link/slug against its own
+    // repo (the anchor). Workspace mode fetches GitHub state per-selection, not
+    // in one cross-repo bulk pass — see `refresh_linked_github_statuses_for_worktrees`.
+    app.refresh_link();
     app.status = format!(
       "workspace {} — {} repo(s), {} worktree(s) · press ? for help",
       root.display(),
@@ -638,10 +639,20 @@ impl App {
         self.repo_name = meta.name;
         self.workdir = meta.workdir;
         self.config = meta.config;
+        // The branch types drive the create form; re-resolve them from the
+        // newly-active repo's config so a per-repo `[[branch_types]]` override
+        // applies to the row being acted on (Codex review #303 P2).
+        self.branch_types = self.config.resolved_branch_types().types;
         if let Some(ws) = self.workspace.as_mut() {
           ws.active = target;
         }
         self.invalidate_sidebar_cache();
+        // Re-resolve the GitHub link + slug against the now-active repo so the
+        // Issue/PR panel and the `F` refresh act on the selected row's own
+        // repo, not the previously-active one (Codex review #303 P2). The
+        // per-repo nav hook (`on_navigation`) ran `refresh_link` *before* this
+        // swap, while `self.repo` still pointed at the old repo.
+        self.refresh_link();
       }
       Err(e) => {
         self.status = format!("workspace: failed to open repo '{}': {}", meta.name, e);
@@ -682,8 +693,12 @@ impl App {
       ws.row_repo = row_repo;
     }
     self.apply_refreshed_worktrees(worktrees);
-    // The selection may now land on a different repo's row — re-align.
+    // The selection may now land on a different repo's row — re-align the
+    // active repo. `sync_active_repo` only refreshes the link when the repo
+    // actually changes, so re-resolve the selected row's link/slug here too
+    // (the bulk prefetch is a no-op in workspace mode).
     self.sync_active_repo();
+    self.refresh_link();
   }
 
   /// Builder-style setter for `trust_mode`. The TUI entrypoint
@@ -3296,6 +3311,16 @@ impl App {
   }
 
   fn refresh_linked_github_statuses_for_worktrees(&mut self) -> u32 {
+    // Workspace mode (#36): this bulk prefetch resolves every merged row's
+    // issue/PR against a single repo's slug (`self.github.link_slug`), which
+    // mis-attributes numbers across child repos with different remotes (Codex
+    // review #303 P2). In workspace mode GitHub state is fetched per-selection
+    // instead — `sync_active_repo`/`on_navigation` call `refresh_link`, which
+    // re-resolves the slug from the selected row's own repo. So skip the bulk
+    // cross-repo prefetch here.
+    if self.is_workspace() {
+      return 0;
+    }
     let Some(slug) = self.github.link_slug.clone() else {
       return 0;
     };

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -160,11 +160,46 @@ pub enum OpenTarget {
 /// learning the new module path.
 pub use super::state::link_prompt::LinkPromptStage;
 
+/// One repo's session-stable metadata in workspace mode (issue #36). The live
+/// `git2::Repository` is *not* stored here (it isn't `Send`/`Clone` and would
+/// duplicate `App.repo`); it is re-opened from `workdir` when this repo
+/// becomes the active one. `config` is cloned into `App.config` on activation
+/// so per-row actions (`create`, bootstrap, hooks) read the right repo's
+/// `.gwm.toml` — matching the issue's "each row inherits its own repo's
+/// config" contract. Keymap/theme stay session-level (resolved once from the
+/// first repo), the same "resolved once, relaunch to change" contract as
+/// single-repo mode.
+#[derive(Debug, Clone)]
+pub struct RepoMeta {
+  pub name: String,
+  pub workdir: PathBuf,
+  pub config: Config,
+}
+
+/// Workspace-mode state (issue #36). `None` in single-repo mode (the default).
+/// The *active* repo lives in `App`'s core fields (`repo`/`repo_name`/
+/// `workdir`/`config`); this holds everything needed to swap a different repo
+/// into those fields as the selection moves between repos.
+#[derive(Debug, Clone)]
+pub struct WorkspaceState {
+  /// The root `--workspace` pointed at.
+  pub root: PathBuf,
+  /// Session-stable repo metadata, in discovery (alphabetical) order.
+  pub repos: Vec<RepoMeta>,
+  /// The owning repo index for each `App.worktrees[i]` row, parallel to that
+  /// vec. Rebuilt by every workspace refresh so it never drifts.
+  pub row_repo: Vec<usize>,
+  /// Index into `repos` of the currently active repo (mirrors `App.repo*`).
+  pub active: usize,
+}
+
 pub struct App {
   pub repo: Repository,
   pub repo_name: String,
   pub workdir: PathBuf,
   pub config: Config,
+  /// Workspace-mode state (issue #36); `None` in single-repo mode.
+  pub workspace: Option<WorkspaceState>,
   pub worktrees: Vec<WorktreeInfo>,
   pub list_state: TableState,
   pub view: View,
@@ -431,6 +466,7 @@ impl App {
       repo_name,
       workdir,
       config,
+      workspace: None,
       worktrees,
       list_state: state,
       view: View::List,
@@ -485,6 +521,169 @@ impl App {
       out.status = String::from("fetching GitHub status…");
     }
     Ok(out)
+  }
+
+  /// Workspace-mode constructor (issue #36): open the TUI over every git repo
+  /// one level below `root`, merging their worktree listings into one
+  /// repo-tagged table. Anchors the session on the first repo (alphabetical)
+  /// for keymap/theme resolution and the event-loop channels, then swaps the
+  /// merged list and per-row repo map in. Errors with [`GwmError::EmptyWorkspace`]
+  /// when no repo sits directly under `root`.
+  pub fn new_workspace_at_layered(root: &Path, global_path: Option<&Path>) -> Result<Self> {
+    let ws = crate::workspace::discover(root)?;
+    if ws.is_empty() {
+      return Err(GwmError::EmptyWorkspace {
+        root: root.display().to_string(),
+      });
+    }
+
+    // Load each repo's `.gwm.toml` once — session-stable metadata swapped into
+    // the active slot on navigation.
+    let mut repos: Vec<RepoMeta> = Vec::with_capacity(ws.repos.len());
+    for r in &ws.repos {
+      let config = Config::load_layered(&r.path, global_path)?;
+      repos.push(RepoMeta {
+        name: r.name.clone(),
+        workdir: r.path.clone(),
+        config,
+      });
+    }
+
+    // Anchor the session on the first repo: this resolves the keymap, theme,
+    // branch types, and sets up the task channels exactly as single-repo mode.
+    let mut app = Self::new_at_layered(Some(&repos[0].workdir), global_path)?;
+
+    // Replace the single-repo list with the merged, repo-tagged one.
+    let name_to_idx: HashMap<&str, usize> = repos.iter().enumerate().map(|(i, m)| (m.name.as_str(), i)).collect();
+    let rows = crate::workspace::merge_worktrees(&ws)?;
+    let mut worktrees = Vec::with_capacity(rows.len());
+    let mut row_repo = Vec::with_capacity(rows.len());
+    for row in &rows {
+      let idx = name_to_idx.get(row.repo_name.as_str()).copied().unwrap_or(0);
+      worktrees.push(row.info.clone());
+      row_repo.push(idx);
+    }
+
+    let repo_count = repos.len();
+    let wt_count = worktrees.len();
+    app.worktrees = worktrees;
+    app.workspace = Some(WorkspaceState {
+      root: root.to_path_buf(),
+      repos,
+      row_repo,
+      active: 0,
+    });
+    app.filter.invalidate();
+    app.list_state.select(if wt_count == 0 { None } else { Some(0) });
+    // Resolve GitHub statuses across the full merged set (construction only
+    // refreshed the anchor repo's rows).
+    app.refresh_linked_github_statuses_for_worktrees();
+    app.status = format!(
+      "workspace {} — {} repo(s), {} worktree(s) · press ? for help",
+      root.display(),
+      repo_count,
+      wt_count
+    );
+    Ok(app)
+  }
+
+  /// True when the TUI is in workspace mode (issue #36).
+  pub fn is_workspace(&self) -> bool {
+    self.workspace.is_some()
+  }
+
+  /// Display name of the repo owning raw worktree row `raw_index` (the index
+  /// into [`Self::worktrees`], not the filtered view). `None` in single-repo
+  /// mode or for an out-of-range index. Drives the TUI `REPO` column.
+  pub fn row_repo_name(&self, raw_index: usize) -> Option<&str> {
+    let ws = self.workspace.as_ref()?;
+    let idx = *ws.row_repo.get(raw_index)?;
+    ws.repos.get(idx).map(|m| m.name.as_str())
+  }
+
+  /// Raw `worktrees` index of the current selection, hopping through the fuzzy
+  /// filter map (the selection indexes the filtered view, not the raw vec).
+  fn selected_raw_index(&self) -> Option<usize> {
+    let i = self.list_state.selected()?;
+    let filtered = self.filter.snapshot_indices(&self.worktrees, fuzzy_match_indices);
+    filtered.get(i).copied()
+  }
+
+  /// Align the active repo (`repo`/`repo_name`/`workdir`/`config`) with the
+  /// selected worktree's repo (issue #36). A no-op in single-repo mode and
+  /// when the selection still belongs to the active repo, so the event loop
+  /// can call it every frame cheaply. On the repo actually changing it
+  /// re-opens the `git2::Repository` from the target workdir and invalidates
+  /// the sidebar preview; an open failure keeps the current repo and reports
+  /// on the status bar rather than panicking mid-render.
+  pub fn sync_active_repo(&mut self) {
+    let Some(ws) = self.workspace.as_ref() else {
+      return;
+    };
+    let Some(raw) = self.selected_raw_index() else {
+      return;
+    };
+    let Some(&target) = ws.row_repo.get(raw) else {
+      return;
+    };
+    if target == ws.active {
+      return;
+    }
+    let Some(meta) = ws.repos.get(target).cloned() else {
+      return;
+    };
+    match Repository::open(&meta.workdir) {
+      Ok(repo) => {
+        self.repo = repo;
+        self.repo_name = meta.name;
+        self.workdir = meta.workdir;
+        self.config = meta.config;
+        if let Some(ws) = self.workspace.as_mut() {
+          ws.active = target;
+        }
+        self.invalidate_sidebar_cache();
+      }
+      Err(e) => {
+        self.status = format!("workspace: failed to open repo '{}': {}", meta.name, e);
+      }
+    }
+  }
+
+  /// Re-list every repo in the workspace and rebuild the merged table +
+  /// row→repo map (issue #36). The single-repo async refresh would clobber the
+  /// merged list with one repo's worktrees, so workspace refresh runs
+  /// synchronously across all repos instead. Repos are fixed for the session
+  /// (a new repo under the root needs a relaunch, matching the config "resolved
+  /// once" contract), so this re-lists the stored metas rather than re-walking
+  /// the root.
+  fn refresh_workspace(&mut self) {
+    let Some(ws) = self.workspace.as_ref() else {
+      return;
+    };
+    let targets: Vec<(usize, PathBuf)> = ws
+      .repos
+      .iter()
+      .enumerate()
+      .map(|(i, m)| (i, m.workdir.clone()))
+      .collect();
+    let mut worktrees = Vec::new();
+    let mut row_repo = Vec::new();
+    for (idx, workdir) in &targets {
+      if let Ok(repo) = Repository::open(workdir) {
+        if let Ok(trees) = worktree::list(&repo) {
+          for t in trees {
+            worktrees.push(t);
+            row_repo.push(*idx);
+          }
+        }
+      }
+    }
+    if let Some(ws) = self.workspace.as_mut() {
+      ws.row_repo = row_repo;
+    }
+    self.apply_refreshed_worktrees(worktrees);
+    // The selection may now land on a different repo's row — re-align.
+    self.sync_active_repo();
   }
 
   /// Builder-style setter for `trust_mode`. The TUI entrypoint
@@ -570,6 +769,11 @@ impl App {
     // `apply_refreshed_worktrees` so the async drain, which shares that
     // tail, does not re-invalidate the run it just applied.
     self.tasks.invalidate(TaskKind::RefreshWorktrees);
+    if self.is_workspace() {
+      // Workspace mode re-lists every repo, not just the active one (#36).
+      self.refresh_workspace();
+      return Ok(());
+    }
     let worktrees = worktree::list(&self.repo)?;
     self.apply_refreshed_worktrees(worktrees);
     Ok(())
@@ -631,6 +835,12 @@ impl App {
   /// while loading is a no-op) and seeds the loader label + spinner. The
   /// result is applied by [`Self::drain_task_results`].
   pub fn request_refresh(&mut self) {
+    if self.is_workspace() {
+      // No single-repo async worker in workspace mode — it would clobber the
+      // merged list with one repo's worktrees (#36). Refresh synchronously.
+      let _ = self.refresh();
+      return;
+    }
     let Some(generation) = self.tasks.request(TaskKind::RefreshWorktrees) else {
       // A refresh is already in flight — coalesce onto it.
       return;
@@ -654,6 +864,11 @@ impl App {
       return false;
     }
     self.last_auto_refresh_at = now;
+    if self.is_workspace() {
+      // Synchronous merged refresh in workspace mode (#36) — see `refresh`.
+      let _ = self.refresh();
+      return true;
+    }
     let Some(generation) = self.tasks.request(TaskKind::RefreshWorktrees) else {
       return false;
     };

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -164,6 +164,26 @@ impl Action {
     COMPAT_ALIASES.iter().find(|(slug, _)| *slug == s).map(|(_, a)| *a)
   }
 
+  /// Whether this action mutates a repo through the *active* repo context
+  /// (`App.repo`/`workdir`/`config`) rather than only the selected worktree's
+  /// path. In workspace mode (#304) these are blocked while the selected row's
+  /// repo can't be activated, since they would otherwise target the previously
+  /// active repo. Navigation, yanks and read-only launchers are absent on
+  /// purpose — they don't write through the active repo handle.
+  pub fn is_repo_mutating(self) -> bool {
+    matches!(
+      self,
+      Action::Create
+        | Action::DeleteConfirm
+        | Action::Bootstrap
+        | Action::Sync
+        | Action::Pull
+        | Action::Push
+        | Action::EditWorktree
+        | Action::LinkPrompt
+    )
+  }
+
   /// The pre-#290 alias slug(s) that resolve to this action, if any. Used by
   /// the in-TUI keymap editor (issue #294) to strip a stale alias from a
   /// legacy config when the canonical slug is (re)written — otherwise the

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -181,6 +181,9 @@ impl Action {
         | Action::Push
         | Action::EditWorktree
         | Action::LinkPrompt
+        // FetchGithub persists detected PR/issue titles + states into the
+        // active repo's git config, so it writes through `App.repo` too (#304).
+        | Action::FetchGithub
     )
   }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,7 @@ use crossterm::{
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
@@ -103,6 +103,23 @@ pub fn run(trust_mode: crate::trust::TrustMode) -> Result<()> {
   leave_terminal(&mut terminal)?;
   // #290: ExitToWorktree prints the selected path to stdout so a shell
   // wrapper (`cd "$(gwm)"`) can change directory.
+  if let Some(path) = result? {
+    println!("{}", path.display());
+  }
+  Ok(())
+}
+
+/// Workspace-mode entry point (issue #36): open the TUI over every git repo
+/// one level below `root`. Same teardown-safety contract as [`run`] — App
+/// construction (discovery + per-repo config load) happens before the
+/// terminal is touched, so a failure (no repos, bad config) leaves the
+/// terminal cooked.
+pub fn run_workspace(root: &Path, trust_mode: crate::trust::TrustMode) -> Result<()> {
+  let app =
+    App::new_workspace_at_layered(root, crate::config::global_config_path().as_deref())?.with_trust_mode(trust_mode);
+  let mut terminal = enter_terminal()?;
+  let result = run_app(&mut terminal, app);
+  leave_terminal(&mut terminal)?;
   if let Some(path) = result? {
     println!("{}", path.display());
   }
@@ -213,6 +230,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         app.close_pty_overlay();
       }
     }
+
+    // Issue #36: in workspace mode keep the active repo aligned with the
+    // selected worktree's repo before drawing (so the sidebar preview reads
+    // the right repo) and before the next key fires an action against it. A
+    // no-op in single-repo mode and when the selection hasn't crossed repos.
+    app.sync_active_repo();
 
     terminal.draw(|f| ui::draw(f, &mut app))?;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -674,6 +674,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
 /// worker is still in flight. The loop checks the flag at the top and
 /// bottom of every iteration.
 fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut App, action: Action) -> Result<()> {
+  // Issue #304: in workspace mode, block repo-mutating actions while the
+  // selected row's repo could not be activated (moved/deleted/corrupt since
+  // listing) — `app.repo`/`workdir`/`config` still point at the previously
+  // active repo, so the write would hit the wrong repository. Navigation and
+  // refresh stay live so the user can recover (a refresh drops the dead repo).
+  if app.workspace_active_stale && action.is_repo_mutating() {
+    app.status = "workspace: selected repo is unavailable (moved/deleted?) — press r to refresh".into();
+    return Ok(());
+  }
+
   match action {
     // Issue #32/#267: signal quit via `app.should_quit` so palette
     // and keymap paths share the same graceful-shutdown gate.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -452,6 +452,24 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   // borrow handed to `render_stateful_widget`.
   let theme = app.theme;
 
+  // Workspace mode (issue #36): a leading REPO column naming each row's repo.
+  // Names are resolved per visible row up front so the immutable `app` reads
+  // don't clash with the mutable `list_state` borrow at render time.
+  let is_workspace = app.is_workspace();
+  let repo_names: Vec<String> = if is_workspace {
+    filtered
+      .iter()
+      .map(|&raw| app.row_repo_name(raw).unwrap_or("?").to_string())
+      .collect()
+  } else {
+    Vec::new()
+  };
+  let repo_w = if is_workspace {
+    column_width(repo_names.iter().map(|s| s.as_str()), 6, 24)
+  } else {
+    0
+  };
+
   // Dynamic column widths derived from the visible subset so columns fit the
   // rows actually on screen. The path column is always last and absorbs the
   // remaining width.
@@ -459,23 +477,26 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   let branch_w = column_width(visible.iter().map(|w| w.branch.as_deref().unwrap_or("-")), 18, 38);
   let status_w: u16 = 16;
 
-  let header = Row::new(vec![
-    // Age column lives at column 0 — recency-first, lazygit-style. No
-    // caption; the glyphs (`2d`, `3w`, `1M`, `5y`, `-`) are self-evident
-    // and a header would steal space from BRANCH on narrow terminals.
-    Cell::from(""),
-    // Issue / PR badge column (the `●/●` pastilles) — `I/P` fits its 3 cells.
-    Cell::from("I/P"),
-    Cell::from("NAME"),
-    Cell::from("BRANCH"),
-    Cell::from("STATUS"),
-    Cell::from("PATH"),
-  ])
-  .style(Style::default().fg(theme.muted).add_modifier(Modifier::BOLD));
+  // Header cells, with an optional REPO column after the (caption-less) age
+  // column in workspace mode.
+  let mut header_cells = vec![Cell::from("")];
+  if is_workspace {
+    header_cells.push(Cell::from("REPO"));
+  }
+  header_cells.push(Cell::from("I/P"));
+  header_cells.push(Cell::from("NAME"));
+  header_cells.push(Cell::from("BRANCH"));
+  header_cells.push(Cell::from("STATUS"));
+  header_cells.push(Cell::from("PATH"));
+  let header = Row::new(header_cells).style(Style::default().fg(theme.muted).add_modifier(Modifier::BOLD));
 
   let rows: Vec<Row> = visible
     .iter()
-    .map(|w| build_row(w, name_w, branch_w, status_w, &theme))
+    .enumerate()
+    .map(|(vi, w)| {
+      let repo = is_workspace.then(|| (repo_names[vi].as_str(), repo_w));
+      build_row(w, repo, name_w, branch_w, status_w, &theme)
+    })
     .collect();
 
   // ratatui's Layout solver squeezes the FIRST `Length` column to
@@ -491,14 +512,19 @@ fn draw_list(f: &mut Frame, area: Rect, app: &mut App) {
   //   - `Fill(1)` for path: takes whatever's left, vanishes last.
   // Verified by standalone probe down to 40-cell terminals: col 0
   // stays at 4 cells across every size.
-  let widths = [
-    Constraint::Length(4),
+  let mut widths = vec![Constraint::Length(4)];
+  if is_workspace {
+    // REPO column sits between age and the I/P marker; a hard length so the
+    // solver doesn't starve it on narrow terminals.
+    widths.push(Constraint::Length(repo_w));
+  }
+  widths.extend([
     Constraint::Length(3),
     Constraint::Min(name_w),
     Constraint::Min(branch_w),
     Constraint::Length(status_w),
     Constraint::Fill(1),
-  ];
+  ]);
 
   let list_has_focus = !(app.sidebar.open && app.sidebar.focused);
   let border_color = panel_border_color(list_has_focus, &app.theme);
@@ -1610,7 +1636,18 @@ pub fn help_label_style(theme: &Theme) -> Style {
   Style::default().fg(theme.name)
 }
 
-fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16, theme: &Theme) -> Row<'static> {
+/// Build one worktree table row. In workspace mode (issue #36) `repo` is
+/// `Some((name, width))` and a leading `REPO` cell is inserted after the age
+/// column, painted in the `accent` role; in single-repo mode it is `None` and
+/// the row keeps its historical shape.
+fn build_row(
+  w: &WorktreeInfo,
+  repo: Option<(&str, u16)>,
+  name_w: u16,
+  branch_w: u16,
+  status_w: u16,
+  theme: &Theme,
+) -> Row<'static> {
   let marker = table_marker(w, theme);
   let branch_text = w.branch.clone().unwrap_or_else(|| "-".into());
 
@@ -1641,14 +1678,19 @@ fn build_row(w: &WorktreeInfo, name_w: u16, branch_w: u16, status_w: u16, theme:
   // `Gray`) — a structural mid-grey distinct from `muted`/`DarkGray`.
   let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(worktree_path_style(theme));
 
-  Row::new(vec![
-    age_cell,
-    Cell::from(marker),
-    name_cell,
-    branch_cell,
-    status_cell,
-    path_cell,
-  ])
+  let mut cells = vec![age_cell];
+  if let Some((repo_name, repo_w)) = repo {
+    cells.push(
+      Cell::from(trunc(repo_name, repo_w as usize))
+        .style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+    );
+  }
+  cells.push(Cell::from(marker));
+  cells.push(name_cell);
+  cells.push(branch_cell);
+  cells.push(status_cell);
+  cells.push(path_cell);
+  Row::new(cells)
 }
 
 /// Owned-String wrapper around `worktree::format_relative_duration` so

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -60,6 +60,10 @@ pub fn discover(root: &Path) -> Result<Workspace> {
   let entries = std::fs::read_dir(root)?;
 
   let mut repos: Vec<WorkspaceRepo> = Vec::new();
+  // Canonical main-workdir of each repo already admitted, so two entries that
+  // resolve to the same main repo (a main checkout and one of its linked
+  // worktrees, both under the root) collapse to a single row.
+  let mut seen: Vec<PathBuf> = Vec::new();
   for entry in entries.flatten() {
     let path = entry.path();
     if !path.is_dir() {
@@ -74,27 +78,38 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     if repo.is_bare() {
       continue;
     }
-    // Skip a linked worktree that happens to sit as a sibling under the root:
-    // its owning repo's `worktree::list` already emits it, so admitting it as
-    // a separate `WorkspaceRepo` would duplicate rows and anchor some actions
-    // to the worktree path instead of the main repo (Codex review #303 P2).
-    if repo.is_worktree() {
+    // Resolve the entry to the *main* repo it belongs to: a normal repo is its
+    // own main; a linked worktree resolves to the main checkout that owns it
+    // (which may live outside the root). `None` ⇒ unresolvable, skip.
+    let Some(main_workdir) = main_workdir(&repo) else {
+      continue;
+    };
+    // A non-worktree entry must BE its own repo root. When `--workspace` points
+    // at a directory that is itself a repo, `read_dir` surfaces the root's own
+    // `.git/`; `Repository::open` succeeds on it but resolves to the *parent*
+    // repo (main workdir = root, not `root/.git`), so this drops that bogus
+    // `.git` row (Codex review #303 P2).
+    if !repo.is_worktree() && !paths_equal(&main_workdir, &path) {
       continue;
     }
-    // The opened repo's workdir must BE this child dir. When `--workspace`
-    // points at a directory that is itself a repo, `read_dir` surfaces the
-    // root's own `.git/`, and `Repository::open` on it succeeds but resolves
-    // to the *parent* repo (workdir = root, not `root/.git`). Admitting it
-    // would add a bogus `.git` repo aimed at the parent (Codex review #303 P2).
-    let workdir_is_child = repo.workdir().is_some_and(|w| paths_equal(w, &path));
-    if !workdir_is_child {
+    // Dedupe by the resolved main workdir: a main checkout and a linked
+    // worktree of it that both sit under the root collapse to one row (the
+    // main repo's `worktree::list` already emits that worktree). A linked
+    // worktree whose owner is NOT under the root resolves to its owner and is
+    // still included — its checkout would otherwise be invisible (#304).
+    let canon = main_workdir.canonicalize().unwrap_or_else(|_| main_workdir.clone());
+    if seen.contains(&canon) {
       continue;
     }
-    let name = path
+    seen.push(canon);
+    let name = main_workdir
       .file_name()
       .map(|n| n.to_string_lossy().to_string())
       .unwrap_or_else(|| "repo".into());
-    repos.push(WorkspaceRepo { name, path });
+    repos.push(WorkspaceRepo {
+      name,
+      path: main_workdir,
+    });
   }
 
   repos.sort_by(|a, b| a.name.cmp(&b.name));
@@ -102,6 +117,22 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     root: root.to_path_buf(),
     repos,
   })
+}
+
+/// The working directory of the *main* repo an opened entry belongs to. A
+/// normal repo is its own main (`workdir()`); a linked worktree resolves to
+/// the main checkout that owns it — its gitdir is
+/// `<main>/.git/worktrees/<id>/`, so three parents up is `<main>`, which we
+/// re-open to read its real workdir. `None` when the path layout can't be
+/// resolved or the repo has no workdir (bare).
+fn main_workdir(repo: &Repository) -> Option<PathBuf> {
+  if repo.is_worktree() {
+    let admin = repo.path();
+    let main = admin.parent()?.parent()?.parent()?;
+    Repository::open(main).ok()?.workdir().map(Path::to_path_buf)
+  } else {
+    repo.workdir().map(Path::to_path_buf)
+  }
 }
 
 /// Compare two paths for the same on-disk location, canonicalizing first so a

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -81,6 +81,15 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     if repo.is_worktree() {
       continue;
     }
+    // The opened repo's workdir must BE this child dir. When `--workspace`
+    // points at a directory that is itself a repo, `read_dir` surfaces the
+    // root's own `.git/`, and `Repository::open` on it succeeds but resolves
+    // to the *parent* repo (workdir = root, not `root/.git`). Admitting it
+    // would add a bogus `.git` repo aimed at the parent (Codex review #303 P2).
+    let workdir_is_child = repo.workdir().is_some_and(|w| paths_equal(w, &path));
+    if !workdir_is_child {
+      continue;
+    }
     let name = path
       .file_name()
       .map(|n| n.to_string_lossy().to_string())
@@ -93,6 +102,17 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     root: root.to_path_buf(),
     repos,
   })
+}
+
+/// Compare two paths for the same on-disk location, canonicalizing first so a
+/// trailing separator (libgit2 workdirs carry one) or a `/var`↔`/private/var`
+/// symlink (macOS tempdirs) doesn't make equal paths compare unequal. Falls
+/// back to the raw path when canonicalization fails (e.g. a not-yet-created
+/// path), which is the conservative "compare as-is" behaviour.
+fn paths_equal(a: &Path, b: &Path) -> bool {
+  let ca = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
+  let cb = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
+  ca == cb
 }
 
 /// Heuristic trigger for the auto-detect prompt (issue #36): when bare `gwm`

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -112,7 +112,11 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     });
   }
 
-  repos.sort_by(|a, b| a.name.cmp(&b.name));
+  // Sort by name, then by path as a stable tie-breaker so two repos that share
+  // a basename always order the same way across runs / filesystems — otherwise
+  // the `-N` suffixing below would assign `main` / `main-2` non-deterministically
+  // and `--repo main-2` could target a different physical repo per run (#304).
+  repos.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
   // Display names come from the main workdir basename, which can collide for
   // distinct repos (a linked worktree resolving to an owner outside the root,
   // or symlinked children). `--repo <name>` and the TUI must address each repo

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -74,6 +74,13 @@ pub fn discover(root: &Path) -> Result<Workspace> {
     if repo.is_bare() {
       continue;
     }
+    // Skip a linked worktree that happens to sit as a sibling under the root:
+    // its owning repo's `worktree::list` already emits it, so admitting it as
+    // a separate `WorkspaceRepo` would duplicate rows and anchor some actions
+    // to the worktree path instead of the main repo (Codex review #303 P2).
+    if repo.is_worktree() {
+      continue;
+    }
     let name = path
       .file_name()
       .map(|n| n.to_string_lossy().to_string())

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -113,6 +113,25 @@ pub fn discover(root: &Path) -> Result<Workspace> {
   }
 
   repos.sort_by(|a, b| a.name.cmp(&b.name));
+  // Display names come from the main workdir basename, which can collide for
+  // distinct repos (a linked worktree resolving to an owner outside the root,
+  // or symlinked children). `--repo <name>` and the TUI must address each repo
+  // unambiguously, so suffix any duplicate with the smallest free `-N` (#304).
+  let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
+  for r in &mut repos {
+    if used.insert(r.name.clone()) {
+      continue;
+    }
+    let mut n = 2;
+    loop {
+      let candidate = format!("{}-{}", r.name, n);
+      if used.insert(candidate.clone()) {
+        r.name = candidate;
+        break;
+      }
+      n += 1;
+    }
+  }
   Ok(Workspace {
     root: root.to_path_buf(),
     repos,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,115 @@
+//! Workspace mode (issue #36): a bird's-eye view across every git repo that
+//! sits one level below a workspace root (e.g. `~/Projects`).
+//!
+//! `gwm` is single-repo by default. Workspace mode is an orthogonal
+//! dimension layered on top: discover every direct-child git repo under a
+//! root, then merge their worktree listings into one table where each row
+//! remembers which repo it belongs to. `.gwm.toml` stays per-repo — there is
+//! no workspace-level config in this version of the feature.
+
+use crate::error::Result;
+use crate::worktree::{self, WorktreeInfo};
+use git2::Repository;
+use std::path::{Path, PathBuf};
+
+/// One git repo discovered directly under the workspace root.
+#[derive(Debug, Clone)]
+pub struct WorkspaceRepo {
+  /// Display name — the repo directory's basename.
+  pub name: String,
+  /// The repo's working directory (a direct child of the workspace root).
+  pub path: PathBuf,
+}
+
+/// The set of repos found under a workspace root.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+  /// The root the user pointed `--workspace` at.
+  pub root: PathBuf,
+  /// Direct-child git repos, sorted alphabetically by name.
+  pub repos: Vec<WorkspaceRepo>,
+}
+
+impl Workspace {
+  /// True when no git repo was found directly under the root.
+  pub fn is_empty(&self) -> bool {
+    self.repos.is_empty()
+  }
+}
+
+/// A merged worktree row: the owning repo plus the worktree info itself.
+#[derive(Debug, Clone)]
+pub struct WorkspaceRow {
+  /// Display name of the repo this worktree belongs to.
+  pub repo_name: String,
+  /// Working directory of the owning repo (the workspace child dir).
+  pub repo_path: PathBuf,
+  /// The per-worktree listing, identical to single-repo `worktree::list`.
+  pub info: WorktreeInfo,
+}
+
+/// Walk one level deep under `root`, opening each direct-child directory as a
+/// git repo. Non-directories and non-repo directories are ignored; nested
+/// repos two levels down are *not* discovered (workspace mode is intentionally
+/// shallow). Repos are returned sorted by name for a stable listing.
+///
+/// Errors if `root` cannot be read (missing / not a directory / no
+/// permission). An existing but repo-free root is *not* an error — it yields
+/// an empty [`Workspace`]; callers decide whether that is worth surfacing.
+pub fn discover(root: &Path) -> Result<Workspace> {
+  let entries = std::fs::read_dir(root)?;
+
+  let mut repos: Vec<WorkspaceRepo> = Vec::new();
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if !path.is_dir() {
+      continue;
+    }
+    // `Repository::open` (not `discover`) so a non-repo child can't make us
+    // walk *up* and latch onto an unrelated ancestor repo: the child dir
+    // itself must be the repo root.
+    let Ok(repo) = Repository::open(&path) else {
+      continue;
+    };
+    if repo.is_bare() {
+      continue;
+    }
+    let name = path
+      .file_name()
+      .map(|n| n.to_string_lossy().to_string())
+      .unwrap_or_else(|| "repo".into());
+    repos.push(WorkspaceRepo { name, path });
+  }
+
+  repos.sort_by(|a, b| a.name.cmp(&b.name));
+  Ok(Workspace {
+    root: root.to_path_buf(),
+    repos,
+  })
+}
+
+/// Merge every repo's worktree listing into one flat, repo-tagged table.
+///
+/// Rows are grouped by repo in `workspace.repos` (alphabetical) order; within
+/// a repo the order is `worktree::list`'s (main worktree first). A repo whose
+/// listing fails (corrupt `.git`, transient git error) is skipped rather than
+/// aborting the whole table — the bird's-eye view is best-effort across repos.
+pub fn merge_worktrees(workspace: &Workspace) -> Result<Vec<WorkspaceRow>> {
+  let mut rows: Vec<WorkspaceRow> = Vec::new();
+  for repo in &workspace.repos {
+    let Ok(handle) = Repository::open(&repo.path) else {
+      continue;
+    };
+    let Ok(trees) = worktree::list(&handle) else {
+      continue;
+    };
+    for info in trees {
+      rows.push(WorkspaceRow {
+        repo_name: repo.name.clone(),
+        repo_path: repo.path.clone(),
+        info,
+      });
+    }
+  }
+  Ok(rows)
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -88,6 +88,28 @@ pub fn discover(root: &Path) -> Result<Workspace> {
   })
 }
 
+/// Heuristic trigger for the auto-detect prompt (issue #36): when bare `gwm`
+/// is run in a directory that is *not* itself inside a git repo but *does*
+/// hold direct-child git repos, offer to open it as a workspace.
+///
+/// Returns the discovered [`Workspace`] when the heuristic fires, else `None`.
+/// The interactive prompt lives in the CLI layer — this is the pure decision
+/// so it can be tested without stdin. Being inside a repo (at `cwd` or any
+/// ancestor) always loses to single-repo mode.
+pub fn autodetect(cwd: &Path) -> Option<Workspace> {
+  // `discover` here is libgit2's repo discovery (walks up); an `Ok` means we
+  // are inside a repo, so single-repo mode wins and we never auto-workspace.
+  if Repository::discover(cwd).is_ok() {
+    return None;
+  }
+  let ws = discover(cwd).ok()?;
+  if ws.is_empty() {
+    None
+  } else {
+    Some(ws)
+  }
+}
+
 /// Merge every repo's worktree listing into one flat, repo-tagged table.
 ///
 /// Rows are grouped by repo in `workspace.repos` (alphabetical) order; within

--- a/tests/cli_workspace_tests.rs
+++ b/tests/cli_workspace_tests.rs
@@ -154,6 +154,22 @@ fn create_in_workspace_with_unknown_repo_lists_available() {
 }
 
 #[test]
+fn workspace_flag_rejected_on_unsupported_subcommand() {
+  // `--workspace` is global, so clap accepts it on `remove`, but `run` only
+  // implements it for `list`/`create`/TUI. It must be rejected rather than
+  // silently acting on the current repo — a wrong-target footgun (#303 P2).
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .arg("--workspace")
+    .arg(root.path())
+    .args(["remove", "foo"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("only supported with"));
+}
+
+#[test]
 fn bare_gwm_in_workspace_root_declines_autodetect_without_a_tty() {
   // assert_cmd pipes stdin (not a tty), so the auto-detect prompt must decline
   // silently and fall through to single-repo discovery — which then fails with

--- a/tests/cli_workspace_tests.rs
+++ b/tests/cli_workspace_tests.rs
@@ -154,6 +154,21 @@ fn create_in_workspace_with_unknown_repo_lists_available() {
 }
 
 #[test]
+fn bare_gwm_in_workspace_root_declines_autodetect_without_a_tty() {
+  // assert_cmd pipes stdin (not a tty), so the auto-detect prompt must decline
+  // silently and fall through to single-repo discovery — which then fails with
+  // NotInGitRepo because the workspace root is not itself a repo. This proves
+  // bare `gwm` never blocks on an unanswerable prompt in a pipe / CI.
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(root.path())
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
 fn list_workspace_names_format_lists_worktrees_per_repo() {
   // `--format names` in workspace mode qualifies each worktree with its repo
   // (`<repo>/<name>`) so a shell-completion candidate is unambiguous.

--- a/tests/cli_workspace_tests.rs
+++ b/tests/cli_workspace_tests.rs
@@ -1,0 +1,105 @@
+//! End-to-end tests for workspace mode on the CLI (issue #36): the
+//! `--workspace <dir>` global flag and the merged `gwm list` table.
+
+use assert_cmd::Command;
+use git2::{Repository, Signature};
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Init a git repo at `path` (created if missing) on `main` with one commit.
+fn init_repo_at(path: &Path) {
+  fs::create_dir_all(path).unwrap();
+  let repo = Repository::init(path).unwrap();
+  repo.set_head("refs/heads/main").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = {
+    let mut index = repo.index().unwrap();
+    index.write_tree().unwrap()
+  };
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+}
+
+/// A workspace root with two child repos plus a non-repo dir to ignore.
+fn workspace_root() -> TempDir {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+  fs::create_dir_all(root.path().join("notes")).unwrap();
+  root
+}
+
+#[test]
+fn list_workspace_prints_repo_column_and_every_repo() {
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .args(["list", "--workspace"])
+    .arg(root.path())
+    .assert()
+    .success()
+    // The merged table leads with a REPO column ahead of NAME/BRANCH/STATUS.
+    .stdout(predicate::str::contains("REPO"))
+    .stdout(predicate::str::contains("NAME"))
+    .stdout(predicate::str::contains("BRANCH"))
+    .stdout(predicate::str::contains("STATUS"))
+    // Both child repos appear; the non-repo `notes/` dir does not.
+    .stdout(predicate::str::contains("alpha"))
+    .stdout(predicate::str::contains("beta"))
+    .stdout(predicate::str::contains("notes").not());
+}
+
+#[test]
+fn workspace_flag_is_global_before_the_subcommand() {
+  // `gwm --workspace <root> list` parses identically to `gwm list
+  // --workspace <root>` because the flag is `global = true`.
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .arg("--workspace")
+    .arg(root.path())
+    .arg("list")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("alpha"))
+    .stdout(predicate::str::contains("beta"));
+}
+
+#[test]
+fn list_workspace_missing_root_fails() {
+  let root = TempDir::new().unwrap();
+  let missing = root.path().join("nope");
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["list", "--workspace"]).arg(&missing).assert().failure();
+}
+
+#[test]
+fn list_workspace_empty_root_reports_no_repos() {
+  let root = TempDir::new().unwrap();
+  fs::create_dir_all(root.path().join("plain")).unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .args(["list", "--workspace"])
+    .arg(root.path())
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("no git repos"));
+}
+
+#[test]
+fn list_workspace_names_format_lists_worktrees_per_repo() {
+  // `--format names` in workspace mode qualifies each worktree with its repo
+  // (`<repo>/<name>`) so a shell-completion candidate is unambiguous.
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .args(["list", "--workspace"])
+    .arg(root.path())
+    .args(["--format", "names"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("alpha/alpha"))
+    .stdout(predicate::str::contains("beta/beta"));
+}

--- a/tests/cli_workspace_tests.rs
+++ b/tests/cli_workspace_tests.rs
@@ -88,6 +88,71 @@ fn list_workspace_empty_root_reports_no_repos() {
     .stderr(predicate::str::contains("no git repos"));
 }
 
+/// Minimal `.gwm.toml` pinning the worktree base into `base` with no
+/// bootstrap commands, so `create --no-bootstrap` never hits the trust prompt.
+fn write_min_config(repo_root: &Path, base: &Path) {
+  let body = format!(
+    "[worktree]\nbase = \"{}\"\npath_pattern = \"{{type}}-{{issue}}-{{desc}}\"\nbranch_pattern = \"{{type}}/#{{issue}}-{{desc}}\"\n",
+    base.display().to_string().replace('\\', "\\\\").replace('"', "\\\"")
+  );
+  fs::write(repo_root.join(".gwm.toml"), body).unwrap();
+}
+
+#[test]
+fn create_in_workspace_without_repo_flag_fails() {
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .arg("--workspace")
+    .arg(root.path())
+    .args(["create", "feat", "42", "demo", "--no-bootstrap"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("--repo"));
+}
+
+#[test]
+fn create_in_workspace_targets_the_named_repo() {
+  let root = workspace_root();
+  let base = TempDir::new().unwrap();
+  write_min_config(&root.path().join("alpha"), base.path());
+
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .arg("--workspace")
+    .arg(root.path())
+    .args(["create", "feat", "42", "demo", "--repo", "alpha", "--no-bootstrap"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat/#42-demo"));
+
+  // The branch lands in alpha, not beta.
+  let alpha = Repository::open(root.path().join("alpha")).unwrap();
+  assert!(
+    alpha.find_branch("feat/#42-demo", git2::BranchType::Local).is_ok(),
+    "branch must be created in the alpha repo"
+  );
+  let beta = Repository::open(root.path().join("beta")).unwrap();
+  assert!(
+    beta.find_branch("feat/#42-demo", git2::BranchType::Local).is_err(),
+    "branch must NOT leak into the beta repo"
+  );
+}
+
+#[test]
+fn create_in_workspace_with_unknown_repo_lists_available() {
+  let root = workspace_root();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .arg("--workspace")
+    .arg(root.path())
+    .args(["create", "feat", "42", "demo", "--repo", "ghost", "--no-bootstrap"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("ghost"))
+    .stderr(predicate::str::contains("alpha"));
+}
+
 #[test]
 fn list_workspace_names_format_lists_worktrees_per_repo() {
   // `--format names` in workspace mode qualifies each worktree with its repo

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -5,7 +5,7 @@
 //! ever drawing a frame.
 
 use git2::{Repository, Signature};
-use gwm::tui::{draw, App};
+use gwm::tui::{draw, App, SettingField};
 use ratatui::{backend::TestBackend, Terminal};
 use std::fs;
 use std::path::Path;
@@ -167,6 +167,35 @@ fn workspace_list_renders_a_repo_column_with_repo_names() {
   assert!(
     text.contains("beta"),
     "the beta repo name renders in a row, got:\n{text}"
+  );
+}
+
+#[test]
+fn workspace_settings_edit_survives_a_repo_swap_roundtrip() {
+  // Editing a setting in workspace mode must update the active repo's *cached*
+  // config too, not just `self.config` — otherwise navigating away and back
+  // restores the stale cached config and silently reverts the edit (Codex
+  // review #303 P3).
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  assert_eq!(app.repo_name, "alpha");
+
+  // Edit alpha's auto-refresh seconds via the Settings panel (Project layer).
+  app.apply_setting(SettingField::AutoRefreshSecs, "99");
+  assert_eq!(app.config.tui.auto_refresh_secs, 99, "edit applies live");
+
+  // Navigate to beta and back to alpha.
+  let last = app.worktrees.len() - 1;
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "beta");
+  app.list_state.select(Some(0));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "alpha");
+
+  assert_eq!(
+    app.config.tui.auto_refresh_secs, 99,
+    "the settings edit survived the repo-swap round-trip"
   );
 }
 

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -5,7 +5,7 @@
 //! ever drawing a frame.
 
 use git2::{Repository, Signature};
-use gwm::tui::{draw, App, SettingField};
+use gwm::tui::{draw, App, SettingField, SettingsLayer};
 use ratatui::{backend::TestBackend, Terminal};
 use std::fs;
 use std::path::Path;
@@ -196,6 +196,34 @@ fn workspace_settings_edit_survives_a_repo_swap_roundtrip() {
   assert_eq!(
     app.config.tui.auto_refresh_secs, 99,
     "the settings edit survived the repo-swap round-trip"
+  );
+}
+
+#[test]
+fn workspace_global_setting_edit_propagates_to_every_repo() {
+  // A Global-layer edit changes the deep-merged config for *every* repo. After
+  // it, navigating to another repo must see the new value, not the config that
+  // repo was loaded with at startup (Codex review #303 P2).
+  let root = workspace_root();
+  let global = root.path().join("global-config.toml");
+  fs::write(&global, "").unwrap();
+  let mut app = App::new_workspace_at_layered(root.path(), Some(&global)).unwrap();
+
+  app.config_panel.layer = SettingsLayer::Global;
+  app.apply_setting(SettingField::AutoRefreshSecs, "77");
+  assert_eq!(
+    app.config.tui.auto_refresh_secs, 77,
+    "global edit applies to the active repo"
+  );
+
+  // Navigate to beta: its cached config must reflect the global edit too.
+  let last = app.worktrees.len() - 1;
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "beta");
+  assert_eq!(
+    app.config.tui.auto_refresh_secs, 77,
+    "the global edit reached the other repo's cached config"
   );
 }
 

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -186,6 +186,34 @@ fn no_visible_selection_marks_workspace_stale() {
 }
 
 #[test]
+fn stale_selection_blocks_project_config_edits() {
+  // With a stale selection (the selected repo vanished), a Project-layer config
+  // edit would write to the previously active repo's `.gwm.toml` — refuse it
+  // (the wrong-target write the guard prevents); #304.
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  let before = app.config.tui.auto_refresh_secs;
+
+  fs::remove_dir_all(root.path().join("beta")).unwrap();
+  let last = app.worktrees.len() - 1;
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+  assert!(app.workspace_active_stale, "precondition: selection is stale");
+
+  // config_panel defaults to the Project layer.
+  app.apply_setting(SettingField::AutoRefreshSecs, "42");
+  assert_eq!(
+    app.config.tui.auto_refresh_secs, before,
+    "a Project-layer edit is refused while the selected repo is unavailable"
+  );
+  assert!(
+    app.status.contains("unavailable"),
+    "the refusal is surfaced on the status bar, got: {}",
+    app.status
+  );
+}
+
+#[test]
 fn repo_mutating_actions_are_classified() {
   // The guard in `run_action` keys off this classification (#304).
   assert!(Action::Create.is_repo_mutating());

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -164,6 +164,28 @@ fn failed_repo_activation_marks_the_selection_stale_then_recovers() {
 }
 
 #[test]
+fn no_visible_selection_marks_workspace_stale() {
+  // When the filter hides every row (no selection), workspace mode has no
+  // active repo the selection points at, so write actions must be blocked:
+  // `sync_active_repo` flags the state stale (issue #304).
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  assert!(!app.workspace_active_stale, "a fresh selection is not stale");
+
+  app.list_state.select(None);
+  app.sync_active_repo();
+  assert!(
+    app.workspace_active_stale,
+    "no selected row → stale (blocks create/etc.)"
+  );
+
+  // Restoring a selection clears it again.
+  app.list_state.select(Some(0));
+  app.sync_active_repo();
+  assert!(!app.workspace_active_stale, "a valid selection clears the stale flag");
+}
+
+#[test]
 fn repo_mutating_actions_are_classified() {
   // The guard in `run_action` keys off this classification (#304).
   assert!(Action::Create.is_repo_mutating());

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -99,6 +99,39 @@ fn sync_active_repo_follows_the_selection_across_repos() {
 }
 
 #[test]
+fn sync_active_repo_reresolves_branch_types_from_the_selected_repo() {
+  // beta declares its own `[[branch_types]]`; alpha uses the defaults. After
+  // the active repo swaps to beta, the create form's branch types must follow
+  // beta's config, not stay on alpha's defaults (Codex review #303 P2).
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+  fs::write(
+    root.path().join("beta").join(".gwm.toml"),
+    "[[branch_types]]\nname = \"wibble\"\ndescription = \"custom\"\n",
+  )
+  .unwrap();
+
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  // alpha (row 0) → default types include `feat`, and not `wibble`.
+  assert!(
+    app.branch_types.iter().any(|t| t.name == "feat"),
+    "alpha uses default branch types"
+  );
+
+  let last = app.worktrees.len() - 1; // beta's main
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "beta", "swapped to beta");
+  let names: Vec<&str> = app.branch_types.iter().map(|t| t.name.as_str()).collect();
+  assert_eq!(
+    names,
+    vec!["wibble"],
+    "branch types now follow beta's config, got {names:?}"
+  );
+}
+
+#[test]
 fn sync_active_repo_is_a_noop_in_single_repo_mode() {
   // A non-workspace App must be unaffected by the swap hook.
   let (dir, _repo) = {

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -5,6 +5,7 @@
 //! ever drawing a frame.
 
 use git2::{Repository, Signature};
+use gwm::tui::keymap::Action;
 use gwm::tui::{draw, App, SettingField, SettingsLayer};
 use ratatui::{backend::TestBackend, Terminal};
 use std::fs;
@@ -129,6 +130,51 @@ fn sync_active_repo_reresolves_branch_types_from_the_selected_repo() {
     vec!["wibble"],
     "branch types now follow beta's config, got {names:?}"
   );
+}
+
+#[test]
+fn failed_repo_activation_marks_the_selection_stale_then_recovers() {
+  // A repo that was listed but then vanished on disk must not silently leave
+  // the active context pointing at the previous repo: the selection is flagged
+  // stale (which blocks repo-mutating actions), and navigating back to a live
+  // repo clears it (issue #304).
+  let root = workspace_root(); // alpha, beta
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  assert!(!app.workspace_active_stale, "fresh workspace is not stale");
+
+  // Delete beta's checkout on disk, then select its (now-dead) row.
+  fs::remove_dir_all(root.path().join("beta")).unwrap();
+  let last = app.worktrees.len() - 1;
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+
+  assert!(app.workspace_active_stale, "an unreachable selected repo is stale");
+  assert_eq!(
+    app.repo_name, "alpha",
+    "the active repo stays on the last live one, not the dead beta"
+  );
+
+  // Navigating back to a reachable repo clears the stale flag.
+  app.list_state.select(Some(0));
+  app.sync_active_repo();
+  assert!(
+    !app.workspace_active_stale,
+    "selecting a live repo clears the stale flag"
+  );
+}
+
+#[test]
+fn repo_mutating_actions_are_classified() {
+  // The guard in `run_action` keys off this classification (#304).
+  assert!(Action::Create.is_repo_mutating());
+  assert!(Action::DeleteConfirm.is_repo_mutating());
+  assert!(Action::Bootstrap.is_repo_mutating());
+  assert!(Action::EditWorktree.is_repo_mutating());
+  assert!(Action::LinkPrompt.is_repo_mutating());
+  // Navigation / read-only launchers are not blocked.
+  assert!(!Action::Down.is_repo_mutating());
+  assert!(!Action::Refresh.is_repo_mutating());
+  assert!(!Action::YankPath.is_repo_mutating());
 }
 
 #[test]

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -1,0 +1,161 @@
+//! State-machine tests for the TUI workspace mode (issue #36). Ratatui-free:
+//! they pin the merged-list construction, the per-row repo mapping, and the
+//! swap-on-navigation that keeps `App`'s active repo (`repo`/`workdir`/
+//! `repo_name`/`config`) aligned with the selected worktree's repo — without
+//! ever drawing a frame.
+
+use git2::{Repository, Signature};
+use gwm::tui::{draw, App};
+use ratatui::{backend::TestBackend, Terminal};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Flatten a `TestBackend` buffer into one string of cell symbols.
+fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+  terminal
+    .backend()
+    .buffer()
+    .content()
+    .iter()
+    .map(|c| c.symbol())
+    .collect()
+}
+
+/// Init a git repo at `path` (created if missing) on `main` with one commit.
+fn init_repo_at(path: &Path) {
+  fs::create_dir_all(path).unwrap();
+  let repo = Repository::init(path).unwrap();
+  repo.set_head("refs/heads/main").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = {
+    let mut index = repo.index().unwrap();
+    index.write_tree().unwrap()
+  };
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+}
+
+/// A workspace root with two child repos (alpha, beta) plus a non-repo dir.
+fn workspace_root() -> TempDir {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+  fs::create_dir_all(root.path().join("notes")).unwrap();
+  root
+}
+
+#[test]
+fn workspace_app_builds_a_merged_list_across_repos() {
+  let root = workspace_root();
+  let app = App::new_workspace_at_layered(root.path(), None).unwrap();
+
+  assert!(app.is_workspace(), "the app is in workspace mode");
+  // Both repos contribute their main worktree → at least two rows.
+  assert!(
+    app.worktrees.len() >= 2,
+    "merged list spans both repos: {}",
+    app.worktrees.len()
+  );
+  // Every row maps to a repo name; alpha sorts first, so row 0 is alpha.
+  assert_eq!(app.row_repo_name(0), Some("alpha"), "row 0 belongs to alpha");
+  let last = app.worktrees.len() - 1;
+  assert_eq!(app.row_repo_name(last), Some("beta"), "the last row belongs to beta");
+}
+
+#[test]
+fn workspace_app_starts_active_on_the_first_repo() {
+  let root = workspace_root();
+  let app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  assert_eq!(app.repo_name, "alpha", "active repo starts on the first row's repo");
+  assert!(
+    app.workdir.ends_with("alpha"),
+    "active workdir points at alpha, got {:?}",
+    app.workdir
+  );
+}
+
+#[test]
+fn sync_active_repo_follows_the_selection_across_repos() {
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+
+  // Select the last row (beta's main) and let the swap fire.
+  let last = app.worktrees.len() - 1;
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+
+  assert_eq!(app.repo_name, "beta", "active repo follows the selection to beta");
+  assert!(
+    app.workdir.ends_with("beta"),
+    "active workdir swapped to beta, got {:?}",
+    app.workdir
+  );
+
+  // Selecting back to row 0 swaps the active repo back to alpha.
+  app.list_state.select(Some(0));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "alpha", "active repo swaps back to alpha");
+}
+
+#[test]
+fn sync_active_repo_is_a_noop_in_single_repo_mode() {
+  // A non-workspace App must be unaffected by the swap hook.
+  let (dir, _repo) = {
+    let dir = TempDir::new().unwrap();
+    init_repo_at(dir.path());
+    (dir, ())
+  };
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  assert!(!app.is_workspace(), "single-repo app is not in workspace mode");
+  let before = app.workdir.clone();
+  app.sync_active_repo();
+  assert_eq!(app.workdir, before, "sync is inert without a workspace");
+}
+
+#[test]
+fn workspace_list_renders_a_repo_column_with_repo_names() {
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+
+  let backend = TestBackend::new(140, 30);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+
+  let text = buffer_text(&terminal);
+  assert!(
+    text.contains("REPO"),
+    "the list header carries a REPO column, got:\n{text}"
+  );
+  assert!(
+    text.contains("alpha"),
+    "the alpha repo name renders in a row, got:\n{text}"
+  );
+  assert!(
+    text.contains("beta"),
+    "the beta repo name renders in a row, got:\n{text}"
+  );
+}
+
+#[test]
+fn workspace_refresh_rebuilds_the_full_merged_list() {
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  let before = app.worktrees.len();
+
+  // A refresh in workspace mode must re-list EVERY repo, not just the active
+  // one — the merged list keeps its full span and the row→repo map stays in
+  // sync (last row still beta).
+  app.refresh().unwrap();
+  assert_eq!(
+    app.worktrees.len(),
+    before,
+    "merged list keeps spanning every repo after refresh"
+  );
+  let last = app.worktrees.len() - 1;
+  assert_eq!(
+    app.row_repo_name(last),
+    Some("beta"),
+    "row→repo map survives the refresh"
+  );
+}

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -86,6 +86,45 @@ fn discover_missing_root_is_an_error() {
 }
 
 #[test]
+fn autodetect_fires_when_cwd_is_not_a_repo_but_holds_child_repos() {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+
+  let ws = workspace::autodetect(root.path()).expect("a repo-free dir with child repos triggers");
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(
+    names,
+    vec!["alpha", "beta"],
+    "auto-detected workspace lists the children"
+  );
+}
+
+#[test]
+fn autodetect_declines_when_cwd_is_itself_a_repo() {
+  // Inside a git repo, single-repo mode wins — never auto-open a workspace,
+  // even if the repo happens to contain nested child repos.
+  let root = TempDir::new().unwrap();
+  init_repo_at(root.path());
+  init_repo_at(&root.path().join("vendored"));
+
+  assert!(
+    workspace::autodetect(root.path()).is_none(),
+    "a directory that is itself a repo must not auto-open as a workspace"
+  );
+}
+
+#[test]
+fn autodetect_declines_when_no_child_repos() {
+  let root = TempDir::new().unwrap();
+  fs::create_dir_all(root.path().join("plain")).unwrap();
+  assert!(
+    workspace::autodetect(root.path()).is_none(),
+    "no child repos → nothing to open as a workspace"
+  );
+}
+
+#[test]
 fn merge_worktrees_tags_each_row_with_its_repo() {
   let root = TempDir::new().unwrap();
   init_repo_at(&root.path().join("alpha"));

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -69,6 +69,27 @@ fn discover_does_not_recurse_below_one_level() {
 }
 
 #[test]
+fn discover_skips_a_linked_worktree_sibling() {
+  // A linked worktree of `main` sitting as a sibling under the root must NOT
+  // be admitted as its own repo: `main`'s `worktree::list` already emits it,
+  // so admitting it would duplicate rows (Codex review #303 P2).
+  let root = TempDir::new().unwrap();
+  let main = init_repo_at(&root.path().join("main"));
+  // Create a linked worktree at root/wt (a sibling of main, one level deep).
+  main
+    .worktree("wt", &root.path().join("wt"), None)
+    .expect("create linked worktree");
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(
+    names,
+    vec!["main"],
+    "the linked worktree sibling is skipped, got {names:?}"
+  );
+}
+
+#[test]
 fn discover_empty_root_yields_no_repos() {
   let root = TempDir::new().unwrap();
   fs::create_dir_all(root.path().join("plain")).unwrap();

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -1,0 +1,117 @@
+//! Integration tests for workspace mode discovery + merge (issue #36).
+//!
+//! Workspace mode gives a bird's-eye view across every git repo that sits
+//! one level below a workspace root (e.g. `~/Projects`). These tests pin the
+//! discovery contract (one level deep, ignore non-repos, sort by name) and
+//! the merged worktree listing (each row tagged with the owning repo) against
+//! real `git2` repos created under a `tempfile::TempDir`.
+
+use git2::{Repository, Signature};
+use gwm::workspace;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Initialise a git repo at `path` (created if missing) on `main` with one
+/// empty commit, mirroring `tests/common::init_repo` but at a caller-chosen
+/// location so several repos can share one workspace-root tempdir.
+fn init_repo_at(path: &Path) -> Repository {
+  fs::create_dir_all(path).unwrap();
+  let repo = Repository::init(path).unwrap();
+  repo.set_head("refs/heads/main").ok();
+  let sig = Signature::now("gwm-test", "gwm@test").unwrap();
+  let tree_id = {
+    let mut index = repo.index().unwrap();
+    index.write_tree().unwrap()
+  };
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  Repository::open(path).unwrap()
+}
+
+#[test]
+fn discover_finds_child_repos_and_ignores_non_repos() {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+  // A plain directory (no .git) must be ignored.
+  fs::create_dir_all(root.path().join("notes")).unwrap();
+  // A loose file at the root must be ignored.
+  fs::write(root.path().join("README.md"), "hi").unwrap();
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(names, vec!["alpha", "beta"], "only the two git repos, got {names:?}");
+}
+
+#[test]
+fn discover_sorts_repos_alphabetically() {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("zulu"));
+  init_repo_at(&root.path().join("mike"));
+  init_repo_at(&root.path().join("alfa"));
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(names, vec!["alfa", "mike", "zulu"], "alphabetical, got {names:?}");
+}
+
+#[test]
+fn discover_does_not_recurse_below_one_level() {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  // A repo nested two levels deep must NOT be discovered (one level only).
+  init_repo_at(&root.path().join("group").join("nested"));
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(names, vec!["alpha"], "nested repo excluded, got {names:?}");
+}
+
+#[test]
+fn discover_empty_root_yields_no_repos() {
+  let root = TempDir::new().unwrap();
+  fs::create_dir_all(root.path().join("plain")).unwrap();
+
+  let ws = workspace::discover(root.path()).unwrap();
+  assert!(ws.repos.is_empty(), "no git repos under the root");
+  assert!(ws.is_empty(), "is_empty() reflects an empty repo set");
+}
+
+#[test]
+fn discover_missing_root_is_an_error() {
+  let root = TempDir::new().unwrap();
+  let missing = root.path().join("does-not-exist");
+  assert!(workspace::discover(&missing).is_err(), "a missing root must error");
+}
+
+#[test]
+fn merge_worktrees_tags_each_row_with_its_repo() {
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let rows = workspace::merge_worktrees(&ws).unwrap();
+
+  // Each repo contributes at least its main worktree; rows are grouped by
+  // repo in discovery (alphabetical) order.
+  let repo_names: Vec<&str> = rows.iter().map(|r| r.repo_name.as_str()).collect();
+  assert!(repo_names.contains(&"alpha"), "alpha rows present: {repo_names:?}");
+  assert!(repo_names.contains(&"beta"), "beta rows present: {repo_names:?}");
+
+  // The main worktree of each repo is its repo directory.
+  let alpha_main = rows
+    .iter()
+    .find(|r| r.repo_name == "alpha" && r.info.is_main)
+    .expect("alpha main worktree row");
+  assert!(
+    alpha_main.info.path.ends_with("alpha"),
+    "main worktree path points at the repo dir, got {:?}",
+    alpha_main.info.path
+  );
+  // alpha sorts before beta — its rows come first.
+  let first_beta = repo_names.iter().position(|n| *n == "beta").unwrap();
+  let last_alpha = repo_names.iter().rposition(|n| *n == "alpha").unwrap();
+  assert!(last_alpha < first_beta, "alpha rows precede beta rows: {repo_names:?}");
+}

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -120,6 +120,32 @@ fn discover_includes_an_orphan_linked_worktree_via_its_owner() {
 }
 
 #[test]
+fn discover_disambiguates_duplicate_repo_names() {
+  // Two orphan linked worktrees resolving to distinct owners that share a
+  // basename ("main") must get unique display names so `--repo` and the
+  // row→repo map can address each one (issue #304).
+  let owner_a = TempDir::new().unwrap();
+  let owner_b = TempDir::new().unwrap();
+  let a = init_repo_at(&owner_a.path().join("main"));
+  let b = init_repo_at(&owner_b.path().join("main"));
+  let root = TempDir::new().unwrap();
+  a.worktree("wt-a", &root.path().join("wt-a"), None).unwrap();
+  b.worktree("wt-b", &root.path().join("wt-b"), None).unwrap();
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let mut names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  names.sort_unstable();
+  assert_eq!(ws.repos.len(), 2, "two distinct owners, got {:?}", ws.repos);
+  assert_eq!(
+    names,
+    vec!["main", "main-2"],
+    "duplicate basenames disambiguated, got {names:?}"
+  );
+  // The two paths are genuinely distinct repos.
+  assert_ne!(ws.repos[0].path, ws.repos[1].path, "distinct owner paths");
+}
+
+#[test]
 fn discover_skips_the_root_repos_own_git_dir() {
   // When the root is itself a git repo, `read_dir` surfaces its `.git/`, which
   // `Repository::open` resolves back to the root repo. That must NOT appear as

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -90,6 +90,21 @@ fn discover_skips_a_linked_worktree_sibling() {
 }
 
 #[test]
+fn discover_skips_the_root_repos_own_git_dir() {
+  // When the root is itself a git repo, `read_dir` surfaces its `.git/`, which
+  // `Repository::open` resolves back to the root repo. That must NOT appear as
+  // a bogus `.git` child — only the genuine child repo does (Codex review
+  // #303 P2).
+  let root = TempDir::new().unwrap();
+  init_repo_at(root.path()); // the root is itself a repo
+  init_repo_at(&root.path().join("kid"));
+
+  let ws = workspace::discover(root.path()).unwrap();
+  let names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
+  assert_eq!(names, vec!["kid"], "only the real child repo, no `.git`, got {names:?}");
+}
+
+#[test]
 fn discover_empty_root_yields_no_repos() {
   let root = TempDir::new().unwrap();
   fs::create_dir_all(root.path().join("plain")).unwrap();

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -90,6 +90,36 @@ fn discover_skips_a_linked_worktree_sibling() {
 }
 
 #[test]
+fn discover_includes_an_orphan_linked_worktree_via_its_owner() {
+  // A linked worktree under the root whose *owner* main checkout lives OUTSIDE
+  // the root must not be dropped: it resolves to (and is listed as) its owner,
+  // so the checkout stays reachable (issue #304).
+  let owner_dir = TempDir::new().unwrap();
+  let owner = init_repo_at(owner_dir.path());
+  let root = TempDir::new().unwrap();
+  owner
+    .worktree("wt", &root.path().join("wt"), None)
+    .expect("create linked worktree under the root");
+
+  let ws = workspace::discover(root.path()).unwrap();
+  assert_eq!(
+    ws.repos.len(),
+    1,
+    "the orphan worktree resolves to one owner repo, got {:?}",
+    ws.repos
+  );
+  let got = ws.repos[0]
+    .path
+    .canonicalize()
+    .unwrap_or_else(|_| ws.repos[0].path.clone());
+  let want = owner_dir
+    .path()
+    .canonicalize()
+    .unwrap_or_else(|_| owner_dir.path().to_path_buf());
+  assert_eq!(got, want, "the workspace repo is the owner checkout");
+}
+
+#[test]
 fn discover_skips_the_root_repos_own_git_dir() {
   // When the root is itself a git repo, `read_dir` surfaces its `.git/`, which
   // `Repository::open` resolves back to the root repo. That must NOT appear as

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -133,16 +133,15 @@ fn discover_disambiguates_duplicate_repo_names() {
   b.worktree("wt-b", &root.path().join("wt-b"), None).unwrap();
 
   let ws = workspace::discover(root.path()).unwrap();
-  let mut names: Vec<&str> = ws.repos.iter().map(|r| r.name.as_str()).collect();
-  names.sort_unstable();
   assert_eq!(ws.repos.len(), 2, "two distinct owners, got {:?}", ws.repos);
+  // Deterministic: repos sort by (name, path), so the smaller-path owner always
+  // gets `main` and the other `main-2` — stable across runs / filesystems.
+  assert!(ws.repos[0].path < ws.repos[1].path, "stable path tie-break order");
+  assert_eq!(ws.repos[0].name, "main", "smaller-path owner keeps the bare name");
   assert_eq!(
-    names,
-    vec!["main", "main-2"],
-    "duplicate basenames disambiguated, got {names:?}"
+    ws.repos[1].name, "main-2",
+    "the collision is suffixed deterministically"
   );
-  // The two paths are genuinely distinct repos.
-  assert_ne!(ws.repos[0].path, ws.repos[1].path, "distinct owner paths");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Multi-repo **workspace mode**: operate across every git repo one level below a
root directory instead of a single repo. Built in one PR (CLI + TUI) per the
issue's full scope, TDD throughout.

Closes #36

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **`workspace` module** (pure): `discover` walks one level under a root,
  opening each direct-child dir as a repo (ignores non-dirs / non-repos / bare,
  sorted by name); `merge_worktrees` flattens every repo's `worktree::list`
  into one repo-tagged table; `autodetect` is the bare-`gwm` trigger.
- **CLI**: global `--workspace <DIR>` flag; `gwm list --workspace` prints the
  merged table with a leading `REPO` column (per-row `--detect-pr`, `--format
  names` → `<repo>/<name>`); empty root → `GwmError::EmptyWorkspace`.
- **`gwm create --repo <name>`** required in workspace mode to pick the target
  child repo (lists candidates when absent/unknown).
- **Auto-detect**: bare `gwm` in a repo-free dir that holds child repos prompts
  `Open <dir> as a workspace? [Y/n]`; declines silently without a tty (pipes/CI
  keep the old single-repo behaviour).
- **TUI workspace mode**: `App` gains a `WorkspaceState` (per-repo session meta
  + per-row repo map); the active repo (`repo`/`workdir`/`config`/`repo_name`)
  follows the selection via `sync_active_repo` (re-opens the selected row's repo
  before each draw), so every selection-driven action operates on the right
  repo with no per-handler routing. `refresh` re-lists every repo synchronously
  in workspace mode. The list table renders a `REPO` column. Keymap/theme stay
  session-level (resolved once from the first repo).

## Tests

- [x] `cargo test` passes locally (full suite: 67 binaries green, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD red→green per phase):
  - `tests/workspace_tests.rs` — discover / merge / autodetect (pure + git2 tempdirs)
  - `tests/cli_workspace_tests.rs` — `list`/`create`/autodetect-decline E2E
  - `tests/tui_workspace_tests.rs` — merged-list construction, swap-on-navigation, REPO-column render
- New tests also re-validated under a stripped CI-like `PATH` (env-independent).

## Notes for reviewers

- **Single-repo mode is untouched**: `App.workspace` is `None`, `sync_active_repo`
  is a no-op, and the existing `repo`/`workdir`/`config` fields keep their exact
  semantics — that's what kept the 60+ existing test files green.
- **Deliberate v1 scope**: no workspace-level config; repos are fixed for the
  session (a new repo under the root needs a relaunch, matching the config
  "resolved once" contract). Follow-up candidate: async per-repo merge for the
  workspace refresh (today it's synchronous, bounded by repo count).
- `#[allow(clippy::too_many_arguments)]` on `cmd_create` is intentional and
  commented — `--repo`/`start` push it to 8 args mirroring the subcommand 1:1.

## Linked issues / docs

- Issue: #36