### PR TITLE
🐛 fix(config): read global config from `~/.config` on every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Windows) resolved only `dirs::config_dir()` — `~/Library/Application
   Support/gwm/config.toml` — so a config placed at the documented `~/.config`
   path was silently ignored unless `$XDG_CONFIG_HOME` was set. Resolution is
-  now `$XDG_CONFIG_HOME` → `~/.config` → platform dir (first existing wins),
-  keeping an existing `Application Support` config working. (#372)
+  now: an explicit `$XDG_CONFIG_HOME` wins outright, otherwise the first
+  existing of `~/.config` then the platform dir — keeping an existing
+  `Application Support` config working. A non-UTF-8 `$XDG_CONFIG_HOME` is read
+  via `var_os` so it can no longer be masked by `~/.config`. (#372)
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- The user-level global config is now read from the documented
+  `~/.config/gwm/config.toml` on **every** platform. Previously macOS (and
+  Windows) resolved only `dirs::config_dir()` — `~/Library/Application
+  Support/gwm/config.toml` — so a config placed at the documented `~/.config`
+  path was silently ignored unless `$XDG_CONFIG_HOME` was set. Resolution is
+  now `$XDG_CONFIG_HOME` → `~/.config` → platform dir (first existing wins),
+  keeping an existing `Application Support` config working. (#372)
 
 ## Past releases
 

--- a/docs/4.configuration/6.global-config.md
+++ b/docs/4.configuration/6.global-config.md
@@ -13,7 +13,7 @@ The same `.gwm.toml` schema may also live at a **user-level** location, applied 
 ~/.config/gwm/config.toml
 ```
 
-The path honours `$XDG_CONFIG_HOME` first (`$XDG_CONFIG_HOME/gwm/config.toml`), then falls back to the platform config dir (`dirs::config_dir()` — `Application Support` on macOS, `%APPDATA%` on Windows). It accepts the **identical schema** to `.gwm.toml` — see [`.gwm.toml` schema](/configuration/gwm-toml).
+The path honours `$XDG_CONFIG_HOME` first (`$XDG_CONFIG_HOME/gwm/config.toml`), then the cross-platform `~/.config/gwm/config.toml`, and only then the platform config dir (`dirs::config_dir()` — `Application Support` on macOS, `%APPDATA%` on Windows) if a config already lives there. The first that exists wins; with none present, `~/.config/gwm/config.toml` is the canonical location on every platform (issue #372 — before it, macOS silently looked only under `Application Support`). It accepts the **identical schema** to `.gwm.toml` — see [`.gwm.toml` schema](/configuration/gwm-toml).
 
 ```toml
 # ~/.config/gwm/config.toml

--- a/docs/4.configuration/6.global-config.md
+++ b/docs/4.configuration/6.global-config.md
@@ -13,7 +13,7 @@ The same `.gwm.toml` schema may also live at a **user-level** location, applied 
 ~/.config/gwm/config.toml
 ```
 
-The path honours `$XDG_CONFIG_HOME` first (`$XDG_CONFIG_HOME/gwm/config.toml`), then the cross-platform `~/.config/gwm/config.toml`, and only then the platform config dir (`dirs::config_dir()` — `Application Support` on macOS, `%APPDATA%` on Windows) if a config already lives there. The first that exists wins; with none present, `~/.config/gwm/config.toml` is the canonical location on every platform (issue #372 — before it, macOS silently looked only under `Application Support`). It accepts the **identical schema** to `.gwm.toml` — see [`.gwm.toml` schema](/configuration/gwm-toml).
+`$XDG_CONFIG_HOME`, when set, is honoured **outright** (`$XDG_CONFIG_HOME/gwm/config.toml`) — an explicit config home wins whether or not the file exists there. Otherwise gwm considers the cross-platform `~/.config/gwm/config.toml` and the platform config dir (`dirs::config_dir()` — `Application Support` on macOS, `%APPDATA%` on Windows), and the **first that exists wins**; with neither present, `~/.config/gwm/config.toml` is the canonical location on every platform (issue #372 — before it, macOS silently looked only under `Application Support`). It accepts the **identical schema** to `.gwm.toml` — see [`.gwm.toml` schema](/configuration/gwm-toml).
 
 ```toml
 # ~/.config/gwm/config.toml

--- a/docs/fr/4.configuration/6.global-config.md
+++ b/docs/fr/4.configuration/6.global-config.md
@@ -13,7 +13,7 @@ Le même schéma que `.gwm.toml` peut aussi vivre à un emplacement **au niveau 
 ~/.config/gwm/config.toml
 ```
 
-Le chemin honore `$XDG_CONFIG_HOME` d'abord (`$XDG_CONFIG_HOME/gwm/config.toml`), puis se rabat sur le répertoire de config de la plateforme (`dirs::config_dir()` — `Application Support` sur macOS, `%APPDATA%` sur Windows). Il accepte le **schéma identique** à `.gwm.toml` — voir [schéma `.gwm.toml`](/fr/configuration/gwm-toml).
+Le chemin honore `$XDG_CONFIG_HOME` d'abord (`$XDG_CONFIG_HOME/gwm/config.toml`), puis le chemin multiplateforme `~/.config/gwm/config.toml`, et seulement ensuite le répertoire de config de la plateforme (`dirs::config_dir()` — `Application Support` sur macOS, `%APPDATA%` sur Windows) si une config y vit déjà. Le premier qui existe l'emporte ; si aucun n'est présent, `~/.config/gwm/config.toml` est l'emplacement canonique sur toutes les plateformes (issue #372 — auparavant, macOS ne regardait en silence que sous `Application Support`). Il accepte le **schéma identique** à `.gwm.toml` — voir [schéma `.gwm.toml`](/fr/configuration/gwm-toml).
 
 ```toml
 # ~/.config/gwm/config.toml

--- a/docs/fr/4.configuration/6.global-config.md
+++ b/docs/fr/4.configuration/6.global-config.md
@@ -13,7 +13,7 @@ Le même schéma que `.gwm.toml` peut aussi vivre à un emplacement **au niveau 
 ~/.config/gwm/config.toml
 ```
 
-Le chemin honore `$XDG_CONFIG_HOME` d'abord (`$XDG_CONFIG_HOME/gwm/config.toml`), puis le chemin multiplateforme `~/.config/gwm/config.toml`, et seulement ensuite le répertoire de config de la plateforme (`dirs::config_dir()` — `Application Support` sur macOS, `%APPDATA%` sur Windows) si une config y vit déjà. Le premier qui existe l'emporte ; si aucun n'est présent, `~/.config/gwm/config.toml` est l'emplacement canonique sur toutes les plateformes (issue #372 — auparavant, macOS ne regardait en silence que sous `Application Support`). Il accepte le **schéma identique** à `.gwm.toml` — voir [schéma `.gwm.toml`](/fr/configuration/gwm-toml).
+`$XDG_CONFIG_HOME`, s'il est défini, est honoré **directement** (`$XDG_CONFIG_HOME/gwm/config.toml`) — un config home explicite l'emporte, que le fichier existe ou non. Sinon gwm considère le chemin multiplateforme `~/.config/gwm/config.toml` et le répertoire de config de la plateforme (`dirs::config_dir()` — `Application Support` sur macOS, `%APPDATA%` sur Windows), et le **premier qui existe l'emporte** ; si aucun n'est présent, `~/.config/gwm/config.toml` est l'emplacement canonique sur toutes les plateformes (issue #372 — auparavant, macOS ne regardait en silence que sous `Application Support`). Il accepte le **schéma identique** à `.gwm.toml` — voir [schéma `.gwm.toml`](/fr/configuration/gwm-toml).
 
 ```toml
 # ~/.config/gwm/config.toml

--- a/src/config.rs
+++ b/src/config.rs
@@ -1396,7 +1396,10 @@ pub fn global_config_path() -> Option<PathBuf> {
   if crate::trust::env_truthy("GWM_NO_GLOBAL_CONFIG") {
     return None;
   }
-  let xdg = std::env::var("XDG_CONFIG_HOME").ok().filter(|s| !s.is_empty());
+  // `var_os`, not `var`: a non-UTF-8 `$XDG_CONFIG_HOME` (valid on Unix) must
+  // still win outright. Reading it as a `String` would drop it, letting a
+  // `~/.config` file silently mask an explicit XDG config home.
+  let xdg = std::env::var_os("XDG_CONFIG_HOME").filter(|s| !s.is_empty());
   let home = dirs::home_dir();
   let platform = dirs::config_dir();
   resolve_global_config_path(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1336,12 +1336,56 @@ pub fn global_config_path_in(config_home: &Path) -> PathBuf {
   config_home.join("gwm").join("config.toml")
 }
 
-/// Resolve the user-level global config path, honouring
-/// `$XDG_CONFIG_HOME` first and falling back to `dirs::config_dir()` —
-/// the same resolution order as `~/.config/gwm/aliases.toml` and the
-/// trust ledger. Returns `None` on systems where neither resolves
-/// (sandboxed CI / containers without `$HOME`), in which case loading
-/// degrades to repo-only. Issue #190.
+/// Pure resolver behind [`global_config_path`]: given the candidate config
+/// homes and an existence predicate, pick the effective `gwm/config.toml`.
+///
+/// Precedence:
+///   1. `$XDG_CONFIG_HOME/gwm/config.toml` — an explicit user override wins
+///      outright, whether or not it exists (mirrors the pre-#372 contract).
+///   2. `~/.config/gwm/config.toml` — the documented cross-platform path.
+///   3. `dirs::config_dir()/gwm/config.toml` — the platform fallback
+///      (`Application Support` on macOS, `%APPDATA%` on Windows).
+///
+/// With no `$XDG_CONFIG_HOME`, #2 and #3 are the candidate set: the first
+/// that EXISTS wins, so a macOS user who put their config at the documented
+/// `~/.config` path is finally honoured (issue #372), while an existing
+/// `Application Support` config keeps working. When neither exists the
+/// canonical `~/.config` path is returned so doctor / error messages point
+/// at the documented location. On Linux #2 and #3 coincide, so resolution is
+/// byte-for-byte the pre-#372 behaviour.
+///
+/// Pure (existence is injected) so the OS-dependent contract is unit-testable
+/// against a tempdir without touching the runner's real `$HOME`. Issue #372.
+pub fn resolve_global_config_path(
+  xdg_config_home: Option<&Path>,
+  home_dir: Option<&Path>,
+  platform_config_dir: Option<&Path>,
+  exists: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+  // An explicit $XDG_CONFIG_HOME is an intentional user choice — honour it
+  // outright, existent or not (the pre-#372 contract; `merge_layered` treats
+  // an absent file as no global).
+  if let Some(xdg) = xdg_config_home {
+    return Some(global_config_path_in(xdg));
+  }
+  let dotconfig = home_dir.map(|h| global_config_path_in(&h.join(".config")));
+  let platform = platform_config_dir.map(global_config_path_in);
+  // First existing candidate wins (documented ~/.config before the platform
+  // fallback); else the canonical ~/.config path, else the platform dir.
+  if let Some(p) = dotconfig.as_ref().filter(|p| exists(p)) {
+    return Some(p.clone());
+  }
+  if let Some(p) = platform.as_ref().filter(|p| exists(p)) {
+    return Some(p.clone());
+  }
+  dotconfig.or(platform)
+}
+
+/// Resolve the user-level global config path, honouring `$XDG_CONFIG_HOME`
+/// first, then the documented `~/.config/gwm/config.toml`, then the platform
+/// config dir (`dirs::config_dir()`). Returns `None` on systems where none
+/// resolves (sandboxed CI / containers without `$HOME`), in which case
+/// loading degrades to repo-only. Issues #190, #372.
 pub fn global_config_path() -> Option<PathBuf> {
   // Opt-out: `GWM_NO_GLOBAL_CONFIG=1` reports no global path, forcing
   // repo-only loading. `load_for_repo` reads the real user-level file,
@@ -1352,12 +1396,15 @@ pub fn global_config_path() -> Option<PathBuf> {
   if crate::trust::env_truthy("GWM_NO_GLOBAL_CONFIG") {
     return None;
   }
-  if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-    if !xdg.is_empty() {
-      return Some(global_config_path_in(Path::new(&xdg)));
-    }
-  }
-  dirs::config_dir().map(|p| global_config_path_in(&p))
+  let xdg = std::env::var("XDG_CONFIG_HOME").ok().filter(|s| !s.is_empty());
+  let home = dirs::home_dir();
+  let platform = dirs::config_dir();
+  resolve_global_config_path(
+    xdg.as_deref().map(Path::new),
+    home.as_deref(),
+    platform.as_deref(),
+    |p| p.exists(),
+  )
 }
 
 impl Config {

--- a/tests/config_global_tests.rs
+++ b/tests/config_global_tests.rs
@@ -172,6 +172,43 @@ fn gwm_no_global_config_env_forces_repo_only() {
   }
 }
 
+#[cfg(unix)]
+#[test]
+fn non_utf8_xdg_config_home_still_wins_outright() {
+  // Regression (#372 review): a valid-but-non-UTF-8 $XDG_CONFIG_HOME (legal on
+  // Unix) must be honoured, not dropped by a `String`-only read that would let
+  // a `~/.config` file mask the explicit config home. `global_config_path`
+  // reads via `var_os`, so the raw `OsString` survives.
+  use std::os::unix::ffi::OsStrExt;
+  let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+  let prev_flag = std::env::var_os("GWM_NO_GLOBAL_CONFIG");
+  let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+
+  // 0xFF is not valid UTF-8, so `std::env::var` would report this path absent.
+  let raw = std::ffi::OsStr::from_bytes(b"/tmp/xdg-\xff-home");
+  let expected = Path::new(raw).join("gwm").join("config.toml");
+
+  // SAFETY: env mutation is serialised by `env_lock()`; restored below.
+  unsafe {
+    std::env::remove_var("GWM_NO_GLOBAL_CONFIG");
+    std::env::set_var("XDG_CONFIG_HOME", raw);
+  }
+  let got = global_config_path();
+
+  // SAFETY: restoration paired with the mutations above, still guarded.
+  unsafe {
+    match prev_flag {
+      Some(v) => std::env::set_var("GWM_NO_GLOBAL_CONFIG", v),
+      None => std::env::remove_var("GWM_NO_GLOBAL_CONFIG"),
+    }
+    match prev_xdg {
+      Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+      None => std::env::remove_var("XDG_CONFIG_HOME"),
+    }
+  }
+  assert_eq!(got, Some(expected), "non-UTF-8 XDG must win outright, not be dropped");
+}
+
 #[test]
 fn no_files_resolve_to_default() {
   let repo = TempDir::new().unwrap();

--- a/tests/config_global_tests.rs
+++ b/tests/config_global_tests.rs
@@ -7,7 +7,7 @@
 //! `$XDG_CONFIG_HOME` (env-independence rule). `global_config_path_in`
 //! pins the on-disk location separately.
 
-use gwm::config::{global_config_path, global_config_path_in, Config};
+use gwm::config::{global_config_path, global_config_path_in, resolve_global_config_path, Config};
 use std::path::Path;
 use std::sync::Mutex;
 use tempfile::TempDir;
@@ -38,6 +38,94 @@ fn write_global(dir: &Path, contents: &str) -> std::path::PathBuf {
 fn global_config_path_lives_under_gwm_config_toml() {
   let home = Path::new("/tmp/xdg-home");
   assert_eq!(global_config_path_in(home), home.join("gwm").join("config.toml"));
+}
+
+// --- issue #372: the documented `~/.config` path is honoured across
+// platforms, not just where `dirs::config_dir()` happens to be `~/.config`.
+// These drive the pure resolver seam (existence injected) so the contract
+// holds identically on every runner OS, per the env-independence rule.
+
+/// Build a `.../gwm/config.toml` under `home/.config` and `touch` it.
+fn touch_dotconfig(home: &Path) -> std::path::PathBuf {
+  let dir = home.join(".config").join("gwm");
+  std::fs::create_dir_all(&dir).unwrap();
+  let cfg = dir.join("config.toml");
+  std::fs::write(&cfg, "").unwrap();
+  cfg
+}
+
+#[test]
+fn resolver_prefers_dotconfig_when_it_exists() {
+  // A macOS user who followed the docs and put their config at
+  // ~/.config/gwm/config.toml must be honoured even though the platform
+  // config dir (Application Support) differs from ~/.config (issue #372).
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap(); // stand-in for Application Support
+  let cfg = touch_dotconfig(home.path());
+
+  let resolved = resolve_global_config_path(None, Some(home.path()), Some(platform.path()), |p| p.exists());
+  assert_eq!(
+    resolved,
+    Some(cfg),
+    "the documented ~/.config path must win when present"
+  );
+}
+
+#[test]
+fn resolver_falls_back_to_platform_dir_when_only_it_exists() {
+  // Back-compat: a config already living at the platform dir keeps working
+  // when ~/.config has none.
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap();
+  let cfg = global_config_path_in(platform.path());
+  std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+  std::fs::write(&cfg, "").unwrap();
+
+  let resolved = resolve_global_config_path(None, Some(home.path()), Some(platform.path()), |p| p.exists());
+  assert_eq!(
+    resolved,
+    Some(cfg),
+    "an existing platform-dir config must still resolve"
+  );
+}
+
+#[test]
+fn resolver_returns_canonical_dotconfig_when_nothing_exists() {
+  // Neither present → point doctor / callers at the documented location.
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap();
+
+  let resolved = resolve_global_config_path(None, Some(home.path()), Some(platform.path()), |_| false);
+  assert_eq!(
+    resolved,
+    Some(global_config_path_in(&home.path().join(".config"))),
+    "with nothing on disk the canonical ~/.config path is reported"
+  );
+}
+
+#[test]
+fn resolver_honours_xdg_outright_even_when_dotconfig_exists() {
+  // An explicit $XDG_CONFIG_HOME wins over both candidates and is returned
+  // whether or not the file exists — the pre-#372 contract.
+  let xdg = TempDir::new().unwrap();
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap();
+  touch_dotconfig(home.path()); // present, yet XDG must still win
+
+  let resolved = resolve_global_config_path(Some(xdg.path()), Some(home.path()), Some(platform.path()), |p| {
+    p.exists()
+  });
+  assert_eq!(resolved, Some(global_config_path_in(xdg.path())));
+}
+
+#[test]
+fn resolver_linux_dotconfig_equals_platform_dir_is_unchanged() {
+  // On Linux dirs::config_dir() == ~/.config, so both candidates coincide
+  // and resolution is byte-for-byte pre-#372 whether or not the file exists.
+  let home = TempDir::new().unwrap();
+  let platform = home.path().join(".config"); // simulate the Linux equality
+  let resolved = resolve_global_config_path(None, Some(home.path()), Some(&platform), |_| false);
+  assert_eq!(resolved, Some(global_config_path_in(&platform)));
 }
 
 #[test]


### PR DESCRIPTION
## Description

The user-level global config was resolved via `dirs::config_dir()`, which is `~/Library/Application Support/gwm/config.toml` on macOS (and `%APPDATA%\gwm\config.toml` on Windows) — not the `~/.config/gwm/config.toml` the docs promise. A macOS user who placed their config at the documented path saw it silently ignored unless `$XDG_CONFIG_HOME` was set. That's exactly the repro in the issue: config at `~/.config/gwm/config.toml`, no local `.gwm.toml`, global not respected.

Closes #372

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- Extract a pure `resolve_global_config_path(xdg, home, platform, exists)` seam (existence injected → OS-independent, unit-testable against a tempdir).
- Resolution is now `$XDG_CONFIG_HOME` → `~/.config` → platform dir, **first existing wins**:
  - an explicit `$XDG_CONFIG_HOME` still wins outright (pre-#372 contract);
  - a macOS/Windows user's config at the documented `~/.config` path is finally read;
  - an existing `Application Support` / `%APPDATA%` config keeps working (back-compat);
  - with nothing on disk the canonical `~/.config` path is reported (doctor/error messages);
  - on Linux the two candidates coincide → resolution is byte-for-byte unchanged.
- Docs (EN + FR global-config page) reworded: `~/.config` is the cross-platform canonical path, `Application Support`/`%APPDATA%` demoted to a fallback — this fixes the doc contradiction that was half the bug.
- CHANGELOG `[Unreleased] > Fixed` entry.

## Scope note

`trust.toml` (auto-written TOFU state) and `aliases.toml` share the same `dirs::config_dir()` resolution. `trust.toml` is intentionally left on `dirs::config_dir()` — it's machine-local state gwm writes itself, so moving it would force a re-TOFU of every repo (breaking). `aliases.toml` is the same manual-file nature as `config.toml` and could get the same treatment — deferred to a follow-up to keep this PR atomic (config-only, the issue's surface).

## Tests

- [x] `cargo test` passes locally (all suites green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/config_global_tests.rs` (TDD: red on `.config`-preferred + canonical, green after the fix; XDG-outright / platform-fallback / Linux-equality pinned too). Verified end-to-end against the release binary with the exact issue repro.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a — no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a — schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #372
- Docs: `docs/4.configuration/6.global-config.md` (+ `docs/fr/…`)