### PR TITLE
✨ feat(config): config presets for `gwm init --preset <stack>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Config presets for `gwm init`** (issue #37): `gwm init --preset <name>`
+  seeds an opinionated `.gwm.toml` for a known stack instead of the generic
+  template. Built-ins: `laravel` (env copies + AWS-RDS guard + `vendor/`
+  no-symlink + composer install), `node` / `nuxt` (`node_modules/`
+  no-symlink + bun-or-npm install), `rust` (`target/` no-symlink + cargo
+  fetch), `go` (`bin/` no-symlink + `go mod download`), `python-uv`
+  (`.venv/` no-symlink + `uv sync`), and `generic` (the documented default).
+  `gwm init --list-presets` enumerates them with one-line descriptions, and
+  `gwm init --preset <name> --show` prints the resolved TOML to stdout
+  without writing (handy for diffing against an existing config). Preset
+  bodies are embedded in the binary and kept in sync with
+  `examples/presets/<name>.toml`. `gwm init` with no flag stays byte-for-byte
+  the generic template.
 - **Multi-repo workspace mode** (issue #36): operate across every git repo one
   level below a root directory instead of a single repo. Two entry points:
   - `gwm --workspace ~/Projects` opens the TUI over every direct-child repo,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Full install matrix and verification steps: [`docs/getting-started/install.md`](
 ```bash
 cd /path/to/your/repo
 gwm init                                          # write a default .gwm.toml
+gwm init --preset laravel                          # …or seed a stack preset (laravel/node/rust/go/python-uv)
+gwm init --list-presets                            # list the built-in presets
 gwm create feat 42 user-authentication            # → ~/cc-worktree/<repo>/feat-42-user-authentication
                                                   # → branch feat/#42-user-authentication
 gwm                                               # opens the TUI on the current repo

--- a/examples/presets/go.toml
+++ b/examples/presets/go.toml
@@ -1,0 +1,22 @@
+# gwm preset: go
+#
+# Opinionated .gwm.toml for a Go module:
+#   - refuses to inherit the `bin/` symlink (build output stays per-worktree)
+#   - runs `go mod download` after the worktree is created
+#
+# Preview with `gwm init --preset go --show`. See
+# examples/gwm.toml.example for the full schema.
+
+[worktree]
+base = "{home}/cc-worktree/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+
+[[bootstrap.no_symlink]]
+path = "bin"
+
+[[hooks.post_create]]
+name = "go mod download"
+run = "go mod download"
+when = "file_exists:go.mod"
+on_fail = "warn"

--- a/examples/presets/laravel.toml
+++ b/examples/presets/laravel.toml
@@ -1,0 +1,47 @@
+# gwm preset: laravel
+#
+# Opinionated .gwm.toml for a Laravel app:
+#   - copies `.env` (guarded against AWS RDS hosts) and `.env.testing`
+#   - refuses to inherit the `vendor/` symlink
+#   - runs `composer install` + `direnv allow` after the worktree is created
+#
+# Preview with `gwm init --preset laravel --show`; write with
+# `gwm init --preset laravel`. See examples/gwm.toml.example for the full
+# schema and every available knob.
+
+[worktree]
+base = "{home}/cc-worktree/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+
+[[bootstrap.copy]]
+from = ".env"
+to = ".env"
+required = false
+guards = ["no-aws-rds"]
+
+[[bootstrap.copy]]
+from = ".env.testing"
+to = ".env.testing"
+required = false
+
+[[bootstrap.guard]]
+name = "no-aws-rds"
+deny_patterns = ["amazonaws\\.com", "\\.rds\\."]
+on_match = "seed-from-example"
+example_file = ".env.example"
+
+[[bootstrap.no_symlink]]
+path = "vendor"
+
+[[hooks.post_create]]
+name = "composer install"
+run = "composer install --no-interaction --prefer-dist"
+when = "file_exists:composer.json"
+on_fail = "warn"
+
+[[hooks.post_create]]
+name = "direnv allow"
+run = "direnv allow ."
+when = "file_exists:.envrc"
+on_fail = "ignore"

--- a/examples/presets/node.toml
+++ b/examples/presets/node.toml
@@ -32,11 +32,13 @@ path = "node_modules"
 name = "install (bun if available)"
 run = "bun install"
 when = "file_exists:package.json && cmd_exists:bun"
+on_fail = "warn"
 
 [[hooks.post_create]]
 name = "install (npm fallback)"
 run = "npm ci"
 when = "file_exists:package.json && !cmd_exists:bun"
+on_fail = "warn"
 
 [[hooks.post_create]]
 name = "direnv allow"

--- a/examples/presets/node.toml
+++ b/examples/presets/node.toml
@@ -1,0 +1,45 @@
+# gwm preset: node / nuxt
+#
+# Opinionated .gwm.toml for a Node / Nuxt app:
+#   - copies `.env` and `.env.local`
+#   - refuses to inherit the `node_modules/` symlink
+#   - package-manager-aware install: `bun install` when bun is on PATH,
+#     otherwise `npm ci`
+#
+# `nuxt` is an alias of this preset. Preview with
+# `gwm init --preset node --show`. See examples/gwm.toml.example for the
+# full schema.
+
+[worktree]
+base = "{home}/cc-worktree/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+
+[[bootstrap.copy]]
+from = ".env"
+to = ".env"
+required = false
+
+[[bootstrap.copy]]
+from = ".env.local"
+to = ".env.local"
+required = false
+
+[[bootstrap.no_symlink]]
+path = "node_modules"
+
+[[hooks.post_create]]
+name = "install (bun if available)"
+run = "bun install"
+when = "file_exists:package.json && cmd_exists:bun"
+
+[[hooks.post_create]]
+name = "install (npm fallback)"
+run = "npm ci"
+when = "file_exists:package.json && !cmd_exists:bun"
+
+[[hooks.post_create]]
+name = "direnv allow"
+run = "direnv allow ."
+when = "file_exists:.envrc"
+on_fail = "ignore"

--- a/examples/presets/python-uv.toml
+++ b/examples/presets/python-uv.toml
@@ -1,0 +1,22 @@
+# gwm preset: python-uv
+#
+# Opinionated .gwm.toml for a Python project managed with uv:
+#   - refuses to inherit the `.venv/` symlink (each worktree gets its own)
+#   - runs `uv sync` after the worktree is created
+#
+# Preview with `gwm init --preset python-uv --show`. See
+# examples/gwm.toml.example for the full schema.
+
+[worktree]
+base = "{home}/cc-worktree/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+
+[[bootstrap.no_symlink]]
+path = ".venv"
+
+[[hooks.post_create]]
+name = "uv sync"
+run = "uv sync"
+when = "file_exists:pyproject.toml"
+on_fail = "warn"

--- a/examples/presets/rust.toml
+++ b/examples/presets/rust.toml
@@ -1,0 +1,29 @@
+# gwm preset: rust
+#
+# Opinionated .gwm.toml for a Rust crate:
+#   - refuses to inherit the `target/` symlink, so each worktree keeps its
+#     own build cache instead of sharing the main repo's
+#   - runs `cargo fetch` + `direnv allow` after the worktree is created
+#
+# Preview with `gwm init --preset rust --show`. See
+# examples/gwm.toml.example for the full schema.
+
+[worktree]
+base = "{home}/cc-worktree/{repo}"
+path_pattern = "{type}-{issue}-{desc}"
+branch_pattern = "{type}/#{issue}-{desc}"
+
+[[bootstrap.no_symlink]]
+path = "target"
+
+[[hooks.post_create]]
+name = "cargo fetch"
+run = "cargo fetch"
+when = "file_exists:Cargo.toml"
+on_fail = "warn"
+
+[[hooks.post_create]]
+name = "direnv allow"
+run = "direnv allow ."
+when = "file_exists:.envrc"
+on_fail = "ignore"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ use crate::multiplexer::{
 };
 use crate::naming::{parse_branch, BranchSpec};
 use crate::pr_templates::{self, PrTemplateContext};
+use crate::presets;
 use crate::sync::{self, SyncAction, SyncReport, SyncStrategy};
 use crate::trust::{self, TrustLedger, TrustMode, TrustOutcome};
 use crate::workspace;
@@ -89,8 +90,22 @@ pub enum LinkTarget {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-  /// Write a default .gwm.toml to the current repo.
-  Init,
+  /// Write a .gwm.toml to the current repo, optionally from a stack preset.
+  Init {
+    /// Seed an opinionated .gwm.toml for a known stack (e.g. `laravel`,
+    /// `node`/`nuxt`, `rust`, `go`, `python-uv`). Omit for the generic
+    /// documented template. Run `gwm init --list-presets` to see them all.
+    #[arg(long, value_name = "NAME")]
+    preset: Option<String>,
+    /// List the built-in presets with one-line descriptions and exit
+    /// (writes nothing, needs no git repo).
+    #[arg(long)]
+    list_presets: bool,
+    /// Print the resolved preset to stdout instead of writing .gwm.toml —
+    /// handy for diffing a preset against an existing config.
+    #[arg(long)]
+    show: bool,
+  },
   /// List worktrees in the current repo.
   List {
     /// Output format. `names` prints one worktree name per line (for shell completion).
@@ -774,7 +789,11 @@ pub fn run(cli: Cli) -> Result<()> {
   }
 
   match cmd {
-    Command::Init => cmd_init(),
+    Command::Init {
+      preset,
+      list_presets,
+      show,
+    } => cmd_init(preset, list_presets, show),
     Command::List { format, detect_pr } => match cli.workspace {
       Some(root) => cmd_list_workspace(&root, format, detect_pr),
       None => cmd_list(format, detect_pr),
@@ -1095,11 +1114,40 @@ fn cmd_tui_keys() -> Result<()> {
   Ok(())
 }
 
-fn cmd_init() -> Result<()> {
+fn cmd_init(preset: Option<String>, list_presets: bool, show: bool) -> Result<()> {
+  // `--list-presets` is a pure enumeration: it wins over everything and
+  // returns before touching the filesystem or resolving a git repo.
+  if list_presets {
+    let name_w = presets::all().iter().map(|p| p.name.len()).max().unwrap_or(0);
+    for p in presets::all() {
+      let aliases = if p.aliases.is_empty() {
+        String::new()
+      } else {
+        format!(" (alias: {})", p.aliases.join(", "))
+      };
+      println!("  {:<w$}  {}{}", p.name, p.description, aliases, w = name_w);
+    }
+    return Ok(());
+  }
+
+  // Resolve the preset (default `generic` = the documented example).
+  let name = preset.as_deref().unwrap_or("generic");
+  let resolved = presets::lookup(name).ok_or_else(|| {
+    GwmError::Config(format!(
+      "unknown preset {name:?} — run `gwm init --list-presets` to see the built-ins"
+    ))
+  })?;
+
+  // `--show` prints the body and writes nothing, so it needs no git repo.
+  if show {
+    print!("{}", resolved.body);
+    return Ok(());
+  }
+
   let repo = worktree::discover_repo(None)?;
   let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
-  let path = Config::write_default(workdir)?;
-  println!("wrote {}", path.display());
+  let path = Config::write_preset(workdir, resolved.body)?;
+  println!("wrote {} (preset: {})", path.display(), resolved.name);
   Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1324,11 +1324,18 @@ impl Config {
 
   /// Write a default config to the given repo root.
   pub fn write_default(repo_root: &Path) -> Result<PathBuf> {
+    Self::write_preset(repo_root, crate::presets::GENERIC_BODY)
+  }
+
+  /// Write a `.gwm.toml` body (a built-in preset, see [`crate::presets`])
+  /// to the repo root, refusing to clobber an existing file. Factored out
+  /// of [`Self::write_default`] so `gwm init --preset <name>` seeds a
+  /// stack-specific template through the same idempotency guard.
+  pub fn write_preset(repo_root: &Path, body: &str) -> Result<PathBuf> {
     let target = repo_root.join(CONFIG_FILE);
     if target.exists() {
       return Err(GwmError::Config(format!("{} already exists", target.display())));
     }
-    let body = include_str!("../examples/gwm.toml.example");
     std::fs::write(&target, body)?;
     Ok(target)
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod milestones;
 pub mod multiplexer;
 pub mod naming;
 pub mod pr_templates;
+pub mod presets;
 pub mod sync;
 pub mod templating;
 pub mod trust;

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,0 +1,83 @@
+//! Built-in `.gwm.toml` presets for `gwm init --preset <name>` (issue #37).
+//!
+//! Every new project repeats the same `gwm init` → trim → customise dance:
+//! Laravel wants the AWS-RDS guard + composer install + a `vendor/`
+//! no-symlink, Nuxt wants `node_modules/` no-symlink + a package-manager
+//! aware install, Rust wants `target/` no-symlink + cargo fetch. These
+//! patterns recur across users yet every repo re-derives them.
+//!
+//! A preset seeds an opinionated `.gwm.toml` for a known stack. The bodies
+//! are TOML templates embedded in the binary via [`include_str!`], kept in
+//! sync with `examples/presets/<name>.toml`. The `generic` preset's body is
+//! the documented `examples/gwm.toml.example`, so `gwm init` with no preset
+//! stays byte-for-byte identical to its historical behaviour.
+
+/// A built-in config preset: a canonical name, optional aliases, a one-line
+/// description for `--list-presets`, and the embedded `.gwm.toml` body.
+#[derive(Debug, Clone, Copy)]
+pub struct Preset {
+  /// Canonical name accepted by `--preset <name>`.
+  pub name: &'static str,
+  /// Alternative names that resolve to this same preset (e.g. `nuxt` → `node`).
+  pub aliases: &'static [&'static str],
+  /// One-line summary shown by `gwm init --list-presets`.
+  pub description: &'static str,
+  /// The `.gwm.toml` body this preset writes.
+  pub body: &'static str,
+}
+
+/// The generic preset's body is the documented example shipped with the
+/// binary — identical to what `gwm init` (no preset) has always written.
+pub const GENERIC_BODY: &str = include_str!("../examples/gwm.toml.example");
+
+/// The built-in preset registry. Order is the display order of
+/// `--list-presets` (generic first, then stacks alphabetically).
+const PRESETS: &[Preset] = &[
+  Preset {
+    name: "generic",
+    aliases: &[],
+    description: "The fully-documented default template (same as `gwm init`).",
+    body: GENERIC_BODY,
+  },
+  Preset {
+    name: "go",
+    aliases: &[],
+    description: "Go module: bin/ no-symlink + `go mod download`.",
+    body: include_str!("../examples/presets/go.toml"),
+  },
+  Preset {
+    name: "laravel",
+    aliases: &[],
+    description: "Laravel: env copies + AWS-RDS guard + vendor/ no-symlink + composer install.",
+    body: include_str!("../examples/presets/laravel.toml"),
+  },
+  Preset {
+    name: "node",
+    aliases: &["nuxt"],
+    description: "Node / Nuxt: node_modules/ no-symlink + bun-or-npm install.",
+    body: include_str!("../examples/presets/node.toml"),
+  },
+  Preset {
+    name: "python-uv",
+    aliases: &[],
+    description: "Python (uv): .venv/ no-symlink + `uv sync`.",
+    body: include_str!("../examples/presets/python-uv.toml"),
+  },
+  Preset {
+    name: "rust",
+    aliases: &[],
+    description: "Rust crate: target/ no-symlink + `cargo fetch`.",
+    body: include_str!("../examples/presets/rust.toml"),
+  },
+];
+
+/// All built-in presets, in display order.
+pub fn all() -> &'static [Preset] {
+  PRESETS
+}
+
+/// Resolve a preset by canonical name or alias. Returns `None` for an
+/// unknown name so the caller can surface a `--list-presets` hint.
+pub fn lookup(name: &str) -> Option<&'static Preset> {
+  PRESETS.iter().find(|p| p.name == name || p.aliases.contains(&name))
+}

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1630,6 +1630,98 @@ fn init_outside_git_repo_fails() {
     .stderr(predicate::str::contains("not inside a git repository"));
 }
 
+// --- init --preset (issue #37) ------------------------------------------
+
+#[test]
+fn init_list_presets_enumerates_builtins() {
+  // `--list-presets` is a pure stdout enumeration — it must work without a
+  // git repo (it returns before `discover_repo`) and name every built-in.
+  let dir = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["init", "--list-presets"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("generic"))
+    .stdout(predicate::str::contains("laravel"))
+    .stdout(predicate::str::contains("node"))
+    .stdout(predicate::str::contains("rust"))
+    .stdout(predicate::str::contains("python-uv"));
+}
+
+#[test]
+fn init_preset_show_prints_without_writing() {
+  // `--show` prints the resolved preset to stdout and writes nothing — so a
+  // user can diff a preset against an existing config.
+  let (dir, _repo) = init_repo();
+  let cfg_path = dir.path().join(".gwm.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["init", "--preset", "rust", "--show"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("[[bootstrap.no_symlink]]"))
+    .stdout(predicate::str::contains("target"));
+
+  assert!(!cfg_path.exists(), "--show must not write .gwm.toml to disk");
+}
+
+#[test]
+fn init_preset_writes_stack_config() {
+  // `--preset laravel` seeds the opinionated stack config: the AWS-RDS guard
+  // and the vendor/ no-symlink are the markers that distinguish it from the
+  // generic template.
+  let (dir, _repo) = init_repo();
+  let cfg_path = dir.path().join(".gwm.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["init", "--preset", "laravel"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(".gwm.toml"));
+
+  let body = std::fs::read_to_string(&cfg_path).unwrap();
+  assert!(body.contains("no-aws-rds"), "laravel preset missing the AWS-RDS guard");
+  assert!(body.contains("vendor"), "laravel preset missing the vendor no-symlink");
+}
+
+#[test]
+fn init_unknown_preset_fails() {
+  // An unknown preset name must fail loudly and point the user at
+  // `--list-presets` rather than silently writing the generic template.
+  let (dir, _repo) = init_repo();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["init", "--preset", "cobol"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("cobol"))
+    .stderr(predicate::str::contains("list-presets"));
+}
+
+#[test]
+fn init_preset_nuxt_alias_writes_node_body() {
+  // `nuxt` is an alias of `node`: it must seed the node_modules no-symlink.
+  let (dir, _repo) = init_repo();
+  let cfg_path = dir.path().join(".gwm.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["init", "--preset", "nuxt"])
+    .assert()
+    .success();
+
+  let body = std::fs::read_to_string(&cfg_path).unwrap();
+  assert!(body.contains("node_modules"), "nuxt alias must seed the node preset");
+}
+
 // --- create -------------------------------------------------------------
 
 /// Write a `.gwm.toml` that redirects `[worktree].base` into the test's

--- a/tests/presets_tests.rs
+++ b/tests/presets_tests.rs
@@ -1,0 +1,70 @@
+//! Unit tests for the built-in `.gwm.toml` presets (issue #37).
+//!
+//! The "loads as Config" test is the real guard: it runs every embedded
+//! preset through the same validation path as the runtime
+//! (`Config::load_layered`), so a preset that deserialises but fails
+//! `validate_bootstrap_guards` (bad regex), references an undefined guard,
+//! or trips a path check is caught here, not at `gwm create` time.
+
+use gwm::config::Config;
+use gwm::presets;
+use tempfile::TempDir;
+
+#[test]
+fn lookup_resolves_canonical_names() {
+  for name in ["generic", "laravel", "node", "rust", "go", "python-uv"] {
+    assert!(presets::lookup(name).is_some(), "missing preset {name}");
+  }
+}
+
+#[test]
+fn lookup_resolves_aliases() {
+  // `nuxt` is an alias of the `node` preset — they share the same body.
+  let nuxt = presets::lookup("nuxt").expect("nuxt alias resolves");
+  let node = presets::lookup("node").expect("node preset");
+  assert_eq!(nuxt.name, node.name, "nuxt must resolve to the node preset");
+  assert_eq!(nuxt.body, node.body);
+}
+
+#[test]
+fn lookup_rejects_unknown() {
+  assert!(presets::lookup("cobol").is_none());
+}
+
+#[test]
+fn generic_preset_is_the_documented_example() {
+  // `gwm init` (no preset) must stay byte-identical to the shipped example,
+  // so the generic preset's body IS that file.
+  let generic = presets::lookup("generic").expect("generic preset");
+  assert_eq!(generic.body, include_str!("../examples/gwm.toml.example"));
+}
+
+#[test]
+fn every_preset_has_a_nonempty_description() {
+  for p in presets::all() {
+    assert!(
+      !p.description.trim().is_empty(),
+      "preset {} lacks a one-line description for --list-presets",
+      p.name
+    );
+  }
+}
+
+#[test]
+fn every_preset_loads_as_valid_config() {
+  // The strong invariant: each embedded preset must pass the full runtime
+  // validation chain (regex compilation, path checks, guard references),
+  // not merely serde deserialisation.
+  for p in presets::all() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join(".gwm.toml"), p.body).unwrap();
+    // No global layer: validate the repo file in isolation.
+    let res = Config::load_layered(dir.path(), None);
+    assert!(
+      res.is_ok(),
+      "preset {} failed to load as Config: {:?}",
+      p.name,
+      res.err()
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds `gwm init --preset <name>` (issue #37) so a fresh repo can seed an
opinionated `.gwm.toml` for a known stack instead of trimming the generic
template by hand.

Closes #37

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- New `src/presets.rs` registry: `all()` / `lookup()` over built-in presets,
  each carrying a canonical name, optional aliases, a one-line description,
  and an embedded `.gwm.toml` body (`include_str!`, kept in sync with
  `examples/presets/<name>.toml`).
- Built-ins: `laravel` (env copies + AWS-RDS guard + `vendor/` no-symlink +
  composer install), `node` / `nuxt` (`node_modules/` no-symlink + bun-or-npm
  install), `rust` (`target/` no-symlink + cargo fetch), `go` (`bin/`
  no-symlink + `go mod download`), `python-uv` (`.venv/` no-symlink +
  `uv sync`), and `generic` (the documented default = `examples/gwm.toml.example`).
- `gwm init` gains `--preset <name>`, `--list-presets`, `--show`. Unknown
  presets fail with a `--list-presets` hint. `--list-presets` / `--show`
  return before `discover_repo`, so they need no git repo and write nothing.
- `Config::write_preset` factors the no-clobber idempotency guard out of
  `write_default`; bare `gwm init` stays byte-for-byte the generic template.
- Docs: CHANGELOG `[Unreleased]` + README 30-second tour.

## Tests

- [x] `cargo test` passes locally (all binaries green, 0 failed)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

`tests/presets_tests.rs` pins the strong invariant: **every embedded preset
loads through the full runtime validation chain** (`Config::load_layered` —
regex compilation, path checks, guard references), not just serde. Plus
name/alias resolution and `generic == examples/gwm.toml.example`.
`tests/cli_binary.rs` covers the five CLI surfaces (list / show-no-write /
write-stack / unknown-fails / nuxt-alias). Existing `init` tests pass
unchanged (byte-identical default preserved).

Also ran `gwm doctor` locally on each generated preset (CLAUDE.md requirement
for bootstrap-schema changes) — all checks ✓, guard regexes compile, exit 0.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (CLI surface changed)
- [x] `examples/` updated (new `examples/presets/*.toml`)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code (CLI-only change)

## Linked issues / docs

- Issue: #37