### PR TITLE
✅ test(tui): stop racing the workers the refresh test spawns (#425)

### DIFF
--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6321,24 +6321,21 @@ fn worktree_refresh_fetches_issue_and_pr_status_for_every_linked_worktree() {
     .unwrap();
   assert!(app.drain_task_results(), "the worktree refresh result must apply");
 
-  assert!(
-    app.tasks.is_loading(TaskKind::GithubIssue(42)),
-    "worktree refresh must fetch the selected issue"
-  );
-  assert!(
-    app.tasks.is_loading(TaskKind::GithubPr(61)),
-    "worktree refresh must fetch the selected PR"
-  );
-  assert!(
-    app.tasks.is_loading(TaskKind::GithubIssue(283)),
-    "worktree refresh must fetch issues from non-selected rows too"
-  );
-  assert!(
-    app.tasks.is_loading(TaskKind::GithubPr(286)),
-    "worktree refresh must fetch PRs from non-selected rows too"
-  );
+  // Issue #425: do NOT assert `tasks.is_loading(GithubIssue(42))` here. Applying
+  // the refresh requests four fetches, each spawning a worker that runs the
+  // `fake_gh` shell script above. On an idle runner those workers can finish and
+  // have their results consumed inside the very `drain_task_results()` call
+  // above, so the tasks are already out of `running` by the time the assertion
+  // reads it — the test would be racing the workers it just spawned. Whether a
+  // task is still in `running` at an arbitrary instant is an implementation
+  // timing detail, not a contract.
+  //
+  // The contract ("refresh fetches issue and PR status for every linked
+  // worktree") is asserted below, and asserted more strongly: the marker colours
+  // and the persisted link titles/states can only be right if every fetch was
+  // both requested and completed, on the non-selected row as well.
 
-  for _ in 0..50 {
+  for _ in 0..200 {
     if !app.tasks.is_loading(TaskKind::GithubIssue(42))
       && !app.tasks.is_loading(TaskKind::GithubPr(61))
       && !app.tasks.is_loading(TaskKind::GithubIssue(283))


### PR DESCRIPTION
Closes #425. Test-only; the binary is untouched.

## Why now

This flake blocked the v1.2.0 release PR (#424): one CI run went red on **both** `ubuntu-latest` and `macos-latest`, the next run went green on both, and the full suite passes locally on the same commit. With `enforce_admins` on `main`, a two-in-three flake rate is not something to re-run past.

## Root cause

The test asserted a transient state:

```rust
assert!(app.drain_task_results(), "the worktree refresh result must apply");
assert!(app.tasks.is_loading(TaskKind::GithubIssue(42)), "...");
```

`is_loading` is `running.contains(&kind)`. Applying the refresh requests four fetches, each spawning a worker that runs the `fake_gh` shell script the test writes. On an idle runner those workers finish and their results are consumed **inside the same `drain_task_results()` call**, so the tasks leave `running` before the assertion reads it. The test was racing the workers it had just spawned.

## Fix

Removed the four `is_loading` assertions instead of making them wait, because what they claimed to check is already checked below and checked more strongly: the marker colours and the persisted link titles/states can only be right if every fetch was both requested **and** completed, including on the non-selected row. A comment at the removal site explains why, so they do not get reintroduced as a perceived gap.

Also widened the settle loop from 500ms to 2s. Same shape and same budget as #328, which widened an async drain that was too tight at 500ms on Windows; four `sh` spawns on a loaded runner do not reliably fit in half a second.

## Tests

Per CLAUDE.md this removes assertions, so the burden is showing coverage did not go with them. Stubbed `spawn_github_issue` to return early and re-ran: the test still fails, on `issue #42 marker should reflect the fetched closed state`. Restored before committing, the mutation is not in the diff.

- `cargo fmt --check` clean
- `cargo test --test tui_app_tests` under a CI-like minimal PATH: 356 passed, 0 failed

https://claude.ai/code/session_01CkxW6d3UATXKb38zPw3okM