### PR TITLE
👷 ci(release): .deb + .rpm native Linux packages (#377, #378)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
         shell: bash
         run: |
           cargo install cargo-deb cargo-generate-rpm --locked
-          cargo deb --no-build --target ${{ matrix.target }} --output dist/
+          # `--no-strip`: the release profile already strips (`strip = true`),
+          # AND cargo-deb's default strip runs the HOST `strip` — which can't
+          # process the aarch64 ELF that `cross` built, failing the arm64 job.
+          # cargo-generate-rpm does not strip, so it needs no such flag.
+          cargo deb --no-build --no-strip --target ${{ matrix.target }} --output dist/
           cargo generate-rpm --target ${{ matrix.target }} --output dist/
           ( cd dist && for f in *.deb *.rpm; do shasum -a 256 "$f" > "$f.sha256"; done )
           ls -la dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,23 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 "dist/$STAGE.zip").Hash.ToLower()
           Set-Content -Path "dist/$STAGE.zip.sha256" -Encoding ascii -Value "$hash  $STAGE.zip"
 
+      # Native Linux packages (issues #377 / #378). cargo-deb and
+      # cargo-generate-rpm rewrite the `target/release` asset prefix to the
+      # per-target dir when `--target` is passed, so they package the binary
+      # the (cross-)build step above already produced — no rebuild. `--no-build`
+      # (deb) keeps it from recompiling; the explicit `depends`/`auto-req = no`
+      # in Cargo.toml skip dpkg-shlibdeps / rpm dep-detection, which can't run
+      # against the cross-built aarch64 binary on an x86_64 runner.
+      - name: package (linux .deb / .rpm)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          cargo install cargo-deb cargo-generate-rpm --locked
+          cargo deb --no-build --target ${{ matrix.target }} --output dist/
+          cargo generate-rpm --target ${{ matrix.target }} --output dist/
+          ( cd dist && for f in *.deb *.rpm; do shasum -a 256 "$f" > "$f.sha256"; done )
+          ls -la dist
+
       - name: upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -103,6 +120,18 @@ jobs:
             dist/*.tar.gz.sha256
             dist/*.zip
             dist/*.zip.sha256
+          if-no-files-found: error
+
+      - name: upload artifacts (linux packages)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: gwm-linux-packages-${{ matrix.target }}
+          path: |
+            dist/*.deb
+            dist/*.deb.sha256
+            dist/*.rpm
+            dist/*.rpm.sha256
           if-no-files-found: error
 
   release:
@@ -172,7 +201,11 @@ jobs:
             dist/*.tar.gz \
             dist/*.tar.gz.sha256 \
             dist/*.zip \
-            dist/*.zip.sha256
+            dist/*.zip.sha256 \
+            dist/*.deb \
+            dist/*.deb.sha256 \
+            dist/*.rpm \
+            dist/*.rpm.sha256
 
   homebrew-tap-update:
     name: update homebrew tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Scoop install channel for Windows** — `scoop bucket add gwm
-  https://github.com/kbrdn1/scoop-gwm && scoop install gwm`. A new
+  https://github.com/kbrdn1/scoop-gwm; scoop install gwm`. A new
   `scoop-bucket-update` job in `release.yml` renders
   `packaging/scoop/gwm.json.template` and pushes `bucket/gwm.json` to the
   `kbrdn1/scoop-gwm` bucket on every stable release (mirroring the Homebrew
   tap; pre-releases filtered out). `scoop update gwm` picks up each new
   version once the release job pushes the refreshed manifest. (#376)
+- **`.deb` packages for Debian / Ubuntu** — `x86_64` and `aarch64`, built by
+  `cargo-deb` and attached to every stable release (`sudo dpkg -i
+  gwm-cli_<ver>-1_amd64.deb`). The package is named `gwm-cli` to avoid
+  Debian's unrelated `gwm` window-manager package; the command stays `gwm`.
+  (#377)
+- **`.rpm` packages for Fedora / RHEL / openSUSE** — `x86_64` and `aarch64`,
+  built by `cargo-generate-rpm` and attached to every stable release (`sudo
+  rpm -i gwm-cli-<ver>-1.x86_64.rpm`). (#378)
 
 ## Past releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "git2",
  "glob",
  "libc",
+ "libz-sys",
  "nucleo-matcher",
  "portable-pty",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,13 @@ libgit2, per-repo .gwm.toml bootstrap (file copies, regex guards, lifecycle
 hooks), and a ratatui TUI. The installed command is `gwm`."""
 section = "utils"
 priority = "optional"
-depends = "libc6"
+# `>= 2.34`: the binaries are built on `ubuntu-latest`, whose CRT objects pull
+# GLIBC_2.34, so this is a definite lower bound. Declaring it makes dpkg refuse
+# cleanly on older glibc (RHEL 8 = 2.28, Ubuntu 20.04 = 2.31) instead of
+# installing then failing at load. It is a conservative floor, not the exact
+# per-arch ABI floor — computing that from the ELF in CI (and doing the same for
+# the tarballs) is tracked as a follow-up (#386).
+depends = "libc6 (>= 2.34)"
 conflicts = "gwm"
 assets = [
   ["target/release/gwm", "usr/bin/", "755"],
@@ -83,7 +89,7 @@ assets = [
 summary = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 license = "MIT"
 auto-req = "no"
-requires = { glibc = "*" }
+requires = { glibc = ">= 2.34" }
 assets = [
   { source = "target/release/gwm", dest = "/usr/bin/gwm", mode = "755" },
   { source = "README.md", dest = "/usr/share/doc/gwm-cli/README.md", mode = "644" },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,16 @@ pkg-fmt = "zip"
 
 # `.deb` packages (issue #377) — built + attached to each stable Release by
 # `release.yml` via `cargo deb --no-build --target <triple>`. The package name
-# is the crate name (`gwm-cli`, not `gwm`) to avoid colliding with Debian's
-# unrelated `gwm` window-manager package; the installed command stays `gwm`.
+# is the crate name (`gwm-cli`, not `gwm`); the installed command stays `gwm`.
+# `conflicts = "gwm"` is still needed because Debian's unrelated `gwm`
+# window-manager package also owns `/usr/bin/gwm`, so the two can't coexist —
+# dpkg refuses cleanly instead of erroring on the file clash at unpack time.
 # `depends = "libc6"` is set explicitly (not `$auto`) so cargo-deb skips
-# `dpkg-shlibdeps` — the binary vendors libgit2 statically and needs only
-# glibc, and skipping shlibdeps is what lets the aarch64 (cross-built) package
-# be produced from an x86_64 runner.
+# `dpkg-shlibdeps` — the binary vendors both libgit2 AND zlib statically (see
+# the libz-sys dep above), so glibc is its only dynamic dependency. Skipping
+# shlibdeps is what lets the cross-built aarch64 package be produced from an
+# x86_64 runner. glibc is not version-pinned (that needs per-arch symbol
+# analysis we can't run cross); the same implicit floor applies to the tarballs.
 [package.metadata.deb]
 maintainer = "Kylian Bardini <onepiecekylian@gmail.com>"
 copyright = "2026 Kylian Bardini"
@@ -61,6 +65,7 @@ hooks), and a ratatui TUI. The installed command is `gwm`."""
 section = "utils"
 priority = "optional"
 depends = "libc6"
+conflicts = "gwm"
 assets = [
   ["target/release/gwm", "usr/bin/", "755"],
   ["README.md", "usr/share/doc/gwm-cli/README.md", "644"],
@@ -70,12 +75,15 @@ assets = [
 # `.rpm` packages (issue #378) — built + attached by `release.yml` via
 # `cargo generate-rpm --target <triple>`. `auto-req = "no"` disables rpm's
 # dependency auto-detection (it needs the target's rpm tooling, unavailable
-# when cross-packaging aarch64 from an x86_64 runner); the statically-vendored
-# binary needs only glibc, present on every target.
+# when cross-packaging aarch64 from an x86_64 runner). With libgit2 and zlib
+# both statically linked, glibc is the only dynamic dependency, declared
+# explicitly via `requires` so a minimal Fedora/RHEL still pulls it. (No `gwm`
+# window-manager package exists on Fedora, so no rpm `conflicts` is needed.)
 [package.metadata.generate-rpm]
 summary = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 license = "MIT"
 auto-req = "no"
+requires = { glibc = "*" }
 assets = [
   { source = "target/release/gwm", dest = "/usr/bin/gwm", mode = "755" },
   { source = "README.md", dest = "/usr/share/doc/gwm-cli/README.md", mode = "644" },
@@ -112,6 +120,15 @@ ratatui = "0.30"
 # and which its own tests pin, beats hand-rolling the sequence here (#367).
 crossterm = { version = "0.29", features = ["osc52"] }
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
+# Force a statically-linked zlib (issue #377/#378 review). git2 pulls libz-sys,
+# which by default links the system `libz.so.1` dynamically — so the release
+# binary, and the .deb/.rpm built from it, would need a zlib runtime package too.
+# Static-linking it means everything depends only on glibc, so the packages can
+# declare accurate deps without per-distro zlib package names (zlib1g / zlib /
+# zlib-ng) or arch-specific sonames, and the cross-built aarch64 package is
+# correct too. Applied as a Cargo feature so it propagates inside the `cross`
+# container without env passthrough.
+libz-sys = { version = "1", features = ["static"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,47 @@ bin-dir = "gwm-v{ version }-{ target }/{ bin }"
 pkg-url = "{ repo }/releases/download/v{ version }/gwm-v{ version }-{ target }.zip"
 pkg-fmt = "zip"
 
+# `.deb` packages (issue #377) — built + attached to each stable Release by
+# `release.yml` via `cargo deb --no-build --target <triple>`. The package name
+# is the crate name (`gwm-cli`, not `gwm`) to avoid colliding with Debian's
+# unrelated `gwm` window-manager package; the installed command stays `gwm`.
+# `depends = "libc6"` is set explicitly (not `$auto`) so cargo-deb skips
+# `dpkg-shlibdeps` — the binary vendors libgit2 statically and needs only
+# glibc, and skipping shlibdeps is what lets the aarch64 (cross-built) package
+# be produced from an x86_64 runner.
+[package.metadata.deb]
+maintainer = "Kylian Bardini <onepiecekylian@gmail.com>"
+copyright = "2026 Kylian Bardini"
+license-file = ["LICENSE.md", "0"]
+extended-description = """
+git worktree manager — a terminal UI and CLI over git worktrees. Native
+libgit2, per-repo .gwm.toml bootstrap (file copies, regex guards, lifecycle
+hooks), and a ratatui TUI. The installed command is `gwm`."""
+section = "utils"
+priority = "optional"
+depends = "libc6"
+assets = [
+  ["target/release/gwm", "usr/bin/", "755"],
+  ["README.md", "usr/share/doc/gwm-cli/README.md", "644"],
+  ["CHANGELOG.md", "usr/share/doc/gwm-cli/CHANGELOG.md", "644"],
+]
+
+# `.rpm` packages (issue #378) — built + attached by `release.yml` via
+# `cargo generate-rpm --target <triple>`. `auto-req = "no"` disables rpm's
+# dependency auto-detection (it needs the target's rpm tooling, unavailable
+# when cross-packaging aarch64 from an x86_64 runner); the statically-vendored
+# binary needs only glibc, present on every target.
+[package.metadata.generate-rpm]
+summary = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
+license = "MIT"
+auto-req = "no"
+assets = [
+  { source = "target/release/gwm", dest = "/usr/bin/gwm", mode = "755" },
+  { source = "README.md", dest = "/usr/share/doc/gwm-cli/README.md", mode = "644" },
+  { source = "LICENSE.md", dest = "/usr/share/doc/gwm-cli/LICENSE.md", mode = "644" },
+  { source = "CHANGELOG.md", dest = "/usr/share/doc/gwm-cli/CHANGELOG.md", mode = "644" },
+]
+
 [lib]
 name = "gwm"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                            |
 | Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm; scoop install gwm` |
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
+| Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dpkg -i gwm-cli_<ver>-1_amd64.deb` |
+| Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo rpm -i gwm-cli-<ver>-1.x86_64.rpm` |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
 
 The crate is published as **`gwm-cli`** (the bare `gwm` name on crates.io belongs to an unrelated project) — the installed command is still `gwm`. `cargo binstall gwm-cli` grabs the prebuilt binary from the matching GitHub Release instead of compiling `git2`/vendored-libgit2 from source — no Rust toolchain needed at install time.

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -65,6 +65,28 @@ Releases at <https://github.com/kbrdn1/gwm-cli/releases> ship signed binaries wi
 
 Drop the binary on your `$PATH`, mark it executable, and you're done.
 
+## Debian / Ubuntu (`.deb`)
+
+Every stable release ships `.deb` packages for `x86_64` (`amd64`) and `aarch64` (`arm64`), built by [`cargo-deb`](https://github.com/kornelski/cargo-deb) and attached to the [release](https://github.com/kbrdn1/gwm-cli/releases). Download the one for your architecture and install it:
+
+```bash
+# x86_64 — grab gwm-cli_<version>-1_amd64.deb from the releases page, then:
+sudo dpkg -i gwm-cli_<version>-1_amd64.deb
+# aarch64 → gwm-cli_<version>-1_arm64.deb
+```
+
+The package is named **`gwm-cli`** (Debian already ships an unrelated `gwm` X11 window manager, so the crate name avoids the collision); the installed command is still `gwm`. Each `.deb` has a `.sha256` sidecar for verification.
+
+## Fedora / RHEL / openSUSE (`.rpm`)
+
+Likewise, `.rpm` packages for `x86_64` and `aarch64` are built by [`cargo-generate-rpm`](https://github.com/cat-in-136/cargo-generate-rpm) and attached to every stable release:
+
+```bash
+# x86_64
+sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
+# aarch64 → gwm-cli-<version>-1.aarch64.rpm
+```
+
 ## via Nix flake
 
 A `flake.nix` lives at the repo root. With flakes enabled:

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc (libgit2 and zlib are statically linked), so `Depends: libc6` and nothing else. Each `.deb` has a `.sha256` sidecar for verification.
+The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc (libgit2 and zlib are statically linked), so `Depends: libc6 (>= 2.34)` and nothing else — the packages are built on `ubuntu-latest`, so they declare a glibc floor and install cleanly only on distributions at or above it (RHEL 8 and Ubuntu 20.04 are too old; use `cargo install` there). Each `.deb` has a `.sha256` sidecar for verification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-The package is named **`gwm-cli`** (Debian already ships an unrelated `gwm` X11 window manager, so the crate name avoids the collision); the installed command is still `gwm`. Each `.deb` has a `.sha256` sidecar for verification.
+The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc (libgit2 and zlib are statically linked), so `Depends: libc6` and nothing else. Each `.deb` has a `.sha256` sidecar for verification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie que glibc (libgit2 et zlib sont liés statiquement), d'où `Depends: libc6` et rien d'autre. Chaque `.deb` a un sidecar `.sha256` pour vérification.
+Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie que glibc (libgit2 et zlib sont liés statiquement), d'où `Depends: libc6 (>= 2.34)` et rien d'autre — les paquets sont construits sur `ubuntu-latest`, ils déclarent donc un plancher glibc et ne s'installent proprement que sur les distributions au niveau ou au-dessus (RHEL 8 et Ubuntu 20.04 sont trop anciennes ; utilisez `cargo install` sur celles-ci). Chaque `.deb` a un sidecar `.sha256` pour vérification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-Le paquet s'appelle **`gwm-cli`** (Debian fournit déjà un gestionnaire de fenêtres X11 `gwm` sans rapport, le nom du crate évite la collision) ; la commande installée reste `gwm`. Chaque `.deb` a un sidecar `.sha256` pour vérification.
+Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie que glibc (libgit2 et zlib sont liés statiquement), d'où `Depends: libc6` et rien d'autre. Chaque `.deb` a un sidecar `.sha256` pour vérification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -65,6 +65,28 @@ Les releases sur <https://github.com/kbrdn1/gwm-cli/releases> fournissent des bi
 
 Déposez le binaire sur votre `$PATH`, rendez-le exécutable, et c'est terminé.
 
+## Debian / Ubuntu (`.deb`)
+
+Chaque release stable fournit des paquets `.deb` pour `x86_64` (`amd64`) et `aarch64` (`arm64`), construits par [`cargo-deb`](https://github.com/kornelski/cargo-deb) et attachés à la [release](https://github.com/kbrdn1/gwm-cli/releases). Téléchargez celui de votre architecture et installez-le :
+
+```bash
+# x86_64 — récupérez gwm-cli_<version>-1_amd64.deb depuis la page des releases, puis :
+sudo dpkg -i gwm-cli_<version>-1_amd64.deb
+# aarch64 → gwm-cli_<version>-1_arm64.deb
+```
+
+Le paquet s'appelle **`gwm-cli`** (Debian fournit déjà un gestionnaire de fenêtres X11 `gwm` sans rapport, le nom du crate évite la collision) ; la commande installée reste `gwm`. Chaque `.deb` a un sidecar `.sha256` pour vérification.
+
+## Fedora / RHEL / openSUSE (`.rpm`)
+
+De même, des paquets `.rpm` pour `x86_64` et `aarch64` sont construits par [`cargo-generate-rpm`](https://github.com/cat-in-136/cargo-generate-rpm) et attachés à chaque release stable :
+
+```bash
+# x86_64
+sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
+# aarch64 → gwm-cli-<version>-1.aarch64.rpm
+```
+
 ## via un flake Nix
 
 Un `flake.nix` se trouve à la racine du dépôt. Avec les flakes activés :

--- a/tests/linux_packaging_metadata_tests.rs
+++ b/tests/linux_packaging_metadata_tests.rs
@@ -48,6 +48,41 @@ fn asset_sources(block: &toml::Value) -> Vec<String> {
     .collect()
 }
 
+// ---- release.yml wiring (#377/#378) -------------------------------------
+//
+// The metadata blocks above are inert without the release job that invokes
+// `cargo deb` / `cargo generate-rpm` and attaches the results. Deleting or
+// mistyping those lines would break the next stable release while leaving the
+// metadata tests green — so the critical wiring is pinned here too.
+
+fn release_yml() -> String {
+  let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/release.yml");
+  std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn release_workflow_builds_both_linux_packages() {
+  let yml = release_yml();
+  // `--no-strip` is load-bearing: without it cargo-deb runs the host strip on
+  // the cross-built aarch64 ELF and the arm64 job fails (see #385 review).
+  assert!(
+    yml.contains("cargo deb --no-build --no-strip --target"),
+    "release.yml must build the .deb with --no-build --no-strip --target"
+  );
+  assert!(
+    yml.contains("cargo generate-rpm --target"),
+    "release.yml must build the .rpm per target"
+  );
+}
+
+#[test]
+fn release_workflow_publishes_both_linux_packages() {
+  let yml = release_yml();
+  for glob in ["dist/*.deb", "dist/*.deb.sha256", "dist/*.rpm", "dist/*.rpm.sha256"] {
+    assert!(yml.contains(glob), "the release upload step must publish {glob}");
+  }
+}
+
 // ---- .deb (#377) --------------------------------------------------------
 
 #[test]

--- a/tests/linux_packaging_metadata_tests.rs
+++ b/tests/linux_packaging_metadata_tests.rs
@@ -107,6 +107,30 @@ fn rpm_ships_the_binary_under_usr_bin() {
 }
 
 #[test]
+fn deb_conflicts_with_debian_gwm_window_manager() {
+  // Debian ships an unrelated `gwm` window manager that also owns
+  // `/usr/bin/gwm`; without Conflicts, dpkg errors on the file clash at unpack.
+  let deb = metadata("deb");
+  assert_eq!(
+    deb.get("conflicts").and_then(|v| v.as_str()),
+    Some("gwm"),
+    "deb must declare Conflicts: gwm"
+  );
+}
+
+#[test]
+fn rpm_declares_glibc_requirement() {
+  // With auto-req off (cross-packaging), the sole dynamic dep — glibc, since
+  // libgit2 and zlib are statically linked — must be declared explicitly.
+  let rpm = metadata("generate-rpm");
+  let requires = rpm.get("requires").expect("rpm requires table is present");
+  assert!(
+    requires.get("glibc").is_some(),
+    "rpm must require glibc explicitly, got: {requires:?}"
+  );
+}
+
+#[test]
 fn rpm_disables_auto_req() {
   let rpm = metadata("generate-rpm");
   // Cross-packaging aarch64 from an x86_64 runner can't run rpm's dependency

--- a/tests/linux_packaging_metadata_tests.rs
+++ b/tests/linux_packaging_metadata_tests.rs
@@ -73,16 +73,18 @@ fn deb_ships_the_binary_under_usr_bin() {
 }
 
 #[test]
-fn deb_skips_shlibdeps_with_an_explicit_depends() {
+fn deb_declares_glibc_with_a_version_floor() {
   let deb = metadata("deb");
-  let depends = deb.get("depends").and_then(|v| v.as_str());
+  let depends = deb
+    .get("depends")
+    .and_then(|v| v.as_str())
+    .expect("depends is a string");
   // Explicit (not `$auto`) so cargo-deb never runs dpkg-shlibdeps — required
-  // to package the cross-built aarch64 binary from an x86_64 runner.
-  assert_eq!(
-    depends,
-    Some("libc6"),
-    "depends must be the explicit glibc dep, not $auto"
-  );
+  // to package the cross-built aarch64 binary from an x86_64 runner — AND
+  // carries a glibc floor so dpkg refuses cleanly on too-old distros instead
+  // of installing then crashing at load.
+  assert!(depends.starts_with("libc6"), "glibc is the sole dynamic dep: {depends}");
+  assert!(depends.contains(">= 2.34"), "depends must pin a glibc floor: {depends}");
 }
 
 // ---- .rpm (#378) --------------------------------------------------------
@@ -124,9 +126,13 @@ fn rpm_declares_glibc_requirement() {
   // libgit2 and zlib are statically linked — must be declared explicitly.
   let rpm = metadata("generate-rpm");
   let requires = rpm.get("requires").expect("rpm requires table is present");
+  let glibc = requires
+    .get("glibc")
+    .and_then(|v| v.as_str())
+    .expect("glibc requirement present");
   assert!(
-    requires.get("glibc").is_some(),
-    "rpm must require glibc explicitly, got: {requires:?}"
+    glibc.contains(">= 2.34"),
+    "rpm glibc requirement must pin a floor, got: {glibc}"
   );
 }
 

--- a/tests/linux_packaging_metadata_tests.rs
+++ b/tests/linux_packaging_metadata_tests.rs
@@ -1,0 +1,146 @@
+//! Pin the `.deb` / `.rpm` packaging contracts (issues #377, #378).
+//!
+//! `release.yml` builds `.deb` (cargo-deb) and `.rpm` (cargo-generate-rpm)
+//! packages for the two Linux targets and attaches them to each stable
+//! Release. Both read their `[package.metadata.*]` block from `Cargo.toml`;
+//! a drift there ships a package that installs the binary to the wrong path,
+//! declares the wrong deps, or fails to build. The contract is asserted
+//! structurally against the parsed manifest — mirrors
+//! `binstall_metadata_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+fn manifest() -> toml::Value {
+  let path: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+  let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+  toml::from_str(&raw).expect("Cargo.toml is valid TOML")
+}
+
+fn metadata(key: &str) -> toml::Value {
+  manifest()
+    .get("package")
+    .and_then(|p| p.get("metadata"))
+    .and_then(|m| m.get(key))
+    .cloned()
+    .unwrap_or_else(|| panic!("[package.metadata.{key}] block is present"))
+}
+
+/// Every asset row's first field (deb: `["src", "dest", "mode"]`;
+/// rpm: `{{ source, dest, mode }}`) → the `source` path.
+fn asset_sources(block: &toml::Value) -> Vec<String> {
+  let assets = block
+    .get("assets")
+    .and_then(|a| a.as_array())
+    .expect("assets is an array");
+  assets
+    .iter()
+    .map(|row| {
+      if let Some(arr) = row.as_array() {
+        arr[0].as_str().expect("deb asset source is a string").to_string()
+      } else {
+        row
+          .get("source")
+          .and_then(|s| s.as_str())
+          .expect("rpm asset source is a string")
+          .to_string()
+      }
+    })
+    .collect()
+}
+
+// ---- .deb (#377) --------------------------------------------------------
+
+#[test]
+fn deb_ships_the_binary_under_usr_bin() {
+  let deb = metadata("deb");
+  let assets = deb
+    .get("assets")
+    .and_then(|a| a.as_array())
+    .expect("deb assets is an array");
+  // The binary row: `["target/release/gwm", "usr/bin/", "755"]`. The
+  // `target/release` prefix is what cargo-deb rewrites to the per-target dir
+  // when `--target` is passed, so it must stay exactly that.
+  let bin_row = assets
+    .iter()
+    .find(|r| {
+      r.as_array()
+        .is_some_and(|a| a[0].as_str() == Some("target/release/gwm"))
+    })
+    .expect("deb must ship target/release/gwm");
+  let row = bin_row.as_array().unwrap();
+  assert_eq!(row[1].as_str(), Some("usr/bin/"), "gwm must land in usr/bin/");
+  assert_eq!(row[2].as_str(), Some("755"), "the binary must be executable");
+}
+
+#[test]
+fn deb_skips_shlibdeps_with_an_explicit_depends() {
+  let deb = metadata("deb");
+  let depends = deb.get("depends").and_then(|v| v.as_str());
+  // Explicit (not `$auto`) so cargo-deb never runs dpkg-shlibdeps — required
+  // to package the cross-built aarch64 binary from an x86_64 runner.
+  assert_eq!(
+    depends,
+    Some("libc6"),
+    "depends must be the explicit glibc dep, not $auto"
+  );
+}
+
+// ---- .rpm (#378) --------------------------------------------------------
+
+#[test]
+fn rpm_ships_the_binary_under_usr_bin() {
+  let rpm = metadata("generate-rpm");
+  let sources = asset_sources(&rpm);
+  assert!(
+    sources.iter().any(|s| s == "target/release/gwm"),
+    "rpm must ship target/release/gwm, got: {sources:?}"
+  );
+  let bin = rpm
+    .get("assets")
+    .and_then(|a| a.as_array())
+    .unwrap()
+    .iter()
+    .find(|r| r.get("source").and_then(|s| s.as_str()) == Some("target/release/gwm"))
+    .expect("rpm binary asset present");
+  assert_eq!(bin.get("dest").and_then(|d| d.as_str()), Some("/usr/bin/gwm"));
+  assert_eq!(bin.get("mode").and_then(|m| m.as_str()), Some("755"));
+}
+
+#[test]
+fn rpm_disables_auto_req() {
+  let rpm = metadata("generate-rpm");
+  // Cross-packaging aarch64 from an x86_64 runner can't run rpm's dependency
+  // auto-detection; the vendored-static binary needs only glibc anyway.
+  assert_eq!(
+    rpm.get("auto-req").and_then(|v| v.as_str()),
+    Some("no"),
+    "auto-req must be disabled for cross-packaging"
+  );
+}
+
+#[test]
+fn both_packages_agree_on_the_doc_dir() {
+  // Both use the crate name (`gwm-cli`) for the doc dir, not `gwm`, matching
+  // the package name and avoiding Debian's unrelated `gwm` package.
+  for key in ["deb", "generate-rpm"] {
+    let sources = asset_sources(&metadata(key));
+    assert!(
+      sources.iter().any(|s| s.contains("README")),
+      "{key} should ship the README"
+    );
+  }
+  // Spot-check the doc dir path shape in each block's raw form.
+  let deb = metadata("deb");
+  let deb_readme = deb
+    .get("assets")
+    .and_then(|a| a.as_array())
+    .unwrap()
+    .iter()
+    .find_map(|r| {
+      r.as_array()
+        .and_then(|a| a[1].as_str())
+        .filter(|d| d.contains("README"))
+    })
+    .expect("deb README dest");
+  assert_eq!(deb_readme, "usr/share/doc/gwm-cli/README.md");
+}


### PR DESCRIPTION
## Description

Adds native Linux packages to every stable release: **`.deb`** (Debian/Ubuntu) and **`.rpm`** (Fedora/RHEL/openSUSE), for `x86_64` and `aarch64`. `cargo binstall` only serves users who already have the Rust toolchain — these reach everyone else via their native package manager. Both are the same generate-and-attach pattern, so they ship in one PR (they touch the same `Cargo.toml` + `release.yml`; splitting would force a stacked rebase on shared files).

Closes #377
Closes #378

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `Cargo.toml`: `[package.metadata.deb]` (cargo-deb) + `[package.metadata.generate-rpm]` (cargo-generate-rpm). Package name `gwm-cli` (crate name) to avoid Debian's unrelated `gwm` window-manager package; command stays `gwm`. `depends = "libc6"` / `auto-req = "no"` skip dpkg-shlibdeps / rpm dep-detection (binary vendors libgit2 statically, only needs glibc; and detection can't run against the cross-built aarch64 binary on an x86_64 runner).
- `.github/workflows/release.yml`: a `package (linux .deb / .rpm)` step on both Linux targets (`cargo deb --no-build --target <t>`, `cargo generate-rpm --target <t>`, + `.sha256` sidecars), a linux-packages artifact upload, and the `.deb`/`.rpm` globs added to the release `gh release upload`.
- `tests/linux_packaging_metadata_tests.rs`: pins both metadata blocks (binary → `/usr/bin/gwm` 755, `target/release` prefix preserved for the `--target` rewrite, shlibdeps/auto-req skipped). Mirrors `binstall_metadata_tests.rs`.
- Docs: README rows, install page EN + FR (`via .deb` / `via .rpm`), CHANGELOG. Also fixed the Scoop CHANGELOG example to `;` (PowerShell 5.1-safe).

## Local validation (beyond CI)

Installed cargo-deb 3.7.0 + cargo-generate-rpm 0.21.0 and **produced real packages locally**, including with `--target` to confirm the `target/release → target/<triple>/release` binary-path rewrite both tools do:

```
gwm-cli_1.1.1-1_arm64.deb
gwm-cli-1.1.1-1.aarch64.rpm
```

So the metadata is accepted and the exact CI invocation works; the per-arch ELF packaging itself runs in CI (like the tarballs).

## Tests

- [x] `cargo test` passes (fmt + clippy + full suite green; new `linux_packaging_metadata_tests` 5/5)
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` pass
- [x] `release.yml` YAML validated; deb/rpm generation smoke-tested locally

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (install matrix)
- [ ] `examples/gwm.toml.example` (n/a — no config schema change)
- [x] No `unwrap()` on user-facing paths (n/a — packaging/CI)
- [x] No `println!` in TUI render code (n/a)

## Linked issues

- Closes #377, #378 · Tracking: #383