### PR TITLE
✅ test(tui): widen async-create drain budget for slow CI (#328)

### DIFF
--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -5510,7 +5510,11 @@ branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
   );
   assert_eq!(app.status, TaskKind::CreateWorktree.loading_label());
 
-  for _ in 0..50 {
+  // A real async worktree create + bootstrap drains in well under 100ms on a
+  // dev box, but a loaded Windows CI runner can take longer. The old 500ms
+  // budget (50 × 10ms) was too tight and flaked (#328); 3s is generous enough
+  // to absorb a slow runner while still bailing fast if the task truly hangs.
+  for _ in 0..300 {
     if app.drain_task_results() {
       break;
     }


### PR DESCRIPTION
## Description

The `submit_create` async-drain test polled `drain_task_results()` 50× with a 10ms sleep — a **500ms** wall-clock budget. A real worktree create + bootstrap drains in well under 100ms on a dev box, but a loaded **Windows CI runner** can exceed 500ms, so the test flaked.

Closes #328

## Type of change

- [x] ✅ Tests

## Changes

- Widen the `submit_create` async-drain budget from 500ms (50 × 10ms) to **3s** (300 × 10ms) in `tests/tui_app_tests.rs`.
- Still bails fast if the background task truly hangs; no production behaviour change.

## Tests

- [x] `cargo test` passes locally (`submit_create*` drains in 0.09s)
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` — N/A, this **is** a test-robustness fix (flaky timing budget), no production behaviour changed

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated — N/A (internal test-timing fix, not user-facing)

## Notes for reviewers

Pure test-patience fix for the Windows flaky #328. The 500ms budget was arbitrary polling patience, not a behavioural contract; 3s absorbs a slow runner while still failing fast on a genuine hang. The structurally identical drain loop at `tui_app_tests.rs:6127` (github-fetch mock) is not touched — it has not been reported flaky; left as a follow-up if it ever surfaces.

https://claude.ai/code/session_01RbvbQ6HsSW16gWdzBqbAFN