### PR TITLE
✨ feat(tui): OSC52 clipboard so yanking works over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`[tui] clipboard` — OSC52 so yanking works over SSH** (#367, part of #363,
+  reported by [@thachck](https://github.com/thachck)). The host clipboard tools
+  write to the clipboard of the machine gwm runs on; over SSH that failed
+  *silently* — `pbcopy` on a remote macOS host is found, succeeds, and gwm
+  reported success while the text was unreachable. `auto` (the default) now
+  emits an OSC52 escape sequence when an SSH session is detected, handing the
+  text to the terminal emulator instead; `osc52` and `tools` force either path.
+  Under tmux the sequence is wrapped in DCS passthrough (requires
+  `allow-passthrough on`); inside GNU screen gwm falls back to the host tools
+  rather than emit a sequence screen would swallow. Oversized payloads are
+  refused rather than truncated into a corrupt paste.
+
 - **`[tui] sidebar_orientation` — persist the sidebar layout** (#365, part of
   #363, reported by [@thachck](https://github.com/thachck)). The orientation
   (`auto` / `side-by-side` / `stacked`) was runtime-only and reset on every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,10 @@ daemon = []
 clap = { version = "4.5", features = ["derive", "color"] }
 clap_complete = "4.5"
 ratatui = "0.30"
-crossterm = "0.29"
+# `osc52` pulls crossterm's `clipboard` module (`CopyToClipboard`) and, with it,
+# base64 — the encoder OSC52 needs. Using the framing crossterm already ships,
+# and which its own tests pin, beats hand-rolling the sequence here (#367).
+crossterm = { version = "0.29", features = ["osc52"] }
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -252,6 +252,10 @@ sidebar_position = "right"
 # "side-by-side", or "auto" (width-driven). Cycle it live with `Space`.
 sidebar_orientation = "stacked"
 
+# How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
+# otherwise), "osc52", or "tools".
+clipboard = "auto"
+
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
 # Issue/PR table state reasonably fresh; set to 0 to disable the auto-refresh
 # loop entirely (you can still refresh on demand with the `refresh` key).
@@ -269,6 +273,22 @@ auto_refresh_secs = 60
 | `"auto"` | Side-by-side at `>= 120` columns, stacked below that. |
 
 `Space` cycles it live (`auto` → side-by-side → stacked → `auto`). Before #365 that live choice was runtime-only and reset on every launch; setting the key here makes it stick. An unknown value is a **hard config error at load time**. It is also exposed in the Settings panel under the **TUI** tab.
+
+`clipboard` (issue #367) selects how yanked text — path, branch, worktree name, command logs — reaches the clipboard:
+
+| Value | Behaviour |
+|:------|:----------|
+| `"auto"` | **Default.** OSC52 when `$SSH_TTY` or `$SSH_CONNECTION` is set, host tools otherwise. |
+| `"osc52"` | Always emit the OSC52 escape sequence. |
+| `"tools"` | Always use `pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip.exe`. |
+
+The host tools write to the clipboard of the machine gwm runs on. Over SSH that is the wrong one, and it fails *silently*: on a remote macOS host `pbcopy` exists, succeeds, and gwm reports `yanked branch name (pbcopy)` while your actual clipboard is untouched. OSC52 hands the text to your terminal emulator, which owns the clipboard you paste from. An unknown value is a **hard config error at load time**. Also exposed in the Settings panel under the **TUI** tab.
+
+Three caveats, all rooted in the fact that **OSC52 is never acknowledged** — gwm can report that it emitted the sequence, never that the terminal took it:
+
+- **tmux** needs `set -g allow-passthrough on`. gwm wraps the sequence in DCS passthrough, but the option is off by default since tmux 3.3 and gwm cannot detect or enable it.
+- **GNU screen** (`$STY`) gets the host tools instead: screen needs its own chunked form, and an unwrapped sequence there is silently swallowed. Falling back is the honest failure.
+- **Terminal support varies** — kitty, WezTerm, Alacritty and iTerm2 (with the setting enabled) honour OSC52; Terminal.app does not. `"tools"` is the escape hatch. It is also the answer for a stale `$SSH_CONNECTION` in a tmux pane, which can make `auto` guess wrong.
 
 `auto_refresh_secs` (issue #285) drives a periodic background refresh of the worktree list so the Issue/PR table state stays current without a manual keystroke. It is a non-negative integer count of seconds; the default is `60` and `0` disables the loop. It is also exposed in the Settings panel under the **TUI** tab.
 
@@ -738,6 +758,7 @@ Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` 
 | `[tui].confirm_countdown_secs`       | `3`                              |
 | `[tui].sidebar_position`             | `right`                          |
 | `[tui].sidebar_orientation`          | `stacked`                        |
+| `[tui].clipboard`                    | `auto`                           |
 | `[tui].auto_refresh_secs`            | `60` (`0` disables)              |
 | `[tui.macro1]` / `[tui.macro2]`      | absent — `h` / `H` are no-ops    |
 | `[tui.keys]`                         | built-in keymap (see table above) |
@@ -753,7 +774,7 @@ Single-pass expansion — `wip = "ll"` followed by `ll = "list --format names"` 
 ## validation rules
 
 - Unknown TOML keys are a **hard load error** — the root `[Config]` table and nearly every sub-table (`[worktree]`, `[bootstrap]`, `[hooks]`, `[doctor]`, `[tui]`, `[tui.open]`, `[git_tui]`, `[review]`, `[[labels]]`, `[[milestones]]`, `[[branch_types]]`, `[issue_template]`, `[pr_template]`) reject fields they don't recognise. A stray top-level key (or an unknown key inside a deny-fields table) fails the load with a `Config` error rather than being ignored. The same check runs on the merged result, so a typo in the global `~/.config/gwm/config.toml` fails just as hard. Exceptions: `[theme]` flattens per-role overrides (arbitrary role-named keys are accepted, then validated against the known role set — see below), and `[gitmoji]` / `[aliases]` are open key→value maps.
-- Unknown `[tui.open].mode`, `[tui].sidebar_position` and `[tui].sidebar_orientation` values **error at load time**.
+- Unknown `[tui.open].mode`, `[tui].sidebar_position`, `[tui].sidebar_orientation` and `[tui].clipboard` values **error at load time**.
 - `[theme]` errors at load on an unknown `preset`, unknown role key, or unparsable colour value.
 - `[tui.keys]` errors at load on an unknown action, an unparsable chord, a chord conflict, or a prefix collision.
 - `[tui.keys.modal.*]` errors at load on an unknown context, an unknown verb, an unparsable or multi-stroke key, binding under a context group instead of a leaf stage, or a per-context conflict.

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -252,6 +252,10 @@ sidebar_position = "right"
 # "side-by-side", or "auto" (width-driven). Cycle it live with `Space`.
 sidebar_orientation = "stacked"
 
+# How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
+# otherwise), "osc52", or "tools".
+clipboard = "auto"
+
 # Periodic worktree-list refresh interval, in seconds. Default 60 keeps the
 # Issue/PR table state reasonably fresh; set to 0 to disable the auto-refresh
 # loop entirely (you can still refresh on demand with the `refresh` key).
@@ -269,6 +273,22 @@ auto_refresh_secs = 60
 | `"auto"` | Côte-à-côte à partir de `120` colonnes, empilé en dessous. |
 
 `Space` la fait cycler en direct (`auto` → côte-à-côte → empilé → `auto`). Avant #365, ce choix en direct était runtime-only et repartait à zéro à chaque lancement ; renseigner la clé ici le rend persistant. Une valeur inconnue est une **erreur de config dure au moment du chargement**. Elle est aussi exposée dans le panneau Settings, sous l'onglet **TUI**.
+
+`clipboard` (issue #367) choisit comment le texte yanké — chemin, branche, nom de worktree, logs de commandes — atteint le presse-papier :
+
+| Valeur | Comportement |
+|:-------|:-------------|
+| `"auto"` | **Défaut.** OSC52 quand `$SSH_TTY` ou `$SSH_CONNECTION` est défini, outils hôte sinon. |
+| `"osc52"` | Émet toujours la séquence d'échappement OSC52. |
+| `"tools"` | Utilise toujours `pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip.exe`. |
+
+Les outils hôte écrivent dans le presse-papier de la machine où tourne gwm. En SSH c'est le mauvais, et l'échec est *silencieux* : sur un hôte macOS distant, `pbcopy` existe, réussit, et gwm affiche `yanked branch name (pbcopy)` alors que votre presse-papier réel n'a pas bougé. OSC52 confie le texte à votre émulateur de terminal, qui possède le presse-papier dans lequel vous collez. Une valeur inconnue est une **erreur de config dure au moment du chargement**. Également exposé dans le panneau Settings, sous l'onglet **TUI**.
+
+Trois réserves, toutes dues au fait qu'**OSC52 n'est jamais acquitté** — gwm peut signaler qu'il a émis la séquence, jamais que le terminal l'a acceptée :
+
+- **tmux** exige `set -g allow-passthrough on`. gwm encapsule la séquence en DCS passthrough, mais l'option est désactivée par défaut depuis tmux 3.3 et gwm ne peut ni la détecter ni l'activer.
+- **GNU screen** (`$STY`) reçoit les outils hôte à la place : screen réclame sa propre forme découpée, et une séquence non encapsulée y est avalée en silence. Se rabattre est l'échec honnête.
+- **Le support varie selon le terminal** — kitty, WezTerm, Alacritty et iTerm2 (option activée) honorent OSC52 ; Terminal.app non. `"tools"` est la porte de sortie. C'est aussi la réponse à un `$SSH_CONNECTION` périmé dans un pane tmux, qui peut faire deviner faux à `auto`.
 
 `auto_refresh_secs` (issue #285) pilote un rafraîchissement périodique en arrière-plan de la liste des worktrees pour que l'état de la table Issue/PR reste à jour sans frappe manuelle. C'est un entier positif ou nul en secondes ; la valeur par défaut est `60` et `0` désactive la boucle. Il est aussi exposé dans le panneau Settings, sous l'onglet **TUI**.
 
@@ -752,7 +772,7 @@ Expansion en une seule passe — `wip = "ll"` suivi de `ll = "list --format name
 ## règles de validation
 
 - Les clés TOML inconnues sont une **erreur de chargement dure** — la table racine `[Config]` et presque toutes les sous-tables (`[worktree]`, `[bootstrap]`, `[hooks]`, `[doctor]`, `[tui]`, `[tui.open]`, `[git_tui]`, `[review]`, `[[labels]]`, `[[milestones]]`, `[[branch_types]]`, `[issue_template]`, `[pr_template]`) rejettent les champs qu'elles ne reconnaissent pas. Une clé errante au niveau racine (ou une clé inconnue dans une table à champs interdits) fait échouer le chargement avec une erreur `Config` au lieu d'être ignorée. Le même check s'exécute sur le résultat fusionné, donc une coquille dans le `~/.config/gwm/config.toml` global échoue tout aussi durement. Exceptions : `[theme]` aplatit les surcharges par rôle (les clés arbitraires nommées d'après un rôle sont acceptées, puis validées face au jeu de rôles connus — voir ci-dessous), et `[gitmoji]` / `[aliases]` sont des maps ouvertes clé→valeur.
-- Les valeurs inconnues de `[tui.open].mode` et `[tui].sidebar_position` **erreurent au chargement**.
+- Les valeurs inconnues de `[tui.open].mode`, `[tui].sidebar_position`, `[tui].sidebar_orientation` et `[tui].clipboard` **erreurent au chargement**.
 - `[theme]` erreure au chargement sur un `preset` inconnu, une clé de rôle inconnue, ou une valeur de couleur non parsable.
 - `[tui.keys]` erreure au chargement sur une action inconnue, un chord non parsable, un conflit de chord, ou une collision de préfixe.
 - `[tui.keys.modal.*]` erreure au chargement sur un contexte inconnu, un verbe inconnu, une touche non parsable ou multi-frappes, un binding sous un groupe de contexte au lieu d'une étape feuille, ou un conflit par contexte.

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -251,6 +251,29 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # sidebar_position    = "left"
 # sidebar_orientation = "side-by-side"
 
+# --- TUI clipboard (issue #367) ----------------------------------------------
+# How yanked text (path / branch / worktree name / command logs) reaches the
+# clipboard:
+#   "auto"   OSC52 when an SSH session is detected, host tools otherwise (default)
+#   "osc52"  always emit the OSC52 escape sequence
+#   "tools"  always use pbcopy / wl-copy / xclip / xsel / clip.exe
+#
+# Why "auto" matters over SSH: the host tools write to the clipboard of the
+# machine gwm runs on. On a remote host `pbcopy` is found, succeeds, and reports
+# success — while the text lands in the *remote* clipboard, out of reach. OSC52
+# hands the text to your terminal emulator instead.
+#
+# Caveats, because OSC52 is never acknowledged by the terminal:
+#   - Under tmux, gwm wraps the sequence in DCS passthrough, but tmux needs
+#     `set -g allow-passthrough on` (off by default since tmux 3.3).
+#   - Inside GNU screen ($STY), gwm falls back to the host tools rather than
+#     emit a sequence screen would silently swallow.
+#   - Terminal support varies (kitty / WezTerm / Alacritty / iTerm2 yes,
+#     Terminal.app no). Use "tools" if your terminal drops it.
+#
+# [tui]
+# clipboard = "auto"
+
 # --- TUI keymap: `[tui.keys]` (issues #87 / #219 / #294) ---------------------
 # Remap any TUI key. An override REPLACES the default for that verb; an empty
 # array unbinds it. Run `gwm tui keys` for the full list of actions, contexts,

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,135 @@
+//! Clipboard routing (issue #367): decide whether yanked text goes to the
+//! host clipboard binaries or to the terminal via an OSC52 escape sequence,
+//! and build the exact bytes for the OSC52 path.
+//!
+//! # Why this exists
+//!
+//! [`crate::tui::clipboard_candidates`] shells out to `pbcopy` / `wl-copy` /
+//! `xclip` / `clip.exe`. Those write to the clipboard of the machine gwm runs
+//! on. Over SSH that is the wrong machine — and the failure is silent rather
+//! than loud: on a remote macOS host `pbcopy` exists, runs, exits 0, so gwm
+//! reports `yanked branch name (pbcopy)` while the user's actual clipboard is
+//! untouched. OSC52 hands the text to the terminal emulator instead, which is
+//! the process that owns the clipboard the user pastes from.
+//!
+//! # Purity
+//!
+//! [`plan_clipboard_write`] takes the environment (SSH, tmux, screen) as
+//! parameters rather than reading `std::env` itself, mirroring
+//! [`crate::multiplexer::detect_tmux`]. The whole decision matrix is then
+//! unit-testable without an SSH session or a live multiplexer — which matters
+//! more than usual here, because OSC52 has no acknowledgement: a wrong
+//! sequence cannot be caught at runtime, only printed as garbage.
+//!
+//! # Known limits (not bugs — inherent to OSC52)
+//!
+//! - **No confirmation.** Nothing reports back whether the terminal accepted
+//!   the sequence. A success message means "emitted", not "copied".
+//! - **tmux needs `allow-passthrough`.** Off by default since tmux 3.3. The
+//!   DCS wrapper below is necessary but not sufficient; the user must enable
+//!   the option. gwm cannot detect or force this.
+//! - **Terminal support varies.** kitty, WezTerm, Alacritty and iTerm2 (with
+//!   the setting on) honour OSC52; Terminal.app does not. Hence
+//!   [`ClipboardMode::Tools`] as an escape hatch.
+
+use crate::config::ClipboardMode;
+use crossterm::clipboard::CopyToClipboard;
+use crossterm::Command;
+
+/// Maximum input length, in bytes, gwm will put in an OSC52 sequence.
+///
+/// Terminals cap the length they will accept and the ceiling is not
+/// standardised — 100k is a common one, several are far lower. This is a
+/// deliberately conservative bound on the *input*: base64 inflates by 4/3, so
+/// 64 KiB of text becomes ~87k of sequence, which stays under the usual caps.
+///
+/// The alternative to a ceiling is emitting a sequence the terminal truncates,
+/// which pastes as corrupt text or swallows subsequent output. Refusing is the
+/// honest failure — the Command Logs copy can realistically reach this size.
+pub const MAX_OSC52_BYTES: usize = 64 * 1024;
+
+/// What the caller should do to put the text on the clipboard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardPlan {
+  /// Write these exact bytes to the terminal. Already framed, and already
+  /// wrapped for the multiplexer when one was detected.
+  Osc52(Vec<u8>),
+  /// Use the host binaries ([`crate::tui::clipboard_candidates`]).
+  Tools,
+  /// The text is too long for an OSC52 sequence. Carries the input length so
+  /// the caller can say so; `bytes` is the input, not the encoded size.
+  TooLarge { bytes: usize },
+}
+
+/// Decide how to copy `text`, and build the sequence when the answer is OSC52.
+///
+/// `is_ssh` / `in_tmux` / `in_screen` are injected (see the module note). The
+/// caller derives them from `$SSH_TTY`/`$SSH_CONNECTION`, `$TMUX` and `$STY`.
+pub fn plan_clipboard_write(
+  text: &str,
+  mode: ClipboardMode,
+  is_ssh: bool,
+  in_tmux: bool,
+  in_screen: bool,
+) -> ClipboardPlan {
+  let wants_osc52 = match mode {
+    ClipboardMode::Tools => false,
+    ClipboardMode::Osc52 => true,
+    ClipboardMode::Auto => is_ssh,
+  };
+  if !wants_osc52 {
+    return ClipboardPlan::Tools;
+  }
+
+  // GNU screen wants its own chunked DCS form, with a per-sequence length limit
+  // well below tmux's. An unwrapped sequence inside screen is silently eaten,
+  // so the user would get a success message and an empty clipboard. Degrading
+  // to the host tools is the honest option: they either work, or report a real
+  // error. Doing screen properly is a follow-up, not a silent half-measure.
+  if in_screen {
+    return ClipboardPlan::Tools;
+  }
+
+  if text.len() > MAX_OSC52_BYTES {
+    return ClipboardPlan::TooLarge { bytes: text.len() };
+  }
+
+  let mut seq = String::new();
+  // Framing (`\x1b]52;c;<base64>\x1b\\`) comes from crossterm's own
+  // `CopyToClipboard`, whose tests pin those bytes — no reason to hand-roll it,
+  // or the base64, here. `write_ansi` renders into a buffer rather than the
+  // terminal, which is what keeps this function pure.
+  if CopyToClipboard::to_clipboard_from(text).write_ansi(&mut seq).is_err() {
+    // Writing into a String cannot fail in practice; fall back to the tools
+    // rather than unwrap on a user-facing path (CLAUDE.md).
+    return ClipboardPlan::Tools;
+  }
+
+  let bytes = if in_tmux {
+    wrap_tmux_passthrough(&seq)
+  } else {
+    seq.into_bytes()
+  };
+  ClipboardPlan::Osc52(bytes)
+}
+
+/// Wrap `seq` in tmux's DCS passthrough so tmux forwards it to the outer
+/// terminal instead of interpreting it: `\x1bPtmux;<seq with ESC doubled>\x1b\\`.
+///
+/// Every ESC inside the payload must be doubled — the OSC52 sequence has two
+/// (the `\x1b]` introducer and the `\x1b\\` terminator).
+///
+/// Requires `set -g allow-passthrough on` in the user's tmux config; it is off
+/// by default since tmux 3.3 and nothing here can change that.
+fn wrap_tmux_passthrough(seq: &str) -> Vec<u8> {
+  let mut out = Vec::with_capacity(seq.len() + 16);
+  out.extend_from_slice(b"\x1bPtmux;");
+  for b in seq.bytes() {
+    if b == 0x1b {
+      out.push(0x1b);
+    }
+    out.push(b);
+  }
+  out.extend_from_slice(b"\x1b\\");
+  out
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -519,6 +519,50 @@ impl SidebarPosition {
   }
 }
 
+/// How the TUI puts yanked text on the clipboard (issue #367).
+///
+/// The host binaries (`pbcopy`, `wl-copy`, `xclip`, …) write to the
+/// clipboard of the machine gwm runs on. Over SSH that is the *remote*
+/// machine: `pbcopy` is found, succeeds, reports success — and the text is
+/// unreachable from the user's actual desktop. OSC52 instead hands the text
+/// to the terminal emulator, which owns the real clipboard.
+///
+/// `lowercase` is enough here (unlike [`SidebarOrientation`]): every variant
+/// is a single word, so there is no `sidebyside`-style trap to dodge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardMode {
+  /// OSC52 when an SSH session is detected, host tools otherwise. Default:
+  /// fixes the SSH case with no configuration, and keeps the host tools
+  /// (which are universally supported) for the local case.
+  #[default]
+  Auto,
+  /// Always emit the OSC52 escape sequence. For local terminals that support
+  /// it, or when the host tools are unwanted.
+  Osc52,
+  /// Always use the host binaries — the pre-#367 behaviour. The escape hatch
+  /// when a terminal mangles or ignores OSC52, and for `$SSH_*` false
+  /// positives (a tmux pane can carry a stale `SSH_CONNECTION`).
+  Tools,
+}
+
+impl ClipboardMode {
+  /// Every variant, in Settings-panel cycle order (default first).
+  /// Keep in sync when adding a variant — the exhaustive `match` in
+  /// [`Self::label`] is what fails to compile and brings you here.
+  pub const ALL: [ClipboardMode; 3] = [ClipboardMode::Auto, ClipboardMode::Osc52, ClipboardMode::Tools];
+
+  /// Status-bar label, equal to the serialised TOML spelling. `const` so the
+  /// Settings-panel choice list is derived from this `match` (#365).
+  pub const fn label(self) -> &'static str {
+    match self {
+      ClipboardMode::Auto => "auto",
+      ClipboardMode::Osc52 => "osc52",
+      ClipboardMode::Tools => "tools",
+    }
+  }
+}
+
 /// How the sidebar is arranged relative to the worktree table (issue
 /// #188). Cycled live with `cycle_sidebar_layout`; seeded from
 /// `[tui] sidebar_orientation` since #365, which is why the enum lives
@@ -667,6 +711,13 @@ pub struct TuiConfig {
   #[serde(default)]
   pub sidebar_orientation: SidebarOrientation,
 
+  /// How yanked text reaches the clipboard (issue #367): `auto` (OSC52 over
+  /// SSH, host tools otherwise), `osc52`, or `tools`. Default `auto` fixes
+  /// yanking over SSH — where `pbcopy` & co. silently write to the *remote*
+  /// clipboard — without needing configuration.
+  #[serde(default)]
+  pub clipboard: ClipboardMode,
+
   /// `[tui.keys]` sub-table (issue #87) — user overrides for the
   /// remappable keymap. Absent → keymap stays at the built-in
   /// defaults. Present → every listed action *replaces* its default
@@ -694,6 +745,7 @@ impl Default for TuiConfig {
       open: TuiOpenConfig::default(),
       sidebar_position: SidebarPosition::default(),
       sidebar_orientation: SidebarOrientation::default(),
+      clipboard: ClipboardMode::default(),
       keys: TuiKeysConfig::default(),
       macro1: None,
       macro2: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod aliases;
 pub mod bootstrap;
 pub mod clean;
 pub mod cli;
+pub mod clipboard;
 pub mod command_log;
 pub mod config;
 pub mod config_cli;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1270,10 +1270,12 @@ fn copy_text_to_clipboard(app: &mut App, text: &str, success: &str) {
     }
     ClipboardPlan::TooLarge { bytes } => {
       // Refuse rather than emit a sequence the terminal will truncate into
-      // corrupt paste content.
+      // corrupt paste content. Round the reported size *up*: truncating
+      // division renders 65_537 bytes as "64 KiB > 64 KiB", which reads as a
+      // bug in the check rather than as a reason for the refusal.
       app.status = format!(
         "too large for osc52 ({} KiB > {} KiB) — set [tui] clipboard = \"tools\"",
-        bytes / 1024,
+        bytes.div_ceil(1024),
         crate::clipboard::MAX_OSC52_BYTES / 1024
       );
       return;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1233,14 +1233,54 @@ fn copy_command_logs_to_clipboard(app: &mut App) {
   copy_text_to_clipboard(app, &text, "copied command logs");
 }
 
-/// Feed `text` to the first available clipboard tool from
-/// [`clipboard_candidates`]. Walks the candidates in order, uses the first
-/// one whose binary is on `$PATH`, and feeds the text through its stdin.
-/// `success` is the status-bar label on a clean copy. Failures and "no tool
-/// found" both surface in the status bar — the TUI must never die on a
-/// clipboard miss.
+/// Put `text` on the clipboard, honouring `[tui] clipboard` (issue #367).
+///
+/// The single chokepoint for every yank action, so routing lives here rather
+/// than in each caller. [`crate::clipboard::plan_clipboard_write`] makes the
+/// decision (it is pure and unit-tested); this function only performs it.
+///
+/// `success` is the status-bar label on a clean copy — suffixed with the path
+/// that actually ran (`(osc52)` / `(pbcopy)`). That suffix is load-bearing:
+/// OSC52 is never acknowledged by the terminal, so when a paste comes back
+/// empty the status line is the only clue about which route was taken.
 fn copy_text_to_clipboard(app: &mut App, text: &str, success: &str) {
+  use crate::clipboard::{plan_clipboard_write, ClipboardPlan};
   use std::io::Write;
+
+  let plan = plan_clipboard_write(
+    text,
+    app.config.tui.clipboard,
+    // `$SSH_TTY` covers an interactive login; `$SSH_CONNECTION` also covers
+    // the cases where no tty was allocated.
+    std::env::var_os("SSH_TTY").is_some() || std::env::var_os("SSH_CONNECTION").is_some(),
+    crate::multiplexer::detect_tmux(std::env::var("TMUX").ok()),
+    std::env::var_os("STY").is_some(),
+  );
+  match plan {
+    ClipboardPlan::Osc52(bytes) => {
+      // The TUI renders to stderr, so the sequence goes to the same fd. It is
+      // an escape sequence, not cells, so ratatui's next draw won't erase it —
+      // but it must be flushed, or it sits in the buffer until the next frame.
+      let mut err = std::io::stderr();
+      match err.write_all(&bytes).and_then(|_| err.flush()) {
+        Ok(()) => app.status = format!("{} (osc52)", success),
+        Err(e) => app.status = format!("osc52 write failed: {}", e),
+      }
+      return;
+    }
+    ClipboardPlan::TooLarge { bytes } => {
+      // Refuse rather than emit a sequence the terminal will truncate into
+      // corrupt paste content.
+      app.status = format!(
+        "too large for osc52 ({} KiB > {} KiB) — set [tui] clipboard = \"tools\"",
+        bytes / 1024,
+        crate::clipboard::MAX_OSC52_BYTES / 1024
+      );
+      return;
+    }
+    ClipboardPlan::Tools => {}
+  }
+
   for (cmd, args) in clipboard_candidates() {
     if which::which(cmd).is_err() {
       continue;

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -19,7 +19,7 @@
 //! the cursor lives here, `max_scroll` / `max_x_scroll` are republished by
 //! the renderer each frame against the live viewport.
 
-use crate::config::{Config, ConfigRow, ConfigSource, SidebarOrientation, SidebarPosition};
+use crate::config::{ClipboardMode, Config, ConfigRow, ConfigSource, SidebarOrientation, SidebarPosition};
 use crate::tui::keymap::{Action, KeyStroke, Keymap};
 use crate::tui::modal_keymap::{ModalAction, ModalKeymap};
 
@@ -78,6 +78,7 @@ impl SettingsTab {
       SettingsTab::Tui => &[
         SettingField::SidebarPosition,
         SettingField::SidebarOrientation,
+        SettingField::Clipboard,
         SettingField::OpenMode,
         SettingField::ConfirmCountdown,
         SettingField::AutoRefreshSecs,
@@ -267,6 +268,11 @@ const SIDEBAR_ORIENTATION_CHOICES: &[&str] = &[
 // `TuiOpenMode` has no `label()` to derive from; the round-trip test
 // (`every_choice_is_a_value_the_config_can_load_back`) guards it instead.
 const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
+const CLIPBOARD_CHOICES: &[&str] = &[
+  ClipboardMode::Auto.label(),
+  ClipboardMode::Osc52.label(),
+  ClipboardMode::Tools.label(),
+];
 
 /// One editable setting, resolved live against the loaded [`Config`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -283,6 +289,8 @@ pub enum SettingField {
   SidebarPosition,
   /// `tui.sidebar_orientation` — stacked / side-by-side / auto.
   SidebarOrientation,
+  /// `tui.clipboard` — auto / osc52 / tools.
+  Clipboard,
   /// `tui.open.mode` — shell / editor / finder.
   OpenMode,
   /// `tui.confirm_countdown_secs` — numeric input.
@@ -305,6 +313,7 @@ impl SettingField {
       SettingField::WorktreeBranchPattern => "branch pattern",
       SettingField::SidebarPosition => "sidebar position",
       SettingField::SidebarOrientation => "sidebar layout",
+      SettingField::Clipboard => "clipboard",
       SettingField::OpenMode => "open mode",
       SettingField::ConfirmCountdown => "confirm countdown (s)",
       SettingField::AutoRefreshSecs => "auto refresh (s)",
@@ -322,6 +331,7 @@ impl SettingField {
       SettingField::WorktreeBranchPattern => "worktree.branch_pattern",
       SettingField::SidebarPosition => "tui.sidebar_position",
       SettingField::SidebarOrientation => "tui.sidebar_orientation",
+      SettingField::Clipboard => "tui.clipboard",
       SettingField::OpenMode => "tui.open.mode",
       SettingField::ConfirmCountdown => "tui.confirm_countdown_secs",
       SettingField::AutoRefreshSecs => "tui.auto_refresh_secs",
@@ -336,6 +346,7 @@ impl SettingField {
       SettingField::ThemePreset
       | SettingField::SidebarPosition
       | SettingField::SidebarOrientation
+      | SettingField::Clipboard
       | SettingField::OpenMode => FieldKind::Choice,
       SettingField::ConfirmCountdown | SettingField::AutoRefreshSecs => FieldKind::Uint,
       SettingField::WorktreeBase
@@ -361,6 +372,7 @@ impl SettingField {
       SettingField::ThemePreset => crate::tui::theme::preset_names(),
       SettingField::SidebarPosition => SIDEBAR_CHOICES,
       SettingField::SidebarOrientation => SIDEBAR_ORIENTATION_CHOICES,
+      SettingField::Clipboard => CLIPBOARD_CHOICES,
       SettingField::OpenMode => OPEN_MODE_CHOICES,
       _ => &[],
     }
@@ -375,6 +387,7 @@ impl SettingField {
       SettingField::WorktreeBranchPattern => cfg.worktree.branch_pattern.clone(),
       SettingField::SidebarPosition => cfg.tui.sidebar_position.label().into(),
       SettingField::SidebarOrientation => cfg.tui.sidebar_orientation.label().into(),
+      SettingField::Clipboard => cfg.tui.clipboard.label().into(),
       SettingField::OpenMode => match cfg.tui.open.mode {
         crate::config::TuiOpenMode::Shell => "shell".into(),
         crate::config::TuiOpenMode::Editor => "editor".into(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3234,18 +3234,33 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   }
   let header_lines = vec![title, subtitle, Line::from(String::new()), Line::from(tab_spans)];
 
-  // Body depends on the active tab. The Keys tab (issue #294) also reports the
-  // line index of the selected row so the renderer can scroll it into view (it
-  // has ~100 rows, unlike the short field tabs).
-  let mut keys_selected_line: Option<usize> = None;
+  // Body depends on the active tab. Every tab with a selection reports the line
+  // index of the selected row so the renderer can scroll it into view.
+  //
+  // This used to be Keys-only, on the reasoning that "the field tabs are short
+  // enough to never need this". That was wrong on any short terminal: the modal
+  // is 60% of the height, so 24 lines leave ~6 body rows, and the TUI tab has
+  // had more fields than that since well before #367 added an 8th. The result
+  // was a selection that walked off screen — the user cycling or editing a row
+  // they cannot see (Codex review #368 P2).
+  //
+  // `settings_fields_lines` renders exactly one line per field, so the field
+  // index *is* the line index.
+  let mut selected_line: Option<usize> = None;
   let body_lines = match tab {
     SettingsTab::All => settings_all_lines(app),
     SettingsTab::Keys => {
       let (lines, sel) = settings_keys_lines(app);
-      keys_selected_line = sel;
+      selected_line = sel;
       lines
     }
-    other => settings_fields_lines(app, other.fields()),
+    other => {
+      let fields = other.fields();
+      if !fields.is_empty() {
+        selected_line = Some(app.config_panel.selected.min(fields.len().saturating_sub(1)));
+      }
+      settings_fields_lines(app, fields)
+    }
   };
 
   // Footer hints — flat accent-bind + muted-action (issue #279), dynamic to
@@ -3277,9 +3292,9 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
   // Publish scroll bounds against the BODY viewport only (issue #279).
   let body_viewport = body_area.height as usize;
   app.config_panel.max_scroll = (body_lines.len().saturating_sub(body_viewport)) as u16;
-  // Keys tab (issue #294): follow the selected row so it stays on screen as
-  // selection moves (the field tabs are short enough to never need this).
-  if let Some(sel) = keys_selected_line {
+  // Follow the selected row so it stays on screen as the selection moves —
+  // every tab that has a selection, not just Keys (see the note above).
+  if let Some(sel) = selected_line {
     let scroll = app.config_panel.scroll as usize;
     if sel < scroll {
       app.config_panel.scroll = sel as u16;

--- a/tests/clipboard_tests.rs
+++ b/tests/clipboard_tests.rs
@@ -1,0 +1,188 @@
+//! Unit tests for the pure clipboard planner (issue #367).
+//!
+//! `plan_clipboard_write` decides *how* to put text on the clipboard —
+//! OSC52 escape sequence vs the host binaries — and builds the exact bytes
+//! for the OSC52 path. It is pure: the environment (SSH / tmux / screen) is
+//! injected as parameters, mirroring `multiplexer::detect_tmux`, so the whole
+//! matrix is testable without an SSH session or a multiplexer.
+//!
+//! The bytes matter here in a way they rarely do: nothing acknowledges an
+//! OSC52 write. A malformed sequence does not error — it silently prints
+//! garbage or vanishes. So the framing is pinned byte-for-byte.
+
+use gwm::clipboard::{plan_clipboard_write, ClipboardPlan, MAX_OSC52_BYTES};
+use gwm::config::ClipboardMode;
+
+/// The env combination for a plain local terminal.
+const LOCAL: Env = Env {
+  ssh: false,
+  tmux: false,
+  screen: false,
+};
+/// A bare SSH session, no multiplexer.
+const SSH: Env = Env {
+  ssh: true,
+  tmux: false,
+  screen: false,
+};
+
+#[derive(Clone, Copy)]
+struct Env {
+  ssh: bool,
+  tmux: bool,
+  screen: bool,
+}
+
+fn plan(text: &str, mode: ClipboardMode, env: Env) -> ClipboardPlan {
+  plan_clipboard_write(text, mode, env.ssh, env.tmux, env.screen)
+}
+
+fn osc_bytes(p: &ClipboardPlan) -> &[u8] {
+  match p {
+    ClipboardPlan::Osc52(b) => b,
+    other => panic!("expected an OSC52 plan, got {other:?}"),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `auto` — the decision the whole issue turns on
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_uses_host_tools_when_not_over_ssh() {
+  // Local terminal: the host tools work and own the clipboard. Emitting OSC52
+  // here would regress users whose terminal ignores it.
+  assert_eq!(plan("x", ClipboardMode::Auto, LOCAL), ClipboardPlan::Tools);
+}
+
+#[test]
+fn auto_uses_osc52_over_ssh() {
+  // The reported bug (#363): over SSH the host tools "succeed" while writing
+  // to the wrong machine's clipboard, so `auto` must route through the
+  // terminal instead.
+  assert!(matches!(plan("x", ClipboardMode::Auto, SSH), ClipboardPlan::Osc52(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Explicit overrides beat detection, both ways
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_osc52_applies_even_locally() {
+  assert!(matches!(
+    plan("x", ClipboardMode::Osc52, LOCAL),
+    ClipboardPlan::Osc52(_)
+  ));
+}
+
+#[test]
+fn explicit_tools_applies_even_over_ssh() {
+  // The escape hatch: a terminal that mangles OSC52 must be able to opt out,
+  // even though `auto` would have picked OSC52 here.
+  assert_eq!(plan("x", ClipboardMode::Tools, SSH), ClipboardPlan::Tools);
+}
+
+// ---------------------------------------------------------------------------
+// Framing — pinned byte-for-byte against crossterm's own contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn osc52_sequence_is_base64_in_an_osc_52_frame() {
+  // "foo" → "Zm9v" is crossterm's own documented example, so this also pins
+  // that we build on its framing rather than reinventing it.
+  let p = plan("foo", ClipboardMode::Osc52, LOCAL);
+  assert_eq!(osc_bytes(&p), b"\x1b]52;c;Zm9v\x1b\\");
+}
+
+#[test]
+fn osc52_encodes_utf8_payloads() {
+  // Branch names are not ASCII-only; base64 operates on the UTF-8 bytes.
+  let p = plan("é", ClipboardMode::Osc52, LOCAL);
+  assert_eq!(osc_bytes(&p), b"\x1b]52;c;w6k=\x1b\\");
+}
+
+#[test]
+fn osc52_handles_empty_text() {
+  // Yanking an empty string must stay a well-formed sequence, not a truncated
+  // frame the terminal would swallow the next keystrokes into.
+  let p = plan("", ClipboardMode::Osc52, LOCAL);
+  assert_eq!(osc_bytes(&p), b"\x1b]52;c;\x1b\\");
+}
+
+// ---------------------------------------------------------------------------
+// Multiplexer passthrough
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tmux_wraps_the_sequence_in_dcs_passthrough_with_doubled_escapes() {
+  // tmux eats a bare OSC52. The DCS passthrough form is `\x1bPtmux;<inner>\x1b\\`
+  // with every ESC of the inner sequence doubled — both of them here (the OSC
+  // introducer and the ST terminator).
+  let env = Env {
+    ssh: true,
+    tmux: true,
+    screen: false,
+  };
+  let p = plan("foo", ClipboardMode::Osc52, env);
+  assert_eq!(osc_bytes(&p), b"\x1bPtmux;\x1b\x1b]52;c;Zm9v\x1b\x1b\\\x1b\\");
+}
+
+#[test]
+fn no_tmux_wrapping_outside_tmux() {
+  let p = plan("foo", ClipboardMode::Osc52, SSH);
+  assert!(
+    !osc_bytes(&p).starts_with(b"\x1bPtmux;"),
+    "a bare terminal must not get the tmux wrapper"
+  );
+}
+
+#[test]
+fn screen_falls_back_to_tools_rather_than_emitting_a_sequence_it_would_eat() {
+  // GNU screen needs its own chunked DCS form; emitting an unwrapped sequence
+  // inside screen is a silent no-op. Degrading to the host tools is honest —
+  // it either works or reports a real error — where a swallowed sequence gives
+  // the user a success message and an empty clipboard.
+  let env = Env {
+    ssh: true,
+    tmux: false,
+    screen: true,
+  };
+  assert_eq!(plan("foo", ClipboardMode::Auto, env), ClipboardPlan::Tools);
+}
+
+// ---------------------------------------------------------------------------
+// Size ceiling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn oversized_payload_is_refused_not_truncated() {
+  // Terminals cap OSC52 length. A truncated sequence pastes as corrupt text
+  // (or eats the following output), so an oversized payload must fail loudly
+  // instead — the Command Logs copy can realistically hit this.
+  let huge = "a".repeat(MAX_OSC52_BYTES * 2);
+  assert_eq!(
+    plan(&huge, ClipboardMode::Osc52, LOCAL),
+    ClipboardPlan::TooLarge {
+      bytes: MAX_OSC52_BYTES * 2
+    }
+  );
+}
+
+#[test]
+fn payload_just_under_the_ceiling_is_still_emitted() {
+  // The boundary is a real one: pin that the check is on the input length and
+  // does not reject a payload that fits.
+  let text = "a".repeat(MAX_OSC52_BYTES);
+  assert!(matches!(
+    plan(&text, ClipboardMode::Osc52, LOCAL),
+    ClipboardPlan::Osc52(_)
+  ));
+}
+
+#[test]
+fn tools_mode_ignores_the_size_ceiling() {
+  // The ceiling is a property of the escape sequence, not of the clipboard.
+  // Piping a huge string into pbcopy is fine, so `tools` must not inherit it.
+  let huge = "a".repeat(MAX_OSC52_BYTES * 2);
+  assert_eq!(plan(&huge, ClipboardMode::Tools, LOCAL), ClipboardPlan::Tools);
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use gwm::config::{
-  expand_placeholders, resolved_rows, review_tool_preset, BranchTypesSource, Config, ConfigRow, ConfigSource,
-  MacroOpenMode, SidebarOrientation, SidebarPosition, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
+  expand_placeholders, resolved_rows, review_tool_preset, BranchTypesSource, ClipboardMode, Config, ConfigRow,
+  ConfigSource, MacroOpenMode, SidebarOrientation, SidebarPosition, TuiOpenMode, WorktreeConfig, CONFIG_FILE,
 };
 use tempfile::TempDir;
 
@@ -2471,4 +2471,51 @@ dirs = [".."]
   )
   .expect_err("escaping dir must fail validation");
   assert!(err.to_string().contains(".."), "{err}");
+}
+
+// ---- [tui] clipboard (issue #367) ------------------------------------------
+
+#[test]
+fn tui_clipboard_defaults_to_auto() {
+  // `auto` is what makes the SSH fix work without configuration; a default of
+  // `tools` would leave the reported bug in place for everyone who never edits
+  // their config.
+  assert_eq!(Config::default().tui.clipboard, ClipboardMode::Auto);
+}
+
+#[test]
+fn tui_clipboard_absent_keeps_auto() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nconfirm_countdown_secs = 2\n").unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.clipboard, ClipboardMode::Auto);
+}
+
+#[test]
+fn tui_clipboard_parses_every_mode() {
+  for (text, expected) in [
+    ("auto", ClipboardMode::Auto),
+    ("osc52", ClipboardMode::Osc52),
+    ("tools", ClipboardMode::Tools),
+  ] {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join(CONFIG_FILE), format!("[tui]\nclipboard = \"{text}\"\n")).unwrap();
+    let cfg = Config::load_layered(dir.path(), None).unwrap();
+    assert_eq!(cfg.tui.clipboard, expected, "{text:?} parses");
+    assert_eq!(
+      cfg.tui.clipboard.label(),
+      text,
+      "label round-trips to the TOML spelling"
+    );
+  }
+}
+
+#[test]
+fn tui_clipboard_invalid_value_errors_at_parse_time() {
+  // Same hard-error contract as the other [tui] enums — silently falling back
+  // would leave the user unsure which clipboard path is live, and this one is
+  // already hard to observe (OSC52 never acknowledges).
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nclipboard = \"osc-52\"\n").unwrap();
+  assert!(Config::load_layered(dir.path(), None).is_err());
 }

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -647,3 +647,50 @@ fn clean_modal_renders_title_report_and_hints() {
   // (width − borders − padding), so the unit suffix is never clipped.
   assert_present(&buf, "KiB", "size unit not clipped on the right edge");
 }
+
+// ---------------------------------------------------------------------------
+// Settings panel: the selected field must be on screen (Codex review #368 P2)
+// ---------------------------------------------------------------------------
+
+/// Render `app` at an explicit size — the module default (100×40) is roomy
+/// enough to hide every clipping bug, and this case is about a short terminal.
+fn render_at(app: &mut App, w: u16, h: u16) -> Buffer {
+  let backend = TestBackend::new(w, h);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, app)).unwrap();
+  terminal.backend().buffer().clone()
+}
+
+#[test]
+fn settings_tui_tab_keeps_the_selected_field_visible_on_a_short_terminal() {
+  // The Settings modal is 60% of the terminal height, so a 24-line terminal —
+  // an entirely ordinary size — leaves only a handful of body lines. The TUI
+  // tab now has 8 fields, and the renderer only scrolled the selection into
+  // view for the Keys tab: every other tab moved `selected` without touching
+  // `scroll`, so the last fields could be selected, cycled and edited while
+  // off screen. The user edits a setting they cannot see.
+  //
+  // #367 added the 8th field and is what pushed this over the edge on a
+  // 24-line terminal, but the gap is older — the guard is written against the
+  // property (selected ⇒ visible) rather than against a field count, so it
+  // holds as fields come and go.
+  use gwm::tui::SettingsTab;
+
+  let (_dir, mut app) = make_app();
+  app.enter_config_panel();
+  app.config_panel.tab = SettingsTab::Tui;
+
+  let fields = SettingsTab::Tui.fields();
+  for (idx, field) in fields.iter().enumerate() {
+    app.config_panel.selected = idx;
+    let buf = render_at(&mut app, 100, 24);
+    let rows = row_strings(&buf);
+    let label = field.label();
+    assert!(
+      rows.iter().any(|r| r.contains(label)),
+      "selected field {field:?} ({label:?}) is off screen on a 24-line terminal — \
+       the user can edit a row they cannot see.\nRendered:\n{}",
+      rows.join("\n")
+    );
+  }
+}

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -156,12 +156,14 @@ fn selected_field_follows_the_tab() {
   let mut panel = ConfigPanel::new();
   // Theme tab → theme preset.
   assert_eq!(panel.selected_field(), Some(SettingField::ThemePreset));
-  // Tui tab → sidebar position / sidebar layout / open / countdown / auto
-  // refresh in order.
+  // Tui tab → sidebar position / sidebar layout / clipboard / open / countdown
+  // / auto refresh in order.
   panel.tab = SettingsTab::Tui;
   assert_eq!(panel.selected_field(), Some(SettingField::SidebarPosition));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::SidebarOrientation));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::Clipboard));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::OpenMode));
   panel.select_next();
@@ -519,6 +521,7 @@ fn every_choice_is_a_value_the_config_can_load_back() {
   for field in [
     SettingField::SidebarPosition,
     SettingField::SidebarOrientation,
+    SettingField::Clipboard,
     SettingField::OpenMode,
   ] {
     let key = field.key_path();
@@ -552,7 +555,7 @@ fn sidebar_choice_lists_cover_every_variant() {
   // that is the exhaustive `match` in `label()`, which fails to compile on a new
   // variant and forces a visit to the `ALL` right above it. Closing the gap
   // properly would need a derive (strum); not worth a dependency for two enums.
-  use gwm::config::{SidebarOrientation, SidebarPosition};
+  use gwm::config::{ClipboardMode, SidebarOrientation, SidebarPosition};
 
   for o in SidebarOrientation::ALL {
     assert!(
@@ -577,6 +580,19 @@ fn sidebar_choice_lists_cover_every_variant() {
   assert_eq!(
     SettingField::SidebarPosition.choices().len(),
     SidebarPosition::ALL.len(),
+    "no stale choice left behind"
+  );
+
+  for m in ClipboardMode::ALL {
+    assert!(
+      SettingField::Clipboard.choices().contains(&m.label()),
+      "{m:?} ({}) is missing from the clipboard choices",
+      m.label()
+    );
+  }
+  assert_eq!(
+    SettingField::Clipboard.choices().len(),
+    ClipboardMode::ALL.len(),
     "no stale choice left behind"
   );
 }


### PR DESCRIPTION
## Description

Yanking over SSH didn't just fail — it *lied*. The clipboard path only shelled out to the host binaries, which write to the clipboard of the machine gwm runs on. On a remote macOS host `pbcopy` is found, runs, exits 0, so gwm reported `yanked branch name (pbcopy)` while the text sat in a clipboard nobody could paste from.

`[tui] clipboard` now picks the route: `auto` (default) emits OSC52 when an SSH session is detected, host tools otherwise; `osc52` / `tools` force one.

Second and last half of #363 (reported by @thachck). The sidebar half shipped as #366.

Closes #367

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **New pure `clipboard` module.** `plan_clipboard_write(text, mode, is_ssh, in_tmux, in_screen)` decides the route and builds the bytes. Environment injected, mirroring `multiplexer::detect_tmux` — that's what makes the matrix testable without an SSH session.
- **Framing from crossterm, not hand-rolled.** Enabled the `osc52` feature on crossterm (already a direct dep) to use `CopyToClipboard`, whose own tests pin the exact bytes. Pulls base64 0.22 transitively; `cargo audit --deny warnings` stays clean.
- **One chokepoint.** All four yanks already funnelled through `copy_text_to_clipboard`, so routing lives there and every yank benefits.
- **tmux DCS passthrough**, `$STY` fallback to tools, 64 KiB ceiling with a refusal rather than truncation.
- Exposed in the Settings panel (TUI tab); docs EN + FR, example, CHANGELOG.

## Tests

- [x] `cargo test` passes locally — 1933 tests, 0 failures
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: written red first, failed on the missing module)
- [x] `gwm doctor` green, `cargo audit --deny warnings` clean, `cargo build --locked` OK

**What is actually verified, and what is not** — this matters here more than usual:

*Verified by construction and tests:* the decision matrix, the framing byte-for-byte, the tmux wrapper, the size ceiling. The base64 vectors were checked against the **system `base64 -d`**, not just against crossterm — `Zm9v` really decodes to `foo`, `w6k=` to `é` — so the tests pin reality rather than crossterm agreeing with itself. The config surface was exercised against the built binary (default `auto`, three modes parsing, `osc-52` rejected with `expected one of auto, osc52, tools`).

*Not verified:* **a real SSH → tmux → terminal round-trip.** I have no SSH host in this session, and OSC52 is unacknowledged by design, so there is no automated way to confirm a terminal accepted the sequence. The write itself (`stderr` + flush) is 3 lines and untested. If you want a real check before merge: set `clipboard = "osc52"` locally in a terminal that supports it (kitty/WezTerm/Alacritty/iTerm2 — **not** Terminal.app), yank, and paste.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — n/a, no CLI surface change
- [x] `examples/gwm.toml.example` updated (config schema changed)
- [x] No `unwrap()` on user-facing paths — the `write_ansi` error path falls back to tools rather than unwrapping
- [x] No `println!` in TUI render code — the sequence goes to stderr (the TUI's own fd) via the status-bar-reporting path

## Notes for reviewers

**`auto` is a behaviour change, and that's the point.** A user who yanks while SSH'd in and *wants* the remote clipboard now gets OSC52 instead. That is the reported bug being fixed, but it is a real change of default; `clipboard = "tools"` restores the old path exactly. Flagged in the issue too.

**Three known limits, documented rather than papered over.** All stem from OSC52 having no acknowledgement — gwm can report that it *emitted* a sequence, never that the terminal *took* it:

1. **tmux needs `set -g allow-passthrough on`** (off by default since 3.3). The DCS wrapper is necessary but not sufficient, and gwm can't detect or enable the option.
2. **GNU screen falls back to the host tools.** It needs its own chunked form; an unwrapped sequence there is silently swallowed. Falling back is the honest failure — the tools either work or report a real error.
3. **`$SSH_CONNECTION` can be stale in a tmux pane**, so `auto` can guess wrong. That is a large part of why the explicit `tools` override exists.

**Why the status suffix matters.** `(osc52)` / `(pbcopy)` in the status bar is the only diagnostic available when a paste comes back empty — worth keeping if you're inclined to trim it.

## Linked issues / docs

- Issue: #367
- Umbrella: #363
- Sibling: #366 (merged)