### PR TITLE
⚡ perf(tui): move synchronous git subprocesses off the TUI render path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#341]: https://github.com/kbrdn1/gwm-cli/issues/341
 
+### Performance
+
+- **Moved the last synchronous git subprocesses off the TUI render path**
+  ([#343]). The details sidebar rebuilt its git-backed sections
+  (`git_diff_stat_vs_base`, `git status --porcelain -z`, `git log`,
+  `git stash list`) synchronously inside `terminal.draw()` on every
+  selection / mode change, stalling `j` / `k` on a large repo or a slow
+  filesystem; workspace-mode auto-refresh re-listed every repo
+  synchronously too. Both now ride the `TaskRunner` (#231): the render
+  path only reads the last-known payload — showing a muted `loading…`
+  placeholder while a rebuild is in flight (the identity card still
+  renders instantly) — and a coalesced worker rebuilds it off-thread,
+  keyed to the current selection. A held `j` coalesces onto the single
+  in-flight worker instead of spawning a thread per row, and the poll
+  cadence tightens to 50 ms while a task is loading so the preview lands
+  fast.
+
+[#343]: https://github.com/kbrdn1/gwm-cli/issues/343
+
 ### Fixed
 
 - **`gwm undo --bootstrap` now goes through the TOFU trust gate** ([#338]).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -939,6 +939,11 @@ impl App {
     // `apply_refreshed_worktrees` so the async drain, which shares that
     // tail, does not re-invalidate the run it just applied.
     self.tasks.invalidate(TaskKind::RefreshWorktrees);
+    // Drop any in-flight sidebar rebuild too (issue #343): it was reading
+    // *pre-mutation* git state, so its late result must not land after this
+    // authoritative re-list. `apply_refreshed_worktrees` also nulls the cache,
+    // so `maybe_refresh_sidebar` re-fetches the post-mutation preview next tick.
+    self.tasks.invalidate(TaskKind::Sidebar);
     if self.is_workspace() {
       // Workspace mode re-lists every repo, not just the active one (#36).
       self.refresh_workspace();
@@ -1072,6 +1077,62 @@ impl App {
         .and_then(|repo| worktree::list(&repo))
         .map_err(|e| e.to_string());
       let _ = tx.send(TaskMsg::RefreshWorktrees(generation, result));
+    });
+  }
+
+  /// Keep the details sidebar's git-backed preview off the render path (issue
+  /// #343). Called once per event-loop tick (after `sync_active_repo`, so the
+  /// active repo's `doctor.trunks` are correct in workspace mode). When the
+  /// cached payload was NOT built for the current selection + mode — a cold
+  /// cache, a navigation (`on_navigation` nulled it), a mode toggle, or a
+  /// post-mutation `invalidate` — this spawns one worker to rebuild it, keyed
+  /// to the *currently selected* worktree.
+  ///
+  /// Pure navigation deliberately does NOT [`TaskRunner::invalidate`] the
+  /// `Sidebar` slot, so a held `j` coalesces onto the single in-flight worker
+  /// instead of spawning a thread per row: the render shows the placeholder
+  /// while scrolling and the settled selection is fetched once the burst ends.
+  /// That coalescing IS the debounce — no timer needed. A worker whose
+  /// selection has since moved stores a payload the render key-check ignores;
+  /// the next tick requests the settled one.
+  pub fn maybe_refresh_sidebar(&mut self) {
+    let Some(w) = self.selected().cloned() else {
+      return;
+    };
+    let mode = self.sidebar.mode;
+    // Already authoritative for this selection + mode → nothing to rebuild.
+    if matches!(&self.sidebar.cache, Some(((p, m), _)) if *p == w.path && *m == mode) {
+      return;
+    }
+    let Some(generation) = self.tasks.request(TaskKind::Sidebar) else {
+      // A rebuild is already in flight — coalesce onto it (the debounce).
+      return;
+    };
+    let trunks = self.config.doctor.trunks.clone();
+    let theme = self.theme;
+    self.spawn_sidebar(generation, w, mode, trunks, theme);
+  }
+
+  /// Spawn one background sidebar-rebuild worker tagged with `generation`
+  /// (issue #343). Mirrors [`Self::spawn_refresh`]: only owned `Send` data
+  /// crosses the boundary (the [`WorktreeInfo`], mode, the active repo's
+  /// `trunks`, and the `Copy` [`Theme`]), and the worker runs
+  /// [`crate::tui::ui::build_sidebar_payload`], which fires every sidebar git
+  /// subprocess off-thread. A `send` failure (the `App`/receiver dropped) is
+  /// ignored.
+  fn spawn_sidebar(
+    &self,
+    generation: u64,
+    w: WorktreeInfo,
+    mode: crate::tui::state::sidebar::SidebarMode,
+    trunks: Vec<String>,
+    theme: crate::tui::theme::Theme,
+  ) {
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let path = w.path.clone();
+      let sections = crate::tui::ui::build_sidebar_payload(&w, mode, &trunks, &theme);
+      let _ = tx.send(TaskMsg::Sidebar(generation, path, mode, sections));
     });
   }
 
@@ -1348,6 +1409,21 @@ impl App {
           }
           applied = true;
           refresh_applied = true;
+        }
+        TaskMsg::Sidebar(generation, path, mode, sections) => {
+          // Late result — the selection moved and `refresh` bumped the slot's
+          // generation (a mutation invalidated a pre-mutation rebuild), so this
+          // payload is stale. Drop it; the next tick requests the current one.
+          if !self.tasks.complete(TaskKind::Sidebar, generation) {
+            continue;
+          }
+          // Store keyed by the worktree + mode it was built for. If the
+          // selection has since moved this key won't match the current one, so
+          // the render shows the placeholder and `maybe_refresh_sidebar` fetches
+          // the settled selection next tick — no stale worktree's git preview
+          // is ever shown under the live header.
+          self.sidebar.cache = Some(((path, mode), sections));
+          applied = true;
         }
       }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -823,26 +823,58 @@ impl App {
   /// once" contract), so this re-lists the stored metas rather than re-walking
   /// the root.
   fn refresh_workspace(&mut self) {
-    let Some(ws) = self.workspace.as_ref() else {
-      return;
-    };
-    let targets: Vec<(usize, PathBuf)> = ws
-      .repos
-      .iter()
-      .enumerate()
-      .map(|(i, m)| (i, m.workdir.clone()))
-      .collect();
-    let mut worktrees = Vec::new();
-    let mut row_repo = Vec::new();
-    for (idx, workdir) in &targets {
+    let targets = self.workspace_refresh_targets();
+    let rows = Self::list_workspace(&targets);
+    self.apply_workspace_worktrees(rows);
+  }
+
+  /// The `(repo_index, workdir)` targets a workspace re-list walks — every
+  /// repo's stored `workdir` (repos are fixed for the session). Owned `Send`
+  /// data, so the async worker ([`Self::spawn_refresh_workspace`], issue #343)
+  /// can move it across the thread boundary; the synchronous path uses it too.
+  fn workspace_refresh_targets(&self) -> Vec<(usize, PathBuf)> {
+    self
+      .workspace
+      .as_ref()
+      .map(|ws| {
+        ws.repos
+          .iter()
+          .enumerate()
+          .map(|(i, m)| (i, m.workdir.clone()))
+          .collect()
+      })
+      .unwrap_or_default()
+  }
+
+  /// Open + list every workspace target into merged `(worktree, repo_index)`
+  /// rows (issue #343 / #36). A static fn taking owned targets so it runs
+  /// unchanged on the async worker thread or the synchronous path. Per-repo
+  /// open / list errors are swallowed — a broken repo drops its rows, the rest
+  /// still list — matching the pre-#343 synchronous behaviour.
+  fn list_workspace(targets: &[(usize, PathBuf)]) -> Vec<(WorktreeInfo, usize)> {
+    let mut rows = Vec::new();
+    for (idx, workdir) in targets {
       if let Ok(repo) = Repository::open(workdir) {
         if let Ok(trees) = worktree::list(&repo) {
           for t in trees {
-            worktrees.push(t);
-            row_repo.push(*idx);
+            rows.push((t, *idx));
           }
         }
       }
+    }
+    rows
+  }
+
+  /// Apply merged workspace rows: rebuild the row→repo map, swap in the merged
+  /// worktree list, and re-align the active repo (issue #343 / #36). Shared by
+  /// the synchronous [`Self::refresh_workspace`] and the async
+  /// `RefreshWorkspace` drain so the two can never drift.
+  fn apply_workspace_worktrees(&mut self, rows: Vec<(WorktreeInfo, usize)>) {
+    let mut worktrees = Vec::with_capacity(rows.len());
+    let mut row_repo = Vec::with_capacity(rows.len());
+    for (t, idx) in rows {
+      worktrees.push(t);
+      row_repo.push(idx);
     }
     if let Some(ws) = self.workspace.as_mut() {
       ws.row_repo = row_repo;
@@ -944,6 +976,10 @@ impl App {
     // authoritative re-list. `apply_refreshed_worktrees` also nulls the cache,
     // so `maybe_refresh_sidebar` re-fetches the post-mutation preview next tick.
     self.tasks.invalidate(TaskKind::Sidebar);
+    // Same for an in-flight async workspace re-list (issue #343): this
+    // synchronous path produces authoritative post-mutation state, so drop the
+    // stale run's generation.
+    self.tasks.invalidate(TaskKind::RefreshWorkspace);
     if self.is_workspace() {
       // Workspace mode re-lists every repo, not just the active one (#36).
       self.refresh_workspace();
@@ -1018,9 +1054,16 @@ impl App {
   /// result is applied by [`Self::drain_task_results`].
   pub fn request_refresh(&mut self) {
     if self.is_workspace() {
-      // No single-repo async worker in workspace mode — it would clobber the
-      // merged list with one repo's worktrees (#36). Refresh synchronously.
-      let _ = self.refresh();
+      // Workspace mode re-lists every repo off-thread on its own slot (issue
+      // #343): the single-repo worker can't be reused (it would clobber the
+      // merged list with one repo's worktrees, #36), so route through
+      // `RefreshWorkspace` instead of the pre-#343 synchronous `refresh()`.
+      let Some(generation) = self.tasks.request(TaskKind::RefreshWorkspace) else {
+        return;
+      };
+      self.spinner.reset();
+      self.status = TaskKind::RefreshWorkspace.loading_label().into();
+      self.spawn_refresh_workspace(generation);
       return;
     }
     let Some(generation) = self.tasks.request(TaskKind::RefreshWorktrees) else {
@@ -1047,8 +1090,16 @@ impl App {
     }
     self.last_auto_refresh_at = now;
     if self.is_workspace() {
-      // Synchronous merged refresh in workspace mode (#36) — see `refresh`.
-      let _ = self.refresh();
+      // Off-thread merged refresh in workspace mode (issue #343 / #36): the
+      // per-repo `Repository::open` + `worktree::list` loop no longer freezes
+      // the event loop on a many-repo workspace. Coalesces onto an in-flight
+      // run so a slow relist never stacks.
+      let Some(generation) = self.tasks.request(TaskKind::RefreshWorkspace) else {
+        return false;
+      };
+      self.spinner.reset();
+      self.status = "auto-refreshing worktrees…".into();
+      self.spawn_refresh_workspace(generation);
       return true;
     }
     let Some(generation) = self.tasks.request(TaskKind::RefreshWorktrees) else {
@@ -1077,6 +1128,20 @@ impl App {
         .and_then(|repo| worktree::list(&repo))
         .map_err(|e| e.to_string());
       let _ = tx.send(TaskMsg::RefreshWorktrees(generation, result));
+    });
+  }
+
+  /// Spawn one background workspace re-list worker tagged with `generation`
+  /// (issue #343 / #36). Mirrors [`Self::spawn_refresh`] for workspace mode:
+  /// the owned `(repo_index, workdir)` targets are the only data crossing the
+  /// boundary, and [`Self::list_workspace`] opens each repo + lists off-thread.
+  /// The drain applies the merged rows via [`Self::apply_workspace_worktrees`].
+  fn spawn_refresh_workspace(&self, generation: u64) {
+    let tx = self.task_tx.clone();
+    let targets = self.workspace_refresh_targets();
+    std::thread::spawn(move || {
+      let rows = Self::list_workspace(&targets);
+      let _ = tx.send(TaskMsg::RefreshWorkspace(generation, rows));
     });
   }
 
@@ -1237,6 +1302,15 @@ impl App {
             Ok(worktrees) => self.apply_refreshed_worktrees(worktrees),
             Err(e) => self.status = format!("refresh failed: {}", e),
           }
+          applied = true;
+          refresh_applied = true;
+        }
+        TaskMsg::RefreshWorkspace(generation, rows) => {
+          if !self.tasks.complete(TaskKind::RefreshWorkspace, generation) {
+            // Late result — a newer run (or a synchronous `refresh`) superseded it.
+            continue;
+          }
+          self.apply_workspace_worktrees(rows);
           applied = true;
           refresh_applied = true;
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -971,14 +971,10 @@ impl App {
     // `apply_refreshed_worktrees` so the async drain, which shares that
     // tail, does not re-invalidate the run it just applied.
     self.tasks.invalidate(TaskKind::RefreshWorktrees);
-    // Drop any in-flight sidebar rebuild too (issue #343): it was reading
-    // *pre-mutation* git state, so its late result must not land after this
-    // authoritative re-list. `apply_refreshed_worktrees` also nulls the cache,
-    // so `maybe_refresh_sidebar` re-fetches the post-mutation preview next tick.
-    self.tasks.invalidate(TaskKind::Sidebar);
     // Same for an in-flight async workspace re-list (issue #343): this
     // synchronous path produces authoritative post-mutation state, so drop the
-    // stale run's generation.
+    // stale run's generation. (The in-flight *sidebar* rebuild is dropped by
+    // `apply_refreshed_worktrees`, the tail every refresh path shares.)
     self.tasks.invalidate(TaskKind::RefreshWorkspace);
     if self.is_workspace() {
       // Workspace mode re-lists every repo, not just the active one (#36).
@@ -1036,6 +1032,13 @@ impl App {
     self.clamp_selection_to_filter();
     let spawned = self.refresh_linked_github_statuses_for_worktrees();
     self.invalidate_sidebar_cache();
+    // The re-list re-read git state, so any in-flight sidebar rebuild is now
+    // reading *pre-refresh* data — bump its generation so a late result is
+    // dropped by the drain instead of stored under the current key and rendered
+    // as fresh until the next navigation (issue #343). Lives here, in the tail
+    // every refresh path shares, so the OFF-thread drains (`RefreshWorktrees` /
+    // `RefreshWorkspace`) get it too, not just the synchronous `refresh`.
+    self.tasks.invalidate(TaskKind::Sidebar);
     self.status = if spawned > 0 {
       format!(
         "refreshed — {} worktree(s); fetching GitHub status…",
@@ -1161,6 +1164,13 @@ impl App {
   /// selection has since moved stores a payload the render key-check ignores;
   /// the next tick requests the settled one.
   pub fn maybe_refresh_sidebar(&mut self) {
+    // A hidden sidebar is not drawn (`draw_body` skips `draw_sidebar`), so
+    // rebuilding its preview would run git work for an invisible panel —
+    // restoring the pre-#343 behaviour where hiding the sidebar (`v`) did no
+    // preview work at all. Opening it (`v`) re-arms the fetch on the next tick.
+    if !self.sidebar.open {
+      return;
+    }
     let Some(w) = self.selected().cloned() else {
       return;
     };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -311,12 +311,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     // Issue #35: tighten the poll cadence while the PTY is open so typed
     // characters and arrow keys feel responsive (< 50 ms round-trip vs.
     // the normal 200 ms status-refresh interval).
-    // Issue #343: also tighten it while any background task is in flight (the
-    // async sidebar rebuild, the worktree/workspace refresh, a GitHub fetch) so
-    // the result lands within ~50 ms instead of up to a full 200 ms poll — that
-    // is what keeps the sidebar's "loading…" placeholder from lingering after a
-    // fast `j` / `k` on a large repo. Idle (nothing loading) stays at 200 ms.
-    let poll_ms = if app.view == View::Pty || app.is_task_loading() || app.is_github_loading() {
+    // Issue #343: also tighten it while a sidebar rebuild is in flight so the
+    // "loading…" placeholder swaps to the real preview within ~50 ms instead of
+    // up to a full 200 ms poll after a fast `j` / `k` on a large repo. Scoped
+    // to the `Sidebar` slot on purpose — a multi-second `sync` / `push` / list
+    // refresh doesn't need the loop spinning at 20 fps for its whole duration.
+    let poll_ms = if app.view == View::Pty || app.tasks.is_loading(TaskKind::Sidebar) {
       50
     } else {
       200

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -66,15 +66,15 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 }
 pub use ui::{
   author_initials, badge_group_width, bootstrap_report_lines, branch_name_color, branch_status_color,
-  build_sidebar_sections, centered_abs, chip_style, ci_indicator, clean_dir_icon, command_logs_footer_hints,
-  config_capture_footer_hints, config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line,
-  confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title, ellipsize_middle,
-  field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color, github_status_lines,
-  header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
-  hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
-  link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line, overlay_modal_width,
-  palette_name_style, pane_counter, panel_border_color, picker_window, pr_badge_color, pr_summary_line,
-  recent_commits_lines, recent_items_pane_title, reclaim_size_color, rename_buttons_line, status_line,
+  build_sidebar_payload, build_sidebar_sections, centered_abs, chip_style, ci_indicator, clean_dir_icon,
+  command_logs_footer_hints, config_capture_footer_hints, config_edit_footer_hints, config_nav_footer_hints,
+  confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_worktree_title,
+  ellipsize_middle, field_input_line, filled_cells_for_progress, footer_line, format_status, freshness_color,
+  github_status_lines, header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows,
+  help_section_style, hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line,
+  link_open_modal_lines, link_prompt_modal_width, link_target_keys, link_target_line, modal_hint_line,
+  overlay_modal_width, palette_name_style, pane_counter, panel_border_color, picker_window, pr_badge_color,
+  pr_summary_line, recent_commits_lines, recent_items_pane_title, reclaim_size_color, rename_buttons_line, status_line,
   status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_counts_footer,
   working_tree_pane_title, working_tree_status_counts, working_tree_status_line, worktree_name_style,
   worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, WorkingTreeCounts,
@@ -261,6 +261,12 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     // (and its config) can't swap under the captured exec/clean target.
     if !app.destructive_overlay_open() {
       app.sync_active_repo();
+      // Issue #343: keep the details sidebar's git preview off the render path.
+      // Runs after `sync_active_repo` so the active repo's `doctor.trunks` are
+      // correct when a workspace-mode rebuild spawns. A no-op when the cache is
+      // already current for the selection; otherwise it spawns one coalesced
+      // worker (the render draws the placeholder until it lands).
+      app.maybe_refresh_sidebar();
     }
 
     terminal.draw(|f| ui::draw(f, &mut app))?;
@@ -305,7 +311,16 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
     // Issue #35: tighten the poll cadence while the PTY is open so typed
     // characters and arrow keys feel responsive (< 50 ms round-trip vs.
     // the normal 200 ms status-refresh interval).
-    let poll_ms = if app.view == View::Pty { 50 } else { 200 };
+    // Issue #343: also tighten it while any background task is in flight (the
+    // async sidebar rebuild, the worktree/workspace refresh, a GitHub fetch) so
+    // the result lands within ~50 ms instead of up to a full 200 ms poll — that
+    // is what keeps the sidebar's "loading…" placeholder from lingering after a
+    // fast `j` / `k` on a large repo. Idle (nothing loading) stays at 200 ms.
+    let poll_ms = if app.view == View::Pty || app.is_task_loading() || app.is_github_loading() {
+      50
+    } else {
+      200
+    };
     if !event::poll(Duration::from_millis(poll_ms))? {
       continue;
     }

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -37,6 +37,8 @@
 use crate::bootstrap::BootstrapReport;
 use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
+use crate::tui::state::sidebar::SidebarMode;
+use crate::tui::ui::SidebarSections;
 use crate::worktree::WorktreeInfo;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -95,6 +97,16 @@ pub enum TaskKind {
   /// worktree directory on disk (`git worktree move`) so the slug stays in
   /// sync. One global slot — a second `c` submit coalesces.
   EditWorktree,
+  /// Off-thread rebuild of the details sidebar's git-backed sections (issue
+  /// #343): `git_diff_stat_vs_base` + `git status --porcelain -z` + `git log` /
+  /// `git stash list` used to run synchronously inside `terminal.draw()` on
+  /// every selection / mode change, stalling `j` / `k` on a large repo. A
+  /// single global slot keyed to *the currently selected* worktree — pure
+  /// navigation never [`TaskRunner::invalidate`]s it, so a held `j` coalesces
+  /// onto the in-flight worker (one at a time) instead of spawning a thread
+  /// per row; the render key-check discards a result for a since-moved
+  /// selection and the next tick requests the settled one.
+  Sidebar,
 }
 
 impl TaskKind {
@@ -112,6 +124,7 @@ impl TaskKind {
       TaskKind::Pull => "pulling…",
       TaskKind::Push => "pushing…",
       TaskKind::EditWorktree => "renaming worktree…",
+      TaskKind::Sidebar => "loading preview…",
     }
   }
 
@@ -202,6 +215,12 @@ pub enum TaskMsg {
   /// rename outcome (new branch/path/name on success, or a stringified error
   /// from `git branch -m` / `git push` / `git worktree move`).
   EditWorktree(u64, std::result::Result<EditWorktreeResult, String>),
+  /// A rebuilt sidebar payload (issue #343): the worker's generation, the
+  /// worktree `path` and [`SidebarMode`] it was built for (the render key), and
+  /// the pre-rendered [`SidebarSections`]. The drain stores it into
+  /// `SidebarState::cache`; a result whose selection has since moved is dropped
+  /// by [`TaskRunner::complete`] (generation) and ignored by the render (key).
+  Sidebar(u64, PathBuf, SidebarMode, SidebarSections),
 }
 
 /// Coalescing + late-drop spine for background tasks (issue #231).

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -97,6 +97,16 @@ pub enum TaskKind {
   /// worktree directory on disk (`git worktree move`) so the slug stays in
   /// sync. One global slot — a second `c` submit coalesces.
   EditWorktree,
+  /// Off-thread re-list of *every* repo in workspace mode (issue #343 /
+  /// #36): `maybe_auto_refresh` and the `f` / `r` key path used to call
+  /// `refresh_workspace` synchronously (a `Repository::open` + `worktree::list`
+  /// per repo) on the event-loop thread, freezing the UI for the duration on a
+  /// many-repo workspace. The single-repo refresh ([`Self::RefreshWorktrees`])
+  /// can't be reused — it would clobber the merged table with one repo's
+  /// worktrees — so this is its workspace-shaped sibling. One global slot; a
+  /// second refresh coalesces. The synchronous `App::refresh` (post-mutation
+  /// callers) stays synchronous and invalidates this slot.
+  RefreshWorkspace,
   /// Off-thread rebuild of the details sidebar's git-backed sections (issue
   /// #343): `git_diff_stat_vs_base` + `git status --porcelain -z` + `git log` /
   /// `git stash list` used to run synchronously inside `terminal.draw()` on
@@ -124,6 +134,7 @@ impl TaskKind {
       TaskKind::Pull => "pulling…",
       TaskKind::Push => "pushing…",
       TaskKind::EditWorktree => "renaming worktree…",
+      TaskKind::RefreshWorkspace => "refreshing worktrees…",
       TaskKind::Sidebar => "loading preview…",
     }
   }
@@ -215,6 +226,12 @@ pub enum TaskMsg {
   /// rename outcome (new branch/path/name on success, or a stringified error
   /// from `git branch -m` / `git push` / `git worktree move`).
   EditWorktree(u64, std::result::Result<EditWorktreeResult, String>),
+  /// A workspace re-list result (issue #343 / #36): the worker's generation and
+  /// the merged `(worktree, repo_index)` rows across every repo. Per-repo open
+  /// / list errors are swallowed exactly as the synchronous path did (a broken
+  /// repo drops its rows, the rest still list), so there is no error arm to
+  /// carry. The drain rebuilds the merged table + row→repo map.
+  RefreshWorkspace(u64, Vec<(WorktreeInfo, usize)>),
   /// A rebuilt sidebar payload (issue #343): the worker's generation, the
   /// worktree `path` and [`SidebarMode`] it was built for (the render key), and
   /// the pre-rendered [`SidebarSections`]. The drain stores it into

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -655,17 +655,6 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   // `w`, so it shows instantly on navigation; only the diff figure and the
   // status / commits blocks wait on the worker. The live `● <name>` header and
   // the Issue / PR block are still built per-frame below (no subprocess).
-  let placeholder = SidebarSections {
-    worktree: worktree_identity_lines(&w, None, &theme),
-    working_tree: match active_mode {
-      super::state::sidebar::SidebarMode::Commits => {
-        vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))]
-      }
-      super::state::sidebar::SidebarMode::Stashes => Vec::new(),
-    },
-    working_tree_counts: WorkingTreeCounts::default(),
-    recent_commits: vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))],
-  };
   // Whether the cached payload is authoritative for the current selection.
   // The sections to render are resolved from this at each read site (lengths
   // below, render pass further down) as a direct match so the immutable cache
@@ -675,6 +664,28 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     &app.sidebar.cache,
     Some(((p, m), _)) if *p == w.path && *m == active_mode
   );
+
+  // The loading placeholder, built ONLY when the cache is stale — on the warm
+  // path it stays an empty `default()` (no per-frame identity-line allocation
+  // in what is, after all, a render-perf change). The identity card renders
+  // straight from `w` (no subprocess), so it shows instantly on navigation;
+  // the status / commits blocks read "loading…" until the worker's payload
+  // lands.
+  let placeholder = if cache_is_current {
+    SidebarSections::default()
+  } else {
+    SidebarSections {
+      worktree: worktree_identity_lines(&w, None, &theme),
+      working_tree: match active_mode {
+        super::state::sidebar::SidebarMode::Commits => {
+          vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))]
+        }
+        super::state::sidebar::SidebarMode::Stashes => Vec::new(),
+      },
+      working_tree_counts: WorkingTreeCounts::default(),
+      recent_commits: vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))],
+    }
+  };
 
   // The live header line and the per-frame Issue / PR block are built BEFORE
   // the long cache borrow so they don't overlap it. The header is the only

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -644,25 +644,37 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     return;
   };
 
-  // Populate (or refresh) the cache for the current selection. After this
-  // short mutable borrow ends, `app.sidebar.cache` is guaranteed `Some`.
-  let needs_refresh = match &app.sidebar.cache {
-    Some(((p, m), _)) => *p != w.path || *m != active_mode,
-    None => true,
+  // Issue #343: the render path NEVER shells out. The git-backed sections
+  // (`git_diff_stat_vs_base` + `git status` + `git log` / `git stash list`)
+  // are rebuilt off-thread by the async sidebar worker (`App::
+  // maybe_refresh_sidebar` → `TaskKind::Sidebar`), which stores the payload in
+  // `app.sidebar.cache` keyed by `(path, mode)`. Here we only READ it, and
+  // only when it was built for the *current* selection + mode — a stale-key or
+  // cold cache renders a muted "loading…" placeholder while the worker catches
+  // up. The identity card (branch / head / path / badges) comes straight from
+  // `w`, so it shows instantly on navigation; only the diff figure and the
+  // status / commits blocks wait on the worker. The live `● <name>` header and
+  // the Issue / PR block are still built per-frame below (no subprocess).
+  let placeholder = SidebarSections {
+    worktree: worktree_identity_lines(&w, None, &theme),
+    working_tree: match active_mode {
+      super::state::sidebar::SidebarMode::Commits => {
+        vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))]
+      }
+      super::state::sidebar::SidebarMode::Stashes => Vec::new(),
+    },
+    working_tree_counts: WorkingTreeCounts::default(),
+    recent_commits: vec![Line::from(Span::styled("loading…", Style::default().fg(theme.muted)))],
   };
-  if needs_refresh {
-    // Committed diff of the branch vs its base trunk (issue #287). Resolved
-    // through `config.doctor.trunks` so the figure matches the base
-    // `gwm pr` would target; folded into the cached payload so the git
-    // call only fires on a selection / mode change, not every frame.
-    let diff = worktree::git_diff_stat_vs_base(&w.path, &app.config.doctor.trunks)
-      .ok()
-      .flatten();
-    app.sidebar.cache = Some((
-      (w.path.clone(), active_mode),
-      build_sidebar_sections(&w, active_mode, diff, &theme),
-    ));
-  }
+  // Whether the cached payload is authoritative for the current selection.
+  // The sections to render are resolved from this at each read site (lengths
+  // below, render pass further down) as a direct match so the immutable cache
+  // borrow stays scoped and never overlaps the `app.sidebar.max_scroll` /
+  // `scroll` writes in between — the pre-#343 borrow discipline, unchanged.
+  let cache_is_current = matches!(
+    &app.sidebar.cache,
+    Some(((p, m), _)) if *p == w.path && *m == active_mode
+  );
 
   // The live header line and the per-frame Issue / PR block are built BEFORE
   // the long cache borrow so they don't overlap it. The header is the only
@@ -672,17 +684,20 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   let header_line = sidebar_header_line(&w, app);
   let issue_pr_lines = github_status_lines(app, issue_pr_inner_width);
 
-  // Read the cached section lengths via a short immutable borrow so the
+  // Read the resolved section lengths via a short immutable borrow so the
   // layout solver and scroll clamp can run before the render borrow. The
   // worktree section gains +1 row for the live header prefix.
   let (worktree_len, working_tree_len, working_tree_counts, commits_len) = {
-    let cache = app.sidebar.cache.as_ref();
-    let s = cache.map(|(_, s)| s);
+    let s = if cache_is_current {
+      app.sidebar.cache.as_ref().map(|(_, s)| s).unwrap_or(&placeholder)
+    } else {
+      &placeholder
+    };
     (
-      s.map(|s| s.worktree.len()).unwrap_or(0) + 1,
-      s.map(|s| s.working_tree.len()).unwrap_or(0),
-      s.map(|s| s.working_tree_counts).unwrap_or_default(),
-      s.map(|s| s.recent_commits.len()).unwrap_or(0) as u16,
+      s.worktree.len() + 1,
+      s.working_tree.len(),
+      s.working_tree_counts,
+      s.recent_commits.len() as u16,
     )
   };
 
@@ -757,55 +772,59 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
     working_tree_counts_footer(&working_tree_counts, &theme)
   };
 
-  // The render borrow: cached sections are read by reference and never
-  // cloned (issue #238). On a cache hit this copies zero commit text — the
-  // up-to-300 `git log` lines stay put in `app.sidebar.cache`; `render_section`
-  // only rebuilds the thin padded `Vec<Span>` per visible row, borrowing the
-  // span content. `app` is only read immutably from here on (all mutation
-  // already happened above), so this long borrow is conflict-free. The
-  // `if let` is guaranteed to bind (the cache was populated above for the
-  // selected worktree) — matching rather than `unwrap()` keeps the render
-  // path panic-free per the house rules.
-  if let Some((_, cache)) = app.sidebar.cache.as_ref() {
+  // The render borrow: sections are read by reference and never cloned (issue
+  // #238). On a cache hit this copies zero commit text — the up-to-300 `git
+  // log` lines stay put in `app.sidebar.cache`; `render_section` only rebuilds
+  // the thin padded `Vec<Span>` per visible row, borrowing the span content.
+  // `app` is only read immutably from here on (all mutation already happened
+  // above), so this long borrow is conflict-free. Resolved from the same
+  // `cache_is_current` decision as the length block: the cached payload when it
+  // is authoritative for the current selection, else the loading placeholder
+  // (issue #343) — never `unwrap()`, keeping the render path panic-free per the
+  // house rules.
+  let sections = if cache_is_current {
+    app.sidebar.cache.as_ref().map(|(_, s)| s).unwrap_or(&placeholder)
+  } else {
+    &placeholder
+  };
+  render_section(
+    f,
+    chunks[0],
+    status_pane_title(),
+    SectionBody::with_prefix(&header_line, &sections.worktree),
+    border_color,
+    0,
+    None,
+  );
+  render_section(
+    f,
+    chunks[1],
+    issue_pr_title,
+    SectionBody::new(&issue_pr_lines),
+    border_color,
+    0,
+    None,
+  );
+  if !sections.working_tree.is_empty() {
     render_section(
       f,
-      chunks[0],
-      status_pane_title(),
-      SectionBody::with_prefix(&header_line, &cache.worktree),
+      chunks[2],
+      working_tree_title,
+      SectionBody::new(&sections.working_tree),
       border_color,
       0,
-      None,
-    );
-    render_section(
-      f,
-      chunks[1],
-      issue_pr_title,
-      SectionBody::new(&issue_pr_lines),
-      border_color,
-      0,
-      None,
-    );
-    if !cache.working_tree.is_empty() {
-      render_section(
-        f,
-        chunks[2],
-        working_tree_title,
-        SectionBody::new(&cache.working_tree),
-        border_color,
-        0,
-        working_tree_footer,
-      );
-    }
-    render_section(
-      f,
-      commits_area,
-      panel_title,
-      SectionBody::new(&cache.recent_commits),
-      border_color,
-      scroll,
-      panel_footer.map(ratatui::text::Line::from),
+      working_tree_footer,
     );
   }
+  render_section(
+    f,
+    commits_area,
+    panel_title,
+    SectionBody::new(&sections.recent_commits),
+    border_color,
+    scroll,
+    panel_footer.map(ratatui::text::Line::from),
+  );
 }
 
 /// Borrowed content for one [`render_section`] block (issue #238).
@@ -956,6 +975,24 @@ pub fn build_sidebar_sections(
     working_tree_counts,
     recent_commits: body,
   }
+}
+
+/// Build the full sidebar payload for one worktree — the diff-vs-base stat
+/// plus [`build_sidebar_sections`] — as a single owned, `Send` value (issue
+/// #343). This is the unit of work the async sidebar worker runs off-thread:
+/// every git subprocess the sidebar needs (`git_diff_stat_vs_base`,
+/// `git status --porcelain -z`, `git log`, `git stash list`) fires here, on a
+/// worker, so `terminal.draw` never shells out. The result is stored into
+/// `SidebarState::cache` by `App::drain_task_results`. `trunks` is the active
+/// repo's `doctor.trunks` (the base `gwm pr` targets) captured at spawn.
+pub fn build_sidebar_payload(
+  w: &WorktreeInfo,
+  mode: super::state::sidebar::SidebarMode,
+  trunks: &[String],
+  theme: &Theme,
+) -> SidebarSections {
+  let diff = worktree::git_diff_stat_vs_base(&w.path, trunks).ok().flatten();
+  build_sidebar_sections(w, mode, diff, theme)
 }
 
 /// Number of stash entries shown in `SidebarMode::Stashes`. Set to

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6185,6 +6185,63 @@ fn refresh_invalidates_an_inflight_sidebar_rebuild() {
   );
 }
 
+#[test]
+fn drain_async_refresh_invalidates_an_inflight_sidebar_rebuild() {
+  // codex review (PR #351): the ASYNC refresh drains re-read git state via
+  // `apply_refreshed_worktrees`, so an in-flight sidebar rebuild is now reading
+  // pre-refresh data. Its late payload must be dropped — the invalidate lives
+  // in the shared tail, not just the synchronous `refresh()`, else the async
+  // `r` / auto-refresh path would store stale sections under the current key
+  // and render them as fresh until the next navigation.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  // A sidebar rebuild is in flight...
+  let stale_sidebar = app.tasks.request(TaskKind::Sidebar).unwrap();
+  let path = app.selected().unwrap().path.clone();
+  let mode = app.sidebar.mode;
+  // ...when an async worktree refresh lands and re-lists.
+  let refresh_gen = app.tasks.request(TaskKind::RefreshWorktrees).unwrap();
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorktrees(
+      refresh_gen,
+      Ok(vec![worktree_fixture("alpha")]),
+    ))
+    .unwrap();
+  assert!(app.drain_task_results(), "the async refresh applies");
+
+  // The pre-refresh sidebar worker reports late.
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sidebar(stale_sidebar, path, mode, SidebarSections::default()))
+    .unwrap();
+  app.drain_task_results();
+
+  assert!(
+    app.sidebar.cache.is_none(),
+    "the async refresh must drop the pre-refresh sidebar payload, not store it as current"
+  );
+}
+
+#[test]
+fn maybe_refresh_sidebar_skips_a_hidden_sidebar() {
+  // codex review (PR #351): a hidden sidebar is not drawn, so rebuilding its
+  // preview would run git work for an invisible panel — the pre-#343 behaviour
+  // was to do none. Guard on `sidebar.open`.
+  use gwm::tui::state::async_task::TaskKind;
+  let (_dir, mut app) = make_app();
+  app.sidebar.open = false;
+  app.sidebar.cache = None; // would otherwise trigger a rebuild
+
+  app.maybe_refresh_sidebar();
+
+  assert!(
+    !app.tasks.is_loading(TaskKind::Sidebar),
+    "a hidden sidebar must do no preview work"
+  );
+}
+
 #[cfg(unix)]
 #[test]
 fn worktree_refresh_fetches_issue_and_pr_status_for_every_linked_worktree() {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6044,6 +6044,147 @@ fn drain_applies_async_refresh_result() {
   );
 }
 
+// ---- sidebar off-thread rebuild (issue #343) -----------------------------
+// The details sidebar's git subprocesses moved off the render path onto the
+// `TaskRunner` (`TaskKind::Sidebar`). These pin the decision + drain contract
+// deterministically — claim the slot / inject a `TaskMsg::Sidebar` / drain,
+// never a real OS worker thread (the #248 flaky trap).
+
+#[test]
+fn maybe_refresh_sidebar_is_a_noop_when_the_cache_is_current() {
+  use gwm::tui::state::async_task::TaskKind;
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  let w = app.selected().expect("a worktree is selected").clone();
+  let mode = app.sidebar.mode;
+  // Cache already built for this selection + mode → nothing to rebuild.
+  app.sidebar.cache = Some(((w.path.clone(), mode), SidebarSections::default()));
+
+  app.maybe_refresh_sidebar();
+
+  assert!(
+    !app.tasks.is_loading(TaskKind::Sidebar),
+    "a cache current for the selection must not spawn a rebuild"
+  );
+}
+
+#[test]
+fn maybe_refresh_sidebar_coalesces_a_held_navigation_onto_one_worker() {
+  // The debounce: while one rebuild is in flight, every subsequent tick (a
+  // held `j` with a stale cache) coalesces onto it instead of claiming a new
+  // generation. Proven by draining the ORIGINAL generation's result — a
+  // re-request would have bumped the generation and this would be dropped.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  let gen = app
+    .tasks
+    .request(TaskKind::Sidebar)
+    .expect("cold slot claims a generation");
+  app.sidebar.cache = None; // stale → maybe_refresh would want to rebuild
+
+  // Several event-loop ticks fire while the worker runs.
+  app.maybe_refresh_sidebar();
+  app.maybe_refresh_sidebar();
+
+  let path = app.selected().unwrap().path.clone();
+  let mode = app.sidebar.mode;
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sidebar(gen, path.clone(), mode, SidebarSections::default()))
+    .unwrap();
+  assert!(
+    app.drain_task_results(),
+    "the original worker's result must still apply — the ticks coalesced, they did not re-request"
+  );
+  assert!(
+    matches!(&app.sidebar.cache, Some(((p, _), _)) if *p == path),
+    "the coalesced worker's payload lands in the cache"
+  );
+}
+
+#[test]
+fn drain_applies_a_sidebar_rebuild_and_clears_the_slot() {
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::state::sidebar::SidebarMode;
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  let gen = app.tasks.request(TaskKind::Sidebar).unwrap();
+  let path = PathBuf::from("/tmp/gwm-test/alpha");
+  let mode = SidebarMode::Commits;
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sidebar(gen, path.clone(), mode, SidebarSections::default()))
+    .unwrap();
+  assert!(app.drain_task_results(), "drain reports it applied the sidebar payload");
+
+  assert!(
+    matches!(&app.sidebar.cache, Some(((p, m), _)) if *p == path && *m == mode),
+    "the payload is stored under the (path, mode) it was built for"
+  );
+  assert!(
+    !app.tasks.is_loading(TaskKind::Sidebar),
+    "the slot is cleared once the result applies"
+  );
+}
+
+#[test]
+fn drain_drops_a_superseded_sidebar_rebuild() {
+  // A selection that moved (or a mutation) bumped the generation mid-flight;
+  // the stale worker's late payload must be discarded, not stored.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::state::sidebar::SidebarMode;
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  let stale = app.tasks.request(TaskKind::Sidebar).unwrap();
+  app.tasks.invalidate(TaskKind::Sidebar); // superseded
+  app.sidebar.cache = None;
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sidebar(
+      stale,
+      PathBuf::from("/tmp/gwm-test/ghost"),
+      SidebarMode::Commits,
+      SidebarSections::default(),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  assert!(
+    app.sidebar.cache.is_none(),
+    "a superseded sidebar payload must be dropped, not stored (the #138 guard)"
+  );
+}
+
+#[test]
+fn refresh_invalidates_an_inflight_sidebar_rebuild() {
+  // Advisor #3 / issue #343: a synchronous `refresh()` (create / delete /
+  // sync / report-close) re-lists worktrees, so an in-flight sidebar rebuild
+  // was reading *pre-mutation* git state. `refresh()` must bump the Sidebar
+  // generation so that late payload is dropped by the drain.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  use gwm::tui::SidebarSections;
+  let (_dir, mut app) = make_app();
+  let stale = app.tasks.request(TaskKind::Sidebar).unwrap();
+  let path = app.selected().unwrap().path.clone();
+  let mode = app.sidebar.mode;
+
+  app.refresh().unwrap();
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::Sidebar(stale, path, mode, SidebarSections::default()))
+    .unwrap();
+  app.drain_task_results();
+
+  assert!(
+    app.sidebar.cache.is_none(),
+    "refresh() must drop a pre-mutation sidebar payload so it can't clobber the fresh preview"
+  );
+}
+
 #[cfg(unix)]
 #[test]
 fn worktree_refresh_fetches_issue_and_pr_status_for_every_linked_worktree() {

--- a/tests/tui_sidebar_render_tests.rs
+++ b/tests/tui_sidebar_render_tests.rs
@@ -88,6 +88,45 @@ fn draw_does_not_shell_out_to_git_or_warm_the_sidebar_cache() {
 }
 
 #[test]
+fn stale_key_cache_renders_the_loading_placeholder_not_another_worktrees_preview() {
+  // Issue #343: the sidebar cache is a single slot, so "render the last-known
+  // value" on a key-miss would mean showing a *different* worktree's commits
+  // under the live header of the current selection. The render deliberately
+  // shows the muted "loading…" placeholder instead — this guards that
+  // deviation against a future refactor silently reinstating the stale render.
+  use gwm::tui::SidebarSections;
+  use ratatui::text::Line;
+  use std::path::PathBuf;
+
+  let dir = repo_with_commits(4);
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let mode = app.sidebar.mode;
+  // Cache holds a payload keyed to a DIFFERENT worktree (stale key), carrying a
+  // distinctive commit subject that must never surface under the current one.
+  app.sidebar.cache = Some((
+    (PathBuf::from("/tmp/gwm-test/some-other-worktree"), mode),
+    SidebarSections {
+      recent_commits: vec![Line::from("GHOST-COMMIT-XYZ")],
+      ..SidebarSections::default()
+    },
+  ));
+
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+
+  let text = buffer_text(&terminal);
+  assert!(
+    text.contains("loading…"),
+    "a stale-key cache must render the loading placeholder: {text}"
+  );
+  assert!(
+    !text.contains("GHOST-COMMIT-XYZ"),
+    "the other worktree's cached commits must NOT render under the current header: {text}"
+  );
+}
+
+#[test]
 fn sidebar_renders_header_name_and_commit_subject_on_warm_cache() {
   let dir = repo_with_commits(8);
   // `None` global path keeps construction off the runner's real config.

--- a/tests/tui_sidebar_render_tests.rs
+++ b/tests/tui_sidebar_render_tests.rs
@@ -10,10 +10,23 @@
 //! known commit subject — content + order, not a brittle full-ANSI
 //! snapshot.
 
-use gwm::tui::{draw, App};
+use gwm::tui::{build_sidebar_payload, draw, App};
 use ratatui::{backend::TestBackend, Terminal};
 use std::path::Path;
 use tempfile::TempDir;
+
+/// Warm `app.sidebar.cache` the way the async worker + drain would (issue
+/// #343): build the payload for the currently selected worktree + mode and
+/// store it under that key. The render path no longer shells out, so a render
+/// test that wants real git content in the sidebar must seed the cache first —
+/// the deterministic analogue of `maybe_refresh_sidebar` spawning a worker and
+/// `drain_task_results` applying its `TaskMsg::Sidebar`, with no OS thread.
+fn warm_sidebar(app: &mut App) {
+  let w = app.selected().expect("a worktree must be selected").clone();
+  let mode = app.sidebar.mode;
+  let payload = build_sidebar_payload(&w, mode, &app.config.doctor.trunks, &app.theme);
+  app.sidebar.cache = Some(((w.path.clone(), mode), payload));
+}
 
 /// Build a temp git repo with `commit_count` commits whose subjects are
 /// `commit-<i>` so the render test can assert a known subject lands in the
@@ -54,6 +67,27 @@ fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
 }
 
 #[test]
+fn draw_does_not_shell_out_to_git_or_warm_the_sidebar_cache() {
+  // Issue #343: the sidebar's git subprocesses (`git_diff_stat_vs_base`,
+  // `git status --porcelain -z`, `git log`, `git stash list`) must run on the
+  // async worker, never inside `terminal.draw()`. The observable contract:
+  // a draw over a cold cache leaves the cache cold — the render path no longer
+  // computes it, so it can't have shelled out. The worker + drain populate it.
+  let dir = repo_with_commits(3);
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  app.sidebar.cache = None; // cold
+
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+
+  assert!(
+    app.sidebar.cache.is_none(),
+    "draw must not run git subprocesses to warm the sidebar cache; the async worker does (issue #343)"
+  );
+}
+
+#[test]
 fn sidebar_renders_header_name_and_commit_subject_on_warm_cache() {
   let dir = repo_with_commits(8);
   // `None` global path keeps construction off the runner's real config.
@@ -65,12 +99,16 @@ fn sidebar_renders_header_name_and_commit_subject_on_warm_cache() {
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
 
-  // First draw populates `app.sidebar.cache` (cold → warm).
-  terminal.draw(|f| draw(f, &mut app)).unwrap();
-  assert!(app.sidebar.cache.is_some(), "first draw must warm the sidebar cache");
+  // Issue #343: the render path no longer warms the cache (the async worker
+  // does), so seed it explicitly to render real git content.
+  warm_sidebar(&mut app);
+  assert!(
+    app.sidebar.cache.is_some(),
+    "the warm helper must seed the sidebar cache"
+  );
 
-  // Second draw is the warm-cache path the #238 refactor optimizes — the
-  // visible content must be identical.
+  // Warm-cache render path the #238 refactor optimizes — the visible content
+  // must carry the header name and the most recent commit subject.
   terminal.draw(|f| draw(f, &mut app)).unwrap();
 
   let text = buffer_text(&terminal);
@@ -90,6 +128,7 @@ fn sidebar_warm_cache_render_is_stable_across_frames() {
   let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
+  warm_sidebar(&mut app);
 
   terminal.draw(|f| draw(f, &mut app)).unwrap();
   let first = buffer_text(&terminal);
@@ -115,6 +154,7 @@ fn working_tree_section_renders_colored_status_counts_footer() {
   let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
+  warm_sidebar(&mut app);
 
   terminal.draw(|f| draw(f, &mut app)).unwrap();
   terminal.draw(|f| draw(f, &mut app)).unwrap();
@@ -143,6 +183,7 @@ fn working_tree_section_renders_file_tree_with_icons() {
   let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
+  warm_sidebar(&mut app);
   terminal.draw(|f| draw(f, &mut app)).unwrap();
   terminal.draw(|f| draw(f, &mut app)).unwrap();
 
@@ -204,6 +245,7 @@ fn status_pane_renders_diff_vs_base_line_on_a_feature_branch() {
   let mut app = App::new_at_layered(Some(path), None).unwrap();
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
+  warm_sidebar(&mut app);
   terminal.draw(|f| draw(f, &mut app)).unwrap();
   terminal.draw(|f| draw(f, &mut app)).unwrap();
 

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -345,3 +345,88 @@ fn workspace_refresh_rebuilds_the_full_merged_list() {
     "row→repo map survives the refresh"
   );
 }
+
+// ---- async workspace re-list (issue #343) --------------------------------
+// `maybe_auto_refresh` / `request_refresh` used to call `refresh_workspace`
+// synchronously in workspace mode, freezing the event loop while every repo
+// was opened + listed. They now ride `TaskKind::RefreshWorkspace`. These pin
+// the async contract deterministically — claim the slot / inject a
+// `TaskMsg::RefreshWorkspace` / drain, never a real OS worker thread.
+
+#[test]
+fn drain_applies_an_async_workspace_relist() {
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  let last = app.worktrees.len() - 1;
+  assert_eq!(app.row_repo_name(0), Some("alpha"));
+  assert_eq!(app.row_repo_name(last), Some("beta"));
+
+  // Claim the slot exactly as `request_refresh` would, then deliver a worker
+  // payload that re-tags every row to repo 0 (alpha) — no OS thread.
+  let generation = app.tasks.request(TaskKind::RefreshWorkspace).unwrap();
+  let rows: Vec<_> = app.worktrees.iter().cloned().map(|w| (w, 0usize)).collect();
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorkspace(generation, rows))
+    .unwrap();
+  assert!(app.drain_task_results(), "drain applies the workspace re-list");
+
+  assert_eq!(app.row_repo_name(0), Some("alpha"));
+  assert_eq!(
+    app.row_repo_name(last),
+    Some("alpha"),
+    "the drain rebuilt the row→repo map from the worker's payload"
+  );
+  assert!(
+    !app.tasks.is_loading(TaskKind::RefreshWorkspace),
+    "the slot is cleared once the result applies"
+  );
+}
+
+#[test]
+fn request_refresh_in_workspace_mode_coalesces_onto_an_inflight_relist() {
+  // Discriminates the async path from the old synchronous one: the pre-#343
+  // code called `refresh()`, which *invalidates* the slot (freeing it); the
+  // async path calls `request(RefreshWorkspace)`, which coalesces (`None`) and
+  // leaves the in-flight run's slot held.
+  use gwm::tui::state::async_task::TaskKind;
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  let _generation = app.tasks.request(TaskKind::RefreshWorkspace).unwrap();
+
+  app.request_refresh(); // a second `r` — coalesces, no second worker
+
+  assert!(
+    app.tasks.is_loading(TaskKind::RefreshWorkspace),
+    "the in-flight workspace re-list is still the one and only run"
+  );
+}
+
+#[test]
+fn refresh_invalidates_an_inflight_async_workspace_relist() {
+  // A synchronous `refresh()` (post-mutation) produces authoritative state, so
+  // an in-flight async workspace re-list is stale — its late payload must be
+  // dropped, not applied on top of the fresh list.
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  let stale = app.tasks.request(TaskKind::RefreshWorkspace).unwrap();
+
+  app.refresh().unwrap();
+
+  // The stale worker reports late, re-tagging every row to repo 0.
+  let rows: Vec<_> = app.worktrees.iter().cloned().map(|w| (w, 0usize)).collect();
+  app
+    .task_result_sender()
+    .send(TaskMsg::RefreshWorkspace(stale, rows))
+    .unwrap();
+  app.drain_task_results();
+
+  let last = app.worktrees.len() - 1;
+  assert_eq!(
+    app.row_repo_name(last),
+    Some("beta"),
+    "the superseded workspace payload was dropped — the fresh map stands"
+  );
+}


### PR DESCRIPTION
## Description

The last synchronous-subprocess tail of the #231 off-thread migration. Two git-backed surfaces still shelled out on the event-loop thread:

1. **The details sidebar** rebuilt its sections (`git_diff_stat_vs_base`, `git status --porcelain -z`, `git log`, `git stash list`) synchronously inside `terminal.draw()` on every selection / mode change — a single-slot cache miss stalled `j` / `k` on a large repo or a slow filesystem.
2. **Workspace-mode auto-refresh** re-listed every repo synchronously (`Repository::open` + `worktree::list` per repo) on the render thread.

Both now ride the existing `TaskRunner` (#231). The render path only READS the last-known payload; a coalesced worker rebuilds it off-thread.

Closes #343

## Type of change

- [x] ⚡ Perf

## Changes

- **`TaskKind::Sidebar`** — `build_sidebar_payload` runs every sidebar git subprocess on a worker; `App::maybe_refresh_sidebar` (once per tick, after `sync_active_repo` so workspace trunks are correct) requests a rebuild when the cache is stale for the current selection; `drain_task_results` stores it keyed by `(path, mode)`.
- **Render path never shells out.** `draw_sidebar` renders the cache only when it is authoritative for the current selection, else a muted `loading…` placeholder (the identity card still renders instantly from `WorktreeInfo`; only the diff figure + status / commits blocks wait on the worker).
- **Coalescing is the debounce.** Pure navigation deliberately does NOT invalidate the `Sidebar` slot, so a held `j` coalesces onto the single in-flight worker instead of spawning a thread per row — no explicit timer. `refresh()` invalidates the slot so a pre-mutation rebuild's late result is dropped.
- **`TaskKind::RefreshWorkspace`** — the per-repo open + list runs on a worker (`list_workspace`, split so the worker and the synchronous path share it); the drain rebuilds the merged table + row→repo map. The synchronous `refresh()` (post-mutation callers) stays synchronous and invalidates the slot.
- **Poll cadence** tightens to 50ms only while a `Sidebar` rebuild is in flight, so the placeholder → content swap lands fast without dragging multi-second sync/push tasks into 20fps spinning.

## Tests

- [x] `cargo test` passes locally (also re-validated under a stripped CI-like PATH)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

TDD anchor written red-first: `draw_does_not_shell_out_to_git_or_warm_the_sidebar_cache` (a draw over a cold cache leaves it cold — the render path can't have shelled out). Plus deterministic state-machine tests (no real OS thread, the #248 trap): sidebar no-op-when-current / coalesce / drain-applies / drain-drops-stale / refresh-invalidates-inflight; workspace drain-applies / coalesce / refresh-invalidates-inflight; and a render test pinning the placeholder-on-key-miss deviation.

## Screenshots / TUI captures

Not captured — the "navigation stays responsive on a large repo" acceptance criterion is a **manual check not run in this environment**. The `draw_does_not_shell_out…` anchor test is the durable structural proof that no git subprocess runs inside `terminal.draw()`.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Notes for reviewers

- **Deliberate deviation from "render the last-known value"** (the issue's wording): the sidebar cache is a single slot, so last-known on a key-miss would be a *different* worktree's commits under the current header. The render shows a `loading…` placeholder instead — pinned by `stale_key_cache_renders_the_loading_placeholder_not_another_worktrees_preview`.
- `ServeOptions`-style public surface unchanged; `build_sidebar_payload` is a new `pub` re-export used by the render tests.

## Linked issues / docs

- Issue: #343