### PR TITLE
📝 docs: correct three claims that would have shipped in v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ![gwm TUI: worktree table and details sidebar](docs/2.tui/_assets/hero.png)
 
-Written in Rust on vendored `libgit2`, so there is no `git` CLI to shell out to and nothing to install alongside it. Installs from Cargo, Homebrew, Scoop, Nix, aqua, the AUR, `.deb` and `.rpm`.
+Written in Rust on vendored `libgit2`, so worktree operations are native rather than shelled out, and there is no `gwq` to install. `git` itself is still required on `PATH` for the operations that call it. Installs from Cargo, Homebrew, Scoop, Nix, aqua, the AUR, `.deb` and `.rpm`.
 
 **What you get that a `git worktree add` wrapper doesn't:**
 
@@ -91,7 +91,7 @@ Step-by-step walkthrough: [`docs/getting-started/first-worktree.md`](docs/1.gett
 
 ## documentation
 
-The full tree lives under [`docs/`](docs/): 39 pages in English, mirrored in French under [`docs/fr/`](docs/fr/). Numeric prefixes drive the sidebar order and every page carries frontmatter, so the tree renders as-is into a static site ([#423](https://github.com/kbrdn1/gwm-cli/issues/423) tracks publishing it). The in-repo tree is the source of truth.
+The full tree lives under [`docs/`](docs/): 39 pages in English, with 36 of them translated in French under [`docs/fr/`](docs/fr/). Numeric prefixes drive the sidebar order and every page carries frontmatter, so the tree renders as-is into a static site ([#423](https://github.com/kbrdn1/gwm-cli/issues/423) tracks publishing it). The in-repo tree is the source of truth.
 
 | Section                                                         | Read this when …                                                              |
 |:----------------------------------------------------------------|:------------------------------------------------------------------------------|

--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,10 +1,12 @@
 # [1.2.0] - 2026-07-21
 
-**Six new ways to install gwm.** This release is almost entirely about reach:
-Windows users get Scoop, Debian/Ubuntu and Fedora/RHEL/openSUSE get native
-packages, Arch gets an AUR package, aqua users get it from the standard
-registry, and winget publishing is wired up ahead of its manifest landing. None of it changes how gwm behaves — the binary is the
-same, there are just more ways to get it. Tracked under
+**Five new ways to install gwm, and a sixth queued.** This release is almost
+entirely about reach: Windows users get Scoop, Debian/Ubuntu and
+Fedora/RHEL/openSUSE get native packages, Arch gets an AUR package, and aqua
+users get it from the standard registry. winget publishing is wired up but the
+channel is not usable yet, because Microsoft has not merged the manifest; it is
+counted separately for that reason. None of it changes how gwm behaves — the
+binary is the same, there are just more ways to get it. Tracked under
 [#383](https://github.com/kbrdn1/gwm-cli/issues/383).
 
 One theme ran through the whole batch and is worth recording: **gwm shells out


### PR DESCRIPTION
Docs and changelog only. Found by the CodeRabbit review on the release PR (#424); two of the three were introduced this morning in the README refresh.

## 1. The README claimed gwm needs no `git` (major)

It read *"there is no `git` CLI to shell out to and nothing to install alongside it"*. Both halves are false:

- `src/clean.rs`, `src/launcher.rs`, `src/tui/app.rs` and `src/worktree.rs` all spawn `git`
- `Cargo.toml` declares `depends = "libc6 (>= 2.34), git"` for the `.deb`

It also contradicted **this release's own headline theme**, which is that gwm shells out to `git` beyond the vendored libgit2 and that the dependency is now declared everywhere it belongs (#388). `docs/index.md` already stated this correctly and precisely; the README was the outlier and now matches it.

## 2. Docs page counts (minor)

"39 pages in English, mirrored in French" implied parity. It is 39 English and 36 French.

## 3. "Six new ways to install gwm" overcounted (minor)

Five channels are usable: Scoop, `.deb`, `.rpm`, AUR, aqua. winget is wired up but its manifest is unmerged at Microsoft, so the channel does not work yet. The notes said exactly that further down while counting it in the headline. Now counted separately, consistent with the rule that a channel gets advertised only once it works.

## Deliberately not done here

- **Promo banner** reads "Zero runtime deps", "v1.0" and "1902 TESTS". Graphic asset, filed separately rather than regenerated inside a release PR.
- **`release.yml` `persist-credentials: false`** on template-only checkouts. Valid security nit, pre-existing, filed separately.
- **CodeRabbit's "keep completed release entries out of the root changelog"** is a misread. The root `CHANGELOG.md` entry it points at is the `## Past releases` **index** of links, which is the file's documented purpose ("This file tracks the in-progress release only. Past releases live under `changelogs/`"). The rule in CLAUDE.md is about not leaving release *bullets* in the root, and `[Unreleased]` is correctly empty. No change.

## Tests

Docs and changelog only, no behaviour, so no test per the CLAUDE.md exception. Verified the `git`-spawn claim against the source rather than assuming, and the page counts by counting.

refs #383

https://claude.ai/code/session_01CkxW6d3UATXKb38zPw3okM