### PR TITLE
✨ feat(config): persist the sidebar orientation in .gwm.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`[tui] sidebar_orientation` — persist the sidebar layout** (#365, part of
+  #363, reported by [@thachck](https://github.com/thachck)). The orientation
+  (`auto` / `side-by-side` / `stacked`) was runtime-only and reset on every
+  launch; only `sidebar_position` survived a restart. It is now a first-class
+  config key, seeded at startup and on config reload, and editable from the
+  Settings panel's TUI tab next to `sidebar position`. Default stays `stacked`
+  (the #217 launch layout). An unknown value is a hard error at load time,
+  consistent with `sidebar_position` and `tui.open.mode`.
+
+### Fixed
+
+- **`SidebarState::orientation` doc-comment claimed the default was `auto`**
+  (#365). It has been `stacked` since #217. The stale comment was live
+  documentation of a default that did not exist.
 
 ## Past releases
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -245,11 +245,11 @@ Runtime knobs for the worktree TUI.
 confirm_countdown_secs = 3
 
 # Which side the worktree-details sidebar sits on in the side-by-side layout.
-# "right" (default, pre-#188 behaviour) or "left". Toggle it live with `H`.
+# "right" (default, pre-#188 behaviour) or "left". Toggle it live with `v`.
 sidebar_position = "right"
 
 # How the sidebar is arranged relative to the table: "stacked" (default),
-# "side-by-side", or "auto" (width-driven). Cycle it live with `V`.
+# "side-by-side", or "auto" (width-driven). Cycle it live with `Space`.
 sidebar_orientation = "stacked"
 
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
@@ -258,7 +258,7 @@ sidebar_orientation = "stacked"
 auto_refresh_secs = 60
 ```
 
-`sidebar_position` (issue #188) sets the default side of the details sidebar in the **side-by-side** layout — `"right"` (default) or `"left"`. `H` toggles it live in the TUI. The **stacked** layout (table on top, sidebar below) ignores this — there the sidebar is always at the bottom. An unknown value is a **hard config error at load time**.
+`sidebar_position` (issue #188) sets the default side of the details sidebar in the **side-by-side** layout — `"right"` (default) or `"left"`. `v` toggles it live in the TUI. The **stacked** layout (table on top, sidebar below) ignores this — there the sidebar is always at the bottom. An unknown value is a **hard config error at load time**.
 
 `sidebar_orientation` (issue #365) sets how the sidebar is arranged relative to the table:
 
@@ -268,7 +268,7 @@ auto_refresh_secs = 60
 | `"side-by-side"` | Always beside the table, whatever the terminal width. |
 | `"auto"` | Side-by-side at `>= 120` columns, stacked below that. |
 
-`V` cycles it live (`auto` → side-by-side → stacked → `auto`). Before #365 that live choice was runtime-only and reset on every launch; setting the key here makes it stick. An unknown value is a **hard config error at load time**. It is also exposed in the Settings panel under the **TUI** tab.
+`Space` cycles it live (`auto` → side-by-side → stacked → `auto`). Before #365 that live choice was runtime-only and reset on every launch; setting the key here makes it stick. An unknown value is a **hard config error at load time**. It is also exposed in the Settings panel under the **TUI** tab.
 
 `auto_refresh_secs` (issue #285) drives a periodic background refresh of the worktree list so the Issue/PR table state stays current without a manual keystroke. It is a non-negative integer count of seconds; the default is `60` and `0` disables the loop. It is also exposed in the Settings panel under the **TUI** tab.
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -248,13 +248,27 @@ confirm_countdown_secs = 3
 # "right" (default, pre-#188 behaviour) or "left". Toggle it live with `H`.
 sidebar_position = "right"
 
+# How the sidebar is arranged relative to the table: "stacked" (default),
+# "side-by-side", or "auto" (width-driven). Cycle it live with `V`.
+sidebar_orientation = "stacked"
+
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
 # Issue/PR table state reasonably fresh; set to 0 to disable the auto-refresh
 # loop entirely (you can still refresh on demand with the `refresh` key).
 auto_refresh_secs = 60
 ```
 
-`sidebar_position` (issue #188) sets the default side of the details sidebar in the **side-by-side** layout — `"right"` (default) or `"left"`. `H` toggles it live in the TUI. The narrow-terminal **stacked** layout (table on top, sidebar below) ignores this — there the sidebar is always at the bottom. Cycle the orientation (`auto` → side-by-side → stacked → `auto`) live with `V`; `auto` picks side-by-side on a wide terminal and stacks on a narrow one. An unknown value is a **hard config error at load time**.
+`sidebar_position` (issue #188) sets the default side of the details sidebar in the **side-by-side** layout — `"right"` (default) or `"left"`. `H` toggles it live in the TUI. The **stacked** layout (table on top, sidebar below) ignores this — there the sidebar is always at the bottom. An unknown value is a **hard config error at load time**.
+
+`sidebar_orientation` (issue #365) sets how the sidebar is arranged relative to the table:
+
+| Value | Behaviour |
+|:------|:----------|
+| `"stacked"` | Table on top, sidebar below. **Default** since issue #217 — the status pane reads best at full terminal width. |
+| `"side-by-side"` | Always beside the table, whatever the terminal width. |
+| `"auto"` | Side-by-side at `>= 120` columns, stacked below that. |
+
+`V` cycles it live (`auto` → side-by-side → stacked → `auto`). Before #365 that live choice was runtime-only and reset on every launch; setting the key here makes it stick. An unknown value is a **hard config error at load time**. It is also exposed in the Settings panel under the **TUI** tab.
 
 `auto_refresh_secs` (issue #285) drives a periodic background refresh of the worktree list so the Issue/PR table state stays current without a manual keystroke. It is a non-negative integer count of seconds; the default is `60` and `0` disables the loop. It is also exposed in the Settings panel under the **TUI** tab.
 
@@ -723,6 +737,7 @@ Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` 
 | `[review]`                           | inert (`R` does nothing)         |
 | `[tui].confirm_countdown_secs`       | `3`                              |
 | `[tui].sidebar_position`             | `right`                          |
+| `[tui].sidebar_orientation`          | `stacked`                        |
 | `[tui].auto_refresh_secs`            | `60` (`0` disables)              |
 | `[tui.macro1]` / `[tui.macro2]`      | absent — `h` / `H` are no-ops    |
 | `[tui.keys]`                         | built-in keymap (see table above) |
@@ -738,7 +753,7 @@ Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` 
 ## validation rules
 
 - Unknown TOML keys are a **hard load error** — the root `[Config]` table and nearly every sub-table (`[worktree]`, `[bootstrap]`, `[hooks]`, `[doctor]`, `[tui]`, `[tui.open]`, `[git_tui]`, `[review]`, `[[labels]]`, `[[milestones]]`, `[[branch_types]]`, `[issue_template]`, `[pr_template]`) reject fields they don't recognise. A stray top-level key (or an unknown key inside a deny-fields table) fails the load with a `Config` error rather than being ignored. The same check runs on the merged result, so a typo in the global `~/.config/gwm/config.toml` fails just as hard. Exceptions: `[theme]` flattens per-role overrides (arbitrary role-named keys are accepted, then validated against the known role set — see below), and `[gitmoji]` / `[aliases]` are open key→value maps.
-- Unknown `[tui.open].mode` and `[tui].sidebar_position` values **error at load time**.
+- Unknown `[tui.open].mode`, `[tui].sidebar_position` and `[tui].sidebar_orientation` values **error at load time**.
 - `[theme]` errors at load on an unknown `preset`, unknown role key, or unparsable colour value.
 - `[tui.keys]` errors at load on an unknown action, an unparsable chord, a chord conflict, or a prefix collision.
 - `[tui.keys.modal.*]` errors at load on an unknown context, an unknown verb, an unparsable or multi-stroke key, binding under a context group instead of a leaf stage, or a per-context conflict.

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -245,11 +245,11 @@ Boutons de réglage runtime pour la TUI de worktree.
 confirm_countdown_secs = 3
 
 # Which side the worktree-details sidebar sits on in the side-by-side layout.
-# "right" (default, pre-#188 behaviour) or "left". Toggle it live with `H`.
+# "right" (default, pre-#188 behaviour) or "left". Toggle it live with `v`.
 sidebar_position = "right"
 
 # How the sidebar is arranged relative to the table: "stacked" (default),
-# "side-by-side", or "auto" (width-driven). Cycle it live with `V`.
+# "side-by-side", or "auto" (width-driven). Cycle it live with `Space`.
 sidebar_orientation = "stacked"
 
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
@@ -258,7 +258,7 @@ sidebar_orientation = "stacked"
 auto_refresh_secs = 60
 ```
 
-`sidebar_position` (issue #188) définit le côté par défaut de la sidebar de détails dans le layout **côte-à-côte** — `"right"` (défaut) ou `"left"`. `H` le bascule en direct dans la TUI. Le layout **empilé** (table en haut, sidebar en dessous) l'ignore — là, la sidebar est toujours en bas. Une valeur inconnue est une **erreur de config dure au moment du chargement**.
+`sidebar_position` (issue #188) définit le côté par défaut de la sidebar de détails dans le layout **côte-à-côte** — `"right"` (défaut) ou `"left"`. `v` le bascule en direct dans la TUI. Le layout **empilé** (table en haut, sidebar en dessous) l'ignore — là, la sidebar est toujours en bas. Une valeur inconnue est une **erreur de config dure au moment du chargement**.
 
 `sidebar_orientation` (issue #365) définit l'agencement de la sidebar par rapport à la table :
 
@@ -268,7 +268,7 @@ auto_refresh_secs = 60
 | `"side-by-side"` | Toujours à côté de la table, quelle que soit la largeur du terminal. |
 | `"auto"` | Côte-à-côte à partir de `120` colonnes, empilé en dessous. |
 
-`V` la fait cycler en direct (`auto` → côte-à-côte → empilé → `auto`). Avant #365, ce choix en direct était runtime-only et repartait à zéro à chaque lancement ; renseigner la clé ici le rend persistant. Une valeur inconnue est une **erreur de config dure au moment du chargement**. Elle est aussi exposée dans le panneau Settings, sous l'onglet **TUI**.
+`Space` la fait cycler en direct (`auto` → côte-à-côte → empilé → `auto`). Avant #365, ce choix en direct était runtime-only et repartait à zéro à chaque lancement ; renseigner la clé ici le rend persistant. Une valeur inconnue est une **erreur de config dure au moment du chargement**. Elle est aussi exposée dans le panneau Settings, sous l'onglet **TUI**.
 
 `auto_refresh_secs` (issue #285) pilote un rafraîchissement périodique en arrière-plan de la liste des worktrees pour que l'état de la table Issue/PR reste à jour sans frappe manuelle. C'est un entier positif ou nul en secondes ; la valeur par défaut est `60` et `0` désactive la boucle. Il est aussi exposé dans le panneau Settings, sous l'onglet **TUI**.
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -248,13 +248,27 @@ confirm_countdown_secs = 3
 # "right" (default, pre-#188 behaviour) or "left". Toggle it live with `H`.
 sidebar_position = "right"
 
+# How the sidebar is arranged relative to the table: "stacked" (default),
+# "side-by-side", or "auto" (width-driven). Cycle it live with `V`.
+sidebar_orientation = "stacked"
+
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
 # Issue/PR table state reasonably fresh; set to 0 to disable the auto-refresh
 # loop entirely (you can still refresh on demand with the `refresh` key).
 auto_refresh_secs = 60
 ```
 
-`sidebar_position` (issue #188) définit le côté par défaut de la sidebar de détails dans le layout **côte-à-côte** — `"right"` (défaut) ou `"left"`. `H` le bascule en direct dans la TUI. Le layout **empilé** pour terminal étroit (table en haut, sidebar en dessous) l'ignore — là, la sidebar est toujours en bas. Faites cycler l'orientation (`auto` → côte-à-côte → empilé → `auto`) en direct avec `V` ; `auto` choisit côte-à-côte sur un terminal large et empile sur un étroit. Une valeur inconnue est une **erreur de config dure au moment du chargement**.
+`sidebar_position` (issue #188) définit le côté par défaut de la sidebar de détails dans le layout **côte-à-côte** — `"right"` (défaut) ou `"left"`. `H` le bascule en direct dans la TUI. Le layout **empilé** (table en haut, sidebar en dessous) l'ignore — là, la sidebar est toujours en bas. Une valeur inconnue est une **erreur de config dure au moment du chargement**.
+
+`sidebar_orientation` (issue #365) définit l'agencement de la sidebar par rapport à la table :
+
+| Valeur | Comportement |
+|:-------|:-------------|
+| `"stacked"` | Table en haut, sidebar en dessous. **Défaut** depuis l'issue #217 — le panneau Status se lit mieux sur toute la largeur du terminal. |
+| `"side-by-side"` | Toujours à côté de la table, quelle que soit la largeur du terminal. |
+| `"auto"` | Côte-à-côte à partir de `120` colonnes, empilé en dessous. |
+
+`V` la fait cycler en direct (`auto` → côte-à-côte → empilé → `auto`). Avant #365, ce choix en direct était runtime-only et repartait à zéro à chaque lancement ; renseigner la clé ici le rend persistant. Une valeur inconnue est une **erreur de config dure au moment du chargement**. Elle est aussi exposée dans le panneau Settings, sous l'onglet **TUI**.
 
 `auto_refresh_secs` (issue #285) pilote un rafraîchissement périodique en arrière-plan de la liste des worktrees pour que l'état de la table Issue/PR reste à jour sans frappe manuelle. C'est un entier positif ou nul en secondes ; la valeur par défaut est `60` et `0` désactive la boucle. Il est aussi exposé dans le panneau Settings, sous l'onglet **TUI**.
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -234,16 +234,22 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # auto_refresh_secs = 60
 
-# --- TUI sidebar position (issue #188) ---------------------------------------
-# Which side the worktree-details preview sidebar sits on in the side-by-side
-# layout: "right" (default, pre-#188 behaviour) or "left". Toggle it live in
-# the TUI with `H`. The narrow-terminal stacked layout (table on top, sidebar
-# below) ignores this — there the sidebar is always at the bottom. Cycle the
-# orientation (auto / side-by-side / stacked) live with `V`; "auto" picks
-# side-by-side on a wide terminal and stacks on a narrow one.
+# --- TUI sidebar layout (issues #188 / #365) ---------------------------------
+# `sidebar_position` — which side the worktree-details preview sidebar sits on
+# in the side-by-side layout: "right" (default, pre-#188 behaviour) or "left".
+# Toggle it live in the TUI with `H`. The stacked layout ignores this: there the
+# sidebar is always at the bottom.
+#
+# `sidebar_orientation` — how the sidebar is arranged relative to the table:
+#   "stacked"       table on top, sidebar below (default since #217)
+#   "side-by-side"  always beside the table, even on a narrow terminal
+#   "auto"          side-by-side at >= 120 columns, stacked below that
+# Cycle it live with `V`. Before #365 this reset on every launch; set it here to
+# make the choice stick. An unknown value is a hard error at load time.
 #
 # [tui]
-# sidebar_position = "left"
+# sidebar_position    = "left"
+# sidebar_orientation = "side-by-side"
 
 # --- TUI keymap: `[tui.keys]` (issues #87 / #219 / #294) ---------------------
 # Remap any TUI key. An override REPLACES the default for that verb; an empty

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -237,14 +237,14 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # --- TUI sidebar layout (issues #188 / #365) ---------------------------------
 # `sidebar_position` — which side the worktree-details preview sidebar sits on
 # in the side-by-side layout: "right" (default, pre-#188 behaviour) or "left".
-# Toggle it live in the TUI with `H`. The stacked layout ignores this: there the
+# Toggle it live in the TUI with `v`. The stacked layout ignores this: there the
 # sidebar is always at the bottom.
 #
 # `sidebar_orientation` — how the sidebar is arranged relative to the table:
 #   "stacked"       table on top, sidebar below (default since #217)
 #   "side-by-side"  always beside the table, even on a narrow terminal
 #   "auto"          side-by-side at >= 120 columns, stacked below that
-# Cycle it live with `V`. Before #365 this reset on every launch; set it here to
+# Cycle it live with `Space`. Before #365 this reset on every launch; set it here to
 # make the choice stick. An unknown value is a hard error at load time.
 #
 # [tui]

--- a/src/config.rs
+++ b/src/config.rs
@@ -484,7 +484,7 @@ fn default_trunks() -> Vec<String> {
 /// TUI layout (issue #188). `Right` preserves the pre-#188 behaviour and
 /// is the default. In the stacked (narrow-terminal) layout the sidebar
 /// always sits at the bottom, so this preference only governs the
-/// side-by-side split. Toggled live with `H`; persisted here so the
+/// side-by-side split. Toggled live with `v`; persisted here so the
 /// choice survives across launches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -628,7 +628,7 @@ pub struct TuiConfig {
 
   /// Which side the worktree-details sidebar sits on in the side-by-side
   /// layout (issue #188). Default `right` preserves pre-#188 behaviour;
-  /// `left` flips the split. Toggled live in the TUI with `H`. Ignored by
+  /// `left` flips the split. Toggled live in the TUI with `v`. Ignored by
   /// the stacked (narrow-terminal) layout, where the sidebar is always at
   /// the bottom.
   #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -497,8 +497,16 @@ pub enum SidebarPosition {
 }
 
 impl SidebarPosition {
+  /// Every variant, in Settings-panel cycle order. Lets the panel's choice
+  /// list be derived from the enum instead of restating it — see
+  /// [`SidebarOrientation::ALL`] for the full reasoning.
+  pub const ALL: [SidebarPosition; 2] = [SidebarPosition::Right, SidebarPosition::Left];
+
   /// Human-readable label for the status bar (`sidebar position: left`).
-  pub fn label(self) -> &'static str {
+  /// Also the serialised TOML spelling, and the Settings-panel choice
+  /// string — `const` so the panel's list is built from this `match`
+  /// rather than duplicating it.
+  pub const fn label(self) -> &'static str {
     match self {
       SidebarPosition::Left => "left",
       SidebarPosition::Right => "right",
@@ -538,9 +546,26 @@ pub enum SidebarOrientation {
 }
 
 impl SidebarOrientation {
+  /// Every variant, in Settings-panel cycle order (default first).
+  ///
+  /// The panel's choice list is built from these variants' labels rather than
+  /// restating the strings, so the displayed choices cannot drift from the
+  /// serde spelling — a drift would make the panel write a `.gwm.toml` that
+  /// no longer loads.
+  ///
+  /// Keep in sync when adding a variant. Nothing enforces that statically; the
+  /// exhaustive `match` in [`Self::label`] is what fails to compile and brings
+  /// you here.
+  pub const ALL: [SidebarOrientation; 3] = [
+    SidebarOrientation::Stacked,
+    SidebarOrientation::SideBySide,
+    SidebarOrientation::Auto,
+  ];
+
   /// Status-bar label (`sidebar layout: auto`). Equal to the serialised
-  /// TOML spelling — see the type-level note.
-  pub fn label(self) -> &'static str {
+  /// TOML spelling — see the type-level note. `const` so the Settings-panel
+  /// choice list can be derived from this `match`.
+  pub const fn label(self) -> &'static str {
     match self {
       SidebarOrientation::Auto => "auto",
       SidebarOrientation::SideBySide => "side-by-side",

--- a/src/config.rs
+++ b/src/config.rs
@@ -511,6 +511,54 @@ impl SidebarPosition {
   }
 }
 
+/// How the sidebar is arranged relative to the worktree table (issue
+/// #188). Cycled live with `cycle_sidebar_layout`; seeded from
+/// `[tui] sidebar_orientation` since #365, which is why the enum lives
+/// here next to [`SidebarPosition`] rather than in the TUI state module
+/// (`tui::state::sidebar` re-exports it).
+///
+/// `kebab-case`, not `lowercase`: the latter would spell `SideBySide`
+/// as `sidebyside`. This is the trap [`MacroOpenMode`] hit on PR #292,
+/// and it also keeps the serialised form equal to [`Self::label`], so a
+/// Settings-panel write-back produces a file that still loads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SidebarOrientation {
+  /// Width-driven: side-by-side at `>= SIDEBAR_MIN_WIDTH`, stacked
+  /// below it. Restores a usable sidebar on narrow terminals where it
+  /// was previously hidden entirely.
+  Auto,
+  /// Always beside the table (table | sidebar), even when narrow.
+  SideBySide,
+  /// Always stacked (table on top, sidebar below), even when wide.
+  /// Default since issue #217: the status pane reads best under the
+  /// worktrees table, where it gets the full terminal width.
+  #[default]
+  Stacked,
+}
+
+impl SidebarOrientation {
+  /// Status-bar label (`sidebar layout: auto`). Equal to the serialised
+  /// TOML spelling — see the type-level note.
+  pub fn label(self) -> &'static str {
+    match self {
+      SidebarOrientation::Auto => "auto",
+      SidebarOrientation::SideBySide => "side-by-side",
+      SidebarOrientation::Stacked => "stacked",
+    }
+  }
+
+  /// Advance to the next orientation in the cycle
+  /// `Auto → SideBySide → Stacked → Auto`. Drives `cycle_sidebar_layout`.
+  pub fn next(self) -> Self {
+    match self {
+      SidebarOrientation::Auto => SidebarOrientation::SideBySide,
+      SidebarOrientation::SideBySide => SidebarOrientation::Stacked,
+      SidebarOrientation::Stacked => SidebarOrientation::Auto,
+    }
+  }
+}
+
 /// Where a macro command runs when fired from the TUI (#290).
 /// Serialised as snake_case strings in `[tui.macro1]` / `[tui.macro2]`
 /// (`open_in = "pty"` / `open_in = "mux_pane"`) — `snake_case`, not
@@ -586,6 +634,14 @@ pub struct TuiConfig {
   #[serde(default)]
   pub sidebar_position: SidebarPosition,
 
+  /// How the sidebar is arranged relative to the table (issue #365):
+  /// `auto` (width-driven), `side-by-side`, or `stacked`. Default
+  /// `stacked` preserves the #217 launch layout. Cycled live in the TUI
+  /// with `cycle_sidebar_layout`; before #365 that choice was runtime-only
+  /// and reset on every launch.
+  #[serde(default)]
+  pub sidebar_orientation: SidebarOrientation,
+
   /// `[tui.keys]` sub-table (issue #87) — user overrides for the
   /// remappable keymap. Absent → keymap stays at the built-in
   /// defaults. Present → every listed action *replaces* its default
@@ -612,6 +668,7 @@ impl Default for TuiConfig {
       auto_refresh_secs: default_auto_refresh_secs(),
       open: TuiOpenConfig::default(),
       sidebar_position: SidebarPosition::default(),
+      sidebar_orientation: SidebarOrientation::default(),
       keys: TuiKeysConfig::default(),
       macro1: None,
       macro2: None,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -587,9 +587,7 @@ impl App {
       edit_original_path: None,
       edit_failure: None,
     };
-    // Seed both sidebar knobs from `[tui]` (issues #188 / #365).
-    out.sidebar.position = out.config.tui.sidebar_position;
-    out.sidebar.orientation = out.config.tui.sidebar_orientation;
+    out.apply_sidebar_config();
     out.refresh_link();
     let spawned = out.refresh_linked_github_statuses_for_worktrees();
     if spawned > 0 {
@@ -700,6 +698,18 @@ impl App {
   /// re-opens the `git2::Repository` from the target workdir and invalidates
   /// the sidebar preview; an open failure keeps the current repo and reports
   /// on the status bar rather than panicking mid-render.
+  /// Apply the `[tui]` sidebar knobs from the live config onto the sidebar
+  /// state. Called from every point where `self.config` becomes authoritative:
+  /// construction, the Settings-panel reload, and the workspace repo swap
+  /// (`sync_active_repo`). Kept as one call rather than open-coded assignments
+  /// so a future knob can't be wired into two of the three and silently drift —
+  /// which is precisely how the repo-swap path came to ignore
+  /// `sidebar_position` (Codex review #366 P2).
+  fn apply_sidebar_config(&mut self) {
+    self.sidebar.position = self.config.tui.sidebar_position;
+    self.sidebar.orientation = self.config.tui.sidebar_orientation;
+  }
+
   pub fn sync_active_repo(&mut self) {
     let Some(ws) = self.workspace.as_ref() else {
       return;
@@ -736,6 +746,10 @@ impl App {
         // newly-active repo's config so a per-repo `[[branch_types]]` override
         // applies to the row being acted on (Codex review #303 P2).
         self.branch_types = self.config.resolved_branch_types().types;
+        // Same reasoning for the sidebar layout: the swap replaced `self.config`
+        // wholesale, so a per-repo `[tui]` sidebar override would otherwise be
+        // ignored until a reload (Codex review #366 P2).
+        self.apply_sidebar_config();
         if let Some(ws) = self.workspace.as_mut() {
           ws.active = target;
         }
@@ -2606,8 +2620,7 @@ impl App {
       Ok(theme) => self.theme = theme,
       Err(e) => self.status = format!("theme: {}", e),
     }
-    self.sidebar.position = self.config.tui.sidebar_position;
-    self.sidebar.orientation = self.config.tui.sidebar_orientation;
+    self.apply_sidebar_config();
     if let Ok(rows) = crate::config::resolved_rows(&self.workdir, self.global_path.as_deref()) {
       self.config_panel.rows = rows;
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -587,9 +587,9 @@ impl App {
       edit_original_path: None,
       edit_failure: None,
     };
-    // Seed the sidebar position from `[tui] sidebar_position` (issue
-    // #188). Orientation stays at its `Auto` default — runtime-only.
+    // Seed both sidebar knobs from `[tui]` (issues #188 / #365).
     out.sidebar.position = out.config.tui.sidebar_position;
+    out.sidebar.orientation = out.config.tui.sidebar_orientation;
     out.refresh_link();
     let spawned = out.refresh_linked_github_statuses_for_worktrees();
     if spawned > 0 {
@@ -2607,6 +2607,7 @@ impl App {
       Err(e) => self.status = format!("theme: {}", e),
     }
     self.sidebar.position = self.config.tui.sidebar_position;
+    self.sidebar.orientation = self.config.tui.sidebar_orientation;
     if let Ok(rows) = crate::config::resolved_rows(&self.workdir, self.global_path.as_deref()) {
       self.config_panel.rows = rows;
     }

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -19,7 +19,7 @@
 //! the cursor lives here, `max_scroll` / `max_x_scroll` are republished by
 //! the renderer each frame against the live viewport.
 
-use crate::config::{Config, ConfigRow, ConfigSource};
+use crate::config::{Config, ConfigRow, ConfigSource, SidebarOrientation, SidebarPosition};
 use crate::tui::keymap::{Action, KeyStroke, Keymap};
 use crate::tui::modal_keymap::{ModalAction, ModalKeymap};
 
@@ -254,9 +254,18 @@ pub enum FieldKind {
   Text,
 }
 
-const SIDEBAR_CHOICES: &[&str] = &["right", "left"];
-/// Mirrors `SidebarOrientation::label()` / its serialised TOML spelling.
-const SIDEBAR_ORIENTATION_CHOICES: &[&str] = &["stacked", "side-by-side", "auto"];
+// Derived from the enums' `const fn label()` rather than restated: the choice
+// string is written verbatim into `.gwm.toml`, so a list that drifted from the
+// serde spelling would make the panel produce a file that no longer loads. Going
+// through `label()` makes that drift impossible to express (#365).
+const SIDEBAR_CHOICES: &[&str] = &[SidebarPosition::Right.label(), SidebarPosition::Left.label()];
+const SIDEBAR_ORIENTATION_CHOICES: &[&str] = &[
+  SidebarOrientation::Stacked.label(),
+  SidebarOrientation::SideBySide.label(),
+  SidebarOrientation::Auto.label(),
+];
+// `TuiOpenMode` has no `label()` to derive from; the round-trip test
+// (`every_choice_is_a_value_the_config_can_load_back`) guards it instead.
 const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
 
 /// One editable setting, resolved live against the loaded [`Config`].

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -77,6 +77,7 @@ impl SettingsTab {
       ],
       SettingsTab::Tui => &[
         SettingField::SidebarPosition,
+        SettingField::SidebarOrientation,
         SettingField::OpenMode,
         SettingField::ConfirmCountdown,
         SettingField::AutoRefreshSecs,
@@ -254,6 +255,8 @@ pub enum FieldKind {
 }
 
 const SIDEBAR_CHOICES: &[&str] = &["right", "left"];
+/// Mirrors `SidebarOrientation::label()` / its serialised TOML spelling.
+const SIDEBAR_ORIENTATION_CHOICES: &[&str] = &["stacked", "side-by-side", "auto"];
 const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
 
 /// One editable setting, resolved live against the loaded [`Config`].
@@ -269,6 +272,8 @@ pub enum SettingField {
   WorktreeBranchPattern,
   /// `tui.sidebar_position` — left / right.
   SidebarPosition,
+  /// `tui.sidebar_orientation` — stacked / side-by-side / auto.
+  SidebarOrientation,
   /// `tui.open.mode` — shell / editor / finder.
   OpenMode,
   /// `tui.confirm_countdown_secs` — numeric input.
@@ -290,6 +295,7 @@ impl SettingField {
       SettingField::WorktreePathPattern => "path pattern",
       SettingField::WorktreeBranchPattern => "branch pattern",
       SettingField::SidebarPosition => "sidebar position",
+      SettingField::SidebarOrientation => "sidebar layout",
       SettingField::OpenMode => "open mode",
       SettingField::ConfirmCountdown => "confirm countdown (s)",
       SettingField::AutoRefreshSecs => "auto refresh (s)",
@@ -306,6 +312,7 @@ impl SettingField {
       SettingField::WorktreePathPattern => "worktree.path_pattern",
       SettingField::WorktreeBranchPattern => "worktree.branch_pattern",
       SettingField::SidebarPosition => "tui.sidebar_position",
+      SettingField::SidebarOrientation => "tui.sidebar_orientation",
       SettingField::OpenMode => "tui.open.mode",
       SettingField::ConfirmCountdown => "tui.confirm_countdown_secs",
       SettingField::AutoRefreshSecs => "tui.auto_refresh_secs",
@@ -317,7 +324,10 @@ impl SettingField {
   /// Whether the field is a cyclable choice, a numeric input, or free text.
   pub fn kind(self) -> FieldKind {
     match self {
-      SettingField::ThemePreset | SettingField::SidebarPosition | SettingField::OpenMode => FieldKind::Choice,
+      SettingField::ThemePreset
+      | SettingField::SidebarPosition
+      | SettingField::SidebarOrientation
+      | SettingField::OpenMode => FieldKind::Choice,
       SettingField::ConfirmCountdown | SettingField::AutoRefreshSecs => FieldKind::Uint,
       SettingField::WorktreeBase
       | SettingField::WorktreePathPattern
@@ -341,6 +351,7 @@ impl SettingField {
     match self {
       SettingField::ThemePreset => crate::tui::theme::preset_names(),
       SettingField::SidebarPosition => SIDEBAR_CHOICES,
+      SettingField::SidebarOrientation => SIDEBAR_ORIENTATION_CHOICES,
       SettingField::OpenMode => OPEN_MODE_CHOICES,
       _ => &[],
     }
@@ -354,6 +365,7 @@ impl SettingField {
       SettingField::WorktreePathPattern => cfg.worktree.path_pattern.clone(),
       SettingField::WorktreeBranchPattern => cfg.worktree.branch_pattern.clone(),
       SettingField::SidebarPosition => cfg.tui.sidebar_position.label().into(),
+      SettingField::SidebarOrientation => cfg.tui.sidebar_orientation.label().into(),
       SettingField::OpenMode => match cfg.tui.open.mode {
         crate::config::TuiOpenMode::Shell => "shell".into(),
         crate::config::TuiOpenMode::Editor => "editor".into(),

--- a/src/tui/state/sidebar.rs
+++ b/src/tui/state/sidebar.rs
@@ -31,9 +31,14 @@
 //!    wraps them with `refresh_link()` in a single `App::on_navigation`
 //!    so the literal triple can't drift back into duplicated copies.
 
-use crate::config::SidebarPosition;
 use crate::tui::ui::SidebarSections;
 use std::path::PathBuf;
+
+/// Re-exported from [`crate::config`], where both sidebar knobs live now
+/// that the orientation is persisted to `.gwm.toml` alongside the
+/// position (issue #365). Kept re-exported here so the state module
+/// still reads as the owner of the sidebar contract.
+pub use crate::config::{SidebarOrientation, SidebarPosition};
 
 /// Minimum total terminal width (in columns) required to render the
 /// sidebar *beside* the worktree table without squeezing the table
@@ -41,46 +46,6 @@ use std::path::PathBuf;
 /// picks the side-by-side split; below it, `Auto` stacks the sidebar
 /// under the table (issue #188) rather than hiding it (pre-#188).
 pub const SIDEBAR_MIN_WIDTH: u16 = 120;
-
-/// How the sidebar is arranged relative to the worktree table (issue
-/// #188). `Auto` is the default: the renderer picks side-by-side on a
-/// wide terminal and stacked on a narrow one. The other two variants
-/// pin the choice regardless of width, set by cycling with `V`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum SidebarOrientation {
-  /// Width-driven: side-by-side at `>= SIDEBAR_MIN_WIDTH`, stacked
-  /// below it. Restores a usable sidebar on narrow terminals where it
-  /// was previously hidden entirely.
-  Auto,
-  /// Always beside the table (table | sidebar), even when narrow.
-  SideBySide,
-  /// Always stacked (table on top, sidebar below), even when wide.
-  /// Default since issue #217: the status pane reads best under the
-  /// worktrees table, where it gets the full terminal width.
-  #[default]
-  Stacked,
-}
-
-impl SidebarOrientation {
-  /// Status-bar label (`sidebar layout: auto`).
-  pub fn label(self) -> &'static str {
-    match self {
-      SidebarOrientation::Auto => "auto",
-      SidebarOrientation::SideBySide => "side-by-side",
-      SidebarOrientation::Stacked => "stacked",
-    }
-  }
-
-  /// Advance to the next orientation in the cycle
-  /// `Auto → SideBySide → Stacked → Auto`. Drives the `V` keybinding.
-  pub fn next(self) -> Self {
-    match self {
-      SidebarOrientation::Auto => SidebarOrientation::SideBySide,
-      SidebarOrientation::SideBySide => SidebarOrientation::Stacked,
-      SidebarOrientation::Stacked => SidebarOrientation::Auto,
-    }
-  }
-}
 
 /// The concrete layout the renderer should draw for the current frame,
 /// resolved from `open` + orientation + position + terminal width by
@@ -163,9 +128,11 @@ pub struct SidebarState {
   /// Ignored by the stacked layout (sidebar always at the bottom).
   pub position: SidebarPosition,
   /// How the sidebar is arranged relative to the table (issue #188).
-  /// Defaults to [`SidebarOrientation::Auto`] (width-driven); cycled
-  /// by [`Self::cycle_orientation`] (`V`). Runtime-only — not persisted
-  /// to `.gwm.toml`, unlike `position`.
+  /// Defaults to [`SidebarOrientation::Stacked`] since #217 — *not*
+  /// `Auto`, which this comment claimed until #365. Seeded from
+  /// `[tui] sidebar_orientation` at `App` construction and re-seeded on
+  /// config reload, exactly like `position`; cycled live by
+  /// [`Self::cycle_orientation`].
   pub orientation: SidebarOrientation,
   /// `true` when keyboard navigation (`j` / `k`) targets the sidebar
   /// (scrolling Recent Commits) instead of the worktree list.

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use gwm::config::{
   expand_placeholders, resolved_rows, review_tool_preset, BranchTypesSource, Config, ConfigRow, ConfigSource,
-  MacroOpenMode, SidebarPosition, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
+  MacroOpenMode, SidebarOrientation, SidebarPosition, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
 };
 use tempfile::TempDir;
 
@@ -519,6 +519,100 @@ sidebar_position = "left"
   let cfg = Config::load_layered(dir.path(), None).unwrap();
   assert_eq!(cfg.tui.sidebar_position, SidebarPosition::Left);
   assert!(cfg.tui.sidebar_position.is_left());
+}
+
+#[test]
+fn tui_sidebar_orientation_defaults_to_stacked() {
+  // #217 made `stacked` the launch layout: the status pane reads best
+  // under the worktrees table where it gets the full width. Making the
+  // orientation configurable (#365) must not move that default — the
+  // `SidebarState::orientation` doc-comment claimed `auto` for two
+  // releases, so pin the real value here rather than trust prose.
+  let cfg = Config::default();
+  assert_eq!(cfg.tui.sidebar_orientation, SidebarOrientation::Stacked);
+}
+
+#[test]
+fn tui_sidebar_orientation_absent_keeps_stacked() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui]
+confirm_countdown_secs = 2
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.sidebar_orientation, SidebarOrientation::Stacked);
+}
+
+#[test]
+fn tui_sidebar_orientation_parses_side_by_side() {
+  // The hyphenated spelling is the contract: `rename_all = "lowercase"`
+  // would deserialise this variant as `sidebyside`, the exact trap
+  // `MacroOpenMode` hit on PR #292 (`mux_pane` → `muxpane`).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui]
+sidebar_orientation = "side-by-side"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.sidebar_orientation, SidebarOrientation::SideBySide);
+}
+
+#[test]
+fn tui_sidebar_orientation_parses_auto() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui]
+sidebar_orientation = "auto"
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.sidebar_orientation, SidebarOrientation::Auto);
+}
+
+#[test]
+fn tui_sidebar_orientation_serialises_back_to_its_label() {
+  // The config panel writes the choice back as the label string, so the
+  // serialised form and `label()` must agree or a panel edit would
+  // produce a file that no longer loads.
+  for orientation in [
+    SidebarOrientation::Auto,
+    SidebarOrientation::SideBySide,
+    SidebarOrientation::Stacked,
+  ] {
+    let serialised = toml::Value::try_from(orientation).unwrap();
+    assert_eq!(
+      serialised.as_str(),
+      Some(orientation.label()),
+      "{orientation:?} must serialise as its status-bar label"
+    );
+  }
+}
+
+#[test]
+fn tui_sidebar_orientation_invalid_value_errors_at_parse_time() {
+  // Same contract as `tui.open.mode` and `sidebar_position`: an unknown
+  // variant is a hard load error, never a silent fallback.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui]
+sidebar_orientation = "diagonal"
+"#,
+  )
+  .unwrap();
+  assert!(Config::load_layered(dir.path(), None).is_err());
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -53,6 +53,18 @@ fn make_app() -> (tempfile::TempDir, App) {
   (dir, app)
 }
 
+/// Index of `field` within the Settings TUI tab. Looked up rather than
+/// hardcoded: inserting a field (as #365 did with `sidebar_orientation`)
+/// silently shifts every literal index below it, which is how two numeric-
+/// input tests started editing the wrong row.
+fn tui_field_index(field: gwm::tui::SettingField) -> usize {
+  gwm::tui::SettingsTab::Tui
+    .fields()
+    .iter()
+    .position(|f| *f == field)
+    .unwrap_or_else(|| panic!("{field:?} is not exposed in the Settings TUI tab"))
+}
+
 #[test]
 fn focus_status_opens_and_focuses_the_sidebar() {
   // Issue #217: pressing `2` (focus_status) must open the sidebar if it was
@@ -7033,14 +7045,86 @@ fn activate_choice_setting_persists_project_layer_and_applies_live() {
 }
 
 #[test]
-fn committing_numeric_input_persists_the_typed_value() {
-  use gwm::config::Config;
-  use gwm::tui::SettingsTab;
+fn sidebar_orientation_is_seeded_from_config_at_construction() {
+  // #365: `[tui] sidebar_orientation` drives the launch layout. Without
+  // the seed the key parses but the TUI ignores it, which is the bug the
+  // issue reports.
+  use gwm::config::SidebarOrientation;
+
+  let (repo, _) = init_repo();
+  std::fs::write(
+    repo.path().join(".gwm.toml"),
+    r#"
+[tui]
+sidebar_orientation = "side-by-side"
+"#,
+  )
+  .unwrap();
+
+  let app = App::new_at_layered(Some(repo.path()), None).unwrap();
+  assert_eq!(
+    app.sidebar.orientation,
+    SidebarOrientation::SideBySide,
+    "config orientation must reach the live sidebar state"
+  );
+}
+
+#[test]
+fn sidebar_orientation_defaults_to_stacked_without_config() {
+  // Guards the #217 launch layout against an accidental flip while
+  // wiring the knob up (#365).
+  use gwm::config::SidebarOrientation;
+
+  let (_dir, app) = make_app();
+  assert_eq!(app.sidebar.orientation, SidebarOrientation::Stacked);
+}
+
+#[test]
+fn activate_sidebar_orientation_setting_persists_and_reseeds_live() {
+  use gwm::config::{Config, SidebarOrientation};
+  use gwm::tui::{SettingField, SettingsTab};
 
   let (dir, mut app) = make_app();
   app.enter_config_panel();
   app.config_panel.tab = SettingsTab::Tui;
-  app.config_panel.selected = 2; // confirm countdown (Uint input)
+  app.config_panel.selected = tui_field_index(SettingField::SidebarOrientation);
+  assert_eq!(app.config.tui.sidebar_orientation, SidebarOrientation::Stacked);
+
+  // Cycle the choice: the write-back must round-trip through a fresh load
+  // *and* re-seed the live sidebar, same contract as sidebar_position.
+  app.activate_selected_setting();
+
+  assert_ne!(
+    app.config.tui.sidebar_orientation,
+    SidebarOrientation::Stacked,
+    "live config updated"
+  );
+  assert_eq!(
+    app.sidebar.orientation, app.config.tui.sidebar_orientation,
+    "live sidebar orientation re-seeded from the edited config"
+  );
+
+  let written = std::fs::read_to_string(dir.path().join(".gwm.toml")).unwrap();
+  assert!(
+    written.contains("sidebar_orientation"),
+    "edit persisted to .gwm.toml: {written}"
+  );
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(
+    cfg.tui.sidebar_orientation, app.config.tui.sidebar_orientation,
+    "edit round-trips through a fresh layered load"
+  );
+}
+
+#[test]
+fn committing_numeric_input_persists_the_typed_value() {
+  use gwm::config::Config;
+  use gwm::tui::{SettingField, SettingsTab};
+
+  let (dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Tui;
+  app.config_panel.selected = tui_field_index(SettingField::ConfirmCountdown);
 
   // Arm the input, retype "5", commit.
   app.activate_selected_setting();
@@ -7060,12 +7144,12 @@ fn committing_numeric_input_persists_the_typed_value() {
 #[test]
 fn committing_auto_refresh_secs_persists_the_typed_value() {
   use gwm::config::Config;
-  use gwm::tui::SettingsTab;
+  use gwm::tui::{SettingField, SettingsTab};
 
   let (dir, mut app) = make_app();
   app.enter_config_panel();
   app.config_panel.tab = SettingsTab::Tui;
-  app.config_panel.selected = 3; // auto refresh (Uint input)
+  app.config_panel.selected = tui_field_index(SettingField::AutoRefreshSecs);
 
   app.activate_selected_setting();
   assert!(

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -12,6 +12,18 @@ use gwm::tui::keymap::{Action, KeyStroke, Keymap};
 use gwm::tui::modal_keymap::{ModalAction, ModalKeymap};
 use gwm::tui::{build_key_rows, ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer, SettingsTab};
 
+/// Index of `field` within the Settings TUI tab. Looked up rather than
+/// hardcoded: inserting a field (as #365 did with `sidebar_orientation`)
+/// shifts every literal index below it, silently pointing these tests at
+/// the wrong row.
+fn tui_idx(field: SettingField) -> usize {
+  SettingsTab::Tui
+    .fields()
+    .iter()
+    .position(|f| *f == field)
+    .unwrap_or_else(|| panic!("{field:?} is not exposed in the Settings TUI tab"))
+}
+
 fn sample_row() -> ConfigRow {
   ConfigRow {
     key: "worktree.base".into(),
@@ -132,7 +144,7 @@ fn prev_tab_wraps_backwards() {
 fn switching_tab_resets_selection_and_edit_buffer() {
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  panel.selected = tui_idx(SettingField::ConfirmCountdown);
   panel.editing = Some("4".into());
   panel.next_tab();
   assert_eq!(panel.selected, 0, "selection resets on tab change");
@@ -144,9 +156,12 @@ fn selected_field_follows_the_tab() {
   let mut panel = ConfigPanel::new();
   // Theme tab → theme preset.
   assert_eq!(panel.selected_field(), Some(SettingField::ThemePreset));
-  // Tui tab → sidebar / open / countdown / auto refresh in order.
+  // Tui tab → sidebar position / sidebar layout / open / countdown / auto
+  // refresh in order.
   panel.tab = SettingsTab::Tui;
   assert_eq!(panel.selected_field(), Some(SettingField::SidebarPosition));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::SidebarOrientation));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::OpenMode));
   panel.select_next();
@@ -162,11 +177,12 @@ fn selected_field_follows_the_tab() {
 #[test]
 fn select_next_clamps_to_the_last_field() {
   let mut panel = ConfigPanel::new();
-  panel.tab = SettingsTab::Tui; // 6 fields
-  for _ in 0..10 {
+  panel.tab = SettingsTab::Tui;
+  let last = SettingsTab::Tui.fields().len() - 1;
+  for _ in 0..(last + 5) {
     panel.select_next();
   }
-  assert_eq!(panel.selected, 5, "never selects past the last field");
+  assert_eq!(panel.selected, last, "never selects past the last field");
 }
 
 #[test]
@@ -189,7 +205,7 @@ fn begin_edit_only_arms_for_a_uint_field() {
   assert!(panel.editing.is_none(), "choice fields are not text-edited");
   // Confirm countdown is a Uint → arms the buffer.
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  panel.selected = tui_idx(SettingField::ConfirmCountdown);
   assert_eq!(panel.selected_field().map(SettingField::kind), Some(FieldKind::Uint));
   panel.begin_edit("4");
   assert_eq!(panel.editing.as_deref(), Some("4"));
@@ -199,7 +215,7 @@ fn begin_edit_only_arms_for_a_uint_field() {
 fn edit_buffer_takes_digits_only_and_commits() {
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  panel.selected = tui_idx(SettingField::ConfirmCountdown);
   panel.begin_edit("");
   panel.push_edit_char('3');
   panel.push_edit_char('x'); // ignored — not a digit
@@ -215,7 +231,7 @@ fn edit_buffer_takes_digits_only_and_commits() {
 fn auto_refresh_secs_accepts_four_plus_digit_intervals() {
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 3;
+  panel.selected = tui_idx(SettingField::AutoRefreshSecs);
   assert_eq!(panel.selected_field(), Some(SettingField::AutoRefreshSecs));
   assert_eq!(panel.selected_field().map(SettingField::kind), Some(FieldKind::Uint));
   panel.begin_edit("");
@@ -231,7 +247,7 @@ fn take_edit_returns_the_raw_buffer() {
   // empty numeric buffer to "0" (an empty text buffer stays empty).
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  panel.selected = tui_idx(SettingField::ConfirmCountdown);
   panel.begin_edit("");
   assert_eq!(
     panel.take_edit().as_deref(),
@@ -259,7 +275,7 @@ fn text_fields_accept_non_digit_characters() {
 fn cancel_edit_discards_the_buffer() {
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  panel.selected = tui_idx(SettingField::ConfirmCountdown);
   panel.begin_edit("4");
   panel.push_edit_char('2');
   panel.cancel_edit();
@@ -428,10 +444,11 @@ fn switching_tab_clears_an_armed_capture() {
 fn select_is_inert_while_editing() {
   let mut panel = ConfigPanel::new();
   panel.tab = SettingsTab::Tui;
-  panel.selected = 2;
+  let armed = tui_idx(SettingField::ConfirmCountdown);
+  panel.selected = armed;
   panel.begin_edit("4");
   panel.select_prev();
-  assert_eq!(panel.selected, 2, "navigation is suppressed while typing");
+  assert_eq!(panel.selected, armed, "navigation is suppressed while typing");
 }
 
 #[test]

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -499,3 +499,84 @@ fn field_source_is_looked_up_from_the_resolved_rows() {
   // A field absent from the rows resolves to no source.
   assert_eq!(panel.field_source(SettingField::OpenMode), None);
 }
+
+// ---------------------------------------------------------------------------
+// Choice sets vs the enums they mirror (#365 follow-up)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_choice_is_a_value_the_config_can_load_back() {
+  // The Settings panel writes the selected choice string verbatim into
+  // `.gwm.toml`. So every string it can offer must round-trip through a real
+  // layered load — a choice list that drifts from its enum's serde spelling
+  // would let the panel write a file that no longer parses, and the user only
+  // finds out on the next launch.
+  //
+  // Covers every Choice field, not just the sidebar ones: the choice lists are
+  // hand-maintained constants sitting next to the enums, and this is the
+  // property that actually matters for all of them.
+  let dir = tempfile::TempDir::new().unwrap();
+  for field in [
+    SettingField::SidebarPosition,
+    SettingField::SidebarOrientation,
+    SettingField::OpenMode,
+  ] {
+    let key = field.key_path();
+    assert!(!field.choices().is_empty(), "{key} is a Choice field with choices");
+    for choice in field.choices() {
+      let (table, name) = key.split_once('.').unwrap();
+      let toml = match table {
+        "tui" => format!("[tui]\n{name} = \"{choice}\"\n"),
+        _ => format!("[{table}]\n{name} = \"{choice}\"\n"),
+      };
+      std::fs::write(dir.path().join(".gwm.toml"), &toml).unwrap();
+      let cfg = Config::load_layered(dir.path(), None)
+        .unwrap_or_else(|e| panic!("choice {choice:?} for {key} must be loadable, got: {e}"));
+      assert_eq!(
+        field.current(&cfg),
+        *choice,
+        "{key}: writing choice {choice:?} must read back as itself"
+      );
+    }
+  }
+}
+
+#[test]
+fn sidebar_choice_lists_cover_every_variant() {
+  // The other drift direction: the choice list and `ALL` disagreeing — a
+  // variant offered by one but not the other. The round-trip test above only
+  // walks the list, so it cannot see a variant the list omits.
+  //
+  // Honest limit: this pins list ↔ `ALL`, not `ALL` ↔ the enum. A variant added
+  // to the enum but left out of `ALL` still slips past both tests. What stops
+  // that is the exhaustive `match` in `label()`, which fails to compile on a new
+  // variant and forces a visit to the `ALL` right above it. Closing the gap
+  // properly would need a derive (strum); not worth a dependency for two enums.
+  use gwm::config::{SidebarOrientation, SidebarPosition};
+
+  for o in SidebarOrientation::ALL {
+    assert!(
+      SettingField::SidebarOrientation.choices().contains(&o.label()),
+      "{o:?} ({}) is missing from the sidebar orientation choices",
+      o.label()
+    );
+  }
+  assert_eq!(
+    SettingField::SidebarOrientation.choices().len(),
+    SidebarOrientation::ALL.len(),
+    "no stale choice left behind"
+  );
+
+  for p in SidebarPosition::ALL {
+    assert!(
+      SettingField::SidebarPosition.choices().contains(&p.label()),
+      "{p:?} ({}) is missing from the sidebar position choices",
+      p.label()
+    );
+  }
+  assert_eq!(
+    SettingField::SidebarPosition.choices().len(),
+    SidebarPosition::ALL.len(),
+    "no stale choice left behind"
+  );
+}

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -133,6 +133,53 @@ fn sync_active_repo_reresolves_branch_types_from_the_selected_repo() {
 }
 
 #[test]
+fn sync_active_repo_reapplies_both_sidebar_knobs_from_the_selected_repo() {
+  // Codex review #366 P2: `sync_active_repo` swapped `self.config` but left the
+  // live sidebar on the previous repo's layout, so a per-repo `[tui]` sidebar
+  // override was ignored until a reload or relaunch. The finding named
+  // `sidebar_orientation` (#365, new); `sidebar_position` had the identical hole
+  // since workspace mode landed (#36). Both are pinned here — the fix is one
+  // shared apply, so one test guards both against drift.
+  use gwm::config::{SidebarOrientation, SidebarPosition};
+
+  let root = TempDir::new().unwrap();
+  init_repo_at(&root.path().join("alpha"));
+  init_repo_at(&root.path().join("beta"));
+  fs::write(
+    root.path().join("beta").join(".gwm.toml"),
+    "[tui]\nsidebar_orientation = \"side-by-side\"\nsidebar_position = \"left\"\n",
+  )
+  .unwrap();
+
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  // alpha (row 0) has no override → the built-in defaults.
+  assert_eq!(app.sidebar.orientation, SidebarOrientation::Stacked);
+  assert_eq!(app.sidebar.position, SidebarPosition::Right);
+
+  let last = app.worktrees.len() - 1; // beta's main
+  app.list_state.select(Some(last));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "beta", "swapped to beta");
+  assert_eq!(
+    app.sidebar.orientation,
+    SidebarOrientation::SideBySide,
+    "orientation follows the newly-active repo's config"
+  );
+  assert_eq!(
+    app.sidebar.position,
+    SidebarPosition::Left,
+    "position follows the newly-active repo's config"
+  );
+
+  // ...and swapping back restores alpha's defaults rather than sticking on beta.
+  app.list_state.select(Some(0));
+  app.sync_active_repo();
+  assert_eq!(app.repo_name, "alpha", "swapped back to alpha");
+  assert_eq!(app.sidebar.orientation, SidebarOrientation::Stacked);
+  assert_eq!(app.sidebar.position, SidebarPosition::Right);
+}
+
+#[test]
 fn failed_repo_activation_marks_the_selection_stale_then_recovers() {
   // A repo that was listed but then vanished on disk must not silently leave
   // the active context pointing at the previous repo: the selection is flagged


### PR DESCRIPTION
## Description

`[tui] sidebar_position` (`left`/`right`) is persisted; the sidebar **orientation** (`auto` / `side-by-side` / `stacked`) was not. It lived only in `SidebarState::orientation`, cycled at runtime, and reset on every launch — so a user who prefers side-by-side had to press the key every single time. This adds `[tui] sidebar_orientation`, wired end to end.

First half of #363 (reported by @thachck). OSC52-over-SSH is the other half and lands separately.

Closes #365

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **`SidebarOrientation` moves to `config`**, next to `SidebarPosition` / `MacroOpenMode` / `TuiOpenMode`, and derives serde. `tui::state::sidebar` re-exports it, so existing paths keep resolving.
- **`rename_all = "kebab-case"`, deliberately not `lowercase`** — the latter spells `SideBySide` as `sidebyside`, the exact trap `MacroOpenMode` hit on PR #292. It also keeps the serialised form equal to `label()`, so a Settings-panel write-back produces a file that still loads. A test pins that round-trip.
- **Seeded at both sites `sidebar_position` uses**: `App` construction and the config-reload path. Missing the second would make the key work at launch but not on reload.
- **Exposed in the Settings panel** (TUI tab) next to `sidebar position`.
- **Default stays `stacked`** (the #217 launch layout) — see the note below.
- Docs EN + FR, `examples/gwm.toml.example`, CHANGELOG.

## Tests

- [x] `cargo test` passes locally — 1913 tests, 0 failures
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: written red first, they failed on the missing field before the wiring existed)
- [x] `gwm doctor` green

Verified end-to-end against a throwaway repo with the built binary, not just the suite:

```
$ gwm config get tui.sidebar_orientation      # with side-by-side set
side-by-side
$ gwm config get tui.sidebar_orientation      # key absent
stacked
$ gwm config set tui.sidebar_orientation auto && gwm config get tui.sidebar_orientation
auto
$ gwm config validate                          # sidebar_orientation = "diagonal"
error: unknown variant `diagonal`, expected one of `auto`, `side-by-side`, `stacked`   # exit 1
$ gwm config validate                          # sidebar_orientation = "sidebyside"
error: unknown variant `sidebyside`, expected one of `auto`, `side-by-side`, `stacked` # exit 1
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — n/a, no CLI surface change
- [x] `examples/gwm.toml.example` updated (config schema changed)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Notes for reviewers

Two things worth a look:

**The default was nearly a silent regression.** The `SidebarState::orientation` doc-comment said *"Defaults to `SidebarOrientation::Auto`"*. It has actually been `Stacked` since #217 — the comment went stale and never got fixed. Seeding the config default from that comment would have flipped every user's launch layout from stacked to auto inside a PR advertised as "just make it configurable". `#[serde(default)]` resolves through the enum's real `#[default]`, `tui_sidebar_orientation_defaults_to_stacked` pins it, and the comment is corrected.

**Nine tests were silently pointing at the wrong row.** Inserting `SidebarOrientation` into the Settings TUI tab shifted every literal `panel.selected = N` below it — two tests failed loudly, seven more in a second file were asserting against rows that had moved. Rebumping the constants would have re-armed the trap for whoever adds the next field, so they now look the index up by `SettingField` (`tui_idx` helper), and the clamp test derives its bound from `fields().len()` instead of a hardcoded `5`. That is why the test diff is larger than the feature diff.

## Linked issues / docs

- Issue: #365
- Umbrella: #363