### PR TITLE
✨ feat(exec,clean): --workspace fan-out across child repos (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`--workspace` fan-out for `gwm exec` / `gwm clean`** (issue #326). Both
+  commands now accept the global `--workspace <root>` flag and fan out across
+  the workspace's child repos, **reversing the #319 deferral** (the refusal
+  is gone). Each repo's command/dir-set is resolved UPFRONT — a missing
+  `--profile`, a malformed `[exec]`/`[clean]`, or an unopenable child repo
+  errors before anything runs (or, for `clean --yes`, before any
+  `remove_dir_all`). Repos then run **sequentially** (parallelism stays
+  bounded *within* a repo, so output never interleaves across repos) under a
+  `══ <repo>` header, with a `<repo>/<worktree>`-tagged rollup / report and an
+  aggregated exit code (non-zero if any worktree in any repo failed; for
+  clean, a delete failure in one worktree is reported but doesn't abort the
+  rest). `--profile` resolves per child repo against that repo's `.gwm.toml`;
+  a slug that matches nothing in a given repo contributes nothing there rather
+  than aborting the fan-out; a bare child repo is tolerated. This is an
+  **additive** transition (a former refusal turning into a success is not
+  breaking). The `--workspace` refusal remains for commands that still don't
+  implement it.
+
 - **Bounded `--jobs` parallelism for `gwm exec`** (issue #324). `gwm exec`
   gains a `--jobs <n>` flag and an `[exec] jobs` config default (with a
   per-profile `[exec.profiles.<name>].jobs` override). Precedence: `--jobs`
@@ -72,13 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default (bounded `--jobs` parallelism is a future opt-in), `clean` keeps its
   built-in `target` / `node_modules` / `dist` / `build` set (the `[clean]` /
   `[exec]` profile config anticipated here now lands additively under #324,
-  above), and `--workspace` fan-out across repos stays refused on both
-  commands until it lands. The one
-  previously-untested frozen behaviour — the `--workspace` refusal on `exec` /
-  `clean`, whose exit code is now under the SemVer pledge — is pinned by two
-  regression tests in `tests/cli_binary.rs`, so a future change that silently
-  accepts the flag (or changes the exit code) breaks CI loudly. No behaviour
-  change.
+  above), and `--workspace` fan-out across repos was refused on both commands
+  pending implementation — which now lands additively under #326 (below). The
+  transition is additive: a previous refusal becoming a success is not a
+  breaking change. No behaviour change at the time of this decision.
 
 ### Docs
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -567,10 +567,13 @@ gwm --workspace ~/Projects               # open the TUI over every direct-child 
 gwm list --workspace ~/Projects          # merged worktree table, leading REPO column
 gwm --workspace ~/Projects list          # same — the global flag may precede the subcommand
 gwm --workspace ~/Projects create feat 12 search --repo my-api   # disambiguate the target
+gwm exec --workspace ~/Projects -- git fetch   # fan out across every child repo's worktrees
+gwm clean --workspace ~/Projects --yes         # reclaim artifacts across every child repo
 ```
 
 - **TUI / `gwm list`** gain a leading **REPO** column naming each row's repo. In the TUI the active repo follows the selection, so every selection-driven action (lazygit, terminal, sync, delete, link, open, …) operates on the highlighted worktree's own repo.
 - **`gwm create`** in workspace mode requires `--repo <name>` to disambiguate which child repo gets the new worktree; an absent or unknown name lists the candidates.
+- **`gwm exec` / `gwm clean`** (issue #326) fan out across every child repo. Each repo's command / dir-set is resolved upfront (a missing `--profile`, a malformed `[exec]`/`[clean]`, or an unopenable child errors before anything runs), then repos run **sequentially** (parallelism stays bounded *within* a repo) under a `══ <repo>` header, with a `<repo>/<worktree>`-tagged rollup / report and an aggregated exit code. `--profile` resolves per repo against that repo's own `.gwm.toml`; a slug matching nothing in a repo contributes nothing there. `gwm clean --workspace` aggregates one report and one `--yes` decision across all repos; a delete failure in one worktree is reported but doesn't abort the rest. **`--workspace` is still refused on commands that don't implement it.**
 - **Bare `gwm`** in a directory that is *not* itself a git repo but holds child repos prompts `No git repo here. Open <dir> as a workspace? [Y/n]`. The prompt is **declined silently when stdin is not a terminal**, so pipes / CI keep the old single-repo behaviour.
 - **`.gwm.toml` stays per-repo** — each row inherits its own repo's config. There is no workspace-level config in this version; the keymap and theme resolve once from the first repo, matching the single-repo "resolved once, relaunch to change" contract.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -567,10 +567,13 @@ gwm --workspace ~/Projects               # open the TUI over every direct-child 
 gwm list --workspace ~/Projects          # merged worktree table, leading REPO column
 gwm --workspace ~/Projects list          # same — the global flag may precede the subcommand
 gwm --workspace ~/Projects create feat 12 search --repo my-api   # disambiguate the target
+gwm exec --workspace ~/Projects -- git fetch   # fan out across every child repo's worktrees
+gwm clean --workspace ~/Projects --yes         # reclaim artifacts across every child repo
 ```
 
 - **Le TUI / `gwm list`** gagnent une colonne **REPO** en tête nommant le dépôt de chaque ligne. Dans le TUI, le dépôt actif suit la sélection, donc chaque action pilotée par la sélection (lazygit, terminal, sync, delete, link, open, …) opère sur le dépôt propre au worktree surligné.
 - **`gwm create`** en mode workspace requiert `--repo <name>` pour lever l'ambiguïté sur le dépôt enfant qui reçoit le nouveau worktree ; un nom absent ou inconnu liste les candidats.
+- **`gwm exec` / `gwm clean`** (issue #326) se déploient (fan-out) sur chaque dépôt enfant. La commande / le jeu de répertoires de chaque dépôt est résolu en amont (un `--profile` manquant, un `[exec]`/`[clean]` malformé, ou un dépôt enfant inouvrable échoue avant toute exécution), puis les dépôts s'exécutent **séquentiellement** (le parallélisme reste borné *au sein* d'un dépôt) sous un en-tête `══ <repo>`, avec un récapitulatif / rapport taggé `<repo>/<worktree>` et un code de sortie agrégé. `--profile` se résout par dépôt contre son propre `.gwm.toml` ; un slug ne correspondant à rien dans un dépôt n'y contribue rien. `gwm clean --workspace` agrège un seul rapport et une seule décision `--yes` sur tous les dépôts ; un échec de suppression dans un worktree est rapporté mais n'interrompt pas les autres. **`--workspace` reste refusé sur les commandes qui ne l'implémentent pas.**
 - **`gwm` seul** dans un répertoire qui n'est *pas* lui-même un dépôt git mais contient des dépôts enfants invite `No git repo here. Open <dir> as a workspace? [Y/n]`. L'invite est **déclinée silencieusement quand stdin n'est pas un terminal**, donc les pipes / la CI conservent l'ancien comportement mono-dépôt.
 - **`.gwm.toml` reste par dépôt** — chaque ligne hérite de la config de son propre dépôt. Il n'y a pas de config au niveau workspace dans cette version ; le keymap et le thème sont résolus une fois depuis le premier dépôt, conformément au contrat mono-dépôt « résolu une fois, relancer pour changer ».
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1112,8 +1112,15 @@ fn cmd_exec_workspace(
   // Resolve targets (ambiguity/typo errors surface here) AND each repo's argv +
   // jobs UPFRONT — before a single command runs.
   let targets_per_repo = resolve_workspace_targets(&repos, &slugs)?;
-  let mut plans: Vec<(&str, &Vec<worktree::WorktreeInfo>, Vec<String>, usize)> = Vec::with_capacity(opened.len());
+  // Resolve config/argv ONLY for repos that have targets. A repo a scoped slug
+  // doesn't touch contributes nothing, so its `[exec]` / `--profile` must not
+  // be resolved — an unrelated repo lacking the profile or with a bad `[exec]`
+  // can't break a run scoped elsewhere (#326 review).
+  let mut plans: Vec<(&str, &Vec<worktree::WorktreeInfo>, Vec<String>, usize)> = Vec::new();
   for ((name, repo), targets) in opened.iter().zip(&targets_per_repo) {
+    if targets.is_empty() {
+      continue;
+    }
     let (argv, job_count) = exec_plan(repo, profile.as_deref(), jobs, &command)?;
     plans.push((name, targets, argv, job_count));
   }
@@ -1122,10 +1129,6 @@ fn cmd_exec_workspace(
   let mut all = Vec::new();
   for (name, targets, argv, job_count) in &plans {
     println!("\n══ {}", name);
-    if targets.is_empty() {
-      println!("no worktrees to run in");
-      continue;
-    }
     all.extend(exec_run(targets, argv, *job_count, Some(name))?);
   }
   print_exec_rollup_and_exit(&all)
@@ -1350,11 +1353,17 @@ fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>,
   let repos: Vec<&Repository> = opened.iter().map(|(_, r)| r).collect();
   let targets_per_repo = resolve_workspace_targets(&repos, &slugs)?;
 
-  // Scan every repo upfront — resolution (config/profile) errors surface here,
-  // before any deletion.
+  // Scan every repo with targets upfront — resolution (config/profile) errors
+  // surface here, before any deletion. A repo a scoped slug doesn't touch
+  // contributes nothing, so its `[clean]` / `--profile` is NOT resolved (an
+  // unrelated repo's bad config can't break a run scoped elsewhere — #326
+  // review).
   let mut reclaims: Vec<clean::WorktreeReclaim> = Vec::new();
   let mut skipped: Vec<(String, String)> = Vec::new();
   for ((name, repo), targets) in opened.iter().zip(&targets_per_repo) {
+    if targets.is_empty() {
+      continue;
+    }
     let (mut rec, mut skip) = clean_scan_repo(repo, targets, profile.as_deref(), Some(name))?;
     reclaims.append(&mut rec);
     skipped.append(&mut skip);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1107,46 +1107,48 @@ fn cmd_exec_workspace(
   jobs: Option<u32>,
   command: Vec<String>,
 ) -> Result<()> {
+  let opened = open_workspace_repos(root)?;
+  let repos: Vec<&Repository> = opened.iter().map(|(_, r)| r).collect();
+  // Resolve targets (ambiguity/typo errors surface here) AND each repo's argv +
+  // jobs UPFRONT — before a single command runs.
+  let targets_per_repo = resolve_workspace_targets(&repos, &slugs)?;
+  let mut plans: Vec<(&str, &Vec<worktree::WorktreeInfo>, Vec<String>, usize)> = Vec::with_capacity(opened.len());
+  for ((name, repo), targets) in opened.iter().zip(&targets_per_repo) {
+    let (argv, job_count) = exec_plan(repo, profile.as_deref(), jobs, &command)?;
+    plans.push((name, targets, argv, job_count));
+  }
+
+  // Run sequentially per repo, aggregating the repo-tagged outcomes.
+  let mut all = Vec::new();
+  for (name, targets, argv, job_count) in &plans {
+    println!("\n══ {}", name);
+    if targets.is_empty() {
+      println!("no worktrees to run in");
+      continue;
+    }
+    all.extend(exec_run(targets, argv, *job_count, Some(name))?);
+  }
+  print_exec_rollup_and_exit(&all)
+}
+
+/// Discover the workspace under `root` and open every child repo (erroring on
+/// an empty workspace or an unopenable child — before any command runs).
+/// Returns `(repo_name, Repository)` pairs in `discover` order.
+fn open_workspace_repos(root: &Path) -> Result<Vec<(String, Repository)>> {
   let ws = workspace::discover(root)?;
   if ws.is_empty() {
     return Err(GwmError::EmptyWorkspace {
       root: root.display().to_string(),
     });
   }
-
-  // Resolve every repo upfront (before any side effect).
-  struct RepoPlan {
-    name: String,
-    targets: Vec<worktree::WorktreeInfo>,
-    argv: Vec<String>,
-    job_count: usize,
-  }
-  let mut plans = Vec::with_capacity(ws.repos.len());
-  for r in &ws.repos {
-    let repo = Repository::open(&r.path)
-      .map_err(|e| GwmError::Other(format!("workspace: cannot open repo `{}`: {e}", r.name)))?;
-    let (argv, job_count) = exec_plan(&repo, profile.as_deref(), jobs, &command)?;
-    let targets = resolve_targets_lenient(&repo, &slugs);
-    plans.push(RepoPlan {
-      name: r.name.clone(),
-      targets,
-      argv,
-      job_count,
-    });
-  }
-
-  // Run sequentially per repo, aggregating the repo-tagged outcomes.
-  let mut all = Vec::new();
-  for p in &plans {
-    println!("\n══ {}", p.name);
-    if p.targets.is_empty() {
-      println!("no worktrees to run in");
-      continue;
-    }
-    let outcomes = exec_run(&p.targets, &p.argv, p.job_count, Some(&p.name))?;
-    all.extend(outcomes);
-  }
-  print_exec_rollup_and_exit(&all)
+  ws.repos
+    .iter()
+    .map(|r| {
+      Repository::open(&r.path)
+        .map(|repo| (r.name.clone(), repo))
+        .map_err(|e| GwmError::Other(format!("workspace: cannot open repo `{}`: {e}", r.name)))
+    })
+    .collect()
 }
 
 /// Resolve the argv to run and the parallelism for `gwm exec` against `repo`
@@ -1255,22 +1257,52 @@ fn print_exec_rollup_and_exit(outcomes: &[exec::ExecOutcome]) -> Result<()> {
   Ok(())
 }
 
-/// Like [`resolve_targets`] but tolerant of a slug that matches nothing in
-/// THIS repo — for workspace fan-out, where a slug naming a worktree in one
-/// child repo is naturally absent from the others (a miss contributes nothing
-/// rather than aborting the whole fan-out). Empty slugs still mean "all
-/// non-main worktrees".
-fn resolve_targets_lenient(repo: &Repository, slugs: &[String]) -> Vec<worktree::WorktreeInfo> {
+/// Resolve `slugs` against the workspace's opened `repos` for a fan-out,
+/// returning the per-repo target lists in `repos` order.
+///
+/// Empty slugs ⇒ all non-main worktrees per repo. With slugs, a slug naming a
+/// worktree in one child repo is naturally absent from the others, so a
+/// per-repo `WorktreeNotFound` just contributes nothing THERE — but the error
+/// distinctions the single-repo path makes are preserved: an **ambiguous**
+/// match in any repo surfaces (propagated), and a slug that matches in **no**
+/// repo at all is an error (a typo must not silently run/clean nothing).
+fn resolve_workspace_targets(repos: &[&Repository], slugs: &[String]) -> Result<Vec<Vec<worktree::WorktreeInfo>>> {
   if slugs.is_empty() {
-    worktree::list(repo)
-      .map(|ws| ws.into_iter().filter(|w| !w.is_main).collect())
-      .unwrap_or_default()
-  } else {
-    slugs
-      .iter()
-      .filter_map(|s| worktree::find_fuzzy(repo, s).ok())
-      .collect()
+    return Ok(
+      repos
+        .iter()
+        .map(|repo| {
+          worktree::list(repo)
+            .map(|ws| ws.into_iter().filter(|w| !w.is_main).collect())
+            .unwrap_or_default()
+        })
+        .collect(),
+    );
   }
+
+  let mut per_repo: Vec<Vec<worktree::WorktreeInfo>> = (0..repos.len()).map(|_| Vec::new()).collect();
+  let mut matched = vec![false; slugs.len()];
+  for (ri, repo) in repos.iter().enumerate() {
+    for (si, slug) in slugs.iter().enumerate() {
+      match worktree::find_fuzzy(repo, slug) {
+        Ok(wt) => {
+          per_repo[ri].push(wt);
+          matched[si] = true;
+        }
+        // Absent from THIS repo is normal in a fan-out — skip it.
+        Err(GwmError::WorktreeNotFound(_)) => {}
+        // Ambiguity (or any other resolution failure) must surface.
+        Err(e) => return Err(e),
+      }
+    }
+  }
+  if let Some(si) = matched.iter().position(|m| !m) {
+    return Err(GwmError::WorktreeNotFound(format!(
+      "{} (no worktree matches it in any workspace repo)",
+      slugs[si]
+    )));
+  }
+  Ok(per_repo)
 }
 
 /// `gwm clean [<slug>...] [--profile <name>] [--yes]` (issues #313, #324).
@@ -1279,8 +1311,11 @@ fn resolve_targets_lenient(repo: &Repository, slugs: &[String]) -> Vec<worktree:
 /// `default` profile, else the built-ins (see [`clean::resolve_clean_dirs`]).
 fn cmd_clean(slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
-  let (reclaims, skipped) = clean_scan_repo(&repo, &slugs, profile.as_deref(), None, false)?;
-  if reclaims.is_empty() && skipped.is_empty() {
+  let targets = resolve_targets(&repo, &slugs)?;
+  // Scan even when empty so an unknown `--profile` / malformed `[clean]` errors
+  // before the "no worktrees" message (it loads/validates the dir set).
+  let (reclaims, skipped) = clean_scan_repo(&repo, &targets, profile.as_deref(), None)?;
+  if targets.is_empty() {
     println!("no worktrees to clean");
     return Ok(());
   }
@@ -1288,28 +1323,23 @@ fn cmd_clean(slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<(
 }
 
 /// `gwm clean --workspace <root> ...` — fan out the reclaim across the
-/// workspace's child repos (issue #326). Every repo's dir set is resolved and
-/// its worktrees scanned UPFRONT (so a missing `--profile` or a malformed
-/// `[clean]` in any repo errors before a single `remove_dir_all`), then one
-/// aggregated `<repo>/<worktree>`-tagged report drives a single `--yes`
-/// decision; a delete failure in one worktree is reported but does not abort
-/// the rest (it surfaces in the exit code).
+/// workspace's child repos (issue #326). Every repo is opened, its targets
+/// resolved (ambiguity/typo errors surface), and its worktrees scanned UPFRONT
+/// (so a missing `--profile` or a malformed `[clean]` in any repo errors before
+/// a single `remove_dir_all`), then one aggregated `<repo>/<worktree>`-tagged
+/// report drives a single `--yes` decision; a delete failure in one worktree is
+/// reported but does not abort the rest (it surfaces in the exit code).
 fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<()> {
-  let ws = workspace::discover(root)?;
-  if ws.is_empty() {
-    return Err(GwmError::EmptyWorkspace {
-      root: root.display().to_string(),
-    });
-  }
+  let opened = open_workspace_repos(root)?;
+  let repos: Vec<&Repository> = opened.iter().map(|(_, r)| r).collect();
+  let targets_per_repo = resolve_workspace_targets(&repos, &slugs)?;
 
   // Scan every repo upfront — resolution (config/profile) errors surface here,
   // before any deletion.
   let mut reclaims: Vec<clean::WorktreeReclaim> = Vec::new();
   let mut skipped: Vec<(String, String)> = Vec::new();
-  for r in &ws.repos {
-    let repo = Repository::open(&r.path)
-      .map_err(|e| GwmError::Other(format!("workspace: cannot open repo `{}`: {e}", r.name)))?;
-    let (mut rec, mut skip) = clean_scan_repo(&repo, &slugs, profile.as_deref(), Some(&r.name), true)?;
+  for ((name, repo), targets) in opened.iter().zip(&targets_per_repo) {
+    let (mut rec, mut skip) = clean_scan_repo(repo, targets, profile.as_deref(), Some(name))?;
     reclaims.append(&mut rec);
     skipped.append(&mut skip);
   }
@@ -1320,18 +1350,17 @@ fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>,
 /// `(display-name, rel-dir)` pairs (not git-ignored / holds tracked files).
 type CleanScan = (Vec<clean::WorktreeReclaim>, Vec<(String, String)>);
 
-/// Scan one repo's targets for reclaimable artifacts, classifying each through
-/// the safety gate. Resolution (config load + `--profile` dir set) happens
-/// here, so an error surfaces before the caller deletes anything. `tag` (the
-/// workspace repo name) prefixes worktree display names with `<repo>/` for the
-/// aggregated report; `lenient` uses [`resolve_targets_lenient`] (workspace
-/// fan-out). Returns the per-worktree reclaims and the skipped `(name, rel)`s.
+/// Scan `targets` (a repo's worktrees, resolved by the caller) for reclaimable
+/// artifacts, classifying each through the safety gate. The dir-set resolution
+/// (config load + `--profile`) happens here, so an error surfaces before the
+/// caller deletes anything. `tag` (the workspace repo name) prefixes worktree
+/// display names with `<repo>/` for the aggregated report. Returns the
+/// per-worktree reclaims and the skipped `(name, rel)`s.
 fn clean_scan_repo(
   repo: &Repository,
-  slugs: &[String],
+  targets: &[worktree::WorktreeInfo],
   profile: Option<&str>,
   tag: Option<&str>,
-  lenient: bool,
 ) -> Result<CleanScan> {
   // Load ONLY `[clean]` (tolerant of unrelated config errors, strict on
   // `[clean]` itself — issue #324); `None` workdir (bare repo) reads the global
@@ -1339,11 +1368,6 @@ fn clean_scan_repo(
   let clean_cfg = Config::load_clean_config(repo.workdir())?;
   let patterns = clean::resolve_clean_dirs(profile, &clean_cfg)?;
 
-  let targets = if lenient {
-    resolve_targets_lenient(repo, slugs)
-  } else {
-    resolve_targets(repo, slugs)?
-  };
   let display = |name: &str| match tag {
     Some(t) => format!("{t}/{name}"),
     None => name.to_string(),
@@ -1356,7 +1380,7 @@ fn clean_scan_repo(
   // as skipped rather than counted.
   let mut reclaims = Vec::with_capacity(targets.len());
   let mut skipped = Vec::new();
-  for w in &targets {
+  for w in targets {
     let scan = clean::scan_worktree(&w.name, &w.path, &patterns);
     let mut deletable = Vec::new();
     for a in scan.artifacts {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1135,6 +1135,24 @@ fn cmd_exec_workspace(
 /// an empty workspace or an unopenable child — before any command runs).
 /// Returns `(repo_name, Repository)` pairs in `discover` order.
 fn open_workspace_repos(root: &Path) -> Result<Vec<(String, Repository)>> {
+  // `workspace::discover` silently skips a child whose `Repository::open`
+  // fails (fine for `list` / `create`), but `exec` / `clean` are destructive
+  // and contract for upfront resolution: a child that LOOKS like a repo (has a
+  // `.git`) but won't open must fail the whole fan-out before any side effect,
+  // not be quietly dropped while the valid repos run (#326 review).
+  for entry in std::fs::read_dir(root)?.flatten() {
+    let path = entry.path();
+    if path.is_dir() && path.join(".git").exists() && Repository::open(&path).is_err() {
+      let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+      return Err(GwmError::Other(format!(
+        "workspace: child repo `{name}` has a `.git` but cannot be opened (corrupt or unreadable)"
+      )));
+    }
+  }
+
   let ws = workspace::discover(root)?;
   if ws.is_empty() {
     return Err(GwmError::EmptyWorkspace {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1176,9 +1176,13 @@ fn open_workspace_repos(root: &Path) -> Result<Vec<(String, Repository)>> {
   // and contract for upfront resolution: a child that LOOKS like a repo (has a
   // `.git`) but won't open must fail the whole fan-out before any side effect,
   // not be quietly dropped while the valid repos run (#326 review).
-  for entry in std::fs::read_dir(root)?.flatten() {
-    let path = entry.path();
-    if path.is_dir() && path.join(".git").exists() && Repository::open(&path).is_err() {
+  //
+  // Use `try_exists` and propagate read_dir / stat errors (e.g. a `.git` that
+  // can't be statted because of permissions) rather than masking them as
+  // "absent" — an UNREADABLE child must surface too, not be skipped (review).
+  for entry in std::fs::read_dir(root)? {
+    let path = entry?.path();
+    if path.is_dir() && path.join(".git").try_exists()? && Repository::open(&path).is_err() {
       let name = path
         .file_name()
         .map(|n| n.to_string_lossy().to_string())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1125,6 +1125,19 @@ fn cmd_exec_workspace(
     plans.push((name, targets, argv, job_count));
   }
 
+  if plans.is_empty() {
+    // Nothing participates (every repo is main-only, or the slug scoped them all
+    // out). No run follows, so it's safe to validate the command/profile against
+    // the repos — a usage error (no command) or a typo'd `--profile` must still
+    // surface instead of a silent exit 0. Accept if ANY repo resolves.
+    let opened_repos = opened.iter().map(|(_, r)| r);
+    if let Some(err) = first_exec_plan_error(opened_repos, profile.as_deref(), jobs, &command) {
+      return Err(err);
+    }
+    println!("no worktrees to run in");
+    return Ok(());
+  }
+
   // Run sequentially per repo, aggregating the repo-tagged outcomes.
   let mut all = Vec::new();
   for (name, targets, argv, job_count) in &plans {
@@ -1132,6 +1145,26 @@ fn cmd_exec_workspace(
     all.extend(exec_run(targets, argv, *job_count, Some(name))?);
   }
   print_exec_rollup_and_exit(&all)
+}
+
+/// Validate the exec command/profile when NO workspace repo has targets:
+/// returns `None` if [`exec_plan`] resolves against any repo (the source is
+/// usable — there's just nothing to run), or the last error if it fails for
+/// every repo (a usage error / unknown profile that must surface).
+fn first_exec_plan_error<'a>(
+  repos: impl Iterator<Item = &'a Repository>,
+  profile: Option<&str>,
+  jobs: Option<u32>,
+  command: &[String],
+) -> Option<GwmError> {
+  let mut last = None;
+  for repo in repos {
+    match exec_plan(repo, profile, jobs, command) {
+      Ok(_) => return None,
+      Err(e) => last = Some(e),
+    }
+  }
+  last
 }
 
 /// Discover the workspace under `root` and open every child repo (erroring on
@@ -1360,13 +1393,35 @@ fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>,
   // review).
   let mut reclaims: Vec<clean::WorktreeReclaim> = Vec::new();
   let mut skipped: Vec<(String, String)> = Vec::new();
+  let mut participated = false;
   for ((name, repo), targets) in opened.iter().zip(&targets_per_repo) {
     if targets.is_empty() {
       continue;
     }
+    participated = true;
     let (mut rec, mut skip) = clean_scan_repo(repo, targets, profile.as_deref(), Some(name))?;
     reclaims.append(&mut rec);
     skipped.append(&mut skip);
+  }
+
+  if !participated {
+    // Nothing participates — no deletion follows, so validate the `--profile`
+    // (a typo / malformed `[clean]`) against the repos instead of silently
+    // reporting "nothing to reclaim". Accept if it resolves against any repo.
+    let mut last_err = None;
+    let mut valid = false;
+    for (_, repo) in &opened {
+      match clean_scan_repo(repo, &[], profile.as_deref(), None) {
+        Ok(_) => {
+          valid = true;
+          break;
+        }
+        Err(e) => last_err = Some(e),
+      }
+    }
+    if !valid {
+      return Err(last_err.expect("open_workspace_repos guarantees a non-empty workspace"));
+    }
   }
   clean_finish(&reclaims, &skipped, yes)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -945,10 +945,16 @@ pub fn run(cli: Cli) -> Result<()> {
   };
 
   // `--workspace` is global (clap accepts it everywhere) but only `list`,
-  // `create` and the bare TUI implement it. Reject it on any other subcommand
-  // rather than silently ignoring it and acting on the current single repo — a
-  // wrong-target footgun for destructive commands (Codex review #303 P2).
-  if cli.workspace.is_some() && !matches!(cmd, Command::List { .. } | Command::Create { .. }) {
+  // `create`, `exec`, `clean` and the bare TUI implement it. Reject it on any
+  // other subcommand rather than silently ignoring it and acting on the current
+  // single repo — a wrong-target footgun for destructive commands (Codex review
+  // #303 P2). `exec` / `clean` fan out across child repos (issue #326).
+  if cli.workspace.is_some()
+    && !matches!(
+      cmd,
+      Command::List { .. } | Command::Create { .. } | Command::Exec { .. } | Command::Clean { .. }
+    )
+  {
     return Err(GwmError::WorkspaceUnsupportedCommand);
   }
 
@@ -1048,8 +1054,14 @@ pub fn run(cli: Cli) -> Result<()> {
       profile,
       jobs,
       command,
-    } => cmd_exec(slugs, profile, jobs, command),
-    Command::Clean { slugs, profile, yes } => cmd_clean(slugs, profile, yes),
+    } => match cli.workspace {
+      Some(root) => cmd_exec_workspace(&root, slugs, profile, jobs, command),
+      None => cmd_exec(slugs, profile, jobs, command),
+    },
+    Command::Clean { slugs, profile, yes } => match cli.workspace {
+      Some(root) => cmd_clean_workspace(&root, slugs, profile, yes),
+      None => cmd_clean(slugs, profile, yes),
+    },
   }
 }
 
@@ -1071,20 +1083,88 @@ fn resolve_targets(repo: &Repository, slugs: &[String]) -> Result<Vec<worktree::
 /// aggregate code (non-zero if any worktree failed).
 fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, command: Vec<String>) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
+  let (argv, job_count) = exec_plan(&repo, profile.as_deref(), jobs, &command)?;
+  let targets = resolve_targets(&repo, &slugs)?;
+  if targets.is_empty() {
+    println!("no worktrees to run in");
+    return Ok(());
+  }
+  let outcomes = exec_run(&targets, &argv, job_count, None)?;
+  print_exec_rollup_and_exit(&outcomes)
+}
 
-  // Read `[exec]` from disk only when a value from it is actually needed, and
-  // only as strictly as that need requires (issue #324). The workdir lookup
-  // lives INSIDE the config-reading branches: a bare repo with linked
-  // worktrees has no workdir, but inline `gwm exec` must still run there (it
-  // enumerates worktrees via `worktree::list`, not `.gwm.toml`).
-  //   - `--profile <name>` → full `load_exec_config` (resolve the command +
-  //     validate every profile, matching `gwm config validate` / doctor);
-  //     needs a workdir to locate `.gwm.toml`.
-  //   - inline + no `--jobs` → only the `[exec] jobs` default is needed; read
-  //     it WITHOUT validating sibling profiles. A bare repo (no workdir) skips
-  //     the repo `.gwm.toml` but still honours the GLOBAL `[exec] jobs`.
-  //   - inline + `--jobs` → the flag is authoritative and the command is on
-  //     the CLI, so nothing from `[exec]` is needed — don't touch config.
+/// `gwm exec --workspace <root> ...` — fan out exec across the workspace's
+/// child repos (issue #326). Every repo's argv + parallelism + targets are
+/// resolved UPFRONT, so a missing `--profile` (or a config error) in any repo
+/// surfaces before a single command runs. Repos then run SEQUENTIALLY
+/// (parallelism stays bounded WITHIN a repo to avoid cross-repo output
+/// interleaving), under a `══ <repo>` header, with a `<repo>/<worktree>`
+/// repo-tagged rollup and an aggregated exit code.
+fn cmd_exec_workspace(
+  root: &Path,
+  slugs: Vec<String>,
+  profile: Option<String>,
+  jobs: Option<u32>,
+  command: Vec<String>,
+) -> Result<()> {
+  let ws = workspace::discover(root)?;
+  if ws.is_empty() {
+    return Err(GwmError::EmptyWorkspace {
+      root: root.display().to_string(),
+    });
+  }
+
+  // Resolve every repo upfront (before any side effect).
+  struct RepoPlan {
+    name: String,
+    targets: Vec<worktree::WorktreeInfo>,
+    argv: Vec<String>,
+    job_count: usize,
+  }
+  let mut plans = Vec::with_capacity(ws.repos.len());
+  for r in &ws.repos {
+    let repo = Repository::open(&r.path)
+      .map_err(|e| GwmError::Other(format!("workspace: cannot open repo `{}`: {e}", r.name)))?;
+    let (argv, job_count) = exec_plan(&repo, profile.as_deref(), jobs, &command)?;
+    let targets = resolve_targets_lenient(&repo, &slugs);
+    plans.push(RepoPlan {
+      name: r.name.clone(),
+      targets,
+      argv,
+      job_count,
+    });
+  }
+
+  // Run sequentially per repo, aggregating the repo-tagged outcomes.
+  let mut all = Vec::new();
+  for p in &plans {
+    println!("\n══ {}", p.name);
+    if p.targets.is_empty() {
+      println!("no worktrees to run in");
+      continue;
+    }
+    let outcomes = exec_run(&p.targets, &p.argv, p.job_count, Some(&p.name))?;
+    all.extend(outcomes);
+  }
+  print_exec_rollup_and_exit(&all)
+}
+
+/// Resolve the argv to run and the parallelism for `gwm exec` against `repo`
+/// (config load + profile/inline resolution + jobs precedence). No side
+/// effects — shared by the single-repo and workspace paths so every repo can
+/// be resolved upfront. See the precedence/config-loading notes inline.
+fn exec_plan(
+  repo: &Repository,
+  profile: Option<&str>,
+  jobs: Option<u32>,
+  command: &[String],
+) -> Result<(Vec<String>, usize)> {
+  // Read `[exec]` only as strictly as the invocation needs (issue #324):
+  //   - `--profile` → full `load_exec_config` (resolve + validate every
+  //     profile); needs a workdir to locate `.gwm.toml`.
+  //   - inline + no `--jobs` → only the `[exec] jobs` default; a bare repo (no
+  //     workdir) skips the repo file but still honours the GLOBAL default.
+  //   - inline + `--jobs` → the flag wins and the command is inline → no config.
   let exec_cfg = if profile.is_some() {
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
     Config::load_exec_config(workdir)?
@@ -1096,43 +1176,49 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
   } else {
     crate::config::ExecConfig::default()
   };
+  let argv = exec::resolve_exec_command(profile, command, &exec_cfg)?;
+  let job_count = exec::resolve_jobs(jobs, profile, &exec_cfg);
+  Ok((argv, job_count))
+}
 
-  // Resolve the argv up-front, from exactly one of `--profile` / inline
-  // `-- <cmd>`. A usage error (both, neither, or an unknown profile) must
-  // surface before we touch any worktree, hence before target discovery.
-  let argv = exec::resolve_exec_command(profile.as_deref(), &command, &exec_cfg)?;
-  // Precedence: `--jobs` > `[exec.profiles.<name>].jobs` > `[exec] jobs` > 1.
-  let job_count = exec::resolve_jobs(jobs, profile.as_deref(), &exec_cfg);
-
-  let targets = resolve_targets(&repo, &slugs)?;
-  if targets.is_empty() {
-    println!("no worktrees to run in");
-    return Ok(());
-  }
-
-  // `resolve_exec_command` guarantees a non-empty argv, but split defensively
-  // rather than indexing — a panic here would be on a user-facing path.
+/// Run `argv` across one repo's `targets`: sequential (live inherited stdio)
+/// when `job_count <= 1`, else bounded-parallel with per-worktree captured
+/// blocks. `tag` (the workspace repo name) prefixes each outcome's display
+/// name with `<repo>/` for the aggregated rollup; the per-worktree header
+/// stays plain (it sits under the `══ <repo>` header). Returns the outcomes.
+fn exec_run(
+  targets: &[worktree::WorktreeInfo],
+  argv: &[String],
+  job_count: usize,
+  tag: Option<&str>,
+) -> Result<Vec<exec::ExecOutcome>> {
+  // `exec_plan` (via `resolve_exec_command`) guarantees a non-empty argv, but
+  // split defensively rather than indexing — a panic would be user-facing.
   let (program, args) = argv
     .split_first()
     .ok_or_else(|| GwmError::Other("exec: no command resolved".into()))?;
   let args = args.to_vec();
+  let display = |name: &str| match tag {
+    Some(t) => format!("{t}/{name}"),
+    None => name.to_string(),
+  };
 
   let mut outcomes = Vec::with_capacity(targets.len());
   if job_count <= 1 {
     // Sequential: inherit the parent's stdio so output streams live, in order.
-    for w in &targets {
+    for w in targets {
       println!("\n━━ {} ({})", w.name, w.path.display());
       let status = exec::exec_in_dir(&w.path, program, &args);
       outcomes.push(exec::ExecOutcome {
-        name: w.name.clone(),
+        name: display(&w.name),
         status,
       });
     }
   } else {
     // Parallel (bounded by `job_count`): capture each worktree's output so
     // concurrent runs don't interleave, then print one block per worktree in
-    // worktree order once the fan-out completes. Write the captured bytes
-    // RAW (not via `String::from_utf8_lossy`) so binary / non-UTF-8 output is
+    // worktree order once the fan-out completes. Write the captured bytes RAW
+    // (not via `String::from_utf8_lossy`) so binary / non-UTF-8 output is
     // re-emitted byte-for-byte, matching the sequential path's inherited stdio.
     use std::io::Write;
     let items: Vec<(String, std::path::PathBuf)> = targets.iter().map(|w| (w.name.clone(), w.path.clone())).collect();
@@ -1144,21 +1230,47 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
       // the whole fan-out, and the rollup/exit code still report the result.
       let _ = writeln!(lock, "\n━━ {} ({})", name, path.display());
       let _ = lock.write_all(&output);
-      outcomes.push(outcome);
+      outcomes.push(exec::ExecOutcome {
+        name: display(name),
+        status: outcome.status,
+      });
     }
     let _ = lock.flush();
   }
+  Ok(outcomes)
+}
 
+/// Print the `✓ / ✗` rollup for the collected outcomes and exit with the
+/// aggregate code (non-zero if any worktree, in any repo, failed). Shared by
+/// the single-repo and workspace exec paths.
+fn print_exec_rollup_and_exit(outcomes: &[exec::ExecOutcome]) -> Result<()> {
   println!("\nrollup:");
-  for o in &outcomes {
+  for o in outcomes {
     println!("  {}", exec::format_outcome(o));
   }
-
-  let code = exec::rollup_exit_code(&outcomes);
+  let code = exec::rollup_exit_code(outcomes);
   if code != 0 {
     std::process::exit(code);
   }
   Ok(())
+}
+
+/// Like [`resolve_targets`] but tolerant of a slug that matches nothing in
+/// THIS repo — for workspace fan-out, where a slug naming a worktree in one
+/// child repo is naturally absent from the others (a miss contributes nothing
+/// rather than aborting the whole fan-out). Empty slugs still mean "all
+/// non-main worktrees".
+fn resolve_targets_lenient(repo: &Repository, slugs: &[String]) -> Vec<worktree::WorktreeInfo> {
+  if slugs.is_empty() {
+    worktree::list(repo)
+      .map(|ws| ws.into_iter().filter(|w| !w.is_main).collect())
+      .unwrap_or_default()
+  } else {
+    slugs
+      .iter()
+      .filter_map(|s| worktree::find_fuzzy(repo, s).ok())
+      .collect()
+  }
 }
 
 /// `gwm clean [<slug>...] [--profile <name>] [--yes]` (issues #313, #324).
@@ -1167,32 +1279,83 @@ fn cmd_exec(slugs: Vec<String>, profile: Option<String>, jobs: Option<u32>, comm
 /// `default` profile, else the built-ins (see [`clean::resolve_clean_dirs`]).
 fn cmd_clean(slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
-
-  // Resolve the directory set up-front so an unknown `--profile` errors
-  // (exit 1) before target discovery.
-  //
-  // The profile blocks are opt-in, so an UNRELATED config error (a `[tui.keys]`
-  // typo, a stray key, another section) must not block `gwm clean`. We load
-  // ONLY the `[clean]` section, tolerant of the rest — but strict on `[clean]`
-  // itself: a malformed `[clean.profiles.default]` still errors rather than
-  // silently reverting to the built-in set before a destructive `--yes`.
-  let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?;
-  let clean_cfg = Config::load_clean_config(workdir)?;
-  let patterns = clean::resolve_clean_dirs(profile.as_deref(), &clean_cfg)?;
-
-  let targets = resolve_targets(&repo, &slugs)?;
-  if targets.is_empty() {
+  let (reclaims, skipped) = clean_scan_repo(&repo, &slugs, profile.as_deref(), None, false)?;
+  if reclaims.is_empty() && skipped.is_empty() {
     println!("no worktrees to clean");
     return Ok(());
   }
+  clean_finish(&reclaims, &skipped, yes)
+}
+
+/// `gwm clean --workspace <root> ...` — fan out the reclaim across the
+/// workspace's child repos (issue #326). Every repo's dir set is resolved and
+/// its worktrees scanned UPFRONT (so a missing `--profile` or a malformed
+/// `[clean]` in any repo errors before a single `remove_dir_all`), then one
+/// aggregated `<repo>/<worktree>`-tagged report drives a single `--yes`
+/// decision; a delete failure in one worktree is reported but does not abort
+/// the rest (it surfaces in the exit code).
+fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<()> {
+  let ws = workspace::discover(root)?;
+  if ws.is_empty() {
+    return Err(GwmError::EmptyWorkspace {
+      root: root.display().to_string(),
+    });
+  }
+
+  // Scan every repo upfront — resolution (config/profile) errors surface here,
+  // before any deletion.
+  let mut reclaims: Vec<clean::WorktreeReclaim> = Vec::new();
+  let mut skipped: Vec<(String, String)> = Vec::new();
+  for r in &ws.repos {
+    let repo = Repository::open(&r.path)
+      .map_err(|e| GwmError::Other(format!("workspace: cannot open repo `{}`: {e}", r.name)))?;
+    let (mut rec, mut skip) = clean_scan_repo(&repo, &slugs, profile.as_deref(), Some(&r.name), true)?;
+    reclaims.append(&mut rec);
+    skipped.append(&mut skip);
+  }
+  clean_finish(&reclaims, &skipped, yes)
+}
+
+/// One repo's clean scan: the per-worktree reclaims plus the skipped
+/// `(display-name, rel-dir)` pairs (not git-ignored / holds tracked files).
+type CleanScan = (Vec<clean::WorktreeReclaim>, Vec<(String, String)>);
+
+/// Scan one repo's targets for reclaimable artifacts, classifying each through
+/// the safety gate. Resolution (config load + `--profile` dir set) happens
+/// here, so an error surfaces before the caller deletes anything. `tag` (the
+/// workspace repo name) prefixes worktree display names with `<repo>/` for the
+/// aggregated report; `lenient` uses [`resolve_targets_lenient`] (workspace
+/// fan-out). Returns the per-worktree reclaims and the skipped `(name, rel)`s.
+fn clean_scan_repo(
+  repo: &Repository,
+  slugs: &[String],
+  profile: Option<&str>,
+  tag: Option<&str>,
+  lenient: bool,
+) -> Result<CleanScan> {
+  // Load ONLY `[clean]` (tolerant of unrelated config errors, strict on
+  // `[clean]` itself — issue #324); `None` workdir (bare repo) reads the global
+  // section and falls back to the built-in set.
+  let clean_cfg = Config::load_clean_config(repo.workdir())?;
+  let patterns = clean::resolve_clean_dirs(profile, &clean_cfg)?;
+
+  let targets = if lenient {
+    resolve_targets_lenient(repo, slugs)
+  } else {
+    resolve_targets(repo, slugs)?
+  };
+  let display = |name: &str| match tag {
+    Some(t) => format!("{t}/{name}"),
+    None => name.to_string(),
+  };
 
   // Classify every found artifact through the SAME safety gate the deletion
   // uses, BEFORE reporting — so the dry-run preview's total and promise match
-  // what `--yes` would actually remove. A default name like `dist/` / `build/`
-  // that is not git-ignored or holds tracked files is unrecoverable (clean is
-  // not journaled), so it is reported as skipped rather than counted.
-  let mut reclaims: Vec<clean::WorktreeReclaim> = Vec::with_capacity(targets.len());
-  let mut skipped: Vec<(String, String)> = Vec::new();
+  // what `--yes` would actually remove. A name that is not git-ignored or holds
+  // tracked files is unrecoverable (clean is not journaled), so it is reported
+  // as skipped rather than counted.
+  let mut reclaims = Vec::with_capacity(targets.len());
+  let mut skipped = Vec::new();
   for w in &targets {
     let scan = clean::scan_worktree(&w.name, &w.path, &patterns);
     let mut deletable = Vec::new();
@@ -1200,20 +1363,27 @@ fn cmd_clean(slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<(
       if dir_is_safe_to_clean(&w.path, &a.rel) {
         deletable.push(a);
       } else {
-        skipped.push((w.name.clone(), a.rel));
+        skipped.push((display(&w.name), a.rel));
       }
     }
     let total_bytes = deletable.iter().map(|a| a.bytes).sum();
     reclaims.push(clean::WorktreeReclaim {
-      name: w.name.clone(),
+      name: display(&w.name),
       path: w.path.clone(),
       artifacts: deletable,
       total_bytes,
     });
   }
+  Ok((reclaims, skipped))
+}
 
-  print!("{}", clean::format_report(&reclaims));
-  for (name, rel) in &skipped {
+/// Render the aggregated reclaim report and, when `yes`, delete the artifacts.
+/// Shared by the single-repo and workspace clean paths. A delete failure in
+/// one worktree is reported and counted but does not abort the rest; if any
+/// failed, the process exits non-zero.
+fn clean_finish(reclaims: &[clean::WorktreeReclaim], skipped: &[(String, String)], yes: bool) -> Result<()> {
+  print!("{}", clean::format_report(reclaims));
+  for (name, rel) in skipped {
     println!("skipped {}/{}: not git-ignored, or holds tracked files", name, rel);
   }
 
@@ -1228,10 +1398,20 @@ fn cmd_clean(slugs: Vec<String>, profile: Option<String>, yes: bool) -> Result<(
   }
 
   let mut freed = 0u64;
-  for r in &reclaims {
-    freed = freed.saturating_add(clean::delete_reclaim(r)?);
+  let mut failures = 0usize;
+  for r in reclaims {
+    match clean::delete_reclaim(r) {
+      Ok(b) => freed = freed.saturating_add(b),
+      Err(e) => {
+        eprintln!("failed to reclaim {}: {e}", r.name);
+        failures += 1;
+      }
+    }
   }
   println!("reclaimed {}", clean::human_size(freed));
+  if failures > 0 {
+    std::process::exit(1);
+  }
   Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1268,16 +1268,14 @@ fn print_exec_rollup_and_exit(outcomes: &[exec::ExecOutcome]) -> Result<()> {
 /// repo at all is an error (a typo must not silently run/clean nothing).
 fn resolve_workspace_targets(repos: &[&Repository], slugs: &[String]) -> Result<Vec<Vec<worktree::WorktreeInfo>>> {
   if slugs.is_empty() {
-    return Ok(
-      repos
-        .iter()
-        .map(|repo| {
-          worktree::list(repo)
-            .map(|ws| ws.into_iter().filter(|w| !w.is_main).collect())
-            .unwrap_or_default()
-        })
-        .collect(),
-    );
+    // Propagate a per-repo listing failure (corrupt / unreadable worktree
+    // metadata) rather than silently skipping that repo — the single-repo path
+    // surfaces it too, and the upfront-resolution contract must not let a
+    // destructive `clean --yes` proceed in the other repos while one is broken.
+    return repos
+      .iter()
+      .map(|repo| Ok(worktree::list(repo)?.into_iter().filter(|w| !w.is_main).collect()))
+      .collect();
   }
 
   let mut per_repo: Vec<Vec<worktree::WorktreeInfo>> = (0..repos.len()).map(|_| Vec::new()).collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1282,8 +1282,12 @@ impl Config {
   /// As with [`Self::load_exec_config`], EVERY `[clean.profiles.*]` is
   /// validated — a sibling profile that escapes the worktree can't slip
   /// through `gwm clean --profile good` while `gwm config validate` rejects it.
-  pub fn load_clean_config(repo_root: &Path) -> Result<CleanConfig> {
-    let cfg: CleanConfig = load_config_section(Some(repo_root), "clean")?;
+  ///
+  /// `repo_root` is `None` for a bare repo (no workdir): the repo `.gwm.toml`
+  /// is skipped but the GLOBAL `[clean]` section still applies (the built-ins
+  /// are used when no `default` profile is defined).
+  pub fn load_clean_config(repo_root: Option<&Path>) -> Result<CleanConfig> {
+    let cfg: CleanConfig = load_config_section(repo_root, "clean")?;
     for (name, p) in &cfg.profiles {
       crate::clean::validate_clean_profile_dirs(name, &p.dirs)?;
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,7 +146,7 @@ pub enum GwmError {
   /// it. Reject it elsewhere rather than silently ignoring it and acting on
   /// the current single repo — a wrong-target footgun for destructive
   /// commands like `gwm remove` (Codex review #303 P2).
-  #[error("--workspace is only supported with `gwm list`, `gwm create`, or bare `gwm` (the TUI) — refusing to run this subcommand against a single repo")]
+  #[error("--workspace is only supported with `gwm list`, `gwm create`, `gwm exec`, `gwm clean`, or bare `gwm` (the TUI) — refusing to run this subcommand against a single repo")]
   WorkspaceUnsupportedCommand,
 
   #[error("{0}")]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5341,6 +5341,34 @@ fn clean_workspace_yes_deletes_in_every_child_repo() {
 }
 
 #[test]
+fn clean_workspace_errors_before_deleting_on_a_corrupt_child_repo() {
+  // A child that looks like a repo (.git present) but won't open must fail the
+  // whole fan-out BEFORE any deletion — not be silently skipped while the valid
+  // repos get cleaned (#326 review).
+  let root = workspace_with_worktrees();
+  let wtdir = root.path().join("alpha-wt");
+  std::fs::create_dir_all(wtdir.join("target")).unwrap();
+  std::fs::write(wtdir.join("target/blob.bin"), vec![0u8; 4096]).unwrap();
+  std::fs::write(wtdir.join(".gitignore"), "/target\n").unwrap();
+  let corrupt = root.path().join("corrupt");
+  std::fs::create_dir_all(&corrupt).unwrap();
+  std::fs::write(corrupt.join(".git"), "gitdir: /nonexistent-gitdir\n").unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["clean", "--workspace"])
+    .arg(root.path())
+    .arg("--yes")
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("corrupt"));
+  // The valid repo's reclaimable target/ survives — nothing was deleted.
+  assert!(wtdir.join("target").exists(), "fan-out must fail before any deletion");
+}
+
+#[test]
 fn workspace_refuses_a_still_unsupported_subcommand() {
   // `--workspace` is still refused on commands that don't implement it (only
   // list/create/exec/clean and the bare TUI do).

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5239,6 +5239,43 @@ fn exec_fans_out_across_workspace_child_repos() {
 }
 
 #[test]
+fn exec_workspace_scopes_to_a_matching_slug() {
+  // A slug matching a worktree in only one child repo scopes the fan-out to
+  // that repo (the others contribute nothing — not an error).
+  let root = workspace_with_worktrees();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["alpha-wt", "--", "sh", "-c", "echo hi > scoped.txt"])
+    .assert()
+    .success();
+  assert!(root.path().join("alpha-wt/scoped.txt").exists(), "alpha matched");
+  assert!(
+    !root.path().join("beta-wt/scoped.txt").exists(),
+    "beta did not match the slug"
+  );
+}
+
+#[test]
+fn exec_workspace_errors_on_a_slug_matching_no_child_repo() {
+  // A typo that matches nothing in ANY child repo is an error, not a silent
+  // exit-0 having run nothing (#326 review).
+  let root = workspace_with_worktrees();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["ghost-typo", "--", "true"])
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("ghost-typo"));
+}
+
+#[test]
 fn exec_workspace_aggregates_a_nonzero_exit() {
   let root = workspace_with_worktrees();
   Command::cargo_bin("gwm")

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5176,8 +5176,12 @@ fn clean_yes_refuses_ignored_dir_holding_tracked_files() {
 
 /// Run `git <args>` in `dir`, asserting success — fixture setup helper.
 fn git_at(dir: &Path, args: &[&str]) {
+  // Pin signing off so a developer with `commit.gpgsign=true` (or a missing
+  // signing key) in their ambient git config doesn't make these fixtures fail
+  // before `gwm` is even exercised (#326 review).
   let ok = std::process::Command::new("git")
     .current_dir(dir)
+    .args(["-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"])
     .args(args)
     .status()
     .unwrap()

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5174,40 +5174,146 @@ fn clean_yes_refuses_ignored_dir_holding_tracked_files() {
   );
 }
 
-// regression: the v1.0 surface decision for `gwm exec` / `gwm clean` (issue
-// #319) is that workspace fan-out is a *deferred, additive* feature — until it
-// lands, `--workspace` against either command is refused, not silently run
-// against the single repo. The refusal is part of the frozen 1.0 contract:
-// the exit code is under the SemVer pledge (see docs/6.development/stability),
-// so a future change that makes either command silently accept `--workspace`
-// (or change its exit code) must break loudly here. Adding real fan-out later
-// is additive — a refusal turning into a success is not a breaking change.
+/// Run `git <args>` in `dir`, asserting success — fixture setup helper.
+fn git_at(dir: &Path, args: &[&str]) {
+  let ok = std::process::Command::new("git")
+    .current_dir(dir)
+    .args(args)
+    .status()
+    .unwrap()
+    .success();
+  assert!(ok, "git {args:?} in {} failed", dir.display());
+}
+
+/// A workspace root with two child repos (`alpha`, `beta`), each carrying one
+/// non-main linked worktree at `<root>/alpha-wt` / `<root>/beta-wt`. `discover`
+/// collapses each worktree onto its owning repo, so the workspace has exactly
+/// the two repos and `exec`/`clean` fan out over their worktrees.
+fn workspace_with_worktrees() -> tempfile::TempDir {
+  let root = tempfile::TempDir::new().unwrap();
+  for (repo, wt) in [("alpha", "alpha-wt"), ("beta", "beta-wt")] {
+    let repo_dir = root.path().join(repo);
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    git_at(&repo_dir, &["init", "-b", "main"]);
+    git_at(&repo_dir, &["config", "user.email", "t@t.t"]);
+    git_at(&repo_dir, &["config", "user.name", "t"]);
+    std::fs::write(repo_dir.join("README.md"), "x").unwrap();
+    git_at(&repo_dir, &["add", "."]);
+    git_at(&repo_dir, &["commit", "-m", "init"]);
+    let wt_path = root.path().join(wt);
+    git_at(
+      &repo_dir,
+      &["worktree", "add", "-b", "feat/x", wt_path.to_str().unwrap()],
+    );
+  }
+  root
+}
+
+// `gwm exec` / `gwm clean` now FAN OUT across a workspace's child repos under
+// `--workspace <root>` (issue #326), reversing the #319 deferral. This is an
+// additive transition — a previous refusal turning into a success is not a
+// breaking change. These tests pin the fan-out: a repo-tagged rollup/report
+// across every child repo, with an aggregated exit code. The `--workspace`
+// refusal now only applies to commands that still don't implement it (covered
+// by `workspace_refuses_unsupported_subcommand` below).
 
 #[test]
-fn exec_refuses_the_workspace_flag() {
-  let (dir, _base, _wt) = repo_with_one_worktree();
-  let ws = tempfile::TempDir::new().unwrap();
+fn exec_fans_out_across_workspace_child_repos() {
+  let root = workspace_with_worktrees();
   Command::cargo_bin("gwm")
     .unwrap()
-    .current_dir(dir.path())
     .env("GWM_NO_GLOBAL_CONFIG", "1")
-    .args(["exec", "--workspace", ws.path().to_str().unwrap(), "--", "echo", "hi"])
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["--", "sh", "-c", "echo ran > ws_exec_marker.txt"])
     .assert()
-    .failure()
-    // Exact exit code is frozen: every GwmError maps to 1 (src/main.rs).
-    .code(1)
-    .stderr(predicate::str::contains("--workspace is only supported"));
+    .success()
+    // A `══ <repo>` header per child repo, and a repo-tagged rollup.
+    .stdout(predicate::str::contains("══ alpha"))
+    .stdout(predicate::str::contains("══ beta"))
+    .stdout(predicate::str::contains("✓ alpha/"))
+    .stdout(predicate::str::contains("✓ beta/"));
+  // The command actually ran in each child repo's worktree.
+  assert!(root.path().join("alpha-wt/ws_exec_marker.txt").exists());
+  assert!(root.path().join("beta-wt/ws_exec_marker.txt").exists());
 }
 
 #[test]
-fn clean_refuses_the_workspace_flag() {
+fn exec_workspace_aggregates_a_nonzero_exit() {
+  let root = workspace_with_worktrees();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["--", "sh", "-c", "exit 3"])
+    .assert()
+    .failure()
+    .stdout(predicate::str::contains("✗ alpha/"))
+    .stdout(predicate::str::contains("✗ beta/"));
+}
+
+#[test]
+fn clean_fans_out_across_workspace_child_repos() {
+  let root = workspace_with_worktrees();
+  // A git-ignored `target/` in each child repo's worktree is reclaimable.
+  for (repo, wt) in [("alpha", "alpha-wt"), ("beta", "beta-wt")] {
+    let _ = repo;
+    let wtdir = root.path().join(wt);
+    std::fs::create_dir_all(wtdir.join("target")).unwrap();
+    std::fs::write(wtdir.join("target/blob.bin"), vec![0u8; 4096]).unwrap();
+    std::fs::write(wtdir.join(".gitignore"), "/target\n").unwrap();
+  }
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["clean", "--workspace"])
+    .arg(root.path())
+    .assert()
+    .success()
+    // Report is repo-tagged; report-only must not delete.
+    .stdout(predicate::str::contains("alpha/"))
+    .stdout(predicate::str::contains("beta/"))
+    .stdout(predicate::str::contains("re-run with --yes"));
+  assert!(
+    root.path().join("alpha-wt/target").exists(),
+    "report-only keeps target/"
+  );
+}
+
+#[test]
+fn clean_workspace_yes_deletes_in_every_child_repo() {
+  let root = workspace_with_worktrees();
+  for wt in ["alpha-wt", "beta-wt"] {
+    let wtdir = root.path().join(wt);
+    std::fs::create_dir_all(wtdir.join("target")).unwrap();
+    std::fs::write(wtdir.join("target/blob.bin"), vec![0u8; 4096]).unwrap();
+    std::fs::write(wtdir.join(".gitignore"), "/target\n").unwrap();
+  }
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["clean", "--workspace"])
+    .arg(root.path())
+    .arg("--yes")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("reclaimed"));
+  assert!(!root.path().join("alpha-wt/target").exists());
+  assert!(!root.path().join("beta-wt/target").exists());
+}
+
+#[test]
+fn workspace_refuses_a_still_unsupported_subcommand() {
+  // `--workspace` is still refused on commands that don't implement it (only
+  // list/create/exec/clean and the bare TUI do).
   let (dir, _base, _wt) = repo_with_one_worktree();
   let ws = tempfile::TempDir::new().unwrap();
   Command::cargo_bin("gwm")
     .unwrap()
     .current_dir(dir.path())
     .env("GWM_NO_GLOBAL_CONFIG", "1")
-    .args(["clean", "--workspace", ws.path().to_str().unwrap()])
+    .args(["sync", "--workspace", ws.path().to_str().unwrap()])
     .assert()
     .failure()
     .code(1)

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5259,6 +5259,28 @@ fn exec_workspace_scopes_to_a_matching_slug() {
 }
 
 #[test]
+fn exec_workspace_scoped_slug_ignores_an_unrelated_repos_missing_profile() {
+  // Only `alpha` defines `[exec.profiles.fmt]`; `beta` has none. Scoping to
+  // `alpha-wt` must not resolve `beta`'s config (it contributes no target), so
+  // the run succeeds despite `beta` lacking the profile (#326 review).
+  let root = workspace_with_worktrees();
+  std::fs::write(
+    root.path().join("alpha/.gwm.toml"),
+    "[exec.profiles.fmt]\ncommand = [\"sh\", \"-c\", \"echo hi > prof.txt\"]\n",
+  )
+  .unwrap();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["alpha-wt", "--profile", "fmt"])
+    .assert()
+    .success();
+  assert!(root.path().join("alpha-wt/prof.txt").exists(), "alpha's profile ran");
+}
+
+#[test]
 fn exec_workspace_errors_on_a_slug_matching_no_child_repo() {
   // A typo that matches nothing in ANY child repo is an error, not a silent
   // exit-0 having run nothing (#326 review).

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -5209,6 +5209,23 @@ fn workspace_with_worktrees() -> tempfile::TempDir {
   root
 }
 
+/// A workspace root with two child repos that have ONLY their main checkout
+/// (no linked worktrees) — so exec/clean fan-out finds no targets anywhere.
+fn workspace_main_only() -> tempfile::TempDir {
+  let root = tempfile::TempDir::new().unwrap();
+  for repo in ["alpha", "beta"] {
+    let repo_dir = root.path().join(repo);
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    git_at(&repo_dir, &["init", "-b", "main"]);
+    git_at(&repo_dir, &["config", "user.email", "t@t.t"]);
+    git_at(&repo_dir, &["config", "user.name", "t"]);
+    std::fs::write(repo_dir.join("README.md"), "x").unwrap();
+    git_at(&repo_dir, &["add", "."]);
+    git_at(&repo_dir, &["commit", "-m", "init"]);
+  }
+  root
+}
+
 // `gwm exec` / `gwm clean` now FAN OUT across a workspace's child repos under
 // `--workspace <root>` (issue #326), reversing the #319 deferral. This is an
 // additive transition — a previous refusal turning into a success is not a
@@ -5388,6 +5405,69 @@ fn clean_workspace_errors_before_deleting_on_a_corrupt_child_repo() {
     .stderr(predicate::str::contains("corrupt"));
   // The valid repo's reclaimable target/ survives — nothing was deleted.
   assert!(wtdir.join("target").exists(), "fan-out must fail before any deletion");
+}
+
+#[test]
+fn exec_workspace_all_empty_errors_on_a_missing_command() {
+  // Every repo is main-only (no targets), but a usage error (neither inline
+  // command nor --profile) must still surface, not a silent exit 0 (#326 rev).
+  let root = workspace_main_only();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("provide a command"));
+}
+
+#[test]
+fn exec_workspace_all_empty_errors_on_an_unknown_profile() {
+  let root = workspace_main_only();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["--profile", "ghost"])
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("no profile named `ghost`"));
+}
+
+#[test]
+fn exec_workspace_all_empty_inline_command_exits_zero() {
+  // A valid inline command with no targets anywhere is "nothing to do", exit 0.
+  let root = workspace_main_only();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["exec", "--workspace"])
+    .arg(root.path())
+    .args(["--", "true"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("no worktrees to run in"));
+}
+
+#[test]
+fn clean_workspace_all_empty_errors_on_an_unknown_profile() {
+  // A typo'd `--profile` with no targets anywhere must surface, not silently
+  // report "nothing to reclaim" (#326 review).
+  let root = workspace_main_only();
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
+    .args(["clean", "--workspace"])
+    .arg(root.path())
+    .args(["--profile", "ghost", "--yes"])
+    .assert()
+    .failure()
+    .code(1)
+    .stderr(predicate::str::contains("no profile named `ghost`"));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Reverses the #319 deferral: `gwm exec` / `gwm clean` now accept the global `--workspace <root>` flag and **fan out across the workspace's child repos**, completing the exec/clean 1.0 surface. Builds on #324 (config profiles + `--jobs`).

Closes #326 · Refs #319

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **Guard** (`src/cli.rs`): `--workspace` now allowed on `Exec` / `Clean` (alongside `List` / `Create`); the `WorkspaceUnsupportedCommand` message + refusal stay for the rest.
- **exec**: `exec_plan` (config + argv + jobs, no side effects) + `exec_run` (seq/parallel run, repo-tag-aware) + `print_exec_rollup_and_exit`. `cmd_exec_workspace` resolves **every repo upfront**, then runs repos **sequentially** (parallelism stays bounded *within* a repo — no cross-repo interleaving) under a `══ <repo>` header, `<repo>/<worktree>`-tagged rollup, aggregated exit code.
- **clean**: `clean_scan_repo` + `clean_finish`. `cmd_clean_workspace` scans every repo upfront (errors before any `remove_dir_all`), one aggregated report → one `--yes` decision; a delete failure in one worktree is reported but doesn't abort the rest.
- `resolve_targets_lenient`: a slug matching nothing in a child repo contributes nothing there (no hard abort).
- `Config::load_clean_config(Option<&Path>)`: bare child repo → global `[clean]` + built-ins (mirrors #324b exec fallback).
- `error.rs`: message enumerates exec/clean.

## Frozen-surface reversal (one pass)

- The **two #319 freeze tests** (`exec_refuses` / `clean_refuses_the_workspace_flag`) are **inverted** to `exec_fans_out` / `clean_fans_out` and rewritten to pin the repo-tagged rollup/report + aggregated exit. Their comment block is rewritten.
- `workspace_refuses_a_still_unsupported_subcommand` keeps the refusal contract for other commands.
- CHANGELOG `[Unreleased]`: #326 entry + amended #319 `--workspace` clause.
- Docs EN+FR (Workspace mode section + examples).

## Tests (TDD)

- [x] `cargo test` passes locally (full suite green, 77 binaries)
- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` pass
- [x] New: `exec_fans_out_across_workspace_child_repos`, `exec_workspace_aggregates_a_nonzero_exit`, `clean_fans_out_across_workspace_child_repos`, `clean_workspace_yes_deletes_in_every_child_repo`, `workspace_refuses_a_still_unsupported_subcommand`, `workspace_with_worktrees` fixture
- [x] `gwm doctor` clean

## Checklist

- [x] Branch `<type>/#<issue>-<description>`; Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated; docs EN+FR updated
- [x] No `unwrap()` on user-facing paths

## Notes for reviewers

Per-repo profile resolution is the complete model (each child repo resolves its own `.gwm.toml`). Resolve-everything-upfront-then-act guarantees a missing profile / config error / unopenable child surfaces before any side effect (esp. before `clean --yes` deletes). Repos run sequentially by design (cross-repo parallelism would interleave output).

https://claude.ai/code/session_01RbvbQ6HsSW16gWdzBqbAFN