### PR TITLE
📝 docs: document the `main` branch protection and the PR-only path to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,15 @@ exception; codify the manual test as an integration test.
 
 ## Other house rules
 
+- **`main` is protected: there is no direct push, for anyone.** PRs are
+  required, seven status checks must be green, and `enforce_admins` is
+  on, so `git push origin main` is rejected for the maintainer too and
+  there is no override. `dev` reaches `main` through a PR, hotfixes
+  included; the tag is pushed after the merge (tags are not covered by
+  the protection). Do not plan a release around a local `dev` → `main`
+  merge, which is how v1.0.2 and v1.1.1 were cut: it will now be
+  rejected. Rules and rationale in
+  [CONTRIBUTING.md §Branch protection](CONTRIBUTING.md#branch-protection).
 - **Reconcile open PRs before any tag.** Before cutting an RC or a
   stable, run `gh pr list --state open` and account for every open
   PR: either it's in the changeset, intentionally deferred, or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thanks for your interest in `gwm` — a Rust CLI / TUI for managing git worktree
 - [Labels](#labels)
 - [Pull Requests](#pull-requests)
 - [Merge strategy](#merge-strategy)
+- [Branch protection](#branch-protection)
 - [Releases](#releases)
 
 ## About this repository
@@ -361,6 +362,49 @@ Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`).
 gh pr merge <num> --merge   # NOT --squash, NOT --delete-branch
 ```
 
+## Branch protection
+
+`main` is protected. Nothing reaches it except through a pull request with green
+checks, and **that includes the maintainer**: `enforce_admins` is on, so
+`git push origin main` is rejected outright and there is no admin override. The
+only way to lift it is to disable the protection by hand, which should be a
+deliberate, visible act rather than a reflex.
+
+Active rules (read them with `gh api repos/kbrdn1/gwm-cli/branches/main/protection`):
+
+| Rule | Value |
+|------|-------|
+| Require a pull request | yes, **0 approvals** |
+| Required status checks | `rustfmt`, `clippy`, `test (ubuntu-latest)`, `test (macos-latest)`, `test (windows-latest)`, `pre-commit hook smoke`, `cargo audit` |
+| Require branches up to date (`strict`) | no |
+| Enforce for admins | **yes** |
+| Require linear history | no |
+| Force pushes / deletions | blocked |
+
+Three of those are counter-intuitive and are set that way on purpose:
+
+- **0 required approvals**, not 1. This is a single-maintainer repo and GitHub
+  forbids approving your own pull request, so requiring one approval would be a
+  permanent lockout. The status checks are the real gate; the PR is the rail
+  that makes sure they run.
+- **Linear history off.** Turning it on would force squash or rebase merges and
+  break [Merge strategy](#merge-strategy). The atomic commit history is the
+  artefact, so merge commits have to stay legal.
+- **`gwm doctor (advisory)`, CodeRabbit and GitGuardian are not required.** The
+  first is advisory by design; the other two are third-party and can stop
+  reporting. A required check that never reports blocks the branch forever, so
+  only checks we own and that always run are in the list.
+
+`strict` is off because `main` gains a merge commit that `dev` does not have on
+every release; requiring "up to date" would force a back-merge into `dev` before
+each cut, for no added safety since the checks re-run on the PR anyway.
+
+This does not affect releases mechanically: `release.yml` and `pre-release.yml`
+are triggered by **tags**, and protection guards branch refs, not tags. It does
+change how `dev` reaches `main` (see below), and it means a **hotfix cannot go
+straight to `main` either** (see [Step 0](#step-0--reconcile-open-prs-applies-to-every-tag)):
+branch off `main`, open a PR back into it, let the checks run.
+
 ## Releases
 
 Versioning is SemVer (`MAJOR.MINOR.PATCH`), with `-rc.N` / `-alpha.N` / `-beta.N` suffixes for pre-releases cut from `dev`.
@@ -410,8 +454,14 @@ Once the rc is validated and promoted to `main`:
 1. **Step 0 first** — see above.
 2. Update `Cargo.toml` `version`.
 3. Move the `## [Unreleased]` section out of `CHANGELOG.md` into a new file `changelogs/<version>.md` (e.g. `changelogs/0.3.0.md`), rename its heading to `# [<version>] - YYYY-MM-DD`, and add a one-line entry at the bottom of `CHANGELOG.md`'s `## Past releases` index pointing to the new file. `CHANGELOG.md` at the root then only carries the next `## [Unreleased]` section. (See [`changelogs/0.2.0.md`](changelogs/0.2.0.md) for the expected layout.)
-4. Merge `dev` → `main` (regular merge, never squash; see [Merge strategy](#merge-strategy)).
-5. Tag: `git tag -a v0.x.y -m "v0.x.y" && git push --tags`.
+4. Open a PR from `dev` to `main`, wait for the required checks, then merge it with a **merge commit** (never squash; see [Merge strategy](#merge-strategy)). `main` is [protected](#branch-protection): a local `git push origin main` is rejected, including for the maintainer, so there is no direct-merge path.
+
+   ```bash
+   gh pr create --base main --head dev --title "Release v0.x.y" --body "…"
+   gh pr merge <num> --merge   # once the 7 checks are green
+   ```
+
+5. Tag the merge commit on `main`: `git checkout main && git pull && git tag -a v0.x.y -m "v0.x.y" && git push --tags`. Tags are not covered by the branch protection, so this push goes through as-is.
 6. GitHub Actions (`release.yml`) builds binaries and publishes the stable release. The release body is populated from `changelogs/<version>.md` via `--notes-file` (run `gh release edit v0.x.y --notes-file changelogs/<version>.md` after the workflow if needed).
 
 > ⚠️ **Finalise the crate identity _before_ the tag.** Any change to the


### PR DESCRIPTION
## Description

`main` is now protected: pull requests required, seven status checks required, `enforce_admins` on. The release process documented in `CONTRIBUTING.md` was written around a local `dev` → `main` merge (step 4), which is exactly the push that is now rejected, so the doc had to move with the setting.

Closes #397

## Type of change

- [x] 📝 Docs

## Changes

- `CONTRIBUTING.md`: new `## Branch protection` section, placed between Merge strategy and Releases because it constrains both. Lists the active rules and records why three of them look wrong at a glance.
- `CONTRIBUTING.md`: stable release step 4 now goes through a `dev` → `main` PR; step 5 tags the merge commit and notes that tags are not covered by the protection.
- `CONTRIBUTING.md`: table of contents entry.
- `CLAUDE.md`: house rule, placed first in the list since it gates every release, naming the two cuts (v1.0.2, v1.1.1) done the way that no longer works.

## Tests

- [x] `cargo test` passes locally: 1972 passed, 0 failed
- [x] `cargo fmt --check` passes: exit 0
- [x] `cargo clippy --all-targets -- -D warnings` passes: exit 0
- [ ] New tests added under `tests/`

**No test, and this is the argued exception.** The protection lives in GitHub server state, not in this repo, so there is no public surface to assert against. This is the comments/docs exception in `CLAUDE.md`. Codifying the protection as a committed ruleset JSON just to have something to test would be over-engineering for a single branch, and the JSON could drift from the real setting anyway, which is the exact failure this PR is cleaning up after (a comment asserting an invariant nothing enforces, same shape as #393). The suite was run anyway and is green.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified`
- [ ] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed

**No CHANGELOG entry on purpose**: contributor-facing docs, nothing a gwm user consumes. Same call as #395 (the signed-commits doc), which shipped without one.

## Notes for reviewers

The applied configuration, for the record:

```
required_status_checks:
  strict:   false
  contexts: rustfmt, clippy, test (ubuntu-latest), test (macos-latest),
            test (windows-latest), pre-commit hook smoke, cargo audit
required_pull_request_reviews:
  required_approving_review_count: 0
enforce_admins:           true
required_linear_history:  false
allow_force_pushes:       false
allow_deletions:          false
```

What was checked before applying it, since a wrong setting here is the kind that only surfaces when you cannot ship:

- `ci.yml` runs on `pull_request: branches: [main, dev]`, so the seven required checks do report on a `dev` → `main` PR. Requiring a check that never reports would block the branch permanently.
- The two `git push` sites in `release.yml` target the Homebrew tap and the Scoop bucket, not `main`, so no release automation breaks.
- Tag-triggered releases are unaffected: protection guards branch refs, not tags.
- `required_signatures` is left off, per the decision recorded in #394: it has real consequences for drive-by contributors and deserves its own call. The `### Signing (preferred)` line saying nothing in CI or branch protection enforces signing therefore stays accurate.

The three rules worth arguing about are covered in the new section, but in short: 0 approvals because a solo repo cannot self-approve and 1 would be a permanent lockout; linear history off so merge commits stay legal; advisory and third-party checks excluded so they cannot wedge the branch.

This PR is itself the first thing to go through the new rail, though against `dev`, which is unprotected.

## Linked issues / docs

- Issue: #397
- Related: #394 / #395 (signing preference, and the `required_signatures` decision left open)
