### PR TITLE
🔖 chore(release): cut v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,39 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **`[tui] clipboard` — OSC52 so yanking works over SSH** (#367, part of #363,
-  reported by [@thachck](https://github.com/thachck)). The host clipboard tools
-  write to the clipboard of the machine gwm runs on; over SSH that failed
-  *silently* — `pbcopy` on a remote macOS host is found, succeeds, and gwm
-  reported success while the text was unreachable. `auto` (the default) now
-  emits an OSC52 escape sequence when an SSH session is detected, handing the
-  text to the terminal emulator instead; `osc52` and `tools` force either path.
-  Under tmux the sequence is wrapped in DCS passthrough (requires
-  `allow-passthrough on`); inside GNU screen gwm falls back to the host tools
-  rather than emit a sequence screen would swallow. Oversized payloads are
-  refused rather than truncated into a corrupt paste.
-
-- **`[tui] sidebar_orientation` — persist the sidebar layout** (#365, part of
-  #363, reported by [@thachck](https://github.com/thachck)). The orientation
-  (`auto` / `side-by-side` / `stacked`) was runtime-only and reset on every
-  launch; only `sidebar_position` survived a restart. It is now a first-class
-  config key, seeded at startup and on config reload, and editable from the
-  Settings panel's TUI tab next to `sidebar position`. Default stays `stacked`
-  (the #217 launch layout). An unknown value is a hard error at load time,
-  consistent with `sidebar_position` and `tui.open.mode`.
-
-### Fixed
-
-- **`SidebarState::orientation` doc-comment claimed the default was `auto`**
-  (#365). It has been `stacked` since #217. The stale comment was live
-  documentation of a default that did not exist.
+_Nothing yet._
 
 ## Past releases
 
 In reverse chronological order:
 
+- [`1.1.0`](changelogs/1.1.0.md) — 2026-07-15
 - [`1.0.3`](changelogs/1.0.3.md) — 2026-07-09
 - [`1.0.2`](changelogs/1.0.2.md) — 2026-07-06
 - [`1.0.1`](changelogs/1.0.1.md) — 2026-07-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm-cli"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # binary and the library crate stay `gwm` (see [[bin]] / [lib] below),
 # so `cargo install gwm-cli` still yields the `gwm` command.
 name = "gwm-cli"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,150 @@
+# [1.1.0] - 2026-07-15
+
+**The first release driven by an outside report.** Both features here come from
+[#363](https://github.com/kbrdn1/gwm-cli/issues/363), filed by
+[@thachck](https://github.com/thachck): the sidebar layout not surviving a
+restart, and yanking being useless over SSH. Two small quality-of-life asks that
+each turned out to sit on top of a real defect.
+
+The SSH one is worth spelling out, because it was not a plain failure. gwm only
+ever shelled out to the host clipboard binaries, which write to the clipboard of
+the machine gwm runs on. Over SSH to a macOS host, `pbcopy` **is** found, runs,
+and exits 0 — so gwm reported `yanked branch name (pbcopy)` while the text sat in
+a clipboard nobody could reach. A success message and an empty clipboard is worse
+than an error, and it is also why the obvious design ("fall back to OSC52 when no
+tool is found") would never have fired: a tool *was* found, and it *did* succeed.
+
+Chasing both reports surfaced three further defects that predated them — the
+sidebar layout being dropped on a workspace repo swap, the Settings selection
+walking off screen on a short terminal, and the sidebar docs naming keys that
+have been wrong since [#290](https://github.com/kbrdn1/gwm-cli/issues/290). All
+are fixed below.
+
+## Added
+
+- **`[tui] clipboard` — OSC52 so yanking works over SSH**
+  ([#367](https://github.com/kbrdn1/gwm-cli/issues/367),
+  [#368](https://github.com/kbrdn1/gwm-cli/pull/368); part of
+  [#363](https://github.com/kbrdn1/gwm-cli/issues/363), reported by
+  [@thachck](https://github.com/thachck)).
+
+  ```toml
+  [tui]
+  clipboard = "auto"     # auto (default) | osc52 | tools
+  ```
+
+  `auto` emits an OSC52 escape sequence when `$SSH_TTY` / `$SSH_CONNECTION` is
+  set — handing the text to the terminal emulator, which owns the clipboard you
+  actually paste from — and uses the host tools otherwise. `osc52` and `tools`
+  force either path. Covers all four yanks (path, branch, worktree name, command
+  logs). The status bar names the route that ran (`(osc52)` / `(pbcopy)`).
+
+  Under tmux the sequence is wrapped in DCS passthrough; inside GNU screen gwm
+  falls back to the host tools rather than emit a sequence screen would silently
+  swallow. Payloads over 64 KiB are refused rather than truncated into a corrupt
+  paste. Framing and base64 come from crossterm's `CopyToClipboard` (feature
+  `osc52`) rather than being hand-rolled.
+
+- **`[tui] sidebar_orientation` — persist the sidebar layout**
+  ([#365](https://github.com/kbrdn1/gwm-cli/issues/365),
+  [#366](https://github.com/kbrdn1/gwm-cli/pull/366); part of
+  [#363](https://github.com/kbrdn1/gwm-cli/issues/363), reported by
+  [@thachck](https://github.com/thachck)).
+
+  ```toml
+  [tui]
+  sidebar_orientation = "stacked"   # auto | side-by-side | stacked
+  ```
+
+  The orientation was runtime-only and reset on every launch; only
+  `sidebar_position` survived a restart. It is now seeded at startup and on
+  config reload, and editable from the Settings panel's TUI tab. Default stays
+  `stacked` (the [#217](https://github.com/kbrdn1/gwm-cli/issues/217) launch
+  layout). Unknown values are a hard error at load time, consistent with
+  `sidebar_position` and `tui.open.mode`.
+
+## Fixed
+
+- **The sidebar layout was ignored when switching repos in workspace mode**
+  ([#366](https://github.com/kbrdn1/gwm-cli/pull/366)). `sync_active_repo`
+  replaced the active config wholesale without re-deriving the sidebar from it,
+  so a per-repo `[tui]` override did not apply until a reload or relaunch. This
+  hole predated the new key: `sidebar_position` had it since workspace mode
+  landed ([#36](https://github.com/kbrdn1/gwm-cli/issues/36)). Both knobs now go
+  through one shared apply, called from all three sites where the config becomes
+  authoritative.
+
+- **The Settings selection could walk off screen on a short terminal**
+  ([#368](https://github.com/kbrdn1/gwm-cli/pull/368)). The modal is 60% of the
+  terminal height, so 24 lines leave about six body rows — but the renderer only
+  scrolled the selection into view on the *Keys* tab, on the stated reasoning
+  that the field tabs were "short enough to never need this". They were not: the
+  sixth TUI field was already off screen at 24 lines, letting you cycle and edit
+  a setting you could not see. The existing mechanism is now used by every tab
+  with a selection; the Worktree tab benefited too.
+
+- **The sidebar docs named the wrong keybindings**
+  ([#366](https://github.com/kbrdn1/gwm-cli/pull/366)). The defaults are `v`
+  (position), `Space` (cycle layout) and `V` (show/hide), but the docs said `H`
+  toggles the position and `V` cycles the layout. `H` has not done that since
+  [#290](https://github.com/kbrdn1/gwm-cli/issues/290) gave `h`/`H` to the user
+  macros — a reader following the docs would fire a macro or hide the sidebar.
+  Corrected across the example template, both locales, and the doc-comments.
+
+- **The oversized-clipboard message contradicted itself**
+  ([#368](https://github.com/kbrdn1/gwm-cli/pull/368)). Truncating division
+  rendered 65 537 bytes as `64 KiB > 64 KiB`, exactly when refusing the copy.
+
+- **`SidebarState::orientation` doc-comment claimed the default was `auto`**
+  ([#365](https://github.com/kbrdn1/gwm-cli/issues/365)). It has been `stacked`
+  since [#217](https://github.com/kbrdn1/gwm-cli/issues/217) — live
+  documentation of a default that did not exist, and the kind of stale comment
+  that talks the next person into seeding the wrong value.
+
+## Changed
+
+- **The Settings choice lists are derived from their enums**
+  ([#366](https://github.com/kbrdn1/gwm-cli/pull/366)). The panel writes the
+  selected choice verbatim into `.gwm.toml`, so a list that drifted from the
+  enum's serde spelling would make the panel produce a file that no longer
+  loads. `label()` is now a `const fn` and the lists are built from it, making
+  that drift impossible to express.
+
+## Dependencies
+
+- Bumped `regex` 1.12.4 → 1.13.0
+  ([#364](https://github.com/kbrdn1/gwm-cli/pull/364)).
+- `crossterm` gains the `osc52` feature, which pulls `base64` 0.22 transitively.
+  `cargo audit --deny warnings` stays clean.
+
+## Compatibility
+
+No breaking change. Both additions are new keys inside the existing `[tui]`
+section, which the [stability policy](../docs/6.development/3.stability.md)
+treats as additive.
+
+One behaviour change worth flagging: `clipboard` defaults to `auto`, so yanking
+while SSH'd now routes through OSC52 instead of the remote host's clipboard.
+That is the reported bug being fixed, but if you *want* the remote clipboard,
+`clipboard = "tools"` restores the previous behaviour exactly.
+
+## Known limits
+
+OSC52 is never acknowledged by the terminal — gwm can report that it *emitted*
+the sequence, never that the terminal *took* it. Three consequences, all
+documented in the [schema reference](../docs/4.configuration/1.gwm-toml.md):
+
+- **tmux needs `set -g allow-passthrough on`** (off by default since tmux 3.3).
+  The DCS wrapper is necessary but not sufficient, and gwm cannot enable it.
+- **`$SSH_CONNECTION` can be stale inside a tmux pane**, so `auto` can guess
+  wrong. `clipboard = "osc52"` / `"tools"` override the detection.
+- **Terminal support varies** — kitty, WezTerm, Alacritty and iTerm2 (with the
+  setting enabled) honour OSC52; Terminal.app does not.
+
+The OSC52 decision logic, escape framing and tmux wrapping are pinned
+byte-for-byte by tests, with the base64 vectors verified against the system
+`base64` rather than only against the library that produces them. A real
+SSH → tmux → terminal round-trip was **not** exercised before release: there is
+no SSH host in the build environment and no acknowledgement to assert against.
+If it misbehaves in your setup, please reopen
+[#363](https://github.com/kbrdn1/gwm-cli/issues/363).


### PR DESCRIPTION
## Description

Cuts **v1.1.0**. The first release driven by an outside report: both features come from #363, filed by @thachck.

Closes nothing on its own — the work is already merged; this is the version bump + changelog.

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `Cargo.toml` / `Cargo.lock`: `1.0.3` → `1.1.0`
- `changelogs/1.1.0.md`: new per-version release notes (the file `release.yml` sources `body_path` from)
- `CHANGELOG.md`: `[Unreleased]` migrated into the per-version file and reset; `1.1.0` indexed under Past releases

## Why minor, not patch

Two new keys inside the existing `[tui]` section. The [stability policy](docs/6.development/3.stability.md) covers the `.gwm.toml` **section set** — renaming or removing a stable section is breaking, adding keys is additive — and TUI behaviour is explicitly *not* covered by SemVer. So: MINOR.

## What's in the train

| PR | |
|:---|:--|
| #366 | `[tui] sidebar_orientation` (#365) + workspace repo-swap fix + keybinding docs fix + choice lists derived from enums |
| #368 | `[tui] clipboard` / OSC52 (#367) + Settings scroll-into-view fix + size-message fix |
| #364 | regex 1.12.4 → 1.13.0 |

**Open-PR reconciliation (Step 0):** `gh pr list --state open` returns nothing beyond this PR. #364 was rebased onto current `dev` before merging — its original CI had gone green against a `dev` that predated #366/#368, so it was revalidated against the real tree rather than trusted.

## Tests

- [x] `cargo test` passes locally — 79 test binaries green
- [x] `cargo fmt --check` passes
- [x] `cargo build --locked` passes (lock bumped alongside the manifest, before preflight)
- [ ] New tests — n/a, version bump only

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated — `[Unreleased]` moved into `changelogs/1.1.0.md` and reset to empty
- [x] `changelogs/1.1.0.md` exists and contains the release contents (verified against the `body_path` the workflow reads — the v0.6.0 failure mode)

## Notes for reviewers

**One behaviour change, deliberately.** `clipboard` defaults to `auto`, so yanking while SSH'd now emits OSC52 instead of writing to the remote host's clipboard. That is the reported bug being fixed, but it *is* a changed default; `clipboard = "tools"` restores the previous path exactly. Flagged in the changelog's Compatibility section rather than buried.

**The changelog documents what was not verified.** No real SSH → tmux → terminal round-trip was exercised: no SSH host in the build environment, and OSC52 gives no acknowledgement to assert against. The framing is pinned byte-for-byte by tests (base64 vectors checked against the system `base64`, not just the library that emits them), but the last hop is unverified. #363 stays open until the reporter confirms — closing it would claim a verification nobody performed.