### PR TITLE
🔖 chore(release): cut v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _Nothing yet._
 
 In reverse chronological order:
 
-- [`1.2.0`](changelogs/1.2.0.md) — 2026-07-20
+- [`1.2.0`](changelogs/1.2.0.md) — 2026-07-21
 - [`1.1.1`](changelogs/1.1.1.md) — 2026-07-16
 - [`1.1.0`](changelogs/1.1.0.md) — 2026-07-15
 - [`1.0.3`](changelogs/1.0.3.md) — 2026-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,66 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **aqua install channel** — `aqua g -i kbrdn1/gwm-cli`. gwm is registered in
-  the aqua **standard registry**
-  ([aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117)),
-  so no custom registry wiring is needed. aqua pulls the prebuilt binary for
-  the platform from the matching GitHub Release and verifies its `sha256`
-  against the published `.sha256` sidecar; Linux, macOS and Windows are
-  covered on both Intel and ARM, with Windows-on-ARM falling back to the x64
-  build under emulation. Requires standard registry `v4.539.0` or newer. (#380)
-- **Scoop install channel for Windows** — `scoop bucket add gwm
-  https://github.com/kbrdn1/scoop-gwm; scoop install gwm`. A new
-  `scoop-bucket-update` job in `release.yml` renders
-  `packaging/scoop/gwm.json.template` and pushes `bucket/gwm.json` to the
-  `kbrdn1/scoop-gwm` bucket on every stable release (mirroring the Homebrew
-  tap; pre-releases filtered out). `scoop update gwm` picks up each new
-  version once the release job pushes the refreshed manifest. (#376)
-- **`.deb` packages for Debian / Ubuntu** — `x86_64` and `aarch64`, built by
-  `cargo-deb` and attached to every stable release (`sudo dpkg -i
-  gwm-cli_<ver>-1_amd64.deb`). The package is named `gwm-cli` to avoid
-  Debian's unrelated `gwm` window-manager package; the command stays `gwm`.
-  (#377)
-- **`.rpm` packages for Fedora / RHEL / openSUSE** — `x86_64` and `aarch64`,
-  built by `cargo-generate-rpm` and attached to every stable release (`sudo
-  rpm -i gwm-cli-<ver>-1.x86_64.rpm`). (#378)
-- **AUR package for Arch Linux** — `yay -S gwm-cli-bin` (or `paru`). A new
-  `aur-publish` job in `release.yml` renders `packaging/aur/PKGBUILD.template`
-  and pushes the `gwm-cli-bin` prebuilt-binary package to the AUR on every
-  stable release (via the SHA-pinned `KSXGitHub/github-actions-deploy-aur`
-  action, which regenerates `.SRCINFO` and builds the package with `makepkg`
-  against the real binary). Installs `gwm` + license + bash/zsh/fish
-  completions; `depends` on `git` (gwm shells out to it); `provides`/`conflicts`
-  `gwm-cli` and `gwm`. Pre-releases filtered out. (#379)
-- **winget publishing automation** — a new `winget-publish` job in
-  `release.yml` opens a manifest PR to `microsoft/winget-pkgs` (`kbrdn1.gwm`)
-  for each stable release, building the manifest from the Windows `.zip` with a
-  pinned, checksum-verified `komac` (run directly rather than via an action that
-  installs tooling from mutable refs at runtime with the token in scope). The
-  initial manifest is submitted manually; the job takes over from the next
-  version. `winget install kbrdn1.gwm` becomes available once Microsoft merges
-  the manifest. Pre-releases filtered out. (#381)
-
-### Fixed
-
-- **`.deb` / `.rpm` packages now depend on `git`** — gwm shells out to the
-  `git` binary (sync, worktree rename, clean, TUI previews) beyond the vendored
-  libgit2, so a minimal Debian/Fedora install without git would break those
-  features. `git` is now declared in `Depends` / `Requires`. (#388)
-- **The Nix flake reports the right version** — it advertised `0.3.0-rc.3`
-  while the code was at `1.1.1`, so `nix profile list`, `nix flake show` and
-  the store path all named a release eight versions old. The built binary was
-  always correct (`gwm --version` reported `1.1.1`), so this was mislabelling
-  rather than a broken build, which is why it went unnoticed. The version is
-  now read out of `Cargo.toml` at eval time instead of being restated in
-  `flake.nix`, making the drift impossible rather than merely fixed. (#393)
+_Nothing yet._
 
 ## Past releases
 
 In reverse chronological order:
 
+- [`1.2.0`](changelogs/1.2.0.md) — 2026-07-20
 - [`1.1.1`](changelogs/1.1.1.md) — 2026-07-16
 - [`1.1.0`](changelogs/1.1.0.md) — 2026-07-15
 - [`1.0.3`](changelogs/1.0.3.md) — 2026-07-09

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gwm-cli"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 # binary and the library crate stay `gwm` (see [[bin]] / [lib] below),
 # so `cargo install gwm-cli` still yields the `gwm` command.
 name = "gwm-cli"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 # MSRV is the floor required by every use in the crate, not just the
 # newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)

--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,4 +1,4 @@
-# [1.2.0] - 2026-07-20
+# [1.2.0] - 2026-07-21
 
 **Six new ways to install gwm.** This release is almost entirely about reach:
 Windows users get Scoop, Debian/Ubuntu and Fedora/RHEL/openSUSE get native
@@ -68,6 +68,27 @@ symptom. It is now declared everywhere it needs to be.
   from the same release as the binary it verifies. `winget install kbrdn1.gwm`
   becomes available once Microsoft merges the manifest; the job is advisory
   until then.
+
+## Changed
+
+- **README leads with the pitch instead of the spec sheet.** The hero was one
+  dense sentence of implementation detail; it now opens with what gwm does, a
+  concrete `gwm create` example, and a scannable block of what it gives you over
+  a `git worktree add` wrapper. The install-channel spread is stated up front,
+  which is the point of this release. The feature list below is unchanged, and
+  no new behaviour is claimed.
+
+- **Repository discovery metadata.** The GitHub description was rewritten in
+  plain terms, and the repository had no topics at all — it now carries the
+  fourteen that describe it (`git-worktree`, `tui`, `ratatui`, `rust`,
+  `developer-tools`, and so on). Cosmetic to the binary, but it is how the
+  project gets found at all.
+
+- **Docs tree description corrected.** The README claimed `docs/` was
+  "structured for Nuxt Content and ready to drop into the future static site".
+  It now states the real page counts (39 English, 36 French), that the in-repo
+  tree is the source of truth, and points at
+  [#423](https://github.com/kbrdn1/gwm-cli/issues/423) for publishing.
 
 ## Fixed
 

--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,127 @@
+# [1.2.0] - 2026-07-20
+
+**Six new ways to install gwm.** This release is almost entirely about reach:
+Windows users get Scoop, Debian/Ubuntu and Fedora/RHEL/openSUSE get native
+packages, Arch gets an AUR package, aqua users get it from the standard
+registry, and winget publishing is wired up ahead of its manifest landing. None of it changes how gwm behaves — the binary is the
+same, there are just more ways to get it. Tracked under
+[#383](https://github.com/kbrdn1/gwm-cli/issues/383).
+
+One theme ran through the whole batch and is worth recording: **gwm shells out
+to the `git` binary**, beyond the vendored libgit2 it links. That is invisible
+to every dependency scanner, because it is an `exec`, not a link. It surfaced
+three separate times in this cycle — in the AUR `depends`, in the `.deb`/`.rpm`
+metadata, and again in the Nix build sandbox — each time through a different
+symptom. It is now declared everywhere it needs to be.
+
+## Added
+
+- **aqua install channel** ([#380](https://github.com/kbrdn1/gwm-cli/issues/380))
+  — `aqua g -i kbrdn1/gwm-cli`. gwm is registered in the aqua **standard
+  registry** ([aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117)),
+  so no custom registry wiring is needed. aqua pulls the prebuilt binary for the
+  platform from the matching GitHub Release and verifies its `sha256` against
+  the published `.sha256` sidecar; Linux, macOS and Windows are covered on both
+  Intel and ARM, with Windows-on-ARM falling back to the x64 build under
+  emulation. Requires standard registry `v4.539.0` or newer, the release that
+  first shipped it.
+
+- **Scoop install channel for Windows**
+  ([#376](https://github.com/kbrdn1/gwm-cli/issues/376)) — `scoop bucket add
+  gwm https://github.com/kbrdn1/scoop-gwm; scoop install gwm`. A new
+  `scoop-bucket-update` job in `release.yml` renders
+  `packaging/scoop/gwm.json.template` and pushes `bucket/gwm.json` to the
+  `kbrdn1/scoop-gwm` bucket on every stable release (mirroring the Homebrew
+  tap; pre-releases filtered out). `scoop update gwm` picks up each new version
+  once the release job pushes the refreshed manifest.
+
+- **`.deb` packages for Debian / Ubuntu**
+  ([#377](https://github.com/kbrdn1/gwm-cli/issues/377)) — `x86_64` and
+  `aarch64`, built by `cargo-deb` and attached to every stable release (`sudo
+  apt install ./gwm-cli_<ver>-1_amd64.deb`). The package is named `gwm-cli` to
+  avoid Debian's unrelated `gwm` window-manager package; the command stays
+  `gwm`.
+
+- **`.rpm` packages for Fedora / RHEL / openSUSE**
+  ([#378](https://github.com/kbrdn1/gwm-cli/issues/378)) — `x86_64` and
+  `aarch64`, built by `cargo-generate-rpm` and attached to every stable release
+  (`sudo dnf install ./gwm-cli-<ver>-1.x86_64.rpm`).
+
+- **AUR package for Arch Linux**
+  ([#379](https://github.com/kbrdn1/gwm-cli/issues/379)) — `yay -S gwm-cli-bin`
+  (or `paru`). A new `aur-publish` job in `release.yml` renders
+  `packaging/aur/PKGBUILD.template` and pushes the `gwm-cli-bin` prebuilt-binary
+  package to the AUR on every stable release, via the SHA-pinned
+  `KSXGitHub/github-actions-deploy-aur` action, which regenerates `.SRCINFO` and
+  builds the package with `makepkg` against the real binary. Installs `gwm` plus
+  the license and bash/zsh/fish completions; `depends` on `git`;
+  `provides`/`conflicts` `gwm-cli` and `gwm`. Pre-releases filtered out.
+
+- **winget publishing automation**
+  ([#381](https://github.com/kbrdn1/gwm-cli/issues/381)) — a new
+  `winget-publish` job in `release.yml` opens a manifest PR to
+  `microsoft/winget-pkgs` (`kbrdn1.gwm`) for each stable release, building the
+  manifest from the Windows `.zip` with a pinned, checksum-verified `komac`.
+  It runs komac directly rather than through an action that would install
+  tooling from mutable refs at runtime with the publishing token in scope, and
+  the expected komac digest is pinned in this repository rather than fetched
+  from the same release as the binary it verifies. `winget install kbrdn1.gwm`
+  becomes available once Microsoft merges the manifest; the job is advisory
+  until then.
+
+## Fixed
+
+- **`.deb` / `.rpm` packages now depend on `git`**
+  ([#388](https://github.com/kbrdn1/gwm-cli/issues/388)) — gwm shells out to the
+  `git` binary (sync, worktree rename, clean, TUI previews) beyond the vendored
+  libgit2, so a minimal Debian/Fedora install without git would break those
+  features. `git` is now declared in `Depends` / `Requires`. The documented
+  install commands moved from `dpkg -i` / `rpm -i` to `apt install ./…` /
+  `dnf install ./…`, since the low-level tools do not resolve dependencies and
+  would now fail on a machine without git.
+
+- **The Nix flake reports the right version**
+  ([#393](https://github.com/kbrdn1/gwm-cli/issues/393)) — it advertised
+  `0.3.0-rc.3` while the code was at `1.1.1`, so `nix profile list`, `nix flake
+  show` and the store path all named a release eight versions old. The built
+  binary was always correct (`gwm --version` reported `1.1.1`), so this was
+  mislabelling rather than a broken build, which is why it survived unnoticed.
+  The root cause was a comment promising a lockstep bump that nothing enforced,
+  so the version is now read out of `Cargo.toml` at eval time rather than
+  restated in `flake.nix` — the drift is impossible now, not merely fixed.
+
+## Dependencies
+
+- Bumped `serde` (and its stack), `anyhow` to 1.0.104, `thiserror` to 2.0.19,
+  `regex` to 1.13.1, and `clap` to 4.6.2
+  ([#400](https://github.com/kbrdn1/gwm-cli/pull/400),
+  [#402](https://github.com/kbrdn1/gwm-cli/pull/402),
+  [#403](https://github.com/kbrdn1/gwm-cli/pull/403),
+  [#404](https://github.com/kbrdn1/gwm-cli/pull/404),
+  [#406](https://github.com/kbrdn1/gwm-cli/pull/406)). Patch-level updates with
+  no behaviour change for gwm.
+
+  The clap bump needed a companion fix
+  ([#405](https://github.com/kbrdn1/gwm-cli/issues/405)): 4.6.2 renders a lone
+  subcommand alias as `[alias: cd]` where 4.6.1 printed `[aliases: cd]`, which
+  broke two `--help` assertions that matched the plural string exactly. They now
+  match `\[alias(es)?: …\]`, so the grammatical number can flip either way
+  without breaking the suite again.
+
+## Notes
+
+Two further channels are submitted and waiting on external review, and are
+deliberately **not** documented yet — a channel gets an install command in the
+README only once it actually works:
+
+- **winget** ([#381](https://github.com/kbrdn1/gwm-cli/issues/381)) —
+  [microsoft/winget-pkgs#403295](https://github.com/microsoft/winget-pkgs/pull/403295),
+  validation passed, awaiting a moderator.
+- **Nixpkgs** ([#382](https://github.com/kbrdn1/gwm-cli/issues/382)) —
+  [NixOS/nixpkgs#542900](https://github.com/NixOS/nixpkgs/pull/542900), lint,
+  eval and build green across platforms.
+
+`main` is now a protected branch
+([#397](https://github.com/kbrdn1/gwm-cli/issues/397)): releases go through a
+`dev` → `main` pull request rather than a local merge. This is the first release
+cut on that rail.


### PR DESCRIPTION
## Description

Release prep for **v1.2.0**. Moves `## [Unreleased]` into `changelogs/1.2.0.md`, resets the root index, and bumps `Cargo.toml` + `Cargo.lock`.

**Still a draft**: parked until the Symfony preset (#392) lands, so it ships in this minor rather than forcing a 1.3.0 right behind it.

refs #383

## Type of change

- [x] 🔧 Chore (release)

## Why 1.2.0 (minor)

Six new install channels — new features, no breaking change, so MINOR:

| Channel | Issue | State |
|:---|:---|:---|
| Scoop (Windows) | #376 | live |
| `.deb` Debian/Ubuntu | #377 | live |
| `.rpm` Fedora/RHEL/openSUSE | #378 | live |
| AUR (Arch) | #379 | live |
| **aqua** | #380 | **live** (registry PR merged 2026-07-17) |
| winget automation | #381 | advisory until the manifest merges |

Plus two fixes — #388 (`git` declared as a runtime dep in `.deb`/`.rpm`) and #393 (the flake no longer mislabels its version) — and five dependency bumps.

## Changes

- `changelogs/1.2.0.md` — per-version release notes
- `CHANGELOG.md` — `[Unreleased]` reset to `_Nothing yet._`, `1.2.0` added to the `Past releases` index
- `Cargo.toml` + `Cargo.lock` — `1.1.1` → `1.2.0`

`flake.nix` is **not** touched: #393 made it read its version out of `Cargo.toml`, so it follows the bump on its own. Verified off this commit:

```
nix eval .#gwm.version → "1.2.0"
```

That is the manual step this repo forgot eight releases running, now gone.

## Rebased on the current `dev` (2026-07-20)

`dev` moved after this branch was first cut, so it was rebased onto b632bca and the notes were updated to match reality rather than left stale:

- **aqua moved from *Notes* to *Added*.** [aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117) merged, so the channel is live and documented (#407). It was listed as "waiting on external review" — that was no longer true.
- **The intro says six channels, not five.** Leaving "Five new ways to install gwm" while shipping a sixth would have been a release note that misdescribes its own release.
- **New `## Dependencies` section** covering #400, #402, #403, #404 and #406, including why the clap bump needed a companion fix (#405).
- **Date moved to 2026-07-20.**

The only rebase conflict was the expected one in `CHANGELOG.md`: `dev` had gained the aqua entry under `[Unreleased]`, which this PR empties. Resolved by keeping the reset and migrating the entry into `changelogs/1.2.0.md`. `Cargo.lock` merged cleanly — the version bump and the dependency bumps touch disjoint, alphabetically-sorted regions.

## Tests

- [x] `cargo test` — 1972 passed, 0 failed
- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0

Re-run after the rebase, not merely before it. No test added: a version bump plus changelog movement has no observable behaviour to pin. `Cargo.lock` was regenerated via `cargo build` **before** the gates, so a `--locked` build off the tag is reproducible (the v1.0.0 lesson).

## Step 0 — Reconcile open PRs

Per CONTRIBUTING, every open PR is accounted for: the five Dependabot PRs (#400-#404) are merged or superseded, #405/#406 (clap) merged, #407 (aqua docs) merged. Only #392 (Symfony preset) remains, and this PR is deliberately waiting for it.

## Known: the winget job will fail on this tag

`winget-publish` runs `komac update kbrdn1.gwm`, which needs the package to already exist in winget-pkgs. [microsoft/winget-pkgs#403295](https://github.com/microsoft/winget-pkgs/pull/403295) is still open, so `manifests/k/kbrdn1/gwm` is a 404 and the job will go red. It is `continue-on-error: true`, so the release is unaffected, and it starts working from the next version once the manifest lands. Flagged so a red advisory job on this release is not mistaken for a regression.

`aur-publish` also runs for real for the first time here (the AUR package was pushed by hand during account setup, so the job itself is untested). It is likewise advisory.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified`
- [x] `changelogs/1.2.0.md` exists and holds the release body (the workflow hard-fails without it)

## Linked issues / docs

- Tracking: #383
- Blocked on: #392 (Symfony preset)