### PR TITLE
✅ test(tests): freeze the exec/clean 1.0 surface decision (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy and the stable-vs-experimental tier of every field. No behaviour
   change to any existing output.
 
+- **Frozen 1.0 surface decision for `exec` / `clean`** (issue #319). The
+  deliberate MVP cuts in `gwm exec` / `gwm clean` (#313) are confirmed as
+  *deferred, additive* features for the 1.0 pledge: `exec` stays sequential by
+  default (bounded `--jobs` parallelism is a future opt-in), `clean` keeps its
+  built-in `target` / `node_modules` / `dist` / `build` set (a `[clean]` /
+  `[exec]` profile config is a future additive section), and `--workspace`
+  fan-out across repos stays refused on both commands until it lands. The one
+  previously-untested frozen behaviour — the `--workspace` refusal on `exec` /
+  `clean`, whose exit code is now under the SemVer pledge — is pinned by two
+  regression tests in `tests/cli_binary.rs`, so a future change that silently
+  accepts the flag (or changes the exit code) breaks CI loudly. No behaviour
+  change.
+
 ### Docs
 
 - **Stability & compatibility policy for 1.0** (issue #318). A new

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4765,3 +4765,41 @@ fn clean_yes_refuses_ignored_dir_holding_tracked_files() {
     "a tracked file under an ignored dir must survive --yes"
   );
 }
+
+// regression: the v1.0 surface decision for `gwm exec` / `gwm clean` (issue
+// #319) is that workspace fan-out is a *deferred, additive* feature — until it
+// lands, `--workspace` against either command is refused, not silently run
+// against the single repo. The refusal is part of the frozen 1.0 contract:
+// the exit code is under the SemVer pledge (see docs/6.development/stability),
+// so a future change that makes either command silently accept `--workspace`
+// (or change its exit code) must break loudly here. Adding real fan-out later
+// is additive — a refusal turning into a success is not a breaking change.
+
+#[test]
+fn exec_refuses_the_workspace_flag() {
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  let ws = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["exec", "--workspace", ws.path().to_str().unwrap(), "--", "echo", "hi"])
+    .assert()
+    .failure()
+    // Exact exit code is frozen: every GwmError maps to 1 (src/main.rs).
+    .code(1)
+    .stderr(predicate::str::contains("--workspace is only supported"));
+}
+
+#[test]
+fn clean_refuses_the_workspace_flag() {
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  let ws = tempfile::TempDir::new().unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["clean", "--workspace", ws.path().to_str().unwrap()])
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("--workspace is only supported"));
+}


### PR DESCRIPTION
## Description

Resolves the #319 1.0-readiness gate: **decide and lock the final shape of the `exec` / `clean` MVP cuts (#313) before the compatibility pledge.** The decision is *defer-all-additively* — every cut can be added later without breaking the 1.0 contract — so the deliverable is to make that freeze **intentional and tested**, not to ship the deferred features.

Closes #319

## Type of change

- [x] ✅ Tests
- [x] 📝 Docs (CHANGELOG)

## The decision (recorded)

| Deferred cut (#313/#319) | Verdict | Constraint that keeps it additive | Follow-up |
|---|---|---|---|
| `exec` bounded parallelism (`--jobs`) | defer | sequential stays the default through 1.x; `--jobs` is opt-in | #324 |
| `exec` output model | defer | live streamed stdio is human-facing → not under SemVer (#318) | #324 / #325 |
| `clean` `[clean]` config | defer | new additive section; a profile **composes with — never bypasses** the safety gate | #324 |
| exec/clean `--workspace` fan-out | defer | currently refused; refusal → success later is additive | #326 |
| exec/clean TUI surface | defer | TUI is not under the SemVer pledge (#318) | #325 |

## Changes

- **Two regression tests** in `tests/cli_binary.rs` pin the one previously-untested frozen behaviour — the `--workspace` refusal on `exec` / `clean`: `failure`, exact exit code **1** (now under the SemVer pledge, #318), and the rejection message. (`default_patterns()` and the help canary were already pinned.)
- **CHANGELOG** note under `[Unreleased]` recording the frozen 1.0 surface decision, keeping the three 1.0 gates (#317/#318/#319) visible together.
- **Follow-up issues filed** for the planned features the user wants next: #324 (config with profiles for `[exec]`/`[clean]`), #325 (TUI surface), #326 (`--workspace` fan-out).

## Tests

- [x] `cargo test` passes locally (full suite, exit 0, 77 `test result: ok` blocks; the 2 new tests green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (the freeze tests — this PR *is* the test)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`test/#319-freeze-exec-clean-surface`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths (test-only; `unwrap()` is fine in tests)
- [x] No `println!` in TUI render code (no TUI code touched)

## Linked issues / docs

- Closes: #319
- Builds on: #317 (frozen machine contracts), #318 (stability policy)
- Follow-ups: #324, #325, #326

## Notes for reviewers

This is a *characterization/freeze* PR — the tests pass against current behaviour by design (the "red" fires only if a future change breaks the frozen surface), matching the `tests/contract_tests.rs` philosophy from #317. No production code changed; the exec/clean features themselves are deferred to the follow-up issues.