### PR TITLE
✨ feat(agents): drop Claude sessions with a dead recorded PID to idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Agent session detection no longer reports an outright-killed Claude Code
+  session as active for the rest of the 5-minute activity window: on Unix,
+  when the live registry (`~/.claude/sessions/<pid>.json`) records the
+  session's PID and that process is gone, the session drops to idle
+  immediately. Backends without a process signal (Codex, opencode, Vibe)
+  and non-Unix platforms keep the artefact-only classification. (#441)
+
 - The release workflow's read-only checkouts no longer persist the
   auto-injected token in `.git/config`. Only the two checkouts that push
   (the Homebrew tap and the Scoop bucket) keep a credential, and both sides

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Written in Rust on vendored `libgit2`, so worktree operations are native rather 
 
 - **Bootstrap that actually runs your project.** File copies with deny-list regexes (born from a real "AWS RDS credentials in a copied `.env`" incident), six lifecycle hook phases, stack presets for Laravel / Node / Rust / Go / Python.
 - **A TUI you can live in.** Embedded lazygit and shell overlays, a details sidebar with CI state and working-tree file explorer, remappable keys, themes, command palette.
-- **It knows which AI agent works where.** Sessions from Claude Code, Codex, opencode and Mistral Vibe are detected from their on-disk artefacts (no process scanning, Windows included) and surfaced everywhere: an AGENT column in the table and TUI, a detail overlay on `a`, `gwm agents` with manual pinning, the JSON/daemon field and the statusline (which rides the daemon socket, so it is Unix-only today).
+- **It knows which AI agent works where.** Sessions from Claude Code, Codex, opencode and Mistral Vibe are detected from their on-disk artefacts (no process enumeration, Windows included; on Unix a dead recorded PID drops the session to idle at once) and surfaced everywhere: an AGENT column in the table and TUI, a detail overlay on `a`, `gwm agents` with manual pinning, the JSON/daemon field and the statusline (which rides the daemon socket, so it is Unix-only today).
 - **A machine surface, not just a human one.** `--format=json`, a JSON-RPC daemon with a push stream, and `gwm statusline` for your prompt. The schemas are frozen under SemVer.
 - **Undo.** `gwm undo` and `gwm history` recover a worktree you removed by mistake, without `git reflog`.
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -244,7 +244,9 @@ else its first prompt; opencode's session title from `opencode.db`;
 Vibe's recorded title) — falling back to the full session id when the
 artefacts carry no name. Detection reads each agent's on-disk session
 artefacts (Claude Code, Codex, opencode, Mistral Vibe) — no process
-scanning, so it works identically on Linux, macOS and Windows. A worktree
+enumeration, same code path on Linux, macOS and Windows (one Unix
+refinement: a Claude Code session whose recorded PID is gone drops to
+idle immediately). A worktree
 with no session opens the overlay with an explicit *no agent session found*
 row rather than a blank modal.
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -246,8 +246,12 @@ gwm list --format=json | jq '.[] | select(.status.is_dirty) | .name'
 
 List the AI-agent sessions detection matched to each worktree, or pin one
 manually. Detection reads each agent's on-disk session artefacts (Claude
-Code, Codex, opencode, Mistral Vibe) — no process scanning, identical
-behaviour on Linux, macOS and Windows. The same data feeds the TUI's AGENT
+Code, Codex, opencode, Mistral Vibe) — no process enumeration, same code
+path on Linux, macOS and Windows. One refinement on Unix: when Claude
+Code's live registry records a session's PID and that process is gone,
+the session drops to idle immediately instead of riding out the activity
+window; elsewhere (and for the other agents) classification stays
+artefact-only. The same data feeds the TUI's AGENT
 column and `a` overlay, `gwm list` (table column + JSON `agents` field), the
 daemon and `gwm statusline` (the statusline consumes the daemon's Unix
 socket, so that one surface is Unix-only today).

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -252,8 +252,9 @@ rename s'affiche — sinon son premier prompt ; le titre de session
 d'opencode depuis `opencode.db` ; le titre enregistré par Vibe) — l'id
 complet quand les artefacts n'ont pas de nom. La détection lit les artefacts de session
 sur disque de chaque agent (Claude Code, Codex, opencode, Mistral Vibe) —
-aucun scan de processus, donc un comportement identique sur Linux, macOS et
-Windows. Un worktree sans session ouvre la surcouche avec une ligne
+aucune énumération de processus, même chemin de code sur Linux, macOS et
+Windows (un raffinement Unix : une session Claude Code dont le PID
+enregistré a disparu passe idle immédiatement). Un worktree sans session ouvre la surcouche avec une ligne
 explicite *no agent session found* plutôt qu'une modale vide.
 
 Les lignes sont sélectionnables : `j` / `k` déplacent la surbrillance (la

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -247,8 +247,12 @@ gwm list --format=json | jq '.[] | select(.status.is_dirty) | .name'
 Liste les sessions d'agents IA que la détection a associées à chaque
 worktree, ou en épingle une manuellement. La détection lit les artefacts de
 session sur disque de chaque agent (Claude Code, Codex, opencode, Mistral
-Vibe) — aucun scan de processus, comportement identique sur Linux, macOS et
-Windows. Les mêmes données alimentent la colonne AGENT et la surcouche `a`
+Vibe) — aucune énumération de processus, même chemin de code sur Linux,
+macOS et Windows. Un raffinement sur Unix : quand le registre live de
+Claude Code enregistre le PID d'une session et que ce process a disparu,
+la session passe idle immédiatement au lieu d'attendre la fin de la
+fenêtre d'activité ; ailleurs (et pour les autres agents), la
+classification reste basée sur les artefacts seuls. Les mêmes données alimentent la colonne AGENT et la surcouche `a`
 de la TUI, `gwm list` (colonne de table + champ JSON `agents`), le daemon et
 `gwm statusline` (la statusline consomme la socket Unix du daemon, cette
 surface-là est donc Unix-only à ce jour).

--- a/src/agent_sessions.rs
+++ b/src/agent_sessions.rs
@@ -245,13 +245,32 @@ fn claude_live_registry(projects_base: &Path) -> std::collections::HashMap<Strin
     let Some(sid) = v.get("sessionId").and_then(|x| x.as_str()) else {
       continue;
     };
-    map.insert(
-      sid.to_string(),
-      LiveEntry {
-        name: v.get("name").and_then(|x| x.as_str()).and_then(clean_session_name),
-        dead: v.get("pid").and_then(|x| x.as_u64()).is_some_and(|p| !pid_is_alive(p)),
-      },
-    );
+    let incoming = LiveEntry {
+      name: v.get("name").and_then(|x| x.as_str()).and_then(clean_session_name),
+      dead: v.get("pid").and_then(|x| x.as_u64()).is_some_and(|p| !pid_is_alive(p)),
+    };
+    // A killed-then-resumed session leaves BOTH registry files behind with
+    // the same sessionId (stale dead PID + fresh live one), and read_dir
+    // order is undefined — so merge instead of last-write-wins: a live PID
+    // always beats a dead one; at equal liveness the first entry stays,
+    // only filling a missing name (Codex review #441).
+    match map.entry(sid.to_string()) {
+      std::collections::hash_map::Entry::Vacant(slot) => {
+        slot.insert(incoming);
+      }
+      std::collections::hash_map::Entry::Occupied(mut slot) => {
+        let current = slot.get_mut();
+        if current.dead && !incoming.dead {
+          let kept_name = incoming.name.or_else(|| current.name.take());
+          *current = LiveEntry {
+            name: kept_name,
+            dead: false,
+          };
+        } else if current.dead == incoming.dead && current.name.is_none() {
+          current.name = incoming.name;
+        }
+      }
+    }
   }
   map
 }

--- a/src/agent_sessions.rs
+++ b/src/agent_sessions.rs
@@ -62,7 +62,9 @@ pub struct AgentSession {
   /// since the slug mapping is lossy and only matches forward).
   pub cwd: PathBuf,
   pub last_activity: SystemTime,
-  /// Only Vibe can observe a terminated session (non-null `end_time`).
+  /// Observed termination: Vibe records one (non-null `end_time`), and a
+  /// Claude Code live-registry entry whose PID is no longer running sets
+  /// it too (issue #441). Everything else degrades to artefact freshness.
   pub ended: bool,
   pub id: String,
   /// Human-readable session name when the artefacts carry one: the first
@@ -187,12 +189,45 @@ fn first_user_text(path: &Path) -> Option<String> {
 /// paths and looks their slugs up — O(#worktrees), no directory sweep.
 pub struct ClaudeCodeSource;
 
-/// Live-session names from `<.claude>/sessions/*.json` — Claude Code's own
-/// registry of running sessions (`{sessionId, name, status}`). The name it
-/// carries is what the app displays, so it beats the first-prompt heuristic
-/// (user feedback 2026-07-22). Missing dir → empty map (dead sessions fall
-/// back to their first prompt).
-fn claude_live_names(projects_base: &Path) -> std::collections::HashMap<String, String> {
+/// One `<.claude>/sessions/<pid>.json` registry entry: the display name the
+/// app shows (beats the first-prompt heuristic, user feedback 2026-07-22),
+/// plus whether the recorded process is still running (issue #441).
+struct LiveEntry {
+  name: Option<String>,
+  dead: bool,
+}
+
+/// Whether `pid` names a running process. Unix: `kill(pid, 0)` probes
+/// existence without delivering a signal — EPERM still means alive (owned
+/// by another user). Non-unix, and an out-of-range or zero pid a corrupt
+/// registry could carry: no reliable probe, so report alive and keep the
+/// artefact-only classification. A dead PID recycled by an unrelated
+/// process reads as alive — that misreport window matches today's
+/// artefact-only one, accepted (#441).
+fn pid_is_alive(pid: u64) -> bool {
+  #[cfg(unix)]
+  {
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+      return true;
+    };
+    if pid <= 0 {
+      return true;
+    }
+    // SAFETY: signal 0 performs error checking only; nothing is delivered.
+    (unsafe { libc::kill(pid, 0) } == 0) || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+  }
+  #[cfg(not(unix))]
+  {
+    let _ = pid;
+    true
+  }
+}
+
+/// Live-session registry from `<.claude>/sessions/*.json` — Claude Code's
+/// own record of running sessions (`{pid, sessionId, name, status}`).
+/// Missing dir → empty map (sessions fall back to their first prompt and
+/// the artefact-only freshness).
+fn claude_live_registry(projects_base: &Path) -> std::collections::HashMap<String, LiveEntry> {
   let mut map = std::collections::HashMap::new();
   let Some(sessions_dir) = projects_base.parent().map(|p| p.join("sessions")) else {
     return map;
@@ -207,14 +242,16 @@ fn claude_live_names(projects_base: &Path) -> std::collections::HashMap<String, 
     let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw) else {
       continue;
     };
-    if let (Some(sid), Some(name)) = (
-      v.get("sessionId").and_then(|x| x.as_str()),
-      v.get("name").and_then(|x| x.as_str()),
-    ) {
-      if let Some(clean) = clean_session_name(name) {
-        map.insert(sid.to_string(), clean);
-      }
-    }
+    let Some(sid) = v.get("sessionId").and_then(|x| x.as_str()) else {
+      continue;
+    };
+    map.insert(
+      sid.to_string(),
+      LiveEntry {
+        name: v.get("name").and_then(|x| x.as_str()).and_then(clean_session_name),
+        dead: v.get("pid").and_then(|x| x.as_u64()).is_some_and(|p| !pid_is_alive(p)),
+      },
+    );
   }
   map
 }
@@ -237,7 +274,7 @@ impl ClaudeCodeSource {
   }
 
   fn scan_impl(&self, base: &Path, worktrees: &[PathBuf], now: SystemTime, sweep: bool) -> Vec<AgentSession> {
-    let live_names = claude_live_names(base);
+    let live = claude_live_registry(base);
     // Normalise before slugging: libgit2 reports the main checkout with a
     // trailing '/', which would grow a trailing '-' the recorded cwd never
     // has. `components()` drops redundant separators lexically.
@@ -256,7 +293,7 @@ impl ClaudeCodeSource {
         continue;
       }
       claimed.insert(slug.as_str());
-      scan_claude_dir(&base.join(slug), wt, &live_names, now, &mut out);
+      scan_claude_dir(&base.join(slug), wt, &live, now, &mut out);
     }
     if !sweep {
       return out;
@@ -277,7 +314,7 @@ impl ClaudeCodeSource {
         if claimed.contains(name.to_string_lossy().as_ref()) {
           continue;
         }
-        scan_claude_dir(&dir, &dir, &live_names, now, &mut out);
+        scan_claude_dir(&dir, &dir, &live, now, &mut out);
       }
     }
     out
@@ -289,7 +326,7 @@ impl ClaudeCodeSource {
 fn scan_claude_dir(
   dir: &Path,
   cwd: &Path,
-  live_names: &std::collections::HashMap<String, String>,
+  live: &std::collections::HashMap<String, LiveEntry>,
   now: SystemTime,
   out: &mut Vec<AgentSession>,
 ) {
@@ -313,13 +350,14 @@ fn scan_claude_dir(
     let Some(id) = clean_id(stem) else {
       continue;
     };
+    let entry = live.get(stem);
     out.push(AgentSession {
       kind: AgentKind::ClaudeCode,
       cwd: cwd.to_path_buf(),
       last_activity: mtime,
-      ended: false,
+      ended: entry.is_some_and(|e| e.dead),
       id,
-      name: live_names.get(stem).cloned().or_else(|| first_user_text(&path)),
+      name: entry.and_then(|e| e.name.clone()).or_else(|| first_user_text(&path)),
     });
   }
 }
@@ -1082,7 +1120,7 @@ fn claude_session_by_id(base: &Path, sid: &str, now: SystemTime) -> Option<Agent
   if sid.contains(['/', '\\']) {
     return None;
   }
-  let live_names = claude_live_names(base);
+  let live = claude_live_registry(base);
   let entries = std::fs::read_dir(base).ok()?;
   for dir in entries.flatten() {
     let path = dir.path().join(format!("{sid}.jsonl"));
@@ -1092,13 +1130,14 @@ fn claude_session_by_id(base: &Path, sid: &str, now: SystemTime) -> Option<Agent
     if !within_scan_window(mtime, now) {
       continue;
     }
+    let entry = live.get(sid);
     return Some(AgentSession {
       kind: AgentKind::ClaudeCode,
       cwd: dir.path(),
       last_activity: mtime,
-      ended: false,
+      ended: entry.is_some_and(|e| e.dead),
       id: clean_id(sid)?,
-      name: live_names.get(sid).cloned().or_else(|| first_user_text(&path)),
+      name: entry.and_then(|e| e.name.clone()).or_else(|| first_user_text(&path)),
     });
   }
   None
@@ -1122,8 +1161,9 @@ pub enum Freshness {
 }
 
 impl Freshness {
-  /// Classify from the last artefact activity. `ended` (only Vibe can set it)
-  /// forces `Idle`; a timestamp in the future clamps to `Active`.
+  /// Classify from the last artefact activity. `ended` (Vibe's recorded
+  /// `end_time`, or a dead live-registry PID for Claude Code, #441) forces
+  /// `Idle`; a timestamp in the future clamps to `Active`.
   pub fn classify(last_activity: SystemTime, ended: bool, now: SystemTime) -> Self {
     if ended {
       return Freshness::Idle;

--- a/tests/agent_sessions_tests.rs
+++ b/tests/agent_sessions_tests.rs
@@ -1384,3 +1384,82 @@ fn claude_live_session_name_beats_the_first_prompt() {
   let sessions = ClaudeCodeSource.scan(&base, std::slice::from_ref(&wt), SystemTime::now());
   assert_eq!(sessions[0].name.as_deref(), Some("feat-408-agent-session-pane"));
 }
+
+// --- process-level liveness (issue #441) ------------------------------------
+
+/// Spawn-and-reap a child so its PID names a real but dead process. The
+/// reuse window between `wait()` and the scan is microseconds on
+/// sequential-PID kernels — accepted; the alternative is no dead-PID
+/// coverage at all.
+#[cfg(unix)]
+fn reaped_pid() -> u32 {
+  let mut child = std::process::Command::new("true").spawn().expect("spawn true");
+  let pid = child.id();
+  child.wait().expect("reap the child");
+  pid
+}
+
+#[cfg(unix)]
+#[test]
+fn a_dead_registry_pid_ends_the_claude_session() {
+  // An agent killed outright leaves its live-registry file behind; the
+  // recorded PID is the process-level signal that it is not coming back,
+  // so the session must not read as active for the rest of ACTIVE_WINDOW.
+  let tmp = tempfile::TempDir::new().unwrap();
+  let base = tmp.path().join(".claude/projects");
+  let wt = PathBuf::from("/Users/x/proj");
+  write(&base.join(claude_slug(&wt)).join("aaaa-1111.jsonl"), "{}");
+  write(
+    &tmp.path().join(".claude/sessions/40001.json"),
+    &format!(
+      r#"{{"pid":{},"sessionId":"aaaa-1111","name":"killed","status":"busy"}}"#,
+      reaped_pid()
+    ),
+  );
+
+  let sessions = ClaudeCodeSource.scan(&base, std::slice::from_ref(&wt), SystemTime::now());
+  assert!(
+    sessions[0].ended,
+    "a registry entry whose process is gone must end the session"
+  );
+}
+
+#[test]
+fn a_live_registry_pid_keeps_the_claude_session_running() {
+  // Our own PID is alive by definition — the registry entry must not
+  // demote the session it names.
+  let tmp = tempfile::TempDir::new().unwrap();
+  let base = tmp.path().join(".claude/projects");
+  let wt = PathBuf::from("/Users/x/proj");
+  write(&base.join(claude_slug(&wt)).join("aaaa-1111.jsonl"), "{}");
+  write(
+    &tmp.path().join(".claude/sessions/40002.json"),
+    &format!(
+      r#"{{"pid":{},"sessionId":"aaaa-1111","name":"alive","status":"busy"}}"#,
+      std::process::id()
+    ),
+  );
+
+  let sessions = ClaudeCodeSource.scan(&base, std::slice::from_ref(&wt), SystemTime::now());
+  assert!(!sessions[0].ended, "a live PID must keep the session running");
+}
+
+#[test]
+fn a_registry_entry_without_a_pid_stays_artefact_only() {
+  // No PID in the registry file → no process signal → the artefact-only
+  // behaviour is the graceful degradation, not a demotion.
+  let tmp = tempfile::TempDir::new().unwrap();
+  let base = tmp.path().join(".claude/projects");
+  let wt = PathBuf::from("/Users/x/proj");
+  write(&base.join(claude_slug(&wt)).join("aaaa-1111.jsonl"), "{}");
+  write(
+    &tmp.path().join(".claude/sessions/40003.json"),
+    r#"{"sessionId":"aaaa-1111","name":"no-pid","status":"busy"}"#,
+  );
+
+  let sessions = ClaudeCodeSource.scan(&base, std::slice::from_ref(&wt), SystemTime::now());
+  assert!(
+    !sessions[0].ended,
+    "no process signal → keep the artefact-only classification"
+  );
+}

--- a/tests/agent_sessions_tests.rs
+++ b/tests/agent_sessions_tests.rs
@@ -1463,3 +1463,37 @@ fn a_registry_entry_without_a_pid_stays_artefact_only() {
     "no process signal → keep the artefact-only classification"
   );
 }
+
+#[cfg(unix)]
+#[test]
+fn a_stale_dead_registry_entry_does_not_shadow_the_live_one() {
+  // A session killed then resumed leaves BOTH registry files behind with
+  // the same sessionId (old dead PID + new live one). read_dir order is
+  // undefined, so the merge must let a live PID win regardless of which
+  // file is read last.
+  let tmp = tempfile::TempDir::new().unwrap();
+  let base = tmp.path().join(".claude/projects");
+  let wt = PathBuf::from("/Users/x/proj");
+  write(&base.join(claude_slug(&wt)).join("aaaa-1111.jsonl"), "{}");
+  write(
+    &tmp.path().join(".claude/sessions/40004.json"),
+    &format!(
+      r#"{{"pid":{},"sessionId":"aaaa-1111","name":"live","status":"busy"}}"#,
+      std::process::id()
+    ),
+  );
+  // Several dead entries around the live one so an unfavourable read_dir
+  // order is overwhelmingly likely to present a dead file last.
+  for (i, dead) in [reaped_pid(), reaped_pid(), reaped_pid()].into_iter().enumerate() {
+    write(
+      &tmp.path().join(format!(".claude/sessions/9000{i}.json")),
+      &format!(r#"{{"pid":{dead},"sessionId":"aaaa-1111","name":"stale","status":"busy"}}"#),
+    );
+  }
+
+  let sessions = ClaudeCodeSource.scan(&base, std::slice::from_ref(&wt), SystemTime::now());
+  assert!(
+    !sessions[0].ended,
+    "a live registry PID must win over stale dead entries for the same sessionId"
+  );
+}


### PR DESCRIPTION
## Description

Agent session detection (#408) was purely artefact based: a session counted as active while its newest artefact mtime fell within `ACTIVE_WINDOW` (300 s), so an agent killed outright stayed shown as active until the window expired. Claude Code's live registry (`~/.claude/sessions/<pid>.json`) records each session's PID: on Unix, detection now probes it with `kill(pid, 0)` and demotes a session whose process is gone by setting the existing `ended` flag (the same one Vibe's recorded `end_time` uses), which `Freshness::classify` already turns into idle. No PID in the registry, another backend (Codex, opencode, Vibe), or a non-Unix platform keep the artefact-only classification as the graceful degradation.

Closes #441

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `src/agent_sessions.rs`: `claude_live_names` becomes `claude_live_registry` (name plus liveness per entry); new `pid_is_alive` probe (`cfg(unix)`, EPERM counts as alive, out-of-range or zero PID degrades to alive); both Claude session constructors (`scan_claude_dir`, `claude_session_by_id`) set `ended` from the registry; field and classify docs updated
- `tests/agent_sessions_tests.rs`: 3 new tests (dead PID via a reaped child ends the session, own PID keeps it running, registry entry without a PID stays artefact-only)
- Docs EN + FR (CLI reference, TUI keybindings, README): "no process scanning, identical behaviour" reworded to "no process enumeration, same code path" plus the one Unix refinement
- `CHANGELOG.md`: entry under `[Unreleased] > Changed`

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

TDD note: red run first (dead-PID test failed by assertion against the current artefact-only behaviour), then green. Full suite run under a stripped CI-like PATH (85 harnesses, zero failures). The dead-PID fixture spawns and reaps a `true` child; the PID-reuse window between reap and scan is microseconds on sequential-PID kernels, accepted and documented in the helper.

## Screenshots / TUI captures

No visual change: the existing active/idle rendering just reacts sooner for a killed Claude session.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed (schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #441
- Related PR: #435 (agent session pane, where the artefact-only scope was recorded)

## Notes for reviewers

A dead PID recycled by an unrelated process reads as alive; that misreport window matches today's artefact-only behaviour and is documented on `pid_is_alive` rather than closed (comparing `procStart` cross-platform is disproportionate). The wire contract is untouched: `ended` already existed and the JSON `agents` field derives from the same classification.