### PR TITLE
🔒 security(deps): drop unsound serde_yml + make cargo audit blocking (#340)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-audit
         run: cargo install cargo-audit --locked
+      # `--deny warnings` makes warning-class advisories (unmaintained /
+      # unsound / yanked) fail the job, not just outright vulnerabilities.
+      # Plain `cargo audit` exits 0 on those, which is why RUSTSEC-2025-0068
+      # (serde_yml, unsound + unmaintained) slipped past for ~9 months even
+      # before accounting for `continue-on-error`. Accepted advisories go in
+      # `audit.toml` (`[advisories] ignore = […]`) with a rationale so each
+      # is a conscious decision (issue #340).
       - name: cargo audit
-        run: cargo audit
-        continue-on-error: true
+        run: cargo audit --deny warnings
 
   doctor:
     name: gwm doctor (advisory)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Dropped the unsound, unmaintained `serde_yml` dependency** ([#340],
+  RUSTSEC-2025-0068). The issue-form front-matter parser now uses the
+  maintained `serde_yaml_ng` fork; bumped `anyhow` to 1.0.103 to clear
+  RUSTSEC-2026-0190. The CI `cargo audit` job is now blocking
+  (`--deny warnings`, `continue-on-error` removed) so warning-class
+  advisories — unmaintained / unsound / yanked — fail the build instead
+  of being silently ignored.
+
+[#340]: https://github.com/kbrdn1/gwm-cli/issues/340
+
 ### Fixed
 
 - **`gwm undo --bootstrap` now goes through the TOFU trust gate** ([#338]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -897,7 +897,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "shell-words",
  "shellexpand",
@@ -1302,19 +1302,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "noyalib"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e493c05128df7a83b9676b709d590e0ebc285c7ed3152bc679668e8c1e506af5"
-dependencies = [
- "indexmap",
- "memchr",
- "rustc-hash",
- "serde",
- "smallvec",
-]
 
 [[package]]
 name = "nucleo-matcher"
@@ -1875,12 +1862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,13 +1969,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.13"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909764a65f86829ccdb5eea9ab355843aa02c019a7bfd47465092953565caa05"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "noyalib",
+ "indexmap",
+ "itoa",
+ "ryu",
  "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2440,6 +2424,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ crossterm = "0.29"
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.13"
 toml = "1.1"
 toml_edit = "0.25"
 anyhow = "1"
@@ -90,6 +89,7 @@ tui-term = "0.3"
 # `rm -rf /tmp /` are visually close but semantically different, so
 # we hash bytes, not parsed TOML.
 sha2 = "0.11"
+serde_yaml_ng = "0.10.0"
 
 # Unix-only: needed for `O_NOFOLLOW` in bootstrap's TOCTOU-safe copy
 # primitives (issue #93). Already pulled in transitively by git2 /

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -80,7 +80,7 @@ pub fn render_form_markdown(raw: &str, ctx: &TemplateContext, defaults: &FormDef
 }
 
 fn parse_issue_form(raw: &str) -> Result<IssueForm> {
-  serde_yml::from_str(raw).map_err(|e| GwmError::Config(format!("issue template YAML: {}", e)))
+  serde_yaml_ng::from_str(raw).map_err(|e| GwmError::Config(format!("issue template YAML: {}", e)))
 }
 
 fn field_value(item: &IssueFormItem, defaults: &FormDefaults) -> Option<String> {


### PR DESCRIPTION
## Description

Removes the unsound, unmaintained `serde_yml` dependency (RUSTSEC-2025-0068) and makes the CI `cargo audit` job actually block on advisories.

Closes #340

## Type of change

- [x] 🔧 Chore (deps) — security remediation
- [x] 👷 CI

## Changes

- **`serde_yml = "0.0.13"` → `serde_yaml_ng`** at the single call site (`templating::parse_issue_form`, parsing GitHub issue-form front-matter). Drop-in `from_str`; the issue-template tests pass unchanged.
- **`anyhow` 1.0.102 → 1.0.103** to clear RUSTSEC-2026-0190 (`Error::downcast_mut()` unsoundness, surfaced by the same audit run).
- **CI audit job is now blocking**: `cargo audit --deny warnings` + `continue-on-error: true` removed (`.github/workflows/ci.yml`).

## Why `--deny warnings` (not just removing `continue-on-error`)

The issue suggested removing `continue-on-error`. Measured locally: **plain `cargo audit` exits 0** on warning-class advisories (unmaintained / unsound / yanked) — `serde_yml`'s own RUSTSEC-2025-0068 is a *warning*, so removing `continue-on-error` alone would still not have blocked it. `cargo audit --deny warnings` exits 1 on those, which is what actually achieves the issue's intent. Accepted advisories go in `audit.toml` (`[advisories] ignore = […]`) with a rationale — none needed today, the tree is clean.

## Tests

- [x] `cargo test` passes locally (full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo build --locked` passes (Cargo.lock in sync)
- [x] `cargo audit --deny warnings` → **exit 0, 0 advisories** (310 deps, net −1)

No new test: behaviour-preserving dependency swap, guarded by the existing `render_form_markdown_converts_issue_form_fields_with_defaults` in `tests/templating_tests.rs` (parses a real issue-form YAML through the swapped path).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]` (new `### Security` section)
- [ ] README updated if CLI surface changed — n/a
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #340

## Notes for reviewers

`serde_yaml_ng` pulls `unsafe-libyaml` (same libyaml binding lineage as dtolnay's archived `serde_yaml`); `cargo audit` reports it clean. If a future reviewer prefers a pure-safe YAML path, `serde_norway` (uses `libyaml-safer`) is the alternative — happy to switch.