### PR TITLE
✨ feat(exec): bounded --jobs parallelism + per-worktree output (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bounded `--jobs` parallelism for `gwm exec`** (issue #324). `gwm exec`
+  gains a `--jobs <n>` flag and an `[exec] jobs` config default (with a
+  per-profile `[exec.profiles.<name>].jobs` override). Precedence: `--jobs`
+  > `profile.jobs` > `[exec] jobs` > `1`. `1` (or absent) keeps the unchanged
+  sequential behaviour with live, inherited output; `> 1` runs up to N
+  worktrees at once, capturing each one's stdout+stderr and printing it as a
+  per-worktree block in worktree order once the fan-out completes (so
+  concurrent runs don't interleave). The aggregate exit code is unchanged
+  (non-zero if any worktree failed). The runner uses a bounded `std::thread`
+  pool — no new dependency. `jobs` is a sub-field of the already-frozen
+  `[exec]` section, so the 1.0 section set is unchanged.
+
 - **Named `[exec]` / `[clean]` config profiles** (issue #324). `.gwm.toml`
   gains two opt-in sections so common fan-out invocations can be saved per
   repo instead of retyped. `[exec.profiles.<name>]` carries a `command`

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -653,20 +653,23 @@ The action column lists the slugs accepted in `[tui.keys]`; the keys column show
 
 Keymap reference and chord grammar: [TUI → Keybindings](/tui/keybindings); the `[tui.keys]` schema: [Configuration → `[tui.keys]`](/configuration/gwm-toml#tuikeys).
 
-## `gwm exec [<slug>...] [--profile <name>] -- <cmd>` (issues #313, #324)
+## `gwm exec [<slug>...] [--profile <name>] [--jobs <n>] -- <cmd>` (issues #313, #324)
 
-Run a command in each worktree, sequentially — a fleet chore across every worktree of the repo.
+Run a command in each worktree — sequentially by default, or with bounded parallelism — a fleet chore across every worktree of the repo.
 
 ```bash
 gwm exec -- git fetch                    # run `git fetch` in every non-main worktree
 gwm exec feat-1 fix-2 -- cargo check     # scope to two fuzzy-matched worktrees
 gwm exec -- git log --oneline -5         # everything after `--` is forwarded verbatim
 gwm exec --profile test                  # run the saved [exec.profiles.test] command
+gwm exec --jobs 4 -- cargo build         # fan out 4 worktrees at a time
 ```
 
 Positional slugs **before** `--` scope the set (fuzzy-matched, same matcher as `gwm path` / `remove`); with none, it targets every non-main worktree. Everything **after** `--` is the command, forwarded verbatim — flags and all. gwm prints a `━━ <name> (<path>)` header per worktree, then a per-worktree `✓ / ✗` rollup, and exits non-zero if any worktree's command failed (so you can gate CI on it). An empty target set prints `no worktrees to run in` and exits `0`.
 
 `--profile <name>` runs a saved [`[exec.profiles.<name>]`](/configuration/gwm-toml#exec-and-clean) command instead of an inline one. The profile's `command` is an argv **array** run with **no shell** — the same contract as the inline form, and a deliberate divergence from the shell-line `command` of `[git_tui]` / `[review]`. `--profile` and an inline `-- <cmd>` are **mutually exclusive** (passing both exits `1`); an **unknown** profile name exits `1`.
+
+`--jobs <n>` sets **bounded parallelism**. `1` (the default) runs sequentially with live, inherited output. `> 1` runs up to N worktrees at once, capturing each one's output and printing it as a per-worktree block (in worktree order) once the fan-out finishes — so concurrent runs don't interleave. Precedence: `--jobs` > a profile's [`jobs`](/configuration/gwm-toml#exec-and-clean) > `[exec] jobs` > `1`. The aggregate exit code is unchanged.
 
 This runs the user's own command against their own worktrees, so **no bootstrap trust gate** ([`gwm trust`](#gwm-trust-listrevokeshow-issue-95)) applies. It is **not** journaled into [`gwm history`](#gwm-history---limit-n---all).
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -203,12 +203,16 @@ default_base = "main"                 # optional override for the base resolutio
 Named profiles for the `gwm exec` and `gwm clean` fan-out commands (issue #324). Both blocks are opt-in: without them, `gwm exec -- <cmd>` and the built-in `gwm clean` set behave exactly as before.
 
 ```toml
+[exec]
+jobs = 1                             # global default parallelism; 1 = sequential
+
 # Saved commands for `gwm exec --profile <name>`.
 [exec.profiles.test]
 command = ["cargo", "test"]          # argv ARRAY — no shell
 
 [exec.profiles.fmt]
 command = ["cargo", "fmt", "--all"]
+jobs = 4                             # this profile fans out 4 at a time
 
 # Saved directory sets for `gwm clean --profile <name>`.
 # `default` is what `gwm clean` uses WITHOUT --profile.
@@ -222,6 +226,8 @@ dirs = ["target", "node_modules", "dist", "build", ".cache", ".venv"]
 **exec — `command` is an argv array, not a shell line.** A profile's `command` is a list of argv tokens (`["cargo", "test"]`) run with **no shell**: no word-splitting, no globbing, no `{path}` placeholders — the program is executed verbatim in each worktree, exactly like the inline `gwm exec -- <cmd>`. This is a deliberate divergence from `[git_tui]` and `[review]`, whose `command` is a single **shell** line (`"lazygit -p {path}"`). The two semantics are frozen for 1.0; don't expect shell features under `[exec.profiles]`.
 
 - `gwm exec --profile <name>` runs the saved command. `--profile` and an inline `-- <cmd>` are **mutually exclusive** (passing both exits 1); an **unknown** profile name exits 1.
+
+**exec — `jobs` is bounded parallelism.** `[exec] jobs` is the global default; a profile's `jobs` overrides it; the `--jobs <n>` flag wins over both. Precedence: `--jobs` > `[exec.profiles.<name>].jobs` > `[exec] jobs` > `1`. **`1` (or absent) runs sequentially** with live, inherited output — the unchanged default. **`> 1` runs up to N worktrees at once**, capturing each one's output and printing it as a per-worktree block (in worktree order) once the fan-out completes, so concurrent runs don't interleave. The aggregate exit code is unchanged: non-zero if any worktree's command failed.
 
 **clean — a profile's `dirs` is a complete set that replaces the built-ins.** `[clean.profiles.<name>].dirs` does **not** add to the built-in `target`/`node_modules`/`dist`/`build` — it **replaces** them wholesale. Each entry must be a **single worktree-relative directory name** — one path component. An absolute path, a `..` traversal, an empty string, a bare `.` (which resolves to the worktree root), a **nested** path like `target/debug`, or a name with **git pathspec metacharacters** (`* ? [ ]` or a leading `:`) is rejected (exit 1). The nesting restriction is deliberate for 1.0 (an intermediate component could be a symlink the scan/delete would follow out of the worktree); the metacharacter restriction keeps the git-ignored / tracked-file safety checks matching the literal directory. A leading `-` is fine. Exact duplicate entries are dropped so a directory is reclaimed once. The safety gate (git-ignored + no tracked files + skip symlinks) still applies to every directory in the set.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -653,20 +653,23 @@ La colonne action liste les slugs acceptés dans `[tui.keys]` ; la colonne keys 
 
 Référence du keymap et grammaire des accords : [TUI → Raccourcis clavier](/fr/tui/keybindings) ; le schéma `[tui.keys]` : [Configuration → `[tui.keys]`](/fr/configuration/gwm-toml#tuikeys).
 
-## `gwm exec [<slug>...] [--profile <nom>] -- <cmd>` (issues #313, #324)
+## `gwm exec [<slug>...] [--profile <nom>] [--jobs <n>] -- <cmd>` (issues #313, #324)
 
-Lance une commande dans chaque worktree, séquentiellement — une corvée de flotte sur chaque worktree du dépôt.
+Lance une commande dans chaque worktree — séquentiellement par défaut, ou avec un parallélisme borné — une corvée de flotte sur chaque worktree du dépôt.
 
 ```bash
 gwm exec -- git fetch                    # run `git fetch` in every non-main worktree
 gwm exec feat-1 fix-2 -- cargo check     # scope to two fuzzy-matched worktrees
 gwm exec -- git log --oneline -5         # everything after `--` is forwarded verbatim
 gwm exec --profile test                  # run the saved [exec.profiles.test] command
+gwm exec --jobs 4 -- cargo build         # fan out 4 worktrees at a time
 ```
 
 Les slugs positionnels **avant** `--` cadrent l'ensemble (correspondance fuzzy, le même matcher que `gwm path` / `remove`) ; sans aucun, il cible chaque worktree non principal. Tout ce qui est **après** `--` est la commande, transmise telle quelle — flags compris. gwm affiche un en-tête `━━ <name> (<path>)` par worktree, puis un récapitulatif `✓ / ✗` par worktree, et sort avec un code non nul si la commande d'un worktree a échoué (vous pouvez donc en faire un garde de CI). Un ensemble cible vide affiche `no worktrees to run in` et sort `0`.
 
 `--profile <nom>` lance une commande sauvegardée [`[exec.profiles.<nom>]`](/fr/configuration/gwm-toml#exec-et-clean) au lieu d'un inline. Le `command` du profil est un **tableau** d'argv exécuté **sans shell** — le même contrat que la forme inline, et une divergence délibérée avec le `command` ligne-shell de `[git_tui]` / `[review]`. `--profile` et un inline `-- <cmd>` sont **mutuellement exclusifs** (les fournir ensemble sort en `1`) ; un nom de profil **inconnu** sort en `1`.
+
+`--jobs <n>` définit un **parallélisme borné**. `1` (le défaut) s'exécute séquentiellement avec la sortie live héritée. `> 1` lance jusqu'à N worktrees à la fois, en capturant la sortie de chacun et en l'imprimant en un bloc par worktree (dans l'ordre des worktrees) une fois le fan-out terminé — pour que les exécutions concurrentes ne s'entremêlent pas. Précédence : `--jobs` > le [`jobs`](/fr/configuration/gwm-toml#exec-et-clean) d'un profil > `[exec] jobs` > `1`. Le code de sortie agrégé est inchangé.
 
 Cela lance la propre commande de l'utilisateur contre ses propres worktrees, donc **aucun garde de confiance de bootstrap** ([`gwm trust`](#gwm-trust-listrevokeshow-issue-95)) ne s'applique. Ce n'est **pas** journalisé dans [`gwm history`](#gwm-history---limit-n---all).
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -203,12 +203,16 @@ default_base = "main"                 # optional override for the base resolutio
 Profils nommés pour les commandes de fan-out `gwm exec` et `gwm clean` (issue #324). Les deux blocs sont opt-in : sans eux, `gwm exec -- <cmd>` et le jeu de répertoires intégré de `gwm clean` se comportent exactement comme avant.
 
 ```toml
+[exec]
+jobs = 1                             # parallélisme par défaut global ; 1 = séquentiel
+
 # Commandes sauvegardées pour `gwm exec --profile <nom>`.
 [exec.profiles.test]
 command = ["cargo", "test"]          # TABLEAU d'argv — pas de shell
 
 [exec.profiles.fmt]
 command = ["cargo", "fmt", "--all"]
+jobs = 4                             # ce profil lance 4 worktrees à la fois
 
 # Jeux de répertoires sauvegardés pour `gwm clean --profile <nom>`.
 # `default` est ce que `gwm clean` utilise SANS --profile.
@@ -222,6 +226,8 @@ dirs = ["target", "node_modules", "dist", "build", ".cache", ".venv"]
 **exec — `command` est un tableau d'argv, pas une ligne shell.** Le `command` d'un profil est une liste de jetons argv (`["cargo", "test"]`) exécutée **sans shell** : pas de découpage en mots, pas de globbing, pas de placeholders `{path}` — le programme est lancé tel quel dans chaque worktree, exactement comme l'inline `gwm exec -- <cmd>`. C'est une divergence **délibérée** avec `[git_tui]` et `[review]`, dont le `command` est une unique ligne **shell** (`"lazygit -p {path}"`). Les deux sémantiques sont **gelées pour la 1.0** ; n'attendez aucune fonctionnalité shell sous `[exec.profiles]`.
 
 - `gwm exec --profile <nom>` lance la commande sauvegardée. `--profile` et un inline `-- <cmd>` sont **mutuellement exclusifs** (les fournir ensemble sort en 1) ; un nom de profil **inconnu** sort en 1.
+
+**exec — `jobs` = parallélisme borné.** `[exec] jobs` est le défaut global ; le `jobs` d'un profil le surcharge ; le flag `--jobs <n>` gagne sur les deux. Précédence : `--jobs` > `[exec.profiles.<nom>].jobs` > `[exec] jobs` > `1`. **`1` (ou absent) s'exécute séquentiellement** avec la sortie live héritée — le défaut inchangé. **`> 1` lance jusqu'à N worktrees à la fois**, en capturant la sortie de chacun et en l'imprimant en un bloc par worktree (dans l'ordre des worktrees) une fois le fan-out terminé, pour que les exécutions concurrentes ne s'entremêlent pas. Le code de sortie agrégé est inchangé : non nul si la commande d'un worktree a échoué.
 
 **clean — le `dirs` d'un profil est un jeu complet qui remplace les intégrés.** `[clean.profiles.<nom>].dirs` ne **s'ajoute pas** aux `target`/`node_modules`/`dist`/`build` intégrés — il les **remplace** intégralement. Chaque entrée doit être un **nom de répertoire unique relatif au worktree** — un seul composant de chemin. Un chemin absolu, une remontée `..`, une chaîne vide, un simple `.` (qui résout vers la racine du worktree), un chemin **imbriqué** comme `target/debug`, ou un nom avec des **métacaractères de pathspec git** (`* ? [ ]` ou un `:` en tête) est rejeté (sortie 1). La restriction sur l'imbrication est délibérée pour la 1.0 (un composant intermédiaire pourrait être un symlink que le scan ou la suppression suivraient hors du worktree) ; la restriction sur les métacaractères garde les contrôles de sûreté (git-ignored / fichier suivi) alignés sur le répertoire littéral. Un `-` en tête est accepté. Les entrées exactement dupliquées sont supprimées pour que chaque répertoire soit récupéré une seule fois. La barrière de sûreté (git-ignored + aucun fichier suivi + skip des symlinks) s'applique toujours à chaque répertoire du jeu.
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -359,11 +359,21 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # `--profile` and an inline `-- <cmd>` are mutually exclusive (exit 1), and an
 # unknown profile name exits 1.
 #
+# `jobs` is bounded parallelism: `[exec] jobs` is the global default, a
+# profile's `jobs` overrides it, and the `--jobs <n>` flag wins over both
+# (precedence: --jobs > profile.jobs > [exec] jobs > 1). `1`/absent runs
+# sequentially with live output; `> 1` runs up to N worktrees at once and
+# prints each one's captured output as a block at the end.
+#
+# [exec]
+# jobs = 1
+#
 # [exec.profiles.test]
 # command = ["cargo", "test"]
 #
 # [exec.profiles.fmt]
 # command = ["cargo", "fmt", "--all"]
+# jobs = 4
 
 # --- `gwm clean` profiles (issue #324) ---------------------------------------
 # Saved directory sets for `gwm clean --profile <name>`. A profile's `dirs` is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1071,22 +1071,30 @@ fn resolve_targets(repo: &Repository, slugs: &[String]) -> Result<Vec<worktree::
 /// aggregate code (non-zero if any worktree failed).
 fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, command: Vec<String>) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
 
   // Read `[exec]` from disk only when a value from it is actually needed, and
-  // only as strictly as that need requires (issue #324):
+  // only as strictly as that need requires (issue #324). The workdir lookup
+  // lives INSIDE the config-reading branches: a bare repo with linked
+  // worktrees has no workdir, but inline `gwm exec` must still run there (it
+  // enumerates worktrees via `worktree::list`, not `.gwm.toml`).
   //   - `--profile <name>` → full `load_exec_config` (resolve the command +
-  //     validate every profile, matching `gwm config validate` / doctor).
+  //     validate every profile, matching `gwm config validate` / doctor);
+  //     needs a workdir to locate `.gwm.toml`.
   //   - inline + no `--jobs` → only the `[exec] jobs` default is needed; read
-  //     it WITHOUT validating sibling profiles (inline uses none of them).
+  //     it WITHOUT validating sibling profiles when a workdir exists, else
+  //     fall back to the default (bare repo → jobs = 1).
   //   - inline + `--jobs` → the flag is authoritative and the command is on
   //     the CLI, so nothing from `[exec]` is needed — don't touch config.
   let exec_cfg = if profile.is_some() {
+    let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
     Config::load_exec_config(workdir)?
   } else if jobs.is_none() {
-    crate::config::ExecConfig {
-      jobs: Config::load_exec_jobs_default(workdir)?,
-      ..Default::default()
+    match repo.workdir() {
+      Some(workdir) => crate::config::ExecConfig {
+        jobs: Config::load_exec_jobs_default(workdir)?,
+        ..Default::default()
+      },
+      None => crate::config::ExecConfig::default(),
     }
   } else {
     crate::config::ExecConfig::default()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1114,14 +1114,22 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
   } else {
     // Parallel (bounded by `job_count`): capture each worktree's output so
     // concurrent runs don't interleave, then print one block per worktree in
-    // worktree order once the fan-out completes.
+    // worktree order once the fan-out completes. Write the captured bytes
+    // RAW (not via `String::from_utf8_lossy`) so binary / non-UTF-8 output is
+    // re-emitted byte-for-byte, matching the sequential path's inherited stdio.
+    use std::io::Write;
     let items: Vec<(String, std::path::PathBuf)> = targets.iter().map(|w| (w.name.clone(), w.path.clone())).collect();
     let results = exec::run_in_dirs_parallel(job_count, &items, program, &args);
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
     for ((name, path), (outcome, output)) in items.iter().zip(results) {
-      println!("\n━━ {} ({})", name, path.display());
-      print!("{}", String::from_utf8_lossy(&output));
+      // Ignore write errors: a closed stdout (e.g. `| head`) shouldn't panic
+      // the whole fan-out, and the rollup/exit code still report the result.
+      let _ = writeln!(lock, "\n━━ {} ({})", name, path.display());
+      let _ = lock.write_all(&output);
       outcomes.push(outcome);
     }
+    let _ = lock.flush();
   }
 
   println!("\nrollup:");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1081,20 +1081,17 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
   //     validate every profile, matching `gwm config validate` / doctor);
   //     needs a workdir to locate `.gwm.toml`.
   //   - inline + no `--jobs` → only the `[exec] jobs` default is needed; read
-  //     it WITHOUT validating sibling profiles when a workdir exists, else
-  //     fall back to the default (bare repo → jobs = 1).
+  //     it WITHOUT validating sibling profiles. A bare repo (no workdir) skips
+  //     the repo `.gwm.toml` but still honours the GLOBAL `[exec] jobs`.
   //   - inline + `--jobs` → the flag is authoritative and the command is on
   //     the CLI, so nothing from `[exec]` is needed — don't touch config.
   let exec_cfg = if profile.is_some() {
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
     Config::load_exec_config(workdir)?
   } else if jobs.is_none() {
-    match repo.workdir() {
-      Some(workdir) => crate::config::ExecConfig {
-        jobs: Config::load_exec_jobs_default(workdir)?,
-        ..Default::default()
-      },
-      None => crate::config::ExecConfig::default(),
+    crate::config::ExecConfig {
+      jobs: Config::load_exec_jobs_default(repo.workdir())?,
+      ..Default::default()
     }
   } else {
     crate::config::ExecConfig::default()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1073,12 +1073,24 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
   let repo = worktree::discover_repo(None)?;
   let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
 
-  // Load the `[exec]` section (tolerant of unrelated config errors, strict on
-  // `[exec]` itself — issue #324) for BOTH the `--profile` lookup AND the
-  // `jobs` default. The inline `gwm exec -- <cmd>` surface stays effectively
-  // unchanged: with no `[exec]` block `jobs` resolves to 1 (sequential, live
-  // stdio), exactly the pre-#324 behaviour.
-  let exec_cfg = Config::load_exec_config(workdir)?;
+  // Read `[exec]` from disk only when a value from it is actually needed, and
+  // only as strictly as that need requires (issue #324):
+  //   - `--profile <name>` → full `load_exec_config` (resolve the command +
+  //     validate every profile, matching `gwm config validate` / doctor).
+  //   - inline + no `--jobs` → only the `[exec] jobs` default is needed; read
+  //     it WITHOUT validating sibling profiles (inline uses none of them).
+  //   - inline + `--jobs` → the flag is authoritative and the command is on
+  //     the CLI, so nothing from `[exec]` is needed — don't touch config.
+  let exec_cfg = if profile.is_some() {
+    Config::load_exec_config(workdir)?
+  } else if jobs.is_none() {
+    crate::config::ExecConfig {
+      jobs: Config::load_exec_jobs_default(workdir)?,
+      ..Default::default()
+    }
+  } else {
+    crate::config::ExecConfig::default()
+  };
 
   // Resolve the argv up-front, from exactly one of `--profile` / inline
   // `-- <cmd>`. A usage error (both, neither, or an unknown profile) must

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -654,6 +654,12 @@ pub enum Command {
     /// an unknown name exits 1.
     #[arg(long, value_name = "NAME")]
     profile: Option<String>,
+    /// Bounded parallelism (issue #324). `1` (default) runs sequentially with
+    /// live, inherited output; `> 1` runs up to N worktrees at once, capturing
+    /// each one's output and printing it as a block at the end. Wins over a
+    /// profile's / `[exec]`'s `jobs`.
+    #[arg(long, value_name = "N")]
+    jobs: Option<u32>,
     /// Command to run, after `--`. Everything past `--` is forwarded
     /// verbatim, e.g. `gwm exec -- git log --oneline`. Provide either this
     /// or `--profile`, never both, and at least one.
@@ -1040,8 +1046,9 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Exec {
       slugs,
       profile,
+      jobs,
       command,
-    } => cmd_exec(slugs, profile, command),
+    } => cmd_exec(slugs, profile, jobs, command),
     Command::Clean { slugs, profile, yes } => cmd_clean(slugs, profile, yes),
   }
 }
@@ -1062,25 +1069,23 @@ fn resolve_targets(repo: &Repository, slugs: &[String]) -> Result<Vec<worktree::
 /// `gwm exec [<slug>...] -- <cmd>` (issue #313). Runs the command in each
 /// target worktree sequentially, prints a ✓ / ✗ rollup, and exits with the
 /// aggregate code (non-zero if any worktree failed).
-fn cmd_exec(slugs: Vec<String>, profile: Option<String>, command: Vec<String>) -> Result<()> {
+fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, command: Vec<String>) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
+  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
+
+  // Load the `[exec]` section (tolerant of unrelated config errors, strict on
+  // `[exec]` itself — issue #324) for BOTH the `--profile` lookup AND the
+  // `jobs` default. The inline `gwm exec -- <cmd>` surface stays effectively
+  // unchanged: with no `[exec]` block `jobs` resolves to 1 (sequential, live
+  // stdio), exactly the pre-#324 behaviour.
+  let exec_cfg = Config::load_exec_config(workdir)?;
 
   // Resolve the argv up-front, from exactly one of `--profile` / inline
   // `-- <cmd>`. A usage error (both, neither, or an unknown profile) must
   // surface before we touch any worktree, hence before target discovery.
-  //
-  // Only the `--profile` lookup needs `.gwm.toml`; the inline `gwm exec --
-  // <cmd>` surface is promised unchanged, so it must NOT read config — an
-  // unrelated config error there would break a command that never used it.
-  let argv = match profile.as_deref() {
-    Some(name) => {
-      let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
-      // Tolerant of unrelated config errors, strict on `[exec]` itself.
-      let exec_cfg = Config::load_exec_config(workdir)?;
-      exec::resolve_exec_command(Some(name), &command, &exec_cfg)?
-    }
-    None => exec::resolve_exec_command(None, &command, &crate::config::ExecConfig::default())?,
-  };
+  let argv = exec::resolve_exec_command(profile.as_deref(), &command, &exec_cfg)?;
+  // Precedence: `--jobs` > `[exec.profiles.<name>].jobs` > `[exec] jobs` > 1.
+  let job_count = exec::resolve_jobs(jobs, profile.as_deref(), &exec_cfg);
 
   let targets = resolve_targets(&repo, &slugs)?;
   if targets.is_empty() {
@@ -1096,13 +1101,27 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, command: Vec<String>) -
   let args = args.to_vec();
 
   let mut outcomes = Vec::with_capacity(targets.len());
-  for w in &targets {
-    println!("\n━━ {} ({})", w.name, w.path.display());
-    let status = exec::exec_in_dir(&w.path, program, &args);
-    outcomes.push(exec::ExecOutcome {
-      name: w.name.clone(),
-      status,
-    });
+  if job_count <= 1 {
+    // Sequential: inherit the parent's stdio so output streams live, in order.
+    for w in &targets {
+      println!("\n━━ {} ({})", w.name, w.path.display());
+      let status = exec::exec_in_dir(&w.path, program, &args);
+      outcomes.push(exec::ExecOutcome {
+        name: w.name.clone(),
+        status,
+      });
+    }
+  } else {
+    // Parallel (bounded by `job_count`): capture each worktree's output so
+    // concurrent runs don't interleave, then print one block per worktree in
+    // worktree order once the fan-out completes.
+    let items: Vec<(String, std::path::PathBuf)> = targets.iter().map(|w| (w.name.clone(), w.path.clone())).collect();
+    let results = exec::run_in_dirs_parallel(job_count, &items, program, &args);
+    for ((name, path), (outcome, output)) in items.iter().zip(results) {
+      println!("\n━━ {} ({})", name, path.display());
+      print!("{}", String::from_utf8_lossy(&output));
+      outcomes.push(outcome);
+    }
   }
 
   println!("\nrollup:");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1013,19 +1013,39 @@ fn merge_toml(base: toml::Value, over: toml::Value) -> toml::Value {
 ///
 /// A missing section yields `T::default()`. A TOML *syntax* error (an
 /// unreadable file) still surfaces — there is no section to read.
-fn load_config_section<T>(repo_root: &Path, key: &str) -> Result<T>
+///
+/// `repo_root` is `None` for a **bare** repo (no workdir, hence no repo
+/// `.gwm.toml`): the repo layer is skipped, but the user-level GLOBAL config
+/// is still read, so a global `[exec] jobs = N` applies even there (#324
+/// review).
+fn load_config_section<T>(repo_root: Option<&Path>, key: &str) -> Result<T>
 where
   T: serde::de::DeserializeOwned + Default,
 {
-  let global_val = match global_config_path() {
-    Some(p) if p.exists() => Some(read_config_value(&p)?),
+  load_config_section_layered(global_config_path().as_deref(), repo_root, key)
+}
+
+/// Core of [`load_config_section`] with the global config path injected, so
+/// the layering can be pinned by a test without touching the runner's real
+/// `$HOME` / `$XDG_CONFIG_HOME`.
+fn load_config_section_layered<T>(global: Option<&Path>, repo_root: Option<&Path>, key: &str) -> Result<T>
+where
+  T: serde::de::DeserializeOwned + Default,
+{
+  let global_val = match global {
+    Some(p) if p.exists() => Some(read_config_value(p)?),
     _ => None,
   };
-  let repo_path = repo_root.join(CONFIG_FILE);
-  let repo_val = if repo_path.exists() {
-    Some(read_config_value(&repo_path)?)
-  } else {
-    None
+  let repo_val = match repo_root {
+    Some(root) => {
+      let repo_path = root.join(CONFIG_FILE);
+      if repo_path.exists() {
+        Some(read_config_value(&repo_path)?)
+      } else {
+        None
+      }
+    }
+    None => None,
   };
   let merged = match (global_val, repo_val) {
     (None, None) => return Ok(T::default()),
@@ -1224,7 +1244,7 @@ impl Config {
   /// same file `Config::load_for_repo` / `gwm config validate` / doctor reject
   /// — a sibling profile's semantic error can't pass on the command path only.
   pub fn load_exec_config(repo_root: &Path) -> Result<ExecConfig> {
-    let cfg: ExecConfig = load_config_section(repo_root, "exec")?;
+    let cfg: ExecConfig = load_config_section(Some(repo_root), "exec")?;
     for (name, p) in &cfg.profiles {
       crate::exec::validate_exec_profile_command(name, &p.command)?;
     }
@@ -1236,8 +1256,19 @@ impl Config {
   /// `--profile`, no `--jobs`) which needs the parallelism default but uses no
   /// profile — so a sibling profile's *semantic* issue must not block it. A
   /// shape error in `[exec]` (unknown field, wrong type) still surfaces.
-  pub fn load_exec_jobs_default(repo_root: &Path) -> Result<Option<u32>> {
+  ///
+  /// `repo_root` is `None` for a bare repo (no workdir): the repo `.gwm.toml`
+  /// is skipped but the GLOBAL `[exec] jobs` still applies.
+  pub fn load_exec_jobs_default(repo_root: Option<&Path>) -> Result<Option<u32>> {
     let cfg: ExecConfig = load_config_section(repo_root, "exec")?;
+    Ok(cfg.jobs)
+  }
+
+  /// Like [`Self::load_exec_jobs_default`] but with the global config path
+  /// injected, so the global-vs-repo layering can be pinned by a test without
+  /// touching the runner's real `$HOME` / `$XDG_CONFIG_HOME`.
+  pub fn load_exec_jobs_default_layered(global: Option<&Path>, repo_root: Option<&Path>) -> Result<Option<u32>> {
+    let cfg: ExecConfig = load_config_section_layered(global, repo_root, "exec")?;
     Ok(cfg.jobs)
   }
 
@@ -1252,7 +1283,7 @@ impl Config {
   /// validated — a sibling profile that escapes the worktree can't slip
   /// through `gwm clean --profile good` while `gwm config validate` rejects it.
   pub fn load_clean_config(repo_root: &Path) -> Result<CleanConfig> {
-    let cfg: CleanConfig = load_config_section(repo_root, "clean")?;
+    let cfg: CleanConfig = load_config_section(Some(repo_root), "clean")?;
     for (name, p) in &cfg.profiles {
       crate::clean::validate_clean_profile_dirs(name, &p.dirs)?;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1231,6 +1231,16 @@ impl Config {
     Ok(cfg)
   }
 
+  /// Read ONLY the `[exec] jobs` default (issue #324), without validating the
+  /// `[exec.profiles.*]` semantics. Used by inline `gwm exec -- <cmd>` (no
+  /// `--profile`, no `--jobs`) which needs the parallelism default but uses no
+  /// profile — so a sibling profile's *semantic* issue must not block it. A
+  /// shape error in `[exec]` (unknown field, wrong type) still surfaces.
+  pub fn load_exec_jobs_default(repo_root: &Path) -> Result<Option<u32>> {
+    let cfg: ExecConfig = load_config_section(repo_root, "exec")?;
+    Ok(cfg.jobs)
+  }
+
   /// Load just the `[clean]` section (layered global → repo), tolerant of
   /// errors elsewhere but strict on `[clean]` itself. Used by `gwm clean` so
   /// an unrelated `.gwm.toml` problem doesn't block the built-in clean, while

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,12 @@ pub struct Config {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExecConfig {
+  /// `[exec] jobs` — the global default parallelism for `gwm exec` (issue
+  /// #324). `1` or absent ⇒ sequential (live, inherited stdio — the MVP
+  /// behaviour); `> 1` ⇒ bounded parallel with per-worktree captured output.
+  /// Precedence: `--jobs` flag > `[exec.profiles.<name>].jobs` > this > `1`.
+  #[serde(default)]
+  pub jobs: Option<u32>,
   /// `[exec.profiles.<name>]` sub-tables. `BTreeMap` for a deterministic
   /// ordering when surfaced.
   #[serde(default)]
@@ -109,6 +115,10 @@ pub struct ExecProfile {
   /// argv to run in each worktree. Required — a profile with no command is
   /// a config error at load time (`deny_unknown_fields` + no `serde(default)`).
   pub command: Vec<String>,
+  /// Per-profile parallelism override (issue #324). Overrides `[exec] jobs`
+  /// when this profile runs; the `--jobs` flag still wins over it.
+  #[serde(default)]
+  pub jobs: Option<u32>,
 }
 
 /// `[clean]` — named directory-set profiles for `gwm clean` (issue #324).

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -12,6 +12,8 @@ use crate::config::ExecConfig;
 use crate::error::{GwmError, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 /// Outcome of running the command inside one worktree.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +34,10 @@ pub struct ExecOutcome {
   pub name: String,
   pub status: ExecStatus,
 }
+
+/// One parallel worktree run: its [`ExecOutcome`] plus the captured
+/// stdout+stderr bytes printed as a block by the caller.
+pub type CapturedRun = (ExecOutcome, Vec<u8>);
 
 /// Resolve the argv `gwm exec` should run, from exactly one source: an
 /// inline `-- <cmd>` or a `--profile <name>` (issue #324).
@@ -93,6 +99,84 @@ pub fn exec_in_dir(dir: &Path, program: &str, args: &[String]) -> ExecStatus {
     },
     Err(e) => ExecStatus::SpawnError(e.to_string()),
   }
+}
+
+/// Resolve the effective parallelism for `gwm exec` (issue #324): the `--jobs`
+/// flag wins, then the selected profile's `jobs`, then the global `[exec]
+/// jobs`, else `1`. A resolved `0` (or absent) means sequential. Always
+/// returns a worker count `>= 1`.
+pub fn resolve_jobs(flag: Option<u32>, profile: Option<&str>, cfg: &ExecConfig) -> usize {
+  let n = flag
+    .or_else(|| profile.and_then(|p| cfg.profiles.get(p)).and_then(|p| p.jobs))
+    .or(cfg.jobs)
+    .unwrap_or(1);
+  n.max(1) as usize
+}
+
+/// Like [`exec_in_dir`], but CAPTURE stdout+stderr (stdout then stderr)
+/// instead of inheriting the parent's stdio. Used by [`run_in_dirs_parallel`]
+/// so concurrent worktrees don't interleave their output — each block is
+/// printed whole, in worktree order, after the fan-out completes.
+pub fn exec_capture_in_dir(dir: &Path, program: &str, args: &[String]) -> (ExecStatus, Vec<u8>) {
+  let resolved = resolve_program(dir, program);
+  match Command::new(&resolved).args(args).current_dir(dir).output() {
+    Ok(out) => {
+      let mut buf = out.stdout;
+      buf.extend_from_slice(&out.stderr);
+      let status = match out.status.code() {
+        Some(0) => ExecStatus::Ok,
+        Some(code) => ExecStatus::Failed(code),
+        None => ExecStatus::Signal,
+      };
+      (status, buf)
+    }
+    Err(e) => (ExecStatus::SpawnError(e.to_string()), Vec::new()),
+  }
+}
+
+/// Run `program args…` in each `(name, dir)` of `items` with up to `jobs`
+/// concurrent workers, capturing each one's output. Returns one
+/// `(ExecOutcome, captured_output)` per item **in input order** (not
+/// completion order), so the caller prints deterministic per-worktree blocks
+/// regardless of which finished first. `jobs` is clamped to `[1, items.len()]`.
+pub fn run_in_dirs_parallel(
+  jobs: usize,
+  items: &[(String, PathBuf)],
+  program: &str,
+  args: &[String],
+) -> Vec<CapturedRun> {
+  if items.is_empty() {
+    return Vec::new();
+  }
+  let workers = jobs.clamp(1, items.len());
+  let next = AtomicUsize::new(0);
+  let slots: Vec<Mutex<Option<CapturedRun>>> = (0..items.len()).map(|_| Mutex::new(None)).collect();
+  std::thread::scope(|s| {
+    for _ in 0..workers {
+      s.spawn(|| loop {
+        let i = next.fetch_add(1, Ordering::Relaxed);
+        if i >= items.len() {
+          break;
+        }
+        let (name, path) = &items[i];
+        let (status, output) = exec_capture_in_dir(path, program, args);
+        // `.lock()` never poisons: the worker body cannot panic (the spawn
+        // primitive returns `SpawnError` instead of unwinding).
+        *slots[i].lock().expect("exec worker mutex never poisoned") = Some((
+          ExecOutcome {
+            name: name.clone(),
+            status,
+          },
+          output,
+        ));
+      });
+    }
+  });
+  slots
+    .into_iter()
+    .map(|m| m.into_inner().expect("exec worker mutex never poisoned"))
+    .map(|slot| slot.expect("every worktree slot filled by a worker"))
+    .collect()
 }
 
 /// Resolve `program` for execution inside `dir`.

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4686,6 +4686,51 @@ fn exec_runs_a_named_profile_command() {
 }
 
 #[test]
+fn exec_jobs_runs_the_parallel_capture_path() {
+  // `--jobs > 1` runs the bounded-parallel path: each worktree's output is
+  // captured and printed as a block (after its header), and the command still
+  // runs and rolls up ✓.
+  let (dir, _base, wt) = repo_with_one_worktree();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args([
+      "exec",
+      "--jobs",
+      "2",
+      "--",
+      "sh",
+      "-c",
+      "echo blockline; echo hi > exec_jobs_marker.txt",
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("blockline")) // captured stdout printed as a block
+    .stdout(predicate::str::contains("feat-1-wt"))
+    .stdout(predicate::str::contains("✓"));
+  assert!(
+    wt.join("exec_jobs_marker.txt").exists(),
+    "the command must still run under --jobs"
+  );
+}
+
+#[test]
+fn exec_jobs_flag_parses_and_propagates_failure() {
+  // The parallel path propagates a non-zero rollup just like sequential.
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--jobs", "3", "--", "sh", "-c", "exit 4"])
+    .assert()
+    .failure()
+    .stdout(predicate::str::contains("✗"))
+    .stdout(predicate::str::contains("exit 4"));
+}
+
+#[test]
 fn exec_inline_command_ignores_a_broken_gwm_toml() {
   // The inline `gwm exec -- <cmd>` surface is promised config-free: an
   // unrelated `.gwm.toml` error must NOT break it (it only reads config for

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4716,6 +4716,26 @@ fn exec_jobs_runs_the_parallel_capture_path() {
 }
 
 #[test]
+fn exec_jobs_preserves_raw_binary_output() {
+  // The parallel path captures bytes, but must re-emit them RAW — a
+  // `String::from_utf8_lossy` would mangle a non-UTF-8 byte (0xFF) into the
+  // U+FFFD replacement char. `printf '\377'` emits a literal 0xFF.
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  let out = Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--jobs", "2", "--", "printf", "\\377"])
+    .output()
+    .unwrap();
+  assert!(out.status.success(), "exec should succeed: {out:?}");
+  assert!(
+    out.stdout.contains(&0xFFu8),
+    "the raw 0xFF byte must survive the capture, not be UTF-8-mangled"
+  );
+}
+
+#[test]
 fn exec_jobs_flag_parses_and_propagates_failure() {
   // The parallel path propagates a non-zero rollup just like sequential.
   let (dir, _base, _wt) = repo_with_one_worktree();

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4736,6 +4736,24 @@ fn exec_jobs_preserves_raw_binary_output() {
 }
 
 #[test]
+fn exec_inline_inside_bare_repo_does_not_require_a_workdir() {
+  // A bare repo has no `workdir()`, so there's no `.gwm.toml` to read — but
+  // inline `gwm exec` must still run (it enumerates worktrees, not config).
+  // Regression: reading the `[exec] jobs` default must fall back gracefully
+  // here instead of failing with `NotInGitRepo` (#324 review).
+  let dir = tempfile::TempDir::new().unwrap();
+  git2::Repository::init_bare(dir.path()).expect("init bare repo");
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--", "true"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no worktrees to run in"));
+}
+
+#[test]
 fn exec_jobs_flag_skips_config_when_inline() {
   // Inline + `--jobs`: the flag is authoritative and the command is on the
   // CLI, so `[exec]` is never read — a malformed sibling profile can't block

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4736,6 +4736,38 @@ fn exec_jobs_preserves_raw_binary_output() {
 }
 
 #[test]
+fn exec_jobs_flag_skips_config_when_inline() {
+  // Inline + `--jobs`: the flag is authoritative and the command is on the
+  // CLI, so `[exec]` is never read — a malformed sibling profile can't block
+  // `gwm exec --jobs N -- <cmd>` (#324 review).
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  append_config(dir.path(), "[exec.profiles.bad]\ncommand = []\n");
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--jobs", "2", "--", "true"])
+    .assert()
+    .success();
+}
+
+#[test]
+fn exec_inline_jobs_default_tolerates_a_semantic_sibling_profile() {
+  // Inline + no `--jobs`: the `[exec] jobs` default IS read, but sibling
+  // profiles are NOT semantically validated (inline uses none of them), so a
+  // `command = []` sibling doesn't block the inline run.
+  let (dir, _base, _wt) = repo_with_one_worktree();
+  append_config(dir.path(), "[exec]\njobs = 1\n[exec.profiles.bad]\ncommand = []\n");
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--", "true"])
+    .assert()
+    .success();
+}
+
+#[test]
 fn exec_jobs_flag_parses_and_propagates_failure() {
   // The parallel path propagates a non-zero rollup just like sequential.
   let (dir, _base, _wt) = repo_with_one_worktree();

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2226,6 +2226,36 @@ command = ["cargo", "fmt", "--all"]
 }
 
 #[test]
+fn exec_jobs_parse_global_and_per_profile() {
+  let cfg = load_toml(
+    r#"
+[exec]
+jobs = 4
+
+[exec.profiles.fmt]
+command = ["cargo", "fmt"]
+jobs = 2
+"#,
+  )
+  .expect("jobs parse");
+  assert_eq!(cfg.exec.jobs, Some(4), "global [exec] jobs");
+  assert_eq!(cfg.exec.profiles["fmt"].jobs, Some(2), "per-profile jobs");
+}
+
+#[test]
+fn exec_jobs_default_to_none() {
+  let cfg = load_toml(
+    r#"
+[exec.profiles.test]
+command = ["cargo", "test"]
+"#,
+  )
+  .expect("parse");
+  assert!(cfg.exec.jobs.is_none(), "no [exec] jobs ⇒ None (sequential)");
+  assert!(cfg.exec.profiles["test"].jobs.is_none());
+}
+
+#[test]
 fn clean_profiles_parse_dirs_as_a_complete_set() {
   let cfg = load_toml(
     r#"

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2243,6 +2243,34 @@ jobs = 2
 }
 
 #[test]
+fn exec_jobs_default_honors_global_even_without_a_repo() {
+  // A bare repo passes `repo = None`, but the GLOBAL `[exec] jobs` still
+  // applies (#324 review). A repo `[exec] jobs` overrides the global.
+  let global_dir = TempDir::new().unwrap();
+  let global = global_dir.path().join("config.toml");
+  std::fs::write(&global, "[exec]\njobs = 4\n").unwrap();
+
+  // repo = None (bare): only the global is read.
+  assert_eq!(
+    Config::load_exec_jobs_default_layered(Some(&global), None).unwrap(),
+    Some(4),
+    "bare repo still honours the global [exec] jobs"
+  );
+
+  // A repo `.gwm.toml` overrides the global default.
+  let repo_dir = TempDir::new().unwrap();
+  std::fs::write(repo_dir.path().join(CONFIG_FILE), "[exec]\njobs = 2\n").unwrap();
+  assert_eq!(
+    Config::load_exec_jobs_default_layered(Some(&global), Some(repo_dir.path())).unwrap(),
+    Some(2),
+    "repo [exec] jobs overrides the global"
+  );
+
+  // No global, no repo ⇒ None (sequential).
+  assert_eq!(Config::load_exec_jobs_default_layered(None, None).unwrap(), None);
+}
+
+#[test]
 fn exec_jobs_default_to_none() {
   let cfg = load_toml(
     r#"

--- a/tests/exec_tests.rs
+++ b/tests/exec_tests.rs
@@ -10,13 +10,15 @@ use clap::Parser;
 use gwm::cli::{Cli, Command};
 use gwm::config::{ExecConfig, ExecProfile};
 use gwm::exec::{
-  exec_in_dir, format_outcome, resolve_exec_command, resolve_program, rollup_exit_code, ExecOutcome, ExecStatus,
+  exec_capture_in_dir, exec_in_dir, format_outcome, resolve_exec_command, resolve_jobs, resolve_program,
+  rollup_exit_code, run_in_dirs_parallel, ExecOutcome, ExecStatus,
 };
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-/// Build an [`ExecConfig`] with the given `[exec.profiles.*]` entries.
+/// Build an [`ExecConfig`] with the given `[exec.profiles.*]` entries (no
+/// `jobs` set anywhere).
 fn exec_cfg(profiles: &[(&str, &[&str])]) -> ExecConfig {
   let mut map = BTreeMap::new();
   for (name, argv) in profiles {
@@ -24,10 +26,14 @@ fn exec_cfg(profiles: &[(&str, &[&str])]) -> ExecConfig {
       (*name).to_string(),
       ExecProfile {
         command: argv.iter().map(|s| s.to_string()).collect(),
+        jobs: None,
       },
     );
   }
-  ExecConfig { profiles: map }
+  ExecConfig {
+    jobs: None,
+    profiles: map,
+  }
 }
 
 #[test]
@@ -177,14 +183,146 @@ fn parses_command_after_double_dash_with_no_slugs() {
     Some(Command::Exec {
       slugs,
       profile,
+      jobs,
       command,
     }) => {
       assert!(slugs.is_empty(), "no slugs before `--`");
       assert!(profile.is_none(), "no --profile given");
+      assert!(jobs.is_none(), "no --jobs given");
       assert_eq!(command, vec!["git".to_string(), "fetch".to_string()]);
     }
     other => panic!("expected Exec, got {other:?}"),
   }
+}
+
+#[test]
+fn parses_jobs_flag() {
+  let cli = Cli::try_parse_from(["gwm", "exec", "--jobs", "4", "--", "echo", "hi"]).expect("should parse");
+  match cli.command {
+    Some(Command::Exec { jobs, command, .. }) => {
+      assert_eq!(jobs, Some(4));
+      assert_eq!(command, vec!["echo".to_string(), "hi".to_string()]);
+    }
+    other => panic!("expected Exec, got {other:?}"),
+  }
+}
+
+// --- jobs precedence + parallel runner (issue #324) ------------------------
+
+/// ExecConfig with an explicit global `jobs` and per-profile `(name, argv, jobs)`.
+fn exec_cfg_jobs(global: Option<u32>, profiles: &[(&str, &[&str], Option<u32>)]) -> ExecConfig {
+  let mut map = BTreeMap::new();
+  for (name, argv, jobs) in profiles {
+    map.insert(
+      (*name).to_string(),
+      ExecProfile {
+        command: argv.iter().map(|s| s.to_string()).collect(),
+        jobs: *jobs,
+      },
+    );
+  }
+  ExecConfig {
+    jobs: global,
+    profiles: map,
+  }
+}
+
+#[test]
+fn resolve_jobs_defaults_to_one() {
+  assert_eq!(resolve_jobs(None, None, &exec_cfg(&[])), 1);
+}
+
+#[test]
+fn resolve_jobs_flag_wins_over_profile_and_global() {
+  let cfg = exec_cfg_jobs(Some(2), &[("p", &["true"], Some(3))]);
+  assert_eq!(resolve_jobs(Some(8), Some("p"), &cfg), 8);
+}
+
+#[test]
+fn resolve_jobs_profile_overrides_global() {
+  let cfg = exec_cfg_jobs(Some(2), &[("p", &["true"], Some(4))]);
+  assert_eq!(resolve_jobs(None, Some("p"), &cfg), 4);
+}
+
+#[test]
+fn resolve_jobs_falls_back_global_then_one() {
+  let cfg = exec_cfg_jobs(Some(5), &[("p", &["true"], None)]);
+  assert_eq!(resolve_jobs(None, Some("p"), &cfg), 5, "profile without jobs → global");
+  assert_eq!(resolve_jobs(None, None, &cfg), 5, "inline → global");
+  assert_eq!(resolve_jobs(None, None, &exec_cfg_jobs(None, &[])), 1, "nothing → 1");
+}
+
+#[test]
+fn resolve_jobs_clamps_zero_to_one() {
+  let cfg = exec_cfg_jobs(Some(0), &[]);
+  assert_eq!(resolve_jobs(Some(0), None, &cfg), 1);
+  assert_eq!(resolve_jobs(None, None, &cfg), 1);
+}
+
+#[test]
+fn exec_capture_captures_stdout() {
+  let dir = TempDir::new().unwrap();
+  let (status, out) = exec_capture_in_dir(dir.path(), "sh", &["-c".into(), "echo captured".into()]);
+  assert_eq!(status, ExecStatus::Ok);
+  assert!(
+    String::from_utf8_lossy(&out).contains("captured"),
+    "stdout should be captured: {out:?}"
+  );
+}
+
+#[test]
+fn exec_capture_reports_exit_code_and_stderr() {
+  let dir = TempDir::new().unwrap();
+  let (status, out) = exec_capture_in_dir(dir.path(), "sh", &["-c".into(), "echo oops 1>&2; exit 3".into()]);
+  assert_eq!(status, ExecStatus::Failed(3));
+  assert!(
+    String::from_utf8_lossy(&out).contains("oops"),
+    "stderr should be captured too: {out:?}"
+  );
+}
+
+#[test]
+fn run_parallel_captures_each_dirs_output_in_input_order() {
+  // Each dir holds an `id.txt`; running `cat id.txt` in each (cwd = the dir)
+  // proves per-worktree capture, and the results must come back in INPUT
+  // order regardless of completion order (bounded at 2 workers).
+  let dirs: Vec<TempDir> = (0..3).map(|_| TempDir::new().unwrap()).collect();
+  let items: Vec<(String, PathBuf)> = dirs
+    .iter()
+    .enumerate()
+    .map(|(i, d)| {
+      std::fs::write(d.path().join("id.txt"), format!("dir-{i}")).unwrap();
+      (format!("wt{i}"), d.path().to_path_buf())
+    })
+    .collect();
+
+  let results = run_in_dirs_parallel(2, &items, "sh", &["-c".into(), "cat id.txt".into()]);
+
+  assert_eq!(results.len(), 3);
+  for (i, (outcome, output)) in results.iter().enumerate() {
+    assert_eq!(outcome.name, format!("wt{i}"), "results stay in input order");
+    assert_eq!(outcome.status, ExecStatus::Ok);
+    assert!(
+      String::from_utf8_lossy(output).contains(&format!("dir-{i}")),
+      "block {i} must carry its own dir's output"
+    );
+  }
+}
+
+#[test]
+fn run_parallel_clamps_jobs_above_item_count() {
+  let dir = TempDir::new().unwrap();
+  let items = vec![("only".to_string(), dir.path().to_path_buf())];
+  // jobs far exceeds the single item — must not panic, returns the one result.
+  let results = run_in_dirs_parallel(64, &items, "sh", &["-c".into(), "true".into()]);
+  assert_eq!(results.len(), 1);
+  assert_eq!(results[0].0.status, ExecStatus::Ok);
+}
+
+#[test]
+fn run_parallel_on_empty_items_returns_empty() {
+  let results = run_in_dirs_parallel(4, &[], "true", &[]);
+  assert!(results.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Description

Second and final sub-PR of #324: `gwm exec` gains **bounded parallelism**, completing the exec/clean 1.0 surface. Builds on the config profiles landed in #330 (#324a).

Closes #324

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **Config** (`src/config.rs`): `jobs: Option<u32>` on `ExecConfig` (the `[exec] jobs` global default) and `ExecProfile` (per-profile override). Sub-fields of the already-frozen `[exec]` section → `contract::CONFIG_SECTIONS` unchanged.
- **exec.rs**: `resolve_jobs` (precedence `--jobs` > `profile.jobs` > `[exec] jobs` > 1, clamps 0→1); `exec_capture_in_dir` (captures stdout+stderr); `run_in_dirs_parallel` (bounded `std::thread::scope` pool capped at `min(jobs, worktrees)`, results **in input order**). No new dependency.
- **cli.rs**: `--jobs <n>` flag; `cmd_exec` resolves jobs and branches — `jobs ≤ 1` keeps the sequential live-stdio path, `> 1` captures and prints one per-worktree block in worktree order. Loads `[exec]` via the tolerant `load_exec_config` for both inline and profile runs (to read the `jobs` default); no `[exec]` block ⇒ jobs = 1 (inline surface behaviourally unchanged).

## Frozen output model (decision #6)

- `jobs = 1` / absent → **sequential**, live inherited stdio (the MVP behaviour, unchanged).
- `jobs > 1` → **bounded parallel**, each worktree's output **captured** and printed as a **block per worktree at completion** (worktree order), so concurrent runs don't interleave. Aggregate exit code unchanged.

## Tests (TDD)

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` pass
- [x] New tests: `resolve_jobs` precedence/clamp, `exec_capture_in_dir` (stdout/stderr/exit code), `run_in_dirs_parallel` (input-order, clamp, empty), `--jobs` clap parse (`exec_tests`); `[exec] jobs` + per-profile parse (`config_tests`); end-to-end `--jobs` capture path + failure propagation (`cli_binary`)
- [x] `gwm doctor` clean; pre-validated under a stripped `PATH`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] `examples/gwm.toml.example` + docs EN/FR updated (config schema changed)
- [x] No `unwrap()` on user-facing paths (only `.expect` on a never-poisoned worker mutex, documented)

## Notes for reviewers

The parallel runner deliberately returns results in **input order** (not completion order) so the per-worktree blocks print deterministically. `cmd_exec` now reads `[exec]` even for inline `-- <cmd>` (for the `jobs` default) via the tolerant section loader from #324a — an unrelated `.gwm.toml` error still doesn't break inline exec, and with no `[exec]` block the behaviour is identical to before.

https://claude.ai/code/session_01RbvbQ6HsSW16gWdzBqbAFN