### PR TITLE
🔒 fix(cli): gate `undo --bootstrap` behind the trust prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet — entries land here as PRs merge into `dev`, then move to a per-RC file under `changelogs/pre-releases/` when the next RC is cut._
+### Fixed
+
+- **`gwm undo --bootstrap` now goes through the TOFU trust gate** ([#338]).
+  Re-running a repo's `[[bootstrap.command]]` shell on undo previously
+  bypassed `trust_or_prompt` entirely — `cmd_undo` called `bootstrap::run`
+  directly with no trust check, so an untrusted `.gwm.toml` could run shell
+  commands unprompted. Undo now mediates the bootstrap re-run through the
+  same gate as `create` / `review --bootstrap` / `bootstrap`, honouring
+  `--allow-bootstrap` / `GWM_ALLOW_BOOTSTRAP` / `--deny-bootstrap`.
+
+[#338]: https://github.com/kbrdn1/gwm-cli/issues/338
 
 ## Past releases
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4272,6 +4272,20 @@ fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
 
   let repo = worktree::discover_repo(None)?;
 
+  // (0) Issue #338: if the caller opted into re-running bootstrap, gate
+  //     it through the SAME TOFU trust prompt as create / review /
+  //     bootstrap — a repo's `[[bootstrap.command]]` shell must never run
+  //     unprompted on undo. Do it BEFORE any resurrection so a denied
+  //     gate (untrusted config in a non-tty, `--deny-bootstrap`, or a
+  //     declined prompt) leaves the journal entry and worktree untouched:
+  //     the undo stays retryable instead of half-applying then exiting
+  //     non-zero. Honours --allow-bootstrap / GWM_ALLOW_BOOTSTRAP /
+  //     --deny-bootstrap.
+  if run_bootstrap {
+    let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+    trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
+  }
+
   // (1) Resurrect the branch at the saved OID — only if a branch was
   //     recorded AND the user opted into deletion (or the branch is
   //     missing for any other reason). Skipping the branch create
@@ -4335,14 +4349,10 @@ fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
   //     user would lose the recovery anchor entirely.
   journal.save(&path)?;
 
-  // (4) Optionally re-run bootstrap.
+  // (4) Optionally re-run bootstrap. Trust was already gated at step
+  //     (0) before any resurrection, so by here we're cleared to run.
   if run_bootstrap {
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-    // Issue #338: mediate the bootstrap re-run through the SAME TOFU
-    // trust gate as create / review / bootstrap. A repo's
-    // `[[bootstrap.command]]` shell must never run unprompted on undo —
-    // honours --allow-bootstrap / GWM_ALLOW_BOOTSTRAP / --deny-bootstrap.
-    trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
     let config = Config::load_for_repo(&workdir)?;
     let ctx = BootstrapCtx {
       main_repo: &workdir,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1046,7 +1046,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Aliases { action } => cmd_aliases(action),
     Command::Config { action } => cmd_config(action),
     Command::History { limit, all } => cmd_history(limit, all),
-    Command::Undo { bootstrap } => cmd_undo(bootstrap),
+    Command::Undo { bootstrap } => cmd_undo(bootstrap, mode),
     Command::Tui { action } => cmd_tui(action),
     Command::Theme { action } => cmd_theme(action),
     Command::Exec {
@@ -4258,7 +4258,7 @@ fn cmd_history(limit: usize, all: bool) -> Result<()> {
   Ok(())
 }
 
-fn cmd_undo(run_bootstrap: bool) -> Result<()> {
+fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
   let path = history::default_journal_path()?;
   let mut journal = history::Journal::load(&path)?;
   let root = current_repo_root()?;
@@ -4338,6 +4338,11 @@ fn cmd_undo(run_bootstrap: bool) -> Result<()> {
   // (4) Optionally re-run bootstrap.
   if run_bootstrap {
     let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
+    // Issue #338: mediate the bootstrap re-run through the SAME TOFU
+    // trust gate as create / review / bootstrap. A repo's
+    // `[[bootstrap.command]]` shell must never run unprompted on undo —
+    // honours --allow-bootstrap / GWM_ALLOW_BOOTSTRAP / --deny-bootstrap.
+    trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
     let config = Config::load_for_repo(&workdir)?;
     let ctx = BootstrapCtx {
       main_repo: &workdir,

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4069,6 +4069,31 @@ run  = "echo trapped"
     .stderr(
       predicate::str::contains("not in the trust ledger").or(predicate::str::contains("stdin is not interactive")),
     );
+
+  // 4. The gate runs BEFORE any resurrection (fail-fast), so a denied
+  //    undo must leave the journal entry and worktree untouched — not
+  //    half-apply then exit non-zero. The worktree must still be gone…
+  let wt_path = base.path().join("feat-338-undo-trust");
+  assert!(
+    !wt_path.exists(),
+    "a denied trust gate must NOT restore the worktree — undo must stay retryable"
+  );
+
+  // …and a follow-up `undo` (no --bootstrap → no gate) must still find
+  //    the journal entry and restore the worktree, proving the denied
+  //    run consumed nothing.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .env("GWM_HISTORY_FILE", &history_file)
+    .arg("undo")
+    .assert()
+    .success();
+  assert!(
+    wt_path.exists(),
+    "retry undo must restore the worktree — the entry was preserved"
+  );
 }
 
 #[test]

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -4003,6 +4003,75 @@ branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
 }
 
 #[test]
+fn undo_bootstrap_without_trust_aborts() {
+  // Issue #338: `gwm undo --bootstrap` must mediate the repo's
+  // `[[bootstrap.command]]` shell through the SAME TOFU trust gate as
+  // create / review / bootstrap. Before the fix, `cmd_undo` had no
+  // `trust_mode` parameter and called `bootstrap::run` directly, so the
+  // bootstrap commands ran unprompted on undo. Pin the gate at the CLI
+  // boundary: create → remove → `undo --bootstrap` from a non-tty with
+  // an empty ledger and no `GWM_ALLOW_BOOTSTRAP` must abort with the
+  // trust message rather than silently running the bootstrap surface.
+  let (dir, _) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let history_dir = tempfile::TempDir::new().unwrap();
+  let history_file = history_dir.path().join("history.toml");
+  let ledger_dir = tempfile::TempDir::new().unwrap();
+  let ledger = ledger_dir.path().join("trust.toml");
+
+  let body = format!(
+    r#"
+[worktree]
+base = "{base}"
+path_pattern = "{{type}}-{{issue}}-{{desc}}"
+branch_pattern = "{{type}}/#{{issue}}-{{desc}}"
+
+[[bootstrap.command]]
+name = "trap"
+run  = "echo trapped"
+"#,
+    base = toml_basic_string(base.path()),
+  );
+  std::fs::write(dir.path().join(".gwm.toml"), body).unwrap();
+
+  // 1. Create — bypass the gate via the env var, skip the shell step.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["create", "feat", "338", "undo-trust", "--no-bootstrap"])
+    .assert()
+    .success();
+
+  // 2. Remove — records the journal entry `undo` will replay.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["remove", "feat-338-undo-trust"])
+    .assert()
+    .success();
+
+  // 3. `undo --bootstrap` with an empty ledger and no allow-bypass,
+  //    from a non-tty → the trust gate must abort rather than running
+  //    the `[[bootstrap.command]]` shell unprompted.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .env("GWM_HISTORY_FILE", &history_file)
+    .args(["undo", "--bootstrap"])
+    .assert()
+    .failure()
+    .stderr(
+      predicate::str::contains("not in the trust ledger").or(predicate::str::contains("stdin is not interactive")),
+    );
+}
+
+#[test]
 fn undo_refuses_detached_head_entry_with_clear_error() {
   // PR #155 Copilot review: a journal entry with `branch = ""` (the
   // serialised form of `branch: None`) flags a worktree that was


### PR DESCRIPTION
## Description

`gwm undo --bootstrap` re-ran a repo's `[[bootstrap.command]]` shell from `.gwm.toml` **without going through the TOFU trust gate** — `cmd_undo` had no `trust_mode` parameter and called `bootstrap::run` directly, unlike `create` / `review --bootstrap` / `bootstrap`, which all gate via `trust_or_prompt`. An untrusted `.gwm.toml` could therefore run arbitrary shell unprompted on undo.

Found during the v1.0.0 ultra-audit (security dimension).

Closes #338

## Type of change

- [x] 🐛 Fix (bug fix) — security-boundary gap

## Changes

- `cmd_undo` now takes a `trust_mode: TrustMode` parameter, threaded from the dispatch (`Command::Undo => cmd_undo(bootstrap, mode)`).
- Before `bootstrap::run`, undo calls `trust_or_prompt(&workdir, Some(&repo), trust_mode)?` — the same gate as `create` / `review` / `bootstrap`, honouring `--allow-bootstrap` / `GWM_ALLOW_BOOTSTRAP` / `--deny-bootstrap`.
- The git resurrection (branch + worktree) is unchanged; only the bootstrap re-run is now gated.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

New end-to-end test `undo_bootstrap_without_trust_aborts` in `tests/cli_binary.rs`, mirroring `create_without_trust_in_non_interactive_aborts_cleanly`: create → remove → `undo --bootstrap` from a non-tty with an empty ledger and no `GWM_ALLOW_BOOTSTRAP` must abort. Confirmed red before the fix (the `trap` command ran, exit 0), green after.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — n/a (no surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed — n/a
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #338

## Notes for reviewers

The fix gates right before `bootstrap::run` (per the issue's suggestion), so undo still restores the branch + worktree, then aborts at the trust gate if the bootstrap surface is untrusted. The security property — `[[bootstrap.command]]` never runs unprompted — is fully satisfied. Open to moving the gate before resurrection (fail-fast) if reviewers prefer that posture.