### PR TITLE
🔖 chore(release): cut v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,26 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Documentation
-
-- Ship the first screenshot / recording set for the docs tree and the
-  README hero (#206). Covers the TUI (hero, details sidebar with
-  side-by-side + stacked layouts, four-preset theme gallery, `:` command
-  palette, the `?` Keybindings overlay, the Settings-panel Keys tab
-  keymap editor, live `/` filter recording, armed safety-countdown
-  recording) and the CLI
-  (`gwm doctor`, the bootstrap step report, the TOFU trust prompt, the
-  first-worktree tour, and the `gcd` shell-init helper) plus the live
-  GitHub issue/PR linking pane. Every capture is wired into both the
-  English pages and their `docs/fr/` mirror. Captures are reproducible:
-  the demo fixture and vhs `.tape` scripts are committed under
-  `docs/_capture/` and regenerable with `docs/_capture/generate.sh`. The
-  `gwm tmux` multiplexer clip is deferred (vhs cannot host a tmux client).
+_Nothing yet._
 
 ## Past releases
 
 In reverse chronological order:
 
+- [`1.0.2`](changelogs/1.0.2.md) — 2026-07-06
 - [`1.0.1`](changelogs/1.0.1.md) — 2026-07-01
 - [`1.0.0`](changelogs/1.0.0.md) — 2026-06-26
 - [`0.9.0`](changelogs/0.9.0.md) — 2026-06-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # binary and the library crate stay `gwm` (see [[bin]] / [lib] below),
 # so `cargo install gwm-cli` still yields the `gwm` command.
 name = "gwm-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/changelogs/1.0.2.md
+++ b/changelogs/1.0.2.md
@@ -1,0 +1,28 @@
+# [1.0.2] - 2026-07-06
+
+A small patch on the 1.0 line: the first documentation screenshot / recording
+set lands, plus a routine dependency bump. No new features, no behaviour
+changes, and the machine contracts frozen in 1.0.0 are untouched.
+
+### Documentation
+
+- **Shipped the first screenshot / recording set** for the docs tree and the
+  README hero ([#206]). Covers the TUI (hero, details sidebar with
+  side-by-side + stacked layouts, four-preset theme gallery, `:` command
+  palette, the `?` Keybindings overlay, the Settings-panel Keys tab keymap
+  editor, live `/` filter recording, armed safety-countdown recording) and
+  the CLI (`gwm doctor`, the bootstrap step report, the TOFU trust prompt,
+  the first-worktree tour, and the `gcd` shell-init helper) plus the live
+  GitHub issue/PR linking pane. Every capture is wired into both the English
+  pages and their `docs/fr/` mirror. Captures are reproducible: the demo
+  fixture and vhs `.tape` scripts are committed under `docs/_capture/` and
+  regenerable with `docs/_capture/generate.sh`. The `gwm tmux` multiplexer
+  clip is deferred (vhs cannot host a tmux client).
+
+### Dependencies
+
+- ⬆️ Bump the clap-stack group: `clap_complete` `4.6.5` → `4.6.7` ([#358]).
+  Routine version bump, no source changes on our side.
+
+[#206]: https://github.com/kbrdn1/gwm-cli/issues/206
+[#358]: https://github.com/kbrdn1/gwm-cli/pull/358


### PR DESCRIPTION
## Summary

Release prep for **v1.0.2** — a patch on the 1.0 line.

- 📸 First docs screenshot / recording set (#206), moved out of `Unreleased` into `changelogs/1.0.2.md`
- ⬆️ `clap_complete` `4.6.5` → `4.6.7` (#358, dependabot, already merged into `dev`)
- 🔖 Version bump `1.0.1` → `1.0.2` (`Cargo.toml` + `Cargo.lock` resynced via `cargo build`)

No new features, no behaviour change. Machine contracts frozen in 1.0.0 are unchanged.

## Tests

- `cargo build --locked` green (lockfile carries 1.0.2 + clap_complete 4.6.7)
- No source change → the full suite is the CI gate on this PR

Cutting the tag from `main` after this lands and `dev → main` is propagated.

https://claude.ai/code/session_013AYiPvX6yipjH97uGCSrtw