### PR TITLE
🔧 chore(1.0.x): hardening backlog — MSRV doc, exec/clean freeze test, clean gate, allow comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#338]: https://github.com/kbrdn1/gwm-cli/issues/338
 
+- **`gwm clean --workspace` no longer panics on the empty-workspace
+  invariant** ([#344]). When nothing participated and no repo validated the
+  `--profile` (nor reported an error), the workspace-clean handler
+  `expect`-panicked on an invariant `open_workspace_repos` already enforces;
+  it now returns a `GwmError` defensively instead of unwinding.
+
+### Changed
+
+- **1.0.x hardening backlog** ([#344]). Froze the `gwm exec` / `gwm clean`
+  flag surface (`--profile` / `--jobs` / `--yes` / the global `--workspace`)
+  with a `contract_tests` canary — the subcommand-name canary
+  (`help_prints_subcommands`) does not see flags. Reconciled the MSRV
+  enforcement story between `Cargo.toml` and the stability doc: CI's clippy
+  job catches an accidental *std-API* use above the 1.86 floor
+  (`clippy::incompatible_msrv` under `-D warnings`), but **not**
+  language/edition features or a dependency raising its own floor — those stay
+  a local pre-bump check (`cargo msrv verify`). Documented the ungated
+  `clean::scan_worktree` / `delete_reclaim` convention (feed them only a
+  `scan_worktree_safe` reclaim) and their narrow TOCTOU window; justified the
+  remaining `#[allow(clippy::too_many_arguments)]`; and added a release-process
+  note to finalise the crate identity before tagging (the `v1.0.0` tag predated
+  the `gwm` → `gwm-cli` rename, so crates.io `gwm-cli@1.0.0` isn't reachable
+  from the tag).
+
+[#344]: https://github.com/kbrdn1/gwm-cli/issues/344
+
 ## Past releases
 
 In reverse chronological order:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,15 @@ Once the rc is validated and promoted to `main`:
 5. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
 6. GitHub Actions (`release.yml`) builds binaries and publishes the stable release. The release body is populated from `changelogs/<version>.md` via `--notes-file` (run `gh release edit v0.x.y --notes-file changelogs/<version>.md` after the workflow if needed).
 
+> ⚠️ **Finalise the crate identity _before_ the tag.** Any change to the
+> crates.io package identity — the `[package] name`, or a `version` bump — must
+> land in the **same commit the tag points at**, so `cargo publish` from that
+> tag is reproducible. The `v1.0.0` tag carried `name = "gwm"`; the rename to
+> `gwm-cli` (the name `gwm` was already taken on crates.io) landed **two commits
+> later**, so the published `gwm-cli@1.0.0` is _not_ reachable by checking out
+> `v1.0.0`. If a rename or identity change is ever needed again, do it in step 2
+> (alongside the `version` bump), before the merge + tag — not after.
+
 Triggering matrix:
 
 | Tag pattern              | Workflow         | `prerelease` flag |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ edition = "2021"
 # wants 1.80; `std::iter::repeat_n` (existing code in src/tui/ui.rs's
 # countdown bar) wants 1.82; `tui-term 0.3.4` (issue #35 PTY overlay)
 # declares `rust-version = "1.86.0"`. The crate as a whole compiles at
-# 1.86+, so MSRV is set to the higher floor. CI's clippy MSRV lint
-# enforces it.
+# 1.86+, so MSRV is set to the higher floor. CI's clippy job catches an
+# accidental *std-API* regression above this floor (`clippy::incompatible_msrv`
+# is warn-by-default, escalated to a hard error by `-D warnings`), but it does
+# NOT cover language/edition features or a dependency raising its own floor —
+# those are verified locally before an MSRV bump with `cargo msrv verify` (or
+# `cargo +1.86.0 build --all-targets --locked`). See
+# `docs/6.development/3.stability.md` §MSRV policy for the full story.
 rust-version = "1.86"
 description = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 authors = ["Kylian Bardini"]

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -88,11 +88,18 @@ of them.
 The Minimum Supported Rust Version is declared as `rust-version` in
 [`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
 (currently **1.86**) — the floor the crate is expected to compile against.
-CI builds and tests on the *stable* toolchain; it does not pin a dedicated
-1.86 job, so the MSRV is verified locally before a bump with
-`cargo clippy --all-targets -- -W clippy::incompatible_msrv` (or
-`cargo msrv verify`), which flags an accidental use of an API newer than the
-declared floor.
+
+CI builds and tests on the *stable* toolchain, so it exercises the code but
+does not compile it *at* 1.86. What it does catch: the clippy job runs with
+`-D warnings`, and `clippy::incompatible_msrv` is warn-by-default, so an
+accidental use of a **std API** newer than the declared floor fails CI. What it
+does **not** catch: a newer **language / edition** feature, or a **dependency**
+raising its own floor — neither surfaces on stable. Those are verified locally
+before an MSRV bump with `cargo msrv verify` (or, without rustup,
+`cargo +1.86.0 build --all-targets --locked`). A dedicated `toolchain@1.86`
+build/test job would close that gap for the exhaustive guarantee; it is not
+wired up yet (its first run has to be confirmed green before it can gate
+merges).
 
 In practice an MSRV bump rides a **minor** release, not a major one — it has
 historically been driven by a dependency raising its own floor (the `1.86`

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -209,6 +209,14 @@ fn dir_size(dir: &Path) -> u64 {
 /// Scan one worktree at `path` for each pattern directory, sizing the ones
 /// that exist. Returns a [`WorktreeReclaim`] (possibly with no artifacts when
 /// the worktree is already clean).
+///
+/// **Ungated.** This does NOT apply the [`dir_is_safe_to_clean`] gate — it will
+/// happily size a `dist/` that holds a force-added tracked file. Every
+/// production caller MUST go through [`scan_worktree_safe`], which wraps this
+/// and drops the unsafe artifacts. This raw entry point is public only so the
+/// unit tests in `tests/clean_tests.rs` can exercise the sizing logic in
+/// isolation; treat it as `pub(crate)` by convention (tightening the actual
+/// visibility is tracked with the broader library-surface review in #342).
 pub fn scan_worktree(name: &str, path: &Path, patterns: &[String]) -> WorktreeReclaim {
   let mut artifacts = Vec::new();
   let mut total = 0u64;
@@ -244,6 +252,23 @@ pub fn scan_worktree(name: &str, path: &Path, patterns: &[String]) -> WorktreeRe
 /// of bytes freed (the sum of the scanned sizes). Only the directories named
 /// in `reclaim.artifacts` are touched — anything else in the worktree is left
 /// untouched.
+///
+/// **Ungated — trusts its input.** This re-runs no safety check; it deletes
+/// exactly the artifacts in `reclaim`. The caller MUST build `reclaim` from
+/// [`scan_worktree_safe`] (all real callers — `gwm clean` and the TUI clean
+/// overlay, #325 — do), never a raw [`scan_worktree`], or a tracked
+/// force-added file could be destroyed. Public only for the `tests/clean_tests.rs`
+/// round-trip; treat as `pub(crate)` by convention (see #342 for the surface
+/// review).
+///
+/// There is a narrow **TOCTOU** window between the gate check inside
+/// `scan_worktree_safe` and the `remove_dir_all` here: a path that was
+/// git-ignored-and-untracked at scan time could be `git add`-ed (or replaced)
+/// in the interval and still be deleted. The exposure is bounded — `gwm clean`
+/// is user-initiated against the user's own build dirs, not a privileged or
+/// adversarial context — so the window is documented rather than closed
+/// (closing it would need re-checking the gate under a lock immediately before
+/// each delete, disproportionate to the threat).
 pub fn delete_reclaim(reclaim: &WorktreeReclaim) -> Result<u64> {
   let mut freed = 0u64;
   for a in &reclaim.artifacts {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1429,7 +1429,16 @@ fn cmd_clean_workspace(root: &Path, slugs: Vec<String>, profile: Option<String>,
       }
     }
     if !valid {
-      return Err(last_err.expect("open_workspace_repos guarantees a non-empty workspace"));
+      // `last_err` is `Some` whenever the loop over `opened` ran and no repo
+      // validated — and `open_workspace_repos` already rejects an empty
+      // workspace with `EmptyWorkspace`, so `opened` is non-empty and the
+      // `None` arm is unreachable. Return that same error defensively rather
+      // than `expect`-panicking, so a future regression that lets an empty
+      // workspace through fails loud with a `GwmError` instead of a panic
+      // (issue #344).
+      return Err(last_err.unwrap_or_else(|| GwmError::EmptyWorkspace {
+        root: root.display().to_string(),
+      }));
     }
   }
   clean_finish(&reclaims, &skipped, yes)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3083,6 +3083,12 @@ impl App {
     Ok(())
   }
 
+  // The rename worker takes each piece of the edit as an owned, `Send`
+  // parameter because only owned data may cross the `thread::spawn` boundary
+  // (`self` / `git2::Repository` are not `Send`) — the same flat signature the
+  // other `spawn_*` workers use. Bundling them into a struct would just add an
+  // indirection between the call site and the move-closure for no gain, so the
+  // arg count is deliberate.
   #[allow(clippy::too_many_arguments)]
   fn spawn_edit_worktree(
     &self,

--- a/tests/contract_tests.rs
+++ b/tests/contract_tests.rs
@@ -27,7 +27,8 @@
 //! a `required` entry from a schema file, turns the relevant parity test
 //! red (verified during development of #317).
 
-use gwm::cli::build_status_json;
+use clap::Parser;
+use gwm::cli::{build_status_json, Cli, Command};
 use gwm::contract;
 use gwm::github::{BranchLink, CiState, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
 use gwm::json_api::{JsonCheck, JsonDoctorReport, JsonPath, JsonStatus, JsonWorktree};
@@ -813,4 +814,115 @@ fn status_schema_required_and_types_are_frozen() {
       ("url", "string"),
     ],
   );
+}
+
+// --- 8. exec / clean CLI flag freeze (issue #344) --------------------------
+// `help_prints_subcommands` (cli_binary.rs) pins the subcommand *names*; it
+// does not see flags. The 1.0 exec/clean surface froze `--profile` / `--jobs`
+// (#324) and the global `--workspace` (#36 / #326) as part of the stable CLI
+// contract, so a rename, a removal, or a change to whether a flag takes a value
+// must be a conscious breaking decision, not a silent clap edit. These parse a
+// full invocation and assert each flag lands on the right field with the right
+// arity — renaming `--jobs`, dropping `--profile`, or making `--yes` take a
+// value turns one of them red.
+
+#[test]
+fn exec_flag_surface_is_frozen() {
+  // `--workspace` is a global flag (on `Cli`); `--profile` / `--jobs` are on
+  // the subcommand; the command follows `--`.
+  let cli = Cli::try_parse_from([
+    "gwm",
+    "--workspace",
+    "/tmp/ws",
+    "exec",
+    "--profile",
+    "ci",
+    "--jobs",
+    "4",
+    "--",
+    "cargo",
+    "test",
+  ])
+  .expect("frozen exec flags must still parse");
+
+  assert_eq!(
+    cli.workspace.as_deref(),
+    Some(std::path::Path::new("/tmp/ws")),
+    "`--workspace <DIR>` is a frozen global flag that takes a value"
+  );
+  match cli.command {
+    Some(Command::Exec {
+      profile,
+      jobs,
+      command,
+      slugs,
+    }) => {
+      assert!(slugs.is_empty(), "no slugs before `--`");
+      assert_eq!(
+        profile.as_deref(),
+        Some("ci"),
+        "`--profile <NAME>` frozen, takes a value"
+      );
+      assert_eq!(jobs, Some(4), "`--jobs <N>` frozen, takes an integer value");
+      assert_eq!(
+        command,
+        vec!["cargo".to_string(), "test".to_string()],
+        "`-- <cmd>` forwarded verbatim"
+      );
+    }
+    other => panic!("expected Command::Exec, got {other:?}"),
+  }
+}
+
+#[test]
+fn clean_flag_surface_is_frozen() {
+  let cli = Cli::try_parse_from([
+    "gwm",
+    "--workspace",
+    "/tmp/ws",
+    "clean",
+    "feat-1",
+    "--profile",
+    "rust",
+    "--yes",
+  ])
+  .expect("frozen clean flags must still parse");
+
+  assert_eq!(
+    cli.workspace.as_deref(),
+    Some(std::path::Path::new("/tmp/ws")),
+    "`--workspace <DIR>` is a frozen global flag that takes a value"
+  );
+  match cli.command {
+    Some(Command::Clean { slugs, profile, yes }) => {
+      assert_eq!(slugs, vec!["feat-1".to_string()], "positional slug still accepted");
+      assert_eq!(
+        profile.as_deref(),
+        Some("rust"),
+        "`--profile <NAME>` frozen, takes a value"
+      );
+      assert!(yes, "`--yes` frozen as a boolean flag (no value)");
+    }
+    other => panic!("expected Command::Clean, got {other:?}"),
+  }
+}
+
+#[test]
+fn clean_yes_flag_takes_no_value() {
+  // Guards the arity of `--yes` specifically. With `--yes` as a bool, a
+  // following bare token is NOT consumed as its value — it lands in `slugs`.
+  // If `--yes` were ever changed to take a value, clap would swallow the token
+  // and `slugs` would be empty, turning this red.
+  let cli = Cli::try_parse_from(["gwm", "clean", "--yes", "trailing-token"]).expect("parses with --yes as a boolean");
+  match cli.command {
+    Some(Command::Clean { slugs, yes, .. }) => {
+      assert!(yes, "--yes set");
+      assert_eq!(
+        slugs,
+        vec!["trailing-token".to_string()],
+        "the trailing token is a slug, not a value consumed by --yes"
+      );
+    }
+    other => panic!("expected Command::Clean, got {other:?}"),
+  }
 }


### PR DESCRIPTION
## Description

Consolidated low-risk 1.0.x hardening from the v1.0.0 ultra-audit (#344), one PR, six items as atomic commits. None is a present breakage — durability / cohesion.

Closes #344

## Type of change

- [x] 🔧 Chore / CI / build
- [x] ✅ Tests
- [x] 🐛 Fix (edge-case panic → error)
- [x] 📝 Docs

## Changes

- **exec/clean flag freeze test** — `help_prints_subcommands` pins subcommand *names* but not flags. Added `contract_tests` canaries freezing `--profile` / `--jobs` / `--yes` and the global `--workspace` (names + arity). Renaming `--jobs`, dropping `--profile`, or making `--yes` take a value turns one red.
- **empty-workspace clean panic → error** — `cmd_clean_workspace` `expect`-panicked on an unreachable invariant (`open_workspace_repos` already rejects empty workspaces). Returns `GwmError::EmptyWorkspace` defensively now; the reachable profile-error path is unchanged.
- **clean gate convention** — documented that `clean::scan_worktree` / `delete_reclaim` are ungated (the gate lives in `scan_worktree_safe`), that every production caller must go through the safe wrapper, and the narrow TOCTOU window (bounded — user-initiated clean of the user's own build dirs — so documented, not closed). Visibility tightening deferred to the library-surface review (#342), since `clean_tests.rs` uses the raw fns.
- **`#[allow]` justification** — `spawn_edit_worktree`'s `#[allow(too_many_arguments)]` now explains the owned-`Send`-across-`thread::spawn` reason (mirrors the other `spawn_*`). `cli.rs:2191` was already documented.
- **MSRV doc reconcile** — `Cargo.toml` said "CI's clippy MSRV lint enforces it"; the stability doc said "no dedicated job". Both now state the accurate partial story (clippy catches std-API regressions above the floor, not language/edition/deps).
- **release-process note** — finalise the crate identity (`[package] name` / `version`) in the commit the tag points at; the `v1.0.0` tag predated the `gwm` → `gwm-cli` rename, so crates.io `gwm-cli@1.0.0` isn't reachable from the tag.

## Tests

- [x] `cargo test` passes locally (45 test binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (freeze canaries in `contract_tests.rs`)

**TDD note (empty-workspace fix):** the change is behaviour-preserving on every *reachable* path — the `Some(err)` branch returns the same profile error, which `resolve_clean_dirs`' unknown-profile error path already pins (`clean_tests.rs`). The only changed branch (`None`) is unreachable because `open_workspace_repos` rejects an empty workspace upstream, so it's observably untestable from the public surface without bypassing the invariant. The freeze test is the real test diff.

## Screenshots / TUI captures

N/A — no TUI change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change — flags frozen, not changed)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths (the `expect` at cli.rs became a `GwmError`)
- [x] No `println!` in TUI render code

## Notes for reviewers

- **MSRV dedicated job is deferred, not added.** I couldn't validate a `toolchain@1.86` build locally (this box has nix rust 1.89, no rustup, asdf 1.86 not installed). Per the "don't push a CI job whose first run you can't predict" principle, the deliverable is the doc reconciliation; the job is noted as future work with the green-first-run caveat.
- **clean gate stays `pub` by convention.** Making it `pub(crate)` breaks `clean_tests.rs` (external crate) and is entangled with #342 (the whole published-lib-API question). The acceptance criterion sanctions "documented as convention."

## Linked issues / docs

- Issue: #344
- Related: #342 (library API surface), #319 (exec/clean 1.0 freeze)