### PR TITLE
♻️ refactor(structure): scope the published lib API as an internal test seam (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#344]: https://github.com/kbrdn1/gwm-cli/issues/344
 
+- **Scoped the published library API as an internal test seam** ([#342]). The
+  `gwm-cli` crate ships a `[lib]` target only so the binary and the `tests/`
+  suite can share one module tree — cargo treats that `pub` surface (~460
+  items) as a de-facto SemVer contract. Rather than gate it with
+  `cargo-semver-checks` (which would force a major bump on every routine
+  internal refactor), the lib is now `#![doc(hidden)]` (nothing is advertised
+  on docs.rs) and explicitly disclaimed: the crate-level docs and
+  `docs/6.development/3.stability.md` state it is **not** a public API and
+  carries no SemVer guarantee. `issue_templates` — the one module no
+  integration test imports — is now `pub(crate)`.
+
+[#342]: https://github.com/kbrdn1/gwm-cli/issues/342
+
 ## Past releases
 
 In reverse chronological order:

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -79,9 +79,20 @@ of them.
 - **Human-readable strings** — log lines, status-bar messages, help blurbs,
   the human (non-`--format=json`) output of any command. Parse the JSON
   surface instead; the prose is allowed to be reworded at any time.
-- **Internal Rust API** — gwm ships as a binary, not a published library
-  crate. The `pub` items in `src/` exist for the test suite and internal
-  reuse; they are not a stable API and carry no SemVer guarantee.
+- **Internal Rust API** — the `gwm-cli` crate publishes a `[lib]` target
+  (named `gwm`) alongside the binary, but **only as a byproduct**: the binary
+  and the `tests/` integration suite share one module tree, and Rust
+  integration tests can reach it only through a `pub` lib. That surface (~460
+  `pub` items across ~33 modules) is an internal test seam, **not** a public
+  API — it is `#![doc(hidden)]` (nothing is advertised on docs.rs) and carries
+  **no SemVer guarantee**. Do not `cargo add gwm-cli` to depend on `gwm::*`;
+  those items may change in any release. (Decision recorded for [#342]: the
+  library API is *disclaimed*, not gated with `cargo-semver-checks` — owning
+  ~460 items as a frozen contract would trip a major bump on every routine
+  internal refactor, which is the wrong trade-off for a seam that exists to be
+  tested, not consumed.)
+
+[#342]: https://github.com/kbrdn1/gwm-cli/issues/342
 
 ## MSRV policy
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,19 @@
 //! gwm — git worktree manager (lib root).
 //!
-//! Used both by the `gwm` binary (`src/main.rs`) and by integration tests
-//! under `tests/`. Module surface is intentionally `pub` for testability.
+//! **Internal test seam — NOT a public API.** This library target exists for
+//! one reason: the binary (`src/main.rs`) and the integration tests under
+//! `tests/` share a single module tree, and Rust integration tests can only
+//! reach it through a `pub` lib. The whole crate is therefore `#![doc(hidden)]`
+//! and every `pub` item below carries **no SemVer guarantee** — signatures,
+//! modules, and types here are free to change in any release, major or not.
+//!
+//! Do not `cargo add gwm-cli` to build on `gwm::*`. The published crate ships
+//! this lib only as a byproduct of shipping the `gwm` binary; it is not a
+//! supported dependency. The contracts that *are* stable — the CLI, the
+//! `--format=json` / daemon payloads, and the `.gwm.toml` schema — are
+//! documented in `docs/6.development/3.stability.md` and frozen by
+//! `tests/contract_tests.rs`.
+#![doc(hidden)]
 
 pub mod aliases;
 pub mod bootstrap;
@@ -19,7 +31,9 @@ pub mod github;
 pub mod gitmoji;
 pub mod history;
 pub mod hooks;
-pub mod issue_templates;
+// `issue_templates` is reached only through `crate::issue_templates` from
+// `cli.rs`; no integration test imports it, so it need not be `pub` (#342).
+pub(crate) mod issue_templates;
 pub mod json_api;
 pub mod labels;
 pub mod launcher;


### PR DESCRIPTION
## Description

`[lib] name = "gwm"` is published inside the `gwm-cli` crate, exposing ~460
`pub` items across ~33 modules. cargo treats a published lib's `pub` API as its
SemVer surface, so `cargo add gwm-cli` would couple downstream code to
`gwm::worktree`, `gwm::config::Config`, etc. — a contract the stability-doc
prose disclaimer does not actually bind.

**Decision (Light / disclaim, not gate):** the lib genuinely *is* an internal
test seam — `main.rs` and 68 `tests/` files share its module tree, and Rust
integration tests can only reach it through a `pub` lib. Bin-only publish is
infeasible here (the binary needs the lib to build; a workspace split just
re-publishes the surface as `gwm-cli-core`). Owning ~460 items with
`cargo-semver-checks` would trip a major bump on every routine internal
refactor. So we disclaim rather than gate:

- crate root `#![doc(hidden)]` → **nothing is advertised on docs.rs** (verified:
  the generated `gwm/index.html` lists no modules; the front page shows only
  the "not a public API / no SemVer guarantee" prose);
- `//!` header + `docs/6.development/3.stability.md` state plainly it is not a
  public API and carries no SemVer guarantee;
- `issue_templates` (the one module **no** test imports, reached only via
  `crate::issue_templates` from `cli.rs`) drops to `pub(crate)`.

Closes #342

## Type of change

- [x] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs

## Changes

- `src/lib.rs`: `#![doc(hidden)]`, rewritten `//!` disclaimer, `issue_templates` → `pub(crate)`
- `docs/6.development/3.stability.md`: corrected the "Internal Rust API" bullet (the crate *does* publish a lib) + recorded the #342 decision
- `CHANGELOG.md`: `### Changed` entry under `[Unreleased]`

## Tests

- [x] `cargo test` passes locally (all binaries green, 0 failed)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

**TDD exception (argued):** this change is *observably untestable from the
public surface* — the two effects are (1) a `#[doc(hidden)]` attribute, which
only alters rustdoc output (not assertable from `cargo test`), and (2) a
visibility reduction of a module that **no** integration test imports (0
`gwm::issue_templates` references). The suite staying green *is* the regression
evidence that nothing public depended on it; the binary still builds because
`cli.rs` reaches it via `crate::`. No behaviour changed, so there is no
behaviour to pin. Verified the doc-hidden effect out-of-band via `cargo doc`
(index advertises no modules; disclaimer prose present).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #342

## Notes for reviewers

The rejected alternatives (bin-only publish, `cargo-semver-checks` gate) are
spelled out in the issue and the stability-doc note. If you want the *strict*
path instead (own the lib as a versioned contract), that is a deliberate
reversal of this decision, not a bug in it — say so and I'll wire the CI gate.