### PR TITLE
✨ feat(cli): Windows named pipe transport for the daemon and statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Windows named pipe transport for the daemon** (#439). `gwm daemon` and
+  `gwm statusline` now work on Windows: the daemon binds an owner-only named
+  pipe under `\\.\pipe\` (default name `gwm-<user>.sock`, `--socket` takes
+  the pipe name) with the same JSON-RPC surface, DoS guards and graceful
+  degradation as the unix socket, and the statusline client rides it — every
+  segment lights up, including the agent indicator from #408. Unix behaviour
+  is untouched; the docs' Unix-only caveats are lifted.
 - **Agent session pane** (#408). gwm now detects AI-agent coding sessions
   (Claude Code, Codex, opencode, Mistral Vibe) per worktree by reading each
   tool's on-disk session artefacts — no process scanning, `std::fs` only, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +908,7 @@ dependencies = [
  "dirs",
  "git2",
  "glob",
+ "interprocess",
  "libc",
  "libz-sys",
  "nucleo-matcher",
@@ -922,6 +929,7 @@ dependencies = [
  "toml_edit",
  "tui-term",
  "which",
+ "widestring",
 ]
 
 [[package]]
@@ -1064,6 +1072,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1846,6 +1867,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -2786,6 +2813,12 @@ checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
  "tui-term",
  "which",
  "widestring",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ libc = "0.2"
 [target."cfg(windows)".dependencies]
 interprocess = "2.4.2"
 widestring = "1.2.1"
+windows-sys = { version = "0.61.2", features = ["Win32_System_Pipes", "Win32_Foundation"] }
 
 [target."cfg(windows)".dev-dependencies]
 interprocess = "2.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,10 @@ rusqlite = { version = "0.40.1", features = ["bundled"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target."cfg(windows)".dependencies]
+interprocess = "2.4.2"
+widestring = "1.2.1"
+
 [dev-dependencies]
 assert_cmd = "2"
 criterion = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,9 @@ libc = "0.2"
 interprocess = "2.4.2"
 widestring = "1.2.1"
 
+[target."cfg(windows)".dev-dependencies]
+interprocess = "2.4.2"
+
 [dev-dependencies]
 assert_cmd = "2"
 criterion = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ libc = "0.2"
 [target."cfg(windows)".dependencies]
 interprocess = "2.4.2"
 widestring = "1.2.1"
-windows-sys = { version = "0.61.2", features = ["Win32_System_Pipes", "Win32_Foundation"] }
+windows-sys = { version = "0.61.2", features = ["Win32_System_Pipes", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading"] }
 
 [target."cfg(windows)".dev-dependencies]
 interprocess = "2.4.2"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Written in Rust on vendored `libgit2`, so worktree operations are native rather 
 
 - **Bootstrap that actually runs your project.** File copies with deny-list regexes (born from a real "AWS RDS credentials in a copied `.env`" incident), six lifecycle hook phases, stack presets for Laravel / Node / Rust / Go / Python.
 - **A TUI you can live in.** Embedded lazygit and shell overlays, a details sidebar with CI state and working-tree file explorer, remappable keys, themes, command palette.
-- **It knows which AI agent works where.** Sessions from Claude Code, Codex, opencode and Mistral Vibe are detected from their on-disk artefacts (no process enumeration, Windows included; on Unix a dead recorded PID drops the session to idle at once) and surfaced everywhere: an AGENT column in the table and TUI, a detail overlay on `a`, `gwm agents` with manual pinning, the JSON/daemon field and the statusline (which rides the daemon socket, so it is Unix-only today).
+- **It knows which AI agent works where.** Sessions from Claude Code, Codex, opencode and Mistral Vibe are detected from their on-disk artefacts (no process enumeration, Windows included; on Unix a dead recorded PID drops the session to idle at once) and surfaced everywhere: an AGENT column in the table and TUI, a detail overlay on `a`, `gwm agents` with manual pinning, the JSON/daemon field and the statusline (fed by the daemon transport everywhere: a unix socket, or a named pipe on Windows).
 - **A machine surface, not just a human one.** `--format=json`, a JSON-RPC daemon with a push stream, and `gwm statusline` for your prompt. The schemas are frozen under SemVer.
 - **Undo.** `gwm undo` and `gwm history` recover a worktree you removed by mistake, without `git reflog`.
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -253,8 +253,8 @@ the session drops to idle immediately instead of riding out the activity
 window; elsewhere (and for the other agents) classification stays
 artefact-only. The same data feeds the TUI's AGENT
 column and `a` overlay, `gwm list` (table column + JSON `agents` field), the
-daemon and `gwm statusline` (the statusline consumes the daemon's Unix
-socket, so that one surface is Unix-only today).
+daemon and `gwm statusline` (fed by the daemon transport on every
+platform — unix socket, or a named pipe on Windows, #439).
 
 ```bash
 gwm agents                       # sessions per worktree: agent, freshness, last activity, id, name
@@ -554,7 +554,7 @@ gwm doctor --format=json | jq '.checks[] | select(.status == "failed")'
 
 ## `gwm daemon [--socket <path>] [--poll-ms <ms>]` (issue #38)
 
-Run gwm as a long-running **JSON-RPC 2.0 daemon** over a unix domain socket, so editors / statusbars / tooling connect once instead of spawning `gwm` per query.
+Run gwm as a long-running **JSON-RPC 2.0 daemon** over a unix domain socket (a named pipe on Windows, #439), so editors / statusbars / tooling connect once instead of spawning `gwm` per query.
 
 ```bash
 gwm daemon                              # bind $XDG_RUNTIME_DIR/gwm.sock (→ $TMPDIR → /tmp)
@@ -578,7 +578,7 @@ printf '{"jsonrpc":"2.0","method":"list","id":1}\n' | nc -U "${XDG_RUNTIME_DIR:-
 
 `subscribe` turns the connection into a one-way push stream: the daemon sends a `worktrees.changed` notification with the current snapshot, then one on every change. Change detection is **interval polling** of the worktree set (tuned by `--poll-ms`, default `1000`) — a deliberate MVP choice over a filesystem watch so there's no extra dependency and the behaviour is deterministic; update latency is bounded by the poll interval.
 
-**Platform / build:** Unix-only, behind the default-on `daemon` Cargo feature. On Windows or a `--no-default-features` build the subcommand exits with an explanatory error (it stays listed so `--help` is identical everywhere).
+**Platform / build:** behind the default-on `daemon` Cargo feature. Unix binds a unix domain socket (`--socket` is a filesystem path); Windows binds a named pipe (#439, `--socket` is the pipe NAME under `\\.\pipe\`, default `gwm-<user>.sock`, restricted to the owner by its security descriptor). On a `--no-default-features` build the subcommand exits with an explanatory error (it stays listed so `--help` is identical everywhere).
 
 `--poll-ms` must be `≥ 1` (`0` is rejected — it would spin the `subscribe` loop with no wait, re-scanning git as fast as the CPU allows).
 

--- a/docs/5.integrations/4.daemon-consumers.md
+++ b/docs/5.integrations/4.daemon-consumers.md
@@ -7,7 +7,7 @@ navigation:
 
 # Daemon consumers
 
-[`gwm daemon`](/cli/reference#gwm-daemon-socket-path-poll-ms-ms-issue-38) is a long-running JSON-RPC 2.0 server over a unix domain socket: editors, statusbars, and tooling connect once and call `list` / `doctor` / `path`, or `subscribe` for pushed `worktrees.changed` notifications — instead of spawning `gwm` per query. This page covers the **consumer** side: the bundled `gwm statusline`, the raw protocol one-liner, and an editor recipe.
+[`gwm daemon`](/cli/reference#gwm-daemon-socket-path-poll-ms-ms-issue-38) is a long-running JSON-RPC 2.0 server over a unix domain socket (a named pipe on Windows, #439): editors, statusbars, and tooling connect once and call `list` / `doctor` / `path`, or `subscribe` for pushed `worktrees.changed` notifications — instead of spawning `gwm` per query. This page covers the **consumer** side: the bundled `gwm statusline`, the raw protocol one-liner, and an editor recipe.
 
 > The daemon is **one per repo** — it answers for the repository it was launched in. Start it from inside the worktree set you want to watch (`cd` into any worktree of the repo, then `gwm daemon`). The default socket path is shared, so to run daemons for **several repos at once** give each a distinct `--socket` (and point that repo's `gwm statusline --socket` at the same path) — otherwise the second `gwm daemon` is refused by the live-socket guard.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -254,8 +254,8 @@ la session passe idle immédiatement au lieu d'attendre la fin de la
 fenêtre d'activité ; ailleurs (et pour les autres agents), la
 classification reste basée sur les artefacts seuls. Les mêmes données alimentent la colonne AGENT et la surcouche `a`
 de la TUI, `gwm list` (colonne de table + champ JSON `agents`), le daemon et
-`gwm statusline` (la statusline consomme la socket Unix du daemon, cette
-surface-là est donc Unix-only à ce jour).
+`gwm statusline` (alimentée par le transport du daemon sur chaque
+plateforme — socket unix, ou un named pipe sous Windows, #439).
 
 ```bash
 gwm agents                       # sessions par worktree : agent, fraîcheur, dernière activité, id, nom
@@ -557,7 +557,7 @@ gwm doctor --format=json | jq '.checks[] | select(.status == "failed")'
 
 ## `gwm daemon [--socket <path>] [--poll-ms <ms>]` (issue #38)
 
-Lance gwm comme **daemon JSON-RPC 2.0** au long cours sur une socket de domaine unix, pour que les éditeurs / barres de statut / outillages se connectent une fois au lieu de lancer `gwm` à chaque requête.
+Lance gwm comme **daemon JSON-RPC 2.0** au long cours sur une socket de domaine unix (un named pipe sous Windows, #439), pour que les éditeurs / barres de statut / outillages se connectent une fois au lieu de lancer `gwm` à chaque requête.
 
 ```bash
 gwm daemon                              # bind $XDG_RUNTIME_DIR/gwm.sock (→ $TMPDIR → /tmp)
@@ -581,7 +581,7 @@ printf '{"jsonrpc":"2.0","method":"list","id":1}\n' | nc -U "${XDG_RUNTIME_DIR:-
 
 `subscribe` transforme la connexion en flux de push à sens unique : le daemon envoie une notification `worktrees.changed` avec le snapshot courant, puis une à chaque changement. La détection de changement est un **polling à intervalle** de l'ensemble des worktrees (réglé par `--poll-ms`, défaut `1000`) — un choix MVP délibéré plutôt qu'une surveillance du système de fichiers, pour qu'il n'y ait pas de dépendance supplémentaire et que le comportement soit déterministe ; la latence de mise à jour est bornée par l'intervalle de polling.
 
-**Plateforme / build :** Unix uniquement, derrière la feature Cargo `daemon` activée par défaut. Sous Windows ou un build `--no-default-features`, la sous-commande quitte avec une erreur explicative (elle reste listée pour que `--help` soit identique partout).
+**Plateforme / build :** derrière la feature Cargo `daemon` activée par défaut. Unix lie une socket de domaine unix (`--socket` est un chemin de fichier) ; Windows lie un named pipe (#439, `--socket` est le NOM du pipe sous `\\.\pipe\`, `gwm-<user>.sock` par défaut, restreint au propriétaire par son descripteur de sécurité). Sur un build `--no-default-features`, la sous-commande quitte avec une erreur explicative (elle reste listée pour que `--help` soit identique partout).
 
 `--poll-ms` doit être `≥ 1` (`0` est rejeté — il ferait tourner la boucle `subscribe` sans attente, re-scannant git aussi vite que le CPU le permet).
 

--- a/docs/fr/5.integrations/4.daemon-consumers.md
+++ b/docs/fr/5.integrations/4.daemon-consumers.md
@@ -7,7 +7,7 @@ navigation:
 
 # Consommateurs du daemon
 
-[`gwm daemon`](/fr/cli/reference#gwm-daemon-socket-path-poll-ms-ms-issue-38) est un serveur JSON-RPC 2.0 au long cours sur une socket de domaine unix : les éditeurs, barres de statut et outillages se connectent une fois et appellent `list` / `doctor` / `path`, ou `subscribe` pour recevoir les notifications `worktrees.changed` poussées — au lieu de lancer `gwm` à chaque requête. Cette page couvre le côté **consommateur** : le `gwm statusline` embarqué, le one-liner du protocole brut, et une recette éditeur.
+[`gwm daemon`](/fr/cli/reference#gwm-daemon-socket-path-poll-ms-ms-issue-38) est un serveur JSON-RPC 2.0 au long cours sur une socket de domaine unix (un named pipe sous Windows, #439) : les éditeurs, barres de statut et outillages se connectent une fois et appellent `list` / `doctor` / `path`, ou `subscribe` pour recevoir les notifications `worktrees.changed` poussées — au lieu de lancer `gwm` à chaque requête. Cette page couvre le côté **consommateur** : le `gwm statusline` embarqué, le one-liner du protocole brut, et une recette éditeur.
 
 > Le daemon est **un par dépôt** — il répond pour le dépôt dans lequel il a été lancé. Lancez-le depuis l'ensemble de worktrees que vous voulez surveiller (`cd` dans n'importe quel worktree du dépôt, puis `gwm daemon`). Le chemin de socket par défaut est partagé : pour faire tourner des daemons pour **plusieurs dépôts à la fois**, donnez à chacun un `--socket` distinct (et pointez le `gwm statusline --socket` du dépôt sur le même chemin) — sinon le second `gwm daemon` est refusé par le garde-fou de socket vivante.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3251,9 +3251,10 @@ fn cmd_doctor(format: OutputFormat) -> Result<()> {
 
 /// `gwm daemon` (issue #38, phase 2). Discovers the repo from the CWD,
 /// binds the JSON-RPC socket, and serves until killed. The serving path
-/// is unix + `daemon`-feature only; elsewhere it returns a clean error so
-/// the subcommand stays present (and help identical) on every platform.
-#[cfg(all(unix, feature = "daemon"))]
+/// needs the `daemon` feature plus a supported transport — a unix domain
+/// socket, or a named pipe on Windows (#439); elsewhere it returns a clean
+/// error so the subcommand stays present (and help identical) everywhere.
+#[cfg(all(any(unix, windows), feature = "daemon"))]
 fn cmd_daemon(socket: Option<PathBuf>, poll_ms: u64) -> Result<()> {
   use std::sync::atomic::AtomicBool;
   use std::sync::Arc;
@@ -3275,11 +3276,11 @@ fn cmd_daemon(socket: Option<PathBuf>, poll_ms: u64) -> Result<()> {
   crate::daemon::serve(&opts, Arc::new(AtomicBool::new(false)))
 }
 
-#[cfg(not(all(unix, feature = "daemon")))]
+#[cfg(not(all(any(unix, windows), feature = "daemon")))]
 fn cmd_daemon(socket: Option<PathBuf>, poll_ms: u64) -> Result<()> {
   let _ = (socket, poll_ms);
   Err(GwmError::Other(
-    "daemon mode is unavailable in this build (requires a Unix platform and the `daemon` feature)".into(),
+    "daemon mode is unavailable in this build (requires the `daemon` feature on a supported platform)".into(),
   ))
 }
 
@@ -3299,7 +3300,7 @@ fn print_statusline(worktrees: &[crate::json_api::JsonWorktree], cwd: &Path) {
   let _ = io::stdout().flush();
 }
 
-#[cfg(all(unix, feature = "daemon"))]
+#[cfg(all(any(unix, windows), feature = "daemon"))]
 fn cmd_statusline(socket: Option<PathBuf>, watch: bool) -> Result<()> {
   let socket = socket.unwrap_or_else(crate::daemon::socket_path);
   // `print_statusline` canonicalises both the cwd and each worktree path,
@@ -3327,16 +3328,14 @@ fn cmd_statusline(socket: Option<PathBuf>, watch: bool) -> Result<()> {
   Ok(())
 }
 
-#[cfg(not(all(unix, feature = "daemon")))]
+#[cfg(not(all(any(unix, windows), feature = "daemon")))]
 fn cmd_statusline(socket: Option<PathBuf>, watch: bool) -> Result<()> {
-  // No daemon transport in this build: the statusline has no source, so it
-  // degrades to the documented empty line (exit 0) rather than erroring.
-  // EVERY segment inherits this ceiling — branch, flags, issue/PR and the
-  // #408 agent indicator alike (docs carry the Unix-only caveat). The
-  // statusline is deliberately daemon-fed (#309: a prompt path must never
-  // open the repo or scan artefact stores itself); lighting it up on
-  // Windows means a named-pipe daemon transport, a follow-up to #38, not a
-  // local-detection fallback here.
+  // No daemon transport in this build (`--no-default-features`, or an
+  // unsupported platform): the statusline has no source, so it degrades to
+  // the documented empty line (exit 0) rather than erroring. The statusline
+  // is deliberately daemon-fed (#309: a prompt path must never open the
+  // repo or scan artefact stores itself); unix rides the socket, Windows
+  // the named pipe (#439).
   let _ = (socket, watch);
   let cwd = std::env::current_dir().unwrap_or_default();
   print_statusline(&[], &cwd);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -366,22 +366,25 @@ pub enum Command {
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
   },
-  /// Run a long-running JSON-RPC 2.0 daemon over a unix domain socket.
+  /// Run a long-running JSON-RPC 2.0 daemon over a local transport.
   ///
   /// Editors, statusbars, and tooling connect once and call `list` /
   /// `doctor` / `path`, or `subscribe` for pushed `worktrees.changed`
   /// notifications — instead of spawning `gwm` per query (issue #38).
   /// Newline-delimited JSON, one request and one response per line.
   ///
-  /// Unix-only and built behind the default-on `daemon` feature; on other
-  /// platforms / `--no-default-features` builds the command exits with an
+  /// The transport is a unix domain socket on unix and a named pipe under
+  /// `\\.\pipe\` on Windows (issue #439). Built behind the default-on
+  /// `daemon` feature; a `--no-default-features` build exits with an
   /// explanatory error.
   Daemon {
-    /// Socket path to bind. Defaults to `$XDG_RUNTIME_DIR/gwm.sock`,
-    /// falling back to `$TMPDIR`, then `/tmp`. When the chosen base dir is
-    /// not owner-only (e.g. the shared `/tmp` last resort), the socket is
-    /// isolated in a per-user `<base>/gwm-<uid>/gwm.sock` instead, so it
-    /// stays un-connectable cross-user.
+    /// Where to bind. On unix: a socket path, defaulting to
+    /// `$XDG_RUNTIME_DIR/gwm.sock`, falling back to `$TMPDIR`, then
+    /// `/tmp` — isolated in a per-user `<base>/gwm-<uid>/gwm.sock` when
+    /// the base dir is not owner-only. On Windows: the pipe NAME under
+    /// `\\.\pipe\` (not a filesystem path), defaulting to
+    /// `gwm-<user>.sock`, restricted to the owner by its security
+    /// descriptor.
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
     /// Worktree-state poll interval in milliseconds for `subscribe` push
@@ -395,7 +398,8 @@ pub enum Command {
   /// Print a compact one-line worktree summary for shell prompts (issue #309).
   ///
   /// The first real consumer of `gwm daemon`: it connects to the daemon's
-  /// unix socket, asks for the worktree set, and renders a single line —
+  /// transport (unix socket, or a named pipe on Windows, issue #439), asks
+  /// for the worktree set, and renders a single line —
   /// active branch, worktree count, dirty / ahead / behind, linked issue /
   /// PR — suitable for a tmux / starship / zsh statusline. With `--watch`
   /// it subscribes to the daemon's `worktrees.changed` stream and reprints
@@ -406,10 +410,11 @@ pub enum Command {
   /// nothing instead of erroring. A CI rollup is intentionally not shown —
   /// it is not part of the daemon's stable schema.
   Statusline {
-    /// Daemon socket path. Defaults to the same resolution as `gwm daemon`:
-    /// `$XDG_RUNTIME_DIR/gwm.sock`, then `$TMPDIR`, then `/tmp` — isolated in
-    /// a per-user `<base>/gwm-<uid>/gwm.sock` when the base dir isn't
-    /// owner-only (the shared `/tmp` fallback).
+    /// Daemon socket path (unix) or pipe name (Windows). Defaults to the
+    /// same resolution as `gwm daemon`: `$XDG_RUNTIME_DIR/gwm.sock`, then
+    /// `$TMPDIR`, then `/tmp` — isolated in a per-user
+    /// `<base>/gwm-<uid>/gwm.sock` when the base dir isn't owner-only —
+    /// and `gwm-<user>.sock` under `\\.\pipe\` on Windows.
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
     /// Stream live updates: subscribe to `worktrees.changed` and reprint

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1335,7 +1335,12 @@ mod server_win {
         }
         match reader.read(&mut buf) {
           Ok(0) => return, // peer closed
-          Ok(_) => {}      // unexpected client chatter on a push stream — ignore
+          // Client chatter ENDS the subscription here, unlike on unix
+          // (which ignores it): the pipe client cannot close its recv
+          // half from another thread the way a unix client's fd drop
+          // does, so writing anything IS the client's hang-up signal —
+          // the close then unblocks its reader thread via EOF (#439).
+          Ok(_) => return,
           Err(e) if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
           Err(e) if e.kind() == ErrorKind::Interrupted => {}
           Err(_) => return, // dead link
@@ -1435,33 +1440,29 @@ pub mod client {
     parse_list_result(line.trim())
   }
 
-  /// Poll cadence of the subscribe reader's nonblocking line loop.
-  const READER_TICK: Duration = Duration::from_millis(15);
-
   /// Subscribe to `worktrees.changed` — same contract as the unix client:
   /// the first snapshot is bounded by [`CLIENT_TIMEOUT`], later pushes wait
   /// indefinitely, and a stream that closes before any snapshot errors so
   /// the caller's degradation branch fires (issue #312).
   ///
-  /// Shape (Codex review #439): the WHOLE connect + handshake + read loop
-  /// lives on a helper thread, so the first `recv_timeout` bounds the
-  /// connect too — a wedged daemon whose pipe accepts no instance must
-  /// degrade `statusline --watch` within the deadline, not hang it. The
-  /// thread owns both stream halves and reads NONBLOCKING under a cancel
-  /// flag: when `on_snapshot` asks to stop, flipping the flag makes the
-  /// thread exit within a tick and drop both halves — actually closing
-  /// the pipe and freeing the server's connection slot (a blocking
-  /// `read_line` would keep both alive until the next push, potentially
-  /// forever).
+  /// Shape (Codex review #439): connect + handshake + the BLOCKING read
+  /// loop all live on a helper thread, so the first `recv_timeout` bounds
+  /// the connect too — a wedged daemon whose pipe accepts no instance
+  /// degrades `statusline --watch` within the deadline instead of hanging
+  /// it. Reads stay blocking on purpose: client-side nonblocking mode on a
+  /// named pipe is `PIPE_NOWAIT`, which Microsoft deprecates and which
+  /// surfaces empty-pipe reads as fatal-looking errors (witnessed in CI).
+  /// Ending the stream is a PROTOCOL affair instead: the send half is
+  /// handed back to this thread, and when `on_snapshot` asks to stop we
+  /// write a hang-up line — the pipe server closes the connection on any
+  /// client chatter, which unblocks the reader thread via EOF and frees
+  /// the daemon's connection slot. If the daemon is wedged and never
+  /// reads, the reader thread leaks until the short-lived CLI process
+  /// exits — the same accepted cost as `list_once`'s timeout path.
   pub fn subscribe(socket: &Path, mut on_snapshot: impl FnMut(&[JsonWorktree]) -> bool) -> Result<()> {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use std::time::Instant;
-
     let socket = socket.to_path_buf();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let flag = Arc::clone(&cancel);
     let (tx, rx) = mpsc::channel::<Result<String>>();
+    let (half_tx, half_rx) = mpsc::channel();
     std::thread::spawn(move || {
       let stream = match connect(&socket) {
         Ok(s) => s,
@@ -1470,74 +1471,23 @@ pub mod client {
           return;
         }
       };
-      if let Err(e) = stream.set_nonblocking(true) {
+      let (recv, mut send) = stream.split();
+      if let Err(e) = writeln!(send, "{SUBSCRIBE_REQUEST}").and_then(|()| send.flush()) {
         let _ = tx.send(Err(GwmError::Other(format!("daemon: {e}"))));
         return;
       }
-      let (recv, mut send) = stream.split();
-      // The handshake write races an empty kernel buffer at worst — retry
-      // WouldBlock briefly rather than treating it as fatal.
-      let frame = format!("{SUBSCRIBE_REQUEST}\n").into_bytes();
-      let deadline = Instant::now() + CLIENT_TIMEOUT;
-      let mut written = 0usize;
-      while written < frame.len() {
-        if flag.load(Ordering::Relaxed) || Instant::now() >= deadline {
-          return; // both halves drop here — the pipe closes
-        }
-        match send.write(&frame[written..]) {
-          Ok(0) => return,
-          Ok(n) => written += n,
-          Err(e)
-            if matches!(
-              e.kind(),
-              std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
-            ) =>
-          {
-            std::thread::sleep(READER_TICK);
-          }
-          Err(e) => {
-            let _ = tx.send(Err(GwmError::Other(format!("daemon: {e}"))));
-            return;
-          }
-        }
-      }
-      // Nonblocking line loop: accumulate until '\n', ship each line. On
-      // cancel or a dead link, fall off the end — dropping BOTH halves
-      // closes the pipe (the whole point of the flag).
-      let mut reader = std::io::BufReader::new(recv);
-      let mut buf: Vec<u8> = Vec::new();
+      // Hand the send half to the consumer so it can hang up (see above).
+      let _ = half_tx.send(send);
+      let mut reader = BufReader::new(recv);
       loop {
-        if flag.load(Ordering::Relaxed) {
-          return;
-        }
-        let chunk = match reader.fill_buf() {
-          Ok(c) => c,
-          Err(e)
-            if matches!(
-              e.kind(),
-              std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
-            ) =>
-          {
-            std::thread::sleep(READER_TICK);
-            continue;
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+          Ok(0) | Err(_) => break, // EOF or dead link — dropping tx ends the stream
+          Ok(_) => {
+            if tx.send(Ok(line)).is_err() {
+              break; // consumer stopped listening
+            }
           }
-          Err(_) => return, // dead link — dropping tx ends the consumer loop
-        };
-        if chunk.is_empty() {
-          return; // EOF — peer closed
-        }
-        if let Some(pos) = chunk.iter().position(|&b| b == b'\n') {
-          buf.extend_from_slice(&chunk[..pos]);
-          reader.consume(pos + 1);
-          let line = String::from_utf8_lossy(&buf).into_owned();
-          buf.clear();
-          if tx.send(Ok(line)).is_err() {
-            return; // consumer stopped listening
-          }
-        } else {
-          let n = chunk.len();
-          buf.extend_from_slice(chunk);
-          reader.consume(n);
         }
       }
     });
@@ -1575,9 +1525,13 @@ pub mod client {
         }
       }
     }
-    // Wake and end the reader thread so it drops both halves promptly —
-    // closing the pipe and freeing the daemon's connection slot.
-    cancel.store(true, Ordering::Relaxed);
+    // Hang up: any client line makes the pipe server close this
+    // connection, which unblocks the reader thread via EOF so both halves
+    // drop and the daemon's slot frees. Best effort — a dead daemon
+    // already ended the stream.
+    if let Ok(mut send) = half_rx.try_recv() {
+      let _ = writeln!(send, "bye").and_then(|()| send.flush());
+    }
     result?;
     if !delivered_any {
       return Err(GwmError::Other(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -962,10 +962,12 @@ pub fn pipe_user_fragment(raw: &str) -> String {
 // the unix module's #341 hardening is battle-tested and stays byte-
 // identical, and the two transports differ exactly where a generic
 // abstraction would be the most contorted —
-// - `interprocess`'s sync streams have no read/write timeouts, so every
-//   guard unix gets from `set_read_timeout` (slow-loris line deadline,
-//   subscription poll tick, dead-peer detection) is rebuilt here on
-//   NONBLOCKING streams plus bounded sleep-retry loops;
+// - `interprocess`'s sync streams have no read/write timeouts, and its
+//   NOWAIT mode is unusable (an empty-pipe read is downgraded to a fake
+//   EOF — see `peek_available`), so every guard unix gets from
+//   `set_read_timeout` (slow-loris line deadline, subscription poll tick,
+//   dead-peer detection) is rebuilt here on BLOCKING streams polled with
+//   `PeekNamedPipe` before every read;
 // - the cross-user barrier is the pipe's owner-only security descriptor,
 //   the named-pipe analogue of `chmod 0600` + the private socket dir
 //   (`\\.\pipe\` has no directories to restrict).
@@ -977,16 +979,18 @@ pub fn pipe_user_fragment(raw: &str) -> String {
 mod server_win {
   use super::*;
   use crate::error::GwmError;
-  use interprocess::local_socket::{
-    prelude::*, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
-  };
-  use interprocess::os::windows::local_socket::ListenerOptionsExt;
+  use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
+  use interprocess::os::windows::named_pipe::{pipe_mode, PipeListenerOptions, PipeMode, PipeStream};
   use interprocess::os::windows::security_descriptor::SecurityDescriptor;
   use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+  use std::os::windows::io::{AsHandle, AsRawHandle};
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
   use std::sync::Arc;
   use std::time::{Duration, Instant};
+
+  /// The accepted duplex byte stream this server speaks over.
+  type Conn = PipeStream<pipe_mode::Bytes, pipe_mode::Bytes>;
 
   /// RAII counter of live client connections — duplicated from the unix
   /// module (see the section comment above).
@@ -1012,28 +1016,10 @@ mod server_win {
   /// shutdown flag — same value and role as the unix module's.
   const ACCEPT_TICK: Duration = Duration::from_millis(50);
 
-  /// Sleep quantum of every nonblocking retry loop (reads, writes, the
+  /// Sleep quantum of the peek-driven wait loops (request reads, the
   /// subscription tick). Small enough that deadlines land promptly, large
   /// enough that an idle connection costs a negligible wakeup rate.
   const NB_TICK: Duration = Duration::from_millis(15);
-
-  /// Raw `ERROR_NO_DATA` (232). In `PIPE_NOWAIT` mode an empty pipe read
-  /// (and some full-buffer writes) surfaces as this raw code, which std
-  /// maps to `ErrorKind::BrokenPipe` — indistinguishable BY KIND from a
-  /// really broken pipe (`ERROR_BROKEN_PIPE`, 109). Every nonblocking
-  /// retry loop below must therefore match on the raw code (Codex review
-  /// #439: kind-only matching closed every idle connection and ended
-  /// subscriptions at their first empty poll tick).
-  const ERROR_NO_DATA: i32 = 232;
-
-  /// Whether this I/O error means "try again later" on a `PIPE_NOWAIT`
-  /// stream: the portable kinds plus the raw `ERROR_NO_DATA` mapping.
-  fn is_transient(e: &std::io::Error) -> bool {
-    matches!(
-      e.kind(),
-      ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted
-    ) || e.raw_os_error() == Some(ERROR_NO_DATA)
-  }
 
   /// Configuration for [`serve`] — same shape as the unix module's so the
   /// CLI builds it identically on both platforms. `socket` holds the PIPE
@@ -1050,9 +1036,10 @@ mod server_win {
     /// Max bytes accepted for a single request line before the connection
     /// is dropped (memory-bounding DoS guard, as on unix).
     pub max_line_len: usize,
-    /// Per-request-line wall-time budget, and the write budget for pushes.
-    /// Rebuilt on nonblocking I/O since the transport has no socket-level
-    /// timeout. `None` disables the deadline.
+    /// Per-request-line wall-time budget, rebuilt on `PeekNamedPipe`
+    /// polling since the transport has no socket-level timeout. `None`
+    /// disables the deadline. Writes are BLOCKING and unbudgeted, matching
+    /// the unix server's `writeln!`.
     pub read_timeout: Option<Duration>,
     /// Max concurrent client connections (thread-bounding DoS guard).
     pub max_connections: usize,
@@ -1118,13 +1105,43 @@ mod server_win {
       .map_err(|e| GwmError::Other(format!("daemon: cannot build the pipe security descriptor: {e}")))
   }
 
-  /// Resolve `opts.socket` into a namespaced local-socket name.
+  /// Resolve `opts.socket` into a namespaced local-socket name (probe side).
   fn ns_name(socket: &Path) -> Result<interprocess::local_socket::Name<'static>> {
     let name_str = socket.to_string_lossy().into_owned();
     name_str
       .clone()
       .to_ns_name::<GenericNamespaced>()
       .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {name_str}: {e}")))
+  }
+
+  /// Bytes currently readable on the connection, or `None` when the peer
+  /// is gone. `PeekNamedPipe` is the canonical non-blocking poll for a
+  /// BLOCKING named pipe — and blocking streams are a hard requirement
+  /// here: in `PIPE_NOWAIT` mode an empty-pipe read surfaces raw
+  /// `ERROR_NO_DATA`, whose kind is `BrokenPipe`, and interprocess's
+  /// `downgrade_eof` then converts it to `Ok(0)` — indistinguishable from
+  /// a real EOF, which silently closed idle connections and ended every
+  /// subscription at its first empty poll (Codex review #439, witnessed in
+  /// CI). Peeking sidesteps the whole NOWAIT minefield.
+  fn peek_available(conn: &Conn) -> Option<usize> {
+    let mut avail: u32 = 0;
+    // SAFETY: PeekNamedPipe with a null buffer only queries the available
+    // byte count; the handle is borrowed from `conn` and outlives the call.
+    let ok = unsafe {
+      windows_sys::Win32::System::Pipes::PeekNamedPipe(
+        conn.as_handle().as_raw_handle(),
+        std::ptr::null_mut(),
+        0,
+        std::ptr::null_mut(),
+        &mut avail,
+        std::ptr::null_mut(),
+      )
+    };
+    if ok == 0 {
+      None // broken / disconnected peer
+    } else {
+      Some(avail as usize)
+    }
   }
 
   /// Bind the pipe and serve connections until `shutdown` flips — the
@@ -1134,15 +1151,14 @@ mod server_win {
     // unix stale-socket check (pipes need no stale cleanup: they vanish
     // with their process). BOUNDED by an EXTERNAL deadline (Codex review
     // #439, twice): `ConnectOptions::wait_mode` is silently ignored by
-    // interprocess 2.4.2's Windows local-socket adapter (`from_options`
-    // calls `connect_by_path` unbounded), so the connect runs on a helper
-    // thread and the wait is taken on the channel — a squatted pipe with
-    // no available instance must never hang `gwm daemon` startup. The
-    // parked helper thread leaks in that case; a one-off thread at daemon
-    // startup is an accepted cost. The probe is not the real guard —
-    // `create_sync` claims the name with `FILE_FLAG_FIRST_PIPE_INSTANCE`,
-    // so an occupied name fails the bind below even when the probe timed
-    // out.
+    // interprocess 2.4.2's Windows local-socket adapter, so the connect
+    // runs on a helper thread and the wait is taken on the channel — a
+    // squatted pipe with no available instance must never hang `gwm
+    // daemon` startup. The parked helper thread leaks in that case; a
+    // one-off thread at daemon startup is an accepted cost. The probe is
+    // not the real guard — the first listener instance is created with
+    // `FILE_FLAG_FIRST_PIPE_INSTANCE`, so an occupied name fails the bind
+    // below even when the probe timed out.
     {
       let probe_name = opts.socket.clone();
       let (ptx, prx) = std::sync::mpsc::channel();
@@ -1159,22 +1175,24 @@ mod server_win {
         )));
       }
     }
-    let listener = ListenerOptions::new()
-      .name(ns_name(&opts.socket)?)
-      .security_descriptor(owner_only_descriptor()?)
-      .create_sync()
-      .map_err(|e| {
-        GwmError::Other(format!(
-          "daemon: failed to bind pipe {} (a name that is already claimed is refused — first-instance guard): {e}",
-          opts.socket.display()
-        ))
-      })?;
-    // Nonblocking on BOTH sides: `accept` so this loop can poll the
-    // shutdown flag (as on unix), and the accepted streams because every
-    // per-connection deadline below is a sleep-retry loop over
-    // `WouldBlock` — the transport has no `set_read_timeout` to lean on.
+    let path = widestring::U16CString::from_str(format!("\\\\.\\pipe\\{}", opts.socket.display()))
+      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {}: {e}", opts.socket.display())))?;
+    let mut options = PipeListenerOptions::new();
+    options.path = std::borrow::Cow::Owned(path);
+    options.mode = PipeMode::Bytes;
+    options.security_descriptor = Some(owner_only_descriptor()?);
+    let listener = options.create_duplex::<pipe_mode::Bytes>().map_err(|e| {
+      GwmError::Other(format!(
+        "daemon: failed to bind pipe {} (a name that is already claimed is refused — first-instance guard): {e}",
+        opts.socket.display()
+      ))
+    })?;
+    // Nonblocking ACCEPT so this loop can poll the shutdown flag (as on
+    // unix). The listener flag also marks the accepted streams
+    // nonblocking, so each one is flipped back to BLOCKING right after
+    // accept — see `peek_available` for why NOWAIT streams are unusable.
     listener
-      .set_nonblocking(ListenerNonblockingMode::Both)
+      .set_nonblocking(true)
       .map_err(|e| GwmError::Other(format!("daemon: set_nonblocking failed: {e}")))?;
 
     let active = Arc::new(AtomicUsize::new(0));
@@ -1185,7 +1203,11 @@ mod server_win {
         break;
       }
       match listener.accept() {
-        Ok(stream) => {
+        Ok(conn) => {
+          if let Err(e) = conn.set_nonblocking(false) {
+            eprintln!("daemon: failed to set connection blocking: {e}");
+            continue;
+          }
           let Some(guard) = ActiveGuard::try_acquire(&active, opts.max_connections) else {
             continue;
           };
@@ -1196,7 +1218,7 @@ mod server_win {
           let shutdown = Arc::clone(&shutdown);
           std::thread::spawn(move || {
             let _guard = guard;
-            handle_connection(stream, &workdir, poll, max_line_len, read_timeout, &shutdown);
+            handle_connection(&conn, &workdir, poll, max_line_len, read_timeout, &shutdown);
           });
         }
         Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
@@ -1211,13 +1233,16 @@ mod server_win {
     Ok(())
   }
 
-  /// Read one newline-terminated request line from the nonblocking stream:
-  /// the unix `read_request_line` with the socket timeout replaced by a
-  /// sleep-retry loop bounded by `deadline` (slow-loris guard) and the
-  /// shutdown flag. Same return contract: `None` on EOF / deadline /
+  /// Read one newline-terminated request line: the unix `read_request_line`
+  /// with the socket timeout replaced by a `PeekNamedPipe` wait loop
+  /// bounded by `deadline` (slow-loris guard) and the shutdown flag. The
+  /// peek only runs when the BufReader holds nothing — buffered bytes must
+  /// drain first, or a pipelined second line would wait on a peek that can
+  /// never see it. Same return contract: `None` on EOF / deadline /
   /// oversize / error, and the caller drops the connection.
   fn read_request_line(
-    reader: &mut BufReader<RecvHalf>,
+    conn: &Conn,
+    reader: &mut BufReader<&Conn>,
     max_len: usize,
     deadline: Option<Instant>,
     shutdown: &AtomicBool,
@@ -1232,12 +1257,19 @@ mod server_win {
           return None; // per-line deadline exceeded — slow-loris
         }
       }
+      if reader.buffer().is_empty() {
+        match peek_available(conn) {
+          None => return None, // peer gone
+          Some(0) => {
+            std::thread::sleep(NB_TICK);
+            continue;
+          }
+          Some(_) => {} // bytes ready — the blocking fill below won't block
+        }
+      }
       let chunk = match reader.fill_buf() {
         Ok(c) => c,
-        Err(e) if is_transient(&e) => {
-          std::thread::sleep(NB_TICK);
-          continue;
-        }
+        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
         Err(_) => return None, // reset / dead link
       };
       if chunk.is_empty() {
@@ -1260,55 +1292,29 @@ mod server_win {
     }
   }
 
-  /// `write_all` + `flush` over the nonblocking half, bounded by `budget`.
-  /// The unix server relies on blocking writes here; on a nonblocking pipe
-  /// a full kernel buffer surfaces as `WouldBlock`, so the loop retries —
-  /// and the budget reaps a subscriber that never drains its end.
-  fn write_all_nb(send: &mut SendHalf, bytes: &[u8], budget: Option<Duration>) -> std::io::Result<()> {
-    let deadline = budget.map(|t| Instant::now() + t);
-    let expired = |deadline: Option<Instant>| deadline.is_some_and(|dl| Instant::now() >= dl);
-    let mut written = 0usize;
-    while written < bytes.len() {
-      if expired(deadline) {
-        return Err(std::io::Error::from(ErrorKind::TimedOut));
-      }
-      match send.write(&bytes[written..]) {
-        // A full PIPE_NOWAIT byte-mode buffer reports a SUCCESSFUL write
-        // of zero bytes, not WouldBlock (Codex review #439) — that is
-        // backpressure to retry under the deadline, not a dead sink.
-        Ok(0) => std::thread::sleep(NB_TICK),
-        Ok(n) => written += n,
-        Err(e) if is_transient(&e) => std::thread::sleep(NB_TICK),
-        Err(e) => return Err(e),
-      }
-    }
-    loop {
-      if expired(deadline) {
-        return Err(std::io::Error::from(ErrorKind::TimedOut));
-      }
-      match send.flush() {
-        Ok(()) => return Ok(()),
-        Err(e) if is_transient(&e) => std::thread::sleep(NB_TICK),
-        Err(e) => return Err(e),
-      }
-    }
+  /// Blocking `write_all` + `flush` of one newline-terminated frame — the
+  /// pipe counterpart of the unix server's `writeln!`. Blocking and
+  /// unbudgeted on purpose: a subscriber that never drains its end parks
+  /// only its own connection thread, exactly as on unix.
+  fn write_frame(mut conn: &Conn, bytes: &[u8]) -> std::io::Result<()> {
+    conn.write_all(bytes)?;
+    conn.flush()
   }
 
-  /// Serve one connection — the unix `handle_connection` on split
-  /// nonblocking halves. Same guards, same `subscribe` upgrade.
+  /// Serve one connection — the unix `handle_connection` on a blocking
+  /// duplex pipe stream. Same guards, same `subscribe` upgrade.
   fn handle_connection(
-    stream: Stream,
+    conn: &Conn,
     workdir: &Path,
     poll: Duration,
     max_line_len: usize,
     read_timeout: Option<Duration>,
     shutdown: &AtomicBool,
   ) {
-    let (recv, mut send) = stream.split();
-    let mut reader = BufReader::new(recv);
+    let mut reader = BufReader::new(conn);
     loop {
       let deadline = read_timeout.map(|t| Instant::now() + t);
-      let Some(bytes) = read_request_line(&mut reader, max_line_len, deadline, shutdown) else {
+      let Some(bytes) = read_request_line(conn, &mut reader, max_line_len, deadline, shutdown) else {
         return; // EOF, deadline, oversize, or dead link — drop the connection
       };
       let line = match std::str::from_utf8(&bytes) {
@@ -1322,13 +1328,13 @@ mod server_win {
         .map(|r| r.method == "subscribe")
         .unwrap_or(false);
       if is_subscribe {
-        stream_subscription(&mut send, &mut reader, workdir, poll, read_timeout, shutdown);
+        stream_subscription(conn, &mut reader, workdir, poll, shutdown);
         return;
       }
       if let Some(response) = handle_line(workdir, line) {
         let mut frame = response.into_bytes();
         frame.push(b'\n');
-        if write_all_nb(&mut send, &frame, read_timeout).is_err() {
+        if write_frame(conn, &frame).is_err() {
           return;
         }
       }
@@ -1336,41 +1342,43 @@ mod server_win {
   }
 
   /// Push `worktrees.changed` notifications — the unix `stream_subscription`
-  /// with the timeout-as-poll-tick replaced by an explicit sliced sleep:
-  /// each tick sleeps in `NB_TICK` steps while probing the (nonblocking)
-  /// read half, so a closed peer and the shutdown flag are noticed promptly.
+  /// with the timeout-as-poll-tick replaced by a sliced `PeekNamedPipe`
+  /// wait: each tick sleeps in `NB_TICK` steps while probing the peer, so
+  /// a closed pipe and the shutdown flag are noticed promptly.
   fn stream_subscription(
-    send: &mut SendHalf,
-    reader: &mut BufReader<RecvHalf>,
+    conn: &Conn,
+    reader: &mut BufReader<&Conn>,
     workdir: &Path,
     poll: Duration,
-    write_budget: Option<Duration>,
     shutdown: &AtomicBool,
   ) {
     let mut last: Option<Vec<JsonWorktree>> = None;
     if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
-      if send_notification(send, &snapshot, write_budget).is_err() {
+      if send_notification(conn, &snapshot).is_err() {
         return;
       }
       last = Some(snapshot);
     }
-    let mut buf = [0u8; 64];
     loop {
       let tick_end = Instant::now() + poll;
       loop {
         if shutdown.load(Ordering::Relaxed) {
           return;
         }
-        match reader.read(&mut buf) {
-          Ok(0) => return, // peer closed
-          // Client chatter ENDS the subscription here, unlike on unix
-          // (which ignores it): the pipe client cannot close its recv
-          // half from another thread the way a unix client's fd drop
-          // does, so writing anything IS the client's hang-up signal —
-          // the close then unblocks its reader thread via EOF (#439).
-          Ok(_) => return,
-          Err(e) if is_transient(&e) => {}
-          Err(_) => return, // dead link
+        // Client chatter ENDS the subscription here, unlike on unix
+        // (which ignores it): the pipe client cannot close its recv half
+        // from another thread the way a unix client's fd drop does, so
+        // writing anything IS the client's hang-up signal — the close
+        // then unblocks its reader thread via EOF (#439). Bytes may sit
+        // in the BufReader (pipelined after the subscribe line) or on
+        // the pipe itself.
+        if !reader.buffer().is_empty() {
+          return;
+        }
+        match peek_available(conn) {
+          None => return,    // peer closed or dead link
+          Some(0) => {}      // idle — keep ticking
+          Some(_) => return, // chatter — hang up
         }
         let now = Instant::now();
         if now >= tick_end {
@@ -1379,7 +1387,7 @@ mod server_win {
         std::thread::sleep(NB_TICK.min(tick_end - now));
       }
       if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
-        if send_notification(send, &snapshot, write_budget).is_err() {
+        if send_notification(conn, &snapshot).is_err() {
           return;
         }
         last = Some(snapshot);
@@ -1387,17 +1395,12 @@ mod server_win {
     }
   }
 
-  fn send_notification(
-    send: &mut SendHalf,
-    worktrees: &[JsonWorktree],
-    budget: Option<Duration>,
-  ) -> std::io::Result<()> {
+  fn send_notification(conn: &Conn, worktrees: &[JsonWorktree]) -> std::io::Result<()> {
     let mut frame = worktrees_changed_notification(worktrees).to_string().into_bytes();
     frame.push(b'\n');
-    write_all_nb(send, &frame, budget)
+    write_frame(conn, &frame)
   }
 }
-
 #[cfg(all(windows, feature = "daemon"))]
 pub use server_win::{default_socket, serve, socket_path, ServeOptions};
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -929,6 +929,30 @@ mod server {
 #[cfg(all(unix, feature = "daemon"))]
 pub use server::{default_socket, serve, socket_in, socket_path, ServeOptions};
 
+/// Injective pipe-name fragment for a Windows account identity (issue
+/// #439). ASCII alphanumerics pass through; every other character —
+/// including the `\` of `DOMAIN\user` — becomes `_XX` (uppercase hex of
+/// each UTF-8 byte), so `alice.smith` / `alice-smith`, or same-named
+/// accounts on two domains, can never share a default pipe name (a lossy
+/// fold would let the owner-only DACL lock the second user out of its own
+/// default). `_` itself is escaped too, which is what makes the mapping
+/// injective. Compiled on every platform so the property is unit-testable
+/// off Windows; only the Windows `socket_path` consumes it.
+pub fn pipe_user_fragment(raw: &str) -> String {
+  let mut out = String::with_capacity(raw.len());
+  for c in raw.chars() {
+    if c.is_ascii_alphanumeric() {
+      out.push(c);
+    } else {
+      let mut buf = [0u8; 4];
+      for b in c.encode_utf8(&mut buf).bytes() {
+        out.push_str(&format!("_{b:02X}"));
+      }
+    }
+  }
+  out
+}
+
 // ---------------------------------------------------------------------------
 // Named-pipe server & client — Windows only, behind the `daemon` feature
 // (issue #439). Exposes the same public interface as the unix module, so
@@ -954,10 +978,11 @@ mod server_win {
   use super::*;
   use crate::error::GwmError;
   use interprocess::local_socket::{
-    prelude::*, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
+    prelude::*, ConnectOptions, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
   };
   use interprocess::os::windows::local_socket::ListenerOptionsExt;
   use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+  use interprocess::ConnectWaitMode;
   use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -1037,19 +1062,22 @@ mod server_win {
     }
   }
 
-  /// Default pipe name. `\\.\pipe\` is machine-global, so the username
-  /// namespaces the default and two users' daemons don't fight over one
-  /// name — but the [`owner_only_descriptor`] is the actual access
-  /// barrier; the name only prevents accidental clashes. Characters
-  /// outside `[A-Za-z0-9]` are folded to `-` (a username is not a valid
-  /// pipe-name fragment by construction).
+  /// Default pipe name. `\\.\pipe\` is machine-global, so the identity
+  /// fragment namespaces the default and two users' daemons don't fight
+  /// over one name — but the [`owner_only_descriptor`] is the actual
+  /// access barrier; the name only prevents accidental clashes. The
+  /// fragment is [`pipe_user_fragment`] over `USERDOMAIN\USERNAME`
+  /// (injective escaping, Codex review #439): two accounts whose names
+  /// differ only in punctuation, or same-named accounts on different
+  /// domains, get distinct default names — a lossy fold would let the
+  /// DACL lock the second user out of its own default.
   pub fn socket_path() -> PathBuf {
     let user = std::env::var("USERNAME").unwrap_or_else(|_| "default".to_string());
-    let safe: String = user
-      .chars()
-      .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-      .collect();
-    PathBuf::from(format!("gwm-{safe}.sock"))
+    let identity = match std::env::var("USERDOMAIN") {
+      Ok(domain) if !domain.is_empty() => format!("{domain}\\{user}"),
+      _ => user,
+    };
+    PathBuf::from(format!("gwm-{}.sock", pipe_user_fragment(&identity)))
   }
 
   /// The default [`socket_path`] plus the manage-dir flag, which is always
@@ -1085,10 +1113,19 @@ mod server_win {
   /// Bind the pipe and serve connections until `shutdown` flips — the
   /// Windows counterpart of the unix `serve`, same loop shape.
   pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
-    // Refuse a name a live daemon already owns, mirroring the unix stale-
-    // socket check (pipes need no stale cleanup: they vanish with their
-    // process). The probe-then-bind window is the same benign TOCTOU.
-    if Stream::connect(ns_name(&opts.socket)?).is_ok() {
+    // Courtesy probe for a clear "already in use" message, mirroring the
+    // unix stale-socket check (pipes need no stale cleanup: they vanish
+    // with their process). BOUNDED (Codex review #439): a squatted or
+    // wedged pipe with no available instance would park an unbounded
+    // connect forever and this must never hang `gwm daemon` startup. The
+    // probe is not the real guard — `create_sync` claims the name with
+    // `FILE_FLAG_FIRST_PIPE_INSTANCE`, so an occupied name fails the bind
+    // below even when the probe timed out.
+    let probe = ConnectOptions::new()
+      .name(ns_name(&opts.socket)?)
+      .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(1)))
+      .connect_sync();
+    if probe.is_ok() {
       return Err(GwmError::Other(format!(
         "daemon: pipe {} is already in use by a live daemon",
         opts.socket.display()
@@ -1098,7 +1135,12 @@ mod server_win {
       .name(ns_name(&opts.socket)?)
       .security_descriptor(owner_only_descriptor()?)
       .create_sync()
-      .map_err(|e| GwmError::Other(format!("daemon: failed to bind pipe {}: {e}", opts.socket.display())))?;
+      .map_err(|e| {
+        GwmError::Other(format!(
+          "daemon: failed to bind pipe {} (a name that is already claimed is refused — first-instance guard): {e}",
+          opts.socket.display()
+        ))
+      })?;
     // Nonblocking on BOTH sides: `accept` so this loop can poll the
     // shutdown flag (as on unix), and the accepted streams because every
     // per-connection deadline below is a sleep-retry loop over
@@ -1393,52 +1435,150 @@ pub mod client {
     parse_list_result(line.trim())
   }
 
+  /// Poll cadence of the subscribe reader's nonblocking line loop.
+  const READER_TICK: Duration = Duration::from_millis(15);
+
   /// Subscribe to `worktrees.changed` — same contract as the unix client:
   /// the first snapshot is bounded by [`CLIENT_TIMEOUT`], later pushes wait
   /// indefinitely, and a stream that closes before any snapshot errors so
-  /// the caller's degradation branch fires (issue #312). A reader thread
-  /// pumps lines into a channel; it ends when the stream closes, and the
-  /// send half is kept alive for the loop's whole lifetime so the pipe
-  /// stays fully open.
+  /// the caller's degradation branch fires (issue #312).
+  ///
+  /// Shape (Codex review #439): the WHOLE connect + handshake + read loop
+  /// lives on a helper thread, so the first `recv_timeout` bounds the
+  /// connect too — a wedged daemon whose pipe accepts no instance must
+  /// degrade `statusline --watch` within the deadline, not hang it. The
+  /// thread owns both stream halves and reads NONBLOCKING under a cancel
+  /// flag: when `on_snapshot` asks to stop, flipping the flag makes the
+  /// thread exit within a tick and drop both halves — actually closing
+  /// the pipe and freeing the server's connection slot (a blocking
+  /// `read_line` would keep both alive until the next push, potentially
+  /// forever).
   pub fn subscribe(socket: &Path, mut on_snapshot: impl FnMut(&[JsonWorktree]) -> bool) -> Result<()> {
-    let stream = connect(socket)?;
-    let (recv, mut send) = stream.split();
-    writeln!(send, "{SUBSCRIBE_REQUEST}").map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
-    send.flush().map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
-    let (tx, rx) = mpsc::channel();
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    let socket = socket.to_path_buf();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&cancel);
+    let (tx, rx) = mpsc::channel::<Result<String>>();
     std::thread::spawn(move || {
-      let mut reader = BufReader::new(recv);
-      loop {
-        let mut line = String::new();
-        match reader.read_line(&mut line) {
-          Ok(0) | Err(_) => break, // EOF or dead link — dropping tx ends the stream
-          Ok(_) => {
-            if tx.send(line).is_err() {
-              break; // consumer stopped listening
-            }
+      let stream = match connect(&socket) {
+        Ok(s) => s,
+        Err(e) => {
+          let _ = tx.send(Err(e));
+          return;
+        }
+      };
+      if let Err(e) = stream.set_nonblocking(true) {
+        let _ = tx.send(Err(GwmError::Other(format!("daemon: {e}"))));
+        return;
+      }
+      let (recv, mut send) = stream.split();
+      // The handshake write races an empty kernel buffer at worst — retry
+      // WouldBlock briefly rather than treating it as fatal.
+      let frame = format!("{SUBSCRIBE_REQUEST}\n").into_bytes();
+      let deadline = Instant::now() + CLIENT_TIMEOUT;
+      let mut written = 0usize;
+      while written < frame.len() {
+        if flag.load(Ordering::Relaxed) || Instant::now() >= deadline {
+          return; // both halves drop here — the pipe closes
+        }
+        match send.write(&frame[written..]) {
+          Ok(0) => return,
+          Ok(n) => written += n,
+          Err(e)
+            if matches!(
+              e.kind(),
+              std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+            ) =>
+          {
+            std::thread::sleep(READER_TICK);
+          }
+          Err(e) => {
+            let _ = tx.send(Err(GwmError::Other(format!("daemon: {e}"))));
+            return;
           }
         }
       }
+      // Nonblocking line loop: accumulate until '\n', ship each line. On
+      // cancel or a dead link, fall off the end — dropping BOTH halves
+      // closes the pipe (the whole point of the flag).
+      let mut reader = std::io::BufReader::new(recv);
+      let mut buf: Vec<u8> = Vec::new();
+      loop {
+        if flag.load(Ordering::Relaxed) {
+          return;
+        }
+        let chunk = match reader.fill_buf() {
+          Ok(c) => c,
+          Err(e)
+            if matches!(
+              e.kind(),
+              std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+            ) =>
+          {
+            std::thread::sleep(READER_TICK);
+            continue;
+          }
+          Err(_) => return, // dead link — dropping tx ends the consumer loop
+        };
+        if chunk.is_empty() {
+          return; // EOF — peer closed
+        }
+        if let Some(pos) = chunk.iter().position(|&b| b == b'\n') {
+          buf.extend_from_slice(&chunk[..pos]);
+          reader.consume(pos + 1);
+          let line = String::from_utf8_lossy(&buf).into_owned();
+          buf.clear();
+          if tx.send(Ok(line)).is_err() {
+            return; // consumer stopped listening
+          }
+        } else {
+          let n = chunk.len();
+          buf.extend_from_slice(chunk);
+          reader.consume(n);
+        }
+      }
     });
+
     let mut delivered_any = false;
+    let mut result = Ok(());
     loop {
-      let line = if delivered_any {
+      let msg = if delivered_any {
         rx.recv().ok()
       } else {
         rx.recv_timeout(CLIENT_TIMEOUT).ok()
       };
-      let Some(line) = line else { break };
+      let Some(msg) = msg else { break };
+      let line = match msg {
+        Ok(line) => line,
+        Err(e) => {
+          result = Err(e);
+          break;
+        }
+      };
       let trimmed = line.trim();
       if trimmed.is_empty() {
         continue;
       }
-      let worktrees = parse_worktrees_changed(trimmed)?;
-      delivered_any = true;
-      if !on_snapshot(&worktrees) {
-        break;
+      match parse_worktrees_changed(trimmed) {
+        Ok(worktrees) => {
+          delivered_any = true;
+          if !on_snapshot(&worktrees) {
+            break;
+          }
+        }
+        Err(e) => {
+          result = Err(e);
+          break;
+        }
       }
     }
-    drop(send);
+    // Wake and end the reader thread so it drops both halves promptly —
+    // closing the pipe and freeing the daemon's connection slot.
+    cancel.store(true, Ordering::Relaxed);
+    result?;
     if !delivered_any {
       return Err(GwmError::Other(
         "daemon: stream closed before the first snapshot".to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -982,7 +982,7 @@ mod server_win {
   use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
   use interprocess::os::windows::named_pipe::{pipe_mode, PipeListenerOptions, PipeMode, PipeStream};
   use interprocess::os::windows::security_descriptor::SecurityDescriptor;
-  use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+  use std::io::{BufRead, BufReader, ErrorKind, Write};
   use std::os::windows::io::{AsHandle, AsRawHandle};
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -978,11 +978,10 @@ mod server_win {
   use super::*;
   use crate::error::GwmError;
   use interprocess::local_socket::{
-    prelude::*, ConnectOptions, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
+    prelude::*, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
   };
   use interprocess::os::windows::local_socket::ListenerOptionsExt;
   use interprocess::os::windows::security_descriptor::SecurityDescriptor;
-  use interprocess::ConnectWaitMode;
   use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
   use std::path::PathBuf;
   use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -1017,6 +1016,24 @@ mod server_win {
   /// subscription tick). Small enough that deadlines land promptly, large
   /// enough that an idle connection costs a negligible wakeup rate.
   const NB_TICK: Duration = Duration::from_millis(15);
+
+  /// Raw `ERROR_NO_DATA` (232). In `PIPE_NOWAIT` mode an empty pipe read
+  /// (and some full-buffer writes) surfaces as this raw code, which std
+  /// maps to `ErrorKind::BrokenPipe` — indistinguishable BY KIND from a
+  /// really broken pipe (`ERROR_BROKEN_PIPE`, 109). Every nonblocking
+  /// retry loop below must therefore match on the raw code (Codex review
+  /// #439: kind-only matching closed every idle connection and ended
+  /// subscriptions at their first empty poll tick).
+  const ERROR_NO_DATA: i32 = 232;
+
+  /// Whether this I/O error means "try again later" on a `PIPE_NOWAIT`
+  /// stream: the portable kinds plus the raw `ERROR_NO_DATA` mapping.
+  fn is_transient(e: &std::io::Error) -> bool {
+    matches!(
+      e.kind(),
+      ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted
+    ) || e.raw_os_error() == Some(ERROR_NO_DATA)
+  }
 
   /// Configuration for [`serve`] — same shape as the unix module's so the
   /// CLI builds it identically on both platforms. `socket` holds the PIPE
@@ -1115,21 +1132,32 @@ mod server_win {
   pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
     // Courtesy probe for a clear "already in use" message, mirroring the
     // unix stale-socket check (pipes need no stale cleanup: they vanish
-    // with their process). BOUNDED (Codex review #439): a squatted or
-    // wedged pipe with no available instance would park an unbounded
-    // connect forever and this must never hang `gwm daemon` startup. The
-    // probe is not the real guard — `create_sync` claims the name with
-    // `FILE_FLAG_FIRST_PIPE_INSTANCE`, so an occupied name fails the bind
-    // below even when the probe timed out.
-    let probe = ConnectOptions::new()
-      .name(ns_name(&opts.socket)?)
-      .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(1)))
-      .connect_sync();
-    if probe.is_ok() {
-      return Err(GwmError::Other(format!(
-        "daemon: pipe {} is already in use by a live daemon",
-        opts.socket.display()
-      )));
+    // with their process). BOUNDED by an EXTERNAL deadline (Codex review
+    // #439, twice): `ConnectOptions::wait_mode` is silently ignored by
+    // interprocess 2.4.2's Windows local-socket adapter (`from_options`
+    // calls `connect_by_path` unbounded), so the connect runs on a helper
+    // thread and the wait is taken on the channel — a squatted pipe with
+    // no available instance must never hang `gwm daemon` startup. The
+    // parked helper thread leaks in that case; a one-off thread at daemon
+    // startup is an accepted cost. The probe is not the real guard —
+    // `create_sync` claims the name with `FILE_FLAG_FIRST_PIPE_INSTANCE`,
+    // so an occupied name fails the bind below even when the probe timed
+    // out.
+    {
+      let probe_name = opts.socket.clone();
+      let (ptx, prx) = std::sync::mpsc::channel();
+      std::thread::spawn(move || {
+        let alive = ns_name(&probe_name)
+          .map(|n| Stream::connect(n).is_ok())
+          .unwrap_or(false);
+        let _ = ptx.send(alive);
+      });
+      if prx.recv_timeout(Duration::from_secs(1)) == Ok(true) {
+        return Err(GwmError::Other(format!(
+          "daemon: pipe {} is already in use by a live daemon",
+          opts.socket.display()
+        )));
+      }
     }
     let listener = ListenerOptions::new()
       .name(ns_name(&opts.socket)?)
@@ -1206,8 +1234,7 @@ mod server_win {
       }
       let chunk = match reader.fill_buf() {
         Ok(c) => c,
-        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-        Err(e) if e.kind() == ErrorKind::WouldBlock => {
+        Err(e) if is_transient(&e) => {
           std::thread::sleep(NB_TICK);
           continue;
         }
@@ -1246,10 +1273,12 @@ mod server_win {
         return Err(std::io::Error::from(ErrorKind::TimedOut));
       }
       match send.write(&bytes[written..]) {
-        Ok(0) => return Err(std::io::Error::from(ErrorKind::WriteZero)),
+        // A full PIPE_NOWAIT byte-mode buffer reports a SUCCESSFUL write
+        // of zero bytes, not WouldBlock (Codex review #439) — that is
+        // backpressure to retry under the deadline, not a dead sink.
+        Ok(0) => std::thread::sleep(NB_TICK),
         Ok(n) => written += n,
-        Err(e) if e.kind() == ErrorKind::Interrupted => {}
-        Err(e) if e.kind() == ErrorKind::WouldBlock => std::thread::sleep(NB_TICK),
+        Err(e) if is_transient(&e) => std::thread::sleep(NB_TICK),
         Err(e) => return Err(e),
       }
     }
@@ -1259,8 +1288,7 @@ mod server_win {
       }
       match send.flush() {
         Ok(()) => return Ok(()),
-        Err(e) if e.kind() == ErrorKind::Interrupted => {}
-        Err(e) if e.kind() == ErrorKind::WouldBlock => std::thread::sleep(NB_TICK),
+        Err(e) if is_transient(&e) => std::thread::sleep(NB_TICK),
         Err(e) => return Err(e),
       }
     }
@@ -1341,8 +1369,7 @@ mod server_win {
           // does, so writing anything IS the client's hang-up signal —
           // the close then unblocks its reader thread via EOF (#439).
           Ok(_) => return,
-          Err(e) if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
-          Err(e) if e.kind() == ErrorKind::Interrupted => {}
+          Err(e) if is_transient(&e) => {}
           Err(_) => return, // dead link
         }
         let now = Instant::now();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1465,7 +1465,10 @@ pub mod client {
       if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
         return Err(deny("cannot open the process token"));
       }
-      let mut user_buf = [0u8; 256];
+      // u64 storage so the buffer is 8-aligned: casting a byte array to
+      // TOKEN_USER trips Rust's misaligned-dereference abort (witnessed
+      // in CI as STATUS_STACK_BUFFER_OVERRUN).
+      let mut user_buf = [0u64; 32];
       let mut len = 0u32;
       // SAFETY: advapi fills a TOKEN_USER into the (large enough) buffer.
       let got = unsafe {
@@ -1473,7 +1476,7 @@ pub mod client {
           token,
           TokenUser,
           user_buf.as_mut_ptr().cast(),
-          user_buf.len() as u32,
+          (user_buf.len() * 8) as u32,
           &mut len,
         )
       };
@@ -1492,8 +1495,8 @@ pub mod client {
       // An elevated daemon's objects can be owned by BUILTIN\Administrators
       // rather than the user SID. Accepting that group opens nothing to an
       // unprivileged attacker — a local admin already controls the machine.
-      let mut admin_buf = [0u8; SECURITY_MAX_SID_SIZE as usize];
-      let mut admin_len = admin_buf.len() as u32;
+      let mut admin_buf = [0u64; (SECURITY_MAX_SID_SIZE as usize).div_ceil(8)];
+      let mut admin_len = (admin_buf.len() * 8) as u32;
       // SAFETY: CreateWellKnownSid fills the (max-sized) buffer.
       let admin_ok = unsafe {
         CreateWellKnownSid(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -928,3 +928,522 @@ mod server {
 
 #[cfg(all(unix, feature = "daemon"))]
 pub use server::{default_socket, serve, socket_in, socket_path, ServeOptions};
+
+// ---------------------------------------------------------------------------
+// Named-pipe server & client — Windows only, behind the `daemon` feature
+// (issue #439). Exposes the same public interface as the unix module, so
+// `cmd_daemon` / `cmd_statusline` compile identically on both platforms.
+//
+// This is a sibling of `server`, not a shared generic core, on purpose:
+// the unix module's #341 hardening is battle-tested and stays byte-
+// identical, and the two transports differ exactly where a generic
+// abstraction would be the most contorted —
+// - `interprocess`'s sync streams have no read/write timeouts, so every
+//   guard unix gets from `set_read_timeout` (slow-loris line deadline,
+//   subscription poll tick, dead-peer detection) is rebuilt here on
+//   NONBLOCKING streams plus bounded sleep-retry loops;
+// - the cross-user barrier is the pipe's owner-only security descriptor,
+//   the named-pipe analogue of `chmod 0600` + the private socket dir
+//   (`\\.\pipe\` has no directories to restrict).
+// The small shared bits (`ActiveGuard`, `ACCEPT_TICK`) are deliberately
+// duplicated rather than hoisted, to keep the unix module untouched.
+// ---------------------------------------------------------------------------
+
+#[cfg(all(windows, feature = "daemon"))]
+mod server_win {
+  use super::*;
+  use crate::error::GwmError;
+  use interprocess::local_socket::{
+    prelude::*, GenericNamespaced, ListenerNonblockingMode, ListenerOptions, RecvHalf, SendHalf, Stream,
+  };
+  use interprocess::os::windows::local_socket::ListenerOptionsExt;
+  use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+  use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+  use std::path::PathBuf;
+  use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+  use std::sync::Arc;
+  use std::time::{Duration, Instant};
+
+  /// RAII counter of live client connections — duplicated from the unix
+  /// module (see the section comment above).
+  struct ActiveGuard(Arc<AtomicUsize>);
+
+  impl ActiveGuard {
+    fn try_acquire(active: &Arc<AtomicUsize>, max: usize) -> Option<Self> {
+      if active.fetch_add(1, Ordering::SeqCst) + 1 > max {
+        active.fetch_sub(1, Ordering::SeqCst);
+        return None;
+      }
+      Some(ActiveGuard(Arc::clone(active)))
+    }
+  }
+
+  impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+      self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+  }
+
+  /// How long the accept loop sleeps on `WouldBlock` before re-checking the
+  /// shutdown flag — same value and role as the unix module's.
+  const ACCEPT_TICK: Duration = Duration::from_millis(50);
+
+  /// Sleep quantum of every nonblocking retry loop (reads, writes, the
+  /// subscription tick). Small enough that deadlines land promptly, large
+  /// enough that an idle connection costs a negligible wakeup rate.
+  const NB_TICK: Duration = Duration::from_millis(15);
+
+  /// Configuration for [`serve`] — same shape as the unix module's so the
+  /// CLI builds it identically on both platforms. `socket` holds the PIPE
+  /// NAME (`gwm-<user>.sock` → `\\.\pipe\gwm-<user>.sock`), not a
+  /// filesystem path, and `manage_socket_dir` is accepted but meaningless
+  /// (pipe names have no parent directory to secure).
+  pub struct ServeOptions {
+    /// Name of the pipe to create under `\\.\pipe\`.
+    pub socket: PathBuf,
+    /// The repo this daemon answers for (its main workdir).
+    pub repo_workdir: PathBuf,
+    /// Interval between worktree-state polls for `subscribe` streams.
+    pub poll_interval: Duration,
+    /// Max bytes accepted for a single request line before the connection
+    /// is dropped (memory-bounding DoS guard, as on unix).
+    pub max_line_len: usize,
+    /// Per-request-line wall-time budget, and the write budget for pushes.
+    /// Rebuilt on nonblocking I/O since the transport has no socket-level
+    /// timeout. `None` disables the deadline.
+    pub read_timeout: Option<Duration>,
+    /// Max concurrent client connections (thread-bounding DoS guard).
+    pub max_connections: usize,
+    /// Interface parity with unix; no-op here (see the struct docs).
+    pub manage_socket_dir: bool,
+  }
+
+  impl ServeOptions {
+    /// Same defaults, same rationale as the unix module.
+    pub const DEFAULT_MAX_LINE_LEN: usize = 64 * 1024;
+    pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+    pub const DEFAULT_MAX_CONNECTIONS: usize = 128;
+
+    pub fn new(socket: PathBuf, repo_workdir: PathBuf, poll_interval: Duration) -> Self {
+      Self {
+        socket,
+        repo_workdir,
+        poll_interval,
+        max_line_len: Self::DEFAULT_MAX_LINE_LEN,
+        read_timeout: Some(Self::DEFAULT_READ_TIMEOUT),
+        max_connections: Self::DEFAULT_MAX_CONNECTIONS,
+        manage_socket_dir: false,
+      }
+    }
+  }
+
+  /// Default pipe name. `\\.\pipe\` is machine-global, so the username
+  /// namespaces the default and two users' daemons don't fight over one
+  /// name — but the [`owner_only_descriptor`] is the actual access
+  /// barrier; the name only prevents accidental clashes. Characters
+  /// outside `[A-Za-z0-9]` are folded to `-` (a username is not a valid
+  /// pipe-name fragment by construction).
+  pub fn socket_path() -> PathBuf {
+    let user = std::env::var("USERNAME").unwrap_or_else(|_| "default".to_string());
+    let safe: String = user
+      .chars()
+      .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+      .collect();
+    PathBuf::from(format!("gwm-{safe}.sock"))
+  }
+
+  /// The default [`socket_path`] plus the manage-dir flag, which is always
+  /// `false` here: pipe names are not filesystem paths, there is no parent
+  /// directory to create or secure.
+  pub fn default_socket() -> (PathBuf, bool) {
+    (socket_path(), false)
+  }
+
+  /// Owner-only DACL for the pipe: `D:P` (protected, no inheritance) with a
+  /// single ACE granting `GENERIC_ALL` to OWNER RIGHTS (`S-1-3-4`) — the
+  /// user the daemon runs as. A non-empty protected DACL implicitly denies
+  /// every other SID, so a cross-user connect fails outright: the
+  /// named-pipe analogue of the unix module's `chmod 0600`. Fail closed:
+  /// a descriptor error refuses to serve rather than exposing the pipe
+  /// with the default (Everyone-readable) DACL.
+  fn owner_only_descriptor() -> Result<SecurityDescriptor> {
+    let sddl = widestring::U16CString::from_str("D:P(A;;GA;;;OW)")
+      .map_err(|e| GwmError::Other(format!("daemon: cannot encode the pipe SDDL: {e}")))?;
+    SecurityDescriptor::deserialize(&sddl)
+      .map_err(|e| GwmError::Other(format!("daemon: cannot build the pipe security descriptor: {e}")))
+  }
+
+  /// Resolve `opts.socket` into a namespaced local-socket name.
+  fn ns_name(socket: &Path) -> Result<interprocess::local_socket::Name<'static>> {
+    let name_str = socket.to_string_lossy().into_owned();
+    name_str
+      .clone()
+      .to_ns_name::<GenericNamespaced>()
+      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {name_str}: {e}")))
+  }
+
+  /// Bind the pipe and serve connections until `shutdown` flips — the
+  /// Windows counterpart of the unix `serve`, same loop shape.
+  pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
+    // Refuse a name a live daemon already owns, mirroring the unix stale-
+    // socket check (pipes need no stale cleanup: they vanish with their
+    // process). The probe-then-bind window is the same benign TOCTOU.
+    if Stream::connect(ns_name(&opts.socket)?).is_ok() {
+      return Err(GwmError::Other(format!(
+        "daemon: pipe {} is already in use by a live daemon",
+        opts.socket.display()
+      )));
+    }
+    let listener = ListenerOptions::new()
+      .name(ns_name(&opts.socket)?)
+      .security_descriptor(owner_only_descriptor()?)
+      .create_sync()
+      .map_err(|e| GwmError::Other(format!("daemon: failed to bind pipe {}: {e}", opts.socket.display())))?;
+    // Nonblocking on BOTH sides: `accept` so this loop can poll the
+    // shutdown flag (as on unix), and the accepted streams because every
+    // per-connection deadline below is a sleep-retry loop over
+    // `WouldBlock` — the transport has no `set_read_timeout` to lean on.
+    listener
+      .set_nonblocking(ListenerNonblockingMode::Both)
+      .map_err(|e| GwmError::Other(format!("daemon: set_nonblocking failed: {e}")))?;
+
+    let active = Arc::new(AtomicUsize::new(0));
+    eprintln!("gwm daemon listening on \\\\.\\pipe\\{}", opts.socket.display());
+
+    loop {
+      if shutdown.load(Ordering::Relaxed) {
+        break;
+      }
+      match listener.accept() {
+        Ok(stream) => {
+          let Some(guard) = ActiveGuard::try_acquire(&active, opts.max_connections) else {
+            continue;
+          };
+          let workdir = opts.repo_workdir.clone();
+          let poll = opts.poll_interval;
+          let max_line_len = opts.max_line_len;
+          let read_timeout = opts.read_timeout;
+          let shutdown = Arc::clone(&shutdown);
+          std::thread::spawn(move || {
+            let _guard = guard;
+            handle_connection(stream, &workdir, poll, max_line_len, read_timeout, &shutdown);
+          });
+        }
+        Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+          std::thread::sleep(ACCEPT_TICK);
+        }
+        Err(e) => {
+          eprintln!("daemon: accept error: {e}");
+          std::thread::sleep(ACCEPT_TICK);
+        }
+      }
+    }
+    Ok(())
+  }
+
+  /// Read one newline-terminated request line from the nonblocking stream:
+  /// the unix `read_request_line` with the socket timeout replaced by a
+  /// sleep-retry loop bounded by `deadline` (slow-loris guard) and the
+  /// shutdown flag. Same return contract: `None` on EOF / deadline /
+  /// oversize / error, and the caller drops the connection.
+  fn read_request_line(
+    reader: &mut BufReader<RecvHalf>,
+    max_len: usize,
+    deadline: Option<Instant>,
+    shutdown: &AtomicBool,
+  ) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    loop {
+      if shutdown.load(Ordering::Relaxed) {
+        return None;
+      }
+      if let Some(dl) = deadline {
+        if Instant::now() >= dl {
+          return None; // per-line deadline exceeded — slow-loris
+        }
+      }
+      let chunk = match reader.fill_buf() {
+        Ok(c) => c,
+        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+        Err(e) if e.kind() == ErrorKind::WouldBlock => {
+          std::thread::sleep(NB_TICK);
+          continue;
+        }
+        Err(_) => return None, // reset / dead link
+      };
+      if chunk.is_empty() {
+        return None; // EOF (a partial line here is an incomplete request)
+      }
+      if let Some(pos) = chunk.iter().position(|&b| b == b'\n') {
+        if buf.len() + pos > max_len {
+          return None; // oversize before the newline
+        }
+        buf.extend_from_slice(&chunk[..pos]);
+        reader.consume(pos + 1);
+        return Some(buf);
+      }
+      if buf.len() + chunk.len() > max_len {
+        return None; // unterminated line past the cap
+      }
+      let n = chunk.len();
+      buf.extend_from_slice(chunk);
+      reader.consume(n);
+    }
+  }
+
+  /// `write_all` + `flush` over the nonblocking half, bounded by `budget`.
+  /// The unix server relies on blocking writes here; on a nonblocking pipe
+  /// a full kernel buffer surfaces as `WouldBlock`, so the loop retries —
+  /// and the budget reaps a subscriber that never drains its end.
+  fn write_all_nb(send: &mut SendHalf, bytes: &[u8], budget: Option<Duration>) -> std::io::Result<()> {
+    let deadline = budget.map(|t| Instant::now() + t);
+    let expired = |deadline: Option<Instant>| deadline.is_some_and(|dl| Instant::now() >= dl);
+    let mut written = 0usize;
+    while written < bytes.len() {
+      if expired(deadline) {
+        return Err(std::io::Error::from(ErrorKind::TimedOut));
+      }
+      match send.write(&bytes[written..]) {
+        Ok(0) => return Err(std::io::Error::from(ErrorKind::WriteZero)),
+        Ok(n) => written += n,
+        Err(e) if e.kind() == ErrorKind::Interrupted => {}
+        Err(e) if e.kind() == ErrorKind::WouldBlock => std::thread::sleep(NB_TICK),
+        Err(e) => return Err(e),
+      }
+    }
+    loop {
+      if expired(deadline) {
+        return Err(std::io::Error::from(ErrorKind::TimedOut));
+      }
+      match send.flush() {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == ErrorKind::Interrupted => {}
+        Err(e) if e.kind() == ErrorKind::WouldBlock => std::thread::sleep(NB_TICK),
+        Err(e) => return Err(e),
+      }
+    }
+  }
+
+  /// Serve one connection — the unix `handle_connection` on split
+  /// nonblocking halves. Same guards, same `subscribe` upgrade.
+  fn handle_connection(
+    stream: Stream,
+    workdir: &Path,
+    poll: Duration,
+    max_line_len: usize,
+    read_timeout: Option<Duration>,
+    shutdown: &AtomicBool,
+  ) {
+    let (recv, mut send) = stream.split();
+    let mut reader = BufReader::new(recv);
+    loop {
+      let deadline = read_timeout.map(|t| Instant::now() + t);
+      let Some(bytes) = read_request_line(&mut reader, max_line_len, deadline, shutdown) else {
+        return; // EOF, deadline, oversize, or dead link — drop the connection
+      };
+      let line = match std::str::from_utf8(&bytes) {
+        Ok(s) => s.trim(),
+        Err(_) => return, // not a UTF-8 JSON-RPC client
+      };
+      if line.is_empty() {
+        continue;
+      }
+      let is_subscribe = serde_json::from_str::<RpcRequest>(line)
+        .map(|r| r.method == "subscribe")
+        .unwrap_or(false);
+      if is_subscribe {
+        stream_subscription(&mut send, &mut reader, workdir, poll, read_timeout, shutdown);
+        return;
+      }
+      if let Some(response) = handle_line(workdir, line) {
+        let mut frame = response.into_bytes();
+        frame.push(b'\n');
+        if write_all_nb(&mut send, &frame, read_timeout).is_err() {
+          return;
+        }
+      }
+    }
+  }
+
+  /// Push `worktrees.changed` notifications — the unix `stream_subscription`
+  /// with the timeout-as-poll-tick replaced by an explicit sliced sleep:
+  /// each tick sleeps in `NB_TICK` steps while probing the (nonblocking)
+  /// read half, so a closed peer and the shutdown flag are noticed promptly.
+  fn stream_subscription(
+    send: &mut SendHalf,
+    reader: &mut BufReader<RecvHalf>,
+    workdir: &Path,
+    poll: Duration,
+    write_budget: Option<Duration>,
+    shutdown: &AtomicBool,
+  ) {
+    let mut last: Option<Vec<JsonWorktree>> = None;
+    if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
+      if send_notification(send, &snapshot, write_budget).is_err() {
+        return;
+      }
+      last = Some(snapshot);
+    }
+    let mut buf = [0u8; 64];
+    loop {
+      let tick_end = Instant::now() + poll;
+      loop {
+        if shutdown.load(Ordering::Relaxed) {
+          return;
+        }
+        match reader.read(&mut buf) {
+          Ok(0) => return, // peer closed
+          Ok(_) => {}      // unexpected client chatter on a push stream — ignore
+          Err(e) if matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
+          Err(e) if e.kind() == ErrorKind::Interrupted => {}
+          Err(_) => return, // dead link
+        }
+        let now = Instant::now();
+        if now >= tick_end {
+          break;
+        }
+        std::thread::sleep(NB_TICK.min(tick_end - now));
+      }
+      if let Some(snapshot) = next_subscription_push(&last, run_list(workdir)) {
+        if send_notification(send, &snapshot, write_budget).is_err() {
+          return;
+        }
+        last = Some(snapshot);
+      }
+    }
+  }
+
+  fn send_notification(
+    send: &mut SendHalf,
+    worktrees: &[JsonWorktree],
+    budget: Option<Duration>,
+  ) -> std::io::Result<()> {
+    let mut frame = worktrees_changed_notification(worktrees).to_string().into_bytes();
+    frame.push(b'\n');
+    write_all_nb(send, &frame, budget)
+  }
+}
+
+#[cfg(all(windows, feature = "daemon"))]
+pub use server_win::{default_socket, serve, socket_path, ServeOptions};
+
+/// Daemon **client** transport for Windows — same public surface as the
+/// unix `client` module. The sync pipe streams have no read timeout, so
+/// every bounded wait runs the blocking read on a helper thread and takes
+/// the deadline on the channel instead: a wedged daemon must degrade the
+/// statusline to its documented blank line, never freeze the shell prompt.
+#[cfg(all(windows, feature = "daemon"))]
+pub mod client {
+  use super::*;
+  use crate::error::GwmError;
+  use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
+  use std::io::{BufRead, BufReader, Write};
+  use std::sync::mpsc;
+  use std::time::Duration;
+
+  /// Same value and rationale as the unix client's handshake deadline.
+  const CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+  fn connect(socket: &Path) -> Result<Stream> {
+    let name_str = socket.to_string_lossy().into_owned();
+    let name = name_str
+      .clone()
+      .to_ns_name::<GenericNamespaced>()
+      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {name_str}: {e}")))?;
+    Stream::connect(name)
+      .map_err(|e| GwmError::Other(format!("daemon: cannot connect to \\\\.\\pipe\\{name_str}: {e}")))
+  }
+
+  /// One-shot `list` with the default handshake deadline.
+  pub fn list_once(socket: &Path) -> Result<Vec<JsonWorktree>> {
+    list_once_with_timeout(socket, Some(CLIENT_TIMEOUT))
+  }
+
+  /// [`list_once`] with an explicit deadline (test seam, as on unix). The
+  /// round-trip runs on a helper thread; on timeout that thread leaks
+  /// until the short-lived CLI process exits — the accepted cost of the
+  /// transport's missing read timeout.
+  #[doc(hidden)]
+  pub fn list_once_with_timeout(socket: &Path, timeout: Option<Duration>) -> Result<Vec<JsonWorktree>> {
+    let socket = socket.to_path_buf();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+      let _ = tx.send(round_trip(&socket));
+    });
+    match timeout {
+      Some(t) => rx
+        .recv_timeout(t)
+        .map_err(|_| GwmError::Other("daemon: timed out waiting for the response".to_string()))?,
+      None => rx
+        .recv()
+        .map_err(|_| GwmError::Other("daemon: client thread died".to_string()))?,
+    }
+  }
+
+  fn round_trip(socket: &Path) -> Result<Vec<JsonWorktree>> {
+    let stream = connect(socket)?;
+    let (recv, mut send) = stream.split();
+    writeln!(send, "{LIST_REQUEST}").map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
+    send.flush().map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
+    let mut reader = BufReader::new(recv);
+    let mut line = String::new();
+    reader
+      .read_line(&mut line)
+      .map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
+    parse_list_result(line.trim())
+  }
+
+  /// Subscribe to `worktrees.changed` — same contract as the unix client:
+  /// the first snapshot is bounded by [`CLIENT_TIMEOUT`], later pushes wait
+  /// indefinitely, and a stream that closes before any snapshot errors so
+  /// the caller's degradation branch fires (issue #312). A reader thread
+  /// pumps lines into a channel; it ends when the stream closes, and the
+  /// send half is kept alive for the loop's whole lifetime so the pipe
+  /// stays fully open.
+  pub fn subscribe(socket: &Path, mut on_snapshot: impl FnMut(&[JsonWorktree]) -> bool) -> Result<()> {
+    let stream = connect(socket)?;
+    let (recv, mut send) = stream.split();
+    writeln!(send, "{SUBSCRIBE_REQUEST}").map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
+    send.flush().map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+      let mut reader = BufReader::new(recv);
+      loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+          Ok(0) | Err(_) => break, // EOF or dead link — dropping tx ends the stream
+          Ok(_) => {
+            if tx.send(line).is_err() {
+              break; // consumer stopped listening
+            }
+          }
+        }
+      }
+    });
+    let mut delivered_any = false;
+    loop {
+      let line = if delivered_any {
+        rx.recv().ok()
+      } else {
+        rx.recv_timeout(CLIENT_TIMEOUT).ok()
+      };
+      let Some(line) = line else { break };
+      let trimmed = line.trim();
+      if trimmed.is_empty() {
+        continue;
+      }
+      let worktrees = parse_worktrees_changed(trimmed)?;
+      delivered_any = true;
+      if !on_snapshot(&worktrees) {
+        break;
+      }
+    }
+    drop(send);
+    if !delivered_any {
+      return Err(GwmError::Other(
+        "daemon: stream closed before the first snapshot".to_string(),
+      ));
+    }
+    Ok(())
+  }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -979,9 +979,9 @@ pub fn pipe_user_fragment(raw: &str) -> String {
 mod server_win {
   use super::*;
   use crate::error::GwmError;
-  use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
   use interprocess::os::windows::named_pipe::{pipe_mode, PipeListenerOptions, PipeMode, PipeStream};
   use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+  use interprocess::ConnectWaitMode;
   use std::io::{BufRead, BufReader, ErrorKind, Write};
   use std::os::windows::io::{AsHandle, AsRawHandle};
   use std::path::PathBuf;
@@ -1105,15 +1105,6 @@ mod server_win {
       .map_err(|e| GwmError::Other(format!("daemon: cannot build the pipe security descriptor: {e}")))
   }
 
-  /// Resolve `opts.socket` into a namespaced local-socket name (probe side).
-  fn ns_name(socket: &Path) -> Result<interprocess::local_socket::Name<'static>> {
-    let name_str = socket.to_string_lossy().into_owned();
-    name_str
-      .clone()
-      .to_ns_name::<GenericNamespaced>()
-      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {name_str}: {e}")))
-  }
-
   /// Bytes currently readable on the connection, or `None` when the peer
   /// is gone. `PeekNamedPipe` is the canonical non-blocking poll for a
   /// BLOCKING named pipe — and blocking streams are a hard requirement
@@ -1149,34 +1140,23 @@ mod server_win {
   pub fn serve(opts: &ServeOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
     // Courtesy probe for a clear "already in use" message, mirroring the
     // unix stale-socket check (pipes need no stale cleanup: they vanish
-    // with their process). BOUNDED by an EXTERNAL deadline (Codex review
-    // #439, twice): `ConnectOptions::wait_mode` is silently ignored by
-    // interprocess 2.4.2's Windows local-socket adapter, so the connect
-    // runs on a helper thread and the wait is taken on the channel — a
-    // squatted pipe with no available instance must never hang `gwm
-    // daemon` startup. The parked helper thread leaks in that case; a
-    // one-off thread at daemon startup is an accepted cost. The probe is
-    // not the real guard — the first listener instance is created with
+    // with their process). BOUNDED for real this time (Codex review #439,
+    // twice): the `local_socket` adapter silently ignores
+    // `ConnectOptions::wait_mode`, but the native API honours it — a
+    // squatted pipe with no available instance times out instead of
+    // hanging `gwm daemon` startup. The probe is not the real guard —
+    // the first listener instance is created with
     // `FILE_FLAG_FIRST_PIPE_INSTANCE`, so an occupied name fails the bind
     // below even when the probe timed out.
-    {
-      let probe_name = opts.socket.clone();
-      let (ptx, prx) = std::sync::mpsc::channel();
-      std::thread::spawn(move || {
-        let alive = ns_name(&probe_name)
-          .map(|n| Stream::connect(n).is_ok())
-          .unwrap_or(false);
-        let _ = ptx.send(alive);
-      });
-      if prx.recv_timeout(Duration::from_secs(1)) == Ok(true) {
-        return Err(GwmError::Other(format!(
-          "daemon: pipe {} is already in use by a live daemon",
-          opts.socket.display()
-        )));
-      }
-    }
     let path = widestring::U16CString::from_str(format!("\\\\.\\pipe\\{}", opts.socket.display()))
       .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {}: {e}", opts.socket.display())))?;
+    let probe = Conn::connect_by_path_with_wait_mode(path.as_ucstr(), ConnectWaitMode::Timeout(Duration::from_secs(1)));
+    if probe.is_ok() {
+      return Err(GwmError::Other(format!(
+        "daemon: pipe {} is already in use by a live daemon",
+        opts.socket.display()
+      )));
+    }
     let mut options = PipeListenerOptions::new();
     options.path = std::borrow::Cow::Owned(path);
     options.mode = PipeMode::Bytes;
@@ -1413,22 +1393,141 @@ pub use server_win::{default_socket, serve, socket_path, ServeOptions};
 pub mod client {
   use super::*;
   use crate::error::GwmError;
-  use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
+  use interprocess::os::windows::named_pipe::{pipe_mode, PipeStream};
+  use interprocess::ConnectWaitMode;
   use std::io::{BufRead, BufReader, Write};
+  use std::os::windows::io::{AsHandle, AsRawHandle};
   use std::sync::mpsc;
   use std::time::Duration;
+
+  /// The duplex byte stream this client speaks over — the NATIVE named-pipe
+  /// API rather than the `local_socket` adapter, for two reasons (Codex
+  /// review #439): the adapter silently ignores `ConnectOptions::wait_mode`
+  /// (unbounded connects), and it hides the handle needed to authenticate
+  /// the server (see [`verify_server_owner`]).
+  type Conn = PipeStream<pipe_mode::Bytes, pipe_mode::Bytes>;
 
   /// Same value and rationale as the unix client's handshake deadline.
   const CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
 
-  fn connect(socket: &Path) -> Result<Stream> {
-    let name_str = socket.to_string_lossy().into_owned();
-    let name = name_str
-      .clone()
-      .to_ns_name::<GenericNamespaced>()
-      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {name_str}: {e}")))?;
-    Stream::connect(name)
-      .map_err(|e| GwmError::Other(format!("daemon: cannot connect to \\\\.\\pipe\\{name_str}: {e}")))
+  /// `\\.\pipe\<name>` as the UTF-16 path the native connect expects.
+  fn pipe_path(socket: &Path) -> Result<widestring::U16CString> {
+    widestring::U16CString::from_str(format!("\\\\.\\pipe\\{}", socket.display()))
+      .map_err(|e| GwmError::Other(format!("daemon: invalid pipe name {}: {e}", socket.display())))
+  }
+
+  /// Refuse a pipe server not owned by the current user (or the builtin
+  /// Administrators group, which an elevated same-user daemon can own):
+  /// `\\.\pipe\` names are first-come-first-served and predictable, so
+  /// another local account could squat `gwm-<user>.sock` with a permissive
+  /// DACL and feed forged worktree data to the statusline and every other
+  /// consumer (Codex review #439). The owner SID is read from the CONNECTED
+  /// kernel object itself, so there is no PID-reuse race; any API failure
+  /// fails closed. The unix analogue is the owner-only socket directory,
+  /// which makes squatting the path impossible in the first place.
+  fn verify_server_owner(conn: &Conn) -> Result<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+    use windows_sys::Win32::Security::{
+      CreateWellKnownSid, EqualSid, GetTokenInformation, TokenUser, WinBuiltinAdministratorsSid,
+      OWNER_SECURITY_INFORMATION, PSID, SECURITY_MAX_SID_SIZE, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let deny = |what: &str| GwmError::Other(format!("daemon: refusing untrusted pipe server ({what})"));
+
+    // Owner of the connected pipe object.
+    let mut owner: PSID = std::ptr::null_mut();
+    let mut descriptor = std::ptr::null_mut();
+    // SAFETY: the handle is borrowed from the live connection; out-pointers
+    // are valid locals. On success `owner` points INTO `descriptor`, which
+    // must stay alive until the comparisons below and then be LocalFree'd.
+    let status = unsafe {
+      GetSecurityInfo(
+        conn.as_handle().as_raw_handle(),
+        SE_KERNEL_OBJECT,
+        OWNER_SECURITY_INFORMATION,
+        &mut owner,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut descriptor,
+      )
+    };
+    if status != 0 || owner.is_null() {
+      return Err(deny("cannot read the pipe owner"));
+    }
+    // Free `descriptor` on every path from here on.
+    let result = (|| {
+      // SID of the user this process runs as.
+      let mut token = std::ptr::null_mut();
+      // SAFETY: querying our own process token; closed right after the copy.
+      if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(deny("cannot open the process token"));
+      }
+      let mut user_buf = [0u8; 256];
+      let mut len = 0u32;
+      // SAFETY: advapi fills a TOKEN_USER into the (large enough) buffer.
+      let got = unsafe {
+        GetTokenInformation(
+          token,
+          TokenUser,
+          user_buf.as_mut_ptr().cast(),
+          user_buf.len() as u32,
+          &mut len,
+        )
+      };
+      // SAFETY: `token` came from a successful OpenProcessToken.
+      unsafe { CloseHandle(token) };
+      if got == 0 {
+        return Err(deny("cannot read the token user"));
+      }
+      // SAFETY: on success the buffer holds a valid TOKEN_USER.
+      let user_sid = unsafe { (*user_buf.as_ptr().cast::<TOKEN_USER>()).User.Sid };
+
+      // SAFETY: both SIDs are valid for the duration of the call.
+      if unsafe { EqualSid(owner, user_sid) } != 0 {
+        return Ok(());
+      }
+      // An elevated daemon's objects can be owned by BUILTIN\Administrators
+      // rather than the user SID. Accepting that group opens nothing to an
+      // unprivileged attacker — a local admin already controls the machine.
+      let mut admin_buf = [0u8; SECURITY_MAX_SID_SIZE as usize];
+      let mut admin_len = admin_buf.len() as u32;
+      // SAFETY: CreateWellKnownSid fills the (max-sized) buffer.
+      let admin_ok = unsafe {
+        CreateWellKnownSid(
+          WinBuiltinAdministratorsSid,
+          std::ptr::null_mut(),
+          admin_buf.as_mut_ptr().cast(),
+          &mut admin_len,
+        )
+      };
+      // SAFETY: both SIDs are valid; admin_buf holds a well-known SID.
+      if admin_ok != 0 && unsafe { EqualSid(owner, admin_buf.as_ptr().cast_mut().cast()) } != 0 {
+        return Ok(());
+      }
+      Err(deny("owned by another account"))
+    })();
+    // SAFETY: `descriptor` came from a successful GetSecurityInfo.
+    unsafe { LocalFree(descriptor.cast()) };
+    result
+  }
+
+  /// Connect with a REAL bounded wait (the native API honours
+  /// [`ConnectWaitMode`], unlike the `local_socket` adapter) and refuse a
+  /// server we cannot authenticate.
+  fn connect(socket: &Path) -> Result<Conn> {
+    let path = pipe_path(socket)?;
+    let conn = Conn::connect_by_path_with_wait_mode(path.as_ucstr(), ConnectWaitMode::Timeout(CLIENT_TIMEOUT))
+      .map_err(|e| {
+        GwmError::Other(format!(
+          "daemon: cannot connect to \\\\.\\pipe\\{}: {e}",
+          socket.display()
+        ))
+      })?;
+    verify_server_owner(&conn)?;
+    Ok(conn)
   }
 
   /// One-shot `list` with the default handshake deadline.
@@ -1458,8 +1557,8 @@ pub mod client {
   }
 
   fn round_trip(socket: &Path) -> Result<Vec<JsonWorktree>> {
-    let stream = connect(socket)?;
-    let (recv, mut send) = stream.split();
+    let conn = connect(socket)?;
+    let (recv, mut send) = conn.split();
     writeln!(send, "{LIST_REQUEST}").map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
     send.flush().map_err(|e| GwmError::Other(format!("daemon: {e}")))?;
     let mut reader = BufReader::new(recv);
@@ -1477,31 +1576,28 @@ pub mod client {
   ///
   /// Shape (Codex review #439): connect + handshake + the BLOCKING read
   /// loop all live on a helper thread, so the first `recv_timeout` bounds
-  /// the connect too — a wedged daemon whose pipe accepts no instance
-  /// degrades `statusline --watch` within the deadline instead of hanging
-  /// it. Reads stay blocking on purpose: client-side nonblocking mode on a
-  /// named pipe is `PIPE_NOWAIT`, which Microsoft deprecates and which
-  /// surfaces empty-pipe reads as fatal-looking errors (witnessed in CI).
-  /// Ending the stream is a PROTOCOL affair instead: the send half is
-  /// handed back to this thread, and when `on_snapshot` asks to stop we
-  /// write a hang-up line — the pipe server closes the connection on any
-  /// client chatter, which unblocks the reader thread via EOF and frees
-  /// the daemon's connection slot. If the daemon is wedged and never
-  /// reads, the reader thread leaks until the short-lived CLI process
-  /// exits — the same accepted cost as `list_once`'s timeout path.
+  /// them all — a wedged daemon degrades `statusline --watch` within the
+  /// deadline instead of hanging it. Ending the stream is a PROTOCOL
+  /// affair: the send half is handed back to this side, and when
+  /// `on_snapshot` asks to stop we write a hang-up line — the pipe server
+  /// closes the connection on any client chatter, which unblocks the
+  /// reader thread via EOF and frees the daemon's connection slot. If the
+  /// daemon is wedged and never reads, the reader thread leaks until the
+  /// short-lived CLI process exits — the same accepted cost as
+  /// `list_once`'s timeout path.
   pub fn subscribe(socket: &Path, mut on_snapshot: impl FnMut(&[JsonWorktree]) -> bool) -> Result<()> {
     let socket = socket.to_path_buf();
     let (tx, rx) = mpsc::channel::<Result<String>>();
     let (half_tx, half_rx) = mpsc::channel();
     std::thread::spawn(move || {
-      let stream = match connect(&socket) {
+      let conn = match connect(&socket) {
         Ok(s) => s,
         Err(e) => {
           let _ = tx.send(Err(e));
           return;
         }
       };
-      let (recv, mut send) = stream.split();
+      let (recv, mut send) = conn.split();
       if let Err(e) = writeln!(send, "{SUBSCRIBE_REQUEST}").and_then(|()| send.flush()) {
         let _ = tx.send(Err(GwmError::Other(format!("daemon: {e}"))));
         return;

--- a/tests/daemon_pipe_integration.rs
+++ b/tests/daemon_pipe_integration.rs
@@ -168,7 +168,19 @@ fn a_stopped_subscription_frees_its_server_connection_slot() {
     thread::sleep(Duration::from_millis(10));
   }
 
-  client::subscribe(&daemon.pipe, |_| false).expect("one snapshot then stop");
+  // The readiness list_once above may still hold the single slot for a
+  // beat after its handle closed (the server thread has to observe the
+  // EOF and drop the guard) — retry the subscribe instead of racing it
+  // (Codex review #439).
+  let mut subscribed = false;
+  for _ in 0..100 {
+    if client::subscribe(&daemon.pipe, |_| false).is_ok() {
+      subscribed = true;
+      break;
+    }
+    thread::sleep(Duration::from_millis(20));
+  }
+  assert!(subscribed, "the subscription must eventually claim the freed slot");
   // The reader thread exits within a tick; give it a moment, then the
   // single slot must be usable again.
   let mut freed = false;

--- a/tests/daemon_pipe_integration.rs
+++ b/tests/daemon_pipe_integration.rs
@@ -138,3 +138,46 @@ fn statusline_render_shape_survives_the_pipe() {
     "with a live pipe daemon the statusline is not the blank degradation: {stdout:?}"
   );
 }
+
+#[test]
+fn a_stopped_subscription_frees_its_server_connection_slot() {
+  // Codex review #439: when the callback stops the subscription, both
+  // stream halves must actually drop (closing the pipe) — with a daemon
+  // capped at ONE connection, a leaked subscribe connection would make
+  // every later request fail, so a passing list_once IS the proof the
+  // slot was released.
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
+  let pipe = pipe_name("slot");
+  let shutdown = Arc::new(AtomicBool::new(false));
+  let mut opts = ServeOptions::new(pipe.clone(), workdir, Duration::from_millis(50));
+  opts.max_connections = 1;
+  let flag = Arc::clone(&shutdown);
+  let handle = thread::spawn(move || {
+    serve(&opts, flag).expect("serve must bind and run");
+  });
+  let daemon = TestDaemon {
+    pipe,
+    shutdown,
+    handle: Some(handle),
+  };
+  for _ in 0..200 {
+    if client::list_once(&daemon.pipe).is_ok() {
+      break;
+    }
+    thread::sleep(Duration::from_millis(10));
+  }
+
+  client::subscribe(&daemon.pipe, |_| false).expect("one snapshot then stop");
+  // The reader thread exits within a tick; give it a moment, then the
+  // single slot must be usable again.
+  let mut freed = false;
+  for _ in 0..100 {
+    if client::list_once(&daemon.pipe).is_ok() {
+      freed = true;
+      break;
+    }
+    thread::sleep(Duration::from_millis(20));
+  }
+  assert!(freed, "the subscription's connection slot must be released after stop");
+}

--- a/tests/daemon_pipe_integration.rs
+++ b/tests/daemon_pipe_integration.rs
@@ -10,13 +10,11 @@ mod common;
 
 use common::init_repo;
 use gwm::daemon::{client, serve, ServeOptions};
-use gwm::worktree;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use tempfile::TempDir;
 
 /// A unique pipe name per test: pipe names are machine-global (no tempdir
 /// isolation like unix socket paths), so each test namespaces its own with
@@ -70,9 +68,8 @@ impl Drop for TestDaemon {
 
 #[test]
 fn list_once_round_trips_over_the_named_pipe() {
-  let tmp = TempDir::new().unwrap();
-  let repo = init_repo(tmp.path());
-  let workdir = repo.workdir().unwrap().to_path_buf();
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
   let daemon = TestDaemon::start(&workdir, "list", Duration::from_millis(50));
 
   let worktrees = client::list_once(&daemon.pipe).expect("list must round-trip");
@@ -84,9 +81,8 @@ fn list_once_round_trips_over_the_named_pipe() {
 
 #[test]
 fn subscribe_delivers_the_initial_snapshot() {
-  let tmp = TempDir::new().unwrap();
-  let repo = init_repo(tmp.path());
-  let workdir = repo.workdir().unwrap().to_path_buf();
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
   let daemon = TestDaemon::start(&workdir, "subscribe", Duration::from_millis(50));
 
   let mut snapshots = 0u32;
@@ -109,9 +105,8 @@ fn list_once_errors_when_no_daemon_is_listening() {
 
 #[test]
 fn a_second_daemon_on_the_same_pipe_is_refused() {
-  let tmp = TempDir::new().unwrap();
-  let repo = init_repo(tmp.path());
-  let workdir = repo.workdir().unwrap().to_path_buf();
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
   let daemon = TestDaemon::start(&workdir, "dup", Duration::from_millis(50));
 
   let opts = ServeOptions::new(daemon.pipe.clone(), workdir, Duration::from_millis(50));
@@ -126,9 +121,8 @@ fn statusline_render_shape_survives_the_pipe() {
   // End-to-end through the public binary surface: `gwm statusline` against
   // the pipe daemon must print a non-empty segment line for the repo cwd.
   use std::process::Command;
-  let tmp = TempDir::new().unwrap();
-  let repo = init_repo(tmp.path());
-  let workdir = repo.workdir().unwrap().to_path_buf();
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
   let daemon = TestDaemon::start(&workdir, "statusline", Duration::from_millis(50));
 
   let out = Command::new(env!("CARGO_BIN_EXE_gwm"))

--- a/tests/daemon_pipe_integration.rs
+++ b/tests/daemon_pipe_integration.rs
@@ -1,0 +1,146 @@
+//! Named-pipe round-trip tests for the daemon on Windows (issue #439) —
+//! the pipe counterpart of `daemon_integration.rs`. Windows + `daemon`-
+//! feature only: the pipe transport is `cfg`-compiled out elsewhere, so
+//! this file compiles to nothing on unix. These tests CANNOT run on the
+//! development machines (macOS/Linux) — the CI `windows-latest` job is
+//! their execution environment, deliberately.
+#![cfg(all(windows, feature = "daemon"))]
+
+mod common;
+
+use common::init_repo;
+use gwm::daemon::{client, serve, ServeOptions};
+use gwm::worktree;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// A unique pipe name per test: pipe names are machine-global (no tempdir
+/// isolation like unix socket paths), so each test namespaces its own with
+/// the process id plus a per-test tag.
+fn pipe_name(tag: &str) -> PathBuf {
+  PathBuf::from(format!("gwm-test-{}-{tag}.sock", std::process::id()))
+}
+
+/// A running daemon under test — same teardown contract as the unix
+/// harness: flip the flag, join the serve thread.
+struct TestDaemon {
+  pipe: PathBuf,
+  shutdown: Arc<AtomicBool>,
+  handle: Option<JoinHandle<()>>,
+}
+
+impl TestDaemon {
+  fn start(repo_workdir: &Path, tag: &str, poll: Duration) -> Self {
+    let pipe = pipe_name(tag);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let opts = ServeOptions::new(pipe.clone(), repo_workdir.to_path_buf(), poll);
+    let flag = Arc::clone(&shutdown);
+    let handle = thread::spawn(move || {
+      serve(&opts, flag).expect("serve must bind and run");
+    });
+    // Wait for the bind: a client list_once succeeds only once the pipe
+    // exists. Retry briefly rather than sleeping a fixed amount.
+    let daemon = TestDaemon {
+      pipe,
+      shutdown,
+      handle: Some(handle),
+    };
+    for _ in 0..200 {
+      if client::list_once(&daemon.pipe).is_ok() {
+        return daemon;
+      }
+      thread::sleep(Duration::from_millis(10));
+    }
+    panic!("daemon never became reachable on {}", daemon.pipe.display());
+  }
+}
+
+impl Drop for TestDaemon {
+  fn drop(&mut self) {
+    self.shutdown.store(true, Ordering::Relaxed);
+    if let Some(h) = self.handle.take() {
+      let _ = h.join();
+    }
+  }
+}
+
+#[test]
+fn list_once_round_trips_over_the_named_pipe() {
+  let tmp = TempDir::new().unwrap();
+  let repo = init_repo(tmp.path());
+  let workdir = repo.workdir().unwrap().to_path_buf();
+  let daemon = TestDaemon::start(&workdir, "list", Duration::from_millis(50));
+
+  let worktrees = client::list_once(&daemon.pipe).expect("list must round-trip");
+  assert!(
+    worktrees.iter().any(|w| w.is_main),
+    "the main worktree must be in the snapshot: {worktrees:?}"
+  );
+}
+
+#[test]
+fn subscribe_delivers_the_initial_snapshot() {
+  let tmp = TempDir::new().unwrap();
+  let repo = init_repo(tmp.path());
+  let workdir = repo.workdir().unwrap().to_path_buf();
+  let daemon = TestDaemon::start(&workdir, "subscribe", Duration::from_millis(50));
+
+  let mut snapshots = 0u32;
+  client::subscribe(&daemon.pipe, |worktrees| {
+    assert!(!worktrees.is_empty(), "the initial snapshot carries the worktree set");
+    snapshots += 1;
+    false // one snapshot is enough — end the stream
+  })
+  .expect("subscribe must deliver the initial snapshot");
+  assert_eq!(snapshots, 1);
+}
+
+#[test]
+fn list_once_errors_when_no_daemon_is_listening() {
+  // The statusline's graceful degradation depends on a prompt error here,
+  // not a hang: nothing listens on this name.
+  let err = client::list_once(&pipe_name("nobody"));
+  assert!(err.is_err(), "connecting to an unbound pipe must error");
+}
+
+#[test]
+fn a_second_daemon_on_the_same_pipe_is_refused() {
+  let tmp = TempDir::new().unwrap();
+  let repo = init_repo(tmp.path());
+  let workdir = repo.workdir().unwrap().to_path_buf();
+  let daemon = TestDaemon::start(&workdir, "dup", Duration::from_millis(50));
+
+  let opts = ServeOptions::new(daemon.pipe.clone(), workdir, Duration::from_millis(50));
+  let err = serve(&opts, Arc::new(AtomicBool::new(true)));
+  assert!(err.is_err(), "a live daemon must not be silently displaced");
+  let msg = format!("{}", err.unwrap_err());
+  assert!(msg.contains("already in use"), "the error names the conflict: {msg}");
+}
+
+#[test]
+fn statusline_render_shape_survives_the_pipe() {
+  // End-to-end through the public binary surface: `gwm statusline` against
+  // the pipe daemon must print a non-empty segment line for the repo cwd.
+  use std::process::Command;
+  let tmp = TempDir::new().unwrap();
+  let repo = init_repo(tmp.path());
+  let workdir = repo.workdir().unwrap().to_path_buf();
+  let daemon = TestDaemon::start(&workdir, "statusline", Duration::from_millis(50));
+
+  let out = Command::new(env!("CARGO_BIN_EXE_gwm"))
+    .args(["statusline", "--socket"])
+    .arg(&daemon.pipe)
+    .current_dir(&workdir)
+    .output()
+    .expect("gwm statusline must run");
+  assert!(out.status.success(), "statusline exits 0: {out:?}");
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    !stdout.trim().is_empty(),
+    "with a live pipe daemon the statusline is not the blank degradation: {stdout:?}"
+  );
+}

--- a/tests/daemon_pipe_integration.rs
+++ b/tests/daemon_pipe_integration.rs
@@ -181,3 +181,43 @@ fn a_stopped_subscription_frees_its_server_connection_slot() {
   }
   assert!(freed, "the subscription's connection slot must be released after stop");
 }
+
+#[test]
+fn an_idle_connection_survives_between_two_requests() {
+  // Codex review #439 (P1): an empty PIPE_NOWAIT read surfaces raw
+  // ERROR_NO_DATA, which std maps to BrokenPipe — kind-only matching
+  // treated the idle gap between two requests as a dead link and closed
+  // the connection. A raw client sends two `list` requests 200 ms apart
+  // on ONE connection; both must get a response line.
+  use gwm::daemon::LIST_REQUEST;
+  use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
+  use std::io::{BufRead, BufReader, Write};
+
+  let (dir, _repo) = init_repo();
+  let workdir = dir.path().to_path_buf();
+  let daemon = TestDaemon::start(&workdir, "idle", Duration::from_millis(50));
+
+  let name = daemon
+    .pipe
+    .to_string_lossy()
+    .into_owned()
+    .to_ns_name::<GenericNamespaced>()
+    .expect("pipe name");
+  let stream = Stream::connect(name).expect("connect");
+  let (recv, mut send) = stream.split();
+  let mut reader = BufReader::new(recv);
+
+  for round in 0..2u8 {
+    writeln!(send, "{LIST_REQUEST}").expect("request write");
+    send.flush().expect("request flush");
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).expect("response read");
+    assert!(n > 0, "round {round}: the connection must still be open");
+    assert!(
+      line.contains("\"result\""),
+      "round {round}: a JSON-RPC response is expected: {line:?}"
+    );
+    // Idle gap spanning many NB_TICK polls before the second request.
+    thread::sleep(Duration::from_millis(200));
+  }
+}

--- a/tests/daemon_tests.rs
+++ b/tests/daemon_tests.rs
@@ -331,3 +331,49 @@ fn client_request_lines_are_valid_rpc_for_their_methods() {
   let sub: Value = serde_json::from_str(SUBSCRIBE_REQUEST).unwrap();
   assert_eq!(sub["method"], serde_json::json!("subscribe"));
 }
+
+// --- pipe-name user fragment (issue #439, Codex review) ---------------------
+
+#[test]
+fn pipe_user_fragments_stay_distinct_for_punctuation_variants() {
+  // `alice.smith` and `alice-smith` are two different accounts; a lossy
+  // fold-to-dash would give both the same global pipe name, and the DACL
+  // would then lock the second user's daemon out of its own default name.
+  let a = gwm::daemon::pipe_user_fragment("alice.smith");
+  let b = gwm::daemon::pipe_user_fragment("alice-smith");
+  assert_ne!(a, b, "punctuation variants must not collide: {a} vs {b}");
+}
+
+#[test]
+fn pipe_user_fragments_keep_plain_names_readable() {
+  assert_eq!(gwm::daemon::pipe_user_fragment("kylian"), "kylian");
+  assert_eq!(gwm::daemon::pipe_user_fragment("User123"), "User123");
+}
+
+#[test]
+fn pipe_user_fragments_are_valid_pipe_name_material() {
+  // Whatever the input (separators, unicode, empty), the fragment must be
+  // ASCII-alphanumeric plus '_' only — always a legal pipe-name chunk.
+  for raw in ["DOMAIN\\alice", "a b", "é", "", "x:y/z"] {
+    let frag = gwm::daemon::pipe_user_fragment(raw);
+    assert!(
+      frag.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+      "fragment for {raw:?} must be pipe-safe: {frag:?}"
+    );
+  }
+}
+
+#[test]
+fn pipe_user_fragments_are_injective_on_distinct_inputs() {
+  let inputs = ["DOMAIN\\alice", "DOMAIN_alice", "domain\\alice", "a.b", "a_b", "a-b"];
+  let frags: Vec<String> = inputs.iter().map(|i| gwm::daemon::pipe_user_fragment(i)).collect();
+  for i in 0..frags.len() {
+    for j in (i + 1)..frags.len() {
+      assert_ne!(
+        frags[i], frags[j],
+        "{} and {} must map to distinct fragments",
+        inputs[i], inputs[j]
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Description

`gwm daemon` only exposed a unix domain socket, so on Windows `gwm statusline` had no data source and printed the blank degradation line with every segment missing, including the agent indicator from #408. This PR adds a named pipe transport on Windows through the `interprocess` crate (target-gated dependency, MSRV 1.75, well under our 1.86): the daemon binds an owner-only pipe under `\\.\pipe\` with the same JSON-RPC surface, DoS guards and degradation contract as the unix socket, and the statusline client rides it. The statusline stays daemon-fed by design (#309); this is a transport, not a local-detection fallback. Unix code paths are untouched.

Closes #439

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `src/daemon.rs`: new `server_win` + Windows `client` modules behind `cfg(all(windows, feature = "daemon"))`, exporting the same names (`serve`, `ServeOptions`, `socket_path`, `default_socket`, `client::{list_once, subscribe}`) so the CLI compiles identically on both platforms. The transport has no read/write timeouts, so the unix guards are rebuilt: nonblocking streams plus sleep-retry loops with wall-clock deadlines on the server (slow-loris line deadline, bounded pushes, poll tick), a channel deadline over a helper thread on the client. Cross-user access is blocked by an owner-only security descriptor (SDDL `D:P(A;;GA;;;OW)`), the pipe analogue of `chmod 0600` plus the private socket dir. A live daemon on the same name is refused, mirroring the unix stale-socket guard (pipes need no stale cleanup: they vanish with their process)
- `src/cli.rs`: `cmd_daemon` / `cmd_statusline` gates widen from `unix` to `any(unix, windows)`; the fallback branch remains for `--no-default-features`
- `Cargo.toml`: `interprocess` + `widestring` as `[target.'cfg(windows)'.dependencies]` (and dev-dependencies for the test file)
- `tests/daemon_pipe_integration.rs`: pipe round-trip suite (list, subscribe initial snapshot, no-daemon degradation, duplicate-name refusal, end-to-end `gwm statusline` render), gated `cfg(all(windows, feature = "daemon"))`
- Docs EN + FR: daemon intro and platform note, statusline caveats in the CLI reference, daemon-consumers intro, README bullet; CHANGELOG under `[Unreleased] > Added`

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Honest platform note: the new integration tests are `cfg(windows)` and CANNOT run on the development machine (macOS) — the CI `windows-latest` job is their execution environment, stated in the file header. The local 86-harness suite (stripped CI-like PATH) is green and pins that unix behaviour is untouched; the Windows code compiles only in CI. Expect the possibility of a CI round-trip on the windows job.

## Screenshots / TUI captures

No TUI change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed (schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #439
- Related PR: #306 (#38 daemon), #311 (#309 statusline), #435 (#408 agents statusline segment)

## Notes for reviewers

The Windows module is a deliberate sibling of the unix one, not a shared generic core: the #341 hardening on unix is battle-tested and stays byte-identical, and the transports differ exactly where an abstraction would be most contorted (timeout model, access control). The duplicated small bits (`ActiveGuard`, `ACCEPT_TICK`) are called out in the section comment. On the client, a timed-out helper thread leaks until the short-lived CLI process exits — documented as the accepted cost of the transport's missing read timeout.