### PR TITLE
📝 docs: document the signed-commits preference (#394)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,51 @@ Suffix the type with `!` and add a `BREAKING CHANGE:` footer:
 BREAKING CHANGE: configs using the old keys must migrate to the new schema.
 ```
 
+### Signing (preferred)
+
+Commits on a PR should show up as **`Verified`** on GitHub. GPG is preferred;
+SSH signing is equally accepted (GitHub verifies both the same way).
+
+This is a preference, not a gate: nothing in CI or branch protection enforces
+it, and a PR will not be rejected for unsigned commits. It is asked for because
+a signed history is worth having, not because tooling demands it.
+
+Signing a commit and getting it **verified** are two different things. GitHub
+shows `Verified` only when *both* hold:
+
+- the **public** key is registered on your GitHub account
+  (Settings → SSH and GPG keys)
+- the **committer email** matches a uid on the key **and** a verified email on
+  your account
+
+The second one is what usually bites. A commit signed with a perfectly good key
+whose uid does not match the committer email stays `Unverified` forever. If you
+use different `user.email` values across repos, check before you push:
+
+```bash
+git config user.email                  # the committer email git will stamp
+gpg --list-secret-keys --keyid-format=long   # the uid(s) on your key
+```
+
+To turn signing on for this repo only:
+
+```bash
+git config user.signingkey <KEY_ID>
+git config commit.gpgsign true
+# SSH instead of GPG:
+git config gpg.format ssh
+git config user.signingkey ~/.ssh/id_ed25519.pub
+```
+
+Verify what GitHub actually thinks, which is the only opinion that counts here
+(local `git log --show-signature` can disagree with it, e.g. on a keyring it
+cannot read):
+
+```bash
+gh api /repos/<owner>/<repo>/commits/<sha> \
+  --jq '.commit.verification | "\(.verified) \(.reason)"'   # want: true valid
+```
+
 ## Labels
 
 See [`.github/LABELS.md`](.github/LABELS.md) for the full matrix. Quick reference:
@@ -300,6 +345,7 @@ Before opening a PR:
 - [ ] `cargo fmt`
 - [ ] `cargo clippy -- -D warnings`
 - [ ] `cargo test` (all green)
+- [ ] Commits show as `Verified` on GitHub (preferred, see [Signing](#signing-preferred))
 - [ ] CHANGELOG.md updated under `## [Unreleased]`
 - [ ] If the public CLI changed: the `docs/3.cli` section updated (the README is a landing page that delegates to `docs/`)
 - [ ] If the config schema changed: `examples/gwm.toml.example` and the `docs/4.configuration` section updated


### PR DESCRIPTION
## Description

Documents that commits on a PR should show up as `Verified` on GitHub (GPG preferred, SSH accepted), as a `### Signing (preferred)` subsection under **Commits**, plus one PR checklist line.

The preference existed but lived nowhere: `dev` has no branch protection, `required_signatures` is off, and `CONTRIBUTING.md` said nothing about signing. It was being asked for contributor by contributor (#392), which does not scale and only surfaces after someone has already pushed.

Closes #394

## Type of change

- [x] 📝 Documentation

## Changes

- `### Signing (preferred)` under `## Commits`: GPG + SSH, how to enable per-repo, and the `Verified` conditions
- PR checklist line linking to it

The section leads with the part that actually bites, which is not "sign your commits" but that **signing and being verified are different things**. GitHub shows `Verified` only when the public key is on the account *and* the committer email matches both a uid on the key and a verified account email. A perfectly good key with a mismatched uid stays `Unverified` forever.

That is not hypothetical: it hit [aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117) this week. Commits carried two different author emails against a single-uid key, so half of them could never have verified, and the registry's `check-commit-signing` gate stayed red until both were normalised onto the key's uid.

The doc also tells contributors to trust `gh api ... .commit.verification` over local `git log --show-signature`, because the local check can disagree with GitHub (a keyboxd keyring reports `Can't check signature: No public key` on commits GitHub verifies fine — also witnessed on that PR).

## Framing: preference, not rule

Written as an explicit non-gate. Nothing in CI or branch protection enforces it, and a PR will not be rejected for unsigned commits. Claiming otherwise would be exposed by the first unsigned PR that sails through, and would be unfair to anyone who only reads the doc after pushing.

Turning on `required_signatures` on `dev` is deliberately **out of scope**: it has real consequences for drive-by contributors and deserves its own decision rather than riding along in a docs PR.

## Tests

- [x] No test added — TDD exception, argued below

Per `CLAUDE.md`, the bar to skip a test is "the change is observably untestable from the public surface". This is prose in a contributor-facing Markdown file: no CLI, config schema, or library behaviour changes. I checked that nothing asserts this file's contents — `tests/doctor_tests.rs` and `tests/gitmoji_tests.rs` mention `CONTRIBUTING.md` only in comments citing it as the source of a rule, and neither parses it, so no assertion needed updating.

## CHANGELOG

Deliberately **not** updated. The root `CHANGELOG.md` follows Keep a Changelog and is aimed at people who *use* gwm; how a contributor signs commits changes nothing for anyone installing it. The precedent supports this: past `CONTRIBUTING.md` edits that did get changelog entries (AUR, winget) were logged for their user-facing install channel, not for the contributor prose that shipped alongside.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified` (this PR practices what it documents)
- [x] CHANGELOG.md intentionally untouched (rationale above)

## Linked issues / docs

- Issue: #394
- Context: #392 (where the ask surfaced), aquaproj/aqua-registry#57117 (the failure mode)