### PR TITLE
🐛 fix(build): derive the flake version from Cargo.toml (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `git` binary (sync, worktree rename, clean, TUI previews) beyond the vendored
   libgit2, so a minimal Debian/Fedora install without git would break those
   features. `git` is now declared in `Depends` / `Requires`. (#388)
+- **The Nix flake reports the right version** — it advertised `0.3.0-rc.3`
+  while the code was at `1.1.1`, so `nix profile list`, `nix flake show` and
+  the store path all named a release eight versions old. The built binary was
+  always correct (`gwm --version` reported `1.1.1`), so this was mislabelling
+  rather than a broken build, which is why it went unnoticed. The version is
+  now read out of `Cargo.toml` at eval time instead of being restated in
+  `flake.nix`, making the drift impossible rather than merely fixed. (#393)
 
 ## Past releases
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,14 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      # Bumped in lockstep with `Cargo.toml` `version` at release time.
-      version = "0.3.0-rc.3";
+      # Read straight out of `Cargo.toml` rather than restated here: a literal
+      # silently drifted for eight releases (#393) because the comment claiming
+      # it was "bumped in lockstep at release time" was enforced by nothing.
+      #
+      # Only the version is derived. `Cargo.toml` names the crate `gwm-cli`
+      # (the bare `gwm` name was taken on crates.io) while the binary, and so
+      # the package, is `gwm` — see `pname` below.
+      version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
     in
     flake-utils.lib.eachDefaultSystem (system:
       let

--- a/tests/flake_tests.rs
+++ b/tests/flake_tests.rs
@@ -24,9 +24,54 @@ fn has_field_at_indent(s: &str, name: &str, indent: usize) -> bool {
   s.lines().any(|line| line.starts_with(&prefix))
 }
 
+// True iff a line assigns a *literal* version, e.g. `version = "0.3.0-rc.3";`.
+// A derived version (`version = (builtins.fromTOML ...).package.version;`) has
+// no opening quote, and an interpolated one does not start with a digit, so
+// neither trips this.
+fn has_hardcoded_version_literal(s: &str) -> bool {
+  s.lines().any(|line| {
+    line
+      .trim()
+      .strip_prefix("version = \"")
+      .is_some_and(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+  })
+}
+
 #[test]
 fn flake_exists_at_repo_root() {
   assert!(flake_path().exists(), "flake.nix must exist at the repo root");
+}
+
+#[test]
+fn flake_derives_its_version_from_cargo_toml() {
+  // Issue #393: the flake advertised `0.3.0-rc.3` while Cargo.toml was at
+  // 1.1.1 — eight releases of drift. The root cause was not the number but a
+  // comment ("Bumped in lockstep with Cargo.toml at release time") asserting
+  // an invariant that nothing enforced. `nix flake check` never caught it:
+  // the version is metadata, so the build stayed green and `gwm --version`
+  // stayed correct while the store path, `nix flake show` and
+  // `nix profile list` all lied.
+  //
+  // Deriving the version makes the drift structurally impossible, so this
+  // test pins the mechanism rather than comparing two numbers (which would be
+  // tautological once derived). It fails if someone later "simplifies" the
+  // expression back into a literal.
+  let s = read_flake();
+  assert!(
+    !has_hardcoded_version_literal(&s),
+    "flake.nix must not hardcode a version literal — derive it with \
+     `version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;` \
+     so it cannot drift from Cargo.toml again (#393)"
+  );
+  assert!(
+    s.contains("fromTOML") && s.contains("./Cargo.toml"),
+    "flake.nix must read its version out of Cargo.toml"
+  );
+  // Only the *version* is derived. Cargo.toml's `name` is `gwm-cli` (the bare
+  // `gwm` crate name was taken on crates.io) while the binary — and so the
+  // package — is `gwm`. `flake_exposes_gwm_package_via_build_rust_package`
+  // pins `pname = "gwm"`, which is what stops a well-meaning "derive
+  // everything from Cargo.toml" from renaming the package.
 }
 
 #[test]


### PR DESCRIPTION
## Description

`flake.nix` advertised `version = "0.3.0-rc.3"` while `Cargo.toml` was at `1.1.1`. The version is now read out of `Cargo.toml` at eval time instead of being restated.

Found while packaging for Nixpkgs (#382), which meant building the flake for the first time in a long while.

Closes #393

## Type of change

- [x] 🐛 Bug fix

## The bug

```nix
# Bumped in lockstep with `Cargo.toml` `version` at release time.
version = "0.3.0-rc.3";
```

`git log -1 -- flake.nix` still points at 9bc5320 (2026-05-19), the commit that **created** the file. The lockstep the comment promised never happened once, across eight releases (v0.9.0, v0.10.0-rc.1..4, v1.0.0 → v1.1.1).

**The impact was mislabelling, not a broken build.** The derivation builds `src = ./.`, so the binary was always current and `gwm --version` printed `1.1.1`. What lied was the derivation name, the store path, `nix flake show`, and `nix profile list`.

That still matters: the flake is an **advertised install channel** (`README.md:31`, plus a section in the install docs), so a user reporting a bug would quote a version eight releases old.

Three things kept it invisible: `nix flake check` cannot catch it (the version is metadata, not a build failure), no user hits a functional symptom, and nobody had built the flake in months.

## The fix, and why this shape

```nix
version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
```

The root cause is not the number, it is **a comment asserting an invariant that nothing enforces**. So a one-off bump would just restart the clock. Deriving the value removes the class of bug: nothing can drift, and there is nothing to remember at tag time — in a release process that already has plenty to remember, and that demonstrably dropped this step eight times running.

Pure builtins: no `lib`, no IFD, no new input.

**Only the version is derived.** `Cargo.toml` names the crate `gwm-cli` (the bare `gwm` name is taken on crates.io by an unrelated project) while the binary — and so the package — is `gwm`. Deriving `pname` too would rename the package and break `nix profile install`. The pre-existing `flake_exposes_gwm_package_via_build_rust_package` assertion on `pname = "gwm"` already guards that.

## Changes

- `flake.nix`: version derived from `Cargo.toml`, comment rewritten to explain the constraint rather than promise a ritual
- `tests/flake_tests.rs`: new `flake_derives_its_version_from_cargo_toml`
- `CHANGELOG.md` under `## [Unreleased]` → `### Fixed`

## Tests

- [x] `cargo test` — 1972 passed, 0 failed
- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0

`tests/flake_tests.rs` already existed and covered the flake's structure, but never its version: that is precisely the gap `0.3.0-rc.3` slipped through. The new test pins the **mechanism** (no hardcoded literal, version read from `Cargo.toml`) rather than comparing two numbers, which would be tautological once the value is derived. It fails if someone later "simplifies" the expression back into a constant, which is the only way this can regress.

Committed red-first (f5f2f9b fails against the old flake), green after the fix (57a9cb7).

Verified against nix itself, not just the string assertions:

```
nix eval .#gwm.name    → "gwm-1.1.1"   (was "gwm-0.3.0-rc.3")
nix eval .#gwm.version → "1.1.1"
nix eval .#gwm.pname   → "gwm"         (unchanged — the trap avoided)
nix flake show         → all outputs evaluate on every platform
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified`
- [x] CHANGELOG.md updated under `## [Unreleased]`

## Linked issues / docs

- Issue: #393
- Found via: #382 (Nixpkgs packaging, [NixOS/nixpkgs#542900](https://github.com/NixOS/nixpkgs/pull/542900))