### PR TITLE
📝 docs(docs): publish the 1.0 stability & compatibility policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy and the stable-vs-experimental tier of every field. No behaviour
   change to any existing output.
 
+### Docs
+
+- **Stability & compatibility policy for 1.0** (issue #318). A new
+  [Stability](docs/6.development/3.stability.md) page (EN + `docs/fr/`) is the
+  explicit, published SemVer contract behind the `1.0` line: which surfaces
+  are covered (CLI subcommands/flags, exit codes, the `--format=json` schemas,
+  the daemon JSON-RPC protocol, the `.gwm.toml` section set), which are free
+  to change in a minor/patch (TUI layout & colours, human-readable strings,
+  the internal Rust API), the MSRV policy (currently 1.86, bumps ride a
+  minor), and the deprecation process. It distinguishes surfaces *frozen by
+  `tests/contract_tests.rs`* from those *covered by the written promise*, and
+  defers the per-field stable/experimental tiers to
+  [`docs/schema/README.md`](docs/schema/README.md). Linked from the README and
+  `CONTRIBUTING.md`.
+
 ## Past releases
 
 In reverse chronological order:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,6 +324,11 @@ Versioning is SemVer (`MAJOR.MINOR.PATCH`), with `-rc.N` / `-alpha.N` / `-beta.N
 - `PATCH` → bug fix
 - `-rc.N` / `-alpha.N` / `-beta.N` → release candidate / alpha / beta cut from `dev` before promotion to `main`
 
+What a "breaking change" actually covers — the published 1.0 compatibility
+contract (which surfaces are covered by this SemVer promise, which are free to
+change in a minor/patch, the MSRV policy, and the deprecation process) — lives
+in [Stability & compatibility](docs/6.development/3.stability.md).
+
 ### Step 0 — Reconcile open PRs (applies to every tag)
 
 Before any RC or stable cut, run:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ MIT — see [LICENSE.md](LICENSE.md).
 
 - [`CHANGELOG.md`](CHANGELOG.md) — release index (root = `[Unreleased]`; per-version archives under [`changelogs/`](changelogs/))
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch / commit / PR conventions
+- [Stability & compatibility](docs/6.development/3.stability.md) — the 1.0 SemVer contract: what's covered, what's free to change, MSRV, deprecations
 - [`ROADMAP.md`](ROADMAP.md) — long-form roadmap with grouped categories
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - [`.github/LABELS.md`](.github/LABELS.md)

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -44,9 +44,9 @@ is a conscious **major** version decision.
 
 ### Frozen by test vs. covered by promise
 
-Two of these surfaces are *mechanically* frozen — a rename fails CI before it
-can ship: the **JSON schemas**, the **daemon method/notification names**, and
-the **`.gwm.toml` section set**, all pinned by `tests/contract_tests.rs`
+Three of these surfaces are *mechanically* frozen — a rename fails CI before
+it can ship: the **JSON schemas**, the **daemon method/notification names**,
+and the **`.gwm.toml` section set**, all pinned by `tests/contract_tests.rs`
 against the single source of truth in
 [`src/contract.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/contract.rs).
 

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -1,0 +1,125 @@
+---
+title: Stability & compatibility
+description: What gwm's 1.0 SemVer promise covers, what it deliberately leaves free to change, the MSRV policy, and how deprecations are run.
+navigation:
+  title: Stability
+---
+
+# Stability & compatibility
+
+gwm follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(`MAJOR.MINOR.PATCH`). This page is the explicit, published compatibility
+contract that backs the `1.0` line: it states which surfaces are covered by
+that promise (a breaking change there forces a **major** bump) and which are
+deliberately left free to change in a **minor** or **patch**.
+
+The rule of thumb: anything a *machine* parses is covered; anything a *human*
+reads on screen is not.
+
+## Covered by SemVer (breaking change → major)
+
+These surfaces are part of the public contract. A backward-incompatible change
+— renaming or removing something, or changing its type or documented meaning —
+is a conscious **major** version decision.
+
+- **CLI surface** — the subcommands, their flags, and their documented
+  argument shapes. Adding a subcommand or an optional flag is additive
+  (minor); renaming or removing one is breaking.
+- **Exit codes** — the deterministic `0` / `1` / `2` contract documented per
+  command (e.g. `gwm doctor`'s severity-derived code). Scripts and CI jobs key
+  off these, so a code's meaning is frozen under this promise.
+- **`--format=json` output schemas** — the JSON payloads of `gwm list`,
+  `gwm doctor`, `gwm path`, and `gwm status --json`, documented under
+  [`docs/schema/`](/development) and pinned by `tests/contract_tests.rs`.
+- **Daemon JSON-RPC 2.0 protocol** — the `list` / `doctor` / `path` /
+  `subscribe` methods, the `worktrees.changed` notification, and the standard
+  JSON-RPC error codes. A daemon `list` result is byte-identical to
+  `gwm list --format=json`, so the two share one `SCHEMA_VERSION`.
+- **`.gwm.toml` schema** — the top-level section set
+  (`worktree`, `bootstrap`, `hooks`, `doctor`, `tui`, `theme`, `git_tui`,
+  `review`, `labels`, `milestones`, `branch_types`, `aliases`, `gitmoji`,
+  `issue_template`, `pr_template`). A renamed or removed stable section is
+  breaking.
+
+### Frozen by test vs. covered by promise
+
+Two of these surfaces are *mechanically* frozen — a rename fails CI before it
+can ship: the **JSON schemas**, the **daemon method/notification names**, and
+the **`.gwm.toml` section set**, all pinned by `tests/contract_tests.rs`
+against the single source of truth in
+[`src/contract.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/contract.rs).
+
+The **CLI subcommands/flags** and the **exit-code meanings** are *not* freeze-
+tested end-to-end (only `doctor`'s `exit_code` field rides the JSON schema);
+they are covered by this written SemVer promise and reviewed per PR. Treat
+them as just as binding — the absence of a guard test is not a licence to
+break them silently.
+
+### The machine-contract detail lives elsewhere
+
+The per-field tiers (which exact fields are **stable** vs **experimental**),
+the drift-detection mechanism (`SCHEMA_VERSION` on the daemon notification,
+`gwm --version` for one-shot CLI consumers), and the `additionalProperties`
+rules are documented in full in
+[`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md).
+Notably, a few fields are **experimental** and may change without a major bump
+— e.g. the workspace-only `repo` field on a `list` row and the top-level
+`repo` on `status --json`. When in doubt about a specific field, that tiers
+table is authoritative.
+
+## NOT covered by SemVer (may change in minor/patch)
+
+These are free to change without a major bump. Do not build automation on top
+of them.
+
+- **TUI layout & colours** — pane arrangement, widget placement, the theme /
+  colour scheme, and any visual detail of the ratatui interface. Scripting
+  against the rendered TUI is unsupported.
+- **Human-readable strings** — log lines, status-bar messages, help blurbs,
+  the human (non-`--format=json`) output of any command. Parse the JSON
+  surface instead; the prose is allowed to be reworded at any time.
+- **Internal Rust API** — gwm ships as a binary, not a published library
+  crate. The `pub` items in `src/` exist for the test suite and internal
+  reuse; they are not a stable API and carry no SemVer guarantee.
+
+## MSRV policy
+
+The Minimum Supported Rust Version is declared as `rust-version` in
+[`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
+(currently **1.86**). It is the floor the crate compiles and is tested
+against in CI.
+
+In practice an MSRV bump rides a **minor** release, not a major one — it has
+historically been driven by a dependency raising its own floor (the `1.86`
+bump came in with `tui-term` / `portable-pty` when the PTY overlay landed),
+and is treated as a routine toolchain update rather than a breaking change to
+the public contract. Bumps are called out in the changelog so packagers are
+not surprised.
+
+## Deprecation process
+
+When a covered surface has to change in a backward-incompatible way:
+
+1. **Announce** — document the deprecation in the changelog under the release
+   that introduces it, and (where the surface supports it) emit a runtime
+   warning pointing at the replacement.
+2. **Keep the old path working** through the rest of the current major line —
+   a deprecation is a heads-up, not an immediate removal.
+3. **Remove only on a major bump**, with the removal listed in that release's
+   notes alongside the migration path.
+
+Additive changes (a new subcommand, an optional flag, a new optional JSON
+field, a new daemon method) are **not** deprecations — they ship in a minor
+release and require no warning, because existing consumers keep working
+unchanged (consumers MUST ignore unknown JSON fields).
+
+## See also
+
+- [`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md)
+  — the per-field stable/experimental tiers and the drift-detection contract.
+- [`src/contract.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/contract.rs)
+  — the single source of truth for `SCHEMA_VERSION` and the frozen
+  method/section sets.
+- [Contributing → Releases](/development/contributing) and
+  [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md)
+  — the SemVer release process and tagging workflow.

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -30,7 +30,8 @@ is a conscious **major** version decision.
   off these, so a code's meaning is frozen under this promise.
 - **`--format=json` output schemas** — the JSON payloads of `gwm list`,
   `gwm doctor`, `gwm path`, and `gwm status --json`, documented under
-  [`docs/schema/`](/development) and pinned by `tests/contract_tests.rs`.
+  [`docs/schema/`](https://github.com/kbrdn1/gwm-cli/tree/main/docs/schema)
+  and pinned by `tests/contract_tests.rs`.
 - **Daemon JSON-RPC 2.0 protocol** — the `list` / `doctor` / `path` /
   `subscribe` methods, the `worktrees.changed` notification, and the standard
   JSON-RPC error codes. A daemon `list` result is byte-identical to

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -87,8 +87,12 @@ of them.
 
 The Minimum Supported Rust Version is declared as `rust-version` in
 [`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
-(currently **1.86**). It is the floor the crate compiles and is tested
-against in CI.
+(currently **1.86**) — the floor the crate is expected to compile against.
+CI builds and tests on the *stable* toolchain; it does not pin a dedicated
+1.86 job, so the MSRV is verified locally before a bump with
+`cargo clippy --all-targets -- -W clippy::incompatible_msrv` (or
+`cargo msrv verify`), which flags an accidental use of an API newer than the
+declared floor.
 
 In practice an MSRV bump rides a **minor** release, not a major one — it has
 historically been driven by a dependency raising its own floor (the `1.86`

--- a/docs/6.development/index.md
+++ b/docs/6.development/index.md
@@ -11,6 +11,7 @@ gwm is a small Rust crate (single binary). Build, test, and ship workflows are d
 
 - **[Testing](/development/testing)** — the integration test files (~1700+ tests across 74 test files, run on the ubuntu / macos / windows matrix), the mandatory red → green → refactor TDD loop, how to run a subset, and the `// regression:` sentinel-test convention.
 - **[Contributing](/development/contributing)** — the Gitmoji + Conventional-Commit format, branch naming, the PR checklist, and the rules around the `CHANGELOG.md` / `changelogs/<version>.md` split.
+- **[Stability](/development/stability)** — the 1.0 SemVer compatibility contract: which surfaces are covered (CLI, exit codes, JSON schemas, daemon RPC, `.gwm.toml`), which are free to change (TUI, human strings, internal Rust API), the MSRV policy, and the deprecation process.
 
 ## quick reference
 

--- a/docs/fr/6.development/3.stability.md
+++ b/docs/fr/6.development/3.stability.md
@@ -47,7 +47,7 @@ documentée — est une décision consciente de version **majeure**.
 
 ### Gelé par un test vs. couvert par la promesse
 
-Deux de ces surfaces sont gelées *mécaniquement* — un renommage casse la CI
+Trois de ces surfaces sont gelées *mécaniquement* — un renommage casse la CI
 avant de pouvoir être publié : les **schémas JSON**, les **noms de
 méthodes/notification du daemon** et l'**ensemble des sections `.gwm.toml`**,
 tous figés par `tests/contract_tests.rs` face à la source de vérité unique de

--- a/docs/fr/6.development/3.stability.md
+++ b/docs/fr/6.development/3.stability.md
@@ -92,8 +92,12 @@ d'automatisation par-dessus.
 
 La version Rust minimale supportée est déclarée via `rust-version` dans
 [`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
-(actuellement **1.86**). C'est le plancher contre lequel la crate compile et
-est testée en CI.
+(actuellement **1.86**) — le plancher contre lequel la crate est censée
+compiler. La CI build et teste sur la toolchain *stable* ; elle n'épingle pas
+de job 1.86 dédié, donc le MSRV est vérifié localement avant un bump avec
+`cargo clippy --all-targets -- -W clippy::incompatible_msrv` (ou
+`cargo msrv verify`), qui signale l'usage accidentel d'une API plus récente
+que le plancher déclaré.
 
 En pratique, un bump MSRV ride une release **mineure**, pas majeure — il a
 historiquement été piloté par une dépendance relevant son propre plancher (le

--- a/docs/fr/6.development/3.stability.md
+++ b/docs/fr/6.development/3.stability.md
@@ -32,7 +32,8 @@ documentée — est une décision consciente de version **majeure**.
   promesse.
 - **Schémas de sortie `--format=json`** — les payloads JSON de `gwm list`,
   `gwm doctor`, `gwm path` et `gwm status --json`, documentés sous
-  [`docs/schema/`](/fr/development) et figés par `tests/contract_tests.rs`.
+  [`docs/schema/`](https://github.com/kbrdn1/gwm-cli/tree/main/docs/schema)
+  et figés par `tests/contract_tests.rs`.
 - **Protocole daemon JSON-RPC 2.0** — les méthodes `list` / `doctor` /
   `path` / `subscribe`, la notification `worktrees.changed` et les codes
   d'erreur JSON-RPC standard. Un résultat `list` du daemon est octet-pour-octet

--- a/docs/fr/6.development/3.stability.md
+++ b/docs/fr/6.development/3.stability.md
@@ -1,0 +1,132 @@
+---
+title: Stabilité & compatibilité
+description: Ce que couvre la promesse SemVer 1.0 de gwm, ce qu'elle laisse délibérément libre d'évoluer, la politique MSRV et la conduite des dépréciations.
+navigation:
+  title: Stabilité
+---
+
+# Stabilité & compatibilité
+
+gwm suit le [versionnage sémantique](https://semver.org/lang/fr/)
+(`MAJEUR.MINEUR.CORRECTIF`). Cette page est le contrat de compatibilité
+explicite et publié qui adosse la ligne `1.0` : elle énonce quelles surfaces
+sont couvertes par cette promesse (un changement cassant y force une version
+**majeure**) et lesquelles restent délibérément libres d'évoluer en
+**mineure** ou en **correctif**.
+
+La règle générale : tout ce qu'une *machine* parse est couvert ; tout ce qu'un
+*humain* lit à l'écran ne l'est pas.
+
+## Couvert par SemVer (changement cassant → majeure)
+
+Ces surfaces font partie du contrat public. Un changement rétro-incompatible —
+renommer ou supprimer un élément, ou changer son type ou sa signification
+documentée — est une décision consciente de version **majeure**.
+
+- **Surface CLI** — les sous-commandes, leurs flags et la forme documentée de
+  leurs arguments. Ajouter une sous-commande ou un flag optionnel est additif
+  (mineure) ; en renommer ou en supprimer un est cassant.
+- **Codes de sortie** — le contrat déterministe `0` / `1` / `2` documenté par
+  commande (ex. le code dérivé de la sévérité de `gwm doctor`). Les scripts et
+  jobs CI s'y appuient, donc la signification d'un code est gelée sous cette
+  promesse.
+- **Schémas de sortie `--format=json`** — les payloads JSON de `gwm list`,
+  `gwm doctor`, `gwm path` et `gwm status --json`, documentés sous
+  [`docs/schema/`](/fr/development) et figés par `tests/contract_tests.rs`.
+- **Protocole daemon JSON-RPC 2.0** — les méthodes `list` / `doctor` /
+  `path` / `subscribe`, la notification `worktrees.changed` et les codes
+  d'erreur JSON-RPC standard. Un résultat `list` du daemon est octet-pour-octet
+  identique à `gwm list --format=json`, donc les deux partagent un unique
+  `SCHEMA_VERSION`.
+- **Schéma `.gwm.toml`** — l'ensemble des sections de premier niveau
+  (`worktree`, `bootstrap`, `hooks`, `doctor`, `tui`, `theme`, `git_tui`,
+  `review`, `labels`, `milestones`, `branch_types`, `aliases`, `gitmoji`,
+  `issue_template`, `pr_template`). Une section stable renommée ou supprimée
+  est cassante.
+
+### Gelé par un test vs. couvert par la promesse
+
+Deux de ces surfaces sont gelées *mécaniquement* — un renommage casse la CI
+avant de pouvoir être publié : les **schémas JSON**, les **noms de
+méthodes/notification du daemon** et l'**ensemble des sections `.gwm.toml`**,
+tous figés par `tests/contract_tests.rs` face à la source de vérité unique de
+[`src/contract.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/contract.rs).
+
+Les **sous-commandes/flags CLI** et les **significations des codes de sortie**
+ne sont *pas* figés par un test de bout en bout (seul le champ `exit_code` de
+`doctor` ride le schéma JSON) ; ils sont couverts par cette promesse SemVer
+écrite et revus à chaque PR. Considère-les comme tout aussi contraignants —
+l'absence de test garde-fou n'autorise pas à les casser en silence.
+
+### Le détail du contrat machine vit ailleurs
+
+Les paliers par champ (quels champs exacts sont **stables** vs
+**expérimentaux**), le mécanisme de détection de dérive (`SCHEMA_VERSION` sur
+la notification daemon, `gwm --version` pour les consommateurs CLI one-shot)
+et les règles `additionalProperties` sont documentés en entier dans
+[`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md).
+Notamment, quelques champs sont **expérimentaux** et peuvent changer sans bump
+majeur — ex. le champ `repo` propre au mode workspace sur une ligne `list` et
+le `repo` de premier niveau sur `status --json`. En cas de doute sur un champ
+précis, cette table de paliers fait foi.
+
+## NON couvert par SemVer (peut changer en mineure/correctif)
+
+Ces surfaces sont libres de changer sans bump majeur. Ne construis pas
+d'automatisation par-dessus.
+
+- **Disposition & couleurs de la TUI** — agencement des panneaux, placement
+  des widgets, le thème / la palette, et tout détail visuel de l'interface
+  ratatui. Scripter contre la TUI rendue n'est pas supporté.
+- **Chaînes lisibles par un humain** — lignes de log, messages de la barre de
+  statut, blurbs d'aide, la sortie humaine (non `--format=json`) de n'importe
+  quelle commande. Parse plutôt la surface JSON ; la prose peut être reformulée
+  à tout moment.
+- **API Rust interne** — gwm est livré comme binaire, pas comme crate
+  bibliothèque publiée. Les éléments `pub` de `src/` existent pour la suite de
+  tests et la réutilisation interne ; ils ne forment pas une API stable et ne
+  portent aucune garantie SemVer.
+
+## Politique MSRV
+
+La version Rust minimale supportée est déclarée via `rust-version` dans
+[`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
+(actuellement **1.86**). C'est le plancher contre lequel la crate compile et
+est testée en CI.
+
+En pratique, un bump MSRV ride une release **mineure**, pas majeure — il a
+historiquement été piloté par une dépendance relevant son propre plancher (le
+bump `1.86` est arrivé avec `tui-term` / `portable-pty` lors de l'ajout de
+l'overlay PTY), et est traité comme une mise à jour de toolchain de routine
+plutôt qu'un changement cassant du contrat public. Les bumps sont signalés
+dans le changelog pour que les packagers ne soient pas surpris.
+
+## Processus de dépréciation
+
+Quand une surface couverte doit changer de façon rétro-incompatible :
+
+1. **Annoncer** — documenter la dépréciation dans le changelog, sous la
+   release qui l'introduit, et (lorsque la surface le permet) émettre un
+   avertissement à l'exécution pointant vers le remplaçant.
+2. **Garder l'ancien chemin fonctionnel** pendant le reste de la ligne majeure
+   courante — une dépréciation est un préavis, pas une suppression immédiate.
+3. **Supprimer uniquement sur un bump majeur**, la suppression étant listée
+   dans les notes de cette release avec le chemin de migration.
+
+Les changements additifs (nouvelle sous-commande, flag optionnel, nouveau
+champ JSON optionnel, nouvelle méthode daemon) ne sont **pas** des
+dépréciations — ils sont livrés en release mineure et ne nécessitent aucun
+avertissement, car les consommateurs existants continuent de fonctionner
+inchangés (les consommateurs DOIVENT ignorer les champs JSON inconnus).
+
+## Voir aussi
+
+- [`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md)
+  — les paliers stable/expérimental par champ et le contrat de détection de
+  dérive.
+- [`src/contract.rs`](https://github.com/kbrdn1/gwm-cli/blob/main/src/contract.rs)
+  — la source de vérité unique pour `SCHEMA_VERSION` et les ensembles gelés de
+  méthodes/sections.
+- [Contribuer → Releases](/fr/development/contributing) et
+  [`CONTRIBUTING.md`](https://github.com/kbrdn1/gwm-cli/blob/main/CONTRIBUTING.md)
+  — le processus de release SemVer et le workflow de tag.

--- a/docs/fr/6.development/index.md
+++ b/docs/fr/6.development/index.md
@@ -11,6 +11,7 @@ gwm est une petite crate Rust (binaire unique). Les workflows de build, de test 
 
 - **[Tests](/fr/development/testing)** — les fichiers de tests d'intégration (~1700+ tests répartis sur 74 fichiers de tests, exécutés sur la matrice ubuntu / macos / windows), la boucle TDD obligatoire red → green → refactor, comment exécuter un sous-ensemble et la convention de test-sentinelle `// regression:`.
 - **[Contribuer](/fr/development/contributing)** — le format Gitmoji + Conventional Commits, le nommage des branches, la checklist de PR et les règles autour de la séparation `CHANGELOG.md` / `changelogs/<version>.md`.
+- **[Stabilité](/fr/development/stability)** — le contrat de compatibilité SemVer 1.0 : quelles surfaces sont couvertes (CLI, codes de sortie, schémas JSON, RPC daemon, `.gwm.toml`), lesquelles sont libres d'évoluer (TUI, chaînes humaines, API Rust interne), la politique MSRV et le processus de dépréciation.
 
 ## référence rapide
 


### PR DESCRIPTION
## Description

Adds the explicit, published **stability & compatibility policy** for the `1.0` line, building on the frozen machine contracts from #317. A new Stability page (EN + `docs/fr/`) states what the SemVer promise covers, what stays free to change, the MSRV policy, and the deprecation process.

Closes #318

## Type of change

- [x] 📝 Docs

## Changes

- New `docs/6.development/3.stability.md` (EN) + `docs/fr/6.development/3.stability.md` (FR): the SemVer compatibility contract.
  - **Covered (breaking → major)**: CLI subcommands/flags, exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, the `.gwm.toml` section set.
  - **NOT covered (minor/patch)**: TUI layout & colours, human-readable strings, the internal Rust API.
  - MSRV policy (1.86, bumps ride a minor) + deprecation process.
- Distinguishes surfaces *frozen by `tests/contract_tests.rs`* from those *covered only by the written promise* (CLI/exit codes are not freeze-tested e2e — only `doctor`'s `exit_code` field rides the JSON schema), and defers the per-field stable/experimental tiers to `docs/schema/README.md` rather than duplicating them.
- Listed in the Development index (`docs/6.development/index.md` + FR mirror); linked from the README related-docs list and the `CONTRIBUTING.md` Releases section.
- `CHANGELOG.md` entry under `[Unreleased] > Docs`.

## Tests

- [x] `cargo test` passes locally (full suite re-run green, exit 0, 77 `test result: ok` blocks)
- [x] `cargo fmt --check` passes (no `.rs` touched)
- [x] `cargo clippy -- -D warnings` passes (no `.rs` touched)
- [ ] New tests added under `tests/` — **N/A, argued**: docs-only change, no production code and no observable behaviour change, so it falls under the documented TDD exception ("observably untestable from the public surface"). Confirmed no test reads the docs markdown tree (`tests/contract_tests.rs` loads `docs/schema/*.json`, untouched; `cli_binary.rs` canary covers subcommands, none added).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`docs/#318-stability-policy`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (related-docs link added)
- [x] No `unwrap()` on user-facing paths (no code changed)
- [x] No `println!` in TUI render code (no code changed)

## Linked issues / docs

- Issue: #318
- Builds on: #317 (frozen machine contracts) — first gate of the 1.0 sprint #320

## Notes for reviewers

The page is the **policy umbrella**; the byte-level machine-contract detail (per-field tiers, `SCHEMA_VERSION`, drift detection, `additionalProperties` rules) intentionally stays in `docs/schema/README.md` to keep a single source of truth. EN/FR parity is 1:1. The `/segment` links are repo-root-relative per the `docs/README.md` authoring convention (they render as cross-references on GitHub until the static site is live).