### PR TITLE
📝 docs: finish the 1.0.0 documentation sync (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#342]: https://github.com/kbrdn1/gwm-cli/issues/342
 
+### Documentation
+
+- **Finished the 1.0.0 documentation sync** ([#339]). The in-repo `docs/`
+  tree and `skills/SKILL.md` still described the v0.10.0 line: fixed the
+  install command (`cargo binstall gwm` → `cargo binstall gwm-cli`; the bare
+  `gwm` crate on crates.io is an unrelated project), added a `cargo install
+  gwm-cli` crates.io channel to the install page, ported the site roadmap to
+  v1.0.0 (with the 1.0 lot #317–#334), and refreshed the test counters to the
+  real 1.0.0 figures (75 `tests/*.rs` files, 1902 `#[test]` markers). EN/FR
+  parity preserved.
+
+[#339]: https://github.com/kbrdn1/gwm-cli/issues/339
+
 ## Past releases
 
 In reverse chronological order:

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install gwm from source, Homebrew, prebuilt binaries, or a Nix flake.
+description: Install gwm from crates.io, source, Homebrew, prebuilt binaries, or a Nix flake.
 ---
 
 # Install
@@ -16,6 +16,14 @@ cargo install --path .
 ```
 
 The binary lands in `~/.cargo/bin/gwm`. Requires a recent stable Rust toolchain — MSRV is **1.86**.
+
+## from crates.io
+
+```bash
+cargo install gwm-cli
+```
+
+The crate is published as [`gwm-cli`](https://crates.io/crates/gwm-cli) — the bare `gwm` name on crates.io is an unrelated third-party project — and still installs the `gwm` command. This compiles from the published source (same toolchain / MSRV requirement as *from source* above); use *via cargo-binstall* below to skip the `git2` / vendored-libgit2 build entirely.
 
 ## via cargo-binstall
 

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -1,11 +1,11 @@
 ---
 title: Testing
-description: The cargo test matrix (~1700 tests across ubuntu / macos / windows), the integration test files, the sentinel-test convention, and the mandatory TDD loop.
+description: The cargo test matrix (~1900 tests across ubuntu / macos / windows), the integration test files, the sentinel-test convention, and the mandatory TDD loop.
 ---
 
 # Testing
 
-`cargo test` runs the full suite — **~1700 tests** (1738 `#[test]` markers as of v0.10.0) across 73 integration files under `tests/` plus the unit tests embedded in `src/`. Average run on a recent laptop: ~1 second.
+`cargo test` runs the full suite — **~1900 tests** (1902 `#[test]` markers as of v1.0.0) across 75 integration files under `tests/` plus the unit tests embedded in `src/`. Average run on a recent laptop: ~1 second.
 
 The suite runs on every push as a matrix across **`ubuntu-latest`, `macos-latest`, and `windows-latest`** (wired in `ci.yml`); each merge into `dev` is gated on all three turning green, and pre-release artifacts are built from the same commit by `pre-release.yml`. Windows was added to the matrix in v0.8.0-rc.1 ([#112](https://github.com/kbrdn1/gwm-cli/issues/112)).
 
@@ -22,7 +22,7 @@ Anything observable from outside the function under test counts as behaviour: a 
 ## quick reference
 
 ```bash
-cargo test                            # full suite (~1700 tests)
+cargo test                            # full suite (~1900 tests)
 cargo test --test tui_app_tests       # one integration file
 cargo test refresh_github             # name-substring filter across the whole suite
 cargo test -- --nocapture             # let println! / dbg! through
@@ -125,7 +125,7 @@ tests/
 └── commit_graph_perf_tests.rs   # commit-graph pipe allocation invariants
 ```
 
-(Not exhaustive — `ls tests/*.rs` is the live list (73 files as of v0.10.0); the matrix runs all of them.)
+(Not exhaustive — `ls tests/*.rs` is the live list (75 files as of v1.0.0); the matrix runs all of them.)
 
 ## sentinel tests
 

--- a/docs/6.development/index.md
+++ b/docs/6.development/index.md
@@ -9,7 +9,7 @@ navigation:
 
 gwm is a small Rust crate (single binary). Build, test, and ship workflows are documented here.
 
-- **[Testing](/development/testing)** — the integration test files (~1700+ tests across 74 test files, run on the ubuntu / macos / windows matrix), the mandatory red → green → refactor TDD loop, how to run a subset, and the `// regression:` sentinel-test convention.
+- **[Testing](/development/testing)** — the integration test files (~1900+ tests across 75 test files, run on the ubuntu / macos / windows matrix), the mandatory red → green → refactor TDD loop, how to run a subset, and the `// regression:` sentinel-test convention.
 - **[Contributing](/development/contributing)** — the Gitmoji + Conventional-Commit format, branch naming, the PR checklist, and the rules around the `CHANGELOG.md` / `changelogs/<version>.md` split.
 - **[Stability](/development/stability)** — the 1.0 SemVer compatibility contract: which surfaces are covered (CLI, exit codes, JSON schemas, daemon RPC, `.gwm.toml`), which are free to change (TUI, human strings, internal Rust API), the MSRV policy, and the deprecation process.
 
@@ -17,7 +17,7 @@ gwm is a small Rust crate (single binary). Build, test, and ship workflows are d
 
 ```bash
 cargo build              # debug build
-cargo test               # ~1700+ tests across the integration files + unit tests
+cargo test               # ~1900+ tests across the integration files + unit tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,15 +1,29 @@
 ---
 title: Roadmap
-description: What's shipped — the v0.10.0 surface (the editability + TUI-enrichment cycle, PTY overlays, workspace mode, presets, JSON API/daemon, review/statusline, fleet chores, and the TOFU trust ledger) — and the link to the issue tracker.
+description: What's shipped — the v1.0.0 stable surface (frozen machine contracts on top of the v0.10.0 editability + TUI-enrichment train, PTY overlays, workspace mode, presets, JSON API/daemon, review/statusline, fleet chores, and the TOFU trust ledger) — and the link to the issue tracker.
 ---
 
 # Roadmap
 
 The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
 
-## current state — v0.10.0 stable
+## current state — v1.0.0 stable
 
-The current **stable** line is **v0.10.0** (`Cargo.toml` `version = "0.10.0"`). It promotes the editability + TUI-enrichment cycle that landed across the `v0.10.0-rc.1` … `rc.3` pre-release trains. The two `v0.10.0 — …` sections further down split the release into the themes those trains carried; the preceding v0.9.0 and v0.8.0 cycles follow them for reference.
+The current **stable** line is **v1.0.0** (`Cargo.toml` `version = "1.0.0"`, tagged 2026-06-26) — the SemVer milestone. The surface is feature-complete and the **machine-readable contracts are now frozen**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)).
+
+1.0.0 promotes the entire **v0.10.0 train** — the `rc.1` … `rc.4` pre-releases, split by theme into the two `v0.10.0 — …` sections further down — and adds the **1.0 commitment** work described in the next section. The preceding v0.9.0 and v0.8.0 cycles follow them for reference. The project MSRV is **1.86** (raised by the PTY overlay's `portable-pty` / `tui-term` dependencies; MSRV bumps ride a minor per the [stability policy](/development/stability)).
+
+## v1.0.0 — the 1.0 commitment
+
+The post-`rc.4` stable delta completes the 1.0 commitment: frozen, versioned machine contracts plus the additive features that freeze anticipated. Consolidated notes: [`changelogs/1.0.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.0.0.md). Key additions:
+
+- **Frozen, versioned machine contracts** ([#317](https://github.com/kbrdn1/gwm-cli/issues/317)) — `tests/contract_tests.rs` pins `SCHEMA_VERSION = 1`, the daemon `schema_version`, and the four machine surfaces (`--format=json` on `list` / `doctor` / `path`, plus `status --json`) against baselines; the per-field tiers live in [`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md).
+- **Published stability & compatibility policy** ([#318](https://github.com/kbrdn1/gwm-cli/issues/318)) — what's covered by SemVer versus free to change in a minor / patch, EN + FR ([Stability & compatibility](/development/stability)).
+- **Frozen `exec` / `clean` surface** ([#319](https://github.com/kbrdn1/gwm-cli/issues/319)) — the `gwm exec` / `gwm clean` flag surface is locked for the 1.0 line (all non-frozen extensions deferred as additive), pinned by a `contract_tests` canary.
+- **Named `[exec]` / `[clean]` profiles + bounded `--jobs`** ([#324](https://github.com/kbrdn1/gwm-cli/issues/324)) — reusable command / reclaim profiles selected with `--profile`, plus opt-in bounded parallelism (`--jobs`) for the fan-out.
+- **`--workspace` fan-out for `gwm exec` / `gwm clean`** ([#326](https://github.com/kbrdn1/gwm-cli/issues/326)) — run the fleet chores across every repo one level below a workspace root, not just the current repo's worktrees.
+- **TUI exec / clean overlays** ([#325](https://github.com/kbrdn1/gwm-cli/issues/325)) — `x` runs an `[exec]` profile and `X` a `[clean]` profile from inside the TUI, with a live output overlay.
+- **Help-overlay + overlay polish** ([#334](https://github.com/kbrdn1/gwm-cli/issues/334)) — the `?` help overlay now documents every action (pinned by a completeness test), plus assorted overlay refinements.
 
 ### preceding TUI cycle — v0.9.0
 
@@ -63,7 +77,7 @@ The full v0.8.0 notes live at [`changelogs/0.8.0.md`](https://github.com/kbrdn1/
 
 ## what's next
 
-v0.10.0 closed the big-ticket roadmap items: the PTY overlay (#35), multi-repo workspace mode (#36), config presets (#37), the JSON-RPC API + daemon (#38), the GitHub inbound half (`gwm review`, #308), the first daemon consumer (`gwm statusline`, #309), fleet chores (`gwm exec` / `gwm clean`, #313), and the TOFU trust ledger (#95) all shipped in this line.
+**1.0.0 is cut** (2026-06-26). The v0.10.0 train closed the big-ticket roadmap items — the PTY overlay (#35), multi-repo workspace mode (#36), config presets (#37), the JSON-RPC API + daemon (#38), the GitHub inbound half (`gwm review`, #308), the first daemon consumer (`gwm statusline`, #309), fleet chores (`gwm exec` / `gwm clean`, #313), and the TOFU trust ledger (#95) — and the 1.0 commitment work (frozen contracts #317, stability policy #318, the `exec` / `clean` surface freeze #319 and its additive follow-ons #324 / #325 / #326, help-overlay polish #334) promoted the whole surface to the stable line.
 
 Housekeeping:
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Installez gwm depuis les sources, Homebrew, des binaires précompilés ou un flake Nix.
+description: Installez gwm depuis crates.io, les sources, Homebrew, des binaires précompilés ou un flake Nix.
 ---
 
 # Installation
@@ -16,6 +16,14 @@ cargo install --path .
 ```
 
 Le binaire arrive dans `~/.cargo/bin/gwm`. Nécessite une toolchain Rust stable récente — le MSRV est **1.86**.
+
+## depuis crates.io
+
+```bash
+cargo install gwm-cli
+```
+
+Le crate est publié sous le nom [`gwm-cli`](https://crates.io/crates/gwm-cli) — le nom nu `gwm` sur crates.io est un projet tiers sans rapport — et installe malgré tout la commande `gwm`. Ceci compile depuis les sources publiées (mêmes exigences de toolchain / MSRV que *depuis les sources* ci-dessus) ; utilisez *via cargo-binstall* ci-dessous pour éviter entièrement la compilation de `git2` / vendored-libgit2.
 
 ## via cargo-binstall
 

--- a/docs/fr/6.development/1.testing.md
+++ b/docs/fr/6.development/1.testing.md
@@ -1,11 +1,11 @@
 ---
 title: Tests
-description: La matrice cargo test (~1700 tests sur ubuntu / macos / windows), les fichiers de tests d'intégration, la convention de test-sentinelle et la boucle TDD obligatoire.
+description: La matrice cargo test (~1900 tests sur ubuntu / macos / windows), les fichiers de tests d'intégration, la convention de test-sentinelle et la boucle TDD obligatoire.
 ---
 
 # Tests
 
-`cargo test` exécute la suite complète — **~1700 tests** (1738 marqueurs `#[test]` à partir de la v0.10.0) répartis entre 73 fichiers d'intégration sous `tests/` plus les tests unitaires embarqués dans `src/`. Durée moyenne sur un ordinateur portable récent : ~1 seconde.
+`cargo test` exécute la suite complète — **~1900 tests** (1902 marqueurs `#[test]` à partir de la v1.0.0) répartis entre 75 fichiers d'intégration sous `tests/` plus les tests unitaires embarqués dans `src/`. Durée moyenne sur un ordinateur portable récent : ~1 seconde.
 
 La suite s'exécute à chaque push sous forme de matrice sur **`ubuntu-latest`, `macos-latest` et `windows-latest`** (câblée dans `ci.yml`) ; chaque merge dans `dev` est conditionné au passage au vert des trois, et les artefacts de pré-release sont construits à partir du même commit par `pre-release.yml`. Windows a été ajouté à la matrice en v0.8.0-rc.1 ([#112](https://github.com/kbrdn1/gwm-cli/issues/112)).
 
@@ -22,7 +22,7 @@ Tout ce qui est observable depuis l'extérieur de la fonction testée compte com
 ## référence rapide
 
 ```bash
-cargo test                            # full suite (~1700 tests)
+cargo test                            # full suite (~1900 tests)
 cargo test --test tui_app_tests       # one integration file
 cargo test refresh_github             # name-substring filter across the whole suite
 cargo test -- --nocapture             # let println! / dbg! through
@@ -125,7 +125,7 @@ tests/
 └── commit_graph_perf_tests.rs   # commit-graph pipe allocation invariants
 ```
 
-(Non exhaustif — `ls tests/*.rs` est la liste à jour (73 fichiers à partir de la v0.10.0) ; la matrice les exécute tous.)
+(Non exhaustif — `ls tests/*.rs` est la liste à jour (75 fichiers à partir de la v1.0.0) ; la matrice les exécute tous.)
 
 ## tests-sentinelles
 

--- a/docs/fr/6.development/index.md
+++ b/docs/fr/6.development/index.md
@@ -9,7 +9,7 @@ navigation:
 
 gwm est une petite crate Rust (binaire unique). Les workflows de build, de test et de publication sont documentés ici.
 
-- **[Tests](/fr/development/testing)** — les fichiers de tests d'intégration (~1700+ tests répartis sur 74 fichiers de tests, exécutés sur la matrice ubuntu / macos / windows), la boucle TDD obligatoire red → green → refactor, comment exécuter un sous-ensemble et la convention de test-sentinelle `// regression:`.
+- **[Tests](/fr/development/testing)** — les fichiers de tests d'intégration (~1900+ tests répartis sur 75 fichiers de tests, exécutés sur la matrice ubuntu / macos / windows), la boucle TDD obligatoire red → green → refactor, comment exécuter un sous-ensemble et la convention de test-sentinelle `// regression:`.
 - **[Contribuer](/fr/development/contributing)** — le format Gitmoji + Conventional Commits, le nommage des branches, la checklist de PR et les règles autour de la séparation `CHANGELOG.md` / `changelogs/<version>.md`.
 - **[Stabilité](/fr/development/stability)** — le contrat de compatibilité SemVer 1.0 : quelles surfaces sont couvertes (CLI, codes de sortie, schémas JSON, RPC daemon, `.gwm.toml`), lesquelles sont libres d'évoluer (TUI, chaînes humaines, API Rust interne), la politique MSRV et le processus de dépréciation.
 
@@ -17,7 +17,7 @@ gwm est une petite crate Rust (binaire unique). Les workflows de build, de test 
 
 ```bash
 cargo build              # debug build
-cargo test               # ~1700+ tests across the integration files + unit tests
+cargo test               # ~1900+ tests across the integration files + unit tests
 cargo fmt && cargo clippy -- -D warnings
 cargo run                # opens TUI in the current repo
 cargo install --path .   # install locally

--- a/docs/fr/7.roadmap.md
+++ b/docs/fr/7.roadmap.md
@@ -1,15 +1,29 @@
 ---
 title: Roadmap
-description: Ce qui est livré — la surface v0.10.0 (le cycle éditabilité + enrichissement TUI, les overlays PTY, le mode workspace, les presets, l'API JSON/daemon, review/statusline, les fleet chores et le registre de confiance TOFU) — et le lien vers le tracker d'issues.
+description: Ce qui est livré — la surface stable v1.0.0 (contrats machine gelés au-dessus du train v0.10.0 éditabilité + enrichissement TUI, overlays PTY, mode workspace, presets, API JSON/daemon, review/statusline, fleet chores et le registre de confiance TOFU) — et le lien vers le tracker d'issues.
 ---
 
 # Roadmap
 
 La roadmap complète (avec les catégories groupées et les liens d'issues par item) vit dans [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) à la racine du repo. Le tracker d'issues est la source de vérité pour les détails de scope, les critères d'acceptation et les alternatives considérées.
 
-## état courant — stable v0.10.0
+## état courant — stable v1.0.0
 
-La ligne **stable** courante est **v0.10.0** (`Cargo.toml` `version = "0.10.0"`). Elle promeut le cycle éditabilité + enrichissement TUI qui a atterri à travers les trains de pre-release `v0.10.0-rc.1` … `rc.3`. Les deux sections `v0.10.0 — …` plus bas découpent la release selon les thèmes que ces trains ont portés ; les cycles v0.9.0 et v0.8.0 précédents les suivent pour référence.
+La ligne **stable** courante est **v1.0.0** (`Cargo.toml` `version = "1.0.0"`, taguée le 2026-06-26) — le jalon SemVer. La surface est complète et les **contrats lisibles par machine sont désormais gelés** : les sous-commandes / flags / codes de sortie de la CLI, les schémas `--format=json`, le protocole JSON-RPC du daemon et l'ensemble des sections `.gwm.toml` ne casseront pas sans un bump majeur (voir [Stabilité & compatibilité](/fr/development/stability)).
+
+1.0.0 promeut l'intégralité du **train v0.10.0** — les pre-releases `rc.1` … `rc.4`, découpées par thème dans les deux sections `v0.10.0 — …` plus bas — et ajoute le travail du **jalon 1.0** décrit dans la section suivante. Les cycles v0.9.0 et v0.8.0 précédents les suivent pour référence. Le MSRV du projet est **1.86** (relevé par les dépendances `portable-pty` / `tui-term` de l'overlay PTY ; les bumps de MSRV suivent une version mineure selon la [politique de stabilité](/fr/development/stability)).
+
+## v1.0.0 — le jalon 1.0
+
+Le delta stable post-`rc.4` complète le jalon 1.0 : contrats machine gelés et versionnés, plus les fonctionnalités additives que ce gel anticipait. Notes consolidées : [`changelogs/1.0.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.0.0.md). Ajouts clés :
+
+- **Contrats machine gelés et versionnés** ([#317](https://github.com/kbrdn1/gwm-cli/issues/317)) — `tests/contract_tests.rs` fige `SCHEMA_VERSION = 1`, le `schema_version` du daemon et les quatre surfaces machine (`--format=json` sur `list` / `doctor` / `path`, plus `status --json`) contre des baselines ; les tiers par champ vivent dans [`docs/schema/README.md`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/README.md).
+- **Politique de stabilité & compatibilité publiée** ([#318](https://github.com/kbrdn1/gwm-cli/issues/318)) — ce qui est couvert par SemVer versus ce qui est libre de changer en mineur / patch, EN + FR ([Stabilité & compatibilité](/fr/development/stability)).
+- **Surface `exec` / `clean` gelée** ([#319](https://github.com/kbrdn1/gwm-cli/issues/319)) — la surface de flags de `gwm exec` / `gwm clean` est verrouillée pour la ligne 1.0 (toutes les extensions non gelées différées en additif), épinglée par un canari `contract_tests`.
+- **Profils `[exec]` / `[clean]` nommés + `--jobs` borné** ([#324](https://github.com/kbrdn1/gwm-cli/issues/324)) — profils de commande / reclaim réutilisables sélectionnés par `--profile`, plus un parallélisme borné opt-in (`--jobs`) pour le fan-out.
+- **Fan-out `--workspace` pour `gwm exec` / `gwm clean`** ([#326](https://github.com/kbrdn1/gwm-cli/issues/326)) — exécute les fleet chores sur chaque repo un niveau sous une racine de workspace, pas seulement les worktrees du repo courant.
+- **Overlays TUI exec / clean** ([#325](https://github.com/kbrdn1/gwm-cli/issues/325)) — `x` lance un profil `[exec]` et `X` un profil `[clean]` depuis la TUI, avec un overlay de sortie en direct.
+- **Polish de l'overlay d'aide** ([#334](https://github.com/kbrdn1/gwm-cli/issues/334)) — l'overlay d'aide `?` documente désormais chaque action (épinglé par un test de complétude), plus divers raffinements d'overlays.
 
 ### cycle TUI précédent — v0.9.0
 
@@ -63,7 +77,7 @@ Les notes complètes de la v0.8.0 vivent dans [`changelogs/0.8.0.md`](https://gi
 
 ## la suite
 
-v0.10.0 a bouclé les gros items de la roadmap : l'overlay PTY (#35), le mode workspace multi-repos (#36), les presets de configuration (#37), l'API JSON-RPC + daemon (#38), la moitié entrante GitHub (`gwm review`, #308), le premier consommateur du daemon (`gwm statusline`, #309), les fleet chores (`gwm exec` / `gwm clean`, #313) et le registre de confiance TOFU (#95) ont tous été livrés dans cette ligne.
+**1.0.0 est cut** (2026-06-26). Le train v0.10.0 a bouclé les gros items de la roadmap — l'overlay PTY (#35), le mode workspace multi-repos (#36), les presets de configuration (#37), l'API JSON-RPC + daemon (#38), la moitié entrante GitHub (`gwm review`, #308), le premier consommateur du daemon (`gwm statusline`, #309), les fleet chores (`gwm exec` / `gwm clean`, #313) et le registre de confiance TOFU (#95) — et le travail du jalon 1.0 (contrats gelés #317, politique de stabilité #318, le gel de la surface `exec` / `clean` #319 et ses suites additives #324 / #325 / #326, le polish de l'overlay d'aide #334) a promu toute la surface vers la ligne stable.
 
 Entretien :
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli — latest stable: `0.9.0`; `0.10.0-rc.4` on `dev` (MSRV 1.86). The v0.10 train adds: `gwm exec` / `gwm clean` (fleet command fan-out + build-artifact reclaim, #313), `gwm review <PR#>` (materialise a PR into a worktree, #308), the JSON API + `gwm daemon` + `gwm statusline` (#38 / #309), `gwm init --preset` stack templates (#37), multi-repo `--workspace` mode (#36), embedded PTY overlays for lazygit / shell (#35), a redesigned & fully-rebindable keymap incl. contextual modal keys + a live Settings panel with a Keys tab (#290 / #219 / #294), a Working Tree file-explorer pane and a current-PR CI indicator (#300 / #299).
+Source: https://github.com/kbrdn1/gwm-cli — latest stable: `1.0.0` (the SemVer milestone; machine contracts frozen — MSRV 1.86). 1.0.0 ships: `gwm exec` / `gwm clean` (fleet command fan-out + build-artifact reclaim, #313), `gwm review <PR#>` (materialise a PR into a worktree, #308), the JSON API + `gwm daemon` + `gwm statusline` (#38 / #309), `gwm init --preset` stack templates (#37), multi-repo `--workspace` mode (#36), embedded PTY overlays for lazygit / shell (#35), a redesigned & fully-rebindable keymap incl. contextual modal keys + a live Settings panel with a Keys tab (#290 / #219 / #294), a Working Tree file-explorer pane and a current-PR CI indicator (#300 / #299).
 
 ## When to use this skill
 
@@ -57,7 +57,7 @@ cargo install --path .         # → ~/.cargo/bin/gwm
 gwm --version
 ```
 
-No Rust toolchain at hand? `cargo binstall gwm` pulls the prebuilt binary from the matching GitHub Release (via `[package.metadata.binstall]`) and drops it in `~/.cargo/bin/` without compiling `git2`/vendored-libgit2 from source — much faster on first install.
+No Rust toolchain at hand? `cargo binstall gwm-cli` pulls the prebuilt binary from the matching GitHub Release (via `[package.metadata.binstall]`) and drops it in `~/.cargo/bin/` without compiling `git2`/vendored-libgit2 from source — much faster on first install.
 
 Prebuilt releases (Linux x86_64/aarch64, macOS Intel/Apple Silicon, Windows): https://github.com/kbrdn1/gwm-cli/releases. A Homebrew formula ships under `packaging/homebrew/` and a Nix `flake.nix` is at the repo root.
 


### PR DESCRIPTION
## Description

Finish porting the in-repo `docs/` tree + `skills/SKILL.md` to v1.0.0. The
root `README.md` / `ROADMAP.md` / `CHANGELOG.md` were already correct; the gaps
were in the site docs and the skill.

Closes #339

## Type of change

- [x] 📝 Docs

## Changes

- **Install / crate name (highest impact):** `skills/SKILL.md` `cargo binstall gwm` → `cargo binstall gwm-cli` (the bare `gwm` crate on crates.io is an unrelated third-party project). Added a `cargo install gwm-cli` crates.io channel to `docs/{,fr/}1.getting-started/1.install.md` (the canonical install page had only `cargo install --path .`).
- **Roadmap:** `docs/{,fr/}7.roadmap.md` reframed from "current stable v0.10.0" to **v1.0.0**, added a "v1.0.0 — the 1.0 commitment" section (#317 / #318 / #319 / #324 / #325 / #326 / #334), updated the closing to "1.0.0 is cut (2026-06-26)" — mirroring the repo-root `ROADMAP.md`. v0.10.0 / v0.9.0 / v0.8.0 sections kept as historical reference.
- **SKILL.md header:** "latest stable: 0.9.0; 0.10.0-rc.4 on dev" → **1.0.0**.
- **Test counters:** `docs/{,fr/}6.development/1.testing.md` + `…/index.md` updated from "1738 markers / 73 files as of v0.10.0" to the real **1902 `#[test]` markers / 75 `tests/*.rs` files** (verified `ls tests/*.rs | wc -l` = 75, `grep -rh '#[test]' tests/ | wc -l` = 1902), "as of v1.0.0".

## Tests

- [ ] `cargo test` — n/a (docs + `skills/SKILL.md` only; no `src/` change)
- [x] `cargo fmt --check` — unaffected (markdown)
- [ ] New tests added under `tests/` — **TDD exception:** documentation-only change (CLAUDE.md "comments-only / user-facing-string typo" exception). No behaviour touched; the reviewer heuristic `git log --stat tests/` correctly shows no test diff.

## Acceptance criteria

- [x] No doc claims a stable line other than 1.0.0 (audited: `latest stable` / `current stable` all say 1.0.0)
- [x] No `cargo install gwm` / `cargo binstall gwm` (bare) outside the immutable historical changelogs (audited: 0 hits)
- [x] EN/FR parity preserved (roadmap 7/7 headings, install 8/8, both carry the new sections)
- [x] Test counters match reality (75 files / 1902 markers)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]` (`### Documentation`)

## Notes for reviewers

The issue's "~1881 markers" estimate was stale — the real current count is
**1902** (more tests landed since it was filed). Historical references (the
`## v0.10.0 — …` roadmap section titles, the "v0.10 keymap redesign #290"
mentions, `changelogs/0.7–0.9`'s `cargo install gwm`) are left untouched — they
describe when things shipped, they don't claim a current stable line. This is
the in-repo `docs/` tree, distinct from the separate `../kbrdn-docs` site sync.