### PR TITLE
👷 ci(release): Scoop install channel for Windows (#376)

### DIFF
--- a/.github/scripts/render-scoop-manifest.sh
+++ b/.github/scripts/render-scoop-manifest.sh
@@ -17,8 +17,9 @@
 # Exit 1 on usage / validation errors, with a message on stderr.
 #
 # Only the `__FOO__` placeholders are substituted; the Scoop autoupdate
-# variables (`$version`, `$url`) are left verbatim so `scoop update` can bump
-# versions on its own between our pushes.
+# variables (`$version`, `$url`) are left verbatim so Scoop's maintainer-side
+# checkver/excavator tooling can regenerate the manifest. (Client `scoop update
+# gwm` pulls whatever bucket/gwm.json this job has already pushed.)
 
 set -eu
 

--- a/.github/scripts/render-scoop-manifest.sh
+++ b/.github/scripts/render-scoop-manifest.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# render-scoop-manifest.sh — substitute placeholders in the Scoop manifest
+# template and emit the rendered manifest on stdout.
+#
+# Used by .github/workflows/release.yml > scoop-bucket-update to refresh
+# bucket/gwm.json on kbrdn1/scoop-gwm after every stable release (issue #376).
+#
+# Usage:
+#   render-scoop-manifest.sh TAG VERSION SHA256_X86_64 TEMPLATE
+#
+#   TAG            v-prefixed git tag (e.g. v1.1.1)
+#   VERSION        semver string without leading v (e.g. 1.1.1)
+#   SHA256_X86_64  64-char hex sha256 of the Windows x86_64 zip
+#   TEMPLATE       path to packaging/scoop/gwm.json.template
+#
+# Output: rendered manifest on stdout.
+# Exit 1 on usage / validation errors, with a message on stderr.
+#
+# Only the `__FOO__` placeholders are substituted; the Scoop autoupdate
+# variables (`$version`, `$url`) are left verbatim so `scoop update` can bump
+# versions on its own between our pushes.
+
+set -eu
+
+if [ "$#" -ne 4 ]; then
+  printf 'usage: %s TAG VERSION SHA256_X86_64 TEMPLATE\n' "$0" >&2
+  printf 'render-scoop-manifest: missing arguments (got %d, expected 4)\n' "$#" >&2
+  exit 1
+fi
+
+TAG="$1"
+VERSION="$2"
+SHA_X86_64="$3"
+TEMPLATE="$4"
+
+if [ ! -f "$TEMPLATE" ]; then
+  printf 'render-scoop-manifest: template not found: %s\n' "$TEMPLATE" >&2
+  exit 1
+fi
+
+# A typo in the release pipeline would otherwise ship a manifest that
+# `scoop install` rejects with a confusing hash mismatch — fail loud here so
+# the release run catches it on the spot.
+validate_sha() {
+  name="$1"
+  value="$2"
+  case "$value" in
+    *[!0-9a-fA-F]*)
+      printf 'render-scoop-manifest: %s is not hex: %s\n' "$name" "$value" >&2
+      exit 1
+      ;;
+  esac
+  len=$(printf %s "$value" | wc -c | tr -d ' ')
+  if [ "$len" -ne 64 ]; then
+    printf 'render-scoop-manifest: invalid sha256 %s — must be 64 hex chars, got %d: %s\n' \
+      "$name" "$len" "$value" >&2
+    exit 1
+  fi
+}
+
+validate_sha SHA256_X86_64 "$SHA_X86_64"
+
+# Placeholders are __FOO__ — alnum + underscores only, no sed-meta to escape.
+sed \
+  -e "s|__TAG__|${TAG}|g" \
+  -e "s|__VERSION__|${VERSION}|g" \
+  -e "s|__SHA256_X86_64__|${SHA_X86_64}|g" \
+  "$TEMPLATE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,3 +266,88 @@ jobs:
           fi
           git commit -m "gwm ${TAG#v} (${TAG})"
           git push
+
+  scoop-bucket-update:
+    name: update scoop bucket
+    needs: [release]
+    runs-on: ubuntu-latest
+    # Stable releases only — rc/alpha/beta must never reach `scoop install gwm`,
+    # otherwise users tracking the bucket would silently move to a pre-release.
+    # Same reasoning as homebrew-tap-update above (the whole workflow is
+    # implicitly tag-scoped via the upstream jobs).
+    if: |
+      !contains(github.event.inputs.tag || github.ref_name, '-rc.') &&
+      !contains(github.event.inputs.tag || github.ref_name, '-alpha.') &&
+      !contains(github.event.inputs.tag || github.ref_name, '-beta.')
+    # While SCOOP_BUCKET_TOKEN is being provisioned the first time, a missing
+    # secret would fail this job. Keep it advisory so the GitHub release still
+    # lands and the bucket refresh can be re-driven manually via
+    # workflow_dispatch once the secret exists. Flip to false after the first
+    # successful sync (see CONTRIBUTING.md > Releases > Scoop bucket).
+    continue-on-error: true
+    steps:
+      - name: verify SCOOP_BUCKET_TOKEN is configured
+        env:
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+        run: |
+          if [ -z "${SCOOP_BUCKET_TOKEN:-}" ]; then
+            echo "::error::SCOOP_BUCKET_TOKEN secret is not configured."
+            echo "Bootstrap: see CONTRIBUTING.md > Releases > Scoop bucket setup."
+            exit 1
+          fi
+
+      - name: checkout gwm-cli (template + render script)
+        uses: actions/checkout@v7
+        with:
+          path: gwm-cli
+
+      - name: checkout kbrdn1/scoop-gwm
+        uses: actions/checkout@v7
+        with:
+          repository: kbrdn1/scoop-gwm
+          path: scoop-gwm
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+
+      - name: fetch sha256 sidecar from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p sha
+          gh release download "$TAG" \
+            --repo kbrdn1/gwm-cli \
+            --pattern "gwm-${TAG}-x86_64-pc-windows-msvc.zip.sha256" \
+            --dir sha
+          ls -la sha
+
+      - name: render bucket/gwm.json
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          SHA_X86_64=$(awk '{print $1}' "sha/gwm-${TAG}-x86_64-pc-windows-msvc.zip.sha256")
+          mkdir -p scoop-gwm/bucket
+          sh gwm-cli/.github/scripts/render-scoop-manifest.sh \
+            "$TAG" "$VERSION" "$SHA_X86_64" \
+            gwm-cli/packaging/scoop/gwm.json.template \
+            > scoop-gwm/bucket/gwm.json
+          echo "=== rendered bucket/gwm.json ==="
+          cat scoop-gwm/bucket/gwm.json
+
+      - name: commit + push to bucket
+        working-directory: scoop-gwm
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name  "gwm-cli release bot"
+          git config user.email "release-bot@gwm-cli.local"
+          git add bucket/gwm.json
+          if git diff --cached --quiet; then
+            echo "bucket/gwm.json unchanged — nothing to push."
+            exit 0
+          fi
+          git commit -m "gwm ${TAG#v} (${TAG})"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scoop-bucket-update` job in `release.yml` renders
   `packaging/scoop/gwm.json.template` and pushes `bucket/gwm.json` to the
   `kbrdn1/scoop-gwm` bucket on every stable release (mirroring the Homebrew
-  tap; pre-releases filtered out). The manifest carries Scoop autoupdate
-  metadata so `scoop update gwm` works between pushes. (#376)
+  tap; pre-releases filtered out). `scoop update gwm` picks up each new
+  version once the release job pushes the refreshed manifest. (#376)
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Scoop install channel for Windows** — `scoop bucket add gwm
+  https://github.com/kbrdn1/scoop-gwm && scoop install gwm`. A new
+  `scoop-bucket-update` job in `release.yml` renders
+  `packaging/scoop/gwm.json.template` and pushes `bucket/gwm.json` to the
+  `kbrdn1/scoop-gwm` bucket on every stable release (mirroring the Homebrew
+  tap; pre-releases filtered out). The manifest carries Scoop autoupdate
+  metadata so `scoop update gwm` works between pushes. (#376)
 
 ## Past releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,6 +416,28 @@ gh workflow run release.yml --ref <tag>   # e.g. v0.5.0
 
 The `workflow_dispatch` path is gated to the same stable-only condition; rc/alpha/beta will skip the tap step automatically.
 
+### Scoop bucket (`scoop install gwm`)
+
+Stable releases automatically refresh [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) via the `scoop-bucket-update` job in [`release.yml`](.github/workflows/release.yml), mirroring the Homebrew tap. Pre-releases are filtered out so `scoop install gwm` always tracks the latest stable. End users add the bucket once:
+
+```powershell
+scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
+scoop install gwm
+```
+
+The canonical manifest source lives at [`packaging/scoop/gwm.json.template`](packaging/scoop/gwm.json.template); the render + Scoop-autoupdate contract is pinned by [`tests/scoop_manifest_tests.rs`](tests/scoop_manifest_tests.rs). Only the `__FOO__` placeholders are substituted at release time — the Scoop `$version` / `$url` autoupdate variables are left verbatim so `scoop update` keeps working between pushes.
+
+#### One-time bootstrap (maintainer)
+
+Same shape as the Homebrew tap:
+
+1. Create the `kbrdn1/scoop-gwm` repo (a `bucket/gwm.json` + README).
+2. Generate a fine-grained PAT scoped to `kbrdn1/scoop-gwm` only, **Contents → Read and write**.
+3. Add it as the `SCOOP_BUCKET_TOKEN` secret on `gwm-cli`: <https://github.com/kbrdn1/gwm-cli/settings/secrets/actions/new>.
+4. Flip `continue-on-error: true` to `false` on the `scoop-bucket-update` job after the first successful sync.
+
+Re-drive a failed sync the same way: `gh workflow run release.yml --ref <tag>`.
+
 ---
 
 By contributing, you agree your changes are licensed under the MIT License (see `LICENSE.md`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -425,7 +425,7 @@ scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
 scoop install gwm
 ```
 
-The canonical manifest source lives at [`packaging/scoop/gwm.json.template`](packaging/scoop/gwm.json.template); the render + Scoop-autoupdate contract is pinned by [`tests/scoop_manifest_tests.rs`](tests/scoop_manifest_tests.rs). Only the `__FOO__` placeholders are substituted at release time — the Scoop `$version` / `$url` autoupdate variables are left verbatim so `scoop update` keeps working between pushes.
+The canonical manifest source lives at [`packaging/scoop/gwm.json.template`](packaging/scoop/gwm.json.template); the render + Scoop-autoupdate contract is pinned by [`tests/scoop_manifest_tests.rs`](tests/scoop_manifest_tests.rs). Only the `__FOO__` placeholders are substituted at release time — the Scoop `$version` / `$url` autoupdate variables are left verbatim so Scoop's maintainer-side `checkver`/excavator tooling can regenerate the manifest. End users get new versions from `scoop update gwm` once the `scoop-bucket-update` job pushes the refreshed `bucket/gwm.json`, so keep the job green (that is what the client actually pulls).
 
 #### One-time bootstrap (maintainer)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Cargo (source)   | `cargo install --path .`                                             |
 | cargo-binstall   | `cargo binstall gwm-cli`                                             |
 | Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                            |
-| Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm && scoop install gwm` |
+| Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm; scoop install gwm` |
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Cargo (source)   | `cargo install --path .`                                             |
 | cargo-binstall   | `cargo binstall gwm-cli`                                             |
 | Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                            |
+| Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm && scoop install gwm` |
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -53,7 +53,7 @@ scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
 scoop install gwm
 ```
 
-The manifest lives at [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) and is refreshed automatically on every **stable** release by the `scoop-bucket-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — the Windows counterpart of the Homebrew tap. The canonical template is at [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Pre-release tags are filtered out, so `scoop install gwm` always points at a stable build, and `scoop update gwm` picks up new versions via the manifest's autoupdate block.
+The manifest lives at [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) and is refreshed automatically on every **stable** release by the `scoop-bucket-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — the Windows counterpart of the Homebrew tap. The canonical template is at [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Pre-release tags are filtered out, so `scoop install gwm` always points at a stable build. `scoop update gwm` picks up each new version once the release job pushes the refreshed `bucket/gwm.json` — the manifest's `autoupdate` block is maintainer-side metadata (consumed by Scoop's `checkver`/excavator tooling to regenerate the manifest), not what drives client-side updates.
 
 ## prebuilt binaries
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -46,6 +46,15 @@ The formula lives at [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/homebrew-
 
 See [Integrations → Homebrew & Nix](/integrations/homebrew-nix) for the tap-update pipeline and the flake outputs in detail.
 
+## via Scoop (Windows)
+
+```powershell
+scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
+scoop install gwm
+```
+
+The manifest lives at [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) and is refreshed automatically on every **stable** release by the `scoop-bucket-update` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — the Windows counterpart of the Homebrew tap. The canonical template is at [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Pre-release tags are filtered out, so `scoop install gwm` always points at a stable build, and `scoop update gwm` picks up new versions via the manifest's autoupdate block.
+
 ## prebuilt binaries
 
 Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries with `.sha256` sidecars for:

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -53,7 +53,7 @@ scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
 scoop install gwm
 ```
 
-Le manifest se trouve dans [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) et est rafraîchi automatiquement à chaque release **stable** par le job `scoop-bucket-update` de [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — l'équivalent Windows du tap Homebrew. Le template canonique se trouve dans [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Les tags de pré-release sont filtrés, donc `scoop install gwm` pointe toujours vers un build stable, et `scoop update gwm` récupère les nouvelles versions via le bloc autoupdate du manifest.
+Le manifest se trouve dans [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) et est rafraîchi automatiquement à chaque release **stable** par le job `scoop-bucket-update` de [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — l'équivalent Windows du tap Homebrew. Le template canonique se trouve dans [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Les tags de pré-release sont filtrés, donc `scoop install gwm` pointe toujours vers un build stable. `scoop update gwm` récupère chaque nouvelle version une fois que le job de release a poussé le `bucket/gwm.json` rafraîchi — le bloc `autoupdate` du manifest est une métadonnée côté mainteneur (consommée par l'outillage `checkver`/excavator de Scoop pour régénérer le manifest), pas ce qui déclenche les mises à jour côté client.
 
 ## binaires précompilés
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -46,6 +46,15 @@ La formule se trouve dans [`kbrdn1/homebrew-tap`](https://github.com/kbrdn1/home
 
 Voir [Intégrations → Homebrew & Nix](/fr/integrations/homebrew-nix) pour le détail du pipeline de mise à jour du tap et des sorties du flake.
 
+## via Scoop (Windows)
+
+```powershell
+scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
+scoop install gwm
+```
+
+Le manifest se trouve dans [`kbrdn1/scoop-gwm`](https://github.com/kbrdn1/scoop-gwm) (`bucket/gwm.json`) et est rafraîchi automatiquement à chaque release **stable** par le job `scoop-bucket-update` de [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) — l'équivalent Windows du tap Homebrew. Le template canonique se trouve dans [`packaging/scoop/gwm.json.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/scoop/gwm.json.template). Les tags de pré-release sont filtrés, donc `scoop install gwm` pointe toujours vers un build stable, et `scoop update gwm` récupère les nouvelles versions via le bloc autoupdate du manifest.
+
 ## binaires précompilés
 
 Les releases sur <https://github.com/kbrdn1/gwm-cli/releases> fournissent des binaires signés accompagnés de sidecars `.sha256` pour :

--- a/packaging/scoop/gwm.json.template
+++ b/packaging/scoop/gwm.json.template
@@ -1,0 +1,26 @@
+{
+  "version": "__VERSION__",
+  "description": "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap",
+  "homepage": "https://github.com/kbrdn1/gwm-cli",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/kbrdn1/gwm-cli/releases/download/__TAG__/gwm-__TAG__-x86_64-pc-windows-msvc.zip",
+      "hash": "__SHA256_X86_64__",
+      "extract_dir": "gwm-__TAG__-x86_64-pc-windows-msvc"
+    }
+  },
+  "bin": "gwm.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/kbrdn1/gwm-cli/releases/download/v$version/gwm-v$version-x86_64-pc-windows-msvc.zip",
+        "extract_dir": "gwm-v$version-x86_64-pc-windows-msvc"
+      }
+    },
+    "hash": {
+      "url": "$url.sha256"
+    }
+  }
+}

--- a/tests/scoop_manifest_tests.rs
+++ b/tests/scoop_manifest_tests.rs
@@ -54,8 +54,9 @@ fn template_exists_and_carries_all_placeholders() {
       t.display()
     );
   }
-  // The Scoop autoupdate variables must live in the template verbatim so
-  // `scoop update` can bump versions on its own — they must NOT be rendered.
+  // The Scoop autoupdate variables must survive rendering so Scoop's
+  // maintainer-side checkver/excavator tooling can regenerate the manifest —
+  // they must NOT be substituted.
   assert!(
     body.contains("$version"),
     "template missing the Scoop $version autoupdate var"

--- a/tests/scoop_manifest_tests.rs
+++ b/tests/scoop_manifest_tests.rs
@@ -1,0 +1,149 @@
+//! Integration tests for `.github/scripts/render-scoop-manifest.sh`.
+//!
+//! The script substitutes placeholders in `packaging/scoop/gwm.json.template`
+//! to produce the final `bucket/gwm.json` that `release.yml >
+//! scoop-bucket-update` pushes to `kbrdn1/scoop-gwm` after every stable
+//! release. A malformed manifest would silently break `scoop install gwm` for
+//! every Windows user, so the contract — valid JSON, right URL/hash, and the
+//! Scoop autoupdate variables left intact — is exercised in tests (issue
+//! #376). Mirrors `homebrew_formula_tests.rs`.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn project_root() -> PathBuf {
+  Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn script_path() -> PathBuf {
+  project_root().join(".github/scripts/render-scoop-manifest.sh")
+}
+
+fn template_path() -> PathBuf {
+  project_root().join("packaging/scoop/gwm.json.template")
+}
+
+fn run_script(args: &[&str]) -> Output {
+  Command::new("sh")
+    .arg(script_path())
+    .args(args)
+    .output()
+    .expect("script ran")
+}
+
+#[test]
+fn script_exists_and_is_executable() {
+  let p = script_path();
+  assert!(p.exists(), "render script missing at {}", p.display());
+  let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+  assert!(mode & 0o111 != 0, "render script not executable: mode={:o}", mode);
+}
+
+#[test]
+fn template_exists_and_carries_all_placeholders() {
+  let t = template_path();
+  let body = std::fs::read_to_string(&t).expect("template should exist");
+  for ph in ["__TAG__", "__VERSION__", "__SHA256_X86_64__"] {
+    assert!(
+      body.contains(ph),
+      "template missing placeholder {}: {}",
+      ph,
+      t.display()
+    );
+  }
+  // The Scoop autoupdate variables must live in the template verbatim so
+  // `scoop update` can bump versions on its own — they must NOT be rendered.
+  assert!(
+    body.contains("$version"),
+    "template missing the Scoop $version autoupdate var"
+  );
+  assert!(body.contains("autoupdate"), "template missing the autoupdate block");
+}
+
+#[test]
+fn renders_a_complete_valid_json_manifest() {
+  let x86 = "b".repeat(64);
+  let out = run_script(&["v0.5.0", "0.5.0", &x86, template_path().to_str().unwrap()]);
+  assert!(
+    out.status.success(),
+    "render failed: stderr={}",
+    String::from_utf8_lossy(&out.stderr)
+  );
+  let stdout = String::from_utf8_lossy(&out.stdout);
+
+  // A broken manifest is worse than no manifest — the rendered output must be
+  // valid JSON.
+  let v: serde_json::Value =
+    serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("rendered manifest is not valid JSON ({e}): {stdout}"));
+
+  assert_eq!(v["version"], "0.5.0", "version not substituted: {stdout}");
+  assert_eq!(
+    v["bin"], "gwm.exe",
+    "bin must point at the Windows executable: {stdout}"
+  );
+  let arch = &v["architecture"]["64bit"];
+  assert_eq!(
+    arch["url"], "https://github.com/kbrdn1/gwm-cli/releases/download/v0.5.0/gwm-v0.5.0-x86_64-pc-windows-msvc.zip",
+    "x86_64 URL missing or mis-tagged: {stdout}"
+  );
+  assert_eq!(arch["hash"], x86, "x86_64 sha not substituted: {stdout}");
+  assert_eq!(
+    arch["extract_dir"], "gwm-v0.5.0-x86_64-pc-windows-msvc",
+    "extract_dir must match the versioned folder inside the zip: {stdout}"
+  );
+
+  // Autoupdate vars survive rendering so `scoop update` keeps working.
+  assert!(
+    stdout.contains("v$version"),
+    "autoupdate $version var was clobbered: {stdout}"
+  );
+  assert!(
+    stdout.contains("$url.sha256"),
+    "autoupdate hash-from-sidecar var was clobbered: {stdout}"
+  );
+
+  for ph in ["__TAG__", "__VERSION__", "__SHA256_X86_64__"] {
+    assert!(!stdout.contains(ph), "leftover placeholder {ph} after render: {stdout}");
+  }
+}
+
+#[test]
+fn fails_when_required_args_missing() {
+  let out = run_script(&["v0.5.0"]);
+  assert!(!out.status.success(), "should fail with too few args");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.to_lowercase().contains("usage") || stderr.to_lowercase().contains("missing"),
+    "stderr should explain usage/missing arg: {stderr}"
+  );
+}
+
+#[test]
+fn fails_when_template_path_does_not_exist() {
+  let x86 = "b".repeat(64);
+  let out = run_script(&["v0.5.0", "0.5.0", &x86, "/nonexistent/path/gwm.json.template"]);
+  assert!(!out.status.success(), "should fail when template not found");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.to_lowercase().contains("not found")
+      || stderr.to_lowercase().contains("no such file")
+      || stderr.contains("/nonexistent/"),
+    "stderr should mention missing template: {stderr}"
+  );
+}
+
+#[test]
+fn rejects_obviously_invalid_sha256_lengths() {
+  let out = run_script(&["v0.5.0", "0.5.0", "tooshort", template_path().to_str().unwrap()]);
+  assert!(!out.status.success(), "should reject sha256 that is not 64 hex chars");
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.to_lowercase().contains("sha256")
+      || stderr.to_lowercase().contains("64")
+      || stderr.to_lowercase().contains("invalid"),
+    "stderr should explain the sha rejection: {stderr}"
+  );
+}


### PR DESCRIPTION
## Description

Adds the **Scoop** install channel for Windows — the biggest gap in the matrix (we build the `x86_64-pc-windows-msvc` binary but Windows users only had the raw `.zip`). Mirrors the Homebrew tap: a self-hosted bucket refreshed automatically on every stable release.

End users:

```powershell
scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm
scoop install gwm
```

First of the distribution campaign (#383), simplest → most complex. The bucket repo `kbrdn1/scoop-gwm` is already live with the v1.1.1 manifest.

Closes #376

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `packaging/scoop/gwm.json.template` — canonical Scoop manifest (arch/url/hash/extract_dir/bin + `checkver`/`autoupdate`).
- `.github/scripts/render-scoop-manifest.sh` — substitutes `__FOO__` placeholders, validates the sha256, leaves Scoop's `$version`/`$url` autoupdate vars intact.
- `.github/workflows/release.yml` — new `scoop-bucket-update` job: stable-only, fetches the Windows zip `.sha256`, renders `bucket/gwm.json`, pushes to `kbrdn1/scoop-gwm`. Advisory (`continue-on-error`) until `SCOOP_BUCKET_TOKEN` is provisioned.
- `tests/scoop_manifest_tests.rs` — pins the render contract (valid JSON, right URL/hash/extract_dir/bin, autoupdate vars preserved, sha/arg validation). Mirrors `homebrew_formula_tests.rs`.
- Docs: README install row, install page EN + FR, CONTRIBUTING §Releases (Scoop bucket setup + `SCOOP_BUCKET_TOKEN` bootstrap), CHANGELOG.

## Out-of-band (already done)

- Created **`kbrdn1/scoop-gwm`** (public) with `bucket/gwm.json` (rendered for v1.1.1, verified valid JSON against the real release sha256) + README.

## Follow-up needed (maintainer, can't be scripted)

- Provision the `SCOOP_BUCKET_TOKEN` secret (fine-grained PAT, Contents:write on `kbrdn1/scoop-gwm`) — steps in CONTRIBUTING. Until then the job is advisory and skips gracefully. Flip `continue-on-error` to `false` after the first successful sync.

## Tests

- [x] `cargo test` passes (fmt + clippy + full suite green; new `scoop_manifest_tests` 6/6)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `release.yml` YAML validated; manual render verified valid JSON against the live v1.1.1 sha256

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (install matrix)
- [ ] `examples/gwm.toml.example` updated (n/a — no config schema change)
- [x] No `unwrap()` on user-facing paths (n/a — packaging/CI only)
- [x] No `println!` in TUI render code (n/a)

## Linked issues / docs

- Issue: #376 · Tracking: #383