### PR TITLE
💄 fix(tui): exec/clean help entries + overlay polish (#334)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -66,7 +66,7 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, ci_indicator, command_logs_footer_hints,
+  build_sidebar_sections, centered_abs, chip_style, ci_indicator, clean_dir_icon, command_logs_footer_hints,
   config_capture_footer_hints, config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line,
   confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
   field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -73,12 +73,12 @@ pub use ui::{
   header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
   hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
   link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
-  panel_border_color, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
-  rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home, type_selector_line,
-  working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts, working_tree_status_line,
-  worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections,
-  WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON,
-  WT_DELETED_ICON, WT_MODIFIED_ICON,
+  panel_border_color, picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
+  reclaim_size_color, rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home,
+  type_selector_line, working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts,
+  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
+  SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
+  WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -72,13 +72,14 @@ pub use ui::{
   field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,
   header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
   hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
-  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, palette_name_style, pane_counter,
-  panel_border_color, picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
-  reclaim_size_color, rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home,
-  type_selector_line, working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts,
-  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
-  SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
-  WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
+  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, overlay_modal_width,
+  palette_name_style, pane_counter, panel_border_color, picker_window, pr_badge_color, pr_summary_line,
+  recent_commits_lines, recent_items_pane_title, reclaim_size_color, rename_buttons_line, status_line,
+  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_counts_footer,
+  working_tree_pane_title, working_tree_status_counts, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, WorkingTreeCounts,
+  COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON,
+  WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4100,23 +4100,96 @@ fn draw_link_prompt(f: &mut Frame, app: &App) {
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
 }
 
+/// Magnitude heatmap for a reclaimable size (issue #325 overlay polish):
+/// green (small) → yellow (medium) → red (large) so a big reclaim stands out
+/// at a glance. Thresholds tuned for build artifacts (50 MiB / 500 MiB).
+pub fn reclaim_size_color(bytes: u64, theme: &Theme) -> Color {
+  const MIB: u64 = 1024 * 1024;
+  if bytes >= 500 * MIB {
+    theme.prunable
+  } else if bytes >= 50 * MIB {
+    theme.dirty
+  } else {
+    theme.clean
+  }
+}
+
+/// The visible `[start, end)` slice of a `len`-item picker when at most
+/// `max_visible` rows fit, keeping `selected` in view (centred while
+/// scrolling). Returns the whole list when it fits (issue #325 polish).
+pub fn picker_window(len: usize, selected: usize, max_visible: usize) -> (usize, usize) {
+  if max_visible == 0 || len <= max_visible {
+    return (0, len);
+  }
+  let half = max_visible / 2;
+  let start = selected.saturating_sub(half).min(len - max_visible);
+  (start, start + max_visible)
+}
+
+/// Build the centred, fixed-width, scrollable rows for an overlay profile
+/// picker (issue #325 polish). Every row is padded to the same width so the
+/// selection highlight reads as a consistent bar and the labels align; the
+/// visible window follows `selected` with `↑ / ↓ N more` markers when the
+/// list overflows `max_visible`.
+fn picker_lines(labels: &[&str], selected: usize, max_visible: usize, theme: &Theme) -> Vec<Line<'static>> {
+  let mut out = Vec::new();
+  if labels.is_empty() {
+    return out;
+  }
+  let labelw = labels.iter().map(|l| l.chars().count()).max().unwrap_or(0);
+  let (start, end) = picker_window(labels.len(), selected, max_visible);
+  if start > 0 {
+    out.push(
+      Line::from(Span::styled(
+        format!("↑ {start} more"),
+        Style::default().fg(theme.muted),
+      ))
+      .centered(),
+    );
+  }
+  for (i, label) in labels.iter().enumerate().take(end).skip(start) {
+    let marker = if i == selected { "▸" } else { " " };
+    let txt = format!("{marker} {label:<labelw$} ");
+    let style = if i == selected {
+      Style::default()
+        .fg(theme.accent)
+        .bg(theme.selection_bg)
+        .add_modifier(Modifier::BOLD)
+    } else {
+      Style::default().fg(theme.muted)
+    };
+    out.push(Line::from(Span::styled(txt, style)).centered());
+  }
+  if end < labels.len() {
+    out.push(
+      Line::from(Span::styled(
+        format!("↓ {} more", labels.len() - end),
+        Style::default().fg(theme.muted),
+      ))
+      .centered(),
+    );
+  }
+  out
+}
+
 /// Render the exec profile picker overlay (issue #325). A small centred
-/// modal listing the `[exec.profiles.*]` names; the highlighted row reads
-/// in the accent with a `▸` marker, the rest muted. `Enter` resolves the
-/// highlight and the run loop spawns it in a PTY overlay.
+/// modal listing the `[exec.profiles.*]` names; the highlighted row reads in
+/// the accent (with a selection bar) and a `▸` marker, the rest muted. The
+/// list is aligned, same-width, and scrolls to keep the highlight in view.
+/// `Enter` resolves the highlight and the run loop spawns it in a PTY overlay.
 fn draw_exec_picker(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
-  let muted = app.theme.muted;
-  let selected = app.exec_picker.selected_index();
-  let mut lines = overlay_title_lines("run exec profile", accent);
-  for (i, name) in app.exec_picker.profiles().iter().enumerate() {
-    let line = if i == selected {
-      Line::from(format!("▸ {name}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
-    } else {
-      Line::from(format!("  {name}")).style(Style::default().fg(muted))
-    };
-    lines.push(line.centered());
-  }
+  let term = f.area();
+  let mut lines = overlay_title_lines("Run an exec profile", accent);
+  // Leave room for the title + hint + borders; the picker scrolls past that.
+  let max_visible = (term.height as usize).saturating_sub(8).max(3);
+  let labels: Vec<&str> = app.exec_picker.profiles().iter().map(String::as_str).collect();
+  lines.extend(picker_lines(
+    &labels,
+    app.exec_picker.selected_index(),
+    max_visible,
+    &app.theme,
+  ));
   push_modal_hint(
     &mut lines,
     HintContext::ExecPicker,
@@ -4125,7 +4198,6 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let term = f.area();
   let width = link_prompt_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
@@ -4144,39 +4216,71 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
   let danger = app.theme.prunable;
   let armed = app.clean_overlay.confirm.is_armed();
   let border = if armed { danger } else { accent };
+  let term = f.area();
 
-  let mut lines = overlay_title_lines("reclaim build artifacts", border);
+  let mut lines = overlay_title_lines("Reclaim build artifacts", border);
 
   // Profile picker — the `(default)` choice plus any `[clean.profiles]`.
-  // Only worth rendering when the repo configures named profiles.
+  // Aligned, same-width, scrollable; only rendered when named profiles exist.
   if app.clean_overlay.has_profiles() {
-    let selected = app.clean_overlay.selected_index();
-    for (i, label) in app.clean_overlay.choice_labels().iter().enumerate() {
-      let line = if i == selected {
-        Line::from(format!("▸ {label}")).style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
-      } else {
-        Line::from(format!("  {label}")).style(Style::default().fg(muted))
-      };
-      lines.push(line.centered());
-    }
+    let labels = app.clean_overlay.choice_labels();
+    let max_visible = (term.height as usize).saturating_sub(14).max(3);
+    lines.extend(picker_lines(
+      &labels,
+      app.clean_overlay.selected_index(),
+      max_visible,
+      &app.theme,
+    ));
     lines.push(Line::from(""));
   }
 
   // The gated reclaim report — only the git-ignored, untracked artifacts.
+  // Two aligned columns (dir left, size right) with a size heatmap; the list
+  // is capped to the modal height with a `… N more` overflow marker.
   match app.clean_overlay.reclaim() {
     Some(reclaim) if !reclaim.artifacts.is_empty() => {
-      for a in &reclaim.artifacts {
+      // Equal column widths so every row (and the total) lines up.
+      let relw = reclaim
+        .artifacts
+        .iter()
+        .map(|a| a.rel.chars().count())
+        .max()
+        .unwrap_or(0)
+        .clamp(5, 20);
+      let row = |left: &str, left_style: Style, bytes: u64, size_style: Style| -> Line<'static> {
+        Line::from(vec![
+          Span::styled(format!("{:<relw$}  ", ellipsize_middle(left, relw)), left_style),
+          Span::styled(format!("{:>10}", crate::clean::human_size(bytes)), size_style),
+        ])
+        .centered()
+      };
+      let max_rows = (term.height as usize).saturating_sub(14).max(3);
+      let shown = reclaim.artifacts.len().min(max_rows);
+      for a in reclaim.artifacts.iter().take(shown) {
+        lines.push(row(
+          &a.rel,
+          Style::default().fg(muted),
+          a.bytes,
+          Style::default().fg(reclaim_size_color(a.bytes, &app.theme)),
+        ));
+      }
+      if reclaim.artifacts.len() > shown {
         lines.push(
-          Line::from(format!("{:<14} {}", a.rel, crate::clean::human_size(a.bytes)))
-            .style(Style::default().fg(muted))
-            .centered(),
+          Line::from(Span::styled(
+            format!("… {} more", reclaim.artifacts.len() - shown),
+            Style::default().fg(muted),
+          ))
+          .centered(),
         );
       }
-      lines.push(
-        Line::from(format!("total {}", crate::clean::human_size(reclaim.total_bytes)))
-          .style(Style::default().fg(accent).add_modifier(Modifier::BOLD))
-          .centered(),
-      );
+      lines.push(row(
+        "total",
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+        reclaim.total_bytes,
+        Style::default()
+          .fg(reclaim_size_color(reclaim.total_bytes, &app.theme))
+          .add_modifier(Modifier::BOLD),
+      ));
     }
     _ => {
       lines.push(
@@ -4215,7 +4319,6 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let term = f.area();
   let width = link_prompt_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2568,14 +2568,18 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
   rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
   rows.push(entry(Action::ConfigPanel, "show the resolved configuration panel"));
-  rows.push(entry(
-    Action::ExecOverlay,
-    "pick an [exec.profiles] profile and run it in a PTY",
-  ));
-  rows.push(entry(
-    Action::CleanOverlay,
-    "preview and reclaim build artifacts (with confirm)",
-  ));
+  // #334 review: the exec / clean overlays are picker-gated (`run_action`
+  // no-ops them in `gwm switch`), so only advertise them outside picker mode.
+  if !picker_mode {
+    rows.push(entry(
+      Action::ExecOverlay,
+      "pick an [exec.profiles] profile and run it in a PTY",
+    ));
+    rows.push(entry(
+      Action::CleanOverlay,
+      "preview and reclaim build artifacts (with confirm)",
+    ));
+  }
   rows.push(entry(
     Action::Filter,
     "open fuzzy filter bar (enter: sticky, esc: clear)",
@@ -4114,6 +4118,25 @@ pub fn reclaim_size_color(bytes: u64, theme: &Theme) -> Color {
   }
 }
 
+/// A nerd-font glyph matched to a reclaimable directory name (issue #334
+/// polish) — the ecosystem the artifact belongs to (`node_modules` → node,
+/// `target` → Rust, `vendor` → PHP, `.venv` → Python, `dist`/`build` →
+/// package, `.cache` → archive…), falling back to a generic folder. Leading
+/// dots are stripped so `.venv` / `.nuxt` match like `venv` / `nuxt`.
+pub fn clean_dir_icon(rel: &str) -> &'static str {
+  match rel.trim_start_matches('.').to_ascii_lowercase().as_str() {
+    "node_modules" => "\u{e718}",      // nf-dev-nodejs
+    "target" => wt_tree::WT_RUST_ICON, // nf-dev-rust
+    "vendor" => "\u{e73d}",            // nf-dev-php
+    "venv" | "__pycache__" | "pytest_cache" | "mypy_cache" | "tox" => "\u{e73c}", // nf-dev-python
+    "dist" | "build" | "out" | "output" | "bin" => "\u{f487}", // nf-oct-package
+    "cache" | "turbo" | "parcel-cache" => "\u{f187}", // nf-fa-archive
+    "nuxt" | "next" | "svelte-kit" | "astro" | "vite" => "\u{e74e}", // nf-dev-javascript
+    "coverage" => "\u{f201}",          // nf-fa-line_chart
+    _ => wt_tree::WT_DIR_ICON,         // generic folder
+  }
+}
+
 /// The visible `[start, end)` slice of a `len`-item picker when at most
 /// `max_visible` rows fit, keeping `selected` in view (centred while
 /// scrolling). Returns the whole list when it fits (issue #325 polish).
@@ -4247,8 +4270,11 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
         .max()
         .unwrap_or(0)
         .clamp(5, 20);
-      let row = |left: &str, left_style: Style, bytes: u64, size_style: Style| -> Line<'static> {
+      // Each row: a matched nerd-font icon (#334), the dir name (left), and
+      // the heatmap-coloured size (right) — all in fixed columns so they align.
+      let row = |icon: &str, left: &str, left_style: Style, bytes: u64, size_style: Style| -> Line<'static> {
         Line::from(vec![
+          Span::styled(format!("{icon}  "), Style::default().fg(accent)),
           Span::styled(format!("{:<relw$}  ", ellipsize_middle(left, relw)), left_style),
           Span::styled(format!("{:>10}", crate::clean::human_size(bytes)), size_style),
         ])
@@ -4258,6 +4284,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
       let shown = reclaim.artifacts.len().min(max_rows);
       for a in reclaim.artifacts.iter().take(shown) {
         lines.push(row(
+          clean_dir_icon(&a.rel),
           &a.rel,
           Style::default().fg(muted),
           a.bytes,
@@ -4273,7 +4300,9 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
           .centered(),
         );
       }
+      // The total row uses an aggregate (sigma) glyph in the icon column.
       lines.push(row(
+        "\u{f03a}",
         "total",
         Style::default().fg(accent).add_modifier(Modifier::BOLD),
         reclaim.total_bytes,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4222,7 +4222,7 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
   let term = f.area();
   let width = overlay_modal_width(term.width);
-  let inner = width.saturating_sub(2) as usize; // inside the borders
+  let inner = width.saturating_sub(6) as usize; // inside borders (1) + overlay_block padding (2) each side
   let mut lines = overlay_title_lines("Run an exec profile", accent);
   // Leave room for the title + hint + borders; the picker scrolls past that.
   let max_visible = (term.height as usize).saturating_sub(8).max(3);
@@ -4261,7 +4261,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
   let border = if armed { danger } else { accent };
   let term = f.area();
   let width = overlay_modal_width(term.width);
-  let inner = width.saturating_sub(2) as usize; // inside the borders
+  let inner = width.saturating_sub(6) as usize; // inside borders (1) + overlay_block padding (2) each side
 
   let mut lines = overlay_title_lines("Reclaim build artifacts", border);
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3506,14 +3506,14 @@ pub fn link_prompt_modal_width(term_width: u16) -> u16 {
   width.min(72).min(term_width)
 }
 
-/// Modal width for the exec / clean overlays (issue #334 polish). Wider than
-/// the link-prompt modal so the icon + dir name + size columns of the clean
-/// report have room to breathe on a roomy terminal, while staying readable on
-/// a narrow one. ~70 % of the width (90 % when ≤ 80 cols), clamped to
-/// `[48, 110]`.
+/// Modal width for the exec / clean overlays (issue #334 polish). A bit wider
+/// than the link-prompt modal so the full-width clean report (icon + dir name
+/// pinned left, size pinned right) uses the horizontal space — but capped so
+/// the name↔size gap never stretches absurdly on an ultra-wide terminal.
+/// ~62 % of the width (90 % when ≤ 80 cols), clamped to `[48, 88]`.
 pub fn overlay_modal_width(term_width: u16) -> u16 {
-  let pct = if term_width <= 80 { 90 } else { 70 };
-  (term_width.saturating_mul(pct) / 100).clamp(48, 110).min(term_width)
+  let pct = if term_width <= 80 { 90 } else { 62 };
+  (term_width.saturating_mul(pct) / 100).clamp(48, 88).min(term_width)
 }
 
 /// Section-heading style for the Keybindings overlay body. Kept pure so the
@@ -4159,17 +4159,24 @@ pub fn picker_window(len: usize, selected: usize, max_visible: usize) -> (usize,
   (start, start + max_visible)
 }
 
-/// Build the centred, fixed-width, scrollable rows for an overlay profile
-/// picker (issue #325 polish). Every row is padded to the same width so the
-/// selection highlight reads as a consistent bar and the labels align; the
-/// visible window follows `selected` with `↑ / ↓ N more` markers when the
-/// list overflows `max_visible`.
-fn picker_lines(labels: &[&str], selected: usize, max_visible: usize, theme: &Theme) -> Vec<Line<'static>> {
+/// Build the full-width, scrollable rows for an overlay profile picker (issue
+/// #334 polish). Each row spans the modal's `inner` width — left-aligned so
+/// the labels start at the same column and the selection highlight reads as a
+/// full-width bar — and the visible window follows `selected` with
+/// `↑ / ↓ N more` markers (centred) when the list overflows `max_visible`.
+fn picker_lines(
+  labels: &[&str],
+  selected: usize,
+  max_visible: usize,
+  inner: usize,
+  theme: &Theme,
+) -> Vec<Line<'static>> {
   let mut out = Vec::new();
   if labels.is_empty() {
     return out;
   }
-  let labelw = labels.iter().map(|l| l.chars().count()).max().unwrap_or(0);
+  // Width available for the label text after the ` ▸ ` marker gutter.
+  let textw = inner.saturating_sub(3);
   let (start, end) = picker_window(labels.len(), selected, max_visible);
   if start > 0 {
     out.push(
@@ -4182,7 +4189,8 @@ fn picker_lines(labels: &[&str], selected: usize, max_visible: usize, theme: &Th
   }
   for (i, label) in labels.iter().enumerate().take(end).skip(start) {
     let marker = if i == selected { "▸" } else { " " };
-    let txt = format!("{marker} {label:<labelw$} ");
+    // Pad to the full inner width so the selection bar fills the whole row.
+    let txt = format!(" {marker} {:<textw$}", ellipsize_middle(label, textw));
     let style = if i == selected {
       Style::default()
         .fg(theme.accent)
@@ -4191,7 +4199,7 @@ fn picker_lines(labels: &[&str], selected: usize, max_visible: usize, theme: &Th
     } else {
       Style::default().fg(theme.muted)
     };
-    out.push(Line::from(Span::styled(txt, style)).centered());
+    out.push(Line::from(Span::styled(txt, style)));
   }
   if end < labels.len() {
     out.push(
@@ -4213,6 +4221,8 @@ fn picker_lines(labels: &[&str], selected: usize, max_visible: usize, theme: &Th
 fn draw_exec_picker(f: &mut Frame, app: &App) {
   let accent = app.theme.accent;
   let term = f.area();
+  let width = overlay_modal_width(term.width);
+  let inner = width.saturating_sub(2) as usize; // inside the borders
   let mut lines = overlay_title_lines("Run an exec profile", accent);
   // Leave room for the title + hint + borders; the picker scrolls past that.
   let max_visible = (term.height as usize).saturating_sub(8).max(3);
@@ -4221,6 +4231,7 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
     &labels,
     app.exec_picker.selected_index(),
     max_visible,
+    inner,
     &app.theme,
   ));
   push_modal_hint(
@@ -4231,7 +4242,6 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let width = overlay_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
@@ -4250,11 +4260,13 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
   let armed = app.clean_overlay.confirm.is_armed();
   let border = if armed { danger } else { accent };
   let term = f.area();
+  let width = overlay_modal_width(term.width);
+  let inner = width.saturating_sub(2) as usize; // inside the borders
 
   let mut lines = overlay_title_lines("Reclaim build artifacts", border);
 
   // Profile picker — the `(default)` choice plus any `[clean.profiles]`.
-  // Aligned, same-width, scrollable; only rendered when named profiles exist.
+  // Full-width, scrollable; only rendered when named profiles exist.
   if app.clean_overlay.has_profiles() {
     let labels = app.clean_overlay.choice_labels();
     let max_visible = (term.height as usize).saturating_sub(14).max(3);
@@ -4262,33 +4274,28 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
       &labels,
       app.clean_overlay.selected_index(),
       max_visible,
+      inner,
       &app.theme,
     ));
     lines.push(Line::from(""));
   }
 
   // The gated reclaim report — only the git-ignored, untracked artifacts.
-  // Two aligned columns (dir left, size right) with a size heatmap; the list
-  // is capped to the modal height with a `… N more` overflow marker.
+  // Each row fills the modal's inner width: a matched nerd-font icon (#334) +
+  // dir name pinned left, the heatmap-coloured size pinned to the right edge,
+  // so the columns use the whole box. Capped to the modal height with a
+  // `… N more` overflow marker.
   match app.clean_overlay.reclaim() {
     Some(reclaim) if !reclaim.artifacts.is_empty() => {
-      // Equal column widths so every row (and the total) lines up.
-      let relw = reclaim
-        .artifacts
-        .iter()
-        .map(|a| a.rel.chars().count())
-        .max()
-        .unwrap_or(0)
-        .clamp(5, 32);
-      // Each row: a matched nerd-font icon (#334), the dir name (left), and
-      // the heatmap-coloured size (right) — all in fixed columns so they align.
+      // Name column = inner width minus the ` icon  ` gutter (4) and the
+      // `<size> ` tail (11), so the size lands flush on the right edge.
+      let namew = inner.saturating_sub(15).max(5);
       let row = |icon: &str, left: &str, left_style: Style, bytes: u64, size_style: Style| -> Line<'static> {
         Line::from(vec![
-          Span::styled(format!("{icon}  "), Style::default().fg(accent)),
-          Span::styled(format!("{:<relw$}  ", ellipsize_middle(left, relw)), left_style),
-          Span::styled(format!("{:>10}", crate::clean::human_size(bytes)), size_style),
+          Span::styled(format!(" {icon}  "), Style::default().fg(accent)),
+          Span::styled(format!("{:<namew$}", ellipsize_middle(left, namew)), left_style),
+          Span::styled(format!("{:>10} ", crate::clean::human_size(bytes)), size_style),
         ])
-        .centered()
       };
       let max_rows = (term.height as usize).saturating_sub(14).max(3);
       let shown = reclaim.artifacts.len().min(max_rows);
@@ -4358,7 +4365,6 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let width = overlay_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(border)), area);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2569,6 +2569,14 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
   rows.push(entry(Action::ConfigPanel, "show the resolved configuration panel"));
   rows.push(entry(
+    Action::ExecOverlay,
+    "pick an [exec.profiles] profile and run it in a PTY",
+  ));
+  rows.push(entry(
+    Action::CleanOverlay,
+    "preview and reclaim build artifacts (with confirm)",
+  ));
+  rows.push(entry(
     Action::Filter,
     "open fuzzy filter bar (enter: sticky, esc: clear)",
   ));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3506,6 +3506,16 @@ pub fn link_prompt_modal_width(term_width: u16) -> u16 {
   width.min(72).min(term_width)
 }
 
+/// Modal width for the exec / clean overlays (issue #334 polish). Wider than
+/// the link-prompt modal so the icon + dir name + size columns of the clean
+/// report have room to breathe on a roomy terminal, while staying readable on
+/// a narrow one. ~70 % of the width (90 % when ≤ 80 cols), clamped to
+/// `[48, 110]`.
+pub fn overlay_modal_width(term_width: u16) -> u16 {
+  let pct = if term_width <= 80 { 90 } else { 70 };
+  (term_width.saturating_mul(pct) / 100).clamp(48, 110).min(term_width)
+}
+
 /// Section-heading style for the Keybindings overlay body. Kept pure so the
 /// title/body colour split is pinned outside the ratatui renderer.
 pub fn help_section_style(section: Color) -> Style {
@@ -4221,7 +4231,7 @@ fn draw_exec_picker(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let width = link_prompt_modal_width(term.width);
+  let width = overlay_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
@@ -4269,7 +4279,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
         .map(|a| a.rel.chars().count())
         .max()
         .unwrap_or(0)
-        .clamp(5, 20);
+        .clamp(5, 32);
       // Each row: a matched nerd-font icon (#334), the dir name (left), and
       // the heatmap-coloured size (right) — all in fixed columns so they align.
       let row = |icon: &str, left: &str, left_style: Style, bytes: u64, size_style: Style| -> Line<'static> {
@@ -4348,7 +4358,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
     &app.theme,
   );
   let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-  let width = link_prompt_modal_width(term.width);
+  let width = overlay_modal_width(term.width);
   let area = centered_abs(width, height, term);
   f.render_widget(Clear, area);
   f.render_widget(Paragraph::new(lines).block(overlay_block(border)), area);

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -609,3 +609,32 @@ fn help_rows_cover_every_bound_list_view_action() {
     );
   }
 }
+
+#[test]
+fn help_rows_hide_exec_and_clean_in_switch_picker_mode() {
+  // #334 review: `x` / `X` are picker-gated (`run_action` no-ops them in
+  // `gwm switch`), so the help overlay must not advertise them in the Picker
+  // context — only in the focus-mode List View.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::Keymap;
+  use gwm::tui::modal_keymap::ModalKeymap;
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  let modal = ModalKeymap::defaults();
+  let labels: Vec<String> = help_rows(&km, &modal, HintContext::Picker)
+    .iter()
+    .filter_map(|r| match r {
+      HelpRow::Entry { label, .. } => Some(label.clone()),
+      _ => None,
+    })
+    .collect();
+  assert!(
+    !labels.iter().any(|l| l.contains("[exec.profiles]")),
+    "the exec overlay must be hidden from the switch-picker help"
+  );
+  assert!(
+    !labels.iter().any(|l| l.contains("reclaim build artifacts")),
+    "the clean overlay must be hidden from the switch-picker help"
+  );
+}

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -546,3 +546,66 @@ fn help_overlay_reflects_a_modal_rebind() {
     lines.join("\n")
   );
 }
+
+#[test]
+fn help_rows_document_the_exec_and_clean_overlays() {
+  // #334: the #325 exec (`x`) / clean (`X`) overlays were added to the keymap
+  // and palette but omitted from the hand-curated help overlay (`?`). Pin them
+  // so they can't silently disappear from `?` again.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::{Action, Keymap};
+  use gwm::tui::modal_keymap::ModalKeymap;
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  let modal = ModalKeymap::defaults();
+  let rows = help_rows(&km, &modal, HintContext::Worktrees);
+
+  let documents = |action: Action, label_needle: &str| -> bool {
+    let keys = km.keys_display(action);
+    rows
+      .iter()
+      .any(|r| matches!(r, HelpRow::Entry { keys: k, label } if *k == keys && label.contains(label_needle)))
+  };
+  assert!(
+    documents(Action::ExecOverlay, "exec"),
+    "the help overlay must document the exec picker (x): {rows:?}"
+  );
+  assert!(
+    documents(Action::CleanOverlay, "reclaim"),
+    "the help overlay must document the clean overlay (X): {rows:?}"
+  );
+}
+
+#[test]
+fn help_rows_cover_every_bound_list_view_action() {
+  // #334: the help overlay is hand-curated, so a newly bound Action can be
+  // reachable by key + palette yet missing from `?` (exactly how exec/clean
+  // slipped). Guard it: every action bound by default must appear in the List
+  // View help, except the handful documented only in their own modal context.
+  use gwm::tui::help_rows;
+  use gwm::tui::keymap::{Action, Keymap};
+  use gwm::tui::modal_keymap::ModalKeymap;
+  use gwm::tui::{HelpRow, HintContext};
+
+  let km = Keymap::defaults();
+  let modal = ModalKeymap::defaults();
+  let rows = help_rows(&km, &modal, HintContext::Worktrees);
+  let documented: std::collections::HashSet<String> = rows
+    .iter()
+    .filter_map(|r| match r {
+      HelpRow::Entry { keys, .. } if !keys.is_empty() => Some(keys.clone()),
+      _ => None,
+    })
+    .collect();
+
+  // Strict: EVERY bound action is documented today (no exclusions), so a new
+  // omission goes red immediately.
+  for action in Action::all() {
+    let keys = km.keys_display(action);
+    assert!(
+      documented.contains(&keys),
+      "Action::{action:?} (keys {keys:?}) is bound but missing from the help overlay — add it to help_rows()"
+    );
+  }
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -621,7 +621,7 @@ fn exec_picker_modal_renders_title_profiles_and_hints() {
   app.enter_exec_picker();
   assert_eq!(app.view, View::ExecPicker);
   let buf = render(&mut app);
-  assert_present(&buf, "run exec profile", "exec picker title");
+  assert_present(&buf, "Run an exec profile", "exec picker title (capitalised)");
   assert_present(&buf, "build", "exec profile name");
   assert_present(&buf, "run", "exec run hint");
 }
@@ -640,7 +640,7 @@ fn clean_modal_renders_title_report_and_hints() {
   app.enter_clean_overlay();
   assert_eq!(app.view, View::CleanReport);
   let buf = render(&mut app);
-  assert_present(&buf, "reclaim build artifacts", "clean overlay title");
+  assert_present(&buf, "Reclaim build artifacts", "clean overlay title (capitalised)");
   assert_present(&buf, "target", "clean artifact name");
   assert_present(&buf, "total", "clean total line");
 }

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -643,4 +643,7 @@ fn clean_modal_renders_title_report_and_hints() {
   assert_present(&buf, "Reclaim build artifacts", "clean overlay title (capitalised)");
   assert_present(&buf, "target", "clean artifact name");
   assert_present(&buf, "total", "clean total line");
+  // #335 review: the right-aligned size column must fit the drawable area
+  // (width − borders − padding), so the unit suffix is never clipped.
+  assert_present(&buf, "KiB", "size unit not clipped on the right edge");
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -1039,8 +1039,8 @@ fn overlay_modal_width_is_wider_but_clamped() {
   // On a wide terminal it is meaningfully wider than the 72-col link modal.
   assert!(overlay_modal_width(160) > link_prompt_modal_width(160));
   assert!(overlay_modal_width(120) >= 72);
-  // Clamped: never wider than the terminal, never past the 110 ceiling.
-  assert!(overlay_modal_width(300) <= 110);
+  // Clamped: never wider than the terminal, never past the 88 ceiling.
+  assert!(overlay_modal_width(300) <= 88);
   assert!(overlay_modal_width(40) <= 40);
   assert!(overlay_modal_width(50) >= 45, "narrow terminals still get a usable box");
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -1030,3 +1030,17 @@ fn clean_dir_icon_matches_the_ecosystem() {
     assert!(!clean_dir_icon(d).is_empty(), "icon for {d:?} must be non-empty");
   }
 }
+
+#[test]
+fn overlay_modal_width_is_wider_but_clamped() {
+  // #334 polish: the exec/clean overlays use more horizontal space than the
+  // link-prompt modal on a roomy terminal, but stay readable / clamped.
+  use gwm::tui::{link_prompt_modal_width, overlay_modal_width};
+  // On a wide terminal it is meaningfully wider than the 72-col link modal.
+  assert!(overlay_modal_width(160) > link_prompt_modal_width(160));
+  assert!(overlay_modal_width(120) >= 72);
+  // Clamped: never wider than the terminal, never past the 110 ceiling.
+  assert!(overlay_modal_width(300) <= 110);
+  assert!(overlay_modal_width(40) <= 40);
+  assert!(overlay_modal_width(50) >= 45, "narrow terminals still get a usable box");
+}

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -997,3 +997,36 @@ fn reclaim_size_color_is_a_magnitude_heatmap() {
   assert_eq!(reclaim_size_color(500 * MIB, &t), t.prunable, "500 MiB boundary → red");
   assert_eq!(reclaim_size_color(3 * 1024 * MIB, &t), t.prunable, "large → red");
 }
+
+#[test]
+fn clean_dir_icon_matches_the_ecosystem() {
+  // #334 polish: each reclaimable dir gets a nerd-font glyph matched to its
+  // ecosystem; unknown names fall back to the generic folder. Leading dots
+  // are ignored so `.venv` matches like `venv`.
+  use gwm::tui::clean_dir_icon;
+  let folder = clean_dir_icon("some-unknown-dir");
+  assert_ne!(clean_dir_icon("node_modules"), folder, "node_modules has its own icon");
+  assert_ne!(clean_dir_icon("target"), folder, "target (Rust) has its own icon");
+  assert_eq!(
+    clean_dir_icon(".venv"),
+    clean_dir_icon("venv"),
+    "leading dot is ignored"
+  );
+  assert_eq!(clean_dir_icon(".cache"), clean_dir_icon("cache"));
+  // Distinct ecosystems get distinct glyphs.
+  assert_ne!(clean_dir_icon("node_modules"), clean_dir_icon("target"));
+  assert_ne!(clean_dir_icon("vendor"), clean_dir_icon("venv"));
+  // Every glyph is a single non-empty token.
+  for d in [
+    "node_modules",
+    "target",
+    "vendor",
+    ".venv",
+    "dist",
+    ".cache",
+    "coverage",
+    "whatever",
+  ] {
+    assert!(!clean_dir_icon(d).is_empty(), "icon for {d:?} must be non-empty");
+  }
+}

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -965,3 +965,35 @@ fn working_tree_counts_footer_shows_only_nonzero_colored_segments() {
     "deleted paints the `prunable` role"
   );
 }
+
+#[test]
+fn picker_window_keeps_the_selection_visible() {
+  // #325 overlay polish: the picker scrolls to keep the highlight in view.
+  use gwm::tui::picker_window;
+  // Fits within the budget → the whole list, no scroll.
+  assert_eq!(picker_window(3, 0, 5), (0, 3));
+  assert_eq!(picker_window(5, 4, 5), (0, 5));
+  // Overflows → a `max`-row window clamped to the bounds, selection inside.
+  assert_eq!(picker_window(10, 0, 4), (0, 4));
+  assert_eq!(picker_window(10, 9, 4), (6, 10));
+  let (s, e) = picker_window(10, 5, 4);
+  assert!(s <= 5 && 5 < e && e - s == 4, "selection in a 4-row window: {s}..{e}");
+  // Degenerate inputs are safe.
+  assert_eq!(picker_window(0, 0, 5), (0, 0));
+  assert_eq!(picker_window(5, 2, 0), (0, 5));
+}
+
+#[test]
+fn reclaim_size_color_is_a_magnitude_heatmap() {
+  // #325 overlay polish: green (small) → yellow (medium) → red (large).
+  use gwm::tui::reclaim_size_color;
+  use gwm::tui::theme::Theme;
+  let t = Theme::default();
+  const MIB: u64 = 1024 * 1024;
+  assert_eq!(reclaim_size_color(0, &t), t.clean, "zero → green");
+  assert_eq!(reclaim_size_color(10 * MIB, &t), t.clean, "small → green");
+  assert_eq!(reclaim_size_color(50 * MIB, &t), t.dirty, "50 MiB boundary → yellow");
+  assert_eq!(reclaim_size_color(200 * MIB, &t), t.dirty, "medium → yellow");
+  assert_eq!(reclaim_size_color(500 * MIB, &t), t.prunable, "500 MiB boundary → red");
+  assert_eq!(reclaim_size_color(3 * 1024 * MIB, &t), t.prunable, "large → red");
+}


### PR DESCRIPTION
## Description

Follow-up polish to the #325 exec / clean overlays.

Closes #334

## Type of change

- [x] 🐛 Fix (bug fix) — help overlay omission
- [x] 💄 UI / polish

## Changes

- **Help overlay (`?`)** documented the exec (`x`) / clean (`X`) overlays — they were in the keymap / palette but missing from the hand-curated `help_rows`. Added a **strict completeness test** so a future Action can't silently miss `?`.
- **Capitalised titles**: "Run an exec profile" / "Reclaim build artifacts".
- **Aligned, same-width profile picker** (both overlays) via a shared `picker_lines` helper — consistent-width rows, a `selection_bg` highlight bar, aligned labels.
- **Aligned clean report columns** (dir left / size right) so rows + total line up.
- **Size heatmap** (`reclaim_size_color`): green (small) → yellow (medium) → red (≥ 500 MiB).
- **Scroll**: `picker_window` keeps the highlight in view with `↑ / ↓ N more` markers; the clean report caps with `… N more`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

`tui_chord_tests` (exec/clean rows + help completeness invariant), `tui_ui_helpers_tests` (`picker_window` windowing/clamping, `reclaim_size_color` thresholds), `tui_modal_render_tests` (capitalised titles).

## Screenshots / TUI captures

<!-- exec/clean overlays; capture deferred to #206 -->

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG — n/a (TUI-only polish, no user-facing config/CLI change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #334 (follow-up to #325 / PR #333)

## Notes for reviewers

- TUI-only; no contract / CLI surface change.
- The help-completeness test is strict (every default-bound action must be in the List View help) — `CommandPalette` is already documented, so no exclusions today.

https://claude.ai/code/session_01M9eLxtdMFK1RBCCABndY9H