### PR TITLE
🐛 fix(clean): tolerate ENOTEMPTY races during artifact removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the Homebrew tap and the Scoop bucket) keep a credential, and both sides
   of that split are pinned by a test. (#429)
 
+### Fixed
+
+- `gwm clean --yes` no longer fails wholesale when a concurrent writer (a
+  watcher such as rust-analyzer regenerating files inside `target/`) races
+  the removal: a transient ENOTEMPTY is retried with a bounded budget, and a
+  directory already reclaimed by someone else counts as success instead of
+  aborting the command. (#440)
+
 ## Past releases
 
 In reverse chronological order:

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -273,10 +273,44 @@ pub fn delete_reclaim(reclaim: &WorktreeReclaim) -> Result<u64> {
   let mut freed = 0u64;
   for a in &reclaim.artifacts {
     let target = reclaim.path.join(&a.rel);
-    std::fs::remove_dir_all(&target)?;
+    remove_dir_all_tolerant(&target, |p| std::fs::remove_dir_all(p))?;
     freed = freed.saturating_add(a.bytes);
   }
   Ok(freed)
+}
+
+/// Bounded-retry wrapper around a recursive directory removal (issue #440).
+///
+/// `gwm clean --yes` races concurrent writers: a watcher such as
+/// rust-analyzer can recreate a file inside `target/` after `remove_dir_all`
+/// emptied a subdirectory but before it removed the parent, and the whole
+/// command then fails with ENOTEMPTY even though the reclaim mostly worked.
+/// One more pass deletes the freshly written files, so `DirectoryNotEmpty`
+/// is retried (bounded, so a writer that never stops cannot spin the command
+/// forever). A `NotFound` means someone else already reclaimed the directory
+/// — that is a success, not an error. Every other error propagates on the
+/// first hit.
+///
+/// The removal primitive is injected so `tests/clean_tests.rs` can pin the
+/// retry contract deterministically (the real race is timing dependent);
+/// production callers go through [`delete_reclaim`], which passes
+/// `std::fs::remove_dir_all`. Public for that test seam only — treat as
+/// `pub(crate)` by convention (see #342 for the surface review).
+pub fn remove_dir_all_tolerant<F>(target: &Path, mut remove: F) -> std::io::Result<()>
+where
+  F: FnMut(&Path) -> std::io::Result<()>,
+{
+  const REMOVE_ATTEMPTS: u32 = 3;
+  let mut attempt = 0;
+  loop {
+    attempt += 1;
+    match remove(target) {
+      Ok(()) => return Ok(()),
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+      Err(e) if e.kind() == std::io::ErrorKind::DirectoryNotEmpty && attempt < REMOVE_ATTEMPTS => continue,
+      Err(e) => return Err(e),
+    }
+  }
 }
 
 /// Format `bytes` as a human-readable size with a binary unit (`B`, `KiB`,

--- a/tests/clean_tests.rs
+++ b/tests/clean_tests.rs
@@ -6,7 +6,8 @@
 //! which is deterministic across filesystems (CLAUDE.md env-independence).
 
 use gwm::clean::{
-  default_patterns, delete_reclaim, format_report, human_size, resolve_clean_dirs, scan_worktree, WorktreeReclaim,
+  default_patterns, delete_reclaim, format_report, human_size, remove_dir_all_tolerant, resolve_clean_dirs,
+  scan_worktree, WorktreeReclaim,
 };
 use gwm::config::{CleanConfig, CleanProfile};
 use std::collections::BTreeMap;
@@ -153,6 +154,94 @@ fn delete_reclaim_removes_artifact_dirs_only() {
   assert_eq!(freed, 2048);
   assert!(!wt.join("target").exists(), "target/ should be deleted");
   assert!(wt.join("src").exists(), "src/ must be preserved");
+}
+
+// --- ENOTEMPTY race tolerance (issue #440) ----------------------------------
+
+#[test]
+fn delete_reclaim_tolerates_an_artifact_already_gone() {
+  // Another process (or a parallel `gwm clean`) reclaimed target/ between the
+  // scan and the delete — a NotFound is a success, not a wholesale failure.
+  let dir = TempDir::new().unwrap();
+  let wt = dir.path();
+  make_artifact(wt, "target", 2048);
+  let r = scan_worktree("feat-1", wt, &default_patterns());
+  fs::remove_dir_all(wt.join("target")).unwrap();
+
+  let freed = delete_reclaim(&r).expect("an already-missing artifact must not fail the command");
+  assert_eq!(freed, 2048, "freed still reports the scanned size");
+}
+
+#[test]
+fn retry_recovers_when_a_concurrent_writer_races_the_removal() {
+  // Simulates rust-analyzer recreating a file inside target/ mid-removal:
+  // the first passes hit ENOTEMPTY, the next pass deletes what was rewritten.
+  let dir = TempDir::new().unwrap();
+  let target = dir.path().join("target");
+  make_artifact(dir.path(), "target", 64);
+  let mut calls = 0u32;
+
+  let res = remove_dir_all_tolerant(&target, |p| {
+    calls += 1;
+    if calls < 3 {
+      Err(std::io::Error::new(std::io::ErrorKind::DirectoryNotEmpty, "ENOTEMPTY"))
+    } else {
+      fs::remove_dir_all(p)
+    }
+  });
+
+  assert!(res.is_ok(), "a transient ENOTEMPTY must be retried: {res:?}");
+  assert_eq!(calls, 3, "two failed passes then the successful one");
+  assert!(!target.exists());
+}
+
+#[test]
+fn retry_gives_up_after_bounded_attempts() {
+  // A writer that never stops must not spin the command forever.
+  let dir = TempDir::new().unwrap();
+  let target = dir.path().join("target");
+  let mut calls = 0u32;
+
+  let res = remove_dir_all_tolerant(&target, |_| {
+    calls += 1;
+    Err(std::io::Error::new(std::io::ErrorKind::DirectoryNotEmpty, "ENOTEMPTY"))
+  });
+
+  let err = res.expect_err("a persistent ENOTEMPTY must surface after the retries");
+  assert_eq!(err.kind(), std::io::ErrorKind::DirectoryNotEmpty);
+  assert_eq!(calls, 3, "the retry budget is bounded");
+}
+
+#[test]
+fn retry_does_not_mask_other_errors() {
+  // Only the ENOTEMPTY race is transient; anything else propagates first hit.
+  let dir = TempDir::new().unwrap();
+  let target = dir.path().join("target");
+  let mut calls = 0u32;
+
+  let res = remove_dir_all_tolerant(&target, |_| {
+    calls += 1;
+    Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "EACCES"))
+  });
+
+  let err = res.expect_err("a non-ENOTEMPTY error must propagate");
+  assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+  assert_eq!(calls, 1, "no retry on non-transient errors");
+}
+
+#[test]
+fn an_already_missing_dir_counts_as_reclaimed_without_retry() {
+  let dir = TempDir::new().unwrap();
+  let target = dir.path().join("target");
+  let mut calls = 0u32;
+
+  let res = remove_dir_all_tolerant(&target, |_| {
+    calls += 1;
+    Err(std::io::Error::new(std::io::ErrorKind::NotFound, "ENOENT"))
+  });
+
+  assert!(res.is_ok(), "NotFound means someone else reclaimed it: {res:?}");
+  assert_eq!(calls, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Description

`gwm clean --yes` could fail wholesale with `Directory not empty` when a concurrent writer (typically rust-analyzer regenerating files inside `target/`) recreates a file after `remove_dir_all` emptied a subdirectory but before it removed the parent. The removal now retries a transient ENOTEMPTY with a bounded budget (one more pass deletes what was rewritten), and a directory already reclaimed by someone else (NotFound) counts as success instead of aborting the command. Every other error still propagates on the first hit.

Closes #440

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `src/clean.rs`: new `remove_dir_all_tolerant` primitive wrapping the recursive removal with a bounded retry on `DirectoryNotEmpty` (3 attempts) and a `NotFound` tolerance; `delete_reclaim` routes through it
- `tests/clean_tests.rs`: 5 new tests pinning the contract (transient ENOTEMPTY recovered, bounded give-up, non-transient errors propagate first hit, NotFound is success with and without injection)
- `CHANGELOG.md`: entry under `[Unreleased] > Fixed`

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

TDD note: red run first (4 assertion failures against a deliberately non-tolerant stub), then green. Full suite also run under a stripped CI-like PATH. The real race is timing dependent, so the retry contract is pinned deterministically through an injected removal primitive rather than a flaky writer-thread test; the writer scenario from the issue is what the injected `DirectoryNotEmpty` sequence simulates.

## Screenshots / TUI captures

Not a TUI change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (surface unchanged)
- [ ] `examples/gwm.toml.example` updated if config schema changed (schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #440
- Related PR: #314 (original `gwm clean`, #313), #435 (where the race was witnessed)

## Notes for reviewers

The retry budget is deliberately small and without sleeps: a second pass deletes what the writer just recreated, and a writer that never stops must surface the error rather than spin the command. The frozen 1.0 exec/clean CLI contract (#319) is untouched: no flag, output or exit-code change on the surface, only the internal removal becomes tolerant.