### PR TITLE
✅ test(tests): tolerate clap 4.6.2 alias rendering + bump clap (#405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -18,8 +18,11 @@ fn help_prints_subcommands() {
   // the description. A loose `contains("cd")` would also match prose like
   // "to cd into it" in another subcommand's description.
   // `cd` is now a visible alias of `path` (clap renders it as
-  // `path  ...  [aliases: cd]`), so we assert the alias marker
-  // rather than a separate `  cd ` row.
+  // `path  ...  [alias: cd]`), so we assert the alias marker rather than a
+  // separate `  cd ` row. The regex tolerates clap's singular/plural churn:
+  // 4.6.1 printed `[aliases: cd]`, 4.6.2 prints `[alias: cd]` for a lone
+  // alias — `alias(es)?` matches both so a cosmetic upstream change to the
+  // help formatter can't break the test again.
   cmd
     .assert()
     .success()
@@ -33,7 +36,7 @@ fn help_prints_subcommands() {
     // Issue #308: materialise an existing PR into a worktree (inbound review).
     .stdout(predicate::str::contains("  review "))
     .stdout(predicate::str::contains("  path "))
-    .stdout(predicate::str::contains("[aliases: cd]"))
+    .stdout(predicate::str::is_match(r"\[alias(es)?: cd\]").unwrap())
     .stdout(predicate::str::contains("  bootstrap "))
     // Issue #24: fetch + rebase/merge a worktree onto its upstream.
     .stdout(predicate::str::contains("  sync "))
@@ -627,13 +630,15 @@ fn switch_alias_s_resolves_to_switch() {
 #[test]
 fn top_level_help_advertises_switch_alias() {
   // The visible alias must show up in the top-level help summary so users
-  // discover `gwm s` without reading the subcommand-specific page.
+  // discover `gwm s` without reading the subcommand-specific page. `aliases?`
+  // tolerates clap's singular/plural rendering (4.6.1 `[aliases: s]`, 4.6.2
+  // `[alias: s]`).
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.arg("--help");
   cmd
     .assert()
     .success()
-    .stdout(predicate::str::contains("switch").and(predicate::str::contains("[aliases: s]")));
+    .stdout(predicate::str::contains("switch").and(predicate::str::is_match(r"\[alias(es)?: s\]").unwrap()));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Fixes the CI breakage from Dependabot #401. clap `4.6.1` → `4.6.2` changed how a lone subcommand alias renders in `--help` (`[aliases: cd]` → `[alias: cd]`), which broke two assertions in `tests/cli_binary.rs`. This PR reworks the assertions to tolerate the change and carries the bump alongside them.

Closes #405

## Type of change

- [x] ✅ Test / 🔧 dependency bump

## Why this supersedes #401

The bump and the assertion fix are inseparable — #401 (bump only) fails the tests, and an assertion-only PR would fail against `dev` (still on clap 4.6.1). So both live here. Dependabot will close #401 once clap 4.6.2 lands on `dev`.

## The fix

clap 4.6.2 got grammatically correct: a subcommand with a single alias now prints `[alias: cd]` (singular) instead of `[aliases: cd]` (plural). Verified against a locally built 4.6.2 binary, not guessed:

```
path   ...  [alias: cd]
switch ...  [alias: s]
```

Rather than re-hardcode the new singular string — which would break again if a second alias ever flips a subcommand back to plural — the assertions now use a regex that absorbs the grammatical number:

```rust
predicate::str::is_match(r"\[alias(es)?: cd\]").unwrap()
```

`(es)?` matches both `[alias: cd]` and `[aliases: cd]`, so the test is immune to this class of churn. `predicates`' `regex` feature is on by default, so no manifest change was needed.

## Commit order

Two commits, each green on its own:

1. `8baddbc` — the resilient assertions, which pass against clap **4.6.1** too (the regex matches the old plural form)
2. `973b3f1` — the clap bump

So `git bisect` never lands on a red commit, and the atomic history stays honest.

## Tests

- [x] `cargo test` — 1972 passed, 0 failed
- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0

`help_prints_subcommands` is the canary CLAUDE.md flags as the one to keep honest when subcommands change — here it did its job, catching a rendering change rather than a subcommand change, and the fix keeps it meaningful.

## CHANGELOG

Not touched. Per Keep a Changelog this is not user-facing (a test-fragility fix plus a patch dependency bump with no behaviour change). The five dependency bumps in this release cycle (serde, anyhow, thiserror, regex, clap) are recorded together under **Dependencies** in `changelogs/1.2.0.md` on the release-prep PR (#399), rather than scattered across each bump PR.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified`
- [x] CHANGELOG.md intentionally untouched (rationale above)

## Linked issues / docs

- Issue: #405
- Supersedes: #401