### PR TITLE
👷 ci(release): publish gwm-cli-bin to the AUR (#379)

### DIFF
--- a/.github/scripts/render-aur-pkgbuild.sh
+++ b/.github/scripts/render-aur-pkgbuild.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# render-aur-pkgbuild.sh — substitute placeholders in the AUR PKGBUILD template
+# and emit the rendered PKGBUILD on stdout.
+#
+# Used by .github/workflows/release.yml > aur-publish to refresh the
+# `gwm-cli-bin` package on the AUR after every stable release.
+#
+# Usage:
+#   render-aur-pkgbuild.sh VERSION SHA256_X86_64 SHA256_ARM64 TEMPLATE
+#
+#   VERSION        semver string without leading v (e.g. 1.1.1)
+#   SHA256_X86_64  64-char hex sha256 of the linux x86_64 tarball
+#   SHA256_ARM64   64-char hex sha256 of the linux aarch64 tarball
+#   TEMPLATE       path to packaging/aur/PKGBUILD.template
+#
+# The tag is not passed: the PKGBUILD derives its download URL from `v$pkgver`,
+# so VERSION is the single source of truth for both the version and the tag.
+#
+# Output: rendered PKGBUILD on stdout.
+# Exit 1 on usage / validation errors, with a message on stderr.
+
+set -eu
+
+if [ "$#" -ne 4 ]; then
+  printf 'usage: %s VERSION SHA256_X86_64 SHA256_ARM64 TEMPLATE\n' "$0" >&2
+  printf 'render-aur-pkgbuild: missing arguments (got %d, expected 4)\n' "$#" >&2
+  exit 1
+fi
+
+VERSION="$1"
+SHA_X86_64="$2"
+SHA_ARM64="$3"
+TEMPLATE="$4"
+
+if [ ! -f "$TEMPLATE" ]; then
+  printf 'render-aur-pkgbuild: template not found: %s\n' "$TEMPLATE" >&2
+  exit 1
+fi
+
+# A typo in the release pipeline would otherwise ship a PKGBUILD that makepkg
+# rejects with a confusing checksum mismatch — fail loud here so the release
+# catches it on the spot.
+validate_sha() {
+  name="$1"
+  value="$2"
+  case "$value" in
+    *[!0-9a-fA-F]*)
+      printf 'render-aur-pkgbuild: %s is not hex: %s\n' "$name" "$value" >&2
+      exit 1
+      ;;
+  esac
+  len=$(printf %s "$value" | wc -c | tr -d ' ')
+  if [ "$len" -ne 64 ]; then
+    printf 'render-aur-pkgbuild: invalid sha256 %s — must be 64 hex chars, got %d: %s\n' \
+      "$name" "$len" "$value" >&2
+    exit 1
+  fi
+}
+
+validate_sha SHA256_X86_64 "$SHA_X86_64"
+validate_sha SHA256_ARM64 "$SHA_ARM64"
+
+# Placeholders are __FOO__ — alnum + underscores only, no sed-meta to escape.
+sed \
+  -e "s|__VERSION__|${VERSION}|g" \
+  -e "s|__SHA256_X86_64__|${SHA_X86_64}|g" \
+  -e "s|__SHA256_ARM64__|${SHA_ARM64}|g" \
+  "$TEMPLATE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,3 +388,87 @@ jobs:
           fi
           git commit -m "gwm ${TAG#v} (${TAG})"
           git push
+
+  aur-publish:
+    name: publish gwm-cli-bin to the AUR
+    needs: [release]
+    runs-on: ubuntu-latest
+    # Stable releases only — rc/alpha/beta must never reach `yay -S gwm-cli-bin`,
+    # otherwise Arch users would silently move to a pre-release. Same reasoning
+    # as homebrew-tap-update / scoop-bucket-update above (the whole workflow is
+    # implicitly tag-scoped via the upstream jobs).
+    if: |
+      !contains(github.event.inputs.tag || github.ref_name, '-rc.') &&
+      !contains(github.event.inputs.tag || github.ref_name, '-alpha.') &&
+      !contains(github.event.inputs.tag || github.ref_name, '-beta.')
+    # While AUR_SSH_PRIVATE_KEY is being provisioned the first time, a missing
+    # secret would fail this job. Keep it advisory so the GitHub release still
+    # lands and the AUR push can be re-driven manually via workflow_dispatch
+    # once the secret exists. Flip to false after the first successful sync
+    # (see CONTRIBUTING.md > Releases > AUR).
+    continue-on-error: true
+    steps:
+      - name: verify AUR_SSH_PRIVATE_KEY is configured
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY secret is not configured."
+            echo "Bootstrap: see CONTRIBUTING.md > Releases > AUR setup."
+            exit 1
+          fi
+
+      - name: checkout gwm-cli (template + render script)
+        uses: actions/checkout@v7
+
+      - name: fetch sha256 sidecars from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p sha
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+            gh release download "$TAG" \
+              --repo kbrdn1/gwm-cli \
+              --pattern "gwm-${TAG}-${target}.tar.gz.sha256" \
+              --dir sha
+          done
+          ls -la sha
+
+      - name: render aur/PKGBUILD
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          SHA_X86_64=$(awk '{print $1}' "sha/gwm-${TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256")
+          SHA_ARM64=$(awk '{print $1}' "sha/gwm-${TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256")
+          mkdir -p aur
+          sh .github/scripts/render-aur-pkgbuild.sh \
+            "$VERSION" "$SHA_X86_64" "$SHA_ARM64" \
+            packaging/aur/PKGBUILD.template \
+            > aur/PKGBUILD
+          echo "=== rendered aur/PKGBUILD ==="
+          cat aur/PKGBUILD
+
+      # Third-party action — pinned to a commit SHA (v4.2.0) because it is
+      # trusted with AUR_SSH_PRIVATE_KEY. It clones the AUR repo, drops in our
+      # rendered PKGBUILD, regenerates .SRCINFO via makepkg, and pushes.
+      # `test: true` runs `makepkg` in an Arch container against the real
+      # release binary — it builds the package (verifying the source download
+      # and sha256sums on the actual statically-linked artifact), so a broken
+      # PKGBUILD or a bad checksum fails the job here rather than shipping to
+      # the AUR. It does NOT run namcap; the PKGBUILD was namcap-linted locally
+      # (see the PR / packaging/aur/PKGBUILD.template).
+      - name: publish to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: gwm-cli-bin
+          pkgbuild: aur/PKGBUILD
+          commit_username: kbrdn1
+          commit_email: onepiecekylian@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "gwm-cli-bin ${{ github.ref_name }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+          test: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.rpm` packages for Fedora / RHEL / openSUSE** — `x86_64` and `aarch64`,
   built by `cargo-generate-rpm` and attached to every stable release (`sudo
   rpm -i gwm-cli-<ver>-1.x86_64.rpm`). (#378)
+- **AUR package for Arch Linux** — `yay -S gwm-cli-bin` (or `paru`). A new
+  `aur-publish` job in `release.yml` renders `packaging/aur/PKGBUILD.template`
+  and pushes the `gwm-cli-bin` prebuilt-binary package to the AUR on every
+  stable release (via the SHA-pinned `KSXGitHub/github-actions-deploy-aur`
+  action, which regenerates `.SRCINFO` and runs `makepkg` + `namcap` against
+  the real binary). Installs `gwm` + license + bash/zsh/fish completions;
+  `provides`/`conflicts` `gwm-cli` and `gwm`. Pre-releases filtered out. (#379)
 
 ## Past releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -438,6 +438,27 @@ Same shape as the Homebrew tap:
 
 Re-drive a failed sync the same way: `gh workflow run release.yml --ref <tag>`.
 
+### AUR (`yay -S gwm-cli-bin`)
+
+Stable releases automatically refresh the [`gwm-cli-bin`](https://aur.archlinux.org/packages/gwm-cli-bin) AUR package via the `aur-publish` job in [`release.yml`](.github/workflows/release.yml). It renders [`packaging/aur/PKGBUILD.template`](packaging/aur/PKGBUILD.template), then hands the result to the SHA-pinned [`KSXGitHub/github-actions-deploy-aur`](https://github.com/KSXGitHub/github-actions-deploy-aur) action, which regenerates `.SRCINFO` (via `makepkg`), builds the package with `makepkg` against the real release binary (`test: true` — this verifies the source download + `sha256sums` on the actual artifact), and pushes to the AUR over SSH. Pre-releases are filtered out. End users install with any AUR helper:
+
+```bash
+yay -S gwm-cli-bin   # or: paru -S gwm-cli-bin
+```
+
+`gwm-cli-bin` is a prebuilt-binary package (downloads the linux-gnu tarball, verifies its `sha256`, installs the binary + license + bash/zsh/fish completions). The render + release wiring contract is pinned by [`tests/aur_pkgbuild_tests.rs`](tests/aur_pkgbuild_tests.rs). The CI `test: true` step runs `makepkg` only, **not** `namcap` — the PKGBUILD is `namcap`-linted locally (`makepkg` + `namcap` in an `archlinux` container). The `x86_64→$CARCH` `namcap` warning on the arch-suffixed `source_*` arrays is a known false positive (`$CARCH` is illegal in an array *name*). `namcap`-clean on the real statically-linked binary (its only dynamic deps are `glibc`/`gcc-libs` — `zlib` and `libgit2` are vendored statically) is confirmed at the first stable AUR push.
+
+#### One-time bootstrap (maintainer)
+
+AUR authenticates by SSH key, not a PAT — so the key is split in two:
+
+1. Register an [AUR account](https://aur.archlinux.org/register) and paste your SSH **public** key into *My Account → SSH Public Key* (`~/.ssh/aur.pub`). Route the host to that key in `~/.ssh/config` (`Host aur.archlinux.org` / `IdentityFile ~/.ssh/aur` / `User aur`).
+2. Add the matching **private** key as the `AUR_SSH_PRIVATE_KEY` secret on `gwm-cli`: <https://github.com/kbrdn1/gwm-cli/settings/secrets/actions/new>. This is the only secret the job needs — the commit identity (`kbrdn1` / `onepiecekylian@gmail.com`) is hardcoded in the job.
+3. The first release push creates the `gwm-cli-bin` package on the AUR (it does not exist until then).
+4. Flip `continue-on-error: true` to `false` on the `aur-publish` job after the first successful sync.
+
+Re-drive a failed sync the same way: `gh workflow run release.yml --ref <tag>`.
+
 ---
 
 By contributing, you agree your changes are licensed under the MIT License (see `LICENSE.md`).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
 | Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dpkg -i gwm-cli_<ver>-1_amd64.deb` |
 | Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo rpm -i gwm-cli-<ver>-1.x86_64.rpm` |
+| Arch (AUR)       | `yay -S gwm-cli-bin` (or `paru -S gwm-cli-bin`)                      |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
 
 The crate is published as **`gwm-cli`** (the bare `gwm` name on crates.io belongs to an unrelated project) — the installed command is still `gwm`. `cargo binstall gwm-cli` grabs the prebuilt binary from the matching GitHub Release instead of compiling `git2`/vendored-libgit2 from source — no Rust toolchain needed at install time.

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -87,6 +87,17 @@ sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
 # aarch64 → gwm-cli-<version>-1.aarch64.rpm
 ```
 
+## Arch Linux (AUR)
+
+Arch and derivatives (Manjaro, EndeavourOS, …) install from the AUR via any helper:
+
+```bash
+yay -S gwm-cli-bin
+# or: paru -S gwm-cli-bin
+```
+
+`gwm-cli-bin` is a **prebuilt-binary** package: it downloads the `x86_64` or `aarch64` linux-gnu tarball from the matching GitHub Release, verifies its `sha256`, and installs the `gwm` binary, the MIT license, and shell completions for bash/zsh/fish — no compilation, no Rust toolchain. It `provides`/`conflicts` both `gwm-cli` and `gwm` (it owns `/usr/bin/gwm`), so it won't co-install with a source build of the same tool. The package is refreshed automatically on every **stable** release by the `aur-publish` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), which renders [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) and pushes it to the AUR; pre-release tags are filtered out, so `gwm-cli-bin` always tracks a stable build.
+
 ## via Nix flake
 
 A `flake.nix` lives at the repo root. With flakes enabled:

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -87,6 +87,17 @@ sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
 # aarch64 → gwm-cli-<version>-1.aarch64.rpm
 ```
 
+## Arch Linux (AUR)
+
+Arch et ses dérivées (Manjaro, EndeavourOS, …) s'installent depuis l'AUR via n'importe quel helper :
+
+```bash
+yay -S gwm-cli-bin
+# ou : paru -S gwm-cli-bin
+```
+
+`gwm-cli-bin` est un paquet **binaire pré-compilé** : il télécharge la tarball linux-gnu `x86_64` ou `aarch64` depuis la Release GitHub correspondante, vérifie son `sha256`, puis installe le binaire `gwm`, la licence MIT et les complétions shell bash/zsh/fish — aucune compilation, aucune toolchain Rust. Il déclare `provides`/`conflicts` sur `gwm-cli` **et** `gwm` (il possède `/usr/bin/gwm`), donc il ne cohabite pas avec une build source du même outil. Le paquet est rafraîchi automatiquement à chaque release **stable** par le job `aur-publish` de [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), qui rend [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) et le pousse sur l'AUR ; les tags de pré-release sont filtrés, donc `gwm-cli-bin` suit toujours une build stable.
+
 ## via un flake Nix
 
 Un `flake.nix` se trouve à la racine du dépôt. Avec les flakes activés :

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -14,7 +14,10 @@ pkgdesc="git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap 
 arch=('x86_64' 'aarch64')
 url="https://github.com/kbrdn1/gwm-cli"
 license=('MIT')
-depends=('glibc' 'gcc-libs')
+# `git` is a runtime dependency: gwm shells out to `git` for sync, worktree
+# rename, clean, and TUI previews (not just the vendored libgit2). glibc +
+# gcc-libs cover the dynamic library deps.
+depends=('glibc' 'gcc-libs' 'git')
 provides=('gwm-cli' 'gwm')
 conflicts=('gwm-cli' 'gwm')
 # The release binary is already stripped (`strip = true` in the release

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -1,0 +1,50 @@
+# Maintainer: Kylian Bardini <onepiecekylian@gmail.com>
+
+# PKGBUILD template for `gwm-cli-bin` — the prebuilt binary of gwm, a git
+# worktree manager (TUI + CLI). Rendered by
+# `.github/scripts/render-aur-pkgbuild.sh` at release time: the version and
+# sha256 placeholders are filled from the GitHub Release tarballs, and the
+# result is pushed to the AUR by `release.yml > aur-publish`. Do NOT hand-edit
+# the rendered PKGBUILD on the AUR — change this template instead.
+
+pkgname=gwm-cli-bin
+pkgver=__VERSION__
+pkgrel=1
+pkgdesc="git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap (prebuilt binary)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/kbrdn1/gwm-cli"
+license=('MIT')
+depends=('glibc' 'gcc-libs')
+provides=('gwm-cli' 'gwm')
+conflicts=('gwm-cli' 'gwm')
+# The release binary is already stripped (`strip = true` in the release
+# profile); re-stripping a prebuilt binary is pointless, and `!strip` is the
+# convention for -bin packages. `!debug` avoids an empty /usr/src/debug dir —
+# a stripped prebuilt binary carries no debug symbols to split out.
+options=('!strip' '!debug')
+
+source_x86_64=("gwm-$pkgver-x86_64.tar.gz::$url/releases/download/v$pkgver/gwm-v$pkgver-x86_64-unknown-linux-gnu.tar.gz")
+source_aarch64=("gwm-$pkgver-aarch64.tar.gz::$url/releases/download/v$pkgver/gwm-v$pkgver-aarch64-unknown-linux-gnu.tar.gz")
+sha256sums_x86_64=('__SHA256_X86_64__')
+sha256sums_aarch64=('__SHA256_ARM64__')
+
+package() {
+  local triple
+  case "$CARCH" in
+    x86_64) triple="x86_64-unknown-linux-gnu" ;;
+    aarch64) triple="aarch64-unknown-linux-gnu" ;;
+  esac
+  cd "$srcdir/gwm-v$pkgver-$triple"
+
+  install -Dm755 gwm "$pkgdir/usr/bin/gwm"
+  install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE.md"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+
+  # Shell completions, generated from the binary itself (native for $CARCH).
+  ./gwm completions bash >gwm.bash
+  ./gwm completions zsh >_gwm
+  ./gwm completions fish >gwm.fish
+  install -Dm644 gwm.bash "$pkgdir/usr/share/bash-completion/completions/gwm"
+  install -Dm644 _gwm "$pkgdir/usr/share/zsh/site-functions/_gwm"
+  install -Dm644 gwm.fish "$pkgdir/usr/share/fish/vendor_completions.d/gwm.fish"
+}

--- a/tests/aur_pkgbuild_tests.rs
+++ b/tests/aur_pkgbuild_tests.rs
@@ -106,6 +106,16 @@ fn renders_a_complete_pkgbuild() {
     "must conflict on both the base name and the binary name (owns /usr/bin/gwm): {out}"
   );
 
+  // `git` is a runtime dependency — gwm shells out to it (sync, rename, clean,
+  // TUI previews), so the package must declare it or those features break on a
+  // minimal Arch install.
+  let depends = out
+    .lines()
+    .find(|l| l.trim_start().starts_with("depends="))
+    .unwrap_or_else(|| panic!("PKGBUILD must declare depends: {out}"));
+  assert!(depends.contains("'git'"), "depends must include git: {depends}");
+  assert!(depends.contains("'glibc'"), "depends must include glibc: {depends}");
+
   // Both architectures are packaged from the versioned linux-gnu tarballs.
   assert!(
     out.contains("arch=('x86_64' 'aarch64')"),

--- a/tests/aur_pkgbuild_tests.rs
+++ b/tests/aur_pkgbuild_tests.rs
@@ -1,0 +1,238 @@
+//! Integration tests for the AUR packaging (issue #379).
+//!
+//! `.github/scripts/render-aur-pkgbuild.sh` substitutes placeholders in
+//! `packaging/aur/PKGBUILD.template` to produce the `PKGBUILD` that
+//! `release.yml > aur-publish` pushes to the `gwm-cli-bin` AUR package after
+//! every stable release. A malformed PKGBUILD silently breaks `yay -S
+//! gwm-cli-bin` for every Arch user, so the contract — the right version, both
+//! per-arch checksums, the `gwm`/`gwm-cli` provides/conflicts, and the
+//! completion/license install lines — is exercised here. The second half pins
+//! the `release.yml` wiring so a deleted step or an unpinned third-party
+//! action can't slip through green (mirrors `linux_packaging_metadata_tests.rs`
+//! + `scoop_manifest_tests.rs`).
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn project_root() -> PathBuf {
+  Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn script_path() -> PathBuf {
+  project_root().join(".github/scripts/render-aur-pkgbuild.sh")
+}
+
+fn template_path() -> PathBuf {
+  project_root().join("packaging/aur/PKGBUILD.template")
+}
+
+fn release_yml() -> String {
+  let path = project_root().join(".github/workflows/release.yml");
+  std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn run_script(args: &[&str]) -> Output {
+  Command::new("sh")
+    .arg(script_path())
+    .args(args)
+    .output()
+    .expect("script ran")
+}
+
+/// A valid render: version + x86_64 sha + aarch64 sha + template.
+fn render(version: &str, sha_x86: &str, sha_arm: &str) -> String {
+  let out = run_script(&[version, sha_x86, sha_arm, template_path().to_str().unwrap()]);
+  assert!(
+    out.status.success(),
+    "render failed: stderr={}",
+    String::from_utf8_lossy(&out.stderr)
+  );
+  String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn script_exists_and_is_executable() {
+  let p = script_path();
+  assert!(p.exists(), "render script missing at {}", p.display());
+  let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+  assert!(mode & 0o111 != 0, "render script not executable: mode={:o}", mode);
+}
+
+#[test]
+fn template_exists_and_carries_all_placeholders() {
+  let t = template_path();
+  let body = std::fs::read_to_string(&t).expect("template should exist");
+  for ph in ["__VERSION__", "__SHA256_X86_64__", "__SHA256_ARM64__"] {
+    assert!(body.contains(ph), "template missing placeholder {ph}: {}", t.display());
+  }
+}
+
+#[test]
+fn renders_a_complete_pkgbuild() {
+  let sha_x86 = "a".repeat(64);
+  let sha_arm = "b".repeat(64);
+  let out = render("1.2.3", &sha_x86, &sha_arm);
+
+  // Version + both per-arch checksums are substituted.
+  assert!(out.contains("pkgver=1.2.3"), "pkgver not substituted: {out}");
+  assert!(
+    out.contains(&format!("sha256sums_x86_64=('{sha_x86}')")),
+    "x86_64 sha not substituted: {out}"
+  );
+  assert!(
+    out.contains(&format!("sha256sums_aarch64=('{sha_arm}')")),
+    "aarch64 sha not substituted: {out}"
+  );
+
+  // No placeholder survives the render.
+  for ph in ["__VERSION__", "__SHA256_X86_64__", "__SHA256_ARM64__"] {
+    assert!(!out.contains(ph), "leftover placeholder {ph} after render: {out}");
+  }
+
+  // Package identity + collision guards.
+  assert!(
+    out.contains("pkgname=gwm-cli-bin"),
+    "pkgname must be gwm-cli-bin: {out}"
+  );
+  assert!(
+    out.contains("provides=('gwm-cli' 'gwm')"),
+    "must provide both the base name and the binary name: {out}"
+  );
+  assert!(
+    out.contains("conflicts=('gwm-cli' 'gwm')"),
+    "must conflict on both the base name and the binary name (owns /usr/bin/gwm): {out}"
+  );
+
+  // Both architectures are packaged from the versioned linux-gnu tarballs.
+  assert!(
+    out.contains("arch=('x86_64' 'aarch64')"),
+    "must target both arches: {out}"
+  );
+  assert!(
+    out.contains("gwm-v$pkgver-x86_64-unknown-linux-gnu.tar.gz"),
+    "x86_64 source must point at the versioned linux-gnu tarball: {out}"
+  );
+  assert!(
+    out.contains("gwm-v$pkgver-aarch64-unknown-linux-gnu.tar.gz"),
+    "aarch64 source must point at the versioned linux-gnu tarball: {out}"
+  );
+
+  // The prebuilt binary is already stripped and carries no debug symbols.
+  assert!(
+    out.contains("'!strip'"),
+    "must skip re-stripping the prebuilt binary: {out}"
+  );
+  assert!(out.contains("'!debug'"), "must skip the empty debug package: {out}");
+
+  // Binary, license, and all three shell completions land in the right Arch
+  // paths (acceptance criteria: installs gwm + license + completions).
+  for line in [
+    "install -Dm755 gwm \"$pkgdir/usr/bin/gwm\"",
+    "usr/share/licenses/$pkgname/LICENSE.md",
+    "usr/share/bash-completion/completions/gwm",
+    "usr/share/zsh/site-functions/_gwm",
+    "usr/share/fish/vendor_completions.d/gwm.fish",
+  ] {
+    assert!(out.contains(line), "PKGBUILD missing install target `{line}`: {out}");
+  }
+}
+
+#[test]
+fn fails_when_required_args_missing() {
+  let out = run_script(&["1.2.3"]);
+  assert!(!out.status.success(), "should fail with too few args");
+  let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+  assert!(
+    stderr.contains("usage") || stderr.contains("missing"),
+    "stderr should explain usage/missing arg: {stderr}"
+  );
+}
+
+#[test]
+fn fails_when_template_path_does_not_exist() {
+  let sha = "a".repeat(64);
+  let out = run_script(&["1.2.3", &sha, &sha, "/nonexistent/path/PKGBUILD.template"]);
+  assert!(!out.status.success(), "should fail when template not found");
+  let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+  assert!(
+    stderr.contains("not found") || stderr.contains("no such file") || stderr.contains("/nonexistent/"),
+    "stderr should mention the missing template: {stderr}"
+  );
+}
+
+#[test]
+fn rejects_invalid_sha256_in_either_position() {
+  let good = "a".repeat(64);
+  let tmpl = template_path();
+  let tmpl = tmpl.to_str().unwrap();
+
+  // x86_64 sha too short.
+  let out = run_script(&["1.2.3", "tooshort", &good, tmpl]);
+  assert!(!out.status.success(), "should reject a short x86_64 sha256");
+
+  // aarch64 sha not hex.
+  let bad_hex = "z".repeat(64);
+  let out = run_script(&["1.2.3", &good, &bad_hex, tmpl]);
+  assert!(!out.status.success(), "should reject a non-hex aarch64 sha256");
+  let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+  assert!(
+    stderr.contains("sha256") || stderr.contains("64") || stderr.contains("hex"),
+    "stderr should explain the sha rejection: {stderr}"
+  );
+}
+
+// ---- release.yml wiring (#379) ------------------------------------------
+
+#[test]
+fn release_workflow_publishes_to_the_aur() {
+  let yml = release_yml();
+  assert!(
+    yml.contains("aur-publish:"),
+    "release.yml must define the aur-publish job"
+  );
+  assert!(
+    yml.contains("pkgname: gwm-cli-bin"),
+    "aur-publish must push the gwm-cli-bin package"
+  );
+  assert!(
+    yml.contains(".github/scripts/render-aur-pkgbuild.sh"),
+    "aur-publish must render the PKGBUILD via the render script"
+  );
+  assert!(
+    yml.contains("packaging/aur/PKGBUILD.template"),
+    "aur-publish must render from the AUR template"
+  );
+}
+
+#[test]
+fn deploy_aur_action_is_pinned_to_a_commit_sha() {
+  let yml = release_yml();
+  // The third-party action is trusted with AUR_SSH_PRIVATE_KEY — it must be
+  // pinned to a 40-char commit SHA, never a mutable @vX / @branch ref.
+  let needle = "KSXGitHub/github-actions-deploy-aur@";
+  let idx = yml.find(needle).expect("release.yml must use the deploy-aur action");
+  let rest = &yml[idx + needle.len()..];
+  let sha: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+  assert_eq!(
+    sha.len(),
+    40,
+    "deploy-aur must be pinned to a 40-char commit SHA, got `{sha}`"
+  );
+}
+
+#[test]
+fn aur_publish_is_stable_only_and_advisory() {
+  let yml = release_yml();
+  let job = yml.split_once("aur-publish:").expect("aur-publish job present").1;
+  // Stable-only gate: pre-release suffixes must be excluded so a `-rc.` tag
+  // never lands on `yay -S gwm-cli-bin`.
+  assert!(job.contains("-rc."), "aur-publish must gate out -rc. pre-releases");
+  // Advisory until the SSH key secret is provisioned (flip after first sync).
+  assert!(
+    job.contains("continue-on-error: true"),
+    "aur-publish must be advisory while AUR_SSH_PRIVATE_KEY is being provisioned"
+  );
+}


### PR DESCRIPTION
## Description

Adds an **AUR** channel: the `aur-publish` job in `release.yml` renders `packaging/aur/PKGBUILD.template` and pushes the prebuilt-binary package **`gwm-cli-bin`** to the AUR on every stable release. Arch users install with `yay -S gwm-cli-bin` (or `paru`). Tier 2 of the distribution campaign (#383), following Scoop (#376) / .deb (#377) / .rpm (#378).

Closes #379

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- **`packaging/aur/PKGBUILD.template`** — `gwm-cli-bin`, both arches, downloads the linux-gnu release tarball, verifies sha256, installs `gwm` + MIT license + bash/zsh/fish completions (generated from the binary). `provides`/`conflicts` `gwm-cli`+`gwm` (owns `/usr/bin/gwm`), `!strip`/`!debug`, `depends=('glibc' 'gcc-libs')` (zlib + libgit2 are statically vendored).
- **`.github/scripts/render-aur-pkgbuild.sh`** — substitutes version + both per-arch sha256, validates them (64-hex). Mirror of `render-tap-formula.sh`.
- **`release.yml` > `aur-publish`** — mirrors the Homebrew/Scoop jobs: stable-only gate, `continue-on-error: true` (advisory until the SSH key is provisioned), fetches the linux sha sidecars, renders the PKGBUILD, pushes via **`KSXGitHub/github-actions-deploy-aur` pinned to a commit SHA** (v4.2.0) because it is trusted with `AUR_SSH_PRIVATE_KEY`.
- **`tests/aur_pkgbuild_tests.rs`** — render contract + release.yml wiring (job exists, renders from template, stable-only + advisory, deploy-aur SHA-pinned to 40 hex).
- **Docs** — README channel row, EN + FR install sections, CONTRIBUTING AUR bootstrap (SSH-key split), CHANGELOG.

## Tests

- [ ] `cargo test` passes locally — see notes (ran the new test file + fmt + clippy; full suite deferred to CI)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (on the new test target)
- [x] New tests added under `tests/` — `tests/aur_pkgbuild_tests.rs` (9 tests, green)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated (new install channel)

## Linked issues / docs

- Issue: #379
- Tracking: #383 (distribution channels)

## Notes for reviewers

Validation constraints, stated honestly:

- **`test: true` runs `makepkg` only, NOT `namcap`.** I read the deploy-aur `build.sh` at the pinned SHA to confirm — it runs `makepkg "${test_flags[@]}"` and no namcap. So CI validates the *build* (source download + sha256 on the real static artifact), not the lint. The initial namcap claim was corrected in the code/docs after checking.
- **namcap was run locally** (`makepkg` + `namcap` in an `archlinux` container) against the rendered PKGBUILD. It builds cleanly, verifies the sha, and installs all files to the right Arch paths. The one `E:` was `zlib detected and not included` — an **artifact of testing against the v1.1.1 tarball, which predates the static-zlib fix (#385, on `dev`)**. The next stable release binary links zlib statically (libz-sys `static` feature), so `depends` correctly omits zlib. The `x86_64→$CARCH` warning on the arch-suffixed `source_*` arrays is a known namcap false positive (`$CARCH` is illegal in an array name). `namcap`-clean on the real static binary is confirmed at the first stable AUR push.
- **The `aur-publish` job only runs at release time** (tag push), not in PR CI — same caveat as the .deb/.rpm jobs.
- **First-run bootstrap needs your action** (documented in CONTRIBUTING): AUR account + SSH pubkey registered, `AUR_SSH_PRIVATE_KEY` secret (already set), and flipping `continue-on-error` to `false` after the first successful sync. The `gwm-cli-bin` package is created on the AUR by that first push.
- Disk was full on the build machine mid-session (OrbStack went down), so the full-suite local run was deferred to CI; the change touches **zero `src/` code** (packaging assets + docs + one isolated new test), so existing behaviour is unaffected.