### PR TITLE
🔖 chore(release): cut v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-
-- Bumped `crossbeam-epoch` to `0.9.20` to clear
-  [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204)
-  (invalid pointer dereference). It reaches the tree only as a dev/bench
-  dependency (`criterion → rayon → crossbeam-deque`); no runtime impact.
-- Added a `SECURITY.md` policy documenting supported versions and a private
-  vulnerability-reporting flow (GitHub private advisories).
+_Nothing yet._
 
 ## Past releases
 
 In reverse chronological order:
 
+- [`1.0.3`](changelogs/1.0.3.md) — 2026-07-09
 - [`1.0.2`](changelogs/1.0.2.md) — 2026-07-06
 - [`1.0.1`](changelogs/1.0.1.md) — 2026-07-01
 - [`1.0.0`](changelogs/1.0.0.md) — 2026-06-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # binary and the library crate stay `gwm` (see [[bin]] / [lib] below),
 # so `cargo install gwm-cli` still yields the `gwm` command.
 name = "gwm-cli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/changelogs/1.0.3.md
+++ b/changelogs/1.0.3.md
@@ -1,0 +1,22 @@
+# [1.0.3] - 2026-07-09
+
+A small security patch on the 1.0 line: it clears a RustSec advisory carried by
+a dev/bench dependency and ships the project's first security policy. No new
+features, no behaviour changes, and the machine contracts frozen in 1.0.0 are
+untouched.
+
+### Security
+
+- ⬆️ Bumped `crossbeam-epoch` `0.9.18` → `0.9.20` to clear
+  [RUSTSEC-2026-0204] (invalid pointer dereference), which was failing the
+  `cargo audit --deny warnings` CI gate. It reaches the tree only as a
+  dev/bench dependency (`criterion → rayon → crossbeam-deque`); no runtime
+  code is affected ([#360], [#361]).
+- 🔒 Added a [`SECURITY.md`] policy documenting supported versions (the 1.0.x
+  line) and a private vulnerability-reporting flow via GitHub advisories, with
+  an email fallback ([#360], [#361]).
+
+[RUSTSEC-2026-0204]: https://rustsec.org/advisories/RUSTSEC-2026-0204
+[`SECURITY.md`]: SECURITY.md
+[#360]: https://github.com/kbrdn1/gwm-cli/issues/360
+[#361]: https://github.com/kbrdn1/gwm-cli/pull/361


### PR DESCRIPTION
## Description

Cut **v1.0.3**, a security patch on the 1.0 line. Bundles the just-merged
security housekeeping (#361): clears [RUSTSEC-2026-0204] (crossbeam-epoch
`0.9.20`) and ships the first `SECURITY.md`. No features, no behaviour changes;
the 1.0.0 machine contracts are untouched.

Refs #360

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- Bump version `1.0.2` → `1.0.3` (`Cargo.toml` + `Cargo.lock`, `gwm-cli` entry only).
- Migrate `## [Unreleased]` into `changelogs/1.0.3.md`; reset the root index.

## Tests

Release-cut commit, no source changes.

- [x] `cargo audit --deny warnings` exits 0
- [x] `cargo build --locked` succeeds (lock bumped before verify)
- [x] Per-version notes file `changelogs/1.0.3.md` present (release.yml sources its body from it)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>` (`chore/release-1.0.3`)
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated (Unreleased migrated to `changelogs/1.0.3.md`)

## Notes for reviewers

Open-PR reconcile before tag: only #361 was open, and it is the content of
this release (now merged). After this merges, `dev` → `main` propagation +
`v1.0.3` tag will trigger `release.yml`.

[RUSTSEC-2026-0204]: https://rustsec.org/advisories/RUSTSEC-2026-0204