### PR TITLE
🐛 fix(packaging): declare git as a runtime dep for .deb/.rpm (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `aur-publish` job in `release.yml` renders `packaging/aur/PKGBUILD.template`
   and pushes the `gwm-cli-bin` prebuilt-binary package to the AUR on every
   stable release (via the SHA-pinned `KSXGitHub/github-actions-deploy-aur`
-  action, which regenerates `.SRCINFO` and runs `makepkg` + `namcap` against
-  the real binary). Installs `gwm` + license + bash/zsh/fish completions;
-  `provides`/`conflicts` `gwm-cli` and `gwm`. Pre-releases filtered out. (#379)
+  action, which regenerates `.SRCINFO` and builds the package with `makepkg`
+  against the real binary). Installs `gwm` + license + bash/zsh/fish
+  completions; `depends` on `git` (gwm shells out to it); `provides`/`conflicts`
+  `gwm-cli` and `gwm`. Pre-releases filtered out. (#379)
+
+### Fixed
+
+- **`.deb` / `.rpm` packages now depend on `git`** — gwm shells out to the
+  `git` binary (sync, worktree rename, clean, TUI previews) beyond the vendored
+  libgit2, so a minimal Debian/Fedora install without git would break those
+  features. `git` is now declared in `Depends` / `Requires`. (#388)
 
 ## Past releases
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,13 @@ pkg-fmt = "zip"
 # `conflicts = "gwm"` is still needed because Debian's unrelated `gwm`
 # window-manager package also owns `/usr/bin/gwm`, so the two can't coexist —
 # dpkg refuses cleanly instead of erroring on the file clash at unpack time.
-# `depends = "libc6"` is set explicitly (not `$auto`) so cargo-deb skips
-# `dpkg-shlibdeps` — the binary vendors both libgit2 AND zlib statically (see
-# the libz-sys dep above), so glibc is its only dynamic dependency. Skipping
-# shlibdeps is what lets the cross-built aarch64 package be produced from an
-# x86_64 runner. glibc is not version-pinned (that needs per-arch symbol
-# analysis we can't run cross); the same implicit floor applies to the tarballs.
+# `depends` is set explicitly (not `$auto`) so cargo-deb skips `dpkg-shlibdeps`
+# — the binary vendors both libgit2 AND zlib statically (see the libz-sys dep
+# above), so glibc is its only dynamic *library* dependency. Skipping shlibdeps
+# is what lets the cross-built aarch64 package be produced from an x86_64
+# runner. `git` is added as a runtime dependency because gwm shells out to the
+# `git` binary (sync, worktree rename, clean, TUI previews) beyond the vendored
+# libgit2 — shlibdeps would never catch an exec dependency (#388).
 [package.metadata.deb]
 maintainer = "Kylian Bardini <onepiecekylian@gmail.com>"
 copyright = "2026 Kylian Bardini"
@@ -70,7 +71,7 @@ priority = "optional"
 # installing then failing at load. It is a conservative floor, not the exact
 # per-arch ABI floor — computing that from the ELF in CI (and doing the same for
 # the tarballs) is tracked as a follow-up (#386).
-depends = "libc6 (>= 2.34)"
+depends = "libc6 (>= 2.34), git"
 conflicts = "gwm"
 assets = [
   ["target/release/gwm", "usr/bin/", "755"],
@@ -82,14 +83,17 @@ assets = [
 # `cargo generate-rpm --target <triple>`. `auto-req = "no"` disables rpm's
 # dependency auto-detection (it needs the target's rpm tooling, unavailable
 # when cross-packaging aarch64 from an x86_64 runner). With libgit2 and zlib
-# both statically linked, glibc is the only dynamic dependency, declared
-# explicitly via `requires` so a minimal Fedora/RHEL still pulls it. (No `gwm`
-# window-manager package exists on Fedora, so no rpm `conflicts` is needed.)
+# both statically linked, glibc is the only dynamic *library* dependency; `git`
+# is added as a runtime dependency because gwm shells out to the `git` binary
+# (sync, worktree rename, clean, TUI previews) beyond the vendored libgit2
+# (#388). Both are declared explicitly via `requires` so a minimal Fedora/RHEL
+# still pulls them. (No `gwm` window-manager package exists on Fedora, so no
+# rpm `conflicts` is needed.)
 [package.metadata.generate-rpm]
 summary = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 license = "MIT"
 auto-req = "no"
-requires = { glibc = ">= 2.34" }
+requires = { glibc = ">= 2.34", git = "*" }
 assets = [
   { source = "target/release/gwm", dest = "/usr/bin/gwm", mode = "755" },
   { source = "README.md", dest = "/usr/share/doc/gwm-cli/README.md", mode = "644" },

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                            |
 | Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm; scoop install gwm` |
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
-| Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dpkg -i gwm-cli_<ver>-1_amd64.deb` |
-| Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo rpm -i gwm-cli-<ver>-1.x86_64.rpm` |
+| Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo apt install ./gwm-cli_<ver>-1_amd64.deb` |
+| Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dnf install ./gwm-cli-<ver>-1.x86_64.rpm` |
 | Arch (AUR)       | `yay -S gwm-cli-bin` (or `paru -S gwm-cli-bin`)                      |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc (libgit2 and zlib are statically linked), so `Depends: libc6 (>= 2.34)` and nothing else — the packages are built on `ubuntu-latest`, so they declare a glibc floor and install cleanly only on distributions at or above it (RHEL 8 and Ubuntu 20.04 are too old; use `cargo install` there). Each `.deb` has a `.sha256` sidecar for verification.
+The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc dynamically (libgit2 and zlib are statically linked), and gwm shells out to the `git` binary at runtime — so `Depends: libc6 (>= 2.34), git`. The packages are built on `ubuntu-latest`, so they declare a glibc floor and install cleanly only on distributions at or above it (RHEL 8 and Ubuntu 20.04 are too old; use `cargo install` there). Each `.deb` has a `.sha256` sidecar for verification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -71,9 +71,11 @@ Every stable release ships `.deb` packages for `x86_64` (`amd64`) and `aarch64` 
 
 ```bash
 # x86_64 — grab gwm-cli_<version>-1_amd64.deb from the releases page, then:
-sudo dpkg -i gwm-cli_<version>-1_amd64.deb
+sudo apt install ./gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
+
+Use `apt install ./…` (note the leading `./`) rather than `dpkg -i`: the package `Depends` on `git`, and `apt` pulls it automatically, whereas `dpkg -i` does not resolve dependencies and fails on a system that doesn't already have git.
 
 The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ships an unrelated `gwm` X11 window manager that also owns `/usr/bin/gwm`, so the two can't be installed together (remove the window manager first if you happen to have it). The installed command is still `gwm`. The binary links only glibc dynamically (libgit2 and zlib are statically linked), and gwm shells out to the `git` binary at runtime — so `Depends: libc6 (>= 2.34), git`. The packages are built on `ubuntu-latest`, so they declare a glibc floor and install cleanly only on distributions at or above it (RHEL 8 and Ubuntu 20.04 are too old; use `cargo install` there). Each `.deb` has a `.sha256` sidecar for verification.
 
@@ -82,10 +84,14 @@ The package is named **`gwm-cli`** and declares `Conflicts: gwm` — Debian ship
 Likewise, `.rpm` packages for `x86_64` and `aarch64` are built by [`cargo-generate-rpm`](https://github.com/cat-in-136/cargo-generate-rpm) and attached to every stable release:
 
 ```bash
-# x86_64
-sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
+# Fedora / RHEL (x86_64)
+sudo dnf install ./gwm-cli-<version>-1.x86_64.rpm
 # aarch64 → gwm-cli-<version>-1.aarch64.rpm
+# openSUSE:
+sudo zypper install ./gwm-cli-<version>-1.x86_64.rpm
 ```
+
+Install via `dnf`/`zypper` (not `rpm -i`): the package `Requires: git`, and those resolve it automatically, whereas `rpm -i` does not pull dependencies and fails without git already installed.
 
 ## Arch Linux (AUR)
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -71,9 +71,11 @@ Chaque release stable fournit des paquets `.deb` pour `x86_64` (`amd64`) et `aar
 
 ```bash
 # x86_64 — récupérez gwm-cli_<version>-1_amd64.deb depuis la page des releases, puis :
-sudo dpkg -i gwm-cli_<version>-1_amd64.deb
+sudo apt install ./gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
+
+Utilisez `apt install ./…` (notez le `./` initial) plutôt que `dpkg -i` : le paquet dépend de `git` (`Depends`), et `apt` le tire automatiquement, alors que `dpkg -i` ne résout pas les dépendances et échoue sur un système qui n'a pas déjà git.
 
 Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie dynamiquement que glibc (libgit2 et zlib sont liés statiquement), et gwm appelle le binaire `git` à l'exécution — d'où `Depends: libc6 (>= 2.34), git`. Les paquets sont construits sur `ubuntu-latest`, ils déclarent donc un plancher glibc et ne s'installent proprement que sur les distributions au niveau ou au-dessus (RHEL 8 et Ubuntu 20.04 sont trop anciennes ; utilisez `cargo install` sur celles-ci). Chaque `.deb` a un sidecar `.sha256` pour vérification.
 
@@ -82,10 +84,14 @@ Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fourni
 De même, des paquets `.rpm` pour `x86_64` et `aarch64` sont construits par [`cargo-generate-rpm`](https://github.com/cat-in-136/cargo-generate-rpm) et attachés à chaque release stable :
 
 ```bash
-# x86_64
-sudo rpm -i gwm-cli-<version>-1.x86_64.rpm
+# Fedora / RHEL (x86_64)
+sudo dnf install ./gwm-cli-<version>-1.x86_64.rpm
 # aarch64 → gwm-cli-<version>-1.aarch64.rpm
+# openSUSE :
+sudo zypper install ./gwm-cli-<version>-1.x86_64.rpm
 ```
+
+Installez via `dnf`/`zypper` (pas `rpm -i`) : le paquet requiert `git` (`Requires`), et ces gestionnaires le résolvent automatiquement, alors que `rpm -i` ne tire pas les dépendances et échoue si git n'est pas déjà installé.
 
 ## Arch Linux (AUR)
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -75,7 +75,7 @@ sudo dpkg -i gwm-cli_<version>-1_amd64.deb
 # aarch64 → gwm-cli_<version>-1_arm64.deb
 ```
 
-Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie que glibc (libgit2 et zlib sont liés statiquement), d'où `Depends: libc6 (>= 2.34)` et rien d'autre — les paquets sont construits sur `ubuntu-latest`, ils déclarent donc un plancher glibc et ne s'installent proprement que sur les distributions au niveau ou au-dessus (RHEL 8 et Ubuntu 20.04 sont trop anciennes ; utilisez `cargo install` sur celles-ci). Chaque `.deb` a un sidecar `.sha256` pour vérification.
+Le paquet s'appelle **`gwm-cli`** et déclare `Conflicts: gwm` — Debian fournit un gestionnaire de fenêtres X11 `gwm` sans rapport qui possède aussi `/usr/bin/gwm`, donc les deux ne peuvent pas être installés ensemble (retirez le gestionnaire de fenêtres d'abord si vous l'avez). La commande installée reste `gwm`. Le binaire ne lie dynamiquement que glibc (libgit2 et zlib sont liés statiquement), et gwm appelle le binaire `git` à l'exécution — d'où `Depends: libc6 (>= 2.34), git`. Les paquets sont construits sur `ubuntu-latest`, ils déclarent donc un plancher glibc et ne s'installent proprement que sur les distributions au niveau ou au-dessus (RHEL 8 et Ubuntu 20.04 sont trop anciennes ; utilisez `cargo install` sur celles-ci). Chaque `.deb` a un sidecar `.sha256` pour vérification.
 
 ## Fedora / RHEL / openSUSE (`.rpm`)
 

--- a/tests/linux_packaging_metadata_tests.rs
+++ b/tests/linux_packaging_metadata_tests.rs
@@ -118,8 +118,31 @@ fn deb_declares_glibc_with_a_version_floor() {
   // to package the cross-built aarch64 binary from an x86_64 runner — AND
   // carries a glibc floor so dpkg refuses cleanly on too-old distros instead
   // of installing then crashing at load.
-  assert!(depends.starts_with("libc6"), "glibc is the sole dynamic dep: {depends}");
+  assert!(depends.starts_with("libc6"), "libc6 leads the depends list: {depends}");
   assert!(depends.contains(">= 2.34"), "depends must pin a glibc floor: {depends}");
+}
+
+#[test]
+fn deb_and_rpm_declare_git_as_a_runtime_dep() {
+  // gwm shells out to the `git` binary (sync, worktree rename, clean, TUI
+  // previews) beyond the vendored libgit2, so the distro packages must pull
+  // git — shlibdeps / rpm auto-req would never catch an exec dependency (#388).
+  let deb = metadata("deb");
+  let depends = deb
+    .get("depends")
+    .and_then(|v| v.as_str())
+    .expect("depends is a string");
+  assert!(
+    depends.split(',').any(|d| d.trim() == "git"),
+    "deb depends must include git: {depends}"
+  );
+
+  let rpm = metadata("generate-rpm");
+  let requires = rpm.get("requires").expect("rpm requires table is present");
+  assert!(
+    requires.get("git").is_some(),
+    "rpm requires must include git: {requires:?}"
+  );
 }
 
 // ---- .rpm (#378) --------------------------------------------------------


### PR DESCRIPTION
## Description

The `.deb` (`depends = "libc6 (>= 2.34)"`) and `.rpm` (`requires = { glibc }`) packages declared only glibc, but gwm shells out to the `git` binary at **14 call sites** (`gwm sync`, worktree rename, `gwm clean`, TUI previews) beyond the vendored libgit2. On a minimal Debian/Fedora install without git, the package installs cleanly and those features then fail at process spawn.

Follow-up to #379 (codex review caught the same gap on the AUR package, where `git` was added to `depends`).

Closes #388

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `Cargo.toml` — deb `depends = "libc6 (>= 2.34), git"`, rpm `requires = { glibc = ">= 2.34", git = "*" }` (comments explain git is an *exec* dep, not a linked lib, so shlibdeps/auto-req can't catch it).
- `tests/linux_packaging_metadata_tests.rs` — `deb_and_rpm_declare_git_as_a_runtime_dep` pins git in both.
- Docs — EN/FR install pages (the "Depends: libc6 and nothing else" line was stale) + CHANGELOG Fixed entry. Also corrected the AUR CHANGELOG entry, which overstated the CI step as `makepkg` + `namcap` (deploy-aur `test: true` runs `makepkg` only).

## Tests

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (on the test target)
- [x] `cargo test --test linux_packaging_metadata_tests` — 10 green (incl. the new git test; it fails on `dev` without the Cargo.toml change)
- [ ] full `cargo test` — deferred to CI (change touches only Cargo.toml metadata + docs + one test assertion)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`

## Notes for reviewers

- `git = "*"` in the rpm `requires` renders as an unversioned `Requires: git` (any version) — cargo-generate-rpm's convention for "no version constraint".
- Verified the 14 shell-outs via `grep -rn 'Command::new("git")' src/` (clean.rs, launcher.rs, worktree.rs).
- The deb/rpm packages are only *generated* at release time (not in PR CI), same caveat as #377/#378 — the metadata contract is what's pinned here.

## Linked issues / docs

- Issue: #388
- Follow-up to: #379