### PR TITLE
📝 docs: state that the AUR package is third-party and lagging (#430)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Written in Rust on vendored `libgit2`, so worktree operations are native rather 
 | aqua             | `aqua g -i kbrdn1/gwm-cli`                                           |
 | Debian / Ubuntu  | `.deb` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo apt install ./gwm-cli_<ver>-1_amd64.deb` |
 | Fedora / RHEL    | `.rpm` from [Releases](https://github.com/kbrdn1/gwm-cli/releases) → `sudo dnf install ./gwm-cli-<ver>-1.x86_64.rpm` |
-| Arch (AUR)       | `yay -S gwm-cli-bin` (or `paru -S gwm-cli-bin`)                      |
+| Arch (AUR) ⚠️     | `yay -S gwm-cli-bin` (or `paru -S gwm-cli-bin`) — community-maintained, currently **1.1.1** ([#430](https://github.com/kbrdn1/gwm-cli/issues/430)) |
 | Prebuilt         | <https://github.com/kbrdn1/gwm-cli/releases> (Linux / macOS / Windows) |
+
+**On the AUR row:** `gwm-cli-bin` is packaged and maintained by a community contributor, not by this project, so its version can lag behind a release (it is at `1.1.1` while the current release is `1.2.0`). Every other channel in the table is published from this repository's release pipeline. See [#430](https://github.com/kbrdn1/gwm-cli/issues/430); if you want the current version on Arch, use `cargo binstall gwm-cli` or a prebuilt tarball in the meantime.
 
 The crate is published as **`gwm-cli`** (the bare `gwm` name on crates.io belongs to an unrelated project) — the installed command is still `gwm`. `cargo binstall gwm-cli` grabs the prebuilt binary from the matching GitHub Release instead of compiling `git2`/vendored-libgit2 from source — no Rust toolchain needed at install time.
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -102,7 +102,14 @@ yay -S gwm-cli-bin
 # or: paru -S gwm-cli-bin
 ```
 
-`gwm-cli-bin` is a **prebuilt-binary** package: it downloads the `x86_64` or `aarch64` linux-gnu tarball from the matching GitHub Release, verifies its `sha256`, and installs the `gwm` binary, the MIT license, and shell completions for bash/zsh/fish — no compilation, no Rust toolchain. It `provides`/`conflicts` both `gwm-cli` and `gwm` (it owns `/usr/bin/gwm`), so it won't co-install with a source build of the same tool. The package is refreshed automatically on every **stable** release by the `aur-publish` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), which renders [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) and pushes it to the AUR; pre-release tags are filtered out, so `gwm-cli-bin` always tracks a stable build.
+> [!WARNING]
+> **`gwm-cli-bin` is maintained by a community contributor, not by this project.** It was submitted to the AUR independently, so gwm's release pipeline has no push rights on it and cannot refresh it. Its version can therefore lag behind a release: at the time of writing it sits at **1.1.1** while the current release is **1.2.0**.
+>
+> Nothing suggests bad faith — the package is correct in shape, points at this repository, and declares the right dependencies. But it is a build produced by a third party, which is worth knowing before installing. For the current version on Arch, use `cargo binstall gwm-cli` or a prebuilt tarball. Tracked in [#430](https://github.com/kbrdn1/gwm-cli/issues/430).
+
+`gwm-cli-bin` is a **prebuilt-binary** package: it downloads the `x86_64` or `aarch64` linux-gnu tarball from the matching GitHub Release, verifies its `sha256`, and installs the `gwm` binary, the MIT license, and shell completions for bash/zsh/fish — no compilation, no Rust toolchain. It `provides`/`conflicts` both `gwm-cli` and `gwm` (it owns `/usr/bin/gwm`), so it won't co-install with a source build of the same tool.
+
+This repository does ship an `aur-publish` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) that renders [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) and is meant to push a stable build on every release, filtering out pre-release tags. It is **not currently effective**, for the ownership reason above.
 
 ## via Nix flake
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -102,7 +102,14 @@ yay -S gwm-cli-bin
 # ou : paru -S gwm-cli-bin
 ```
 
-`gwm-cli-bin` est un paquet **binaire pré-compilé** : il télécharge la tarball linux-gnu `x86_64` ou `aarch64` depuis la Release GitHub correspondante, vérifie son `sha256`, puis installe le binaire `gwm`, la licence MIT et les complétions shell bash/zsh/fish — aucune compilation, aucune toolchain Rust. Il déclare `provides`/`conflicts` sur `gwm-cli` **et** `gwm` (il possède `/usr/bin/gwm`), donc il ne cohabite pas avec une build source du même outil. Le paquet est rafraîchi automatiquement à chaque release **stable** par le job `aur-publish` de [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), qui rend [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) et le pousse sur l'AUR ; les tags de pré-release sont filtrés, donc `gwm-cli-bin` suit toujours une build stable.
+> [!WARNING]
+> **`gwm-cli-bin` est maintenu par un contributeur de la communauté, pas par ce projet.** Il a été soumis à l'AUR de façon indépendante, donc la pipeline de release de gwm n'a aucun droit de push dessus et ne peut pas le rafraîchir. Sa version peut donc être en retard sur une release : à l'heure où ces lignes sont écrites il est en **1.1.1** alors que la release courante est la **1.2.0**.
+>
+> Rien n'indique de mauvaise foi — le paquet est correct dans sa forme, pointe vers ce dépôt et déclare les bonnes dépendances. Mais c'est une build produite par un tiers, ce qu'il vaut mieux savoir avant d'installer. Pour la version courante sur Arch, utilisez `cargo binstall gwm-cli` ou une tarball pré-compilée. Suivi dans [#430](https://github.com/kbrdn1/gwm-cli/issues/430).
+
+`gwm-cli-bin` est un paquet **binaire pré-compilé** : il télécharge la tarball linux-gnu `x86_64` ou `aarch64` depuis la Release GitHub correspondante, vérifie son `sha256`, puis installe le binaire `gwm`, la licence MIT et les complétions shell bash/zsh/fish — aucune compilation, aucune toolchain Rust. Il déclare `provides`/`conflicts` sur `gwm-cli` **et** `gwm` (il possède `/usr/bin/gwm`), donc il ne cohabite pas avec une build source du même outil.
+
+Ce dépôt embarque bien un job `aur-publish` dans [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), qui rend [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) et est censé pousser une build stable à chaque release, en filtrant les tags de pré-release. Il n'est **pas effectif actuellement**, pour la raison d'appartenance ci-dessus.
 
 ## via un flake Nix
 


### PR DESCRIPTION
Docs only. Surfaced by the v1.2.0 release.

## What happened

The `aur-publish` job failed at the tag:

```
Load key "/home/builder/.ssh/aur": invalid format
```

The malformed secret is real, but checking the actual package showed a bigger problem behind it:

```
Name:           gwm-cli-bin
Version:        1.1.1-1
Maintainer:     Dominiquini
FirstSubmitted: 2026-07-16
```

Someone packaged gwm on the AUR **the day before** our own `aur-publish` job (#387) merged into `dev`. The job never had push rights on that package and would not have worked even with a valid key. It is `continue-on-error: true`, so the release run went green while this failed silently.

## What was wrong in the docs

- the README listed `yay -S gwm-cli-bin` beside channels we publish ourselves, with nothing marking the difference
- the install page claimed the package *"is refreshed automatically on every stable release by the `aur-publish` job"* — that has never happened

## What they say now

The package is community-maintained, it can lag behind a release (1.1.1 against 1.2.0), and the job exists but is not effective. Arch users who want the current version are pointed at `cargo binstall gwm-cli` or a prebuilt tarball.

Deliberately written without insinuation, because there is nothing to insinuate: the package is correct in shape, points at this repository, and declares the right dependencies including `git`. It is a build produced by a third party, which is a fact worth surfacing before someone installs it, not an accusation.

EN and FR kept in parity.

## Not done here

Co-maintenance will be raised with the maintainer once the roadmap work lands. Deferred deliberately in #430, along with re-provisioning `AUR_SSH_PRIVATE_KEY` in a valid format so the job works the day push rights exist.

## Tests

Docs only, no behaviour, so no test per the CLAUDE.md exception. `cargo test --test cli_binary` run anyway since the install surface is asserted there: exit 0.

refs #430

https://claude.ai/code/session_01CkxW6d3UATXKb38zPw3okM