### PR TITLE
🐛 fix(config): resolve `aliases.toml` from `~/.config` like the global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing of `~/.config` then the platform dir — keeping an existing
   `Application Support` config working. A non-UTF-8 `$XDG_CONFIG_HOME` is read
   via `var_os` so it can no longer be masked by `~/.config`. (#372)
+- The user-level alias file (`~/.config/gwm/aliases.toml`) now resolves the
+  same way as the global config, so it is read from the documented `~/.config`
+  path on macOS and Windows instead of only `dirs::config_dir()`. Both files
+  share one resolver (`resolve_gwm_config_file`) so they can't drift. (#374)
 
 ## Past releases
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -729,7 +729,7 @@ ll     = "list --format names"
 sync   = "bootstrap"
 ```
 
-A user-level fallback lives at `~/.config/gwm/aliases.toml` (path honours `$XDG_CONFIG_HOME` first, then `dirs::config_dir()`); same `[aliases]` block shape. Repo aliases win over user aliases on name collision.
+A user-level fallback lives at `~/.config/gwm/aliases.toml` (resolved like the [global config](/configuration/global-config#location): `$XDG_CONFIG_HOME` wins outright, otherwise the first existing of `~/.config` then the platform dir — issue #374); same `[aliases]` block shape. Repo aliases win over user aliases on name collision.
 
 Surface the resolved chain with `gwm aliases list` — see [CLI → `gwm aliases list`](/cli/reference#gwm-aliases-list-issue-86) for the rendered output and the per-source flagging.
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -729,7 +729,7 @@ ll     = "list --format names"
 sync   = "bootstrap"
 ```
 
-Un fallback au niveau utilisateur vit à `~/.config/gwm/aliases.toml` (le chemin honore `$XDG_CONFIG_HOME` d'abord, puis `dirs::config_dir()`) ; même forme de bloc `[aliases]`. Les alias de dépôt l'emportent sur les alias utilisateur en cas de collision de nom.
+Un fallback au niveau utilisateur vit à `~/.config/gwm/aliases.toml` (résolu comme la [config globale](/fr/configuration/global-config#location) : `$XDG_CONFIG_HOME` l'emporte directement, sinon le premier existant entre `~/.config` et le répertoire plateforme — issue #374) ; même forme de bloc `[aliases]`. Les alias de dépôt l'emportent sur les alias utilisateur en cas de collision de nom.
 
 Faites apparaître la chaîne résolue avec `gwm aliases list` — voir [CLI → `gwm aliases list`](/fr/cli/reference#gwm-aliases-list-issue-86) pour la sortie rendue et le flagging par source.
 

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -326,18 +326,29 @@ fn first_byte_is_dash(token: &std::ffi::OsStr) -> bool {
   token.as_encoded_bytes().first() == Some(&b'-')
 }
 
-/// Default location of the user-level alias file. Mirrors the
-/// trust-ledger pattern (`~/.config/gwm/trust.toml`): honour
-/// `$XDG_CONFIG_HOME` first, fall back to `dirs::config_dir()` —
-/// returns `None` on systems where neither resolves (sandboxed CI,
-/// containers without `$HOME`).
+/// Default location of the user-level alias file, resolved the same way as
+/// the global config (`~/.config/gwm/config.toml`, issues #372/#374): an
+/// explicit `$XDG_CONFIG_HOME` wins outright, otherwise the first existing of
+/// the documented `~/.config/gwm/aliases.toml` then the platform config dir
+/// (`Application Support` on macOS, `%APPDATA%` on Windows); the canonical
+/// `~/.config` path when neither exists. Returns `None` on systems where no
+/// home resolves (sandboxed CI, containers without `$HOME`). Delegates to the
+/// shared [`crate::config::resolve_gwm_config_file`] so the alias and config
+/// resolvers can't drift.
+///
+/// `var_os`, not `var`: a non-UTF-8 `$XDG_CONFIG_HOME` (legal on Unix) must
+/// still win outright rather than be dropped and masked by `~/.config`.
 fn default_user_path() -> Option<PathBuf> {
-  if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-    if !xdg.is_empty() {
-      return Some(PathBuf::from(xdg).join("gwm").join("aliases.toml"));
-    }
-  }
-  dirs::config_dir().map(|p| p.join("gwm").join("aliases.toml"))
+  let xdg = std::env::var_os("XDG_CONFIG_HOME").filter(|s| !s.is_empty());
+  let home = dirs::home_dir();
+  let platform = dirs::config_dir();
+  crate::config::resolve_gwm_config_file(
+    "aliases.toml",
+    xdg.as_deref().map(Path::new),
+    home.as_deref(),
+    platform.as_deref(),
+    |p| p.exists(),
+  )
 }
 
 /// Internal shape of the user-level alias file. Mirrors the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1336,40 +1336,44 @@ pub fn global_config_path_in(config_home: &Path) -> PathBuf {
   config_home.join("gwm").join("config.toml")
 }
 
-/// Pure resolver behind [`global_config_path`]: given the candidate config
-/// homes and an existence predicate, pick the effective `gwm/config.toml`.
+/// Pure resolver for a user-level `gwm/<filename>` file (`config.toml`,
+/// `aliases.toml`, …): given the candidate config homes and an existence
+/// predicate, pick the effective path. Shared by the global config (#372)
+/// and the user-level alias file (#374) so the two can't drift.
 ///
 /// Precedence:
-///   1. `$XDG_CONFIG_HOME/gwm/config.toml` — an explicit user override wins
+///   1. `$XDG_CONFIG_HOME/gwm/<filename>` — an explicit user override wins
 ///      outright, whether or not it exists (mirrors the pre-#372 contract).
-///   2. `~/.config/gwm/config.toml` — the documented cross-platform path.
-///   3. `dirs::config_dir()/gwm/config.toml` — the platform fallback
+///   2. `~/.config/gwm/<filename>` — the documented cross-platform path.
+///   3. `dirs::config_dir()/gwm/<filename>` — the platform fallback
 ///      (`Application Support` on macOS, `%APPDATA%` on Windows).
 ///
 /// With no `$XDG_CONFIG_HOME`, #2 and #3 are the candidate set: the first
-/// that EXISTS wins, so a macOS user who put their config at the documented
-/// `~/.config` path is finally honoured (issue #372), while an existing
-/// `Application Support` config keeps working. When neither exists the
-/// canonical `~/.config` path is returned so doctor / error messages point
-/// at the documented location. On Linux #2 and #3 coincide, so resolution is
-/// byte-for-byte the pre-#372 behaviour.
+/// that EXISTS wins, so a macOS user who put their file at the documented
+/// `~/.config` path is finally honoured, while an existing `Application
+/// Support` file keeps working. When neither exists the canonical `~/.config`
+/// path is returned so doctor / error messages point at the documented
+/// location. On Linux #2 and #3 coincide, so resolution is byte-for-byte the
+/// pre-#372 behaviour.
 ///
 /// Pure (existence is injected) so the OS-dependent contract is unit-testable
-/// against a tempdir without touching the runner's real `$HOME`. Issue #372.
-pub fn resolve_global_config_path(
+/// against a tempdir without touching the runner's real `$HOME`. Issues #372,
+/// #374.
+pub fn resolve_gwm_config_file(
+  filename: &str,
   xdg_config_home: Option<&Path>,
   home_dir: Option<&Path>,
   platform_config_dir: Option<&Path>,
   exists: impl Fn(&Path) -> bool,
 ) -> Option<PathBuf> {
+  let join = |home: &Path| home.join("gwm").join(filename);
   // An explicit $XDG_CONFIG_HOME is an intentional user choice — honour it
-  // outright, existent or not (the pre-#372 contract; `merge_layered` treats
-  // an absent file as no global).
+  // outright, existent or not (callers treat an absent file as unset).
   if let Some(xdg) = xdg_config_home {
-    return Some(global_config_path_in(xdg));
+    return Some(join(xdg));
   }
-  let dotconfig = home_dir.map(|h| global_config_path_in(&h.join(".config")));
-  let platform = platform_config_dir.map(global_config_path_in);
+  let dotconfig = home_dir.map(|h| join(&h.join(".config")));
+  let platform = platform_config_dir.map(join);
   // First existing candidate wins (documented ~/.config before the platform
   // fallback); else the canonical ~/.config path, else the platform dir.
   if let Some(p) = dotconfig.as_ref().filter(|p| exists(p)) {
@@ -1379,6 +1383,17 @@ pub fn resolve_global_config_path(
     return Some(p.clone());
   }
   dotconfig.or(platform)
+}
+
+/// Pure resolver behind [`global_config_path`] — the `config.toml`
+/// specialisation of [`resolve_gwm_config_file`]. Issue #372.
+pub fn resolve_global_config_path(
+  xdg_config_home: Option<&Path>,
+  home_dir: Option<&Path>,
+  platform_config_dir: Option<&Path>,
+  exists: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+  resolve_gwm_config_file("config.toml", xdg_config_home, home_dir, platform_config_dir, exists)
 }
 
 /// Resolve the user-level global config path, honouring `$XDG_CONFIG_HOME`

--- a/tests/aliases_tests.rs
+++ b/tests/aliases_tests.rs
@@ -14,9 +14,39 @@
 //!     a hard config error surfaced by `Config::load_for_repo`.
 
 use gwm::aliases::{self, BUILT_IN_ALIASES};
-use gwm::config::{Config, CONFIG_FILE};
+use gwm::config::{resolve_gwm_config_file, Config, CONFIG_FILE};
 use gwm::error::GwmError;
 use tempfile::TempDir;
+
+// ---- User-level file location (#374) ------------------------------------
+
+#[test]
+fn user_alias_file_resolves_under_dotconfig() {
+  // The user-level `aliases.toml` must be read from the documented
+  // `~/.config/gwm/aliases.toml` on every platform — same fix as the global
+  // config (#372/#374), not only where `dirs::config_dir()` == `~/.config`.
+  // `default_user_path` delegates to this shared resolver with `var_os`, so
+  // pinning the resolver for `aliases.toml` pins the user-level location.
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap(); // stand-in for Application Support
+  let dir = home.path().join(".config").join("gwm");
+  std::fs::create_dir_all(&dir).unwrap();
+  let aliases_file = dir.join("aliases.toml");
+  std::fs::write(&aliases_file, "").unwrap();
+
+  let resolved = resolve_gwm_config_file(
+    "aliases.toml",
+    None, // $XDG_CONFIG_HOME unset
+    Some(home.path()),
+    Some(platform.path()),
+    |p| p.exists(),
+  );
+  assert_eq!(
+    resolved,
+    Some(aliases_file),
+    "user aliases at the documented ~/.config path must be honoured"
+  );
+}
 
 // ---- Parsing ------------------------------------------------------------
 

--- a/tests/config_global_tests.rs
+++ b/tests/config_global_tests.rs
@@ -7,7 +7,9 @@
 //! `$XDG_CONFIG_HOME` (env-independence rule). `global_config_path_in`
 //! pins the on-disk location separately.
 
-use gwm::config::{global_config_path, global_config_path_in, resolve_global_config_path, Config};
+use gwm::config::{
+  global_config_path, global_config_path_in, resolve_global_config_path, resolve_gwm_config_file, Config,
+};
 use std::path::Path;
 use std::sync::Mutex;
 use tempfile::TempDir;
@@ -126,6 +128,39 @@ fn resolver_linux_dotconfig_equals_platform_dir_is_unchanged() {
   let platform = home.path().join(".config"); // simulate the Linux equality
   let resolved = resolve_global_config_path(None, Some(home.path()), Some(&platform), |_| false);
   assert_eq!(resolved, Some(global_config_path_in(&platform)));
+}
+
+#[test]
+fn shared_resolver_honours_filename_and_dotconfig() {
+  // The resolver is parameterised by filename so config.toml and aliases.toml
+  // share one ~/.config-first contract (issue #374). Exercise it with a
+  // non-config filename to pin the plumbing.
+  let home = TempDir::new().unwrap();
+  let platform = TempDir::new().unwrap();
+  let dir = home.path().join(".config").join("gwm");
+  std::fs::create_dir_all(&dir).unwrap();
+  let cfg = dir.join("aliases.toml");
+  std::fs::write(&cfg, "").unwrap();
+
+  let resolved = resolve_gwm_config_file("aliases.toml", None, Some(home.path()), Some(platform.path()), |p| {
+    p.exists()
+  });
+  assert_eq!(
+    resolved,
+    Some(cfg),
+    "an arbitrary filename resolves under ~/.config when present"
+  );
+
+  // XDG still wins outright, carrying the requested filename.
+  let xdg = TempDir::new().unwrap();
+  let via_xdg = resolve_gwm_config_file(
+    "aliases.toml",
+    Some(xdg.path()),
+    Some(home.path()),
+    Some(platform.path()),
+    |p| p.exists(),
+  );
+  assert_eq!(via_xdg, Some(xdg.path().join("gwm").join("aliases.toml")));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Follow-up to #372/#373. `aliases::default_user_path()` resolved the user-level alias file via `dirs::config_dir()` — `~/Library/Application Support/gwm/aliases.toml` on macOS, `%APPDATA%\gwm\aliases.toml` on Windows — so the documented `~/.config/gwm/aliases.toml` was silently ignored unless `$XDG_CONFIG_HOME` was set. Same double defect as #372 (`var` dropping non-UTF-8, `config_dir()` != `~/.config`), different file.

Closes #374

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- Generalise the #372 resolver into `config::resolve_gwm_config_file(filename, xdg, home, platform, exists)`, shared by `config.toml` and `aliases.toml` so the two resolvers can't drift; `resolve_global_config_path` is now its `config.toml` specialisation.
- Rewire `aliases::default_user_path()` onto the shared resolver, reading `$XDG_CONFIG_HOME` via `var_os` (non-UTF-8 safe, wins outright). Resolution: `$XDG_CONFIG_HOME` outright → first existing of `~/.config` then platform dir → canonical `~/.config`. An existing `Application Support`/`%APPDATA%` alias file keeps working (back-compat).
- Docs (`docs/4.configuration/1.gwm-toml.md` EN + FR) point the alias-file location at the global-config resolution rule instead of the misleading "then `dirs::config_dir()`".
- CHANGELOG `[Unreleased] > Fixed` entry.

## Scope note

`trust.toml` (`trust::default_ledger_path`) shares the same `dirs::config_dir()` resolution but stays there **intentionally**: it is machine-local TOFU state gwm writes itself, so moving it would force a re-TOFU of every repo on macOS (breaking). Aliases and config are user-authored files — safe to move, platform dir kept as fallback.

## Tests

- [x] `cargo test` passes locally (fmt + clippy + full suite green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests: `user_alias_file_resolves_under_dotconfig` (aliases_tests) + `shared_resolver_honours_filename_and_dotconfig` (config_global_tests). TDD: red on the aliases `.config` test with the pre-fix resolver, green after. Existing #372 config resolver tests still green through the generalised helper.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #374
- Follows: #372 / #373