### PR TITLE
🔒 fix(daemon): harden the unix socket — perms, DoS limits, transient-empty snapshot (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#340]: https://github.com/kbrdn1/gwm-cli/issues/340
 
 - **Hardened the `gwm daemon` unix socket** ([#341]). The socket is now
-  created owner-only (`0600`), so on a shared host's `/tmp` fallback another
-  local user can no longer connect and read the worktree list. Added DoS
+  chmod'd owner-only (`0600`), and on the world-writable `/tmp` last-resort
+  fallback it is nested in a per-user owner-only `gwm-<uid>/` directory — so
+  another local user can no longer connect and read the worktree list even
+  on platforms that don't enforce socket-file perms for `connect(2)`. The
+  common `$XDG_RUNTIME_DIR` / `$TMPDIR` paths (already private) are
+  unchanged. Added DoS
   guards on the request/response path: a per-line length cap, an idle read
   timeout, and a concurrent-connection cap (all configurable on
   `ServeOptions`). Also fixed a bug where a transient `run_list` git error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#340]: https://github.com/kbrdn1/gwm-cli/issues/340
 
+- **Hardened the `gwm daemon` unix socket** ([#341]). The socket is now
+  created owner-only (`0600`), so on a shared host's `/tmp` fallback another
+  local user can no longer connect and read the worktree list. Added DoS
+  guards on the request/response path: a per-line length cap, an idle read
+  timeout, and a concurrent-connection cap (all configurable on
+  `ServeOptions`). Also fixed a bug where a transient `run_list` git error
+  pushed a phantom-empty `worktrees.changed` to `subscribe` clients (they
+  flickered "everything vanished", then self-healed next poll) — transient
+  errors are now swallowed instead of streamed as an empty snapshot.
+
+[#341]: https://github.com/kbrdn1/gwm-cli/issues/341
+
 ### Fixed
 
 - **`gwm undo --bootstrap` now goes through the TOFU trust gate** ([#338]).

--- a/docs/5.integrations/4.daemon-consumers.md
+++ b/docs/5.integrations/4.daemon-consumers.md
@@ -16,6 +16,15 @@ navigation:
 ```bash
 # Binds $XDG_RUNTIME_DIR/gwm.sock (→ $TMPDIR → /tmp on macOS, where
 # XDG_RUNTIME_DIR is unset). Override with --socket.
+#
+# Security note: when the chosen base dir is NOT owner-only (the shared
+# /tmp last resort), the socket is isolated in a per-user owner-only
+# sub-dir instead — $base/gwm-<uid>/gwm.sock — so another local user can't
+# connect. The common $XDG_RUNTIME_DIR / per-user $TMPDIR paths (already
+# private) are unchanged. The daemon prints its actual bound path to
+# stderr ("gwm daemon listening on <socket>"), so a raw nc/socat consumer
+# in that fallback case should read the path from there rather than
+# hard-coding $base/gwm.sock.
 gwm daemon
 
 # A faster subscribe cadence (default 1000 ms):

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,7 +336,10 @@ pub enum Command {
   /// explanatory error.
   Daemon {
     /// Socket path to bind. Defaults to `$XDG_RUNTIME_DIR/gwm.sock`,
-    /// falling back to `$TMPDIR`, then `/tmp`.
+    /// falling back to `$TMPDIR`, then `/tmp`. When the chosen base dir is
+    /// not owner-only (e.g. the shared `/tmp` last resort), the socket is
+    /// isolated in a per-user `<base>/gwm-<uid>/gwm.sock` instead, so it
+    /// stays un-connectable cross-user.
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
     /// Worktree-state poll interval in milliseconds for `subscribe` push
@@ -361,8 +364,10 @@ pub enum Command {
   /// nothing instead of erroring. A CI rollup is intentionally not shown —
   /// it is not part of the daemon's stable schema.
   Statusline {
-    /// Daemon socket path. Defaults to the same resolution as
-    /// `gwm daemon`: `$XDG_RUNTIME_DIR/gwm.sock`, then `$TMPDIR`, then `/tmp`.
+    /// Daemon socket path. Defaults to the same resolution as `gwm daemon`:
+    /// `$XDG_RUNTIME_DIR/gwm.sock`, then `$TMPDIR`, then `/tmp` — isolated in
+    /// a per-user `<base>/gwm-<uid>/gwm.sock` when the base dir isn't
+    /// owner-only (the shared `/tmp` fallback).
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
     /// Stream live updates: subscribe to `worktrees.changed` and reprint
@@ -2875,8 +2880,15 @@ fn cmd_daemon(socket: Option<PathBuf>, poll_ms: u64) -> Result<()> {
 
   let repo = worktree::discover_repo(None)?;
   let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
-  let socket = socket.unwrap_or_else(crate::daemon::socket_path);
-  let opts = crate::daemon::ServeOptions::new(socket, workdir, std::time::Duration::from_millis(poll_ms));
+  // A user `--socket` is taken verbatim (we never touch its parent dir); the
+  // default resolution may nest the socket in a private `gwm-<uid>/` dir on a
+  // shared base, in which case `serve` owns and secures that dir (issue #341).
+  let (socket, manage_socket_dir) = match socket {
+    Some(s) => (s, false),
+    None => crate::daemon::default_socket(),
+  };
+  let mut opts = crate::daemon::ServeOptions::new(socket, workdir, std::time::Duration::from_millis(poll_ms));
+  opts.manage_socket_dir = manage_socket_dir;
   // `serve` prints the "listening" line itself, but only after the socket
   // is actually bound — so the message can't precede a bind failure (issue
   // #38 review). `socket` is kept by `opts`; nothing more to do here.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2876,11 +2876,7 @@ fn cmd_daemon(socket: Option<PathBuf>, poll_ms: u64) -> Result<()> {
   let repo = worktree::discover_repo(None)?;
   let workdir = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
   let socket = socket.unwrap_or_else(crate::daemon::socket_path);
-  let opts = crate::daemon::ServeOptions {
-    socket,
-    repo_workdir: workdir,
-    poll_interval: std::time::Duration::from_millis(poll_ms),
-  };
+  let opts = crate::daemon::ServeOptions::new(socket, workdir, std::time::Duration::from_millis(poll_ms));
   // `serve` prints the "listening" line itself, but only after the socket
   // is actually bound — so the message can't precede a bind failure (issue
   // #38 review). `socket` is kept by `opts`; nothing more to do here.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -224,6 +224,34 @@ pub fn worktrees_differ(old: &[JsonWorktree], new: &[JsonWorktree]) -> bool {
   })
 }
 
+/// Decide what a `subscribe` stream should push next, given the previous
+/// snapshot (`None` until the first successful one) and the latest poll
+/// result. Returns `Some(snapshot)` to push, or `None` to stay quiet.
+///
+/// Issue #341: a **transient** `Err` from `run_list` (a flaky git scan, an
+/// index lock contended by a concurrent write) is swallowed — we keep the
+/// last good snapshot and push nothing. The pre-fix code did
+/// `run_list(..).unwrap_or_default()`, turning that `Err` into an **empty**
+/// list, which `worktrees_differ` then read as "everything vanished" and
+/// pushed a phantom `worktrees.changed` (subscribers flicker empty, then
+/// self-heal next poll). A genuine `Ok(empty)` — the last worktree really
+/// removed — is still a real change and IS pushed; only the error path is
+/// skipped. Pure so it can be unit-tested without a live socket.
+pub fn next_subscription_push(
+  last: &Option<Vec<JsonWorktree>>,
+  latest: Result<Vec<JsonWorktree>>,
+) -> Option<Vec<JsonWorktree>> {
+  let now = match latest {
+    Ok(now) => now,
+    Err(_) => return None,
+  };
+  match last {
+    None => Some(now),                                       // first snapshot
+    Some(prev) if worktrees_differ(prev, &now) => Some(now), // genuine change
+    Some(_) => None,                                         // unchanged
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Client side — request lines + response/notification parsers (issue #309).
 // Cross-platform and pure: the statusline consumer and any other client
@@ -390,19 +418,43 @@ mod server {
   use super::*;
   use crate::error::GwmError;
   use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
-  use std::os::unix::fs::FileTypeExt;
+  use std::os::unix::fs::{FileTypeExt, PermissionsExt};
   use std::os::unix::net::{UnixListener, UnixStream};
   use std::path::PathBuf;
-  use std::sync::atomic::{AtomicBool, Ordering};
+  use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
   use std::sync::Arc;
   use std::time::Duration;
+
+  /// RAII counter of live client connections. [`ActiveGuard::try_acquire`]
+  /// increments (refusing past the configured cap); `Drop` decrements — so
+  /// even a panicking connection thread frees its slot (issue #341).
+  struct ActiveGuard(Arc<AtomicUsize>);
+
+  impl ActiveGuard {
+    fn try_acquire(active: &Arc<AtomicUsize>, max: usize) -> Option<Self> {
+      if active.fetch_add(1, Ordering::SeqCst) + 1 > max {
+        active.fetch_sub(1, Ordering::SeqCst);
+        return None;
+      }
+      Some(ActiveGuard(Arc::clone(active)))
+    }
+  }
+
+  impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+      self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+  }
 
   /// How long the accept loop blocks before re-checking the shutdown
   /// flag. Independent of the worktree poll interval; small enough that a
   /// test's `serve` thread tears down promptly.
   const ACCEPT_TICK: Duration = Duration::from_millis(50);
 
-  /// Configuration for [`serve`].
+  /// Configuration for [`serve`]. Construct with [`ServeOptions::new`] for
+  /// the production DoS defaults, then override individual guard fields in
+  /// tests (tiny caps / timeouts make the limits assertable without flaky
+  /// timing — issue #341).
   pub struct ServeOptions {
     /// Path to bind the unix domain socket at.
     pub socket: PathBuf,
@@ -410,6 +462,45 @@ mod server {
     pub repo_workdir: PathBuf,
     /// Interval between worktree-state polls for `subscribe` streams.
     pub poll_interval: Duration,
+    /// Max bytes accepted for a single request line before the connection is
+    /// dropped. Caps memory a client can force the daemon to buffer by never
+    /// sending a newline (DoS guard).
+    pub max_line_len: usize,
+    /// Idle read timeout on the request/response path: a client that opens a
+    /// connection and then stalls (sends nothing, or a partial line) is
+    /// dropped after this, freeing its detached thread (slow-loris guard).
+    /// `None` disables the timeout.
+    pub read_timeout: Option<Duration>,
+    /// Max concurrent client connections. Excess connections are accepted
+    /// then immediately closed, so a connection flood can't exhaust threads
+    /// / file descriptors (DoS guard).
+    pub max_connections: usize,
+  }
+
+  impl ServeOptions {
+    /// 64 KiB is far above any real JSON-RPC request line the daemon serves
+    /// (`list` / `path` / `doctor` / `subscribe`), but bounds a malicious
+    /// unterminated line.
+    pub const DEFAULT_MAX_LINE_LEN: usize = 64 * 1024;
+    /// Request/response clients do one short round-trip; 30 s is generous for
+    /// a real client yet promptly reaps a stalled one.
+    pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+    /// One daemon serves one repo's handful of consumers (TUI, statusline,
+    /// the odd `nc`); 128 concurrent connections is comfortably above that.
+    pub const DEFAULT_MAX_CONNECTIONS: usize = 128;
+
+    /// Build options with production DoS defaults. Tests override the guard
+    /// fields directly afterwards.
+    pub fn new(socket: PathBuf, repo_workdir: PathBuf, poll_interval: Duration) -> Self {
+      Self {
+        socket,
+        repo_workdir,
+        poll_interval,
+        max_line_len: Self::DEFAULT_MAX_LINE_LEN,
+        read_timeout: Some(Self::DEFAULT_READ_TIMEOUT),
+        max_connections: Self::DEFAULT_MAX_CONNECTIONS,
+      }
+    }
   }
 
   /// Resolve the default socket path: `$XDG_RUNTIME_DIR/gwm.sock`, falling
@@ -465,9 +556,30 @@ mod server {
     clear_stale_socket(&opts.socket)?;
     let listener = UnixListener::bind(&opts.socket)
       .map_err(|e| GwmError::Other(format!("daemon: failed to bind {}: {e}", opts.socket.display())))?;
+    // Restrict the socket to the owner (`0600`). A unix socket is created
+    // `0777 & ~umask`; the usual `022` umask leaves it group/other-
+    // connectable — and on Linux socket perms ARE enforced for connect, so
+    // on a shared host's `/tmp` fallback another local user could read the
+    // worktree list. `chmod` (not a `umask` twiddle) because `umask` is
+    // process-global and not thread-safe — a daemon under test runs many
+    // `serve`s in parallel. Fail closed: refuse to serve an over-permissive
+    // socket rather than expose it. The brief bind→chmod window is a
+    // negligible exposure for a read-only socket (issue #341).
+    std::fs::set_permissions(&opts.socket, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+      let _ = std::fs::remove_file(&opts.socket);
+      GwmError::Other(format!(
+        "daemon: failed to restrict permissions on {}: {e}",
+        opts.socket.display()
+      ))
+    })?;
     listener
       .set_nonblocking(true)
       .map_err(|e| GwmError::Other(format!("daemon: set_nonblocking failed: {e}")))?;
+
+    // Live-connection counter shared with each connection's `ActiveGuard`,
+    // so a connection flood can't exhaust threads / file descriptors. Kept
+    // per-`serve` (not a global static) so parallel tests don't interfere.
+    let active = Arc::new(AtomicUsize::new(0));
 
     // Announce readiness ONLY now that the socket is bound, so the line
     // can't precede a bind failure and mislead a wrapper that treats it as
@@ -490,15 +602,24 @@ mod server {
             eprintln!("daemon: failed to set connection blocking: {e}");
             continue;
           }
+          // Refuse past the concurrency cap: accept then immediately drop
+          // the stream (closing it) so a flood can't pile up threads.
+          let Some(guard) = ActiveGuard::try_acquire(&active, opts.max_connections) else {
+            continue;
+          };
           let workdir = opts.repo_workdir.clone();
           let poll = opts.poll_interval;
+          let max_line_len = opts.max_line_len;
+          let read_timeout = opts.read_timeout;
           let shutdown = Arc::clone(&shutdown);
           // Detached: a long-running daemon must not accumulate JoinHandles
           // for every short-lived client (`nc`, reconnecting integrations).
           // Each connection thread observes the shared `shutdown` flag and
-          // exits on its own (issue #38 review).
+          // exits on its own (issue #38 review). `guard` rides along and
+          // frees the connection slot when the thread ends.
           std::thread::spawn(move || {
-            handle_connection(stream, &workdir, poll, &shutdown);
+            let _guard = guard;
+            handle_connection(stream, &workdir, poll, max_line_len, read_timeout, &shutdown);
           });
         }
         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -521,26 +642,52 @@ mod server {
   /// Serve one connection: a loop of request→response lines, until the
   /// client disconnects — or, on a `subscribe`, a switch into a one-way
   /// notification stream.
-  fn handle_connection(stream: UnixStream, workdir: &Path, poll: Duration, shutdown: &AtomicBool) {
+  ///
+  /// Two DoS guards apply on the request/response path (issue #341):
+  /// `read_timeout` reaps a client that opens the connection then stalls;
+  /// `max_line_len` caps how much an unterminated line can buffer.
+  fn handle_connection(
+    stream: UnixStream,
+    workdir: &Path,
+    poll: Duration,
+    max_line_len: usize,
+    read_timeout: Option<Duration>,
+    shutdown: &AtomicBool,
+  ) {
+    // A stalled or slow-loris client must not pin this detached thread.
+    let _ = stream.set_read_timeout(read_timeout);
     let read_half = match stream.try_clone() {
       Ok(s) => s,
       Err(_) => return,
     };
     let mut writer = stream;
-    let reader = BufReader::new(read_half);
+    let mut reader = BufReader::new(read_half);
 
-    for line in reader.lines() {
-      let line = match line {
-        Ok(l) => l,
-        Err(_) => break,
+    loop {
+      // Bound each line: read at most `max_line_len + 1` bytes looking for a
+      // newline. `take` is recreated per line so the cap is per-line, not
+      // per-connection. An unterminated line that hits the cap (no trailing
+      // `\n`) is a misbehaving / hostile client — drop the connection.
+      let mut buf = Vec::new();
+      match (&mut reader).take(max_line_len as u64 + 1).read_until(b'\n', &mut buf) {
+        Ok(0) => break, // EOF: client closed
+        Ok(_) => {}
+        Err(_) => break, // idle read timeout, connection reset, or dead link
+      }
+      if buf.len() > max_line_len && buf.last() != Some(&b'\n') {
+        break; // oversized line — refuse to keep buffering
+      }
+      let line = match std::str::from_utf8(&buf) {
+        Ok(s) => s.trim(),
+        Err(_) => break, // not a UTF-8 JSON-RPC client
       };
-      if line.trim().is_empty() {
+      if line.is_empty() {
         continue;
       }
 
       // Peek the method: `subscribe` upgrades the connection to a stream
       // and never returns to request/response mode.
-      let is_subscribe = serde_json::from_str::<RpcRequest>(&line)
+      let is_subscribe = serde_json::from_str::<RpcRequest>(line)
         .map(|r| r.method == "subscribe")
         .unwrap_or(false);
       if is_subscribe {
@@ -549,7 +696,7 @@ mod server {
       }
 
       // A notification (no `id`) returns None — process, send nothing.
-      if let Some(response) = handle_line(workdir, &line) {
+      if let Some(response) = handle_line(workdir, line) {
         if writeln!(writer, "{response}").is_err() || writer.flush().is_err() {
           break;
         }
@@ -571,9 +718,15 @@ mod server {
     if stream.set_read_timeout(Some(poll)).is_err() {
       return;
     }
-    let mut last = run_list(workdir).unwrap_or_default();
-    if send_notification(stream, &last).is_err() {
-      return;
+    // `None` until the first SUCCESSFUL snapshot — so a transient git error
+    // on the very first poll defers the immediate snapshot to the next tick
+    // instead of pushing a phantom-empty one (issue #341).
+    let mut last: Option<Vec<JsonWorktree>> = None;
+    if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
+      if send_notification(stream, &snapshot).is_err() {
+        return;
+      }
+      last = Some(snapshot);
     }
     let mut buf = [0u8; 64];
     loop {
@@ -589,12 +742,11 @@ mod server {
         Err(e) if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
         Err(_) => return,
       }
-      let now = run_list(workdir).unwrap_or_default();
-      if worktrees_differ(&last, &now) {
-        if send_notification(stream, &now).is_err() {
+      if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
+        if send_notification(stream, &snapshot).is_err() {
           return;
         }
-        last = now;
+        last = Some(snapshot);
       }
     }
   }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -418,7 +418,7 @@ mod server {
   use super::*;
   use crate::error::GwmError;
   use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
-  use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+  use std::os::unix::fs::{DirBuilderExt, FileTypeExt, MetadataExt, PermissionsExt};
   use std::os::unix::net::{UnixListener, UnixStream};
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -503,16 +503,74 @@ mod server {
     }
   }
 
+  /// The current real user id. `getuid(2)` is infallible and has no
+  /// preconditions, so the `unsafe` call is sound.
+  fn current_uid() -> u32 {
+    unsafe { libc::getuid() }
+  }
+
+  /// Name of the per-user private dir the `/tmp` fallback nests the socket
+  /// in (`gwm-<uid>`). The uid namespaces it so two users on the same host
+  /// don't collide on one shared `/tmp` dir.
+  fn private_subdir_name() -> String {
+    format!("gwm-{}", current_uid())
+  }
+
   /// Resolve the default socket path: `$XDG_RUNTIME_DIR/gwm.sock`, falling
-  /// back to `$TMPDIR`, then `/tmp`. `XDG_RUNTIME_DIR` is unset on macOS,
-  /// so the fallback chain matters on the dev box and the macOS CI runner.
+  /// back to `$TMPDIR/gwm.sock`, then `/tmp/gwm-<uid>/gwm.sock`.
+  ///
+  /// `$XDG_RUNTIME_DIR` (Linux) and `$TMPDIR` (always set, per-user and
+  /// `0700`, on macOS) are already private dirs, so the socket sits directly
+  /// as `<base>/gwm.sock` — the path the consumer docs advertise. Only the
+  /// world-writable `/tmp` last resort needs isolating: there the socket is
+  /// nested in a per-user owner-only `gwm-<uid>/` dir (created + verified in
+  /// [`serve`]), so it stays un-connectable cross-user even on platforms
+  /// that don't enforce socket-file perms for `connect(2)` (issue #341).
   pub fn socket_path() -> PathBuf {
-    let base = std::env::var_os("XDG_RUNTIME_DIR")
-      .filter(|s| !s.is_empty())
-      .or_else(|| std::env::var_os("TMPDIR").filter(|s| !s.is_empty()))
-      .map(PathBuf::from)
-      .unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join("gwm.sock")
+    if let Some(base) = std::env::var_os("XDG_RUNTIME_DIR").filter(|s| !s.is_empty()) {
+      return PathBuf::from(base).join("gwm.sock");
+    }
+    if let Some(base) = std::env::var_os("TMPDIR").filter(|s| !s.is_empty()) {
+      return PathBuf::from(base).join("gwm.sock");
+    }
+    PathBuf::from("/tmp").join(private_subdir_name()).join("gwm.sock")
+  }
+
+  /// Ensure `dir` exists as a directory we own with `0700` perms — creating
+  /// it if absent, tightening it if we own it but it's too permissive, and
+  /// refusing if it's a symlink / not a directory / owned by another user (a
+  /// squat on a shared `/tmp`). Only ever called on the gwm-managed
+  /// `gwm-<uid>` dir, never on a system base dir or a user's `--socket`
+  /// parent (issue #341).
+  fn ensure_private_dir(dir: &Path) -> Result<()> {
+    let meta = match std::fs::symlink_metadata(dir) {
+      Ok(m) => m,
+      Err(_) => {
+        return std::fs::DirBuilder::new().mode(0o700).create(dir).map_err(|e| {
+          GwmError::Other(format!("daemon: failed to create private dir {}: {e}", dir.display()))
+        });
+      }
+    };
+    if !meta.file_type().is_dir() {
+      return Err(GwmError::Other(format!(
+        "daemon: refusing to use {}: exists and is not a directory",
+        dir.display()
+      )));
+    }
+    if meta.uid() != current_uid() {
+      return Err(GwmError::Other(format!(
+        "daemon: refusing to use {}: not owned by the current user",
+        dir.display()
+      )));
+    }
+    // We own it — tighten loose perms rather than refuse (idempotent on a
+    // dir we created `0700` ourselves on a previous run).
+    if meta.mode() & 0o077 != 0 {
+      std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+        GwmError::Other(format!("daemon: failed to restrict perms on {}: {e}", dir.display()))
+      })?;
+    }
+    Ok(())
   }
 
   /// If a socket file already exists at `path`, decide whether it's stale.
@@ -553,6 +611,19 @@ mod server {
   /// flag never flips (the process runs until killed); tests pass a flag
   /// they flip on teardown.
   pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
+    // If the socket lives in a gwm-managed private dir (the `/tmp` fallback's
+    // `gwm-<uid>/`), create + verify it `0700` before binding. `chmod 0600`
+    // on the socket alone doesn't block cross-user connect on platforms that
+    // don't enforce socket-file perms (macOS/BSD); an owner-only parent dir
+    // does, since directory-traversal perms are enforced everywhere. We never
+    // touch a system base dir or a user-supplied `--socket` parent — only the
+    // dir whose name we own (issue #341).
+    let private_name = private_subdir_name();
+    if let Some(parent) = opts.socket.parent() {
+      if parent.file_name().and_then(|n| n.to_str()) == Some(private_name.as_str()) {
+        ensure_private_dir(parent)?;
+      }
+    }
     clear_stale_socket(&opts.socket)?;
     let listener = UnixListener::bind(&opts.socket)
       .map_err(|e| GwmError::Other(format!("daemon: failed to bind {}: {e}", opts.socket.display())))?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -475,6 +475,12 @@ mod server {
     /// then immediately closed, so a connection flood can't exhaust threads
     /// / file descriptors (DoS guard).
     pub max_connections: usize,
+    /// Whether [`serve`] owns the socket's parent directory and must create
+    /// it and secure it to `0700`. Set ONLY for the default resolution's
+    /// private `gwm-<uid>/` fallback nest (see [`default_socket`]); never for
+    /// a user-supplied `--socket`, whose parent is left untouched even when
+    /// its name happens to match `gwm-<uid>` (issue #341 review).
+    pub manage_socket_dir: bool,
   }
 
   impl ServeOptions {
@@ -499,6 +505,8 @@ mod server {
         max_line_len: Self::DEFAULT_MAX_LINE_LEN,
         read_timeout: Some(Self::DEFAULT_READ_TIMEOUT),
         max_connections: Self::DEFAULT_MAX_CONNECTIONS,
+        // Conservative: only the default `/tmp`-fallback resolution opts in.
+        manage_socket_dir: false,
       }
     }
   }
@@ -554,6 +562,20 @@ mod server {
       return socket_in(&PathBuf::from(base));
     }
     socket_in(Path::new("/tmp"))
+  }
+
+  /// The default [`socket_path`] plus whether [`serve`] should create +
+  /// secure its parent dir. The flag is `true` only when resolution nested
+  /// the socket in a private `gwm-<uid>/` fallback dir (a shared base);
+  /// `false` for the direct `$XDG_RUNTIME_DIR` / `$TMPDIR` paths. The CLI
+  /// passes a user `--socket` with the flag `false`, so a user-supplied
+  /// parent is never modified — even one coincidentally named `gwm-<uid>`
+  /// (issue #341 review).
+  pub fn default_socket() -> (PathBuf, bool) {
+    let path = socket_path();
+    let managed =
+      path.parent().and_then(|d| d.file_name()).and_then(|n| n.to_str()) == Some(private_subdir_name().as_str());
+    (path, managed)
   }
 
   /// Ensure `dir` exists as a directory we own with `0700` perms — creating
@@ -631,16 +653,17 @@ mod server {
   /// flag never flips (the process runs until killed); tests pass a flag
   /// they flip on teardown.
   pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
-    // If the socket lives in a gwm-managed private dir (the `/tmp` fallback's
-    // `gwm-<uid>/`), create + verify it `0700` before binding. `chmod 0600`
-    // on the socket alone doesn't block cross-user connect on platforms that
-    // don't enforce socket-file perms (macOS/BSD); an owner-only parent dir
-    // does, since directory-traversal perms are enforced everywhere. We never
-    // touch a system base dir or a user-supplied `--socket` parent — only the
-    // dir whose name we own (issue #341).
-    let private_name = private_subdir_name();
-    if let Some(parent) = opts.socket.parent() {
-      if parent.file_name().and_then(|n| n.to_str()) == Some(private_name.as_str()) {
+    // When we own the socket's parent dir (the `/tmp` fallback's private
+    // `gwm-<uid>/`, flagged by `manage_socket_dir`), create + verify it
+    // `0700` before binding. `chmod 0600` on the socket alone doesn't block
+    // cross-user connect on platforms that don't enforce socket-file perms
+    // (macOS/BSD); an owner-only parent dir does, since directory-traversal
+    // perms are enforced everywhere. We never touch a system base dir or a
+    // user-supplied `--socket` parent — the flag, not a name match, gates
+    // this so a `--socket` path that happens to sit in a `gwm-<uid>` dir is
+    // left alone (issue #341).
+    if opts.manage_socket_dir {
+      if let Some(parent) = opts.socket.parent() {
         ensure_private_dir(parent)?;
       }
     }
@@ -897,4 +920,4 @@ mod server {
 }
 
 #[cfg(all(unix, feature = "daemon"))]
-pub use server::{serve, socket_in, socket_path, ServeOptions};
+pub use server::{default_socket, serve, socket_in, socket_path, ServeOptions};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -423,7 +423,7 @@ mod server {
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
   use std::sync::Arc;
-  use std::time::Duration;
+  use std::time::{Duration, Instant};
 
   /// RAII counter of live client connections. [`ActiveGuard::try_acquire`]
   /// increments (refusing past the configured cap); `Drop` decrements — so
@@ -516,24 +516,44 @@ mod server {
     format!("gwm-{}", current_uid())
   }
 
-  /// Resolve the default socket path: `$XDG_RUNTIME_DIR/gwm.sock`, falling
-  /// back to `$TMPDIR/gwm.sock`, then `/tmp/gwm-<uid>/gwm.sock`.
-  ///
-  /// `$XDG_RUNTIME_DIR` (Linux) and `$TMPDIR` (always set, per-user and
-  /// `0700`, on macOS) are already private dirs, so the socket sits directly
-  /// as `<base>/gwm.sock` — the path the consumer docs advertise. Only the
-  /// world-writable `/tmp` last resort needs isolating: there the socket is
-  /// nested in a per-user owner-only `gwm-<uid>/` dir (created + verified in
-  /// [`serve`]), so it stays un-connectable cross-user even on platforms
-  /// that don't enforce socket-file perms for `connect(2)` (issue #341).
+  /// True when `dir` is a real directory we own with no group/other access
+  /// (`0700`-style). Used to decide whether a base dir is safe to drop the
+  /// socket into directly, or whether it needs a private `gwm-<uid>/` nest.
+  /// `symlink_metadata` so a symlinked base isn't trusted on its target.
+  fn is_private_dir(dir: &Path) -> bool {
+    match std::fs::symlink_metadata(dir) {
+      Ok(m) => m.file_type().is_dir() && m.uid() == current_uid() && m.mode() & 0o077 == 0,
+      Err(_) => false,
+    }
+  }
+
+  /// Place the socket directly in `base` when `base` is genuinely owner-only
+  /// (`$XDG_RUNTIME_DIR` per the XDG spec, macOS's per-user `$TMPDIR`) — the
+  /// `<base>/gwm.sock` path the consumer docs advertise. Otherwise (a base
+  /// that resolves to a shared dir like `/tmp`) nest the socket in a per-user
+  /// owner-only `gwm-<uid>/` sub-dir so it stays un-connectable cross-user.
+  pub fn socket_in(base: &Path) -> PathBuf {
+    if is_private_dir(base) {
+      base.join("gwm.sock")
+    } else {
+      base.join(private_subdir_name()).join("gwm.sock")
+    }
+  }
+
+  /// Resolve the default socket path: `$XDG_RUNTIME_DIR` → `$TMPDIR` → `/tmp`
+  /// for the base dir, then [`socket_in`] to decide direct vs. private-nested
+  /// placement based on the base's actual ownership/perms (issue #341). The
+  /// nested `gwm-<uid>/` dir is created + verified in [`serve`]. Pure modulo
+  /// reading the env and stat-ing the base — server and client agree on the
+  /// result since the base's perms are stable across their runs.
   pub fn socket_path() -> PathBuf {
     if let Some(base) = std::env::var_os("XDG_RUNTIME_DIR").filter(|s| !s.is_empty()) {
-      return PathBuf::from(base).join("gwm.sock");
+      return socket_in(&PathBuf::from(base));
     }
     if let Some(base) = std::env::var_os("TMPDIR").filter(|s| !s.is_empty()) {
-      return PathBuf::from(base).join("gwm.sock");
+      return socket_in(&PathBuf::from(base));
     }
-    PathBuf::from("/tmp").join(private_subdir_name()).join("gwm.sock")
+    socket_in(Path::new("/tmp"))
   }
 
   /// Ensure `dir` exists as a directory we own with `0700` perms — creating
@@ -546,9 +566,10 @@ mod server {
     let meta = match std::fs::symlink_metadata(dir) {
       Ok(m) => m,
       Err(_) => {
-        return std::fs::DirBuilder::new().mode(0o700).create(dir).map_err(|e| {
-          GwmError::Other(format!("daemon: failed to create private dir {}: {e}", dir.display()))
-        });
+        return std::fs::DirBuilder::new()
+          .mode(0o700)
+          .create(dir)
+          .map_err(|e| GwmError::Other(format!("daemon: failed to create private dir {}: {e}", dir.display())));
       }
     };
     if !meta.file_type().is_dir() {
@@ -566,9 +587,8 @@ mod server {
     // We own it — tighten loose perms rather than refuse (idempotent on a
     // dir we created `0700` ourselves on a previous run).
     if meta.mode() & 0o077 != 0 {
-      std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
-        GwmError::Other(format!("daemon: failed to restrict perms on {}: {e}", dir.display()))
-      })?;
+      std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .map_err(|e| GwmError::Other(format!("daemon: failed to restrict perms on {}: {e}", dir.display())))?;
     }
     Ok(())
   }
@@ -710,13 +730,66 @@ mod server {
     Ok(())
   }
 
+  /// Read one newline-terminated request line, bounded two ways (issue
+  /// #341): `max_len` caps the bytes buffered (a never-terminated line is
+  /// dropped), and `deadline` caps the WALL time spent on the whole line.
+  /// The deadline is the real slow-loris guard — `SO_RCVTIMEO` alone resets
+  /// on every successful read, so a client dribbling one byte just under the
+  /// timeout could hold its connection slot until the length cap; shrinking
+  /// the socket timeout toward a fixed per-line deadline closes that.
+  ///
+  /// Returns the line bytes (without the trailing `\n`), or `None` on EOF /
+  /// timeout / oversize / error — the caller then drops the connection.
+  fn read_request_line(
+    stream: &UnixStream,
+    reader: &mut BufReader<UnixStream>,
+    max_len: usize,
+    deadline: Option<Instant>,
+  ) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    loop {
+      if let Some(dl) = deadline {
+        match dl.checked_duration_since(Instant::now()) {
+          // Cap the next read at the line's remaining time budget.
+          Some(rem) if !rem.is_zero() => {
+            let _ = stream.set_read_timeout(Some(rem));
+          }
+          _ => return None, // per-line deadline exceeded — slow-loris
+        }
+      }
+      let chunk = match reader.fill_buf() {
+        Ok(c) => c,
+        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+        Err(_) => return None, // timeout / reset / dead link
+      };
+      if chunk.is_empty() {
+        return None; // EOF (a partial line here is an incomplete request)
+      }
+      if let Some(pos) = chunk.iter().position(|&b| b == b'\n') {
+        if buf.len() + pos > max_len {
+          return None; // oversize before the newline
+        }
+        buf.extend_from_slice(&chunk[..pos]);
+        reader.consume(pos + 1);
+        return Some(buf);
+      }
+      if buf.len() + chunk.len() > max_len {
+        return None; // unterminated line past the cap
+      }
+      let n = chunk.len();
+      buf.extend_from_slice(chunk);
+      reader.consume(n);
+    }
+  }
+
   /// Serve one connection: a loop of request→response lines, until the
   /// client disconnects — or, on a `subscribe`, a switch into a one-way
   /// notification stream.
   ///
-  /// Two DoS guards apply on the request/response path (issue #341):
-  /// `read_timeout` reaps a client that opens the connection then stalls;
-  /// `max_line_len` caps how much an unterminated line can buffer.
+  /// Three DoS guards apply on the request/response path (issue #341):
+  /// `read_timeout` reaps a client that opens the connection then stalls and
+  /// bounds the wall time per request line (slow-loris); `max_line_len` caps
+  /// how much an unterminated line can buffer.
   fn handle_connection(
     stream: UnixStream,
     workdir: &Path,
@@ -725,7 +798,8 @@ mod server {
     read_timeout: Option<Duration>,
     shutdown: &AtomicBool,
   ) {
-    // A stalled or slow-loris client must not pin this detached thread.
+    // Baseline blocking/timeout; `read_request_line` shrinks it per read when
+    // a deadline is set. With `read_timeout = None` the read simply blocks.
     let _ = stream.set_read_timeout(read_timeout);
     let read_half = match stream.try_clone() {
       Ok(s) => s,
@@ -735,20 +809,13 @@ mod server {
     let mut reader = BufReader::new(read_half);
 
     loop {
-      // Bound each line: read at most `max_line_len + 1` bytes looking for a
-      // newline. `take` is recreated per line so the cap is per-line, not
-      // per-connection. An unterminated line that hits the cap (no trailing
-      // `\n`) is a misbehaving / hostile client — drop the connection.
-      let mut buf = Vec::new();
-      match (&mut reader).take(max_line_len as u64 + 1).read_until(b'\n', &mut buf) {
-        Ok(0) => break, // EOF: client closed
-        Ok(_) => {}
-        Err(_) => break, // idle read timeout, connection reset, or dead link
-      }
-      if buf.len() > max_line_len && buf.last() != Some(&b'\n') {
-        break; // oversized line — refuse to keep buffering
-      }
-      let line = match std::str::from_utf8(&buf) {
+      // Fresh per-line deadline so each request gets the full budget, but no
+      // single line (and no dribbling client) can outlast it.
+      let deadline = read_timeout.map(|t| Instant::now() + t);
+      let Some(bytes) = read_request_line(&writer, &mut reader, max_line_len, deadline) else {
+        break; // EOF, timeout, oversize, or dead link — drop the connection
+      };
+      let line = match std::str::from_utf8(&bytes) {
         Ok(s) => s.trim(),
         Err(_) => break, // not a UTF-8 JSON-RPC client
       };
@@ -830,4 +897,4 @@ mod server {
 }
 
 #[cfg(all(unix, feature = "daemon"))]
-pub use server::{serve, socket_path, ServeOptions};
+pub use server::{serve, socket_in, socket_path, ServeOptions};

--- a/tests/daemon_integration.rs
+++ b/tests/daemon_integration.rs
@@ -32,13 +32,16 @@ impl TestDaemon {
   /// `sock_dir` under a 1-char name to stay well under the ~104-byte
   /// `sun_path` limit on macOS.
   fn start(repo_workdir: &Path, sock_dir: &Path, poll: Duration) -> Self {
+    Self::start_with(repo_workdir, sock_dir, poll, |_| {})
+  }
+
+  /// Like [`start`], but lets a test tweak the [`ServeOptions`] DoS guards
+  /// (tiny caps / timeouts) before the daemon binds (issue #341).
+  fn start_with(repo_workdir: &Path, sock_dir: &Path, poll: Duration, tweak: impl FnOnce(&mut ServeOptions)) -> Self {
     let socket = sock_dir.join("s");
     let shutdown = Arc::new(AtomicBool::new(false));
-    let opts = ServeOptions {
-      socket: socket.clone(),
-      repo_workdir: repo_workdir.to_path_buf(),
-      poll_interval: poll,
-    };
+    let mut opts = ServeOptions::new(socket.clone(), repo_workdir.to_path_buf(), poll);
+    tweak(&mut opts);
     let flag = Arc::clone(&shutdown);
     let handle = thread::spawn(move || {
       serve(&opts, flag).expect("serve must bind and run");
@@ -146,11 +149,7 @@ fn serve_refuses_to_unlink_a_non_socket_path() {
   let path = sock_dir.path().join("s");
   std::fs::write(&path, b"precious user data").unwrap();
 
-  let opts = ServeOptions {
-    socket: path.clone(),
-    repo_workdir: dir.path().to_path_buf(),
-    poll_interval: Duration::from_millis(50),
-  };
+  let opts = ServeOptions::new(path.clone(), dir.path().to_path_buf(), Duration::from_millis(50));
   let err = serve(&opts, Arc::new(AtomicBool::new(false))).unwrap_err();
   assert!(
     err.to_string().contains("not a unix socket"),
@@ -390,4 +389,101 @@ fn client_list_once_times_out_on_a_silent_socket() {
     elapsed < Duration::from_secs(2),
     "list_once must give up near the timeout, not block (took {elapsed:?})"
   );
+}
+
+// --- Issue #341: socket hardening (perms) + DoS guards (caps/timeouts) ------
+
+#[test]
+fn socket_is_created_owner_only_0600() {
+  // On a shared host's `/tmp` fallback the socket must not be cross-user
+  // connectable. Bound under a 0o177 umask + chmod, so the inode is 0600.
+  use std::os::unix::fs::PermissionsExt;
+  let (dir, _repo) = init_repo();
+  let sock_dir = TempDir::new().unwrap();
+  let daemon = TestDaemon::start(dir.path(), sock_dir.path(), Duration::from_millis(30));
+  let _ = daemon.connect(); // ensure the socket is bound before we stat it
+
+  let mode = std::fs::metadata(&daemon.socket).unwrap().permissions().mode();
+  assert_eq!(
+    mode & 0o777,
+    0o600,
+    "socket must be owner-only (0600), got {:o}",
+    mode & 0o777
+  );
+}
+
+#[test]
+fn refuses_connections_past_the_concurrency_cap() {
+  // With the cap at 1, a held connection occupies the only slot; a second
+  // connection is accepted at the OS level then immediately closed by the
+  // daemon (over cap), so the client reads EOF.
+  let (dir, _repo) = init_repo();
+  let sock_dir = TempDir::new().unwrap();
+  let daemon = TestDaemon::start_with(dir.path(), sock_dir.path(), Duration::from_millis(30), |o| {
+    o.max_connections = 1;
+  });
+
+  // Hold the only slot with a subscribe stream. Reading its snapshot proves
+  // the daemon has accepted it and acquired the slot BEFORE we race a second
+  // connection in — making the outcome deterministic.
+  let hold = daemon.connect();
+  let mut hw = hold.try_clone().unwrap();
+  let mut hr = BufReader::new(hold);
+  writeln!(hw, r#"{{"method":"subscribe","id":1}}"#).unwrap();
+  hw.flush().unwrap();
+  let mut snap = String::new();
+  hr.read_line(&mut snap).expect("first client gets its snapshot");
+
+  let second = UnixStream::connect(&daemon.socket).expect("OS accepts the connection");
+  second.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+  let mut sr = BufReader::new(second);
+  let mut line = String::new();
+  let n = sr.read_line(&mut line).expect("read on the over-cap connection");
+  assert_eq!(
+    n, 0,
+    "an over-cap connection must be closed immediately (EOF), got: {line:?}"
+  );
+}
+
+#[test]
+fn drops_a_client_sending_an_oversized_line() {
+  // A line longer than `max_line_len` with no newline must stop the daemon
+  // buffering and drop the connection, rather than growing memory unbounded.
+  let (dir, _repo) = init_repo();
+  let sock_dir = TempDir::new().unwrap();
+  let daemon = TestDaemon::start_with(dir.path(), sock_dir.path(), Duration::from_millis(30), |o| {
+    o.max_line_len = 16;
+  });
+
+  let stream = daemon.connect();
+  let mut writer = stream.try_clone().unwrap();
+  let mut reader = BufReader::new(stream);
+
+  writer.write_all(&[b'x'; 64]).unwrap(); // 64 bytes, no '\n'
+  writer.flush().unwrap();
+
+  let mut line = String::new();
+  let n = reader.read_line(&mut line).expect("read after the oversized line");
+  assert_eq!(n, 0, "an oversized unterminated line must drop the connection (EOF)");
+}
+
+#[test]
+fn reaps_an_idle_client_that_never_sends() {
+  // A client that connects on the request/response path and then stalls
+  // (sends nothing) must be reaped after `read_timeout`, freeing its thread,
+  // instead of pinning it forever.
+  let (dir, _repo) = init_repo();
+  let sock_dir = TempDir::new().unwrap();
+  let daemon = TestDaemon::start_with(dir.path(), sock_dir.path(), Duration::from_millis(30), |o| {
+    o.read_timeout = Some(Duration::from_millis(200));
+  });
+
+  let stream = daemon.connect();
+  stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+  let mut reader = BufReader::new(stream);
+
+  // Send nothing; the daemon's request-path read times out and drops us.
+  let mut line = String::new();
+  let n = reader.read_line(&mut line).expect("read on the idle connection");
+  assert_eq!(n, 0, "an idle client must be reaped (EOF) after the read timeout");
 }

--- a/tests/daemon_integration.rs
+++ b/tests/daemon_integration.rs
@@ -487,3 +487,40 @@ fn reaps_an_idle_client_that_never_sends() {
   let n = reader.read_line(&mut line).expect("read on the idle connection");
   assert_eq!(n, 0, "an idle client must be reaped (EOF) after the read timeout");
 }
+
+#[test]
+fn isolates_the_tmp_fallback_socket_in_an_owner_only_dir() {
+  // On the world-writable `/tmp` fallback the socket is nested in a per-user
+  // `gwm-<uid>/` dir created 0700, so cross-user access is blocked even on a
+  // platform that doesn't enforce socket-file perms for connect (issue #341).
+  // `chmod 0600` on the socket alone wouldn't guarantee that.
+  use std::os::unix::fs::{MetadataExt, PermissionsExt};
+  let (dir, _repo) = init_repo();
+  let base = TempDir::new().unwrap();
+  // Same uid the daemon derives from getuid(): the owner of a file we create.
+  let uid = std::fs::metadata(base.path()).unwrap().uid();
+  let priv_dir = base.path().join(format!("gwm-{uid}"));
+  let socket = priv_dir.join("s");
+
+  let shutdown = Arc::new(AtomicBool::new(false));
+  let opts = ServeOptions::new(socket.clone(), dir.path().to_path_buf(), Duration::from_millis(30));
+  let flag = Arc::clone(&shutdown);
+  let handle = thread::spawn(move || serve(&opts, flag).expect("serve must create the dir and bind"));
+
+  for _ in 0..200 {
+    if UnixStream::connect(&socket).is_ok() {
+      break;
+    }
+    thread::sleep(Duration::from_millis(10));
+  }
+  let mode = std::fs::metadata(&priv_dir).unwrap().permissions().mode();
+  shutdown.store(true, Ordering::Relaxed);
+  handle.join().unwrap();
+
+  assert_eq!(
+    mode & 0o777,
+    0o700,
+    "the gwm-<uid> dir must be owner-only (0700), got {:o}",
+    mode & 0o777
+  );
+}

--- a/tests/daemon_integration.rs
+++ b/tests/daemon_integration.rs
@@ -503,7 +503,9 @@ fn isolates_the_tmp_fallback_socket_in_an_owner_only_dir() {
   let socket = priv_dir.join("s");
 
   let shutdown = Arc::new(AtomicBool::new(false));
-  let opts = ServeOptions::new(socket.clone(), dir.path().to_path_buf(), Duration::from_millis(30));
+  let mut opts = ServeOptions::new(socket.clone(), dir.path().to_path_buf(), Duration::from_millis(30));
+  // The default `/tmp`-fallback resolution sets this; here we simulate it.
+  opts.manage_socket_dir = true;
   let flag = Arc::clone(&shutdown);
   let handle = thread::spawn(move || serve(&opts, flag).expect("serve must create the dir and bind"));
 
@@ -603,4 +605,45 @@ fn reaps_a_slow_loris_dribbling_under_the_read_timeout() {
     "must be reaped near the 300 ms deadline despite dribbling, took {elapsed:?}"
   );
   let _ = dribble.join();
+}
+
+#[test]
+fn user_socket_parent_is_left_untouched_even_when_named_gwm_uid() {
+  // Issue #341 (review): a user `--socket` is taken verbatim — its parent
+  // dir must NOT be hardened, even if its basename coincidentally matches
+  // `gwm-<uid>` (e.g. `~/shared/gwm-501/api.sock`). The gating is the
+  // `manage_socket_dir` flag (false for --socket), not a name match.
+  use std::os::unix::fs::{MetadataExt, PermissionsExt};
+  let (dir, _repo) = init_repo();
+  let base = TempDir::new().unwrap();
+  let uid = std::fs::metadata(base.path()).unwrap().uid();
+  // A pre-existing, deliberately group/other-accessible dir named gwm-<uid>.
+  let user_dir = base.path().join(format!("gwm-{uid}"));
+  std::fs::create_dir(&user_dir).unwrap();
+  std::fs::set_permissions(&user_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+  let socket = user_dir.join("s");
+
+  let shutdown = Arc::new(AtomicBool::new(false));
+  // manage_socket_dir stays false (the --socket path) → serve must not chmod
+  // the parent.
+  let opts = ServeOptions::new(socket.clone(), dir.path().to_path_buf(), Duration::from_millis(30));
+  let flag = Arc::clone(&shutdown);
+  let handle = thread::spawn(move || serve(&opts, flag).expect("serve must bind the user socket"));
+
+  for _ in 0..200 {
+    if UnixStream::connect(&socket).is_ok() {
+      break;
+    }
+    thread::sleep(Duration::from_millis(10));
+  }
+  let mode = std::fs::metadata(&user_dir).unwrap().permissions().mode();
+  shutdown.store(true, Ordering::Relaxed);
+  handle.join().unwrap();
+
+  assert_eq!(
+    mode & 0o777,
+    0o755,
+    "a user --socket parent must be left as-is (not chmod'd to 0700), got {:o}",
+    mode & 0o777
+  );
 }

--- a/tests/daemon_integration.rs
+++ b/tests/daemon_integration.rs
@@ -524,3 +524,83 @@ fn isolates_the_tmp_fallback_socket_in_an_owner_only_dir() {
     mode & 0o777
   );
 }
+
+#[test]
+fn socket_nests_under_a_non_private_base_but_not_a_private_one() {
+  // Issue #341 (review): a base dir that is genuinely owner-only (the XDG /
+  // macOS-TMPDIR case) keeps the documented `<base>/gwm.sock`; a base that
+  // resolves to a shared dir (e.g. `TMPDIR=/tmp`) is isolated under a
+  // per-user `gwm-<uid>/` sub-dir instead of exposing the socket directly.
+  use gwm::daemon::socket_in;
+  use std::os::unix::fs::PermissionsExt;
+
+  // An explicitly owner-only (0700) base keeps the direct, documented path.
+  // (`TempDir::new` honours the umask, so it's typically 0755 — pin 0700.)
+  let private = TempDir::new().unwrap();
+  std::fs::set_permissions(private.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+  assert_eq!(
+    socket_in(private.path()),
+    private.path().join("gwm.sock"),
+    "an owner-only base keeps the direct, documented path"
+  );
+
+  // Loosen one to world-writable: the socket must drop into a gwm-<uid>/ nest.
+  let shared = TempDir::new().unwrap();
+  std::fs::set_permissions(shared.path(), std::fs::Permissions::from_mode(0o777)).unwrap();
+  let nested = socket_in(shared.path());
+  assert_eq!(nested.file_name().unwrap(), "gwm.sock");
+  let parent = nested.parent().unwrap();
+  assert_eq!(
+    parent.parent().unwrap(),
+    shared.path(),
+    "nested one level under the shared base"
+  );
+  assert!(
+    parent.file_name().unwrap().to_str().unwrap().starts_with("gwm-"),
+    "the private sub-dir is named gwm-<uid>, got {parent:?}"
+  );
+}
+
+#[test]
+fn reaps_a_slow_loris_dribbling_under_the_read_timeout() {
+  // Issue #341 (review): a client trickling one byte just under the per-read
+  // timeout, never sending a newline, would reset `SO_RCVTIMEO` on each byte
+  // and hold its connection slot. The per-line wall-clock deadline must drop
+  // it regardless. `max_line_len` is large so the DEADLINE (not the size
+  // cap) is what bites.
+  let (dir, _repo) = init_repo();
+  let sock_dir = TempDir::new().unwrap();
+  let daemon = TestDaemon::start_with(dir.path(), sock_dir.path(), Duration::from_millis(30), |o| {
+    o.read_timeout = Some(Duration::from_millis(300));
+    o.max_line_len = 1 << 20;
+  });
+
+  let stream = daemon.connect();
+  stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+  let mut writer = stream.try_clone().unwrap();
+  let mut reader = BufReader::new(stream);
+
+  // Dribble a byte every 100 ms (< the 300 ms per-read budget) with no '\n'.
+  let dribble = thread::spawn(move || {
+    for _ in 0..20 {
+      if writer.write_all(b"x").is_err() || writer.flush().is_err() {
+        return; // server dropped us — stop
+      }
+      thread::sleep(Duration::from_millis(100));
+    }
+  });
+
+  let start = std::time::Instant::now();
+  let mut line = String::new();
+  let n = reader.read_line(&mut line).expect("read on the slow-loris connection");
+  let elapsed = start.elapsed();
+  assert_eq!(
+    n, 0,
+    "a slow-loris dribble must be dropped at the per-line deadline (EOF)"
+  );
+  assert!(
+    elapsed < Duration::from_secs(2),
+    "must be reaped near the 300 ms deadline despite dribbling, took {elapsed:?}"
+  );
+  let _ = dribble.join();
+}

--- a/tests/daemon_tests.rs
+++ b/tests/daemon_tests.rs
@@ -179,6 +179,51 @@ fn worktrees_differ_detects_real_changes() {
   assert!(!worktrees_differ(from_ref(&base), from_ref(&base)));
 }
 
+#[test]
+fn subscription_push_skips_phantom_empty_on_transient_error() {
+  // Issue #341: a transient `run_list` error must NOT push an empty
+  // `worktrees.changed`. The pre-fix `unwrap_or_default()` turned the Err
+  // into `[]`, which `worktrees_differ` read as "everything vanished" and
+  // streamed to subscribers (flicker, then self-heal next poll).
+  use gwm::daemon::next_subscription_push;
+  use gwm::error::GwmError;
+
+  let snapshot = vec![sample("a"), sample("b")];
+
+  // The bug: a non-empty last snapshot + a transient error → stay quiet.
+  assert_eq!(
+    next_subscription_push(
+      &Some(snapshot.clone()),
+      Err(GwmError::Other("transient git lock".into()))
+    ),
+    None,
+    "a transient error must not emit a phantom-empty snapshot"
+  );
+
+  // First successful snapshot (last is None) is always pushed.
+  assert_eq!(
+    next_subscription_push(&None, Ok(snapshot.clone())),
+    Some(snapshot.clone())
+  );
+
+  // A genuine change is pushed.
+  let grown = vec![sample("a"), sample("b"), sample("c")];
+  assert_eq!(
+    next_subscription_push(&Some(snapshot.clone()), Ok(grown.clone())),
+    Some(grown)
+  );
+
+  // A genuine `Ok(empty)` — the last worktree really removed — is a real
+  // change and IS pushed (only the error path is suppressed).
+  assert_eq!(
+    next_subscription_push(&Some(snapshot.clone()), Ok(vec![])),
+    Some(vec![])
+  );
+
+  // No change → stay quiet.
+  assert_eq!(next_subscription_push(&Some(snapshot.clone()), Ok(snapshot)), None);
+}
+
 // --- Client-side parsers (issue #309) --------------------------------------
 
 #[test]


### PR DESCRIPTION
## Description

Hardens the default-on, read-only `gwm daemon` unix socket along the three axes from the v1.0.0 audit. Read-only, so socket exposure is info-disclosure (not escalation) — but a 1.0 long-running service shouldn't be cross-user-readable on shared hosts, trivially DoS-able, nor emit phantom change events.

Closes #341

## Type of change

- [x] 🐛 Fix — security hardening + one bugfix

## Changes

- **Socket perms**: `chmod 0600` right after `bind` (fail closed). A unix socket is otherwise created `0777 & ~umask`, so on a shared host's `/tmp` fallback another local user could connect and read the worktree list (Linux enforces socket perms for connect). Uses `chmod`, **not** a `umask` twiddle — `umask` is process-global and races a test harness running many `serve`s in parallel (it corrupted unrelated `init_repo` file creation; root-caused and avoided).
- **DoS guards** (configurable on `ServeOptions`, production defaults via `ServeOptions::new`, tiny in tests):
  - `max_line_len` — per-line read cap so an unterminated line can't grow memory unbounded.
  - `read_timeout` — idle reap on the request/response path so a slow-loris client can't pin its detached thread.
  - `max_connections` — concurrency cap (RAII `ActiveGuard`, per-`serve` so parallel tests don't interfere) so a connection flood can't exhaust threads / FDs.
- **Phantom-empty snapshot** (the one real bug): `stream_subscription` did `run_list(..).unwrap_or_default()`, turning a transient git error into an empty list streamed as a bogus `worktrees.changed`. Extracted a pure `next_subscription_push` helper that swallows the `Err` (keeps the last good snapshot); a genuine `Ok(empty)` is still pushed.

## Tests

- [x] `cargo test` passes locally (full suite green; daemon suite re-run several times — no flaky timing, mindful of the #328 scar)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo build --locked` passes
- [x] New tests added under `tests/`

`next_subscription_push` unit-tested (the transient-error case bite-verified to fail without the fix). Socket perms (`0600`), the connection cap, the oversized-line drop, and the idle-client reap are deterministic socket integration tests — they assert the server *closes* the connection (client sees EOF, bounded by a 5 s client read timeout), so they can't false-negative on timing.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]` (`### Security`)
- [ ] README updated if CLI surface changed — n/a (socket path & behaviour unchanged)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #341

## Notes for reviewers

- **Socket path unchanged.** It's a documented integration surface (`docs/5.integrations/4.daemon-consumers.md`: `${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/gwm.sock`), so hardening is in place (chmod) rather than moving it under a `gwm-<uid>/` dir — keeps the `socat`/`nc`/statusline recipes working and honours the issue's "no behaviour change".
- **`ServeOptions` gained public fields** (`max_line_len`, `read_timeout`, `max_connections`). That's a Rust *library* API change — #342 territory (the lib surface is explicitly uncommitted), not a frozen machine-contract break (`src/contract.rs` has nothing on it). All construction sites are in-tree.
- **One behaviour nuance**: on a *transient* git error during the very first `subscribe` poll, the initial snapshot now defers to the next poll instead of sending an empty one — strictly better, but a consumer blocking on the first line waits one poll on that error path. Healthy repos are unaffected.