### PR TITLE
✨ feat(tui): exec / clean overlays (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TUI exec / clean overlays** (issue #325). The ratatui interface gains two
+  overlays over the worktree list: `x` opens an **exec picker** that lists the
+  `[exec.profiles.*]` names and, on `Enter`, runs the highlighted profile's
+  `command` array — with no shell — in the embedded PTY overlay rooted at the
+  selected worktree; `X` opens a **clean overlay** that previews the
+  reclaimable build artifacts (gated by the exact git-ignored + no-tracked-files
+  safety check `gwm clean --yes` uses) and deletes them behind the same safety
+  countdown as the delete confirm. Both overlays' keys are rebindable under
+  `[tui.keys.modal.exec]` / `[tui.keys.modal.clean]`, and `:exec` / `:clean`
+  reach them from the command palette. The exec overlay runs on the single
+  selected worktree (one PTY cannot fan out, unlike the CLI `--workspace`); the
+  clean safety gate (`dir_is_safe_to_clean` / `scan_worktree_safe`) is now
+  shared between the CLI and the overlay so both honour the identical contract.
+  This is a TUI-only surface — the frozen 1.0 machine contract (config
+  sections, CLI flags) is unchanged.
+
 - **`--workspace` fan-out for `gwm exec` / `gwm clean`** (issue #326). Both
   commands now accept the global `--workspace <root>` flag and fan out across
   the workspace's child repos, **reversing the #319 deferral** (the refusal

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -75,6 +75,8 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `2`         | open (if hidden) and focus the status pane (`focus_status`)                                       |
 | `3`         | open the Command Logs overlay (`command_logs`) — scrollable transcript of the commands gwm ran    |
 | `4`         | open the [Settings panel](#settings-panel-4) (`config_panel`) — edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column |
+| `x`         | open the [exec picker overlay](#exec-picker-overlay-x) (`exec_overlay`) — pick a [`[exec.profiles]`](/configuration/gwm-toml#exec) profile and run it in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) on the selected worktree |
+| `X`         | open the [clean overlay](#clean-overlay-x) (`clean_overlay`) — preview and reclaim build artifacts in the selected worktree (safety countdown before deleting) |
 | `/`         | open the [fuzzy filter](/tui/filter) bar (`filter`; `Enter` confirms · `Esc` clears)              |
 | `:`         | open the [command palette](/tui/keymap-and-palette#command-palette) (`command_palette`)           |
 | `Enter`     | show selected path in status bar                                                                  |
@@ -184,6 +186,42 @@ number.
 | `p`       | open the linked PR in the browser (`pr`) |
 | `Enter`   | open the highlighted target (`accept`)|
 | `Esc` / `q` | dismiss (`close`)                   |
+
+## exec picker overlay (`x`)
+
+Lists the `[exec.profiles.*]` names; `Enter` resolves the highlight to its
+`command` array and runs it — **with no shell** — in an embedded PTY overlay
+rooted at the selected worktree (the same overlay `l` / `r` use). Refuses to
+open with a status-bar hint when no `[exec.profiles]` are configured. Unlike
+the CLI `gwm exec --workspace`, the overlay runs the profile in the **single**
+selected worktree (one PTY cannot fan out).
+
+| Key            | Verb (`[tui.keys.modal.exec]`)        |
+|:---------------|:--------------------------------------|
+| `j` / `↓`      | next profile (`next`)                 |
+| `k` / `↑`      | previous profile (`prev`)             |
+| `Enter`        | run the highlighted profile (`accept`)|
+| `Esc`          | cancel (`cancel`)                     |
+
+## clean overlay (`X`)
+
+Previews the reclaimable build artifacts in the selected worktree and deletes
+them on confirmation. The scan is gated by the **exact** safety check
+`gwm clean --yes` uses — only directories git treats as ignored **and** holding
+no tracked files are counted; anything else is listed as *skipped* and never
+touched. When `[clean.profiles]` are configured, `j` / `k` cycle them
+(re-scanning each time); otherwise the built-in `target` / `node_modules` /
+`dist` / `build` set is used. The confirm key arms the same safety countdown as
+the [delete-confirm overlay](/tui/confirm-countdown) (driven by
+`[tui] confirm_countdown_secs`); a second confirm or `Esc` disarms it, and the
+reclaim fires automatically when the countdown elapses.
+
+| Key            | Verb (`[tui.keys.modal.clean]`)       |
+|:---------------|:--------------------------------------|
+| `j` / `↓`      | next profile (`next`)                 |
+| `k` / `↑`      | previous profile (`prev`)             |
+| `y` / `Enter`  | arm / fire the reclaim (`confirm`)    |
+| `n` / `Esc`    | cancel / disarm (`cancel`)            |
 
 ## help overlay (`?`)
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -216,6 +216,10 @@ the [delete-confirm overlay](/tui/confirm-countdown) (driven by
 `[tui] confirm_countdown_secs`); a second confirm or `Esc` disarms it, and the
 reclaim fires automatically when the countdown elapses.
 
+> The scan runs **synchronously** when the overlay opens, so opening it on a
+> very large `target/` can briefly block the UI while the sizes are computed.
+> Moving the scan onto the off-thread spine (#231) is a follow-up.
+
 | Key            | Verb (`[tui.keys.modal.clean]`)       |
 |:---------------|:--------------------------------------|
 | `j` / `↓`      | next profile (`next`)                 |

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -209,9 +209,11 @@ Previews the reclaimable build artifacts in the selected worktree and deletes
 them on confirmation. The scan is gated by the **exact** safety check
 `gwm clean --yes` uses — only directories git treats as ignored **and** holding
 no tracked files are counted; anything else is listed as *skipped* and never
-touched. When `[clean.profiles]` are configured, `j` / `k` cycle them
-(re-scanning each time); otherwise the built-in `target` / `node_modules` /
-`dist` / `build` set is used. The confirm key arms the same safety countdown as
+touched. The picker always opens on a `(default)` choice — the set `gwm clean`
+resolves with no `--profile` (the built-in `target` / `node_modules` / `dist` /
+`build`, or `[clean.profiles.default]` when defined) — followed by any
+configured `[clean.profiles]`; `j` / `k` cycle them, re-scanning each time. The
+confirm key arms the same safety countdown as
 the [delete-confirm overlay](/tui/confirm-countdown) (driven by
 `[tui] confirm_countdown_secs`); a second confirm or `Esc` disarms it, and the
 reclaim fires automatically when the countdown elapses.

--- a/docs/2.tui/index.md
+++ b/docs/2.tui/index.md
@@ -15,6 +15,7 @@ Bare `gwm` (no arguments) opens the ratatui interface on the current repo. From 
 - **[Confirm-overlay countdown](/tui/confirm-countdown)** — the safety countdown that prevents accidental branch deletions when `D` is armed.
 - **[Configurable launchers](/tui/launchers)** — `[git_tui]` (`l` overlay / `L` fullscreen) and `[review]` (`r` overlay / `R` fullscreen), with `{base} {head} {path} {diff}` placeholders and the embedded PTY overlay.
 - **[Open dispatch](/tui/open-dispatch)** — `o` opens a terminal in an embedded PTY overlay; `O` runs the `[tui.open]` dispatch (`shell` / `editor` / `finder`).
+- **[Exec / clean overlays](/tui/keybindings#exec-picker-overlay-x)** — `x` picks an `[exec.profiles]` profile and runs it in a PTY overlay; `X` previews and reclaims build artifacts (same git-ignored safety gate as `gwm clean --yes`, behind a confirm countdown).
 - **[Themes](/tui/themes)** — role-based `[theme]` colours and the built-in presets (`catppuccin`, `gruvbox`, `tokyo-night`, `claude-dark`).
 - **[Keymap & command palette](/tui/keymap-and-palette)** — remap any binding via `[tui.keys]` (with chord support), or fire an action by name from the `:` palette.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -224,6 +224,10 @@ confirmation arme le même compte à rebours de sécurité que la
 `[tui] confirm_countdown_secs`) ; une seconde confirmation ou `Esc` le désarme,
 et la récupération se déclenche automatiquement à la fin du compte à rebours.
 
+> Le scan est **synchrone** à l'ouverture de la surcouche : l'ouvrir sur un très
+> gros `target/` peut donc bloquer brièvement l'UI le temps de calculer les
+> tailles. Le passage du scan sur le moteur off-thread (#231) est un suivi.
+
 | Touche         | Verbe (`[tui.keys.modal.clean]`)      |
 |:---------------|:--------------------------------------|
 | `j` / `↓`      | profil suivant (`next`)               |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -216,9 +216,11 @@ Prévisualise les artefacts de build récupérables dans le worktree sélectionn
 les supprime sur confirmation. Le scan est filtré par le **même** garde-fou de
 sécurité que `gwm clean --yes` : seuls les répertoires que git considère ignorés
 **et** ne contenant aucun fichier suivi sont comptés ; tout le reste est listé
-comme *ignoré* et jamais touché. Quand des `[clean.profiles]` sont configurés,
-`j` / `k` les font défiler (avec re-scan à chaque fois) ; sinon le jeu intégré
-`target` / `node_modules` / `dist` / `build` est utilisé. La touche de
+comme *ignoré* et jamais touché. Le picker ouvre toujours sur un choix
+`(default)` — le jeu que `gwm clean` résout sans `--profile` (l'intégré
+`target` / `node_modules` / `dist` / `build`, ou `[clean.profiles.default]` s'il
+est défini) — suivi des `[clean.profiles]` configurés ; `j` / `k` les font
+défiler (avec re-scan à chaque fois). La touche de
 confirmation arme le même compte à rebours de sécurité que la
 [surcouche de confirmation de suppression](/fr/tui/confirm-countdown) (piloté par
 `[tui] confirm_countdown_secs`) ; une seconde confirmation ou `Esc` le désarme,

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -79,6 +79,8 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (`focus_status`)                       |
 | `3`         | ouvrir l'overlay Command Logs (`command_logs`) — transcription scrollable des commandes lancées par gwm |
 | `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) (`config_panel`) — éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne |
+| `x`         | ouvrir la [surcouche de sélection exec](#surcouche-de-sélection-exec-x) (`exec_overlay`) — choisir un profil [`[exec.profiles]`](/fr/configuration/gwm-toml#exec) et le lancer dans une [surcouche PTY](/fr/tui/launchers#la-surcouche-pty-embarquée-l--r) sur le worktree sélectionné |
+| `X`         | ouvrir la [surcouche de nettoyage](#surcouche-de-nettoyage-x) (`clean_overlay`) — prévisualiser et récupérer l'espace des artefacts de build du worktree sélectionné (compte à rebours de sécurité avant suppression) |
 | `/`         | ouvrir la barre de [filtre flou](/fr/tui/filter) (`filter` ; `Enter` confirme · `Esc` efface)     |
 | `:`         | ouvrir la [palette de commandes](/fr/tui/keymap-and-palette#palette-de-commandes) (`command_palette`) |
 | `Enter`     | afficher le chemin sélectionné dans la barre de statut                                            |
@@ -190,6 +192,44 @@ prend le numéro.
 | `p`         | ouvrir la PR liée dans le navigateur (`pr`) |
 | `Enter`     | ouvrir la cible surlignée (`accept`)  |
 | `Esc` / `q` | fermer (`close`)                      |
+
+## surcouche de sélection exec (`x`)
+
+Liste les noms `[exec.profiles.*]` ; `Enter` résout la ligne en surbrillance
+vers son tableau `command` et le lance — **sans shell** — dans une surcouche PTY
+embarquée ancrée au worktree sélectionné (la même surcouche que `l` / `r`).
+Refuse de s'ouvrir avec un message en barre de statut quand aucun
+`[exec.profiles]` n'est configuré. Contrairement à `gwm exec --workspace` en
+CLI, la surcouche lance le profil dans l'**unique** worktree sélectionné (un seul
+PTY ne peut pas faire de fan-out).
+
+| Touche         | Verbe (`[tui.keys.modal.exec]`)       |
+|:---------------|:--------------------------------------|
+| `j` / `↓`      | profil suivant (`next`)               |
+| `k` / `↑`      | profil précédent (`prev`)             |
+| `Enter`        | lancer le profil sélectionné (`accept`)|
+| `Esc`          | annuler (`cancel`)                    |
+
+## surcouche de nettoyage (`X`)
+
+Prévisualise les artefacts de build récupérables dans le worktree sélectionné et
+les supprime sur confirmation. Le scan est filtré par le **même** garde-fou de
+sécurité que `gwm clean --yes` : seuls les répertoires que git considère ignorés
+**et** ne contenant aucun fichier suivi sont comptés ; tout le reste est listé
+comme *ignoré* et jamais touché. Quand des `[clean.profiles]` sont configurés,
+`j` / `k` les font défiler (avec re-scan à chaque fois) ; sinon le jeu intégré
+`target` / `node_modules` / `dist` / `build` est utilisé. La touche de
+confirmation arme le même compte à rebours de sécurité que la
+[surcouche de confirmation de suppression](/fr/tui/confirm-countdown) (piloté par
+`[tui] confirm_countdown_secs`) ; une seconde confirmation ou `Esc` le désarme,
+et la récupération se déclenche automatiquement à la fin du compte à rebours.
+
+| Touche         | Verbe (`[tui.keys.modal.clean]`)      |
+|:---------------|:--------------------------------------|
+| `j` / `↓`      | profil suivant (`next`)               |
+| `k` / `↑`      | profil précédent (`prev`)             |
+| `y` / `Enter`  | armer / déclencher la récupération (`confirm`) |
+| `n` / `Esc`    | annuler / désarmer (`cancel`)         |
 
 ## surcouche d'aide (`?`)
 

--- a/docs/fr/2.tui/index.md
+++ b/docs/fr/2.tui/index.md
@@ -15,6 +15,7 @@ Lancer `gwm` sans argument ouvre l'interface ratatui sur le dépôt courant. De 
 - **[Compte à rebours de la surcouche de confirmation](/fr/tui/confirm-countdown)** — le compte à rebours de sécurité qui empêche les suppressions accidentelles de branches lorsque `D` est armé.
 - **[Lanceurs configurables](/fr/tui/launchers)** — `[git_tui]` (`l` overlay / `L` plein écran) et `[review]` (`r` overlay / `R` plein écran), avec les placeholders `{base} {head} {path} {diff}` et l'overlay PTY embarqué.
 - **[Dispatch d'ouverture](/fr/tui/open-dispatch)** — `o` ouvre un terminal dans un overlay PTY embarqué ; `O` exécute le dispatch `[tui.open]` (`shell` / `editor` / `finder`).
+- **[Surcouches exec / clean](/fr/tui/keybindings#surcouche-de-sélection-exec-x)** — `x` choisit un profil `[exec.profiles]` et le lance dans une surcouche PTY ; `X` prévisualise et récupère l'espace des artefacts de build (même garde-fou git-ignore que `gwm clean --yes`, derrière un compte à rebours de confirmation).
 - **[Thèmes](/fr/tui/themes)** — couleurs `[theme]` basées sur des rôles et presets intégrés (`catppuccin`, `gruvbox`, `tokyo-night`, `claude-dark`).
 - **[Keymap & palette de commandes](/fr/tui/keymap-and-palette)** — remappez n'importe quel binding via `[tui.keys]` (avec support des chords), ou déclenchez une action par son nom depuis la palette `:`.
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -289,3 +289,81 @@ pub fn format_report(reclaims: &[WorktreeReclaim]) -> String {
   out.push_str(&format!("\nTotal reclaimable: {}\n", human_size(grand)));
   out
 }
+
+/// The safety gate for deleting an artifact directory: a directory is safe
+/// to delete only when git treats `rel` (relative to `worktree`) as ignored
+/// AND it holds no tracked files. The ignore check alone is not enough — git
+/// tracks files, not directories, so a force-added `dist/index.html` can
+/// survive under a `dist/` ignore rule, and `remove_dir_all` would otherwise
+/// destroy that tracked (possibly edited) file. Every failure path resolves
+/// conservatively to "not safe" (preserve).
+///
+/// Shared by `gwm clean` (CLI) and the TUI clean overlay (issue #325) so both
+/// honour the identical contract — a raw [`scan_worktree`] + [`delete_reclaim`]
+/// would bypass this gate.
+pub fn dir_is_safe_to_clean(worktree: &Path, rel: &str) -> bool {
+  dir_is_git_ignored(worktree, rel) && !dir_has_tracked_files(worktree, rel)
+}
+
+/// Whether git considers `rel` (relative to `worktree`) ignored. Shells out to
+/// `git check-ignore -q -- <rel>` (exit 0 = ignored). Any failure (git missing,
+/// not a repo) is treated as "not ignored" so the default is to preserve.
+///
+/// The `--` delimiter is required: with a config-supplied `[clean.profiles]`
+/// dir, a name like `-cache` would otherwise be parsed by git as an option and
+/// the directory would always read as "not ignored" (skipped). `ls-files`
+/// below already passes `--` for the same reason.
+fn dir_is_git_ignored(worktree: &Path, rel: &str) -> bool {
+  std::process::Command::new("git")
+    .arg("-C")
+    .arg(worktree)
+    .args(["check-ignore", "-q", "--", rel])
+    .status()
+    .map(|s| s.success())
+    .unwrap_or(false)
+}
+
+/// Whether any tracked file lives under `rel`. `git ls-files -- <rel>` prints
+/// one line per tracked path; non-empty stdout ⇒ tracked content present. On
+/// any error we assume `true` (tracked) so the safety gate errs toward
+/// preserving the directory.
+fn dir_has_tracked_files(worktree: &Path, rel: &str) -> bool {
+  std::process::Command::new("git")
+    .arg("-C")
+    .arg(worktree)
+    .args(["ls-files", "--", rel])
+    .output()
+    .map(|o| !o.status.success() || !o.stdout.is_empty())
+    .unwrap_or(true)
+}
+
+/// Scan `path` for `patterns`, then keep only the artifacts that pass
+/// [`dir_is_safe_to_clean`]. Returns the gated [`WorktreeReclaim`] (its
+/// `total_bytes` reflecting only the deletable artifacts) plus the rejected
+/// directory names, so the caller can report what it preserved.
+///
+/// This is the safe entry point both `gwm clean` and the TUI clean overlay
+/// (issue #325) use — a raw [`scan_worktree`] feeding [`delete_reclaim`] would
+/// bypass the gate and could destroy tracked files.
+pub fn scan_worktree_safe(name: &str, path: &Path, patterns: &[String]) -> (WorktreeReclaim, Vec<String>) {
+  let scan = scan_worktree(name, path, patterns);
+  let mut deletable = Vec::new();
+  let mut skipped = Vec::new();
+  for a in scan.artifacts {
+    if dir_is_safe_to_clean(path, &a.rel) {
+      deletable.push(a);
+    } else {
+      skipped.push(a.rel);
+    }
+  }
+  let total_bytes = deletable.iter().map(|a| a.bytes).sum();
+  (
+    WorktreeReclaim {
+      name: name.to_string(),
+      path: path.to_path_buf(),
+      artifacts: deletable,
+      total_bytes,
+    },
+    skipped,
+  )
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1461,26 +1461,17 @@ fn clean_scan_repo(
   // uses, BEFORE reporting — so the dry-run preview's total and promise match
   // what `--yes` would actually remove. A name that is not git-ignored or holds
   // tracked files is unrecoverable (clean is not journaled), so it is reported
-  // as skipped rather than counted.
+  // as skipped rather than counted. The gate lives in `clean::scan_worktree_safe`
+  // so the TUI clean overlay (#325) reuses the identical contract.
   let mut reclaims = Vec::with_capacity(targets.len());
   let mut skipped = Vec::new();
   for w in targets {
-    let scan = clean::scan_worktree(&w.name, &w.path, &patterns);
-    let mut deletable = Vec::new();
-    for a in scan.artifacts {
-      if dir_is_safe_to_clean(&w.path, &a.rel) {
-        deletable.push(a);
-      } else {
-        skipped.push((display(&w.name), a.rel));
-      }
+    let (mut reclaim, skips) = clean::scan_worktree_safe(&w.name, &w.path, &patterns);
+    reclaim.name = display(&w.name);
+    for rel in skips {
+      skipped.push((display(&w.name), rel));
     }
-    let total_bytes = deletable.iter().map(|a| a.bytes).sum();
-    reclaims.push(clean::WorktreeReclaim {
-      name: display(&w.name),
-      path: w.path.clone(),
-      artifacts: deletable,
-      total_bytes,
-    });
+    reclaims.push(reclaim);
   }
   Ok((reclaims, skipped))
 }
@@ -1521,48 +1512,6 @@ fn clean_finish(reclaims: &[clean::WorktreeReclaim], skipped: &[(String, String)
     std::process::exit(1);
   }
   Ok(())
-}
-
-/// The safety gate for `gwm clean --yes`: a directory is safe to delete only
-/// when git treats it as ignored AND it holds no tracked files. The ignore
-/// check alone is not enough — git tracks files, not directories, so a force
-/// added `dist/index.html` can survive under a `dist/` ignore rule, and
-/// `remove_dir_all` would otherwise destroy that tracked (possibly edited)
-/// file. Every failure path resolves conservatively to "not safe" (preserve).
-fn dir_is_safe_to_clean(worktree: &Path, rel: &str) -> bool {
-  dir_is_git_ignored(worktree, rel) && !dir_has_tracked_files(worktree, rel)
-}
-
-/// Whether git considers `rel` (relative to `worktree`) ignored. Shells out to
-/// `git check-ignore -q -- <rel>` (exit 0 = ignored). Any failure (git missing,
-/// not a repo) is treated as "not ignored" so the default is to preserve.
-///
-/// The `--` delimiter is required: with a config-supplied `[clean.profiles]`
-/// dir, a name like `-cache` would otherwise be parsed by git as an option and
-/// the directory would always read as "not ignored" (skipped). `ls-files`
-/// below already passes `--` for the same reason.
-fn dir_is_git_ignored(worktree: &Path, rel: &str) -> bool {
-  std::process::Command::new("git")
-    .arg("-C")
-    .arg(worktree)
-    .args(["check-ignore", "-q", "--", rel])
-    .status()
-    .map(|s| s.success())
-    .unwrap_or(false)
-}
-
-/// Whether any tracked file lives under `rel`. `git ls-files -- <rel>` prints
-/// one line per tracked path; non-empty stdout ⇒ tracked content present. On
-/// any error we assume `true` (tracked) so the safety gate errs toward
-/// preserving the directory.
-fn dir_has_tracked_files(worktree: &Path, rel: &str) -> bool {
-  std::process::Command::new("git")
-    .arg("-C")
-    .arg(worktree)
-    .args(["ls-files", "--", rel])
-    .output()
-    .map(|o| !o.status.success() || !o.stdout.is_empty())
-    .unwrap_or(true)
 }
 
 /// Auto-detect prompt for bare `gwm` (issue #36): when the cwd is not inside a

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2224,10 +2224,33 @@ impl App {
   /// so this only removes what the CLI `gwm clean --yes` would. Reports the
   /// freed size (or the failure) on the status bar.
   pub fn clean_overlay_delete(&mut self) {
-    let Some(reclaim) = self.clean_overlay.reclaim().cloned() else {
+    // Re-scan + re-gate IMMEDIATELY before deleting rather than trusting the
+    // snapshot shown in the overlay (Codex #333 review). That snapshot can be
+    // seconds old — the safety countdown, or just the overlay sitting open —
+    // and a directory may have turned unsafe meanwhile (e.g. `git add -f
+    // target/file` under an ignored `target/`). Deleting a freshly gated
+    // reclaim closes that TOCTOU window, matching the CLI's scan-then-delete.
+    let Some(sel) = self.selected() else {
       self.close_clean_overlay();
       return;
     };
+    let name = sel.name.clone();
+    let path = sel.path.clone();
+    let profile = self.clean_overlay.selected_profile().map(str::to_string);
+    let dirs = match crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean) {
+      Ok(d) => d,
+      Err(e) => {
+        self.status = format!("clean: {e}");
+        self.close_clean_overlay();
+        return;
+      }
+    };
+    let (reclaim, _skipped) = crate::clean::scan_worktree_safe(&name, &path, &dirs);
+    if reclaim.artifacts.is_empty() {
+      self.status = "nothing to reclaim".into();
+      self.close_clean_overlay();
+      return;
+    }
     match crate::clean::delete_reclaim(&reclaim) {
       Ok(freed) => {
         self.status = format!("reclaimed {} from {}", crate::clean::human_size(freed), reclaim.name);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,7 +17,7 @@ use super::state::spinner::Spinner;
 use super::theme::Theme;
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::BranchType;
-use crate::config::{Config, TuiOpenConfig, TuiOpenMode};
+use crate::config::{CleanConfig, Config, ExecConfig, TuiOpenConfig, TuiOpenMode};
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, PrStatus};
 use crate::launcher::{self, ExpandedCommand, LauncherContext};
@@ -444,11 +444,24 @@ pub struct App {
   /// ([`PtyKind::Exec`]) in the selected worktree's directory.
   pub exec_picker: ExecPicker,
 
+  /// The `[exec]` config captured when the exec picker opened (issue #325).
+  /// In workspace mode `sync_active_repo` can swap `self.config` to another
+  /// repo while the overlay is open, so `Enter` resolves the argv against
+  /// this snapshot — the active repo's `[exec]` at open time — not the live
+  /// config (Codex #333 review).
+  exec_picker_cfg: ExecConfig,
+
   /// Clean overlay state (issue #325). Holds the gated reclaim scan of the
   /// selected worktree, the `[clean.profiles.*]` picker, and a dedicated
   /// safety countdown. Filled by [`Self::enter_clean_overlay`]; the run loop
   /// fires [`crate::clean::delete_reclaim`] when the countdown elapses.
   pub clean_overlay: CleanOverlay,
+
+  /// The `[clean]` config captured when the clean overlay opened (issue
+  /// #325) — every re-scan and the delete resolve their dir-set against this
+  /// snapshot, not the live `self.config.clean`, which a workspace
+  /// auto-refresh could swap to another repo's (Codex #333 review).
+  clean_overlay_cfg: CleanConfig,
 
   /// Set by `Action::ExitToWorktree` (#290): the path the main loop
   /// should print to stdout just before quitting so the shell wrapper
@@ -559,7 +572,9 @@ impl App {
       global_path: global_path.map(Path::to_path_buf),
       pty_overlay: None,
       exec_picker: ExecPicker::new(),
+      exec_picker_cfg: ExecConfig::default(),
       clean_overlay: CleanOverlay::new(),
+      clean_overlay_cfg: CleanConfig::default(),
       should_exit_to: None,
       edit_original_branch: None,
       edit_original_path: None,
@@ -2060,9 +2075,12 @@ impl App {
       self.status = "no [exec.profiles] configured — add one to .gwm.toml".into();
       return;
     }
-    // Capture the target worktree path now: an auto-refresh can drift the live
-    // selection while the picker is open, so `Enter` must run in *this*
-    // worktree, not whatever is selected later (Codex #333 review).
+    // Capture the target worktree path AND the active repo's `[exec]` config
+    // now: an auto-refresh can drift the live selection (and, in workspace
+    // mode, the active repo) while the picker is open, so `Enter` must run in
+    // *this* worktree against *this* config — not whatever is live later
+    // (Codex #333 review).
+    self.exec_picker_cfg = self.config.exec.clone();
     self.exec_picker.open(names, cwd);
     self.view = View::ExecPicker;
   }
@@ -2101,7 +2119,8 @@ impl App {
       self.status = "nothing selected".into();
       return None;
     };
-    match crate::exec::resolve_exec_command(Some(&profile), &[], &self.config.exec) {
+    // Resolve against the `[exec]` config captured at open, not the live one.
+    match crate::exec::resolve_exec_command(Some(&profile), &[], &self.exec_picker_cfg) {
       Ok(argv) => Some((argv, cwd)),
       Err(e) => {
         self.status = format!("exec profile {profile:?}: {e}");
@@ -2131,12 +2150,15 @@ impl App {
       self.status = "nothing selected".into();
       return;
     };
-    // Capture the target worktree now: an auto-refresh can drift the live
-    // selection while the overlay is open / armed, so every re-scan and the
-    // delete must pin to *this* worktree (Codex #333 review).
+    // Capture the target worktree AND the active repo's `[clean]` config now:
+    // an auto-refresh can drift the live selection (and, in workspace mode,
+    // the active repo) while the overlay is open / armed, so every re-scan
+    // and the delete must pin to *this* worktree against *this* config
+    // (Codex #333 review).
     let name = sel.name.clone();
     let path = sel.path.clone();
-    let names: Vec<String> = self.config.clean.profiles.keys().cloned().collect();
+    self.clean_overlay_cfg = self.config.clean.clone();
+    let names: Vec<String> = self.clean_overlay_cfg.profiles.keys().cloned().collect();
     self.clean_overlay.open(names, name, path);
     if let Err(e) = self.clean_overlay_rescan() {
       self.status = format!("clean: {e}");
@@ -2158,7 +2180,7 @@ impl App {
       return Ok(());
     };
     let profile = self.clean_overlay.selected_profile().map(str::to_string);
-    let dirs = crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean)?;
+    let dirs = crate::clean::resolve_clean_dirs(profile.as_deref(), &self.clean_overlay_cfg)?;
     let (reclaim, skipped) = crate::clean::scan_worktree_safe(&name, &path, &dirs);
     self.clean_overlay.set_scan(reclaim, skipped);
     Ok(())
@@ -2254,7 +2276,7 @@ impl App {
       return;
     };
     let profile = self.clean_overlay.selected_profile().map(str::to_string);
-    let dirs = match crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean) {
+    let dirs = match crate::clean::resolve_clean_dirs(profile.as_deref(), &self.clean_overlay_cfg) {
       Ok(d) => d,
       Err(e) => {
         self.status = format!("clean: {e}");

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2215,19 +2215,26 @@ impl App {
     Ok(())
   }
 
-  /// Cycle the clean profile picker forward and re-scan (issue #325).
+  /// Cycle the clean profile picker forward and re-scan, but ONLY when the
+  /// highlight actually moved (issue #325 / Codex #333). A no-op move (only
+  /// the `(default)` choice) must not re-scan — that would reset the
+  /// `ConfirmModal` and silently disarm a pending reclaim while the status
+  /// bar still reads `armed`.
   pub fn clean_overlay_next(&mut self) {
-    self.clean_overlay.next();
-    if let Err(e) = self.clean_overlay_rescan() {
-      self.status = format!("clean: {e}");
+    if self.clean_overlay.select_next() {
+      if let Err(e) = self.clean_overlay_rescan() {
+        self.status = format!("clean: {e}");
+      }
     }
   }
 
-  /// Cycle the clean profile picker backward and re-scan (issue #325).
+  /// Cycle the clean profile picker backward and re-scan, only when the
+  /// highlight actually moved (issue #325 / Codex #333).
   pub fn clean_overlay_prev(&mut self) {
-    self.clean_overlay.prev();
-    if let Err(e) = self.clean_overlay_rescan() {
-      self.status = format!("clean: {e}");
+    if self.clean_overlay.select_prev() {
+      if let Err(e) = self.clean_overlay_rescan() {
+        self.status = format!("clean: {e}");
+      }
     }
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -463,6 +463,12 @@ pub struct App {
   /// auto-refresh could swap to another repo's (Codex #333 review).
   clean_overlay_cfg: CleanConfig,
 
+  /// The safety-countdown duration (seconds) captured when the clean overlay
+  /// opened (issue #325). Pinned alongside [`Self::clean_overlay_cfg`] so a
+  /// workspace config swap can't shorten — or clear to `0` — the delay
+  /// before an armed reclaim fires (Codex #333 review).
+  clean_overlay_countdown_secs: u32,
+
   /// Set by `Action::ExitToWorktree` (#290): the path the main loop
   /// should print to stdout just before quitting so the shell wrapper
   /// (`cd "$(gwm)"`) can change directory. `None` → plain quit.
@@ -575,6 +581,7 @@ impl App {
       exec_picker_cfg: ExecConfig::default(),
       clean_overlay: CleanOverlay::new(),
       clean_overlay_cfg: CleanConfig::default(),
+      clean_overlay_countdown_secs: 0,
       should_exit_to: None,
       edit_original_branch: None,
       edit_original_path: None,
@@ -2121,7 +2128,17 @@ impl App {
     };
     // Resolve against the `[exec]` config captured at open, not the live one.
     match crate::exec::resolve_exec_command(Some(&profile), &[], &self.exec_picker_cfg) {
-      Ok(argv) => Some((argv, cwd)),
+      Ok(mut argv) => {
+        // Pin a worktree-relative executable (`./run.sh`, `scripts/build`) to
+        // the captured worktree, exactly like the CLI exec path — otherwise
+        // `argv[0]` would resolve against gwm's own cwd (Codex #333 review).
+        // A bare command (`cargo`) or an absolute path is returned unchanged
+        // (PATH lookup / as-is).
+        if let Some(first) = argv.first_mut() {
+          *first = crate::exec::resolve_program(&cwd, first).to_string_lossy().into_owned();
+        }
+        Some((argv, cwd))
+      }
       Err(e) => {
         self.status = format!("exec profile {profile:?}: {e}");
         None
@@ -2158,6 +2175,7 @@ impl App {
     let name = sel.name.clone();
     let path = sel.path.clone();
     self.clean_overlay_cfg = self.config.clean.clone();
+    self.clean_overlay_countdown_secs = self.config.tui.effective_confirm_countdown_secs();
     let names: Vec<String> = self.clean_overlay_cfg.profiles.keys().cloned().collect();
     self.clean_overlay.open(names, name, path);
     if let Err(e) = self.clean_overlay_rescan() {
@@ -2207,7 +2225,9 @@ impl App {
   /// `[tui] confirm_countdown_secs` directly. `Duration::ZERO` ⇒ classic
   /// single-keystroke confirm.
   pub fn clean_countdown_total(&self) -> Duration {
-    Duration::from_secs(u64::from(self.config.tui.effective_confirm_countdown_secs()))
+    // The value captured at open (Codex #333) — never the live config, which a
+    // workspace refresh could swap (e.g. to `0`, erasing the safety delay).
+    Duration::from_secs(u64::from(self.clean_overlay_countdown_secs))
   }
 
   /// Handle the clean confirm key. Arms / disarms / fires the countdown via

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2068,6 +2068,17 @@ impl App {
 
   // ── Exec picker overlay (issue #325) ───────────────────────────────────
 
+  /// `true` while a destructive overlay — the exec picker or the clean
+  /// report — is open (issue #325). The run loop suspends `maybe_auto_refresh`
+  /// and `sync_active_repo` while one is up, so the worktree list (and thus
+  /// the live selection / active repo) cannot reshuffle under an armed reclaim
+  /// or a pending exec run. This closes the drift class at its source (Codex
+  /// #333 review); the per-overlay open-time snapshots stay as defence in
+  /// depth against an already-in-flight refresh landing its result.
+  pub fn destructive_overlay_open(&self) -> bool {
+    matches!(self.view, View::ExecPicker | View::CleanReport)
+  }
+
   /// Open the exec profile picker (issue #325). Populates it from
   /// `[exec.profiles.*]` and switches to [`View::ExecPicker`]. Refuses
   /// (status-bar message, no transition) when nothing is selected or no

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,6 +6,7 @@ use super::state::command_logs::CommandLogs;
 use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field};
+use super::state::exec_picker::ExecPicker;
 use super::state::filter::{fuzzy_match_indices, FilterState};
 use super::state::github_fetch::{FetchKey, GitHubFetch};
 use super::state::link_prompt::LinkPrompt;
@@ -90,12 +91,35 @@ pub enum View {
   /// kills the child and returns to the list. State lives on
   /// [`App::pty_overlay`].
   Pty,
+  /// Exec profile picker overlay (issue #325). A small centred modal that
+  /// lists the `[exec.profiles.*]` names; `Enter` resolves the highlight
+  /// to an argv and the run loop spawns it in a PTY overlay
+  /// ([`PtyKind::Exec`]) rooted at the selected worktree. State lives on
+  /// [`App::exec_picker`]; keys resolve through
+  /// [`crate::tui::modal_keymap::KeyContext::ExecPicker`].
+  ExecPicker,
   /// Worktree-rename modal (#290). Reuses the Create form (Type / Issue /
   /// Desc) pre-filled by parsing the current branch; submitting renames the
   /// local + remote branch and moves the worktree directory. State lives on
   /// [`App::create_form`] plus [`App::edit_original_branch`] /
   /// [`App::edit_original_path`].
   Edit,
+}
+
+/// What the run loop must do after [`App::handle_exec_picker_key`]
+/// processes a key in the exec picker overlay (issue #325). Mirrors
+/// [`CreateKey`] / [`LinkPromptKey`]: the testable handler owns the
+/// highlight movement, the loop owns the two side effects (resolve the
+/// argv + spawn the PTY overlay, or close back to the list).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ExecPickerKey {
+  /// The key moved the highlight (or was ignored); stay in the picker.
+  Handled,
+  /// `Enter` — the loop should resolve the highlighted profile and spawn
+  /// the PTY overlay.
+  Submit,
+  /// `Esc` — the loop should close the picker back to the list.
+  Cancel,
 }
 
 /// What the run loop must do after [`App::handle_create_key`] processes a
@@ -406,6 +430,12 @@ pub struct App {
   /// Managed by [`Self::open_pty_overlay`] / [`Self::close_pty_overlay`].
   pub pty_overlay: Option<PtyOverlay>,
 
+  /// Exec profile picker overlay state (issue #325). Populated by
+  /// [`Self::enter_exec_picker`] from `[exec.profiles.*]`; on `Enter` the
+  /// run loop resolves the highlight to an argv and spawns a PTY overlay
+  /// ([`PtyKind::Exec`]) in the selected worktree's directory.
+  pub exec_picker: ExecPicker,
+
   /// Set by `Action::ExitToWorktree` (#290): the path the main loop
   /// should print to stdout just before quitting so the shell wrapper
   /// (`cd "$(gwm)"`) can change directory. `None` → plain quit.
@@ -514,6 +544,7 @@ impl App {
       config_panel: ConfigPanel::new(),
       global_path: global_path.map(Path::to_path_buf),
       pty_overlay: None,
+      exec_picker: ExecPicker::new(),
       should_exit_to: None,
       edit_original_branch: None,
       edit_original_path: None,
@@ -1672,6 +1703,7 @@ impl App {
       // modal; the statusbar behind it keeps the underlying pane context.
       View::Config => self.pane_hint_context(),
       View::Pty => super::ui::HintContext::Pty,
+      View::ExecPicker => HintContext::ExecPicker,
       View::Edit => HintContext::Rename,
       View::List => self.pane_hint_context(),
     }
@@ -1992,6 +2024,75 @@ impl App {
     }
     self.pty_overlay = None;
     if self.view == View::Pty {
+      self.view = View::List;
+    }
+  }
+
+  // ── Exec picker overlay (issue #325) ───────────────────────────────────
+
+  /// Open the exec profile picker (issue #325). Populates it from
+  /// `[exec.profiles.*]` and switches to [`View::ExecPicker`]. Refuses
+  /// (status-bar message, no transition) when nothing is selected or no
+  /// exec profiles are configured — there is nothing to pick.
+  pub fn enter_exec_picker(&mut self) {
+    if self.selected().is_none() {
+      self.status = "nothing selected".into();
+      return;
+    }
+    let names: Vec<String> = self.config.exec.profiles.keys().cloned().collect();
+    if names.is_empty() {
+      self.status = "no [exec.profiles] configured — add one to .gwm.toml".into();
+      return;
+    }
+    self.exec_picker.open(names);
+    self.view = View::ExecPicker;
+  }
+
+  /// Handle a key inside the exec picker overlay (issue #325). The
+  /// testable handler owns the highlight movement; the run loop owns the
+  /// two side effects (resolve + spawn, or close). Keys resolve through
+  /// [`KeyContext::ExecPicker`] so they honour `[tui.keys.modal.exec]`.
+  pub fn handle_exec_picker_key(&mut self, key: KeyEvent) -> ExecPickerKey {
+    match self.resolve_modal(KeyContext::ExecPicker, key) {
+      Some(ModalAction::ExecPickerCancel) => ExecPickerKey::Cancel,
+      Some(ModalAction::ExecPickerAccept) => ExecPickerKey::Submit,
+      Some(ModalAction::ExecPickerNext) => {
+        self.exec_picker.next();
+        ExecPickerKey::Handled
+      }
+      Some(ModalAction::ExecPickerPrev) => {
+        self.exec_picker.prev();
+        ExecPickerKey::Handled
+      }
+      _ => ExecPickerKey::Handled,
+    }
+  }
+
+  /// Resolve the highlighted exec profile to an `(argv, cwd)` pair for the
+  /// run loop to spawn in a PTY overlay (issue #325). `None` (with a
+  /// status-bar message) when nothing is selected or the profile fails to
+  /// resolve — e.g. an empty `command` array. The argv is the frozen
+  /// `[exec.profiles.<name>].command` verbatim (no shell), matching the
+  /// 1.0 exec contract; the run loop spawns `argv[0]` directly.
+  pub fn exec_picker_resolve(&mut self) -> Option<(Vec<String>, PathBuf)> {
+    let profile = self.exec_picker.selected_profile()?.to_string();
+    let Some(cwd) = self.selected().map(|wt| wt.path.clone()) else {
+      self.status = "nothing selected".into();
+      return None;
+    };
+    match crate::exec::resolve_exec_command(Some(&profile), &[], &self.config.exec) {
+      Ok(argv) => Some((argv, cwd)),
+      Err(e) => {
+        self.status = format!("exec profile {profile:?}: {e}");
+        None
+      }
+    }
+  }
+
+  /// Close the exec picker without running anything (issue #325). Returns
+  /// to [`View::List`].
+  pub fn close_exec_picker(&mut self) {
+    if self.view == View::ExecPicker {
       self.view = View::List;
     }
   }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2051,16 +2051,19 @@ impl App {
   /// (status-bar message, no transition) when nothing is selected or no
   /// exec profiles are configured — there is nothing to pick.
   pub fn enter_exec_picker(&mut self) {
-    if self.selected().is_none() {
+    let Some(cwd) = self.selected().map(|wt| wt.path.clone()) else {
       self.status = "nothing selected".into();
       return;
-    }
+    };
     let names: Vec<String> = self.config.exec.profiles.keys().cloned().collect();
     if names.is_empty() {
       self.status = "no [exec.profiles] configured — add one to .gwm.toml".into();
       return;
     }
-    self.exec_picker.open(names);
+    // Capture the target worktree path now: an auto-refresh can drift the live
+    // selection while the picker is open, so `Enter` must run in *this*
+    // worktree, not whatever is selected later (Codex #333 review).
+    self.exec_picker.open(names, cwd);
     self.view = View::ExecPicker;
   }
 
@@ -2092,7 +2095,9 @@ impl App {
   /// 1.0 exec contract; the run loop spawns `argv[0]` directly.
   pub fn exec_picker_resolve(&mut self) -> Option<(Vec<String>, PathBuf)> {
     let profile = self.exec_picker.selected_profile()?.to_string();
-    let Some(cwd) = self.selected().map(|wt| wt.path.clone()) else {
+    // Resolve against the worktree captured when the picker opened, NOT the
+    // live selection (which an auto-refresh may have drifted) — #333 review.
+    let Some(cwd) = self.exec_picker.cwd().map(Path::to_path_buf) else {
       self.status = "nothing selected".into();
       return None;
     };
@@ -2122,12 +2127,17 @@ impl App {
   /// nothing is selected. A scan that finds nothing safe still opens — the
   /// report says so.
   pub fn enter_clean_overlay(&mut self) {
-    if self.selected().is_none() {
+    let Some(sel) = self.selected() else {
       self.status = "nothing selected".into();
       return;
-    }
+    };
+    // Capture the target worktree now: an auto-refresh can drift the live
+    // selection while the overlay is open / armed, so every re-scan and the
+    // delete must pin to *this* worktree (Codex #333 review).
+    let name = sel.name.clone();
+    let path = sel.path.clone();
     let names: Vec<String> = self.config.clean.profiles.keys().cloned().collect();
-    self.clean_overlay.open(names);
+    self.clean_overlay.open(names, name, path);
     if let Err(e) = self.clean_overlay_rescan() {
       self.status = format!("clean: {e}");
       return;
@@ -2135,15 +2145,18 @@ impl App {
     self.view = View::CleanReport;
   }
 
-  /// Re-resolve the highlighted profile's dirs and re-scan the selected
-  /// worktree, storing the gated snapshot. Surfaces a profile-resolution
-  /// error (e.g. an invalid `[clean.profiles]` dir) to the caller.
+  /// Re-resolve the highlighted profile's dirs and re-scan the *captured*
+  /// target worktree (not the live selection), storing the gated snapshot.
+  /// Surfaces a profile-resolution error (e.g. an invalid `[clean.profiles]`
+  /// dir) to the caller.
   fn clean_overlay_rescan(&mut self) -> Result<()> {
-    let Some(sel) = self.selected() else {
+    let Some((name, path)) = self
+      .clean_overlay
+      .target()
+      .map(|(n, p)| (n.to_string(), p.to_path_buf()))
+    else {
       return Ok(());
     };
-    let name = sel.name.clone();
-    let path = sel.path.clone();
     let profile = self.clean_overlay.selected_profile().map(str::to_string);
     let dirs = crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean)?;
     let (reclaim, skipped) = crate::clean::scan_worktree_safe(&name, &path, &dirs);
@@ -2230,12 +2243,16 @@ impl App {
     // and a directory may have turned unsafe meanwhile (e.g. `git add -f
     // target/file` under an ignored `target/`). Deleting a freshly gated
     // reclaim closes that TOCTOU window, matching the CLI's scan-then-delete.
-    let Some(sel) = self.selected() else {
+    // Pin to the CAPTURED target worktree, not the live selection (an
+    // auto-refresh may have drifted it while the countdown ran) — #333.
+    let Some((name, path)) = self
+      .clean_overlay
+      .target()
+      .map(|(n, p)| (n.to_string(), p.to_path_buf()))
+    else {
       self.close_clean_overlay();
       return;
     };
-    let name = sel.name.clone();
-    let path = sel.path.clone();
     let profile = self.clean_overlay.selected_profile().map(str::to_string);
     let dirs = match crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean) {
       Ok(d) => d,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,6 +2,7 @@ use super::keymap::{Action, ChordResolution, KeyStroke, Keymap};
 use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::palette::PaletteState;
 use super::state::async_task::{CreateWorktreeResult, EditWorktreeResult, TaskKind, TaskMsg, TaskRunner};
+use super::state::clean_overlay::CleanOverlay;
 use super::state::command_logs::CommandLogs;
 use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
@@ -98,6 +99,13 @@ pub enum View {
   /// [`App::exec_picker`]; keys resolve through
   /// [`crate::tui::modal_keymap::KeyContext::ExecPicker`].
   ExecPicker,
+  /// Clean reclaim overlay (issue #325). A centred modal showing the gated
+  /// `clean::scan_worktree_safe` report for the selected worktree, an
+  /// optional `[clean.profiles.*]` picker, and a safety countdown; the run
+  /// loop fires `clean::delete_reclaim` when the countdown elapses. State
+  /// lives on [`App::clean_overlay`]; keys resolve through
+  /// [`crate::tui::modal_keymap::KeyContext::Clean`].
+  CleanReport,
   /// Worktree-rename modal (#290). Reuses the Create form (Type / Issue /
   /// Desc) pre-filled by parsing the current branch; submitting renames the
   /// local + remote branch and moves the worktree directory. State lives on
@@ -436,6 +444,12 @@ pub struct App {
   /// ([`PtyKind::Exec`]) in the selected worktree's directory.
   pub exec_picker: ExecPicker,
 
+  /// Clean overlay state (issue #325). Holds the gated reclaim scan of the
+  /// selected worktree, the `[clean.profiles.*]` picker, and a dedicated
+  /// safety countdown. Filled by [`Self::enter_clean_overlay`]; the run loop
+  /// fires [`crate::clean::delete_reclaim`] when the countdown elapses.
+  pub clean_overlay: CleanOverlay,
+
   /// Set by `Action::ExitToWorktree` (#290): the path the main loop
   /// should print to stdout just before quitting so the shell wrapper
   /// (`cd "$(gwm)"`) can change directory. `None` → plain quit.
@@ -545,6 +559,7 @@ impl App {
       global_path: global_path.map(Path::to_path_buf),
       pty_overlay: None,
       exec_picker: ExecPicker::new(),
+      clean_overlay: CleanOverlay::new(),
       should_exit_to: None,
       edit_original_branch: None,
       edit_original_path: None,
@@ -1704,6 +1719,7 @@ impl App {
       View::Config => self.pane_hint_context(),
       View::Pty => super::ui::HintContext::Pty,
       View::ExecPicker => HintContext::ExecPicker,
+      View::CleanReport => HintContext::Clean,
       View::Edit => HintContext::Rename,
       View::List => self.pane_hint_context(),
     }
@@ -2093,6 +2109,139 @@ impl App {
   /// to [`View::List`].
   pub fn close_exec_picker(&mut self) {
     if self.view == View::ExecPicker {
+      self.view = View::List;
+    }
+  }
+
+  // ── Clean overlay (issue #325) ─────────────────────────────────────────
+
+  /// Open the clean overlay (issue #325). Populates the `[clean.profiles]`
+  /// picker, scans the selected worktree through the safety gate
+  /// ([`crate::clean::scan_worktree_safe`]), and switches to
+  /// [`View::CleanReport`]. Refuses (status-bar message, no transition) when
+  /// nothing is selected. A scan that finds nothing safe still opens — the
+  /// report says so.
+  pub fn enter_clean_overlay(&mut self) {
+    if self.selected().is_none() {
+      self.status = "nothing selected".into();
+      return;
+    }
+    let names: Vec<String> = self.config.clean.profiles.keys().cloned().collect();
+    self.clean_overlay.open(names);
+    if let Err(e) = self.clean_overlay_rescan() {
+      self.status = format!("clean: {e}");
+      return;
+    }
+    self.view = View::CleanReport;
+  }
+
+  /// Re-resolve the highlighted profile's dirs and re-scan the selected
+  /// worktree, storing the gated snapshot. Surfaces a profile-resolution
+  /// error (e.g. an invalid `[clean.profiles]` dir) to the caller.
+  fn clean_overlay_rescan(&mut self) -> Result<()> {
+    let Some(sel) = self.selected() else {
+      return Ok(());
+    };
+    let name = sel.name.clone();
+    let path = sel.path.clone();
+    let profile = self.clean_overlay.selected_profile().map(str::to_string);
+    let dirs = crate::clean::resolve_clean_dirs(profile.as_deref(), &self.config.clean)?;
+    let (reclaim, skipped) = crate::clean::scan_worktree_safe(&name, &path, &dirs);
+    self.clean_overlay.set_scan(reclaim, skipped);
+    Ok(())
+  }
+
+  /// Cycle the clean profile picker forward and re-scan (issue #325).
+  pub fn clean_overlay_next(&mut self) {
+    self.clean_overlay.next();
+    if let Err(e) = self.clean_overlay_rescan() {
+      self.status = format!("clean: {e}");
+    }
+  }
+
+  /// Cycle the clean profile picker backward and re-scan (issue #325).
+  pub fn clean_overlay_prev(&mut self) {
+    self.clean_overlay.prev();
+    if let Err(e) = self.clean_overlay_rescan() {
+      self.status = format!("clean: {e}");
+    }
+  }
+
+  /// Total duration of the clean safety countdown. Unlike the delete-confirm
+  /// modal, clean has no `delete_branch_on_remove` gate — it reads
+  /// `[tui] confirm_countdown_secs` directly. `Duration::ZERO` ⇒ classic
+  /// single-keystroke confirm.
+  pub fn clean_countdown_total(&self) -> Duration {
+    Duration::from_secs(u64::from(self.config.tui.effective_confirm_countdown_secs()))
+  }
+
+  /// Handle the clean confirm key. Arms / disarms / fires the countdown via
+  /// the dedicated [`CleanOverlay`] modal. Nothing-to-reclaim is a no-op
+  /// guard so the user cannot arm a delete that would free zero bytes.
+  pub fn clean_confirm_press(&mut self, now: Instant) -> ConfirmKeyAction {
+    if self.clean_overlay.is_empty_scan() {
+      self.status = "nothing to reclaim".into();
+      return ConfirmKeyAction::Disarmed;
+    }
+    let total = self.clean_countdown_total();
+    let action = self.clean_overlay.confirm.press_y(now, total);
+    match action {
+      ConfirmKeyAction::Armed => {
+        self.status = format!(
+          "armed — reclaiming {} in {}s",
+          crate::clean::human_size(self.clean_overlay.total_bytes()),
+          total.as_secs()
+        );
+      }
+      ConfirmKeyAction::Disarmed => self.status = "clean cancelled".into(),
+      ConfirmKeyAction::FireNow => {}
+    }
+    action
+  }
+
+  /// Tick the clean safety countdown. Called from the event loop on every
+  /// poll-timeout iteration while the overlay is open.
+  pub fn tick_clean_countdown(&mut self, now: Instant) -> CountdownTickOutcome {
+    self.clean_overlay.confirm.tick(now, self.clean_countdown_total())
+  }
+
+  /// Clean countdown progress in `[0.0, 1.0]` for the UI gauge.
+  pub fn clean_countdown_progress(&self, now: Instant) -> f64 {
+    self.clean_overlay.confirm.progress(now, self.clean_countdown_total())
+  }
+
+  /// Seconds remaining (rounded up) on the clean countdown, for the UI label.
+  pub fn clean_countdown_remaining_secs(&self, now: Instant) -> u64 {
+    self
+      .clean_overlay
+      .confirm
+      .remaining_secs(now, self.clean_countdown_total())
+  }
+
+  /// Delete the gated reclaim of the current clean snapshot (issue #325) and
+  /// return to the list. The snapshot was already filtered to the
+  /// git-ignored, untracked artifacts by [`crate::clean::scan_worktree_safe`],
+  /// so this only removes what the CLI `gwm clean --yes` would. Reports the
+  /// freed size (or the failure) on the status bar.
+  pub fn clean_overlay_delete(&mut self) {
+    let Some(reclaim) = self.clean_overlay.reclaim().cloned() else {
+      self.close_clean_overlay();
+      return;
+    };
+    match crate::clean::delete_reclaim(&reclaim) {
+      Ok(freed) => {
+        self.status = format!("reclaimed {} from {}", crate::clean::human_size(freed), reclaim.name);
+      }
+      Err(e) => self.status = format!("clean failed: {e}"),
+    }
+    self.close_clean_overlay();
+  }
+
+  /// Close the clean overlay, disarming the countdown, and return to
+  /// [`View::List`] (issue #325).
+  pub fn close_clean_overlay(&mut self) {
+    self.clean_overlay.confirm.dismiss();
+    if self.view == View::CleanReport {
       self.view = View::List;
     }
   }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -186,6 +186,14 @@ impl Action {
         // FetchGithub persists detected PR/issue titles + states into the
         // active repo's git config, so it writes through `App.repo` too (#304).
         | Action::FetchGithub
+        // #325: the exec / clean overlays resolve their command / dir-set from
+        // the *active* repo's `[exec]` / `[clean]` config and act on the
+        // selected worktree's path. With a stale workspace selection both the
+        // config and the path belong to the previously active repo — and exec
+        // runs an arbitrary command while clean deletes directories — so they
+        // must be blocked before the overlay opens (Codex #333 review).
+        | Action::ExecOverlay
+        | Action::CleanOverlay
     )
   }
 

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -143,6 +143,7 @@ define_actions! {
   CommandLogs       => "command_logs",
   ConfigPanel       => "config_panel",
   ExecOverlay       => "exec_overlay",
+  CleanOverlay      => "clean_overlay",
   Help              => "help",
   Quit              => "quit",
   // Future surface — bound to ':' by default, picked up by #32.
@@ -490,6 +491,8 @@ impl Keymap {
       def(Action::ConfigPanel, &["4"]),
       // #325: `x` opens the exec profile picker overlay.
       def(Action::ExecOverlay, &["x"]),
+      // #325: `X` opens the clean reclaim overlay.
+      def(Action::CleanOverlay, &["X"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f"]),
       // #290: `s` (lowercase) is now Sync — replaces ToggleSidebarMode.

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -142,6 +142,7 @@ define_actions! {
   // Overlays
   CommandLogs       => "command_logs",
   ConfigPanel       => "config_panel",
+  ExecOverlay       => "exec_overlay",
   Help              => "help",
   Quit              => "quit",
   // Future surface — bound to ':' by default, picked up by #32.
@@ -487,6 +488,8 @@ impl Keymap {
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
       def(Action::ConfigPanel, &["4"]),
+      // #325: `x` opens the exec profile picker overlay.
+      def(Action::ExecOverlay, &["x"]),
       def(Action::Filter, &["/"]),
       def(Action::Refresh, &["f"]),
       // #290: `s` (lowercase) is now Sync — replaces ToggleSidebarMode.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -219,7 +219,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     if app.view == View::CommandLogs {
       app.command_logs.sync();
     }
-    app.maybe_auto_refresh(now);
+    // #325: don't auto-refresh while a destructive overlay (exec picker /
+    // clean report) is open — a re-list would drift the live selection /
+    // active repo out from under the target the overlay captured at open.
+    if !app.destructive_overlay_open() {
+      app.maybe_auto_refresh(now);
+    }
 
     // Issue #35: drain PTY output and detect process death before drawing.
     // `poll_bytes` feeds pending reader-thread bytes into the vt100 parser
@@ -249,7 +254,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     // selected worktree's repo before drawing (so the sidebar preview reads
     // the right repo) and before the next key fires an action against it. A
     // no-op in single-repo mode and when the selection hasn't crossed repos.
-    app.sync_active_repo();
+    // #325: suspended while a destructive overlay is open so the active repo
+    // (and its config) can't swap under the captured exec/clean target.
+    if !app.destructive_overlay_open() {
+      app.sync_active_repo();
+    }
 
     terminal.draw(|f| ui::draw(f, &mut app))?;
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -31,6 +31,7 @@ pub use app::{
   App, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
 };
 pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
+pub use state::clean_overlay::CleanOverlay;
 pub use state::command_logs::CommandLogs;
 pub use state::config_panel::{
   build_key_rows, ConfigPanel, FieldKind, KeyCapture, KeyRow, KeyTarget, SettingField, SettingsLayer, SettingsTab,
@@ -262,6 +263,19 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
             app.status = format!("delete failed: {}", e);
           }
         }
+        CountdownTickOutcome::Pending | CountdownTickOutcome::NotArmed => {}
+      }
+    }
+
+    // #325: drive the clean overlay's safety countdown off the same poll
+    // cadence as the delete confirm above, so an armed reclaim auto-fires
+    // after the configured delay even when no key event arrives.
+    if app.view == View::CleanReport {
+      if app.clean_overlay.confirm.is_armed() {
+        app.spinner.tick();
+      }
+      match app.tick_clean_countdown(now) {
+        CountdownTickOutcome::ReadyToFire => app.clean_overlay_delete(),
         CountdownTickOutcome::Pending | CountdownTickOutcome::NotArmed => {}
       }
     }
@@ -600,6 +614,21 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         ExecPickerKey::Cancel => app.close_exec_picker(),
         ExecPickerKey::Handled => {}
       },
+      // #325: clean reclaim overlay. Mirrors the delete-confirm routing —
+      // `confirm` arms / fires the safety countdown, `cancel` aborts, j/k
+      // cycle the `[clean.profiles]` picker (re-scanning each time). The
+      // countdown auto-fire is driven by the tick block above.
+      View::CleanReport => match app.resolve_modal(KeyContext::Clean, key) {
+        Some(ModalAction::CleanCancel) => app.close_clean_overlay(),
+        Some(ModalAction::CleanConfirm) => {
+          if app.clean_confirm_press(now) == ConfirmKeyAction::FireNow {
+            app.clean_overlay_delete();
+          }
+        }
+        Some(ModalAction::CleanNext) => app.clean_overlay_next(),
+        Some(ModalAction::CleanPrev) => app.clean_overlay_prev(),
+        _ => {}
+      },
       // #290: worktree-rename modal. Reuses the Create form input handler
       // (Type / Issue / Desc), but routes submit to the rename worker. Input
       // is swallowed while the async rename is in flight, mirroring create.
@@ -865,6 +894,9 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     // running a profile in a PTY is a focus-mode action, meaningless in
     // the stripped-down `gwm switch` picker.
     Action::ExecOverlay if !app.picker_mode => app.enter_exec_picker(),
+    // Issue #325: `X` opens the clean reclaim overlay. Picker-gated — it
+    // deletes from the selected worktree, a focus-mode action.
+    Action::CleanOverlay if !app.picker_mode => app.enter_clean_overlay(),
     // Picker-mode-gated actions fall through to no-op when the
     // guard fails (i.e. the user pressed them inside `gwm switch`).
     // Same fallthrough catches future actions not yet wired into

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,7 +27,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-pub use app::{App, CreateKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View};
+pub use app::{
+  App, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, OpenTarget, View,
+};
 pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 pub use state::command_logs::CommandLogs;
 pub use state::config_panel::{
@@ -35,6 +37,7 @@ pub use state::config_panel::{
 };
 pub use state::confirm::{ConfirmButton, ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 pub use state::create_form::{CreateForm, Field};
+pub use state::exec_picker::ExecPicker;
 pub use state::filter::FilterState;
 pub use state::github_fetch::{FetchKey, GitHubFetch, GitHubFetchState};
 pub use state::link_prompt::LinkPrompt;
@@ -572,6 +575,31 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
           }
         }
       },
+      // #325: exec profile picker. The testable handler owns the highlight;
+      // `Submit` resolves the profile to an argv and spawns it in a PTY
+      // overlay rooted at the selected worktree (mirrors `LazyGitPty`).
+      View::ExecPicker => match app.handle_exec_picker_key(key) {
+        ExecPickerKey::Submit => {
+          if let Some((argv, cwd)) = app.exec_picker_resolve() {
+            let sz = terminal.size().unwrap_or_default();
+            let inner_cols = ((sz.width as u32 * 90 / 100) as u16).saturating_sub(6).max(20);
+            let inner_rows = ((sz.height as u32 * 90 / 100) as u16).saturating_sub(4).max(5);
+            let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+            match PtyOverlay::spawn(PtyKind::Exec, &argv_refs, &cwd, inner_cols, inner_rows) {
+              Ok(pty) => app.open_pty_overlay(pty),
+              Err(e) => {
+                app.status = format!("exec overlay failed: {}", e);
+                app.close_exec_picker();
+              }
+            }
+          } else {
+            // Resolve failed (status already set) — close back to the list.
+            app.close_exec_picker();
+          }
+        }
+        ExecPickerKey::Cancel => app.close_exec_picker(),
+        ExecPickerKey::Handled => {}
+      },
       // #290: worktree-rename modal. Reuses the Create form input handler
       // (Type / Issue / Desc), but routes submit to the rename worker. Input
       // is swallowed while the async rename is in flight, mirroring create.
@@ -833,6 +861,10 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     // overlay it is read-only and not picker-gated — harmless inside
     // `gwm switch`, opening from any List state.
     Action::ConfigPanel => app.enter_config_panel(),
+    // Issue #325: `x` opens the exec profile picker. Picker-gated —
+    // running a profile in a PTY is a focus-mode action, meaningless in
+    // the stripped-down `gwm switch` picker.
+    Action::ExecOverlay if !app.picker_mode => app.enter_exec_picker(),
     // Picker-mode-gated actions fall through to no-op when the
     // guard fails (i.e. the user pressed them inside `gwm switch`).
     // Same fallthrough catches future actions not yet wired into

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -239,9 +239,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         // #325: a one-shot exec command exits the instant it finishes — keep
         // its final output on screen and let any key dismiss it, instead of
         // the lazygit / shell behaviour of closing the overlay on child death.
+        // `mark_finished` also reaps the process group now (so a backgrounded
+        // descendant is cleaned in the safe window, not after the linger).
         Some((PtyKind::Exec, false)) => {
           if let Some(p) = app.pty_overlay.as_mut() {
-            p.finished = true;
+            p.mark_finished();
           }
         }
         // Interactive overlays (lazygit / shell / review) close on child exit.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -226,12 +226,22 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     // so the next frame reflects the freshest output. If the process has
     // already exited, close the overlay so the list view is rendered instead.
     if app.view == View::Pty {
-      let is_dead = app.pty_overlay.as_mut().is_none_or(|p| {
+      let status = app.pty_overlay.as_mut().map(|p| {
         p.poll_bytes();
-        !p.is_alive()
+        (p.kind, p.is_alive())
       });
-      if is_dead {
-        app.close_pty_overlay();
+      match status {
+        // #325: a one-shot exec command exits the instant it finishes — keep
+        // its final output on screen and let any key dismiss it, instead of
+        // the lazygit / shell behaviour of closing the overlay on child death.
+        Some((PtyKind::Exec, false)) => {
+          if let Some(p) = app.pty_overlay.as_mut() {
+            p.finished = true;
+          }
+        }
+        // Interactive overlays (lazygit / shell / review) close on child exit.
+        Some((_, false)) | None => app.close_pty_overlay(),
+        Some((_, true)) => {}
       }
     }
 
@@ -581,14 +591,18 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // detach, and routing it through a rebindable context would silently
       // steal a keystroke from the child program. See the `modal_keymap`
       // module note ("What stays hard-coded").
-      View::Pty => match key.code {
-        KeyCode::Esc => app.close_pty_overlay(),
-        _ => {
-          if let Some(ref mut pty) = app.pty_overlay {
-            let _ = pty.write_key(key);
-          }
+      View::Pty => {
+        // #325: once a one-shot exec command has finished, the overlay is
+        // just showing its final output — there is no live child to receive
+        // input, so any key dismisses it. Otherwise `Esc` is the emergency
+        // detach and every other key passes through to the child.
+        let exec_finished = app.pty_overlay.as_ref().is_some_and(|p| p.finished);
+        if key.code == KeyCode::Esc || exec_finished {
+          app.close_pty_overlay();
+        } else if let Some(ref mut pty) = app.pty_overlay {
+          let _ = pty.write_key(key);
         }
-      },
+      }
       // #325: exec profile picker. The testable handler owns the highlight;
       // `Submit` resolves the profile to an argv and spawns it in a PTY
       // overlay rooted at the selected worktree (mirrors `LazyGitPty`).

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -101,6 +101,8 @@ pub enum KeyContext {
   LinkInputNumber,
   /// Exec profile picker overlay (issue #325).
   ExecPicker,
+  /// Clean reclaim overlay (issue #325).
+  Clean,
 }
 
 impl KeyContext {
@@ -119,6 +121,7 @@ impl KeyContext {
       KeyContext::LinkChooseTarget => "link.choose_target",
       KeyContext::LinkInputNumber => "link.input_number",
       KeyContext::ExecPicker => "exec",
+      KeyContext::Clean => "clean",
     }
   }
 
@@ -144,6 +147,7 @@ impl KeyContext {
       LinkChooseTarget,
       LinkInputNumber,
       ExecPicker,
+      Clean,
     ]
   }
 }
@@ -275,6 +279,12 @@ define_modal_actions! {
     ExecPickerPrev   => "prev"   [ "k", "Up" ],
     ExecPickerAccept => "accept" [ "Enter" ],
     ExecPickerCancel => "cancel" [ "Esc" ],
+  }
+  Clean {
+    CleanNext    => "next"    [ "j", "Down" ],
+    CleanPrev    => "prev"    [ "k", "Up" ],
+    CleanConfirm => "confirm" [ "y", "Enter" ],
+    CleanCancel  => "cancel"  [ "n", "Esc" ],
   }
 }
 

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -99,6 +99,8 @@ pub enum KeyContext {
   LinkChooseTarget,
   /// Link prompt, stage 2 — type the issue / PR number.
   LinkInputNumber,
+  /// Exec profile picker overlay (issue #325).
+  ExecPicker,
 }
 
 impl KeyContext {
@@ -116,6 +118,7 @@ impl KeyContext {
       KeyContext::CommandPalette => "palette",
       KeyContext::LinkChooseTarget => "link.choose_target",
       KeyContext::LinkInputNumber => "link.input_number",
+      KeyContext::ExecPicker => "exec",
     }
   }
 
@@ -140,6 +143,7 @@ impl KeyContext {
       CommandPalette,
       LinkChooseTarget,
       LinkInputNumber,
+      ExecPicker,
     ]
   }
 }
@@ -265,6 +269,12 @@ define_modal_actions! {
   LinkInputNumber {
     LinkInputSubmit => "submit" [ "Enter" ],
     LinkInputCancel => "cancel" [ "Esc" ],
+  }
+  ExecPicker {
+    ExecPickerNext   => "next"   [ "j", "Down" ],
+    ExecPickerPrev   => "prev"   [ "k", "Up" ],
+    ExecPickerAccept => "accept" [ "Enter" ],
+    ExecPickerCancel => "cancel" [ "Esc" ],
   }
 }
 

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -232,6 +232,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "pick an [exec.profiles] profile and run it in a PTY",
     },
     PaletteEntry {
+      action: Action::CleanOverlay,
+      name: "clean",
+      description: "preview and reclaim build artifacts in the selected worktree",
+    },
+    PaletteEntry {
       action: Action::MuxPane,
       name: "mux-pane",
       description: "open the selected worktree in a new multiplexer pane/tab",

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -227,6 +227,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "show the resolved configuration panel",
     },
     PaletteEntry {
+      action: Action::ExecOverlay,
+      name: "exec",
+      description: "pick an [exec.profiles] profile and run it in a PTY",
+    },
+    PaletteEntry {
       action: Action::MuxPane,
       name: "mux-pane",
       description: "open the selected worktree in a new multiplexer pane/tab",

--- a/src/tui/state/clean_overlay.rs
+++ b/src/tui/state/clean_overlay.rs
@@ -14,6 +14,7 @@
 
 use super::confirm::ConfirmModal;
 use crate::clean::WorktreeReclaim;
+use std::path::{Path, PathBuf};
 
 /// The picker label for the no-`--profile` choice — the directory set
 /// `gwm clean` resolves with no profile (`[clean.profiles.default]` when
@@ -33,6 +34,11 @@ pub struct CleanOverlay {
   choices: Vec<Option<String>>,
   /// Highlighted choice row.
   selected: usize,
+  /// The worktree (display name + path) the overlay was opened for, captured
+  /// at open so every re-scan and the final delete pin to *that* worktree —
+  /// not the live selection, which an auto-refresh can drift while the
+  /// overlay sits open / armed (Codex #333 review).
+  target: Option<(String, PathBuf)>,
   /// The most recent gated scan snapshot for the selected worktree, filled
   /// by `App::enter_clean_overlay` and re-filled on a choice change. `None`
   /// before the first scan.
@@ -59,13 +65,22 @@ impl CleanOverlay {
   /// Opens on the no-`--profile` choice so the overlay's first preview always
   /// matches what `gwm clean` would resolve — the built-in set, or
   /// `[clean.profiles.default]` when defined — regardless of which optional
-  /// profiles the repo adds.
-  pub fn open(&mut self, profiles: Vec<String>) {
+  /// profiles the repo adds. `name` / `path` are the worktree the overlay
+  /// targets, captured here so re-scans and the delete pin to it.
+  pub fn open(&mut self, profiles: Vec<String>, name: String, path: PathBuf) {
     self.choices = std::iter::once(None).chain(profiles.into_iter().map(Some)).collect();
     self.selected = 0;
+    self.target = Some((name, path));
     self.reclaim = None;
     self.skipped.clear();
     self.confirm.reset();
+  }
+
+  /// The worktree (display name, path) the overlay was opened for. Every scan
+  /// and the delete resolve against this captured target, not the live
+  /// selection.
+  pub fn target(&self) -> Option<(&str, &Path)> {
+    self.target.as_ref().map(|(n, p)| (n.as_str(), p.as_path()))
   }
 
   /// The picker labels, in display order. The no-`--profile` entry renders as

--- a/src/tui/state/clean_overlay.rs
+++ b/src/tui/state/clean_overlay.rs
@@ -1,0 +1,128 @@
+//! Clean overlay state (issue #325).
+//!
+//! Holds the reclaim scan snapshot for the selected worktree, the
+//! `[clean.profiles.*]` picker, and a dedicated safety countdown
+//! ([`ConfirmModal`]) for the destructive delete.
+//!
+//! Pure state: the `App` orchestrator owns the I/O — the
+//! `clean::scan_worktree_safe` walk that fills the snapshot (already gated to
+//! the git-ignored, untracked artifacts the CLI would delete) and the
+//! `clean::delete_reclaim` that consumes it. The countdown reuses the exact
+//! same timer the delete-confirm modal uses (`confirm.rs`), but as a separate
+//! instance driven by `[tui] confirm_countdown_secs` directly — clean has no
+//! `delete_branch_on_remove` gate.
+
+use super::confirm::ConfirmModal;
+use crate::clean::WorktreeReclaim;
+
+/// Pure state for the clean overlay. `Default` is a closed overlay (no
+/// profiles, no snapshot, disarmed countdown).
+#[derive(Debug, Default)]
+pub struct CleanOverlay {
+  /// Configured `[clean.profiles.*]` names (sorted). Empty ⇒ the overlay
+  /// scans the built-in default set and the picker has nothing to cycle.
+  profiles: Vec<String>,
+  /// Highlighted profile row (meaningful only while `profiles` is
+  /// non-empty).
+  selected: usize,
+  /// The most recent gated scan snapshot for the selected worktree, filled
+  /// by `App::enter_clean_overlay` and re-filled on a profile change. `None`
+  /// before the first scan.
+  reclaim: Option<WorktreeReclaim>,
+  /// Directory names found but preserved by the safety gate (not
+  /// git-ignored, or holding tracked files) — surfaced so the user
+  /// understands why a visible `target/` was not counted.
+  skipped: Vec<String>,
+  /// Safety countdown for the delete. Armed by the confirm key; the run
+  /// loop fires `clean::delete_reclaim` when it elapses.
+  pub confirm: ConfirmModal,
+}
+
+impl CleanOverlay {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Populate the picker profile names, reset the highlight, and clear any
+  /// stale snapshot / countdown. The orchestrator follows this with
+  /// [`Self::set_scan`] once the first scan completes.
+  pub fn open(&mut self, profiles: Vec<String>) {
+    self.profiles = profiles;
+    self.selected = 0;
+    self.reclaim = None;
+    self.skipped.clear();
+    self.confirm.reset();
+  }
+
+  /// The configured profile names, in display order.
+  pub fn profiles(&self) -> &[String] {
+    &self.profiles
+  }
+
+  /// `true` when at least one `[clean.profiles]` entry exists (the picker
+  /// can cycle).
+  pub fn has_profiles(&self) -> bool {
+    !self.profiles.is_empty()
+  }
+
+  /// The highlighted profile row.
+  pub fn selected_index(&self) -> usize {
+    self.selected
+  }
+
+  /// The highlighted profile name, or `None` when no profiles are
+  /// configured (the overlay scans the built-in default set).
+  pub fn selected_profile(&self) -> Option<&str> {
+    self.profiles.get(self.selected).map(String::as_str)
+  }
+
+  /// Move the highlight down one row, wrapping. No-op with fewer than two
+  /// profiles (nothing to cycle). Disarms the countdown — changing the
+  /// target must be re-confirmed.
+  pub fn next(&mut self) {
+    if self.profiles.len() < 2 {
+      return;
+    }
+    self.selected = (self.selected + 1) % self.profiles.len();
+    self.confirm.reset();
+  }
+
+  /// Move the highlight up one row, wrapping. No-op with fewer than two
+  /// profiles. Disarms the countdown.
+  pub fn prev(&mut self) {
+    if self.profiles.len() < 2 {
+      return;
+    }
+    self.selected = (self.selected + self.profiles.len() - 1) % self.profiles.len();
+    self.confirm.reset();
+  }
+
+  /// Store a fresh scan snapshot + the gate-preserved names, disarming any
+  /// running countdown (the figures it was about to act on just changed).
+  pub fn set_scan(&mut self, reclaim: WorktreeReclaim, skipped: Vec<String>) {
+    self.reclaim = Some(reclaim);
+    self.skipped = skipped;
+    self.confirm.reset();
+  }
+
+  /// The current gated scan snapshot, if any.
+  pub fn reclaim(&self) -> Option<&WorktreeReclaim> {
+    self.reclaim.as_ref()
+  }
+
+  /// Directory names the safety gate preserved in the current scan.
+  pub fn skipped(&self) -> &[String] {
+    &self.skipped
+  }
+
+  /// Total reclaimable bytes in the current snapshot (`0` before a scan or
+  /// when nothing is safe to delete).
+  pub fn total_bytes(&self) -> u64 {
+    self.reclaim.as_ref().map(|r| r.total_bytes).unwrap_or(0)
+  }
+
+  /// `true` when the current scan has nothing safe to reclaim.
+  pub fn is_empty_scan(&self) -> bool {
+    self.total_bytes() == 0
+  }
+}

--- a/src/tui/state/clean_overlay.rs
+++ b/src/tui/state/clean_overlay.rs
@@ -43,12 +43,16 @@ impl CleanOverlay {
     Self::default()
   }
 
-  /// Populate the picker profile names, reset the highlight, and clear any
+  /// Populate the picker profile names, seed the highlight, and clear any
   /// stale snapshot / countdown. The orchestrator follows this with
   /// [`Self::set_scan`] once the first scan completes.
+  ///
+  /// The highlight opens on the `default` profile when one is configured —
+  /// so the overlay's first preview matches what `gwm clean` with no
+  /// `--profile` would resolve — falling back to the first row otherwise.
   pub fn open(&mut self, profiles: Vec<String>) {
+    self.selected = profiles.iter().position(|p| p == "default").unwrap_or(0);
     self.profiles = profiles;
-    self.selected = 0;
     self.reclaim = None;
     self.skipped.clear();
     self.confirm.reset();

--- a/src/tui/state/clean_overlay.rs
+++ b/src/tui/state/clean_overlay.rs
@@ -15,18 +15,26 @@
 use super::confirm::ConfirmModal;
 use crate::clean::WorktreeReclaim;
 
+/// The picker label for the no-`--profile` choice — the directory set
+/// `gwm clean` resolves with no profile (`[clean.profiles.default]` when
+/// defined, else the built-in `target` / `node_modules` / `dist` / `build`).
+pub const DEFAULT_CHOICE_LABEL: &str = "(default)";
+
 /// Pure state for the clean overlay. `Default` is a closed overlay (no
-/// profiles, no snapshot, disarmed countdown).
+/// choices, no snapshot, disarmed countdown).
 #[derive(Debug, Default)]
 pub struct CleanOverlay {
-  /// Configured `[clean.profiles.*]` names (sorted). Empty ⇒ the overlay
-  /// scans the built-in default set and the picker has nothing to cycle.
-  profiles: Vec<String>,
-  /// Highlighted profile row (meaningful only while `profiles` is
-  /// non-empty).
+  /// Picker choices: `None` (the no-`--profile` path — `gwm clean` resolves
+  /// the `default` profile when defined, else the built-in set) followed by
+  /// each configured `[clean.profiles.*]` name. The leading `None` is always
+  /// present once [`Self::open`] has run, so the overlay's default matches
+  /// the CLI even when a repo defines only non-`default` profiles — and the
+  /// built-in set stays reachable.
+  choices: Vec<Option<String>>,
+  /// Highlighted choice row.
   selected: usize,
   /// The most recent gated scan snapshot for the selected worktree, filled
-  /// by `App::enter_clean_overlay` and re-filled on a profile change. `None`
+  /// by `App::enter_clean_overlay` and re-filled on a choice change. `None`
   /// before the first scan.
   reclaim: Option<WorktreeReclaim>,
   /// Directory names found but preserved by the safety gate (not
@@ -43,61 +51,70 @@ impl CleanOverlay {
     Self::default()
   }
 
-  /// Populate the picker profile names, seed the highlight, and clear any
-  /// stale snapshot / countdown. The orchestrator follows this with
-  /// [`Self::set_scan`] once the first scan completes.
+  /// Populate the picker from the configured profile names, reset the
+  /// highlight to the `(default)` choice, and clear any stale snapshot /
+  /// countdown. The orchestrator follows this with [`Self::set_scan`] once
+  /// the first scan completes.
   ///
-  /// The highlight opens on the `default` profile when one is configured —
-  /// so the overlay's first preview matches what `gwm clean` with no
-  /// `--profile` would resolve — falling back to the first row otherwise.
+  /// Opens on the no-`--profile` choice so the overlay's first preview always
+  /// matches what `gwm clean` would resolve — the built-in set, or
+  /// `[clean.profiles.default]` when defined — regardless of which optional
+  /// profiles the repo adds.
   pub fn open(&mut self, profiles: Vec<String>) {
-    self.selected = profiles.iter().position(|p| p == "default").unwrap_or(0);
-    self.profiles = profiles;
+    self.choices = std::iter::once(None).chain(profiles.into_iter().map(Some)).collect();
+    self.selected = 0;
     self.reclaim = None;
     self.skipped.clear();
     self.confirm.reset();
   }
 
-  /// The configured profile names, in display order.
-  pub fn profiles(&self) -> &[String] {
-    &self.profiles
+  /// The picker labels, in display order. The no-`--profile` entry renders as
+  /// [`DEFAULT_CHOICE_LABEL`]; named profiles render as themselves.
+  pub fn choice_labels(&self) -> Vec<&str> {
+    self
+      .choices
+      .iter()
+      .map(|c| c.as_deref().unwrap_or(DEFAULT_CHOICE_LABEL))
+      .collect()
   }
 
-  /// `true` when at least one `[clean.profiles]` entry exists (the picker
-  /// can cycle).
+  /// `true` when the repo configures at least one named profile, so the
+  /// picker is worth rendering (otherwise there is only the implicit
+  /// `(default)` choice).
   pub fn has_profiles(&self) -> bool {
-    !self.profiles.is_empty()
+    self.choices.len() > 1
   }
 
-  /// The highlighted profile row.
+  /// The highlighted choice row.
   pub fn selected_index(&self) -> usize {
     self.selected
   }
 
-  /// The highlighted profile name, or `None` when no profiles are
-  /// configured (the overlay scans the built-in default set).
+  /// The highlighted profile name to hand to `resolve_clean_dirs`: `None` for
+  /// the `(default)` choice (no `--profile`), `Some(name)` for a configured
+  /// profile.
   pub fn selected_profile(&self) -> Option<&str> {
-    self.profiles.get(self.selected).map(String::as_str)
+    self.choices.get(self.selected).and_then(|c| c.as_deref())
   }
 
   /// Move the highlight down one row, wrapping. No-op with fewer than two
-  /// profiles (nothing to cycle). Disarms the countdown — changing the
-  /// target must be re-confirmed.
+  /// choices (nothing to cycle). Disarms the countdown — changing the target
+  /// must be re-confirmed.
   pub fn next(&mut self) {
-    if self.profiles.len() < 2 {
+    if self.choices.len() < 2 {
       return;
     }
-    self.selected = (self.selected + 1) % self.profiles.len();
+    self.selected = (self.selected + 1) % self.choices.len();
     self.confirm.reset();
   }
 
   /// Move the highlight up one row, wrapping. No-op with fewer than two
-  /// profiles. Disarms the countdown.
+  /// choices. Disarms the countdown.
   pub fn prev(&mut self) {
-    if self.profiles.len() < 2 {
+    if self.choices.len() < 2 {
       return;
     }
-    self.selected = (self.selected + self.profiles.len() - 1) % self.profiles.len();
+    self.selected = (self.selected + self.choices.len() - 1) % self.choices.len();
     self.confirm.reset();
   }
 

--- a/src/tui/state/clean_overlay.rs
+++ b/src/tui/state/clean_overlay.rs
@@ -112,25 +112,29 @@ impl CleanOverlay {
     self.choices.get(self.selected).and_then(|c| c.as_deref())
   }
 
-  /// Move the highlight down one row, wrapping. No-op with fewer than two
-  /// choices (nothing to cycle). Disarms the countdown — changing the target
-  /// must be re-confirmed.
-  pub fn next(&mut self) {
+  /// Move the highlight down one row, wrapping. Returns `true` when the
+  /// highlight actually moved (so the orchestrator re-scans and the re-scan
+  /// disarms the countdown). A no-op — fewer than two choices — returns
+  /// `false` and leaves an armed countdown untouched, so a stray `j` with
+  /// only the `(default)` choice can't silently cancel a pending reclaim
+  /// (Codex #333 review).
+  pub fn select_next(&mut self) -> bool {
     if self.choices.len() < 2 {
-      return;
+      return false;
     }
     self.selected = (self.selected + 1) % self.choices.len();
-    self.confirm.reset();
+    true
   }
 
-  /// Move the highlight up one row, wrapping. No-op with fewer than two
-  /// choices. Disarms the countdown.
-  pub fn prev(&mut self) {
+  /// Move the highlight up one row, wrapping. Returns `true` when the
+  /// highlight actually moved; a no-op (fewer than two choices) returns
+  /// `false` and leaves an armed countdown untouched.
+  pub fn select_prev(&mut self) -> bool {
     if self.choices.len() < 2 {
-      return;
+      return false;
     }
     self.selected = (self.selected + self.choices.len() - 1) % self.choices.len();
-    self.confirm.reset();
+    true
   }
 
   /// Store a fresh scan snapshot + the gate-preserved names, disarming any

--- a/src/tui/state/exec_picker.rs
+++ b/src/tui/state/exec_picker.rs
@@ -7,12 +7,15 @@
 //! PTY overlay with that argv in the selected worktree's directory.
 //!
 //! The picker is deliberately tiny: a sorted list of `[exec.profiles.*]`
-//! names plus a wrapping highlight. `Enter` accepts the highlight, `Esc`
-//! cancels — the `j`/`k`/arrow navigation lives in
-//! [`crate::tui::modal_keymap`] under `KeyContext::ExecPicker`.
+//! names, a wrapping highlight, and the worktree path it was opened for.
+//! `Enter` accepts the highlight, `Esc` cancels — the `j`/`k`/arrow
+//! navigation lives in [`crate::tui::modal_keymap`] under
+//! `KeyContext::ExecPicker`.
+
+use std::path::{Path, PathBuf};
 
 /// Pure state for the exec profile picker. `Default` is an empty, closed
-/// picker (no profiles, highlight at 0).
+/// picker (no profiles, no target, highlight at 0).
 #[derive(Debug, Default)]
 pub struct ExecPicker {
   /// Exec profile names from `[exec.profiles.*]`, in the sorted order the
@@ -21,6 +24,10 @@ pub struct ExecPicker {
   /// Highlighted row index. Always a valid index into `profiles` while
   /// non-empty; the `next`/`prev` wrappers keep it in range.
   selected: usize,
+  /// The worktree directory the picker was opened for. Captured at open so
+  /// `Enter` runs the profile in *that* worktree even if an auto-refresh
+  /// drifts the live selection while the overlay sits open (Codex #333).
+  cwd: Option<PathBuf>,
 }
 
 impl ExecPicker {
@@ -28,12 +35,18 @@ impl ExecPicker {
     Self::default()
   }
 
-  /// (Re)populate the picker from a list of profile names, resetting the
-  /// highlight to the top. Called by the orchestrator's
-  /// `enter_exec_picker` each time the overlay opens.
-  pub fn open(&mut self, profiles: Vec<String>) {
+  /// (Re)populate the picker from a list of profile names + the worktree it
+  /// targets, resetting the highlight to the top. Called by the
+  /// orchestrator's `enter_exec_picker` each time the overlay opens.
+  pub fn open(&mut self, profiles: Vec<String>, cwd: PathBuf) {
     self.profiles = profiles;
     self.selected = 0;
+    self.cwd = Some(cwd);
+  }
+
+  /// The worktree directory the picker was opened for, if any.
+  pub fn cwd(&self) -> Option<&Path> {
+    self.cwd.as_deref()
   }
 
   /// The profile names, in display order.

--- a/src/tui/state/exec_picker.rs
+++ b/src/tui/state/exec_picker.rs
@@ -1,0 +1,77 @@
+//! Exec profile picker state (issue #325).
+//!
+//! Pure state — no `App` / `Config` / PTY dependency beyond the sorted
+//! profile-name list handed in at open time. The `App` orchestrator owns
+//! resolving the highlighted profile to an argv (via
+//! [`crate::exec::resolve_exec_command`]); the run loop owns spawning the
+//! PTY overlay with that argv in the selected worktree's directory.
+//!
+//! The picker is deliberately tiny: a sorted list of `[exec.profiles.*]`
+//! names plus a wrapping highlight. `Enter` accepts the highlight, `Esc`
+//! cancels — the `j`/`k`/arrow navigation lives in
+//! [`crate::tui::modal_keymap`] under `KeyContext::ExecPicker`.
+
+/// Pure state for the exec profile picker. `Default` is an empty, closed
+/// picker (no profiles, highlight at 0).
+#[derive(Debug, Default)]
+pub struct ExecPicker {
+  /// Exec profile names from `[exec.profiles.*]`, in the sorted order the
+  /// orchestrator hands them over (a `BTreeMap` key walk).
+  profiles: Vec<String>,
+  /// Highlighted row index. Always a valid index into `profiles` while
+  /// non-empty; the `next`/`prev` wrappers keep it in range.
+  selected: usize,
+}
+
+impl ExecPicker {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// (Re)populate the picker from a list of profile names, resetting the
+  /// highlight to the top. Called by the orchestrator's
+  /// `enter_exec_picker` each time the overlay opens.
+  pub fn open(&mut self, profiles: Vec<String>) {
+    self.profiles = profiles;
+    self.selected = 0;
+  }
+
+  /// The profile names, in display order.
+  pub fn profiles(&self) -> &[String] {
+    &self.profiles
+  }
+
+  /// `true` when no profiles are loaded (the orchestrator refuses to open
+  /// the overlay in this state, but the picker stays well-defined).
+  pub fn is_empty(&self) -> bool {
+    self.profiles.is_empty()
+  }
+
+  /// The highlighted row index (clamped to `profiles`).
+  pub fn selected_index(&self) -> usize {
+    self.selected
+  }
+
+  /// The highlighted profile name, or `None` when the picker is empty.
+  pub fn selected_profile(&self) -> Option<&str> {
+    self.profiles.get(self.selected).map(String::as_str)
+  }
+
+  /// Move the highlight down one row, wrapping to the top. No-op when
+  /// empty.
+  pub fn next(&mut self) {
+    if self.profiles.is_empty() {
+      return;
+    }
+    self.selected = (self.selected + 1) % self.profiles.len();
+  }
+
+  /// Move the highlight up one row, wrapping to the bottom. No-op when
+  /// empty.
+  pub fn prev(&mut self) {
+    if self.profiles.is_empty() {
+      return;
+    }
+    self.selected = (self.selected + self.profiles.len() - 1) % self.profiles.len();
+  }
+}

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -20,6 +20,7 @@ pub mod command_logs;
 pub mod config_panel;
 pub mod confirm;
 pub mod create_form;
+pub mod exec_picker;
 pub mod filter;
 pub mod github_fetch;
 pub mod link_prompt;

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -16,6 +16,7 @@
 //! - `config_panel` — scroll + resolved-row snapshot for the Configuration overlay (#232)
 
 pub mod async_task;
+pub mod clean_overlay;
 pub mod command_logs;
 pub mod config_panel;
 pub mod confirm;

--- a/src/tui/state/pty_overlay.rs
+++ b/src/tui/state/pty_overlay.rs
@@ -51,6 +51,13 @@ pub struct PtyOverlay {
   /// Set by the `ReviewOverlay` dispatcher when `[review].command` uses `{diff}`.
   /// Dropped (and thus unlinked) when the overlay closes.
   pub diff_file: Option<tempfile::NamedTempFile>,
+  /// Set by the run loop when a [`PtyKind::Exec`] child has exited and the
+  /// overlay is *lingering* so its final output stays on screen (issue #325).
+  /// Unlike lazygit / a shell — which close the overlay the instant the child
+  /// dies — a one-shot exec command (`cargo test`, `npm run build`) exits as
+  /// soon as it finishes, so the overlay must persist until the user
+  /// dismisses it. While `true`, any keystroke closes the overlay.
+  pub finished: bool,
 }
 
 impl std::fmt::Debug for PtyOverlay {
@@ -132,6 +139,7 @@ impl PtyOverlay {
       cols,
       rows,
       diff_file: None,
+      finished: false,
     })
   }
 

--- a/src/tui/state/pty_overlay.rs
+++ b/src/tui/state/pty_overlay.rs
@@ -65,7 +65,11 @@ pub struct PtyOverlay {
   /// The child leader's PID, captured at spawn so the process-group SIGKILL
   /// can target it even after the leader is reaped (its live `process_id()`
   /// may then be `None`). On Unix the child is a session leader (PGID == PID),
-  /// so `kill(-pid)` reaps the whole pipeline.
+  /// so `kill(-pid)` reaps the whole pipeline. Read only inside the
+  /// `#[cfg(unix)]` arm of [`Self::signal_group`]; Windows has no process
+  /// groups (termination goes through `Child::kill`), so the field is unused
+  /// there.
+  #[cfg_attr(not(unix), allow(dead_code))]
   spawn_pid: Option<u32>,
   /// `true` once the process-group SIGKILL has been sent (issue #325 / Codex
   /// #333 review). Sent exactly once — promptly when an exec leader exits

--- a/src/tui/state/pty_overlay.rs
+++ b/src/tui/state/pty_overlay.rs
@@ -58,12 +58,21 @@ pub struct PtyOverlay {
   /// soon as it finishes, so the overlay must persist until the user
   /// dismisses it. While `true`, any keystroke closes the overlay.
   pub finished: bool,
-  /// `true` once the child has been observed exited and reaped (by
-  /// [`Self::is_alive`] or [`Self::kill`]). Guards [`Self::kill`] from sending
-  /// a signal to a PID/PGID that the OS may have recycled to an unrelated
-  /// process after reaping (issue #325 / Codex #333 review) — once reaped,
-  /// `kill` is a no-op.
+  /// `true` once the child leader has been observed exited and reaped (by
+  /// [`Self::is_alive`] or [`Self::kill`]). Guards [`Self::kill`] from blocking
+  /// on a second `wait()` for an already-reaped leader.
   reaped: bool,
+  /// The child leader's PID, captured at spawn so the process-group SIGKILL
+  /// can target it even after the leader is reaped (its live `process_id()`
+  /// may then be `None`). On Unix the child is a session leader (PGID == PID),
+  /// so `kill(-pid)` reaps the whole pipeline.
+  spawn_pid: Option<u32>,
+  /// `true` once the process-group SIGKILL has been sent (issue #325 / Codex
+  /// #333 review). Sent exactly once — promptly when an exec leader exits
+  /// (so backgrounded descendants like `sh -c "sleep 60 &"` are cleaned in
+  /// the safe window, while the PGID is still valid), so the later dismissal
+  /// of a lingering overlay never re-signals a possibly-recycled PGID.
+  signalled: bool,
 }
 
 impl std::fmt::Debug for PtyOverlay {
@@ -106,6 +115,10 @@ impl PtyOverlay {
       .slave
       .spawn_command(cmd)
       .map_err(|e| GwmError::Other(e.to_string()))?;
+    // Capture the leader PID now, while it is valid: after the leader is
+    // reaped, `process_id()` may return `None`, but we still need its PID to
+    // SIGKILL the process group and clean backgrounded descendants (#333).
+    let spawn_pid = child.process_id();
     // Slave fd is no longer needed once the child holds its own copy.
     drop(pair.slave);
 
@@ -147,6 +160,8 @@ impl PtyOverlay {
       diff_file: None,
       finished: false,
       reaped: false,
+      spawn_pid,
+      signalled: false,
     })
   }
 
@@ -191,9 +206,9 @@ impl PtyOverlay {
     });
   }
 
-  /// Returns `true` while the child process is still running. Once it has
-  /// exited, records the reap so [`Self::kill`] never signals the (possibly
-  /// recycled) PID/PGID afterwards (#333 review).
+  /// Returns `true` while the child leader is still running. Once it has
+  /// exited, records the reap so [`Self::kill`] skips a second blocking
+  /// `wait()`.
   pub fn is_alive(&mut self) -> bool {
     match self.child.try_wait() {
       Ok(None) => true,
@@ -204,10 +219,40 @@ impl PtyOverlay {
     }
   }
 
-  /// Send SIGKILL (or the platform equivalent) to the child process and
-  /// wait until it is reaped. On Unix the entire process group is killed so
-  /// that sub-processes spawned by the shell (e.g. `yes | head`) are also
-  /// terminated.
+  /// Send `SIGKILL` to the child's process group exactly once, using the PID
+  /// captured at spawn so it works even after the leader was reaped. On Unix
+  /// the child is a session leader (PGID == PID), so this also terminates any
+  /// backgrounded descendants (`sh -c "sleep 60 &"`). No-op on a second call,
+  /// and on non-Unix.
+  fn signal_group(&mut self) {
+    if self.signalled {
+      return;
+    }
+    self.signalled = true;
+    #[cfg(unix)]
+    if let Some(pid) = self.spawn_pid {
+      unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+    }
+  }
+
+  /// Mark a finished (exited) exec overlay as lingering and PROMPTLY clean its
+  /// process group while the PGID is still valid (#333 review). Sending the
+  /// group SIGKILL the instant the leader exits — rather than deferring it to
+  /// the dismissal keystroke — both reaps backgrounded descendants and keeps
+  /// the signal out of the long linger window where the kernel could recycle
+  /// the PGID. Called by the run loop when it detects a [`PtyKind::Exec`]
+  /// child has died.
+  pub fn mark_finished(&mut self) {
+    self.signal_group();
+    self.finished = true;
+  }
+
+  /// Send SIGKILL to the child's process group and wait until the leader is
+  /// reaped. On Unix the entire group is killed so sub-processes spawned by
+  /// the shell (e.g. `yes | head`, or a backgrounded `sleep`) are terminated
+  /// too — even if the leader already exited (the group signal goes through
+  /// [`Self::signal_group`], which is a no-op once already sent, e.g. by
+  /// [`Self::mark_finished`] for a lingering exec).
   ///
   /// On macOS a PTY child that is blocked in a kernel write (D-state) will
   /// not react to SIGKILL until the PTY master drains enough data to allow
@@ -216,19 +261,14 @@ impl PtyOverlay {
   /// guards against the unexpected: after that we fall back to a blocking
   /// `wait()`.
   pub fn kill(&mut self) {
-    // Already exited and reaped (observed by `is_alive`, or a prior `kill`):
-    // the kernel may have recycled this PID/PGID, so sending SIGKILL to
-    // `-pid` could hit an unrelated process group. Never signal after a reap
-    // — this is the lingering-exec-overlay dismissal path (#333 review), and
-    // also covers lazygit / a shell that exited on its own before close.
+    // Clean the process group (kills backgrounded descendants). Sent at most
+    // once: for a lingering exec overlay `mark_finished` already sent it when
+    // the leader exited, so this is a no-op here and the long-linger PGID is
+    // never re-signalled (#333 review).
+    self.signal_group();
+    // Leader already reaped (by is_alive / mark_finished): nothing to wait on.
     if self.reaped {
       return;
-    }
-    #[cfg(unix)]
-    if let Some(pid) = self.child.process_id() {
-      // portable-pty calls setsid() in pre_exec so the child is session
-      // leader: PGID == PID.  Killing -PGID terminates the whole pipeline.
-      unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
     }
     let _ = self.child.kill();
     // Drain up to 128 buffered chunks per tick so the reader thread can keep
@@ -253,11 +293,16 @@ impl PtyOverlay {
     self.reaped = true;
   }
 
-  /// `true` once the child has been observed exited and reaped — after which
-  /// [`Self::kill`] is a no-op (it must not signal a recycled PID/PGID).
+  /// `true` once the child leader has been observed exited and reaped.
   /// Exposed for the state-machine tests (#333 review).
   pub fn is_reaped(&self) -> bool {
     self.reaped
+  }
+
+  /// `true` once the process-group SIGKILL has been sent (descendant cleanup).
+  /// Exposed for the state-machine tests (#333 review).
+  pub fn group_signalled(&self) -> bool {
+    self.signalled
   }
 
   /// Poll the exit status without blocking. Exposed for tests that need to

--- a/src/tui/state/pty_overlay.rs
+++ b/src/tui/state/pty_overlay.rs
@@ -58,6 +58,12 @@ pub struct PtyOverlay {
   /// soon as it finishes, so the overlay must persist until the user
   /// dismisses it. While `true`, any keystroke closes the overlay.
   pub finished: bool,
+  /// `true` once the child has been observed exited and reaped (by
+  /// [`Self::is_alive`] or [`Self::kill`]). Guards [`Self::kill`] from sending
+  /// a signal to a PID/PGID that the OS may have recycled to an unrelated
+  /// process after reaping (issue #325 / Codex #333 review) — once reaped,
+  /// `kill` is a no-op.
+  reaped: bool,
 }
 
 impl std::fmt::Debug for PtyOverlay {
@@ -140,6 +146,7 @@ impl PtyOverlay {
       rows,
       diff_file: None,
       finished: false,
+      reaped: false,
     })
   }
 
@@ -184,9 +191,17 @@ impl PtyOverlay {
     });
   }
 
-  /// Returns `true` while the child process is still running.
+  /// Returns `true` while the child process is still running. Once it has
+  /// exited, records the reap so [`Self::kill`] never signals the (possibly
+  /// recycled) PID/PGID afterwards (#333 review).
   pub fn is_alive(&mut self) -> bool {
-    matches!(self.child.try_wait(), Ok(None))
+    match self.child.try_wait() {
+      Ok(None) => true,
+      _ => {
+        self.reaped = true;
+        false
+      }
+    }
   }
 
   /// Send SIGKILL (or the platform equivalent) to the child process and
@@ -201,6 +216,14 @@ impl PtyOverlay {
   /// guards against the unexpected: after that we fall back to a blocking
   /// `wait()`.
   pub fn kill(&mut self) {
+    // Already exited and reaped (observed by `is_alive`, or a prior `kill`):
+    // the kernel may have recycled this PID/PGID, so sending SIGKILL to
+    // `-pid` could hit an unrelated process group. Never signal after a reap
+    // — this is the lingering-exec-overlay dismissal path (#333 review), and
+    // also covers lazygit / a shell that exited on its own before close.
+    if self.reaped {
+      return;
+    }
     #[cfg(unix)]
     if let Some(pid) = self.child.process_id() {
       // portable-pty calls setsid() in pre_exec so the child is session
@@ -212,7 +235,10 @@ impl PtyOverlay {
     // consuming from the PTY master fd, preventing a kernel D-state deadlock.
     for _ in 0..100 {
       match self.child.try_wait() {
-        Ok(Some(_)) => return,
+        Ok(Some(_)) => {
+          self.reaped = true;
+          return;
+        }
         _ => {
           for _ in 0..128 {
             if self.rx.try_recv().is_err() {
@@ -224,6 +250,14 @@ impl PtyOverlay {
       }
     }
     let _ = self.child.wait();
+    self.reaped = true;
+  }
+
+  /// `true` once the child has been observed exited and reaped — after which
+  /// [`Self::kill`] is a no-op (it must not signal a recycled PID/PGID).
+  /// Exposed for the state-machine tests (#333 review).
+  pub fn is_reaped(&self) -> bool {
+    self.reaped
   }
 
   /// Poll the exit status without blocking. Exposed for tests that need to

--- a/src/tui/state/pty_overlay.rs
+++ b/src/tui/state/pty_overlay.rs
@@ -27,6 +27,9 @@ pub enum PtyKind {
   Terminal,
   /// The `[review]` launcher (e.g. `codex review --base dev`) in PTY overlay.
   Review,
+  /// An `[exec.profiles.<name>]` profile command, run in the selected
+  /// worktree via the exec picker overlay (issue #325).
+  Exec,
 }
 
 /// Live PTY overlay — one spawned process, one vt100 parser, one mpsc reader

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4139,14 +4139,15 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
 
   let mut lines = overlay_title_lines("reclaim build artifacts", border);
 
-  // Profile picker (only when `[clean.profiles]` are configured).
+  // Profile picker — the `(default)` choice plus any `[clean.profiles]`.
+  // Only worth rendering when the repo configures named profiles.
   if app.clean_overlay.has_profiles() {
     let selected = app.clean_overlay.selected_index();
-    for (i, name) in app.clean_overlay.profiles().iter().enumerate() {
+    for (i, label) in app.clean_overlay.choice_labels().iter().enumerate() {
       let line = if i == selected {
-        Line::from(format!("▸ {name}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+        Line::from(format!("▸ {label}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
       } else {
-        Line::from(format!("  {name}")).style(Style::default().fg(muted))
+        Line::from(format!("  {label}")).style(Style::default().fg(muted))
       };
       lines.push(line.centered());
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -166,6 +166,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::CommandLogs => draw_command_logs(f, app),
     View::Config => draw_config_panel(f, app),
     View::Pty => draw_pty_overlay(f, app),
+    // #325: exec profile picker renders as a small centred modal.
+    View::ExecPicker => draw_exec_picker(f, app),
     // #290: branch-rename inline modal renders over the list.
     View::Edit => draw_edit_worktree(f, app),
     View::List => {}
@@ -1806,6 +1808,9 @@ pub enum HintContext {
   /// PTY overlay (embedded lazygit / terminal). All keys pass through to the
   /// child process; Esc is the only gwm-level escape hatch.
   Pty,
+  /// Exec profile picker overlay (issue #325): j/k pick, Enter runs, Esc
+  /// cancels.
+  ExecPicker,
   /// Branch-rename modal (`View::Edit`, #290).
   Rename,
 }
@@ -1827,6 +1832,7 @@ impl HintContext {
       HintContext::Report => "report",
       HintContext::Help => "help",
       HintContext::Pty => "terminal",
+      HintContext::ExecPicker => "exec",
       HintContext::Rename => "rename",
     }
   }
@@ -1945,6 +1951,14 @@ impl HintContext {
         Hint::Modal(ModalAction::HelpClose, "close"),
       ],
       HintContext::Pty => &[Hint::Lit("Esc", "close")],
+      // #325: pick a profile then run it in a PTY. The j/k movement pair
+      // stays literal (no single resolved key captures it), matching the
+      // palette / create convention.
+      HintContext::ExecPicker => &[
+        Hint::Lit("↑/↓", "pick"),
+        Hint::Modal(ModalAction::ExecPickerAccept, "run"),
+        Hint::Modal(ModalAction::ExecPickerCancel, "cancel"),
+      ],
       // Rename reuses the create-form input handler, hence the `create`
       // context's verbs (#290 / #219).
       HintContext::Rename => &[
@@ -1993,6 +2007,7 @@ impl HintContext {
       HintContext::CommandPalette => KeyContext::CommandPalette,
       HintContext::Report => KeyContext::Report,
       HintContext::Help => KeyContext::Help,
+      HintContext::ExecPicker => KeyContext::ExecPicker,
       HintContext::Worktrees | HintContext::Status | HintContext::Picker | HintContext::Pty => return None,
     })
   }
@@ -3875,6 +3890,7 @@ fn draw_pty_overlay(f: &mut Frame, app: &mut App) {
     Some(PtyKind::LazyGit) => " LazyGit ",
     Some(PtyKind::Terminal) => " Terminal ",
     Some(PtyKind::Review) => " Review ",
+    Some(PtyKind::Exec) => " Exec ",
     None => " Overlay ",
   };
   let block = overlay_block(app.theme.accent)
@@ -4051,6 +4067,38 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
       lines
     }
   };
+  let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
+  let term = f.area();
+  let width = link_prompt_modal_width(term.width);
+  let area = centered_abs(width, height, term);
+  f.render_widget(Clear, area);
+  f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
+}
+
+/// Render the exec profile picker overlay (issue #325). A small centred
+/// modal listing the `[exec.profiles.*]` names; the highlighted row reads
+/// in the accent with a `▸` marker, the rest muted. `Enter` resolves the
+/// highlight and the run loop spawns it in a PTY overlay.
+fn draw_exec_picker(f: &mut Frame, app: &App) {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let selected = app.exec_picker.selected_index();
+  let mut lines = overlay_title_lines("run exec profile", accent);
+  for (i, name) in app.exec_picker.profiles().iter().enumerate() {
+    let line = if i == selected {
+      Line::from(format!("▸ {name}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+    } else {
+      Line::from(format!("  {name}")).style(Style::default().fg(muted))
+    };
+    lines.push(line.centered());
+  }
+  push_modal_hint(
+    &mut lines,
+    HintContext::ExecPicker,
+    &app.keymap,
+    &app.modal_keymap,
+    &app.theme,
+  );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
   let term = f.area();
   let width = link_prompt_modal_width(term.width);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -168,6 +168,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::Pty => draw_pty_overlay(f, app),
     // #325: exec profile picker renders as a small centred modal.
     View::ExecPicker => draw_exec_picker(f, app),
+    // #325: clean reclaim report renders as a centred modal.
+    View::CleanReport => draw_clean_overlay(f, app),
     // #290: branch-rename inline modal renders over the list.
     View::Edit => draw_edit_worktree(f, app),
     View::List => {}
@@ -1811,6 +1813,9 @@ pub enum HintContext {
   /// Exec profile picker overlay (issue #325): j/k pick, Enter runs, Esc
   /// cancels.
   ExecPicker,
+  /// Clean reclaim overlay (issue #325): j/k pick a profile, confirm
+  /// reclaims (safety countdown), Esc cancels.
+  Clean,
   /// Branch-rename modal (`View::Edit`, #290).
   Rename,
 }
@@ -1833,6 +1838,7 @@ impl HintContext {
       HintContext::Help => "help",
       HintContext::Pty => "terminal",
       HintContext::ExecPicker => "exec",
+      HintContext::Clean => "clean",
       HintContext::Rename => "rename",
     }
   }
@@ -1959,6 +1965,14 @@ impl HintContext {
         Hint::Modal(ModalAction::ExecPickerAccept, "run"),
         Hint::Modal(ModalAction::ExecPickerCancel, "cancel"),
       ],
+      // #325: the profile picker pair stays literal; confirm / cancel are
+      // rebindable modal verbs (the safety countdown reuses the delete
+      // confirm's `y` / Enter convention).
+      HintContext::Clean => &[
+        Hint::Lit("↑/↓", "profile"),
+        Hint::Modal(ModalAction::CleanConfirm, "reclaim"),
+        Hint::Modal(ModalAction::CleanCancel, "cancel"),
+      ],
       // Rename reuses the create-form input handler, hence the `create`
       // context's verbs (#290 / #219).
       HintContext::Rename => &[
@@ -2008,6 +2022,7 @@ impl HintContext {
       HintContext::Report => KeyContext::Report,
       HintContext::Help => KeyContext::Help,
       HintContext::ExecPicker => KeyContext::ExecPicker,
+      HintContext::Clean => KeyContext::Clean,
       HintContext::Worktrees | HintContext::Status | HintContext::Picker | HintContext::Pty => return None,
     })
   }
@@ -4105,6 +4120,95 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
+}
+
+/// Render the clean reclaim overlay (issue #325). A centred modal showing
+/// the gated reclaim report for the selected worktree (per-artifact sizes +
+/// total), the `[clean.profiles.*]` picker when configured, the gate-
+/// preserved names, and a danger-coloured armed indicator while the safety
+/// countdown runs. The live countdown progresses on the status bar; the
+/// border switches to the danger colour once armed.
+fn draw_clean_overlay(f: &mut Frame, app: &App) {
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+  let danger = app.theme.prunable;
+  let armed = app.clean_overlay.confirm.is_armed();
+  let border = if armed { danger } else { accent };
+
+  let mut lines = overlay_title_lines("reclaim build artifacts", border);
+
+  // Profile picker (only when `[clean.profiles]` are configured).
+  if app.clean_overlay.has_profiles() {
+    let selected = app.clean_overlay.selected_index();
+    for (i, name) in app.clean_overlay.profiles().iter().enumerate() {
+      let line = if i == selected {
+        Line::from(format!("▸ {name}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+      } else {
+        Line::from(format!("  {name}")).style(Style::default().fg(muted))
+      };
+      lines.push(line.centered());
+    }
+    lines.push(Line::from(""));
+  }
+
+  // The gated reclaim report — only the git-ignored, untracked artifacts.
+  match app.clean_overlay.reclaim() {
+    Some(reclaim) if !reclaim.artifacts.is_empty() => {
+      for a in &reclaim.artifacts {
+        lines.push(
+          Line::from(format!("{:<14} {}", a.rel, crate::clean::human_size(a.bytes)))
+            .style(Style::default().fg(muted))
+            .centered(),
+        );
+      }
+      lines.push(
+        Line::from(format!("total {}", crate::clean::human_size(reclaim.total_bytes)))
+          .style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
+          .centered(),
+      );
+    }
+    _ => {
+      lines.push(
+        Line::from("nothing to reclaim")
+          .style(Style::default().fg(muted))
+          .centered(),
+      );
+    }
+  }
+
+  // Gate-preserved names — explain why a visible `target/` was not counted.
+  for rel in app.clean_overlay.skipped() {
+    lines.push(
+      Line::from(format!("skipped {rel} — not git-ignored / holds tracked files"))
+        .style(Style::default().fg(muted))
+        .centered(),
+    );
+  }
+
+  // Danger-coloured armed indicator; the live countdown shows on the status
+  // bar (set by `clean_confirm_press`), so the render stays time-free.
+  if armed {
+    lines.push(Line::from(""));
+    lines.push(
+      Line::from("⚠ armed — confirm again or cancel to abort")
+        .style(Style::default().fg(danger).add_modifier(Modifier::BOLD))
+        .centered(),
+    );
+  }
+
+  push_modal_hint(
+    &mut lines,
+    HintContext::Clean,
+    &app.keymap,
+    &app.modal_keymap,
+    &app.theme,
+  );
+  let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
+  let term = f.area();
+  let width = link_prompt_modal_width(term.width);
+  let area = centered_abs(width, height, term);
+  f.render_widget(Clear, area);
+  f.render_widget(Paragraph::new(lines).block(overlay_block(border)), area);
 }
 
 /// Render the command palette overlay (issue #32).

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3901,11 +3901,13 @@ fn draw_pty_overlay(f: &mut Frame, app: &mut App) {
 
   f.render_widget(Clear, area);
 
-  let title = match app.pty_overlay.as_ref().map(|p| &p.kind) {
-    Some(PtyKind::LazyGit) => " LazyGit ",
-    Some(PtyKind::Terminal) => " Terminal ",
-    Some(PtyKind::Review) => " Review ",
-    Some(PtyKind::Exec) => " Exec ",
+  let title = match app.pty_overlay.as_ref().map(|p| (p.kind, p.finished)) {
+    Some((PtyKind::LazyGit, _)) => " LazyGit ",
+    Some((PtyKind::Terminal, _)) => " Terminal ",
+    Some((PtyKind::Review, _)) => " Review ",
+    Some((PtyKind::Exec, false)) => " Exec ",
+    // #325: once the one-shot command exits, the title invites dismissal.
+    Some((PtyKind::Exec, true)) => " Exec · done — press any key ",
     None => " Overlay ",
   };
   let block = overlay_block(app.theme.accent)

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -607,3 +607,17 @@ fn from_slug_compat_still_resolves_canonical_slugs() {
   assert_eq!(Action::from_slug_compat("down"), Some(Action::Down));
   assert_eq!(Action::from_slug_compat("nonexistent_slug_xyz"), None);
 }
+
+#[test]
+fn exec_and_clean_overlays_are_repo_mutating() {
+  // Codex #333 review: in workspace mode the stale-selection guard
+  // (`workspace_active_stale && is_repo_mutating`) must block `x` / `X` —
+  // they resolve their command / dir-set from the active repo's config and
+  // act on the selected path, both stale when the row's repo can't activate.
+  assert!(Action::ExecOverlay.is_repo_mutating());
+  assert!(Action::CleanOverlay.is_repo_mutating());
+  // Sanity: read-only / navigation verbs stay non-mutating.
+  assert!(!Action::Down.is_repo_mutating());
+  assert!(!Action::CommandLogs.is_repo_mutating());
+  assert!(!Action::ConfigPanel.is_repo_mutating());
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7677,3 +7677,51 @@ fn clean_overlay_deletes_the_open_time_target_and_config_after_a_drift() {
     "reclaimed via the captured target + config despite the drift"
   );
 }
+
+#[test]
+fn exec_picker_pins_a_worktree_relative_program_to_the_target() {
+  // Codex #333: a `[exec.profiles].command` like `./run.sh` must resolve
+  // against the captured worktree (like the CLI's resolve_program), not gwm's
+  // own cwd.
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.run]\ncommand = [\"./run.sh\", \"--ci\"]\n");
+  let wt = app.selected().unwrap().path.clone();
+  app.enter_exec_picker();
+  let (argv, _cwd) = app.exec_picker_resolve().expect("resolves");
+  // Same anchoring the CLI exec path applies — an absolute path under the
+  // worktree, not gwm's own cwd.
+  assert_eq!(
+    argv[0],
+    gwm::exec::resolve_program(&wt, "./run.sh").to_string_lossy(),
+    "the relative executable is pinned to the worktree"
+  );
+  assert!(std::path::Path::new(&argv[0]).is_absolute(), "and is absolute");
+  assert_eq!(argv[1], "--ci", "the args are passed through unchanged");
+}
+
+#[test]
+fn exec_picker_leaves_a_bare_command_for_path_lookup() {
+  // A bare command (no path separator) must NOT be anchored — it relies on
+  // PATH resolution inside the worktree.
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.t]\ncommand = [\"cargo\", \"test\"]\n");
+  app.enter_exec_picker();
+  let (argv, _cwd) = app.exec_picker_resolve().expect("resolves");
+  assert_eq!(argv, vec!["cargo".to_string(), "test".to_string()]);
+}
+
+#[test]
+fn clean_countdown_is_pinned_to_the_open_time_config() {
+  // Codex #333: the safety delay is captured at open, so a workspace config
+  // swap (e.g. to a repo with confirm_countdown_secs = 0) can't erase it
+  // while the overlay is armed.
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 3\n").unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // Drift: a refresh swapped in a repo with no safety delay.
+  app.config.tui.confirm_countdown_secs = 0;
+  assert_eq!(
+    app.clean_countdown_total(),
+    Duration::from_secs(3),
+    "the safety delay captured at open survives a live config swap"
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7304,3 +7304,93 @@ fn link_modal_binding_on_fetch_key_wins_over_fetch_fallback() {
     "a contextual binding on the fetch key must win over the fetch fallback"
   );
 }
+
+// ── Exec picker overlay (issue #325) ──────────────────────────────────────
+
+/// An `App` over a fresh repo whose `.gwm.toml` carries `toml`, so the exec
+/// config is loaded at construction. The selected worktree is the main one
+/// (the repo root) — a valid `cwd` for an exec run.
+fn app_with_gwm_toml(toml: &str) -> (tempfile::TempDir, App) {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gwm.toml"), toml).unwrap();
+  let app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  (repo, app)
+}
+
+#[test]
+fn exec_picker_refuses_to_open_with_no_profiles() {
+  let (repo, _) = init_repo();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_exec_picker();
+  assert_eq!(app.view, View::List, "no profiles ⇒ no transition");
+  assert!(
+    app.status.contains("exec.profiles"),
+    "the status explains why nothing opened: {}",
+    app.status
+  );
+}
+
+#[test]
+fn exec_picker_opens_and_lists_profiles_sorted() {
+  let (_repo, mut app) = app_with_gwm_toml(
+    "[exec.profiles.test]\ncommand = [\"cargo\", \"test\"]\n\n[exec.profiles.build]\ncommand = [\"cargo\", \"build\"]\n",
+  );
+  app.enter_exec_picker();
+  assert_eq!(app.view, View::ExecPicker);
+  // `BTreeMap` key order ⇒ alphabetical: build, then test.
+  assert_eq!(app.exec_picker.profiles(), &["build".to_string(), "test".to_string()]);
+  assert_eq!(app.exec_picker.selected_profile(), Some("build"));
+}
+
+#[test]
+fn exec_picker_navigation_moves_the_highlight() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::ExecPickerKey;
+  let (_repo, mut app) =
+    app_with_gwm_toml("[exec.profiles.a]\ncommand = [\"true\"]\n\n[exec.profiles.b]\ncommand = [\"true\"]\n");
+  app.enter_exec_picker();
+  let down = app.handle_exec_picker_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+  assert_eq!(down, ExecPickerKey::Handled);
+  assert_eq!(app.exec_picker.selected_profile(), Some("b"));
+  app.handle_exec_picker_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+  assert_eq!(app.exec_picker.selected_profile(), Some("a"));
+}
+
+#[test]
+fn exec_picker_enter_submits_and_esc_cancels() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::ExecPickerKey;
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.a]\ncommand = [\"true\"]\n");
+  app.enter_exec_picker();
+  assert_eq!(
+    app.handle_exec_picker_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+    ExecPickerKey::Submit
+  );
+  assert_eq!(
+    app.handle_exec_picker_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+    ExecPickerKey::Cancel
+  );
+}
+
+#[test]
+fn exec_picker_resolves_the_highlighted_profile_to_its_argv() {
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.build]\ncommand = [\"cargo\", \"build\", \"--release\"]\n");
+  app.enter_exec_picker();
+  let expected_cwd = app.selected().unwrap().path.clone();
+  let (argv, cwd) = app.exec_picker_resolve().expect("a valid profile resolves");
+  assert_eq!(
+    argv,
+    vec!["cargo".to_string(), "build".to_string(), "--release".to_string()],
+    "argv is the frozen command array verbatim (no shell)"
+  );
+  assert_eq!(cwd, expected_cwd, "cwd is the selected worktree's path");
+}
+
+#[test]
+fn exec_picker_close_returns_to_the_list() {
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.a]\ncommand = [\"true\"]\n");
+  app.enter_exec_picker();
+  assert_eq!(app.view, View::ExecPicker);
+  app.close_exec_picker();
+  assert_eq!(app.view, View::List);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7630,3 +7630,36 @@ fn clean_overlay_delete_revalidates_the_gate_just_before_removing() {
   );
   assert_eq!(app.view, View::List, "the overlay still closes");
 }
+
+#[test]
+fn exec_picker_runs_in_the_open_time_worktree_after_a_drift() {
+  // Codex #333: an auto-refresh can drift the live selection while the picker
+  // is open. Resolve must run in the worktree the picker was opened for.
+  let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.a]\ncommand = [\"echo\", \"hi\"]\n");
+  let opened = app.selected().unwrap().path.clone();
+  app.enter_exec_picker();
+  // Drift: a refresh replaced the list with an unrelated worktree.
+  app.worktrees = vec![worktree_fixture("other")];
+  let (argv, cwd) = app.exec_picker_resolve().expect("resolves against the captured cwd");
+  assert_eq!(argv, vec!["echo".to_string(), "hi".to_string()]);
+  assert_eq!(cwd, opened, "runs in the open-time worktree, not the drifted selection");
+}
+
+#[test]
+fn clean_overlay_deletes_the_open_time_worktree_after_a_drift() {
+  // Codex #333: the clean delete must reclaim from the worktree whose report
+  // was previewed, even if the live selection drifted (refresh) meanwhile.
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "build/\n").unwrap();
+  std::fs::create_dir(repo.path().join("build")).unwrap();
+  std::fs::write(repo.path().join("build").join("o"), vec![0u8; 64]).unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // Drift: replace the list with an unrelated (fake-path) row.
+  app.worktrees = vec![worktree_fixture("other")];
+  app.clean_overlay_delete();
+  assert!(
+    !repo.path().join("build").exists(),
+    "reclaimed from the captured worktree despite the drifted selection"
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7533,3 +7533,18 @@ fn clean_overlay_close_returns_to_the_list() {
   app.close_clean_overlay();
   assert_eq!(app.view, View::List);
 }
+
+#[test]
+fn clean_overlay_opens_on_the_default_profile_when_present() {
+  let (repo, _) = init_repo();
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    "[clean.profiles.aggressive]\ndirs = [\"target\"]\n\n[clean.profiles.default]\ndirs = [\"dist\"]\n",
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // `aggressive` sorts first, but the overlay opens on `default` so the
+  // first preview matches `gwm clean` with no --profile.
+  assert_eq!(app.clean_overlay.selected_profile(), Some("default"));
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7632,34 +7632,48 @@ fn clean_overlay_delete_revalidates_the_gate_just_before_removing() {
 }
 
 #[test]
-fn exec_picker_runs_in_the_open_time_worktree_after_a_drift() {
-  // Codex #333: an auto-refresh can drift the live selection while the picker
-  // is open. Resolve must run in the worktree the picker was opened for.
+fn exec_picker_runs_in_the_open_time_worktree_and_config_after_a_drift() {
+  // Codex #333: an auto-refresh can drift the live selection AND (workspace)
+  // swap the active config while the picker is open. Resolve must run in the
+  // captured worktree against the captured `[exec]` config — not the live
+  // ones.
   let (_repo, mut app) = app_with_gwm_toml("[exec.profiles.a]\ncommand = [\"echo\", \"hi\"]\n");
   let opened = app.selected().unwrap().path.clone();
   app.enter_exec_picker();
-  // Drift: a refresh replaced the list with an unrelated worktree.
+  // Drift: the list AND the live config moved out from under the overlay.
   app.worktrees = vec![worktree_fixture("other")];
-  let (argv, cwd) = app.exec_picker_resolve().expect("resolves against the captured cwd");
+  app.config.exec.profiles.clear();
+  let (argv, cwd) = app
+    .exec_picker_resolve()
+    .expect("resolves against the captured cfg + cwd");
   assert_eq!(argv, vec!["echo".to_string(), "hi".to_string()]);
   assert_eq!(cwd, opened, "runs in the open-time worktree, not the drifted selection");
 }
 
 #[test]
-fn clean_overlay_deletes_the_open_time_worktree_after_a_drift() {
-  // Codex #333: the clean delete must reclaim from the worktree whose report
-  // was previewed, even if the live selection drifted (refresh) meanwhile.
+fn clean_overlay_deletes_the_open_time_target_and_config_after_a_drift() {
+  // Codex #333: the clean delete must reclaim the previewed worktree using the
+  // captured `[clean]` config, even if the live selection AND config drifted
+  // (workspace refresh) meanwhile.
   let (repo, _) = init_repo();
   std::fs::write(repo.path().join(".gitignore"), "build/\n").unwrap();
   std::fs::create_dir(repo.path().join("build")).unwrap();
   std::fs::write(repo.path().join("build").join("o"), vec![0u8; 64]).unwrap();
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    "[clean.profiles.x]\ndirs = [\"build\"]\n",
+  )
+  .unwrap();
   let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
   app.enter_clean_overlay();
-  // Drift: replace the list with an unrelated (fake-path) row.
+  app.clean_overlay_next(); // select profile `x` (dirs = build)
+  assert_eq!(app.clean_overlay.selected_profile(), Some("x"));
+  // Drift: replace the list AND drop the live config's profile.
   app.worktrees = vec![worktree_fixture("other")];
+  app.config.clean.profiles.clear();
   app.clean_overlay_delete();
   assert!(
     !repo.path().join("build").exists(),
-    "reclaimed from the captured worktree despite the drifted selection"
+    "reclaimed via the captured target + config despite the drift"
   );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7511,12 +7511,16 @@ fn clean_overlay_profile_picker_rescans_per_profile() {
   .unwrap();
   let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
   app.enter_clean_overlay();
-  // Profile `a` (sorted first) resolves to `cache` only.
+  // Opens on the `(default)` choice (no --profile) — built-in set here, which
+  // doesn't include `cache` / `out`.
+  assert_eq!(app.clean_overlay.selected_profile(), None);
+  // Cycle to profile `a` → re-scans for `cache` only.
+  app.clean_overlay_next();
   assert_eq!(app.clean_overlay.selected_profile(), Some("a"));
   let a = app.clean_overlay.reclaim().unwrap();
   assert!(a.artifacts.iter().any(|x| x.rel == "cache"));
   assert!(!a.artifacts.iter().any(|x| x.rel == "out"));
-  // Cycling to `b` re-scans for `out`.
+  // Cycle to profile `b` → re-scans for `out`.
   app.clean_overlay_next();
   assert_eq!(app.clean_overlay.selected_profile(), Some("b"));
   let b = app.clean_overlay.reclaim().unwrap();
@@ -7535,18 +7539,60 @@ fn clean_overlay_close_returns_to_the_list() {
 }
 
 #[test]
-fn clean_overlay_opens_on_the_default_profile_when_present() {
+fn clean_overlay_opens_on_the_no_profile_default_choice() {
+  // The overlay always opens on the `(default)` / no-`--profile` choice, so
+  // its first preview matches `gwm clean` — even when the repo defines named
+  // profiles that sort before it.
   let (repo, _) = init_repo();
   std::fs::write(
     repo.path().join(".gwm.toml"),
-    "[clean.profiles.aggressive]\ndirs = [\"target\"]\n\n[clean.profiles.default]\ndirs = [\"dist\"]\n",
+    "[clean.profiles.aggressive]\ndirs = [\"target\"]\n",
   )
   .unwrap();
   let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
   app.enter_clean_overlay();
-  // `aggressive` sorts first, but the overlay opens on `default` so the
-  // first preview matches `gwm clean` with no --profile.
-  assert_eq!(app.clean_overlay.selected_profile(), Some("default"));
+  assert_eq!(
+    app.clean_overlay.selected_profile(),
+    None,
+    "opens on the no-profile choice"
+  );
+  assert_eq!(app.clean_overlay.choice_labels().first().copied(), Some("(default)"));
+  assert!(
+    app.clean_overlay.has_profiles(),
+    "a named profile makes the picker worth showing"
+  );
+}
+
+#[test]
+fn clean_overlay_default_choice_uses_builtins_without_a_default_profile() {
+  // Codex #333 review: a repo with only a non-`default` profile must not make
+  // the built-in set unreachable. The `(default)` choice resolves to the
+  // built-in `target` / … set (matching `gwm clean` with no --profile), NOT
+  // the alphabetically-first profile.
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "target/\ncoverage/\n").unwrap();
+  // `target` is a built-in; `coverage` is only reachable via the named profile.
+  std::fs::create_dir(repo.path().join("target")).unwrap();
+  std::fs::write(repo.path().join("target").join("t"), vec![0u8; 128]).unwrap();
+  std::fs::create_dir(repo.path().join("coverage")).unwrap();
+  std::fs::write(repo.path().join("coverage").join("c"), vec![0u8; 256]).unwrap();
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    "[clean.profiles.coverage]\ndirs = [\"coverage\"]\n",
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // The `(default)` choice scans the built-in set → finds `target`, not `coverage`.
+  let r = app.clean_overlay.reclaim().unwrap();
+  assert!(
+    r.artifacts.iter().any(|a| a.rel == "target"),
+    "built-in target/ is reachable"
+  );
+  assert!(
+    !r.artifacts.iter().any(|a| a.rel == "coverage"),
+    "the named profile is not the default"
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7394,3 +7394,142 @@ fn exec_picker_close_returns_to_the_list() {
   app.close_exec_picker();
   assert_eq!(app.view, View::List);
 }
+
+// ── Clean overlay (issue #325) ────────────────────────────────────────────
+
+#[test]
+fn clean_overlay_scans_gitignored_artifacts() {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "target/\n").unwrap();
+  std::fs::create_dir(repo.path().join("target")).unwrap();
+  std::fs::write(repo.path().join("target").join("blob"), vec![0u8; 2048]).unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert_eq!(app.view, View::CleanReport);
+  let reclaim = app.clean_overlay.reclaim().expect("the worktree was scanned");
+  assert!(
+    reclaim.artifacts.iter().any(|a| a.rel == "target"),
+    "the git-ignored target/ is counted: {:?}",
+    reclaim.artifacts
+  );
+  assert!(app.clean_overlay.total_bytes() >= 2048);
+}
+
+#[test]
+fn clean_overlay_gate_skips_non_gitignored_artifacts() {
+  let (repo, _) = init_repo();
+  // No `.gitignore` ⇒ `target/` is NOT ignored ⇒ the safety gate preserves it.
+  std::fs::create_dir(repo.path().join("target")).unwrap();
+  std::fs::write(repo.path().join("target").join("blob"), vec![0u8; 1024]).unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  let reclaim = app.clean_overlay.reclaim().expect("scanned");
+  assert!(reclaim.artifacts.is_empty(), "a non-ignored target/ is never counted");
+  assert!(
+    app.clean_overlay.skipped().contains(&"target".to_string()),
+    "and is reported as skipped: {:?}",
+    app.clean_overlay.skipped()
+  );
+  assert_eq!(app.clean_overlay.total_bytes(), 0);
+}
+
+#[test]
+fn clean_overlay_delete_reclaims_only_the_gated_dir() {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "build/\n").unwrap();
+  std::fs::create_dir(repo.path().join("build")).unwrap();
+  std::fs::write(repo.path().join("build").join("out"), vec![0u8; 512]).unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert!(repo.path().join("build").exists());
+  app.clean_overlay_delete();
+  assert!(!repo.path().join("build").exists(), "the build dir was reclaimed");
+  assert_eq!(app.view, View::List, "and the overlay closed");
+  assert!(
+    app.status.contains("reclaimed"),
+    "status reports the reclaim: {}",
+    app.status
+  );
+}
+
+#[test]
+fn clean_confirm_arms_then_is_ready_after_the_countdown() {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "dist/\n").unwrap();
+  std::fs::create_dir(repo.path().join("dist")).unwrap();
+  std::fs::write(repo.path().join("dist").join("x"), vec![0u8; 100]).unwrap();
+  std::fs::write(repo.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 3\n").unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  let t0 = Instant::now();
+  assert_eq!(app.clean_confirm_press(t0), ConfirmKeyAction::Armed);
+  assert!(app.clean_overlay.confirm.is_armed());
+  assert_eq!(
+    app.tick_clean_countdown(t0 + Duration::from_secs(1)),
+    CountdownTickOutcome::Pending
+  );
+  assert_eq!(
+    app.tick_clean_countdown(t0 + Duration::from_secs(3)),
+    CountdownTickOutcome::ReadyToFire
+  );
+}
+
+#[test]
+fn clean_confirm_with_zero_countdown_fires_immediately() {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "node_modules/\n").unwrap();
+  std::fs::create_dir(repo.path().join("node_modules")).unwrap();
+  std::fs::write(repo.path().join("node_modules").join("y"), vec![0u8; 64]).unwrap();
+  std::fs::write(repo.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 0\n").unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert_eq!(app.clean_confirm_press(Instant::now()), ConfirmKeyAction::FireNow);
+}
+
+#[test]
+fn clean_confirm_is_a_noop_when_nothing_to_reclaim() {
+  let (repo, _) = init_repo(); // no artifact dirs ⇒ empty scan
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert!(app.clean_overlay.is_empty_scan());
+  assert_eq!(app.clean_confirm_press(Instant::now()), ConfirmKeyAction::Disarmed);
+  assert!(app.status.contains("nothing to reclaim"), "status: {}", app.status);
+}
+
+#[test]
+fn clean_overlay_profile_picker_rescans_per_profile() {
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "cache/\nout/\n").unwrap();
+  std::fs::create_dir(repo.path().join("cache")).unwrap();
+  std::fs::write(repo.path().join("cache").join("c"), vec![0u8; 100]).unwrap();
+  std::fs::create_dir(repo.path().join("out")).unwrap();
+  std::fs::write(repo.path().join("out").join("o"), vec![0u8; 200]).unwrap();
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    "[clean.profiles.a]\ndirs = [\"cache\"]\n\n[clean.profiles.b]\ndirs = [\"out\"]\n",
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // Profile `a` (sorted first) resolves to `cache` only.
+  assert_eq!(app.clean_overlay.selected_profile(), Some("a"));
+  let a = app.clean_overlay.reclaim().unwrap();
+  assert!(a.artifacts.iter().any(|x| x.rel == "cache"));
+  assert!(!a.artifacts.iter().any(|x| x.rel == "out"));
+  // Cycling to `b` re-scans for `out`.
+  app.clean_overlay_next();
+  assert_eq!(app.clean_overlay.selected_profile(), Some("b"));
+  let b = app.clean_overlay.reclaim().unwrap();
+  assert!(b.artifacts.iter().any(|x| x.rel == "out"));
+  assert!(!b.artifacts.iter().any(|x| x.rel == "cache"));
+}
+
+#[test]
+fn clean_overlay_close_returns_to_the_list() {
+  let (repo, _) = init_repo();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert_eq!(app.view, View::CleanReport);
+  app.close_clean_overlay();
+  assert_eq!(app.view, View::List);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7548,3 +7548,39 @@ fn clean_overlay_opens_on_the_default_profile_when_present() {
   // first preview matches `gwm clean` with no --profile.
   assert_eq!(app.clean_overlay.selected_profile(), Some("default"));
 }
+
+#[test]
+fn clean_overlay_delete_revalidates_the_gate_just_before_removing() {
+  // Codex #333 review (TOCTOU): the overlay scans on open, but the delete can
+  // fire seconds later (countdown / overlay left open). If a dir turned unsafe
+  // meanwhile, the delete must re-gate and preserve it — not destroy the now
+  // tracked file the stale snapshot still lists.
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "target/\n").unwrap();
+  std::fs::create_dir(repo.path().join("target")).unwrap();
+  std::fs::write(repo.path().join("target").join("blob"), vec![0u8; 256]).unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  // The scan saw a safe (ignored, untracked) `target/`.
+  assert!(app
+    .clean_overlay
+    .reclaim()
+    .unwrap()
+    .artifacts
+    .iter()
+    .any(|a| a.rel == "target"));
+  // Now force-track a file under it — the snapshot is stale.
+  std::process::Command::new("git")
+    .arg("-C")
+    .arg(repo.path())
+    .args(["add", "-f", "target/blob"])
+    .status()
+    .unwrap();
+  app.clean_overlay_delete();
+  // The re-gate catches the now-tracked dir and refuses to remove it.
+  assert!(
+    repo.path().join("target").exists(),
+    "a directory that became tracked after the scan must not be reclaimed"
+  );
+  assert_eq!(app.view, View::List, "the overlay still closes");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7725,3 +7725,23 @@ fn clean_countdown_is_pinned_to_the_open_time_config() {
     "the safety delay captured at open survives a live config swap"
   );
 }
+
+#[test]
+fn destructive_overlay_open_flags_exec_and_clean_views() {
+  // Codex #333: the run loop suspends auto-refresh / active-repo sync while a
+  // destructive overlay is open, gating on this predicate so the captured
+  // exec/clean target can't drift mid-overlay.
+  let (_repo, mut app) = make_app();
+  assert!(
+    !app.destructive_overlay_open(),
+    "list view is not a destructive overlay"
+  );
+  app.view = View::ExecPicker;
+  assert!(app.destructive_overlay_open());
+  app.view = View::CleanReport;
+  assert!(app.destructive_overlay_open());
+  // The delete-confirm modal is not in this class — it has no captured target
+  // to protect and reads the live selection by design.
+  app.view = View::Confirm;
+  assert!(!app.destructive_overlay_open());
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -7745,3 +7745,55 @@ fn destructive_overlay_open_flags_exec_and_clean_views() {
   app.view = View::Confirm;
   assert!(!app.destructive_overlay_open());
 }
+
+#[test]
+fn clean_overlay_noop_profile_move_keeps_the_countdown_armed() {
+  // Codex #333: with only the `(default)` choice, `j`/`k` are no-ops and must
+  // NOT re-scan — a re-scan resets the ConfirmModal, silently disarming a
+  // pending reclaim while the status bar still reads "armed".
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "build/\n").unwrap();
+  std::fs::create_dir(repo.path().join("build")).unwrap();
+  std::fs::write(repo.path().join("build").join("o"), vec![0u8; 64]).unwrap();
+  std::fs::write(repo.path().join(".gwm.toml"), "[tui]\nconfirm_countdown_secs = 3\n").unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert!(!app.clean_overlay.has_profiles(), "only the (default) choice exists");
+  assert_eq!(app.clean_confirm_press(Instant::now()), ConfirmKeyAction::Armed);
+  app.clean_overlay_next();
+  assert!(app.clean_overlay.confirm.is_armed(), "a no-op move must not disarm");
+  app.clean_overlay_prev();
+  assert!(
+    app.clean_overlay.confirm.is_armed(),
+    "prev no-op must not disarm either"
+  );
+}
+
+#[test]
+fn clean_overlay_real_profile_change_disarms_the_countdown() {
+  // The complement: actually changing the target re-requires confirmation.
+  let (repo, _) = init_repo();
+  std::fs::write(repo.path().join(".gitignore"), "a/\nb/\n").unwrap();
+  for d in ["a", "b"] {
+    std::fs::create_dir(repo.path().join(d)).unwrap();
+    std::fs::write(repo.path().join(d).join("x"), vec![0u8; 64]).unwrap();
+  }
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    "[tui]\nconfirm_countdown_secs = 3\n\n[clean.profiles.pa]\ndirs = [\"a\"]\n\n[clean.profiles.pb]\ndirs = [\"b\"]\n",
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  app.enter_clean_overlay();
+  assert!(app.clean_overlay.has_profiles());
+  // The `(default)` choice scans built-ins (empty here), so move to `pa`
+  // (which reclaims `a`) before arming.
+  app.clean_overlay_next(); // (default) → pa
+  assert_eq!(app.clean_overlay.selected_profile(), Some("pa"));
+  assert_eq!(app.clean_confirm_press(Instant::now()), ConfirmKeyAction::Armed);
+  app.clean_overlay_next(); // pa → pb: a real change
+  assert!(
+    !app.clean_overlay.confirm.is_armed(),
+    "changing the target re-requires confirmation"
+  );
+}

--- a/tests/tui_exec_overlay_tests.rs
+++ b/tests/tui_exec_overlay_tests.rs
@@ -1,0 +1,72 @@
+//! State-machine tests for the exec profile picker overlay (issue #325).
+//!
+//! The picker is pure state — no PTY, no config beyond the sorted
+//! profile-name list handed in at open time — so these run ratatui-free
+//! on every platform.
+
+use gwm::tui::ExecPicker;
+
+fn names(v: &[&str]) -> Vec<String> {
+  v.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn opens_empty_by_default() {
+  let p = ExecPicker::new();
+  assert!(p.is_empty());
+  assert_eq!(p.selected_profile(), None);
+  assert!(p.profiles().is_empty());
+}
+
+#[test]
+fn open_populates_and_resets_highlight_to_top() {
+  let mut p = ExecPicker::new();
+  p.open(names(&["build", "test", "lint"]));
+  assert!(!p.is_empty());
+  assert_eq!(p.profiles().len(), 3);
+  assert_eq!(p.selected_index(), 0);
+  assert_eq!(p.selected_profile(), Some("build"));
+}
+
+#[test]
+fn next_advances_then_wraps_to_top() {
+  let mut p = ExecPicker::new();
+  p.open(names(&["build", "test"]));
+  p.next();
+  assert_eq!(p.selected_profile(), Some("test"));
+  p.next(); // wraps back to the first row
+  assert_eq!(p.selected_profile(), Some("build"));
+}
+
+#[test]
+fn prev_retreats_then_wraps_to_bottom() {
+  let mut p = ExecPicker::new();
+  p.open(names(&["build", "test", "lint"]));
+  p.prev(); // wraps to the last row
+  assert_eq!(p.selected_profile(), Some("lint"));
+  p.prev();
+  assert_eq!(p.selected_profile(), Some("test"));
+}
+
+#[test]
+fn navigation_is_noop_when_empty() {
+  let mut p = ExecPicker::new();
+  p.next();
+  p.prev();
+  assert!(p.is_empty());
+  assert_eq!(p.selected_index(), 0);
+  assert_eq!(p.selected_profile(), None);
+}
+
+#[test]
+fn reopen_resets_highlight_and_replaces_profiles() {
+  let mut p = ExecPicker::new();
+  p.open(names(&["a", "b", "c"]));
+  p.next();
+  p.next();
+  assert_eq!(p.selected_index(), 2);
+  p.open(names(&["x", "y"]));
+  assert_eq!(p.selected_index(), 0);
+  assert_eq!(p.profiles(), &["x".to_string(), "y".to_string()]);
+  assert_eq!(p.selected_profile(), Some("x"));
+}

--- a/tests/tui_exec_overlay_tests.rs
+++ b/tests/tui_exec_overlay_tests.rs
@@ -5,9 +5,15 @@
 //! on every platform.
 
 use gwm::tui::ExecPicker;
+use std::path::PathBuf;
 
 fn names(v: &[&str]) -> Vec<String> {
   v.iter().map(|s| s.to_string()).collect()
+}
+
+/// A stand-in worktree path captured at open time.
+fn wt() -> PathBuf {
+  PathBuf::from("/tmp/gwm-test/wt")
 }
 
 #[test]
@@ -21,17 +27,20 @@ fn opens_empty_by_default() {
 #[test]
 fn open_populates_and_resets_highlight_to_top() {
   let mut p = ExecPicker::new();
-  p.open(names(&["build", "test", "lint"]));
+  p.open(names(&["build", "test", "lint"]), wt());
   assert!(!p.is_empty());
   assert_eq!(p.profiles().len(), 3);
   assert_eq!(p.selected_index(), 0);
   assert_eq!(p.selected_profile(), Some("build"));
+  // The target worktree is captured at open so Enter runs there even if the
+  // live selection drifts (#333).
+  assert_eq!(p.cwd(), Some(wt().as_path()));
 }
 
 #[test]
 fn next_advances_then_wraps_to_top() {
   let mut p = ExecPicker::new();
-  p.open(names(&["build", "test"]));
+  p.open(names(&["build", "test"]), wt());
   p.next();
   assert_eq!(p.selected_profile(), Some("test"));
   p.next(); // wraps back to the first row
@@ -41,7 +50,7 @@ fn next_advances_then_wraps_to_top() {
 #[test]
 fn prev_retreats_then_wraps_to_bottom() {
   let mut p = ExecPicker::new();
-  p.open(names(&["build", "test", "lint"]));
+  p.open(names(&["build", "test", "lint"]), wt());
   p.prev(); // wraps to the last row
   assert_eq!(p.selected_profile(), Some("lint"));
   p.prev();
@@ -61,11 +70,11 @@ fn navigation_is_noop_when_empty() {
 #[test]
 fn reopen_resets_highlight_and_replaces_profiles() {
   let mut p = ExecPicker::new();
-  p.open(names(&["a", "b", "c"]));
+  p.open(names(&["a", "b", "c"]), wt());
   p.next();
   p.next();
   assert_eq!(p.selected_index(), 2);
-  p.open(names(&["x", "y"]));
+  p.open(names(&["x", "y"]), wt());
   assert_eq!(p.selected_index(), 0);
   assert_eq!(p.profiles(), &["x".to_string(), "y".to_string()]);
   assert_eq!(p.selected_profile(), Some("x"));

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -606,3 +606,41 @@ fn command_palette_renders_the_input_above_the_matches() {
     rows.join("\n")
   );
 }
+
+#[test]
+fn exec_picker_modal_renders_title_profiles_and_hints() {
+  // #325: the exec picker lists `[exec.profiles]` and offers run / cancel.
+  let (dir, _) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[exec.profiles.build]\ncommand = [\"cargo\", \"build\"]\n",
+  )
+  .unwrap();
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  app.sidebar.open = false;
+  app.enter_exec_picker();
+  assert_eq!(app.view, View::ExecPicker);
+  let buf = render(&mut app);
+  assert_present(&buf, "run exec profile", "exec picker title");
+  assert_present(&buf, "build", "exec profile name");
+  assert_present(&buf, "run", "exec run hint");
+}
+
+#[test]
+fn clean_modal_renders_title_report_and_hints() {
+  // #325: the clean overlay reports the gated reclaim and offers reclaim /
+  // cancel. The scan shells out to `git check-ignore` against the real temp
+  // repo, so it is deterministic though not offline like the other modals.
+  let (dir, _) = init_repo();
+  std::fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();
+  std::fs::create_dir(dir.path().join("target")).unwrap();
+  std::fs::write(dir.path().join("target").join("blob"), vec![0u8; 4096]).unwrap();
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  app.sidebar.open = false;
+  app.enter_clean_overlay();
+  assert_eq!(app.view, View::CleanReport);
+  let buf = render(&mut app);
+  assert_present(&buf, "reclaim build artifacts", "clean overlay title");
+  assert_present(&buf, "target", "clean artifact name");
+  assert_present(&buf, "total", "clean total line");
+}

--- a/tests/tui_state_pty_overlay_tests.rs
+++ b/tests/tui_state_pty_overlay_tests.rs
@@ -283,18 +283,30 @@ fn exec_overlay_lingers_after_a_one_shot_command_exits() {
     std::thread::sleep(std::time::Duration::from_millis(20));
   }
   assert!(dead, "the one-shot exec command must exit on its own");
-  // #333: observing the exit records the reap, so dismissing the lingering
-  // overlay (which calls `kill`) never signals the now-recycled PID/PGID.
-  assert!(pty.is_reaped(), "observing the exit must record the reap");
-  pty.kill(); // no-op after reap — must not hang or signal
-  assert!(pty.is_reaped());
+  assert!(pty.is_reaped(), "observing the exit records the reap");
+  assert!(
+    !pty.group_signalled(),
+    "the group is not signalled until the loop marks it finished"
+  );
+  // #333: the run loop marks a dead exec finished — which lingers the output
+  // AND promptly SIGKILLs the process group (descendant cleanup) in the safe
+  // window, before the dismissal keystroke could let the PGID be recycled.
+  pty.mark_finished();
+  assert!(pty.finished, "the overlay lingers showing its final output");
+  assert!(pty.group_signalled(), "the process group is reaped promptly on finish");
+  // Dismissal calls kill() — idempotent (no second signal), returns fast.
+  let t0 = std::time::Instant::now();
+  pty.kill();
+  assert!(t0.elapsed().as_millis() < 100, "kill after finish is a fast no-op");
 }
 
 #[cfg(unix)]
 #[test]
-fn kill_is_a_noop_after_the_child_was_reaped() {
-  // #333: a child that exited and was reaped (via is_alive) must not be
-  // signalled again by kill — its PID/PGID may have been recycled.
+fn kill_after_reap_still_signals_the_process_group_once() {
+  // #333: my earlier no-op-after-reap guard leaked backgrounded descendants
+  // (`sh -c "sleep 60 &"`) because it skipped the process-group SIGKILL. kill
+  // must STILL signal the group after the leader was reaped — once — so the
+  // descendants are cleaned, without re-signalling a possibly-recycled PGID.
   let (_dir, app) = make_app();
   let mut pty = PtyOverlay::spawn(PtyKind::Terminal, &["sh", "-c", "exit 0"], &app.workdir, 80, 24)
     .expect("PTY spawn must succeed on Unix");
@@ -304,11 +316,19 @@ fn kill_is_a_noop_after_the_child_was_reaped() {
     }
     std::thread::sleep(std::time::Duration::from_millis(20));
   }
-  assert!(pty.is_reaped(), "the child exited and was reaped");
+  assert!(pty.is_reaped(), "the leader exited and was reaped");
+  assert!(!pty.group_signalled(), "no group signal yet");
   let t0 = std::time::Instant::now();
   pty.kill();
   assert!(
-    t0.elapsed().as_millis() < 100,
-    "kill after reap returns immediately (no signal, no drain loop)"
+    pty.group_signalled(),
+    "kill still cleans the process group after a reap"
   );
+  assert!(
+    t0.elapsed().as_millis() < 100,
+    "and returns fast (no drain loop — leader already reaped)"
+  );
+  // A second kill is idempotent — the group is never signalled twice.
+  pty.kill();
+  assert!(pty.group_signalled());
 }

--- a/tests/tui_state_pty_overlay_tests.rs
+++ b/tests/tui_state_pty_overlay_tests.rs
@@ -283,4 +283,32 @@ fn exec_overlay_lingers_after_a_one_shot_command_exits() {
     std::thread::sleep(std::time::Duration::from_millis(20));
   }
   assert!(dead, "the one-shot exec command must exit on its own");
+  // #333: observing the exit records the reap, so dismissing the lingering
+  // overlay (which calls `kill`) never signals the now-recycled PID/PGID.
+  assert!(pty.is_reaped(), "observing the exit must record the reap");
+  pty.kill(); // no-op after reap — must not hang or signal
+  assert!(pty.is_reaped());
+}
+
+#[cfg(unix)]
+#[test]
+fn kill_is_a_noop_after_the_child_was_reaped() {
+  // #333: a child that exited and was reaped (via is_alive) must not be
+  // signalled again by kill — its PID/PGID may have been recycled.
+  let (_dir, app) = make_app();
+  let mut pty = PtyOverlay::spawn(PtyKind::Terminal, &["sh", "-c", "exit 0"], &app.workdir, 80, 24)
+    .expect("PTY spawn must succeed on Unix");
+  for _ in 0..50 {
+    if !pty.is_alive() {
+      break;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(20));
+  }
+  assert!(pty.is_reaped(), "the child exited and was reaped");
+  let t0 = std::time::Instant::now();
+  pty.kill();
+  assert!(
+    t0.elapsed().as_millis() < 100,
+    "kill after reap returns immediately (no signal, no drain loop)"
+  );
 }

--- a/tests/tui_state_pty_overlay_tests.rs
+++ b/tests/tui_state_pty_overlay_tests.rs
@@ -259,3 +259,28 @@ fn pty_kind_review_discriminates_from_lazygit_and_terminal() {
   assert_ne!(PtyKind::Review, PtyKind::LazyGit);
   assert_ne!(PtyKind::Review, PtyKind::Terminal);
 }
+
+#[cfg(unix)]
+#[test]
+fn exec_overlay_lingers_after_a_one_shot_command_exits() {
+  // #325: an exec profile is typically a one-shot command (`cargo test`)
+  // that exits the moment it finishes. The overlay must persist its output —
+  // the run loop sets `finished` and keeps it open — rather than vanish like
+  // an interactive lazygit session. Pin the detectable lifecycle the loop
+  // keys off: a freshly spawned Exec overlay is not yet `finished`, and its
+  // one-shot child reads `!is_alive()` once it exits on its own.
+  let (_dir, app) = make_app();
+  let mut pty = PtyOverlay::spawn(PtyKind::Exec, &["sh", "-c", "exit 0"], &app.workdir, 80, 24)
+    .expect("PTY spawn must succeed on Unix");
+  assert_eq!(pty.kind, PtyKind::Exec);
+  assert!(!pty.finished, "a freshly spawned overlay is not yet lingering");
+  let mut dead = false;
+  for _ in 0..50 {
+    if !pty.is_alive() {
+      dead = true;
+      break;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(20));
+  }
+  assert!(dead, "the one-shot exec command must exit on its own");
+}


### PR DESCRIPTION
## Description

TUI surface for `gwm exec` / `gwm clean` (issue #325, the last task of the exec/clean 1.0 sprint — explicitly a **TUI-only** surface, the frozen machine contract is unchanged). Two overlays over the worktree list:

- **`x` — exec picker**: lists the `[exec.profiles.*]` names; `Enter` runs the highlighted profile's `command` array (**no shell**) in the embedded PTY overlay rooted at the selected worktree.
- **`X` — clean overlay**: previews the reclaimable build artifacts and deletes them behind a safety countdown, gated by the **exact** git-ignored + no-tracked-files check `gwm clean --yes` uses.

Closes #325

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- New pure-state modules `tui::state::exec_picker` + `tui::state::clean_overlay` (ratatui-free), wired through testable `App` methods; the run loop owns the PTY spawn / `delete_reclaim` side effects.
- `View::ExecPicker` / `View::CleanReport` + `PtyKind::Exec`; rebindable modal keys via `KeyContext::ExecPicker` / `KeyContext::Clean` (`[tui.keys.modal.exec]` / `[tui.keys.modal.clean]`); `Action::ExecOverlay` / `Action::CleanOverlay` global verbs + `:exec` / `:clean` palette entries.
- **Safety:** the clean git-ignore gate moves from `cli.rs` into `clean::dir_is_safe_to_clean` / `clean::scan_worktree_safe` — the single source the CLI and the overlay both use, so a raw `scan_worktree` + `delete_reclaim` can never bypass it. `clean_scan_repo` re-pointed at the shared helper (behaviour unchanged).
- Clean reuses the delete-confirm countdown as a **dedicated** `ConfirmModal` driven by `[tui] confirm_countdown_secs` directly (no `delete_branch_on_remove` gate).
- Exec overlay **lingers** showing its final output once a one-shot command exits (any key dismisses), instead of vanishing like an interactive lazygit. Clean overlay opens on the `default` profile when configured (matches `gwm clean`).

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

`tests/tui_exec_overlay_tests.rs` (pure picker state), `tests/tui_app_tests.rs` (open/refuse/navigate/submit/resolve for exec; scan/gate-skip/delete/countdown/profile-rescan/default-seed for clean), `tests/tui_modal_render_tests.rs` (both overlays' layout), `tests/tui_state_pty_overlay_tests.rs` (exec PTY lifecycle). `gwm doctor` green.

## Screenshots / TUI captures

<!-- TUI overlays; capture deferred to the #206 captures pass -->

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — n/a (TUI-only, no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed — n/a (no schema change; `[exec]`/`[clean]` landed in #324)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #325
- Docs: `docs/2.tui/1.keybindings.md` (+ `docs/fr/…`) — new exec/clean overlay sections

## Notes for reviewers

- **TUI-only surface**: the frozen 1.0 machine contract (`contract::CONFIG_SECTIONS`, CLI flags) is untouched.
- **Trust gate**: `cmd_exec` runs `[exec.profiles]` ungated, so the overlay matches it (no divergence).
- **Exec maps to the single selected worktree** (one PTY can't fan out, unlike the CLI `--workspace`).
- The clean scan is **synchronous** on open (documented; #231 async spine is the follow-up).

https://claude.ai/code/session_01M9eLxtdMFK1RBCCABndY9H