### PR TITLE
✨ feat(structure): freeze & version the machine contracts for 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet — the v0.10.0-rc.4 delta moved to [`changelogs/pre-releases/0.10.0-rc.4.md`](changelogs/pre-releases/0.10.0-rc.4.md).
+### Added
+
+- **Frozen, versioned machine contracts for 1.0** (issue #317). The three
+  machine-readable surfaces — the `--format=json` outputs, the daemon
+  JSON-RPC protocol, and the `.gwm.toml` section set — are now pinned by
+  contract tests (`tests/contract_tests.rs`) so a rename or removal of a
+  stable field fails CI rather than slipping out as an accidental break. A
+  new `gwm::contract` module is the single source of truth for
+  `SCHEMA_VERSION` (the 1.0 baseline, `1`), the frozen daemon method/
+  notification names, and the config section set. The daemon's
+  `worktrees.changed` notification now carries `params.schema_version` so a
+  long-lived `subscribe` client can detect a contract drift; the field is
+  additive and ignorable. Each `docs/schema/*.json` declares its `version`,
+  and a new [`docs/schema/README.md`](docs/schema/README.md) documents the
+  versioning policy and the stable-vs-experimental tier of every field. No
+  behaviour change to any existing output.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Frozen, versioned machine contracts for 1.0** (issue #317). The three
-  machine-readable surfaces — the `--format=json` outputs, the daemon
-  JSON-RPC protocol, and the `.gwm.toml` section set — are now pinned by
-  contract tests (`tests/contract_tests.rs`) so a rename or removal of a
-  stable field fails CI rather than slipping out as an accidental break. A
-  new `gwm::contract` module is the single source of truth for
-  `SCHEMA_VERSION` (the 1.0 baseline, `1`), the frozen daemon method/
-  notification names, and the config section set. The daemon's
-  `worktrees.changed` notification now carries `params.schema_version` so a
-  long-lived `subscribe` client can detect a contract drift; the field is
-  additive and ignorable. Each `docs/schema/*.json` declares its `version`,
-  and a new [`docs/schema/README.md`](docs/schema/README.md) documents the
-  versioning policy and the stable-vs-experimental tier of every field. No
-  behaviour change to any existing output.
+- **Frozen, versioned machine contracts for 1.0** (issue #317). The
+  machine-readable surfaces — the `--format=json` outputs (`list`/`doctor`/
+  `path`), `gwm status --json`, the daemon JSON-RPC protocol, and the
+  `.gwm.toml` section set — are now pinned by contract tests
+  (`tests/contract_tests.rs`) so a rename, removal, or type change of a
+  stable field fails CI rather than slipping out as an accidental break. The
+  guards are layered: DTO-vs-schema parity, plus DTO-side and schema-side
+  field/type baselines that also catch a *coordinated* rename or a
+  re-tightened `additionalProperties`. A new `gwm::contract` module is the
+  single source of truth for `SCHEMA_VERSION` (the 1.0 baseline, `1`), the
+  frozen daemon method/notification names, and the config section set. The
+  daemon's `worktrees.changed` notification now carries
+  `params.schema_version` so a long-lived `subscribe` client can detect a
+  contract drift; the field is additive and ignorable. The output schemas use
+  `additionalProperties: true` so an additive field validates under the same
+  version (consumers ignore unknowns), while `.gwm.toml` keeps
+  `deny_unknown_fields` (input rejects typos). Each `docs/schema/*.json`
+  declares its `version`, and a new
+  [`docs/schema/README.md`](docs/schema/README.md) documents the versioning
+  policy and the stable-vs-experimental tier of every field. No behaviour
+  change to any existing output.
 
 ## Past releases
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,0 +1,84 @@
+# gwm machine contracts
+
+gwm exposes three **machine-readable** surfaces that tooling outside this
+repo depends on — editor plugins, status bars, CI scripts. As of 1.0 these
+are **frozen and versioned** (issue #317): a backward-incompatible change to
+a *stable* field is a conscious breaking decision, not an accident.
+
+The freeze is enforced by `tests/contract_tests.rs`. The single source of
+truth for the version and the section/method sets is
+[`src/contract.rs`](../../src/contract.rs).
+
+## The three surfaces
+
+| Surface | Where | Documented by |
+|---------|-------|---------------|
+| **JSON output** | `gwm {list,doctor,path} --format=json` | the `*.schema.json` files here |
+| **Daemon JSON-RPC 2.0** | `gwm daemon` over a unix socket | [`src/daemon.rs`](../../src/daemon.rs) |
+| **`.gwm.toml` config** | per-repo config file | [`docs/4.configuration`](../4.configuration/) |
+
+The JSON output and the daemon RPC results are **byte-identical** (a daemon
+`list` result is the same bytes as `gwm list --format=json`), because both
+are built from the same DTOs in [`src/json_api.rs`](../../src/json_api.rs).
+They therefore share one version, `SCHEMA_VERSION`.
+
+## Versioning policy
+
+`contract::SCHEMA_VERSION` (currently **1**) is bumped **only** on a
+backward-incompatible change to a stable field:
+
+- renaming or removing a field,
+- changing its type or its documented meaning.
+
+Adding a new optional field is **backward-compatible** and does NOT bump the
+version — consumers MUST ignore unknown fields.
+
+### How a consumer detects drift
+
+- **Daemon `subscribe` clients** (long-lived): read
+  `params.schema_version` on each `worktrees.changed` notification. It
+  carries `SCHEMA_VERSION`; a value you weren't built for means the contract
+  moved.
+- **One-shot CLI consumers**: key off `gwm --version`. The array-typed
+  `list` output can't carry a top-level version field without itself
+  becoming a breaking change, so the tool version is the drift signal.
+- Each `*.schema.json` file also declares its `version` for offline
+  validation tooling.
+
+## Tiers — stable vs experimental
+
+Every field/section is one of:
+
+- **Stable** — frozen by a contract test. A rename/removal fails CI. All
+  fields below not marked experimental are stable.
+- **Experimental** — may change without a version bump.
+
+### JSON output (`worktree-list.schema.json`)
+
+Stable: `name`, `id`, `path`, `branch`, `head`, `is_main`, `is_locked`,
+`is_prunable`, `status` (`is_dirty`, `has_upstream`, `ahead`, `behind`,
+`unknown`), `age_seconds`, `issue`, `pr`.
+
+| Field | Tier | Note |
+|-------|------|------|
+| `repo` | **experimental** | present only in `--workspace` mode; rides the young workspace feature (#36). In `properties` but never `required`. |
+
+`doctor.schema.json` (`checks[]`, `severity`, `exit_code`) and
+`path.schema.json` (`name`, `path`, `branch`) are entirely **stable**.
+
+### Daemon JSON-RPC
+
+Stable methods: `list`, `doctor`, `path`, `subscribe`. Stable notification:
+`worktrees.changed`. Stable error codes: the JSON-RPC 2.0 standard set
+(`-32700`/`-32600`/`-32601`/`-32602`/`-32603`). Adding a method is additive
+(non-breaking); renaming or removing one is breaking.
+
+### `.gwm.toml` config
+
+The top-level section set is **stable** and pinned by
+`contract::CONFIG_SECTIONS`: `worktree`, `bootstrap`, `hooks`, `doctor`,
+`tui`, `theme`, `git_tui`, `review`, `labels`, `milestones`, `branch_types`,
+`aliases`, `gitmoji`, `issue_template`, `pr_template`. Individual keys
+within a section follow the same stable-by-default rule; experimental keys
+are called out in the configuration docs. `deny_unknown_fields` means an
+unknown section is a hard error, so a renamed section can't pass silently.

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -31,7 +31,17 @@ backward-incompatible change to a stable field:
 - changing its type or its documented meaning.
 
 Adding a new optional field is **backward-compatible** and does NOT bump the
-version — consumers MUST ignore unknown fields.
+version — consumers MUST ignore unknown fields. To keep that promise true
+even for consumers that strict-validate against these files, the object
+schemas use `additionalProperties: true` (the JSON Schema default): an output
+carrying a field added after a consumer pulled its schema copy still
+validates. A contract test pins this so the constraint can't be silently
+re-tightened. (gwm's own CI still rejects an *undocumented* field via the
+`serialized ⊆ properties` parity test, so the producer side stays honest.)
+
+`.gwm.toml` is the mirror image: it is *input*, so it keeps
+`deny_unknown_fields` — an unknown section is a user typo to reject, not a
+forward-compatible addition to ignore.
 
 ### How a consumer detects drift
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -13,7 +13,7 @@ truth for the version and the section/method sets is
 
 | Surface | Where | Documented by |
 |---------|-------|---------------|
-| **JSON output** | `gwm {list,doctor,path} --format=json` | the `*.schema.json` files here |
+| **JSON output** | `gwm {list,doctor,path} --format=json` and `gwm status --json` | the `*.schema.json` files here |
 | **Daemon JSON-RPC 2.0** | `gwm daemon` over a unix socket | [`src/daemon.rs`](../../src/daemon.rs) |
 | **`.gwm.toml` config** | per-repo config file | [`docs/4.configuration`](../4.configuration/) |
 
@@ -75,6 +75,14 @@ Stable: `name`, `id`, `path`, `branch`, `head`, `is_main`, `is_locked`,
 
 `doctor.schema.json` (`checks[]`, `severity`, `exit_code`) and
 `path.schema.json` (`name`, `path`, `branch`) are entirely **stable**.
+
+`status.schema.json` (`gwm status --json`) is **stable**: top-level `branch`,
+`issue` (`null` or `{number, source, …}`), `pr` (`null` or
+`{number, source, …}`). Like the workspace `repo`, the top-level `repo`
+(GitHub slug, present only with a remote) is **experimental**. The nested live
+fields (`state`, `title`, `labels`, `url`, `checks_passed`, `checks_total`)
+appear only when `gh` resolved the link; their names/types are stable when
+present.
 
 ### Daemon JSON-RPC
 

--- a/docs/schema/doctor.schema.json
+++ b/docs/schema/doctor.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kbrdn1/gwm-cli/docs/schema/doctor.schema.json",
+  "version": 1,
   "title": "gwm doctor report",
   "description": "Output of `gwm doctor --format=json` and the daemon's `doctor` JSON-RPC method (issue #38).",
   "type": "object",

--- a/docs/schema/doctor.schema.json
+++ b/docs/schema/doctor.schema.json
@@ -5,7 +5,7 @@
   "title": "gwm doctor report",
   "description": "Output of `gwm doctor --format=json` and the daemon's `doctor` JSON-RPC method (issue #38).",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["checks", "severity", "exit_code"],
   "properties": {
     "checks": {
@@ -29,7 +29,7 @@
     },
     "check": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["name", "status", "detail", "fix_hint"],
       "properties": {
         "name": { "type": "string" },

--- a/docs/schema/path.schema.json
+++ b/docs/schema/path.schema.json
@@ -5,7 +5,7 @@
   "title": "gwm path result",
   "description": "Output of `gwm path <pattern> --format=json` and the daemon's `path` JSON-RPC method (issue #38).",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["name", "path", "branch"],
   "properties": {
     "name": {

--- a/docs/schema/path.schema.json
+++ b/docs/schema/path.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kbrdn1/gwm-cli/docs/schema/path.schema.json",
+  "version": 1,
   "title": "gwm path result",
   "description": "Output of `gwm path <pattern> --format=json` and the daemon's `path` JSON-RPC method (issue #38).",
   "type": "object",

--- a/docs/schema/status.schema.json
+++ b/docs/schema/status.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kbrdn1/gwm-cli/docs/schema/status.schema.json",
+  "version": 1,
+  "title": "gwm status result",
+  "description": "Output of `gwm status --json` (issue #38) — the issue/PR link of a worktree plus, when `gh` is available, live GitHub state. A stable schema for scripting.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["branch", "issue", "pr"],
+  "properties": {
+    "branch": {
+      "type": "string",
+      "description": "Checked-out branch shorthand of the inspected worktree."
+    },
+    "repo": {
+      "type": "string",
+      "description": "GitHub owner/name slug. Present ONLY when a remote is resolvable; absent for a worktree with no GitHub remote."
+    },
+    "issue": {
+      "description": "Linked issue, or null when none. The live fields (state/title/labels/url) appear only when `gh` resolved the issue.",
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/issue_link" }]
+    },
+    "pr": {
+      "description": "Linked PR, or null when none. The live fields (state/title/checks/url) appear only when `gh` resolved the PR.",
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/pr_link" }]
+    }
+  },
+  "$defs": {
+    "link_source": {
+      "type": "string",
+      "enum": ["none", "branch-name", "explicit", "detected"],
+      "description": "How the link was established."
+    },
+    "issue_link": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["number", "source"],
+      "properties": {
+        "number": { "type": "integer", "minimum": 0 },
+        "source": { "$ref": "#/$defs/link_source" },
+        "state": {
+          "type": "string",
+          "enum": ["open", "closed"],
+          "description": "Live issue state; present only when `gh` resolved it."
+        },
+        "title": { "type": "string" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "url": { "type": "string" }
+      }
+    },
+    "pr_link": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["number", "source"],
+      "properties": {
+        "number": { "type": "integer", "minimum": 0 },
+        "source": { "$ref": "#/$defs/link_source" },
+        "state": {
+          "type": "string",
+          "enum": ["open", "draft", "closed", "merged"],
+          "description": "Live PR state; present only when `gh` resolved it."
+        },
+        "title": { "type": "string" },
+        "checks_passed": { "type": "integer", "minimum": 0 },
+        "checks_total": { "type": "integer", "minimum": 0 },
+        "url": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/schema/worktree-list.schema.json
+++ b/docs/schema/worktree-list.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/kbrdn1/gwm-cli/docs/schema/worktree-list.schema.json",
+  "version": 1,
   "title": "gwm worktree list",
   "description": "Output of `gwm list --format=json` and the daemon's `list` JSON-RPC method (issue #38). A stable array of worktrees, decoupled from gwm's internal types.",
   "type": "array",

--- a/docs/schema/worktree-list.schema.json
+++ b/docs/schema/worktree-list.schema.json
@@ -9,7 +9,7 @@
   "$defs": {
     "worktree": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "name",
         "id",
@@ -72,7 +72,7 @@
     },
     "status": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["is_dirty", "has_upstream", "ahead", "behind", "unknown"],
       "properties": {
         "is_dirty": { "type": "boolean" },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3019,7 +3019,10 @@ fn cmd_status(worktree: Option<String>, json: bool) -> Result<()> {
   let (issue_status, pr_status) = fetch_link_status(&repo, &branch, &link, slug.as_deref());
 
   if json {
-    print_status_json(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
+    println!(
+      "{}",
+      build_status_json(&branch, slug.as_deref(), &link, &issue_status, &pr_status)
+    );
   } else {
     print_status_human(&branch, slug.as_deref(), &link, &issue_status, &pr_status);
   }
@@ -3115,13 +3118,18 @@ fn print_status_human(
   }
 }
 
-fn print_status_json(
+/// Build the `gwm status --json` payload — a stable, hand-built schema for
+/// scripting (frozen by `tests/contract_tests.rs`, documented in
+/// `docs/schema/status.schema.json`, issue #317). Pure: returns the value so
+/// the contract test can pin its shape without spawning the binary or hitting
+/// GitHub. `print`-ing is the caller's job.
+pub fn build_status_json(
   branch: &str,
   slug: Option<&str>,
   link: &BranchLink,
   issue: &Option<IssueStatus>,
   pr: &Option<PrStatus>,
-) {
+) -> serde_json::Value {
   let mut obj = serde_json::Map::new();
   obj.insert("branch".into(), serde_json::Value::String(branch.into()));
   if let Some(s) = slug {
@@ -3179,7 +3187,7 @@ fn print_status_json(
       None => serde_json::Value::Null,
     },
   );
-  println!("{}", serde_json::Value::Object(obj));
+  serde_json::Value::Object(obj)
 }
 
 // ---- Labels commands (issue #81) ----------------------------------------

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,0 +1,81 @@
+//! The frozen, versioned **machine contracts** gwm pledges to keep stable
+//! across a 1.0 line (issue #317).
+//!
+//! Three surfaces are machine-readable and consumed by tooling outside
+//! this repo — editor plugins, status bars, CI scripts:
+//!
+//! 1. **JSON output schemas** — the `--format=json` payloads of `list`,
+//!    `doctor` and `path`, documented in `docs/schema/*.json` and built
+//!    from the [`crate::json_api`] DTOs.
+//! 2. **Daemon JSON-RPC 2.0 protocol** — the `list` / `doctor` / `path` /
+//!    `subscribe` methods and the `worktrees.changed` notification
+//!    ([`crate::daemon`]).
+//! 3. **`.gwm.toml` config schema** — the [`crate::config::Config`]
+//!    section set.
+//!
+//! Surfaces 1 and 2 share the same DTOs (a daemon `list` result is
+//! byte-identical to `gwm list --format=json`), so they share a single
+//! [`SCHEMA_VERSION`]. The config schema evolves on its own cadence and
+//! is governed by `serde(deny_unknown_fields)` + the freeze tests rather
+//! than a runtime version integer.
+//!
+//! ## Versioning policy
+//!
+//! [`SCHEMA_VERSION`] is bumped **only** on a backward-incompatible change
+//! to a *stable* field (rename, removal, or a type/semantics change). Adding
+//! an optional field is backward-compatible and does NOT bump it — consumers
+//! must ignore unknown fields. The integer is surfaced at runtime in the
+//! daemon's `worktrees.changed` notification (`params.schema_version`) so a
+//! long-lived `subscribe` client can detect a drift it was not built for;
+//! one-shot CLI consumers key off `gwm --version`.
+//!
+//! ## Tiers
+//!
+//! Every field/section is **stable** or **experimental** for 1.0:
+//!
+//! - **Stable** — frozen by a contract test; a rename/removal fails CI and
+//!   is a conscious breaking decision (a [`SCHEMA_VERSION`] bump). All
+//!   `docs/schema/*.json` fields, the four daemon methods + the notification,
+//!   and the documented `.gwm.toml` sections are stable.
+//! - **Experimental** — may change without a version bump; called out in
+//!   `docs/schema/README.md`. The workspace-only `repo` field on a
+//!   `worktree-list` row is experimental (it rides the `--workspace`
+//!   feature, itself young).
+//!
+//! The authoritative per-field tier table lives in `docs/schema/README.md`;
+//! the freeze tests in `tests/contract_tests.rs` enforce it.
+
+/// Version of the shared JSON contract — the `--format=json` payloads and
+/// the daemon RPC results/notifications (they are byte-identical). Bumped
+/// only on a backward-incompatible change to a stable field. See the
+/// module docs for the policy.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The daemon JSON-RPC request methods frozen for 1.0. A new method is an
+/// additive (backward-compatible) change; renaming or removing one is a
+/// breaking change. Pinned by `tests/contract_tests.rs`.
+pub const DAEMON_METHODS: &[&str] = &["list", "doctor", "path", "subscribe"];
+
+/// The daemon JSON-RPC notification method(s) frozen for 1.0.
+pub const DAEMON_NOTIFICATIONS: &[&str] = &["worktrees.changed"];
+
+/// The top-level `.gwm.toml` sections frozen as stable for 1.0. Mirrors
+/// the fields of [`crate::config::Config`]; the freeze test cross-checks
+/// the two so a renamed section can't silently drift the contract.
+pub const CONFIG_SECTIONS: &[&str] = &[
+  "worktree",
+  "bootstrap",
+  "hooks",
+  "doctor",
+  "tui",
+  "theme",
+  "git_tui",
+  "review",
+  "labels",
+  "milestones",
+  "branch_types",
+  "aliases",
+  "gitmoji",
+  "issue_template",
+  "pr_template",
+];

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -5,8 +5,9 @@
 //! this repo — editor plugins, status bars, CI scripts:
 //!
 //! 1. **JSON output schemas** — the `--format=json` payloads of `list`,
-//!    `doctor` and `path`, documented in `docs/schema/*.json` and built
-//!    from the [`crate::json_api`] DTOs.
+//!    `doctor` and `path` (built from the [`crate::json_api`] DTOs) plus the
+//!    hand-built `gwm status --json` payload, all documented in
+//!    `docs/schema/*.json`.
 //! 2. **Daemon JSON-RPC 2.0 protocol** — the `list` / `doctor` / `path` /
 //!    `subscribe` methods and the `worktrees.changed` notification
 //!    ([`crate::daemon`]).

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -181,11 +181,19 @@ pub fn handle_line(workdir: &Path, line: &str) -> Option<String> {
 /// Build the `worktrees.changed` notification payload (no `id` — it's a
 /// JSON-RPC notification, not a response). Used for the initial
 /// `subscribe` snapshot and every subsequent change.
+///
+/// `params.schema_version` carries [`crate::contract::SCHEMA_VERSION`] so a
+/// long-lived `subscribe` client can detect a contract drift it was not
+/// built for (issue #317). It is an additive, ignorable field — older
+/// clients that only read `params.worktrees` are unaffected.
 pub fn worktrees_changed_notification(worktrees: &[JsonWorktree]) -> Value {
   json!({
     "jsonrpc": "2.0",
     "method": "worktrees.changed",
-    "params": { "worktrees": worktrees },
+    "params": {
+      "schema_version": crate::contract::SCHEMA_VERSION,
+      "worktrees": worktrees,
+    },
   })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cli;
 pub mod command_log;
 pub mod config;
 pub mod config_cli;
+pub mod contract;
 pub mod daemon;
 pub mod doctor;
 pub mod error;

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -4,11 +4,16 @@
 //! of a *stable* field fails CI and becomes a conscious breaking decision
 //! (a `contract::SCHEMA_VERSION` bump) rather than an accident:
 //!
-//! 1. **JSON output schemas** — `docs/schema/*.json` vs the
-//!    [`gwm::json_api`] DTOs they document.
+//! 1. **JSON output schemas** — `docs/schema/*.json` vs the live output: the
+//!    [`gwm::json_api`] DTOs (`list`/`doctor`/`path`) and the hand-built
+//!    `gwm status --json` payload ([`build_status_json`]).
 //! 2. **Daemon JSON-RPC protocol** — method/notification names, error
 //!    codes, and the `schema_version` carried in `worktrees.changed`.
 //! 3. **`.gwm.toml` config schema** — the top-level section set.
+//!
+//! Sections 5–7 add baselines independent of both DTO and schema so a
+//! *coordinated* rename, a type drift, or a re-tightened `additionalProperties`
+//! is caught too — not just a one-sided DTO-vs-schema divergence.
 //!
 //! Anchor choice: the committed `docs/schema/*.json` files are the source
 //! of truth (they are what external consumers fetch), so the parity tests
@@ -22,7 +27,9 @@
 //! a `required` entry from a schema file, turns the relevant parity test
 //! red (verified during development of #317).
 
+use gwm::cli::build_status_json;
 use gwm::contract;
+use gwm::github::{BranchLink, CiState, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use gwm::json_api::{JsonCheck, JsonDoctorReport, JsonPath, JsonStatus, JsonWorktree};
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -218,7 +225,12 @@ fn schema_version_baseline_is_one() {
 
 #[test]
 fn every_schema_file_declares_the_contract_version() {
-  for file in ["worktree-list.schema.json", "doctor.schema.json", "path.schema.json"] {
+  for file in [
+    "worktree-list.schema.json",
+    "doctor.schema.json",
+    "path.schema.json",
+    "status.schema.json",
+  ] {
     let schema = read_schema(file);
     let v = schema
       .get("version")
@@ -606,6 +618,7 @@ fn output_schemas_tolerate_additive_fields() {
     ("worktree-list.schema.json", &["/$defs/worktree", "/$defs/status"]),
     ("doctor.schema.json", &["", "/$defs/check"]),
     ("path.schema.json", &[""]),
+    ("status.schema.json", &["", "/$defs/issue_link", "/$defs/pr_link"]),
   ];
   for (file, pointers) in cases {
     let schema = read_schema(file);
@@ -620,4 +633,182 @@ fn output_schemas_tolerate_additive_fields() {
       );
     }
   }
+}
+
+// --- 7. `gwm status --json` freeze -----------------------------------------
+//
+// The fourth JSON output surface (#317 review): a hand-built, nested payload
+// documented as "a stable schema for scripting" (cli.rs). It's not a serde
+// DTO, so `build_status_json` was made pure (returns the value) to pin it
+// here without spawning the binary or hitting GitHub. Frozen against
+// `docs/schema/status.schema.json`.
+
+/// A fully-populated status value: a remote slug, a linked issue and PR with
+/// live `gh` state. Exercises every optional nested field so the freeze
+/// covers the widest shape the surface emits.
+fn populated_status() -> Value {
+  let mut link = BranchLink::empty();
+  link.issue = Some(317);
+  link.pr = Some(322);
+  link.issue_source = LinkSource::Explicit;
+  link.pr_source = LinkSource::Detected;
+  let issue = Some(IssueStatus {
+    number: 317,
+    title: "freeze the contracts".into(),
+    state: IssueState::Open,
+    url: "https://example/317".into(),
+    labels: vec!["enhancement".into()],
+    updated_at: "2026-06-17T00:00:00Z".into(),
+  });
+  let pr = Some(PrStatus {
+    number: 322,
+    title: "freeze & version".into(),
+    state: PrState::Open,
+    url: "https://example/322".into(),
+    updated_at: "2026-06-17T00:00:00Z".into(),
+    checks_passed: 3,
+    checks_total: 4,
+    ci: CiState::Running,
+  });
+  build_status_json(
+    "feat/#317-freeze-machine-contracts",
+    Some("kbrdn1/gwm-cli"),
+    &link,
+    &issue,
+    &pr,
+  )
+}
+
+#[test]
+fn status_json_matches_the_schema() {
+  let schema = read_schema("status.schema.json");
+  let top_required = required_set(&schema, "/required");
+  let top_props = object_keys(&schema, "/properties");
+  let v = populated_status();
+
+  let top: BTreeSet<String> = v.as_object().unwrap().keys().cloned().collect();
+  assert_field_contract("status result", &top_required, &top, &top_props);
+
+  let issue_required = required_set(&schema, "/$defs/issue_link/required");
+  let issue_props = object_keys(&schema, "/$defs/issue_link/properties");
+  let issue: BTreeSet<String> = v["issue"].as_object().unwrap().keys().cloned().collect();
+  assert_field_contract("status issue link", &issue_required, &issue, &issue_props);
+
+  let pr_required = required_set(&schema, "/$defs/pr_link/required");
+  let pr_props = object_keys(&schema, "/$defs/pr_link/properties");
+  let pr: BTreeSet<String> = v["pr"].as_object().unwrap().keys().cloned().collect();
+  assert_field_contract("status pr link", &pr_required, &pr, &pr_props);
+}
+
+#[test]
+fn status_json_null_link_still_carries_required_keys() {
+  // No remote, no link: `branch` plus explicit `issue:null` / `pr:null`. The
+  // required keys must be present so a scripting consumer can always read
+  // them; `repo` is absent (it's optional, only with a slug).
+  let v = build_status_json("dev", None, &BranchLink::empty(), &None, &None);
+  let obj = v.as_object().unwrap();
+  assert_eq!(obj["branch"], Value::String("dev".into()));
+  assert_eq!(obj["issue"], Value::Null);
+  assert_eq!(obj["pr"], Value::Null);
+  assert!(!obj.contains_key("repo"), "repo must be absent without a remote slug");
+}
+
+#[test]
+fn status_json_field_types_are_frozen() {
+  let v = populated_status();
+  assert_type_baseline(
+    "status result",
+    &v,
+    &[
+      ("branch", "string"),
+      ("repo", "string"),
+      ("issue", "object"),
+      ("pr", "object"),
+    ],
+  );
+  assert_type_baseline(
+    "status issue link",
+    &v["issue"],
+    &[
+      ("number", "integer"),
+      ("source", "string"),
+      ("state", "string"),
+      ("title", "string"),
+      ("labels", "array"),
+      ("url", "string"),
+    ],
+  );
+  assert_type_baseline(
+    "status pr link",
+    &v["pr"],
+    &[
+      ("number", "integer"),
+      ("source", "string"),
+      ("state", "string"),
+      ("title", "string"),
+      ("checks_passed", "integer"),
+      ("checks_total", "integer"),
+      ("url", "string"),
+    ],
+  );
+}
+
+#[test]
+fn status_schema_required_and_types_are_frozen() {
+  let schema = read_schema("status.schema.json");
+
+  // Top object: `branch`/`repo` are plain types; `issue`/`pr` are
+  // `oneOf[null, $ref]`, asserted structurally below.
+  assert_eq!(
+    required_set(&schema, "/required"),
+    ["branch", "issue", "pr"]
+      .iter()
+      .map(|s| s.to_string())
+      .collect::<BTreeSet<_>>(),
+    "status top-level required set drifted"
+  );
+  assert_eq!(schema_type_descriptor(&schema["properties"]["branch"]), "string");
+  assert_eq!(schema_type_descriptor(&schema["properties"]["repo"]), "string");
+  for field in ["issue", "pr"] {
+    let one_of = schema["properties"][field]["oneOf"]
+      .as_array()
+      .unwrap_or_else(|| panic!("status `{field}` must be a oneOf[null, link]"));
+    let descriptors: BTreeSet<String> = one_of.iter().map(schema_type_descriptor).collect();
+    let expected_ref = format!("$ref:#/$defs/{}_link", field);
+    assert!(descriptors.contains("null"), "status `{field}` must permit null");
+    assert!(
+      descriptors.contains(&expected_ref),
+      "status `{field}` must reference its link definition"
+    );
+  }
+
+  assert_schema_baseline(
+    "status issue link",
+    &schema,
+    "/$defs/issue_link",
+    &["number", "source"],
+    &[
+      ("number", "integer"),
+      ("source", "$ref:#/$defs/link_source"),
+      ("state", "string"),
+      ("title", "string"),
+      ("labels", "array"),
+      ("url", "string"),
+    ],
+  );
+  assert_schema_baseline(
+    "status pr link",
+    &schema,
+    "/$defs/pr_link",
+    &["number", "source"],
+    &[
+      ("number", "integer"),
+      ("source", "$ref:#/$defs/link_source"),
+      ("state", "string"),
+      ("title", "string"),
+      ("checks_passed", "integer"),
+      ("checks_total", "integer"),
+      ("url", "string"),
+    ],
+  );
 }

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -591,3 +591,33 @@ fn path_schema_required_and_types_are_frozen() {
     &[("name", "string"), ("path", "string"), ("branch", "null|string")],
   );
 }
+
+#[test]
+fn output_schemas_tolerate_additive_fields() {
+  // The versioning policy promises additive fields are backward-compatible
+  // and consumers ignore unknowns (#317 review). For a schema-validating
+  // consumer that's only true if the object schemas don't set
+  // `additionalProperties: false` — otherwise a v1 validator would reject
+  // an output carrying a new optional field. Freeze that: nobody may
+  // re-tighten these without consciously breaking the documented policy.
+  // (The producer-side guard `serialized ⊆ properties` still catches an
+  // accidental leaked field at our own CI.)
+  let cases: &[(&str, &[&str])] = &[
+    ("worktree-list.schema.json", &["/$defs/worktree", "/$defs/status"]),
+    ("doctor.schema.json", &["", "/$defs/check"]),
+    ("path.schema.json", &[""]),
+  ];
+  for (file, pointers) in cases {
+    let schema = read_schema(file);
+    for ptr in *pointers {
+      let obj = schema
+        .pointer(ptr)
+        .unwrap_or_else(|| panic!("{file}: no object at '{ptr}'"));
+      assert_ne!(
+        obj.get("additionalProperties"),
+        Some(&Value::Bool(false)),
+        "{file} at '{ptr}': additionalProperties:false breaks the additive-compatibility policy"
+      );
+    }
+  }
+}

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -303,3 +303,131 @@ fn a_config_with_every_frozen_section_round_trips() {
   // Array-of-table and list sections default to empty without a block.
   let _ = serde_json::to_value(&cfg).unwrap();
 }
+
+// --- 5. Frozen field + type baseline ---------------------------------------
+//
+// The parity tests above compare the live DTO to the live schema file, so
+// they catch a DTO field renamed *without* the schema following. They do NOT
+// catch two cases the 1.0 pledge cares about (raised in #317 review):
+//
+//   1. a coordinated rename — DTO field AND its schema entry renamed in the
+//      same commit — leaves `required ⊆ serialized ⊆ properties` still true;
+//   2. a *type* change with the same name (e.g. `head: String` -> `head: u64`)
+//      is invisible to a name-only set comparison.
+//
+// This baseline is a third, independent anchor: a hardcoded `(field, type)`
+// map per surface. A rename now needs THREE coordinated edits (DTO, schema,
+// baseline) and a type change is caught outright — turning an accidental
+// break into a deliberate one that must also bump `SCHEMA_VERSION`. Editing
+// the maps below is the conscious act the freeze exists to force.
+
+/// Coarse JSON type tag of a value, with integers split out from floats so a
+/// `u64 -> f64` drift is caught. A `null` reports `"null"`, but the baseline
+/// is asserted against samples whose nullable fields are populated, so the
+/// *non-null* type is what gets pinned (null is always permitted on a
+/// nullable field).
+fn json_type(v: &Value) -> &'static str {
+  match v {
+    Value::Null => "null",
+    Value::Bool(_) => "bool",
+    Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
+    Value::Number(_) => "number",
+    Value::String(_) => "string",
+    Value::Array(_) => "array",
+    Value::Object(_) => "object",
+  }
+}
+
+/// Assert every `(field, expected_type)` in `baseline` is present in the
+/// serialized object with the matching JSON type. `what` labels failures.
+fn assert_type_baseline<T: serde::Serialize>(what: &str, value: &T, baseline: &[(&str, &str)]) {
+  let v = serde_json::to_value(value).expect("serialize");
+  let obj = v.as_object().expect("DTO must serialize to an object");
+  for (field, expected) in baseline {
+    let actual = obj
+      .get(*field)
+      .unwrap_or_else(|| panic!("{what}: stable field `{field}` is gone from the serialized output (rename/removal?)"));
+    assert_eq!(
+      json_type(actual),
+      *expected,
+      "{what}: stable field `{field}` changed type — was `{expected}`, now `{}`",
+      json_type(actual)
+    );
+  }
+}
+
+#[test]
+fn worktree_field_types_are_frozen() {
+  assert_type_baseline(
+    "worktree-list row",
+    &sample_worktree(),
+    &[
+      ("name", "string"),
+      ("id", "string"),
+      ("path", "string"),
+      ("branch", "string"),
+      ("head", "string"),
+      ("is_main", "bool"),
+      ("is_locked", "bool"),
+      ("is_prunable", "bool"),
+      ("status", "object"),
+      ("age_seconds", "integer"),
+      ("issue", "integer"),
+      ("pr", "integer"),
+    ],
+  );
+  assert_type_baseline(
+    "worktree status",
+    &sample_worktree().status,
+    &[
+      ("is_dirty", "bool"),
+      ("has_upstream", "bool"),
+      ("ahead", "integer"),
+      ("behind", "integer"),
+      ("unknown", "bool"),
+    ],
+  );
+}
+
+#[test]
+fn path_field_types_are_frozen() {
+  let dto = JsonPath {
+    name: "feat-317".into(),
+    path: "/wt/feat-317".into(),
+    branch: Some("feat/#317-freeze-machine-contracts".into()),
+  };
+  assert_type_baseline(
+    "path result",
+    &dto,
+    &[("name", "string"), ("path", "string"), ("branch", "string")],
+  );
+}
+
+#[test]
+fn doctor_field_types_are_frozen() {
+  let report = JsonDoctorReport {
+    checks: vec![JsonCheck {
+      name: "config".into(),
+      status: "ok".into(),
+      detail: "found .gwm.toml".into(),
+      fix_hint: Some("run gwm init".into()),
+    }],
+    severity: "ok".into(),
+    exit_code: 0,
+  };
+  assert_type_baseline(
+    "doctor report",
+    &report,
+    &[("checks", "array"), ("severity", "string"), ("exit_code", "integer")],
+  );
+  assert_type_baseline(
+    "doctor check",
+    &report.checks[0],
+    &[
+      ("name", "string"),
+      ("status", "string"),
+      ("detail", "string"),
+      ("fix_hint", "string"),
+    ],
+  );
+}

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -431,3 +431,163 @@ fn doctor_field_types_are_frozen() {
     ],
   );
 }
+
+// --- 6. Frozen *schema-side* baseline --------------------------------------
+//
+// Section 5 freezes the DTO side (what gwm emits). The committed schema
+// files are themselves a published artifact external validators consume, so
+// they need the symmetric freeze (raised in #317 review):
+//
+//   1. a schema edit that DROPS a stable field from `required` (makes it
+//      optional) while the DTO still emits it leaves the parity check green
+//      (`required` only shrinks, `serialized ⊆ properties` still holds) —
+//      silently weakening the published contract;
+//   2. a schema-only TYPE drift (e.g. `head`'s declared type flipped to
+//      `integer` while the output stays a string) is invisible to a baseline
+//      that only inspects the serialized DTO.
+//
+// So pin the schema's own `required` set and per-field declared `type`/`$ref`
+// against an explicit frozen baseline, independent of the DTO. Experimental
+// fields (`repo`) are deliberately excluded — they may move without a bump.
+
+/// Normalized descriptor of a schema property's declared type: the `$ref`
+/// target verbatim (prefixed), or the `type` keyword with a multi-type
+/// array sorted+joined so `["string","null"]` is stable regardless of order.
+fn schema_type_descriptor(prop: &Value) -> String {
+  if let Some(r) = prop.get("$ref").and_then(|v| v.as_str()) {
+    return format!("$ref:{r}");
+  }
+  match prop.get("type") {
+    Some(Value::String(s)) => s.clone(),
+    Some(Value::Array(a)) => {
+      let mut parts: Vec<String> = a.iter().filter_map(|x| x.as_str().map(String::from)).collect();
+      parts.sort();
+      parts.join("|")
+    }
+    _ => panic!("schema property has neither `$ref` nor `type`"),
+  }
+}
+
+/// Assert the schema object at `base_ptr` has exactly `frozen_required` as
+/// its stable required set (experimental fields excluded by construction),
+/// and that each `(field, descriptor)` in `frozen_types` matches the
+/// property's declared `type`/`$ref`.
+fn assert_schema_baseline(
+  what: &str,
+  schema: &Value,
+  base_ptr: &str,
+  frozen_required: &[&str],
+  frozen_types: &[(&str, &str)],
+) {
+  let required = required_set(schema, &format!("{base_ptr}/required"));
+  let frozen: BTreeSet<String> = frozen_required.iter().map(|s| s.to_string()).collect();
+  assert_eq!(
+    required, frozen,
+    "{what}: schema `required` set drifted from the frozen stable baseline — a dropped/added required field is a contract change"
+  );
+  let props = schema
+    .pointer(&format!("{base_ptr}/properties"))
+    .unwrap_or_else(|| panic!("{what}: no properties at {base_ptr}"));
+  for (field, expected) in frozen_types {
+    let prop = props
+      .get(*field)
+      .unwrap_or_else(|| panic!("{what}: stable field `{field}` missing from schema properties"));
+    assert_eq!(
+      &schema_type_descriptor(prop),
+      expected,
+      "{what}: schema-declared type of `{field}` drifted from the frozen contract"
+    );
+  }
+}
+
+#[test]
+fn worktree_schema_required_and_types_are_frozen() {
+  let schema = read_schema("worktree-list.schema.json");
+  assert_schema_baseline(
+    "worktree-list row",
+    &schema,
+    "/$defs/worktree",
+    // `repo` is experimental — intentionally NOT in the frozen required set.
+    &[
+      "name",
+      "id",
+      "path",
+      "branch",
+      "head",
+      "is_main",
+      "is_locked",
+      "is_prunable",
+      "status",
+      "age_seconds",
+      "issue",
+      "pr",
+    ],
+    &[
+      ("name", "string"),
+      ("id", "string"),
+      ("path", "string"),
+      ("branch", "null|string"),
+      ("head", "null|string"),
+      ("is_main", "boolean"),
+      ("is_locked", "boolean"),
+      ("is_prunable", "boolean"),
+      ("status", "$ref:#/$defs/status"),
+      ("age_seconds", "integer|null"),
+      ("issue", "integer|null"),
+      ("pr", "integer|null"),
+    ],
+  );
+  assert_schema_baseline(
+    "worktree status",
+    &schema,
+    "/$defs/status",
+    &["is_dirty", "has_upstream", "ahead", "behind", "unknown"],
+    &[
+      ("is_dirty", "boolean"),
+      ("has_upstream", "boolean"),
+      ("ahead", "integer"),
+      ("behind", "integer"),
+      ("unknown", "boolean"),
+    ],
+  );
+}
+
+#[test]
+fn doctor_schema_required_and_types_are_frozen() {
+  let schema = read_schema("doctor.schema.json");
+  assert_schema_baseline(
+    "doctor report",
+    &schema,
+    "",
+    &["checks", "severity", "exit_code"],
+    &[
+      ("checks", "array"),
+      ("severity", "$ref:#/$defs/status"),
+      ("exit_code", "integer"),
+    ],
+  );
+  assert_schema_baseline(
+    "doctor check",
+    &schema,
+    "/$defs/check",
+    &["name", "status", "detail", "fix_hint"],
+    &[
+      ("name", "string"),
+      ("status", "$ref:#/$defs/status"),
+      ("detail", "string"),
+      ("fix_hint", "null|string"),
+    ],
+  );
+}
+
+#[test]
+fn path_schema_required_and_types_are_frozen() {
+  let schema = read_schema("path.schema.json");
+  assert_schema_baseline(
+    "path result",
+    &schema,
+    "",
+    &["name", "path", "branch"],
+    &[("name", "string"), ("path", "string"), ("branch", "null|string")],
+  );
+}

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -1,0 +1,305 @@
+//! Contract freeze tests for the 1.0 machine surface (issue #317).
+//!
+//! These pin the three machine-readable contracts so a rename or removal
+//! of a *stable* field fails CI and becomes a conscious breaking decision
+//! (a `contract::SCHEMA_VERSION` bump) rather than an accident:
+//!
+//! 1. **JSON output schemas** — `docs/schema/*.json` vs the
+//!    [`gwm::json_api`] DTOs they document.
+//! 2. **Daemon JSON-RPC protocol** — method/notification names, error
+//!    codes, and the `schema_version` carried in `worktrees.changed`.
+//! 3. **`.gwm.toml` config schema** — the top-level section set.
+//!
+//! Anchor choice: the committed `docs/schema/*.json` files are the source
+//! of truth (they are what external consumers fetch), so the parity tests
+//! read them off disk and compare against the live serialized DTOs. The
+//! relation is deliberately a **subset** check, not exact equality — the
+//! `repo` field is workspace-only and present in `properties` but not in
+//! `required`, so `required ⊆ serialized ⊆ properties` is the correct shape
+//! (an `assert_eq!` would false-fail on it).
+//!
+//! Proven to bite: temporarily renaming a `JsonWorktree` field, or dropping
+//! a `required` entry from a schema file, turns the relevant parity test
+//! red (verified during development of #317).
+
+use gwm::contract;
+use gwm::json_api::{JsonCheck, JsonDoctorReport, JsonPath, JsonStatus, JsonWorktree};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+// --- helpers ---------------------------------------------------------------
+
+fn schema_dir() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs/schema")
+}
+
+fn read_schema(name: &str) -> Value {
+  let path = schema_dir().join(name);
+  let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+  serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+/// Keys of the JSON object at `pointer` within `schema`.
+fn object_keys(schema: &Value, pointer: &str) -> BTreeSet<String> {
+  schema
+    .pointer(pointer)
+    .unwrap_or_else(|| panic!("schema has no object at {pointer}"))
+    .as_object()
+    .unwrap_or_else(|| panic!("{pointer} is not an object"))
+    .keys()
+    .cloned()
+    .collect()
+}
+
+/// Entries of the `required` string array at `pointer` within `schema`.
+fn required_set(schema: &Value, pointer: &str) -> BTreeSet<String> {
+  schema
+    .pointer(pointer)
+    .unwrap_or_else(|| panic!("schema has no `required` at {pointer}"))
+    .as_array()
+    .unwrap_or_else(|| panic!("{pointer} is not an array"))
+    .iter()
+    .map(|v| v.as_str().expect("required entry must be a string").to_string())
+    .collect()
+}
+
+/// Top-level keys of a serialized value (must serialize to an object).
+fn serialized_keys<T: serde::Serialize>(value: &T) -> BTreeSet<String> {
+  serde_json::to_value(value)
+    .expect("serialize")
+    .as_object()
+    .expect("DTO must serialize to an object")
+    .keys()
+    .cloned()
+    .collect()
+}
+
+/// `required ⊆ serialized ⊆ properties` — the field-set contract between a
+/// schema object and the DTO it documents. `what` labels failures.
+fn assert_field_contract(
+  what: &str,
+  required: &BTreeSet<String>,
+  serialized: &BTreeSet<String>,
+  properties: &BTreeSet<String>,
+) {
+  let missing_required: Vec<_> = required.difference(serialized).collect();
+  assert!(
+    missing_required.is_empty(),
+    "{what}: stable field(s) {missing_required:?} are `required` in the schema but no longer serialized — a rename/removal that breaks the contract"
+  );
+  let undocumented: Vec<_> = serialized.difference(properties).collect();
+  assert!(
+    undocumented.is_empty(),
+    "{what}: serialized field(s) {undocumented:?} are not in the schema `properties` — an undocumented field leaking into the frozen output"
+  );
+}
+
+fn sample_worktree() -> JsonWorktree {
+  JsonWorktree {
+    name: "feat-317".into(),
+    id: "feat-317".into(),
+    path: "/wt/feat-317".into(),
+    branch: Some("feat/#317-freeze-machine-contracts".into()),
+    head: Some("a".repeat(40)),
+    is_main: false,
+    is_locked: false,
+    is_prunable: false,
+    status: JsonStatus {
+      is_dirty: true,
+      has_upstream: true,
+      ahead: 1,
+      behind: 0,
+      unknown: false,
+    },
+    age_seconds: Some(10),
+    issue: Some(317),
+    pr: Some(318),
+  }
+}
+
+// --- 1. JSON output schema parity ------------------------------------------
+
+#[test]
+fn worktree_list_schema_matches_the_dto() {
+  let schema = read_schema("worktree-list.schema.json");
+  let required = required_set(&schema, "/$defs/worktree/required");
+  let properties = object_keys(&schema, "/$defs/worktree/properties");
+  let serialized = serialized_keys(&sample_worktree());
+  assert_field_contract("worktree-list row", &required, &serialized, &properties);
+}
+
+#[test]
+fn worktree_status_schema_matches_the_dto() {
+  let schema = read_schema("worktree-list.schema.json");
+  let required = required_set(&schema, "/$defs/status/required");
+  let properties = object_keys(&schema, "/$defs/status/properties");
+  let serialized = serialized_keys(&sample_worktree().status);
+  assert_field_contract("worktree status", &required, &serialized, &properties);
+}
+
+#[test]
+fn workspace_repo_field_is_in_properties_but_not_required() {
+  // The workspace `--workspace ... list --format=json` row flattens a
+  // `JsonWorktree` and prepends `repo` (cli.rs `WorkspaceJsonWorktree`).
+  // The schema must allow that extra field (it's in `properties`) without
+  // demanding it for single-repo rows (it's NOT in `required`).
+  let schema = read_schema("worktree-list.schema.json");
+  let required = required_set(&schema, "/$defs/worktree/required");
+  let properties = object_keys(&schema, "/$defs/worktree/properties");
+  assert!(
+    properties.contains("repo"),
+    "workspace-mode `repo` must be a documented property"
+  );
+  assert!(
+    !required.contains("repo"),
+    "`repo` is workspace-only — requiring it would break single-repo rows"
+  );
+
+  // Replicate the workspace wire shape: flattened worktree + `repo`.
+  let mut row = serde_json::to_value(sample_worktree()).unwrap();
+  row
+    .as_object_mut()
+    .unwrap()
+    .insert("repo".into(), Value::String("gwm-cli".into()));
+  let serialized: BTreeSet<String> = row.as_object().unwrap().keys().cloned().collect();
+  assert_field_contract("workspace worktree row", &required, &serialized, &properties);
+}
+
+#[test]
+fn doctor_schema_matches_the_dtos() {
+  let schema = read_schema("doctor.schema.json");
+
+  let report = JsonDoctorReport {
+    checks: vec![JsonCheck {
+      name: "config".into(),
+      status: "ok".into(),
+      detail: "found .gwm.toml".into(),
+      fix_hint: None,
+    }],
+    severity: "ok".into(),
+    exit_code: 0,
+  };
+  let required = required_set(&schema, "/required");
+  let properties = object_keys(&schema, "/properties");
+  assert_field_contract("doctor report", &required, &serialized_keys(&report), &properties);
+
+  let check_required = required_set(&schema, "/$defs/check/required");
+  let check_properties = object_keys(&schema, "/$defs/check/properties");
+  assert_field_contract(
+    "doctor check",
+    &check_required,
+    &serialized_keys(&report.checks[0]),
+    &check_properties,
+  );
+}
+
+#[test]
+fn path_schema_matches_the_dto() {
+  let schema = read_schema("path.schema.json");
+  let required = required_set(&schema, "/required");
+  let properties = object_keys(&schema, "/properties");
+  let dto = JsonPath {
+    name: "feat-317".into(),
+    path: "/wt/feat-317".into(),
+    branch: Some("feat/#317-freeze-machine-contracts".into()),
+  };
+  assert_field_contract("path result", &required, &serialized_keys(&dto), &properties);
+}
+
+// --- 2. Schema version freeze ----------------------------------------------
+
+#[test]
+fn schema_version_baseline_is_one() {
+  // The 1.0 baseline. Bumping this is a deliberate breaking decision; this
+  // test flags the bump so it can't happen by accident.
+  assert_eq!(contract::SCHEMA_VERSION, 1);
+}
+
+#[test]
+fn every_schema_file_declares_the_contract_version() {
+  for file in ["worktree-list.schema.json", "doctor.schema.json", "path.schema.json"] {
+    let schema = read_schema(file);
+    let v = schema
+      .get("version")
+      .unwrap_or_else(|| panic!("{file} must declare a `version`"))
+      .as_u64()
+      .unwrap_or_else(|| panic!("{file} `version` must be an integer"));
+    assert_eq!(
+      v as u32,
+      contract::SCHEMA_VERSION,
+      "{file} version drifted from contract::SCHEMA_VERSION"
+    );
+  }
+}
+
+// --- 3. Daemon protocol freeze ---------------------------------------------
+
+#[test]
+fn daemon_notification_carries_the_schema_version() {
+  // The runtime drift signal for a long-lived `subscribe` client.
+  let note = gwm::daemon::worktrees_changed_notification(&[]);
+  assert_eq!(note["method"], Value::String("worktrees.changed".into()));
+  assert_eq!(
+    note["params"]["schema_version"]
+      .as_u64()
+      .expect("schema_version present"),
+    contract::SCHEMA_VERSION as u64
+  );
+  // The frozen payload field is still there alongside the version.
+  assert!(note["params"]["worktrees"].is_array());
+}
+
+#[test]
+fn daemon_method_and_notification_names_are_frozen() {
+  assert_eq!(contract::DAEMON_METHODS, &["list", "doctor", "path", "subscribe"]);
+  assert_eq!(contract::DAEMON_NOTIFICATIONS, &["worktrees.changed"]);
+}
+
+#[test]
+fn daemon_jsonrpc_error_codes_are_the_standard_values() {
+  // Frozen to the JSON-RPC 2.0 standard codes — a client maps on these.
+  assert_eq!(gwm::daemon::PARSE_ERROR, -32700);
+  assert_eq!(gwm::daemon::INVALID_REQUEST, -32600);
+  assert_eq!(gwm::daemon::METHOD_NOT_FOUND, -32601);
+  assert_eq!(gwm::daemon::INVALID_PARAMS, -32602);
+  assert_eq!(gwm::daemon::INTERNAL_ERROR, -32603);
+}
+
+// --- 4. Config schema freeze -----------------------------------------------
+
+#[test]
+fn config_top_level_sections_are_frozen() {
+  // The serialized top-level keys of a default Config ARE the `.gwm.toml`
+  // section set. Pinning them against `contract::CONFIG_SECTIONS` makes a
+  // renamed/added/removed section a conscious edit in two places.
+  let serialized = serialized_keys(&gwm::config::Config::default());
+  let frozen: BTreeSet<String> = contract::CONFIG_SECTIONS.iter().map(|s| s.to_string()).collect();
+  assert_eq!(
+    serialized, frozen,
+    "the `.gwm.toml` top-level section set drifted from contract::CONFIG_SECTIONS"
+  );
+}
+
+#[test]
+fn a_config_with_every_frozen_section_round_trips() {
+  // Each frozen section must still parse — `deny_unknown_fields` means a
+  // renamed section would make this fail, a second guard on the set above.
+  let toml = "\
+[worktree]
+[bootstrap]
+[hooks]
+[doctor]
+[tui]
+[theme]
+[git_tui]
+[review]
+[issue_template]
+[pr_template]
+[aliases]
+[gitmoji]
+";
+  let cfg: gwm::config::Config = toml::from_str(toml).expect("frozen sections must parse");
+  // Array-of-table and list sections default to empty without a block.
+  let _ = serde_json::to_value(&cfg).unwrap();
+}


### PR DESCRIPTION
## Description

Freezes and versions the **machine-readable** contracts ahead of the 1.0 compatibility pledge (issue #317): the `--format=json` outputs (`list`/`doctor`/`path`), `gwm status --json`, the daemon JSON-RPC protocol, and the `.gwm.toml` section set. No behaviour change to any existing output — this defines the baseline and adds the tests that defend it.

Closes #317

## Type of change

- [x] ✨ Feature (new functionality)
- [x] ✅ Tests

## Changes

- **`gwm::contract`** — new module, single source of truth for `SCHEMA_VERSION` (1.0 baseline = `1`), the frozen daemon method/notification names, and the `.gwm.toml` section set.
- **Runtime drift signal** — the daemon's `worktrees.changed` notification carries `params.schema_version` (additive, ignorable). The array-typed `list` output is left untouched; one-shot CLI consumers key off `gwm --version`.
- **Four output surfaces frozen** — `list`/`doctor`/`path` (serde DTOs) + `gwm status --json` (hand-built; `build_status_json` extracted as a pure fn, byte-identical output). New `docs/schema/status.schema.json`; each schema declares its `version`.
- **Additive-compatibility** — output object schemas use `additionalProperties: true` so a future optional field validates under the same version (consumers ignore unknowns); `.gwm.toml` keeps `deny_unknown_fields` (input rejects typos).
- **`tests/contract_tests.rs`** (23 tests) — layered guards: DTO↔schema parity, DTO-side and schema-side field/type baselines (catch coordinated renames + type drift), additive-tolerance freeze, daemon protocol freeze, config section freeze.
- **`docs/schema/README.md`** — versioning policy + stable-vs-experimental tier of every field.

## Design notes

- **Version placement.** `worktree-list` is `type: array`, so it can't carry a top-level `schema_version` without a type break. The version lives as a code constant, is surfaced in the daemon notification (an object), and is declared in each schema file. The CLI JSON payloads stay byte-stable.
- **Subset, not equality, in parity.** The workspace-only `repo` field is in `properties` but not `required`. The relation `required ⊆ serialized ⊆ properties` is correct; a dedicated workspace-row case exercises `repo`.
- **Independent baselines.** Parity alone misses a *coordinated* rename (DTO + schema together) and a type change at a constant name, so sections 5–7 add hardcoded `(field, type)` baselines on both the DTO and the schema sides.
- **Tiering is docs + test coverage, not a runtime enum** (YAGNI). `repo` (workspace + status slug) is the only experimental field.

## Tests

- [x] `cargo test` passes locally (whole suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (23 in `contract_tests.rs`)

**Every guard proven to bite (TDD red):** a renamed DTO field, a coordinated DTO+schema rename, a schema `required` drop, a schema type drift, a re-tightened `additionalProperties`, and a renamed `status --json` nested field each turn the relevant test red — verified then reverted. The Codex review loop ran 5 iterations to clean (8 P2 findings, all fixed in-PR — see the loop summary comment).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths (test-only `unwrap`)
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #317
- Part of the 1.0 sprint: #320