### PR TITLE
🔒 chore(security): clear RUSTSEC-2026-0204 + add SECURITY.md policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Security
+
+- Bumped `crossbeam-epoch` to `0.9.20` to clear
+  [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)
+  (invalid pointer dereference). It reaches the tree only as a dev/bench
+  dependency (`criterion → rayon → crossbeam-deque`); no runtime impact.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)
   (invalid pointer dereference). It reaches the tree only as a dev/bench
   dependency (`criterion → rayon → crossbeam-deque`); no runtime impact.
+- Added a `SECURITY.md` policy documenting supported versions and a private
+  vulnerability-reporting flow (GitHub private advisories).
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported versions
+
+`gwm` follows [Semantic Versioning](https://semver.org/). Security fixes land
+on the latest minor line; older lines are not backported.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the [**Security** tab](https://github.com/kbrdn1/gwm-cli/security)
+   of this repository.
+2. Click **Report a vulnerability** to open a private advisory
+   ([direct link](https://github.com/kbrdn1/gwm-cli/security/advisories/new)).
+3. Describe the issue with enough detail to reproduce it: affected version,
+   platform, steps, and impact.
+
+If you cannot use private reporting, email **onepiecekylian@gmail.com** with
+the same details and `SECURITY` in the subject line.
+
+## What to expect
+
+This is a solo-maintained project, so responses are best-effort:
+
+- **Acknowledgement** within 7 days of your report.
+- **Assessment** of severity and affected versions, shared with you as it
+  progresses.
+- **Fix and disclosure** coordinated with you — a patched release and, where
+  warranted, a [RustSec](https://rustsec.org/) advisory. Please give the
+  maintainer a reasonable window to ship a fix before any public disclosure.
+
+## Scope
+
+`gwm` is a local-first CLI/TUI for managing git worktrees. The most relevant
+threat surfaces are:
+
+- The bootstrap step (file copies, command hooks, `.env` guards) — see the
+  trust gate and `gwm doctor`.
+- The `gwm daemon` JSON-RPC unix socket and its consumers.
+- `gwm review`, which fetches untrusted PR refs into a worktree (bootstrap is
+  opt-in behind `--bootstrap` for this reason).
+
+Dependency advisories are gated in CI via `cargo audit --deny warnings`.


### PR DESCRIPTION
## Description

Two security-housekeeping items in one pass:

1. Bump `crossbeam-epoch` `0.9.18 → 0.9.20` to clear
   [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204),
   which is failing `cargo audit --deny warnings` in CI. Transitive dev-only
   dependency (`criterion → rayon → crossbeam-deque`) — no runtime impact.
2. Add a `SECURITY.md` policy (supported versions + private
   vulnerability-reporting flow), per
   [GitHub's guidance](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy).

Closes #360

## Type of change

- [x] 📝 Docs
- [x] 🔧 Chore / CI / build

## Changes

- `Cargo.lock`: `crossbeam-epoch` bumped to `0.9.20`.
- `SECURITY.md` (new): supported versions, private reporting via GitHub
  advisories (email fallback), response expectations, threat-surface scope.
- `CHANGELOG.md`: two bullets under `## [Unreleased] > ### Security`.

## Tests

No production Rust code changed (lockfile bump of a dev/bench dependency +
Markdown docs), so the compiled behaviour is unchanged.

- [x] `cargo audit --deny warnings` exits 0 (was red before the bump)
- [x] `cargo build --locked` succeeds
- [x] Test exemption per `CLAUDE.md`: dependency bumps → CI green is the test; docs-only otherwise.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #360
- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204

## Notes for reviewers

`SECURITY.md` points reporters at GitHub private vulnerability reporting —
that feature must be enabled in **Settings → Code security → Private
vulnerability reporting** for the "Report a vulnerability" button to appear.