### PR TITLE
🔥 ci(release): drop the aur-publish job

### DIFF
--- a/.github/scripts/render-aur-pkgbuild.sh
+++ b/.github/scripts/render-aur-pkgbuild.sh
@@ -2,8 +2,9 @@
 # render-aur-pkgbuild.sh — substitute placeholders in the AUR PKGBUILD template
 # and emit the rendered PKGBUILD on stdout.
 #
-# Used by .github/workflows/release.yml > aur-publish to refresh the
-# `gwm-cli-bin` package on the AUR after every stable release.
+# `gwm-cli-bin` is maintained on the AUR by a third party (#430), so nothing in
+# CI consumes this: it is run by hand after a stable release to produce the
+# PKGBUILD handed to the packager. See CONTRIBUTING.md > Releases > AUR.
 #
 # Usage:
 #   render-aur-pkgbuild.sh VERSION SHA256_X86_64 SHA256_ARM64 TEMPLATE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,101 +403,13 @@ jobs:
           git commit -m "gwm ${TAG#v} (${TAG})"
           git push
 
-  aur-publish:
-    name: publish gwm-cli-bin to the AUR
-    needs: [release]
-    runs-on: ubuntu-latest
-    # Stable releases only — rc/alpha/beta must never reach `yay -S gwm-cli-bin`,
-    # otherwise Arch users would silently move to a pre-release. Same reasoning
-    # as homebrew-tap-update / scoop-bucket-update above (the whole workflow is
-    # implicitly tag-scoped via the upstream jobs).
-    if: |
-      !contains(github.event.inputs.tag || github.ref_name, '-rc.') &&
-      !contains(github.event.inputs.tag || github.ref_name, '-alpha.') &&
-      !contains(github.event.inputs.tag || github.ref_name, '-beta.')
-    # While AUR_SSH_PRIVATE_KEY is being provisioned the first time, a missing
-    # secret would fail this job. Keep it advisory so the GitHub release still
-    # lands and the AUR push can be re-driven manually via workflow_dispatch
-    # once the secret exists. Flip to false after the first successful sync
-    # (see CONTRIBUTING.md > Releases > AUR).
-    continue-on-error: true
-    steps:
-      - name: verify AUR_SSH_PRIVATE_KEY is configured
-        env:
-          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-        run: |
-          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
-            echo "::error::AUR_SSH_PRIVATE_KEY secret is not configured."
-            echo "Bootstrap: see CONTRIBUTING.md > Releases > AUR setup."
-            exit 1
-          fi
-
-      # The AUR push happens in the deploy-aur action below, over SSH with its
-      # own key — nothing here needs the git credential.
-      - name: checkout gwm-cli (template + render script)
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: fetch sha256 sidecars from the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          mkdir -p sha
-          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
-            gh release download "$TAG" \
-              --repo kbrdn1/gwm-cli \
-              --pattern "gwm-${TAG}-${target}.tar.gz.sha256" \
-              --dir sha
-          done
-          ls -la sha
-
-      - name: render aur/PKGBUILD
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          VERSION="${TAG#v}"
-          SHA_X86_64=$(awk '{print $1}' "sha/gwm-${TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256")
-          SHA_ARM64=$(awk '{print $1}' "sha/gwm-${TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256")
-          mkdir -p aur
-          sh .github/scripts/render-aur-pkgbuild.sh \
-            "$VERSION" "$SHA_X86_64" "$SHA_ARM64" \
-            packaging/aur/PKGBUILD.template \
-            > aur/PKGBUILD
-          echo "=== rendered aur/PKGBUILD ==="
-          cat aur/PKGBUILD
-
-      # Third-party action — pinned to a commit SHA (v4.2.0) because it is
-      # trusted with AUR_SSH_PRIVATE_KEY. It clones the AUR repo, drops in our
-      # rendered PKGBUILD, regenerates .SRCINFO via makepkg, and pushes.
-      # `test: true` runs `makepkg` in an Arch container against the real
-      # release binary — it builds the package (verifying the source download
-      # and sha256sums on the actual statically-linked artifact), so a broken
-      # PKGBUILD or a bad checksum fails the job here rather than shipping to
-      # the AUR. It does NOT run namcap; the PKGBUILD was namcap-linted locally
-      # (see the PR / packaging/aur/PKGBUILD.template).
-      - name: publish to the AUR
-        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
-        with:
-          pkgname: gwm-cli-bin
-          pkgbuild: aur/PKGBUILD
-          commit_username: kbrdn1
-          commit_email: onepiecekylian@gmail.com
-          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "gwm-cli-bin ${{ github.ref_name }}"
-          ssh_keyscan_types: rsa,ecdsa,ed25519
-          test: true
-
   winget-publish:
     name: publish kbrdn1.gwm to winget
     needs: [release]
     runs-on: ubuntu-latest
     # Stable releases only — rc/alpha/beta must never reach `winget install
-    # kbrdn1.gwm`. Same reasoning as the homebrew/scoop/aur jobs above (the
-    # whole workflow is implicitly tag-scoped via the upstream jobs).
+    # kbrdn1.gwm`. Same reasoning as the homebrew/scoop jobs above (the whole
+    # workflow is implicitly tag-scoped via the upstream jobs).
     if: |
       !contains(github.event.inputs.tag || github.ref_name, '-rc.') &&
       !contains(github.event.inputs.tag || github.ref_name, '-alpha.') &&
@@ -530,8 +442,8 @@ jobs:
       # `cargo-bins/cargo-binstall@main` (a mutable ref) and installs the latest
       # komac at runtime, so a compromise of either would run with WINGET_TOKEN
       # in scope — a SHA pin on the action alone would not protect the secret.
-      # Pinning the one tool that touches the token is the same posture as the
-      # SHA-pinned deploy-aur job above.
+      # Pinning the one tool that touches the token is the rule for every
+      # third-party binary this workflow trusts with a credential.
       - name: install komac (pinned + digest-anchored)
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- The `aur-publish` job. `gwm-cli-bin` is maintained on the AUR by a third
+  party, so the job never had push rights: being advisory, it failed silently
+  on every stable tag while the release reported success. The AUR is now fed
+  by hand, like Nixpkgs and aqua. The `PKGBUILD` template, its render script
+  and their tests are unchanged, so the handover stays a one-liner. (#430)
+
 ### Changed
 
 - The release workflow's read-only checkouts no longer persist the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -551,15 +551,19 @@ yay -S gwm-cli-bin   # or: paru -S gwm-cli-bin
 Render the PKGBUILD from the release's checksums and hand it over:
 
 ```bash
+TAG=v1.2.0   # the stable tag you just pushed
+
+mkdir -p sha aur
 gh release download "$TAG" --pattern 'gwm-*-unknown-linux-gnu.tar.gz.sha256' --dir sha
 sh .github/scripts/render-aur-pkgbuild.sh \
   "${TAG#v}" \
   "$(awk '{print $1}' "sha/gwm-${TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256")" \
   "$(awk '{print $1}' "sha/gwm-${TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256")" \
-  packaging/aur/PKGBUILD.template
+  packaging/aur/PKGBUILD.template \
+  > aur/PKGBUILD
 ```
 
-The render contract is pinned by [`tests/aur_pkgbuild_tests.rs`](tests/aur_pkgbuild_tests.rs), so the output is trustworthy even though nothing in CI consumes it any more. Lint it locally before sending (`makepkg` + `namcap` in an `archlinux` container). The `x86_64→$CARCH` `namcap` warning on the arch-suffixed `source_*` arrays is a known false positive (`$CARCH` is illegal in an array *name*).
+The script writes to stdout, hence the redirect; `aur/` is scratch space, not tracked. The render contract is pinned by [`tests/aur_pkgbuild_tests.rs`](tests/aur_pkgbuild_tests.rs), so the output is trustworthy even though nothing in CI consumes it any more. Lint `aur/PKGBUILD` locally before sending (`makepkg` + `namcap` in an `archlinux` container). The `x86_64→$CARCH` `namcap` warning on the arch-suffixed `source_*` arrays is a known false positive (`$CARCH` is illegal in an array *name*).
 
 If co-maintenance of `gwm-cli-bin` is ever granted, the job can come back: the template, the render script and its tests all survived the removal intact. That conversation is tracked in #430.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -536,30 +536,38 @@ Re-drive a failed sync the same way: `gh workflow run release.yml --ref <tag>`.
 
 ### AUR (`yay -S gwm-cli-bin`)
 
-Stable releases automatically refresh the [`gwm-cli-bin`](https://aur.archlinux.org/packages/gwm-cli-bin) AUR package via the `aur-publish` job in [`release.yml`](.github/workflows/release.yml). It renders [`packaging/aur/PKGBUILD.template`](packaging/aur/PKGBUILD.template), then hands the result to the SHA-pinned [`KSXGitHub/github-actions-deploy-aur`](https://github.com/KSXGitHub/github-actions-deploy-aur) action, which regenerates `.SRCINFO` (via `makepkg`), builds the package with `makepkg` against the real release binary (`test: true` — this verifies the source download + `sha256sums` on the actual artifact), and pushes to the AUR over SSH. Pre-releases are filtered out. End users install with any AUR helper:
+**This channel is manual, and the package is not ours.** [`gwm-cli-bin`](https://aur.archlinux.org/packages/gwm-cli-bin) was submitted to the AUR on 2026-07-16 by a third-party packager, so we have no push rights on it. There is no `aur-publish` job in [`release.yml`](.github/workflows/release.yml): one existed briefly, but a job that cannot push is a job that fails silently on every tag, which is worse than no job at all (#430). AUR joins Nixpkgs and aqua as a channel we feed by hand.
+
+End users install with any AUR helper:
 
 ```bash
 yay -S gwm-cli-bin   # or: paru -S gwm-cli-bin
 ```
 
-`gwm-cli-bin` is a prebuilt-binary package (downloads the linux-gnu tarball, verifies its `sha256`, installs the binary + license + bash/zsh/fish completions). The render + release wiring contract is pinned by [`tests/aur_pkgbuild_tests.rs`](tests/aur_pkgbuild_tests.rs). The CI `test: true` step runs `makepkg` only, **not** `namcap` — the PKGBUILD is `namcap`-linted locally (`makepkg` + `namcap` in an `archlinux` container). The `x86_64→$CARCH` `namcap` warning on the arch-suffixed `source_*` arrays is a known false positive (`$CARCH` is illegal in an array *name*). `namcap`-clean on the real statically-linked binary (its only dynamic deps are `glibc`/`gcc-libs` — `zlib` and `libgit2` are vendored statically) is confirmed at the first stable AUR push.
+`gwm-cli-bin` is a prebuilt-binary package (downloads the linux-gnu tarball, verifies its `sha256`, installs the binary + license + bash/zsh/fish completions).
 
-#### One-time bootstrap (maintainer)
+#### Refreshing the package after a stable release
 
-AUR authenticates by SSH key, not a PAT — so the key is split in two:
+Render the PKGBUILD from the release's checksums and hand it over:
 
-1. Register an [AUR account](https://aur.archlinux.org/register) and paste your SSH **public** key into *My Account → SSH Public Key* (`~/.ssh/aur.pub`). Route the host to that key in `~/.ssh/config` (`Host aur.archlinux.org` / `IdentityFile ~/.ssh/aur` / `User aur`).
-2. Add the matching **private** key as the `AUR_SSH_PRIVATE_KEY` secret on `gwm-cli`: <https://github.com/kbrdn1/gwm-cli/settings/secrets/actions/new>. This is the only secret the job needs — the commit identity (`kbrdn1` / `onepiecekylian@gmail.com`) is hardcoded in the job.
-3. The first release push creates the `gwm-cli-bin` package on the AUR (it does not exist until then).
-4. Flip `continue-on-error: true` to `false` on the `aur-publish` job after the first successful sync.
+```bash
+gh release download "$TAG" --pattern 'gwm-*-unknown-linux-gnu.tar.gz.sha256' --dir sha
+sh .github/scripts/render-aur-pkgbuild.sh \
+  "${TAG#v}" \
+  "$(awk '{print $1}' "sha/gwm-${TAG}-x86_64-unknown-linux-gnu.tar.gz.sha256")" \
+  "$(awk '{print $1}' "sha/gwm-${TAG}-aarch64-unknown-linux-gnu.tar.gz.sha256")" \
+  packaging/aur/PKGBUILD.template
+```
 
-Re-drive a failed sync the same way: `gh workflow run release.yml --ref <tag>`.
+The render contract is pinned by [`tests/aur_pkgbuild_tests.rs`](tests/aur_pkgbuild_tests.rs), so the output is trustworthy even though nothing in CI consumes it any more. Lint it locally before sending (`makepkg` + `namcap` in an `archlinux` container). The `x86_64→$CARCH` `namcap` warning on the arch-suffixed `source_*` arrays is a known false positive (`$CARCH` is illegal in an array *name*).
+
+If co-maintenance of `gwm-cli-bin` is ever granted, the job can come back: the template, the render script and its tests all survived the removal intact. That conversation is tracked in #430.
 
 ### winget (`winget install kbrdn1.gwm`)
 
 Stable releases automatically open a manifest PR to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) via the `winget-publish` job in [`release.yml`](.github/workflows/release.yml). It runs [`komac`](https://github.com/russellbanks/Komac) directly — from a **pinned, digest-anchored** release binary — to build the manifest for the new version from the release's Windows `.zip` (`InstallerType: zip`, `NestedInstallerType: portable`) and push a PR from your `winget-pkgs` fork. The tag's `v` prefix is stripped to match the winget `PackageVersion`. Pre-releases are filtered out. The release-wiring contract is pinned by [`tests/winget_release_tests.rs`](tests/winget_release_tests.rs).
 
-> **Why not the `winget-releaser` action?** It pulls `cargo-bins/cargo-binstall@main` and installs the latest `komac` at runtime — both mutable refs that would run with `WINGET_TOKEN` in scope, so a SHA pin on the action alone wouldn't protect the token. Pinning the one tool that touches the secret is the same posture as the SHA-pinned `deploy-aur` job.
+> **Why not the `winget-releaser` action?** It pulls `cargo-bins/cargo-binstall@main` and installs the latest `komac` at runtime — both mutable refs that would run with `WINGET_TOKEN` in scope, so a SHA pin on the action alone wouldn't protect the token. Pinning the one tool that touches the secret is the rule for every third-party binary the release workflow trusts with a credential.
 >
 > The expected komac digest (`KOMAC_SHA256`) is stored **in this repo**, not fetched from the same upstream release as the binary — a release whose artifacts *and* its `SHA256SUMS` were both swapped would otherwise still verify. To upgrade komac, bump `KOMAC_VERSION` and `KOMAC_SHA256` together and re-derive the digest yourself (`shasum -a 256 komac-<ver>-x86_64-unknown-linux-gnu.tar.gz`).
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -109,7 +109,7 @@ yay -S gwm-cli-bin
 
 `gwm-cli-bin` is a **prebuilt-binary** package: it downloads the `x86_64` or `aarch64` linux-gnu tarball from the matching GitHub Release, verifies its `sha256`, and installs the `gwm` binary, the MIT license, and shell completions for bash/zsh/fish — no compilation, no Rust toolchain. It `provides`/`conflicts` both `gwm-cli` and `gwm` (it owns `/usr/bin/gwm`), so it won't co-install with a source build of the same tool.
 
-This repository does ship an `aur-publish` job in [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml) that renders [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) and is meant to push a stable build on every release, filtering out pre-release tags. It is **not currently effective**, for the ownership reason above.
+This repository briefly shipped an `aur-publish` job meant to push a stable build on every release. It was removed: for the ownership reason above it could never push, so all it did was fail silently on every tag. The [`PKGBUILD` template](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) and its render script are still maintained and tested, and the AUR is now fed by hand like Nixpkgs and aqua.
 
 ## via Nix flake
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -109,7 +109,7 @@ yay -S gwm-cli-bin
 
 `gwm-cli-bin` est un paquet **binaire pré-compilé** : il télécharge la tarball linux-gnu `x86_64` ou `aarch64` depuis la Release GitHub correspondante, vérifie son `sha256`, puis installe le binaire `gwm`, la licence MIT et les complétions shell bash/zsh/fish — aucune compilation, aucune toolchain Rust. Il déclare `provides`/`conflicts` sur `gwm-cli` **et** `gwm` (il possède `/usr/bin/gwm`), donc il ne cohabite pas avec une build source du même outil.
 
-Ce dépôt embarque bien un job `aur-publish` dans [`release.yml`](https://github.com/kbrdn1/gwm-cli/blob/main/.github/workflows/release.yml), qui rend [`packaging/aur/PKGBUILD.template`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) et est censé pousser une build stable à chaque release, en filtrant les tags de pré-release. Il n'est **pas effectif actuellement**, pour la raison d'appartenance ci-dessus.
+Ce dépôt a embarqué un temps un job `aur-publish` censé pousser une build stable à chaque release. Il a été retiré : pour la raison d'appartenance ci-dessus il ne pouvait pas pousser, donc il se contentait d'échouer en silence à chaque tag. Le [template `PKGBUILD`](https://github.com/kbrdn1/gwm-cli/blob/main/packaging/aur/PKGBUILD.template) et son script de rendu restent maintenus et testés, et l'AUR est désormais alimenté à la main, comme Nixpkgs et aqua.
 
 ## via un flake Nix
 

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -1,11 +1,15 @@
-# Maintainer: Kylian Bardini <onepiecekylian@gmail.com>
+# Contributor: Kylian Bardini <onepiecekylian@gmail.com>
 
 # PKGBUILD template for `gwm-cli-bin` — the prebuilt binary of gwm, a git
 # worktree manager (TUI + CLI). Rendered by
-# `.github/scripts/render-aur-pkgbuild.sh` at release time: the version and
-# sha256 placeholders are filled from the GitHub Release tarballs, and the
-# result is pushed to the AUR by `release.yml > aur-publish`. Do NOT hand-edit
-# the rendered PKGBUILD on the AUR — change this template instead.
+# `.github/scripts/render-aur-pkgbuild.sh` after a stable release: the version
+# and sha256 placeholders are filled from the GitHub Release tarballs.
+#
+# `gwm-cli-bin` is maintained on the AUR by a third-party packager, not by this
+# project (#430), which is why the header above says Contributor and leaves the
+# maintainer line to whoever owns the package. The rendered PKGBUILD is
+# handed to them by hand; nothing in CI pushes it. See CONTRIBUTING.md >
+# Releases > AUR. Fixes belong in this template, not in the rendered output.
 
 pkgname=gwm-cli-bin
 pkgver=__VERSION__

--- a/tests/aur_pkgbuild_tests.rs
+++ b/tests/aur_pkgbuild_tests.rs
@@ -1,15 +1,16 @@
 //! Integration tests for the AUR packaging (issue #379).
 //!
 //! `.github/scripts/render-aur-pkgbuild.sh` substitutes placeholders in
-//! `packaging/aur/PKGBUILD.template` to produce the `PKGBUILD` that
-//! `release.yml > aur-publish` pushes to the `gwm-cli-bin` AUR package after
-//! every stable release. A malformed PKGBUILD silently breaks `yay -S
+//! `packaging/aur/PKGBUILD.template` to produce the `PKGBUILD` for the
+//! `gwm-cli-bin` AUR package. A malformed PKGBUILD silently breaks `yay -S
 //! gwm-cli-bin` for every Arch user, so the contract — the right version, both
 //! per-arch checksums, the `gwm`/`gwm-cli` provides/conflicts, and the
-//! completion/license install lines — is exercised here. The second half pins
-//! the `release.yml` wiring so a deleted step or an unpinned third-party
-//! action can't slip through green (mirrors `linux_packaging_metadata_tests.rs`
-//! + `scoop_manifest_tests.rs`).
+//! completion/license install lines — is exercised here.
+//!
+//! The AUR package is maintained by a third party (#430), so there is no
+//! `release.yml` job to pin: the rendered PKGBUILD is handed over by hand.
+//! That makes the render contract below the *only* guard on the artefact,
+//! rather than one half of it.
 
 #![cfg(unix)]
 
@@ -27,11 +28,6 @@ fn script_path() -> PathBuf {
 
 fn template_path() -> PathBuf {
   project_root().join("packaging/aur/PKGBUILD.template")
-}
-
-fn release_yml() -> String {
-  let path = project_root().join(".github/workflows/release.yml");
-  std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
 fn run_script(args: &[&str]) -> Output {
@@ -191,58 +187,5 @@ fn rejects_invalid_sha256_in_either_position() {
   assert!(
     stderr.contains("sha256") || stderr.contains("64") || stderr.contains("hex"),
     "stderr should explain the sha rejection: {stderr}"
-  );
-}
-
-// ---- release.yml wiring (#379) ------------------------------------------
-
-#[test]
-fn release_workflow_publishes_to_the_aur() {
-  let yml = release_yml();
-  assert!(
-    yml.contains("aur-publish:"),
-    "release.yml must define the aur-publish job"
-  );
-  assert!(
-    yml.contains("pkgname: gwm-cli-bin"),
-    "aur-publish must push the gwm-cli-bin package"
-  );
-  assert!(
-    yml.contains(".github/scripts/render-aur-pkgbuild.sh"),
-    "aur-publish must render the PKGBUILD via the render script"
-  );
-  assert!(
-    yml.contains("packaging/aur/PKGBUILD.template"),
-    "aur-publish must render from the AUR template"
-  );
-}
-
-#[test]
-fn deploy_aur_action_is_pinned_to_a_commit_sha() {
-  let yml = release_yml();
-  // The third-party action is trusted with AUR_SSH_PRIVATE_KEY — it must be
-  // pinned to a 40-char commit SHA, never a mutable @vX / @branch ref.
-  let needle = "KSXGitHub/github-actions-deploy-aur@";
-  let idx = yml.find(needle).expect("release.yml must use the deploy-aur action");
-  let rest = &yml[idx + needle.len()..];
-  let sha: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
-  assert_eq!(
-    sha.len(),
-    40,
-    "deploy-aur must be pinned to a 40-char commit SHA, got `{sha}`"
-  );
-}
-
-#[test]
-fn aur_publish_is_stable_only_and_advisory() {
-  let yml = release_yml();
-  let job = yml.split_once("aur-publish:").expect("aur-publish job present").1;
-  // Stable-only gate: pre-release suffixes must be excluded so a `-rc.` tag
-  // never lands on `yay -S gwm-cli-bin`.
-  assert!(job.contains("-rc."), "aur-publish must gate out -rc. pre-releases");
-  // Advisory until the SSH key secret is provisioned (flip after first sync).
-  assert!(
-    job.contains("continue-on-error: true"),
-    "aur-publish must be advisory while AUR_SSH_PRIVATE_KEY is being provisioned"
   );
 }

--- a/tests/aur_pkgbuild_tests.rs
+++ b/tests/aur_pkgbuild_tests.rs
@@ -64,6 +64,21 @@ fn template_exists_and_carries_all_placeholders() {
   for ph in ["__VERSION__", "__SHA256_X86_64__", "__SHA256_ARM64__"] {
     assert!(body.contains(ph), "template missing placeholder {ph}: {}", t.display());
   }
+
+  // The rendered PKGBUILD is handed to a third-party packager (#430), so it
+  // must not claim maintainership of a package we do not own. AUR convention
+  // puts the packaging author on `# Contributor:` and leaves `# Maintainer:`
+  // to whoever owns it.
+  assert!(
+    body.contains("# Contributor: Kylian Bardini"),
+    "template must credit the packaging author as Contributor: {}",
+    t.display()
+  );
+  assert!(
+    !body.contains("# Maintainer:"),
+    "template must not claim the `# Maintainer:` line: `gwm-cli-bin` is maintained on the AUR by a \
+     third party (#430)"
+  );
 }
 
 #[test]

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -100,8 +100,8 @@ fn release_workflow_checkouts_without_a_token_do_not_persist_credentials() {
   }
 
   assert!(
-    audited >= 5,
-    "expected at least 5 credential-free checkouts in release.yml, found {audited} — the parser is \
+    audited >= 4,
+    "expected at least 4 credential-free checkouts in release.yml, found {audited} — the parser is \
      probably no longer seeing the steps"
   );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -133,6 +133,38 @@ fn release_workflow_publishing_checkouts_keep_their_token() {
   }
 }
 
+/// The AUR publish automation was removed in #430: `gwm-cli-bin` is maintained
+/// on the AUR by a third party, so the job never had push rights on it. Being
+/// advisory, it failed silently on every stable tag while the release run
+/// reported success, which is the worst of both worlds: the docs read as
+/// automated and nobody sees the failure.
+///
+/// `AUR_SSH_PRIVATE_KEY` is pinned alongside the job because the secret was
+/// malformed to begin with (`invalid format` at the v1.2.0 tag). Resurrecting
+/// a reference to it by copy-paste would fail the same way, quietly.
+///
+/// If co-maintenance of the package is ever granted, deleting this test is the
+/// correct first step of the change that brings the job back, not a workaround
+/// for it. The template, render script and their tests were kept intact for
+/// exactly that.
+#[test]
+fn release_workflow_carries_no_aur_publish_automation() {
+  let workflow = fs::read_to_string(".github/workflows/release.yml").unwrap();
+
+  for needle in [
+    "aur-publish",
+    "AUR_SSH_PRIVATE_KEY",
+    "github-actions-deploy-aur",
+    "gwm-cli-bin",
+  ] {
+    assert!(
+      !workflow.contains(needle),
+      "release.yml must not reference `{needle}`: the AUR package is maintained by a third party \
+       (#430) and is refreshed by hand, see CONTRIBUTING.md > Releases > AUR"
+    );
+  }
+}
+
 #[test]
 fn prerelease_workflow_does_not_match_stable_tags() {
   let workflow = fs::read_to_string(".github/workflows/pre-release.yml").unwrap();


### PR DESCRIPTION
## Description

`gwm-cli-bin` is maintained on the AUR by a third-party packager, so the `aur-publish` job never had push rights on the package it targets. Being `continue-on-error: true`, it failed silently on every stable tag while the release run reported success. The AUR now joins Nixpkgs and aqua as a channel fed by hand.

Refs #430. Does not close it: the co-maintenance conversation with the current packager is still open and deliberately deferred.

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- Removed the `aur-publish` job from `release.yml` (88 lines), along with the `KSXGitHub/github-actions-deploy-aur` action.
- Removed the three `release.yml` wiring assertions in `tests/aur_pkgbuild_tests.rs` that pinned the job, plus the now-unused `release_yml()` helper.
- Added `release_workflow_carries_no_aur_publish_automation`, which pins the removal of the job, the action, and the `AUR_SSH_PRIVATE_KEY` secret.
- Dropped the credential-free checkout count in `tests/release_workflow_tests.rs` from 5 to 4.
- `CONTRIBUTING.md > Releases > AUR`: replaced the automated-refresh description and the `AUR_SSH_PRIVATE_KEY` bootstrap with the manual render-and-hand-over procedure.
- `packaging/aur/PKGBUILD.template`: `# Maintainer: Kylian Bardini` becomes `# Contributor:`, and the header no longer says a workflow pushes it. Pinned in the existing template test.
- Install docs, EN and FR: they already warned the job was ineffective, they now say it was removed.

**Kept on purpose:** the PKGBUILD template, `.github/scripts/render-aur-pkgbuild.sh`, and the six render tests. They are what makes the manual handover a one-liner, and if co-maintenance is ever granted the job comes back unchanged.

## Tests

- [x] `cargo test` passes locally (83 test binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a, and its AUR row was already accurate)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (n/a)
- [x] No `println!` in TUI render code (n/a)

## Linked issues / docs

- Issue: #430
- The job was added by #379 / #387

## Notes for reviewers

**I initially declined the guard test and was wrong.** My argument was that pinning the job's absence would fight a future re-enable, by analogy with the flaky assertion in #425. The analogy does not hold: #425 pinned a timing-dependent runtime state that could flip on its own, whereas a workflow file either contains `aur-publish:` or it does not. Every test pins something a later change may deliberately undo, and deleting one test is the correct first step of the change that brings the job back. The part that actually earns its keep is `AUR_SSH_PRIVATE_KEY`: the secret was malformed (`invalid format` at the v1.2.0 tag) and is now unused, so a copy-pasted reference would fail the same silent way. Verified red against `058e252~1`.

**Why remove rather than disable.** An `if: false` leaves a job that reads as a working channel to anyone scanning the file, and the docs drift back to claiming it works. Removing it puts the truth in one place.

**The manual recipe in CONTRIBUTING was run, not just written.** The first version had two defects (`TAG` never assigned, no redirect so the render produced no file). Both are fixed and the corrected recipe was executed end to end against the real v1.2.0 release, producing `pkgver=1.2.0` with both published checksums.

**Verified after the cut:** the workflow still parses and its five remaining jobs keep their full step lists (`build` 11, `release` 4, `homebrew-tap-update` 6, `scoop-bucket-update` 6, `winget-publish` 3).

**Follow-up for you, not for this PR:** the `AUR_SSH_PRIVATE_KEY` secret is now unused and can be deleted from repo settings.