### PR TITLE
📝 docs: document the aqua install channel (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **aqua install channel** — `aqua g -i kbrdn1/gwm-cli`. gwm is registered in
+  the aqua **standard registry**
+  ([aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117)),
+  so no custom registry wiring is needed. aqua pulls the prebuilt binary for
+  the platform from the matching GitHub Release and verifies its `sha256`
+  against the published `.sha256` sidecar; Linux, macOS and Windows are
+  covered on both Intel and ARM, with Windows-on-ARM falling back to the x64
+  build under emulation. Requires standard registry `v4.539.0` or newer. (#380)
 - **Scoop install channel for Windows** — `scoop bucket add gwm
   https://github.com/kbrdn1/scoop-gwm; scoop install gwm`. A new
   `scoop-bucket-update` job in `release.yml` renders

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects. Native `libgit2`
 | Homebrew (macOS) | `brew tap kbrdn1/tap && brew install gwm`                            |
 | Scoop (Windows)  | `scoop bucket add gwm https://github.com/kbrdn1/scoop-gwm; scoop install gwm` |
 | Nix flake        | `nix profile install github:kbrdn1/gwm-cli`                          |
+| aqua             | `aqua g -i kbrdn1/gwm-cli`                                           |
 | Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo apt install ./gwm-cli_<ver>-1_amd64.deb` |
 | Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dnf install ./gwm-cli-<ver>-1.x86_64.rpm` |
 | Arch (AUR)       | `yay -S gwm-cli-bin` (or `paru -S gwm-cli-bin`)                      |

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -122,6 +122,24 @@ environment.systemPackages = [ pkgs.gwm ];
 
 The package is built via `rustPlatform.buildRustPackage` and pins `Cargo.lock`; `git2`'s `vendored-libgit2` feature keeps the closure free of system libgit2.
 
+## via aqua
+
+[aqua](https://aquaproj.github.io/) is a declarative, version-pinned CLI version manager. gwm lives in the **standard registry**, so no custom registry wiring is needed:
+
+```bash
+# add the package to aqua.yaml and install it in one step
+aqua g -i kbrdn1/gwm-cli
+
+# or declare it yourself, then install
+#   packages:
+#     - name: kbrdn1/gwm-cli@v1.1.1
+aqua i
+```
+
+aqua downloads the prebuilt binary for your platform from the matching GitHub Release and verifies its `sha256` against the `.sha256` sidecar published alongside it. No compilation, no Rust toolchain. Linux, macOS and Windows are all covered (Intel and ARM); Windows on ARM runs the x64 build under emulation.
+
+The package requires **standard registry `v4.539.0` or newer**: that is the release that first shipped it. If `aqua g -i kbrdn1/gwm-cli` reports an unknown package, your `aqua.yaml` is pinned to an older registry `ref`; bump it.
+
 ## verify the install
 
 ```bash

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -122,6 +122,24 @@ environment.systemPackages = [ pkgs.gwm ];
 
 Le paquet est construit via `rustPlatform.buildRustPackage` et épingle `Cargo.lock` ; la feature `vendored-libgit2` de `git2` garde la closure exempte de libgit2 système.
 
+## via aqua
+
+[aqua](https://aquaproj.github.io/) est un gestionnaire de versions de CLI déclaratif et épinglé. gwm figure dans le **registre standard**, aucun registre custom à câbler :
+
+```bash
+# ajouter le paquet à aqua.yaml et l'installer en une étape
+aqua g -i kbrdn1/gwm-cli
+
+# ou le déclarer soi-même, puis installer
+#   packages:
+#     - name: kbrdn1/gwm-cli@v1.1.1
+aqua i
+```
+
+aqua télécharge le binaire précompilé correspondant à votre plateforme depuis la Release GitHub associée et vérifie son `sha256` face au fichier `.sha256` publié à côté. Aucune compilation, aucune toolchain Rust. Linux, macOS et Windows sont couverts (Intel et ARM) ; Windows sur ARM exécute la build x64 en émulation.
+
+Le paquet exige le registre standard **`v4.539.0` ou plus récent** : c'est la release qui l'a introduit. Si `aqua g -i kbrdn1/gwm-cli` signale un paquet inconnu, votre `aqua.yaml` est épinglé sur un `ref` de registre plus ancien : montez-le.
+
 ## vérifier l'installation
 
 ```bash


### PR DESCRIPTION
## Description

[aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117) merged on 2026-07-17, so gwm is now in the aqua **standard registry** and `aqua g -i kbrdn1/gwm-cli` works today. This documents the channel.

It was deliberately left undocumented while the upstream PR was open: an install command that 404s is worse than no install command at all.

Closes #380

## Type of change

- [x] 📝 Documentation

## Changes

- `README.md` — `aqua` row in the install table
- `docs/1.getting-started/1.install.md` — a `## via aqua` section
- `docs/fr/1.getting-started/1.install.md` — the FR mirror (parity kept: 13 sections each)
- `CHANGELOG.md` — entry under `[Unreleased]` → `Added`

## Verified, not transcribed

Both documented commands were run against the live registry rather than copied out of the aqua docs:

```
$ aqua i            # aqua.yaml pinned to standard registry v4.539.0
INF create a symbolic link  package_name=kbrdn1/gwm-cli package_version=v1.1.1 command=gwm
$ aqua exec -- gwm --version
gwm 1.1.1

$ aqua g -i kbrdn1/gwm-cli
# aqua.yaml now contains:  - name: kbrdn1/gwm-cli@v1.1.1
```

## The registry floor is documented, and why

The docs state that standard registry **`v4.539.0` or newer** is required. That number is not a guess:

```
v4.539.0 → pkgs/kbrdn1/gwm-cli/registry.yaml  200
v4.538.1 → pkgs/kbrdn1/gwm-cli/registry.yaml  404
```

aqua users pin the registry `ref` in their `aqua.yaml`, so anyone on an older pin gets an *unknown package* error rather than an install. That error is the first thing they would search for, so the fix belongs in the section rather than in an issue later.

## Tests

- [x] `cargo test` — 1972 passed, 0 failed

No test added: this is prose in Markdown with no observable behaviour to pin, which is the TDD exception argued per CLAUDE.md. I checked that nothing asserts these files' contents — the test files that mention `README.md` use it as a fixture inside temporary repos, not as an assertion about ours.

## Note on style

The prose avoids em dashes per the repo's writing preference. The CHANGELOG entry keeps the `**Title** — description` separator, because that is the established structural format of the five sibling entries directly above it and breaking it for one entry would look like a mistake. Say the word if you would rather it be uniform.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] Commits are `Verified`
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] Docs updated in both EN and FR

## Linked issues / docs

- Issue: #380
- Upstream: [aquaproj/aqua-registry#57117](https://github.com/aquaproj/aqua-registry/pull/57117) (merged)
- Tracking: #383