### PR TITLE
👷 ci(release): stop persisting the token on read-only checkouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,14 @@ jobs:
             target: x86_64-pc-windows-msvc
             archive: zip
     steps:
+      # Reads the tree to build and package it, never pushes — so the token
+      # `actions/checkout` would otherwise leave in `.git/config` is a
+      # credential handed to every later step for nothing. Same reasoning for
+      # every checkout below that does not pass an explicit `token:`;
+      # `tests/release_workflow_tests.rs` pins both sides of that split.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -147,7 +154,12 @@ jobs:
       !contains(github.event.inputs.tag || github.ref_name, '-beta.')
     runs-on: ubuntu-latest
     steps:
+      # Only reads `changelogs/` for the release notes. The publish step below
+      # authenticates `gh` through an explicit `GH_TOKEN`, not through the git
+      # credential this checkout would persist.
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: download all artifacts
         uses: actions/download-artifact@v8
@@ -249,6 +261,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: gwm-cli
+          persist-credentials: false
 
       - name: checkout kbrdn1/homebrew-tap
         uses: actions/checkout@v7
@@ -337,6 +350,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: gwm-cli
+          persist-credentials: false
 
       - name: checkout kbrdn1/scoop-gwm
         uses: actions/checkout@v7
@@ -418,8 +432,12 @@ jobs:
             exit 1
           fi
 
+      # The AUR push happens in the deploy-aur action below, over SSH with its
+      # own key — nothing here needs the git credential.
       - name: checkout gwm-cli (template + render script)
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: fetch sha256 sidecars from the release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- The release workflow's read-only checkouts no longer persist the
+  auto-injected token in `.git/config`. Only the two checkouts that push
+  (the Homebrew tap and the Scoop bucket) keep a credential, and both sides
+  of that split are pinned by a test. (#429)
 
 ## Past releases
 

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -49,6 +49,90 @@ fn stable_release_publish_uses_github_cli_with_workflow_token() {
   );
 }
 
+/// Every `actions/checkout` in `release.yml`, paired with its `with:` block.
+///
+/// Parsing the YAML rather than grepping the text keeps the invariant below
+/// honest: a step that spells its inputs differently, or a job that grows a
+/// second checkout, is still seen.
+fn release_workflow_checkout_steps() -> Vec<(String, serde_yaml_ng::Value)> {
+  let workflow: serde_yaml_ng::Value =
+    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/release.yml").unwrap()).unwrap();
+
+  let mut steps = Vec::new();
+  for (job_name, job) in workflow["jobs"].as_mapping().expect("release.yml must define jobs") {
+    let job_name = job_name.as_str().unwrap_or_default().to_string();
+    let Some(job_steps) = job["steps"].as_sequence() else {
+      continue;
+    };
+    for step in job_steps {
+      let uses = step["uses"].as_str().unwrap_or_default();
+      if uses.starts_with("actions/checkout@") {
+        steps.push((job_name.clone(), step["with"].clone()));
+      }
+    }
+  }
+  steps
+}
+
+/// A checkout that is only there to read the tree (sources, packaging
+/// templates, render scripts, `changelogs/`) has no use for the auto-injected
+/// token `actions/checkout` writes into `.git/config`. Leaving it there hands a
+/// credential to every later step in the job, including the ones that render
+/// templates from release data.
+///
+/// The discriminator is the explicit `token:` input: the two checkouts that
+/// genuinely push (the Homebrew tap and the Scoop bucket) pass a scoped PAT and
+/// rely on it being persisted. Everything else must opt out.
+#[test]
+fn release_workflow_checkouts_without_a_token_do_not_persist_credentials() {
+  let mut audited = 0;
+
+  for (job, with) in release_workflow_checkout_steps() {
+    if !with["token"].is_null() {
+      continue;
+    }
+    audited += 1;
+    assert_eq!(
+      with["persist-credentials"].as_bool(),
+      Some(false),
+      "the checkout in job `{job}` does not push, so it must set `persist-credentials: false`"
+    );
+  }
+
+  assert!(
+    audited >= 5,
+    "expected at least 5 credential-free checkouts in release.yml, found {audited} — the parser is \
+     probably no longer seeing the steps"
+  );
+}
+
+/// The mirror of the invariant above: the two checkouts that push must keep the
+/// credential they were handed. A blanket `persist-credentials: false` sweep
+/// across the file would break `git push` in both publish jobs, and it would
+/// break it at tag time, on the one run nobody gets to retry cheaply.
+#[test]
+fn release_workflow_publishing_checkouts_keep_their_token() {
+  let pushing: Vec<_> = release_workflow_checkout_steps()
+    .into_iter()
+    .filter(|(_, with)| !with["token"].is_null())
+    .collect();
+
+  assert_eq!(
+    pushing.len(),
+    2,
+    "expected exactly the tap and bucket checkouts to carry a token, found {}",
+    pushing.len()
+  );
+
+  for (job, with) in pushing {
+    assert_ne!(
+      with["persist-credentials"].as_bool(),
+      Some(false),
+      "job `{job}` pushes with its token, so it must not disable credential persistence"
+    );
+  }
+}
+
 #[test]
 fn prerelease_workflow_does_not_match_stable_tags() {
   let workflow = fs::read_to_string(".github/workflows/pre-release.yml").unwrap();


### PR DESCRIPTION
## Description

Five of the seven `actions/checkout` steps in `release.yml` only read the tree, yet each was leaving the auto-injected token in `.git/config` for every later step in its job to pick up. This sets `persist-credentials: false` on those five and pins the invariant with a test.

Closes #429

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `persist-credentials: false` on the five read-only checkouts: the build matrix, the `release` job (which only reads `changelogs/`), and the three template + render-script checkouts in the tap, bucket and AUR jobs.
- The two checkouts that push, the Homebrew tap and the Scoop bucket, are untouched. They pass their own scoped PAT and rely on it being persisted.
- Two tests in `tests/release_workflow_tests.rs` parse the workflow YAML and pin both sides of the split: no-token checkouts must opt out, token-carrying checkouts must not.

## Tests

- [x] `cargo test` passes locally (83 test binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (test-only `unwrap()`, consistent with the rest of the file)
- [x] No `println!` in TUI render code (n/a)

## Linked issues / docs

- Issue: #429
- Raised by CodeRabbit on the v1.2.0 release PR: #424

## Notes for reviewers

**Why a `token:`-based rule rather than an allow-list of job names.** The discriminator the test uses is the presence of an explicit `token:` input. It happens to separate the file cleanly today, and it stays correct as the file grows: a new checkout that pushes has to pass a token anyway, and a new one that does not is caught.

The mirror test matters as much as the main one. A blanket `persist-credentials: false` sweep across the file would break `git push` in both publish jobs, and it would break it at tag time, on the one run that is expensive to retry.

**Scope.** Deliberately limited to `release.yml`, matching the issue. `ci.yml` (6 checkouts) and `pre-release.yml` (2) have the same shape and none of them push either. Filed as a follow-up rather than widened here.

**Verified before flipping the flag:** no cargo git dependencies (the `git = "*"` in `Cargo.toml` is an RPM runtime `requires`), and the only `git push` calls in the file are inside the two token-carrying working directories.

The AUR checkout is included because the AUR push runs through the SHA-pinned deploy-aur action over SSH with its own key, not through the git credential.