### PR TITLE
🐛 fix(tui): fixed-height attach prompt with a scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The "Attach a session" prompt of the agent detail overlay keeps a fixed
+  frame while typing: the candidate window is sized by the terminal alone
+  (short lists blank-pad), so the modal no longer resizes on every
+  keystroke, and an overflowing list now shows the same scrollbar as the
+  detail mode. (#445)
 - `gwm clean --yes` no longer fails wholesale when a concurrent writer (a
   watcher such as rust-analyzer regenerating files inside `target/`) races
   the removal: a transient ENOTEMPTY is retried with a bounded budget, and a

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4488,9 +4488,11 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
   // over every detected session; Enter pins the highlighted candidate.
   if ov.mode == DetailMode::Input {
     let candidates = app.agent_input_candidates();
-    let max_visible = (term.height as usize).saturating_sub(12).max(3);
-    let visible = candidates.len().min(max_visible);
-    let (start, end) = picker_window(candidates.len(), ov.input_selected, visible.max(1));
+    // FIXED listing height (issue #445): the window is sized by the
+    // terminal alone, never by the filtered candidate count — typing must
+    // not resize the frame. Short lists blank-pad the remaining rows.
+    let list_h = (term.height as usize).saturating_sub(12).max(3);
+    let (start, end) = picker_window(candidates.len(), ov.input_selected, list_h);
     let now = std::time::SystemTime::now();
 
     let mut lines = overlay_title_lines("Attach a session", accent);
@@ -4529,6 +4531,12 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
         Span::styled(" ".repeat(pad), pad_style),
       ]));
     }
+    // Blank-pad up to the fixed window so the frame height is constant
+    // whatever the filter matched (the empty-state line counts as one row).
+    let shown = if candidates.is_empty() { 1 } else { end - start };
+    for _ in shown..list_h {
+      lines.push(Line::from(String::new()));
+    }
     lines.push(Line::from(String::new()));
     lines.push(modal_hint_line(
       &[
@@ -4543,6 +4551,15 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
     let area = centered_abs(width, height, term);
     f.render_widget(Clear, area);
     f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
+    // Scrollbar over the listing sub-area when the candidates overflow the
+    // fixed window — same affordance as the detail mode below (issue #445).
+    let list_rect = Rect {
+      x: area.x + 1,
+      y: area.y + 2 /* border + padding */ + 2 /* title */ + 2, /* id line + blank */
+      width: area.width.saturating_sub(2),
+      height: list_h as u16,
+    };
+    let _ = scrollable_body_area(f, list_rect, start as u16, candidates.len(), &app.theme);
     return;
   }
   let total = ov.rows.len();

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4491,7 +4491,9 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
     // FIXED listing height (issue #445): the window is sized by the
     // terminal alone, never by the filtered candidate count — typing must
     // not resize the frame. Short lists blank-pad the remaining rows.
-    let list_h = (term.height as usize).saturating_sub(12).max(3);
+    // Capped at 10 rows: a full-terminal prompt reads as a takeover, not
+    // a palette (user feedback 2026-07-23); the scrollbar covers the rest.
+    let list_h = (term.height as usize).saturating_sub(12).clamp(3, 10);
     let (start, end) = picker_window(candidates.len(), ov.input_selected, list_h);
     let now = std::time::SystemTime::now();
 
@@ -4553,13 +4555,19 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
     f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
     // Scrollbar over the listing sub-area when the candidates overflow the
     // fixed window — same affordance as the detail mode below (issue #445).
+    // Intersected with the modal's real area: on a tiny terminal
+    // `centered_abs` clamps the frame, and an un-clipped rect would render
+    // past the ratatui buffer and panic (Codex review #445).
     let list_rect = Rect {
       x: area.x + 1,
       y: area.y + 2 /* border + padding */ + 2 /* title */ + 2, /* id line + blank */
       width: area.width.saturating_sub(2),
       height: list_h as u16,
-    };
-    let _ = scrollable_body_area(f, list_rect, start as u16, candidates.len(), &app.theme);
+    }
+    .intersection(area);
+    if list_rect.height > 0 {
+      let _ = scrollable_body_area(f, list_rect, start as u16, candidates.len(), &app.theme);
+    }
     return;
   }
   let total = ov.rows.len();
@@ -4612,13 +4620,18 @@ fn draw_detail_overlay(f: &mut Frame, app: &App) {
   f.render_widget(Paragraph::new(lines).block(overlay_block(accent)), area);
   // Scrollbar over the rows sub-area (right padding column) when the list
   // overflows — the missing affordance from the feedback.
+  // Intersected with the modal's real area for the same tiny-terminal
+  // clamp as the attach prompt above (Codex review #445).
   let rows_rect = Rect {
     x: area.x + 1,
     y: area.y + 2 /* border + padding */ + 2, /* title lines */
     width: area.width.saturating_sub(2),
     height: visible as u16,
-  };
-  let _ = scrollable_body_area(f, rows_rect, start as u16, total, &app.theme);
+  }
+  .intersection(area);
+  if rows_rect.height > 0 {
+    let _ = scrollable_body_area(f, rows_rect, start as u16, total, &app.theme);
+  }
 }
 
 /// Render the clean reclaim overlay (issue #325). A centred modal showing

--- a/tests/tui_attach_modal_render_tests.rs
+++ b/tests/tui_attach_modal_render_tests.rs
@@ -113,3 +113,46 @@ fn attach_prompt_shows_a_scrollbar_when_candidates_overflow() {
     "an overflowing candidate list must render a scrollbar thumb"
   );
 }
+
+#[test]
+fn attach_prompt_survives_a_tiny_terminal() {
+  // Codex review #445: on a terminal of 8 rows or fewer, centered_abs
+  // clamps the modal to the terminal height but the scrollbar rect kept
+  // its full geometry and rendered past the ratatui buffer — a panic.
+  let dir = repo();
+  let mut app = app_with_open_prompt(&dir, 10);
+  let _ = draw_rows(&mut app, 100, 8);
+  let _ = draw_rows(&mut app, 100, 5);
+}
+
+#[test]
+fn detail_overlay_survives_a_tiny_terminal() {
+  // Same class of bug on the sibling detail mode's rows rect.
+  use gwm::agent_sessions::WorktreeAgents;
+  let dir = repo();
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let generation = app.tasks.request(TaskKind::AgentSessions).unwrap();
+  let path = app.worktrees[0].path.to_string_lossy().to_string();
+  let mut map = BTreeMap::new();
+  map.insert(
+    path,
+    WorktreeAgents {
+      sessions: (0..6).map(session).collect(),
+    },
+  );
+  assert!(app.apply_agent_snapshot(generation, map, None, BTreeMap::new()));
+  app.open_agent_overlay();
+  let _ = draw_rows(&mut app, 100, 6);
+  let _ = draw_rows(&mut app, 100, 5);
+}
+
+#[test]
+fn attach_prompt_window_is_capped_on_tall_terminals() {
+  // User feedback 2026-07-23: the fixed window must not swallow the whole
+  // terminal — at most 10 candidate rows, the scrollbar covers the rest.
+  let dir = repo();
+  let mut app = app_with_open_prompt(&dir, 40);
+  let rows = draw_rows(&mut app, 100, 40);
+  let shown = rows.iter().filter(|r| r.contains("aaa-")).count();
+  assert!(shown <= 10, "the candidate window is capped at 10 rows, got {shown}");
+}

--- a/tests/tui_attach_modal_render_tests.rs
+++ b/tests/tui_attach_modal_render_tests.rs
@@ -1,0 +1,115 @@
+//! Render-level tests for the attach-by-id prompt of the agent detail
+//! overlay (issue #445): the modal's frame must keep a FIXED height while
+//! the filter narrows or widens the candidate list (no resize on each
+//! keystroke), and an overflowing candidate list must show a scrollbar —
+//! the two conventions the sibling detail mode already follows. Same
+//! `TestBackend` approach as `tui_table_render_tests.rs`.
+
+use gwm::agent_sessions::{AgentKind, AgentSession};
+use gwm::tui::{draw, App, TaskKind};
+use ratatui::{backend::TestBackend, Terminal};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+/// A minimal one-commit repo the App can open.
+fn repo() -> TempDir {
+  let dir = TempDir::new().unwrap();
+  let repo = git2::Repository::init(dir.path()).unwrap();
+  repo.set_head("refs/heads/main").ok();
+  let sig = git2::Signature::now("gwm-test", "gwm@test").unwrap();
+  std::fs::write(dir.path().join("file.txt"), "seed").unwrap();
+  repo.index().unwrap().add_path(Path::new("file.txt")).unwrap();
+  repo.index().unwrap().write().unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  dir
+}
+
+/// One pool session with a distinctive id.
+fn session(i: usize) -> AgentSession {
+  AgentSession {
+    kind: AgentKind::ClaudeCode,
+    cwd: std::path::PathBuf::from("/x/elsewhere"),
+    last_activity: SystemTime::now() - Duration::from_secs(30),
+    ended: false,
+    id: format!("aaa-{i:02}"),
+    name: None,
+  }
+}
+
+/// An App with the attach prompt open over a `count`-session pool.
+fn app_with_open_prompt(dir: &TempDir, count: usize) -> App {
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let generation = app.tasks.request(TaskKind::AgentSessions).unwrap();
+  let pool: Vec<AgentSession> = (0..count).map(session).collect();
+  assert!(app.apply_agent_snapshot(generation, BTreeMap::new(), Some(pool), BTreeMap::new()));
+  app.open_agent_overlay();
+  app.open_agent_input();
+  assert_eq!(app.agent_input_candidates().len(), count, "the pool feeds the prompt");
+  app
+}
+
+/// Render into a fixed terminal and return the buffer as one row per line.
+fn draw_rows(app: &mut App, width: u16, height: u16) -> Vec<String> {
+  let backend = TestBackend::new(width, height);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, app)).unwrap();
+  let cells: Vec<String> = terminal
+    .backend()
+    .buffer()
+    .content()
+    .iter()
+    .map(|c| c.symbol().to_string())
+    .collect();
+  cells.chunks(width as usize).map(|row| row.concat()).collect()
+}
+
+/// Line indices holding a bottom-left rounded corner — the modal's bottom
+/// border moves iff the frame resizes (the background is identical across
+/// draws of the same App state family).
+fn corner_rows(rows: &[String]) -> Vec<usize> {
+  rows
+    .iter()
+    .enumerate()
+    .filter(|(_, r)| r.contains('╰') || r.contains('└'))
+    .map(|(i, _)| i)
+    .collect()
+}
+
+#[test]
+fn attach_prompt_frame_does_not_resize_while_typing() {
+  let dir = repo();
+  let mut app = app_with_open_prompt(&dir, 8);
+  let before = draw_rows(&mut app, 100, 32);
+  assert!(
+    before.iter().any(|r| r.contains("Attach a session")),
+    "the prompt is on screen"
+  );
+
+  // 'z' matches no id: the candidate list collapses to the empty state.
+  app.agent_input_push('z');
+  assert_eq!(app.agent_input_candidates().len(), 0);
+  let after = draw_rows(&mut app, 100, 32);
+
+  assert_eq!(
+    corner_rows(&before),
+    corner_rows(&after),
+    "the modal frame must keep its height when the filter empties the list"
+  );
+}
+
+#[test]
+fn attach_prompt_shows_a_scrollbar_when_candidates_overflow() {
+  let dir = repo();
+  // 40 candidates against a 24-row terminal: the visible window is far
+  // smaller than the list, so the scrollbar affordance must appear.
+  let mut app = app_with_open_prompt(&dir, 40);
+  let rows = draw_rows(&mut app, 100, 24);
+  assert!(
+    rows.iter().any(|r| r.contains('█')),
+    "an overflowing candidate list must render a scrollbar thumb"
+  );
+}


### PR DESCRIPTION
## Description

The "Attach a session" prompt of the agent detail overlay (#408) derived its modal height from the number of filtered candidates, so every keystroke that narrowed or widened the list resized the whole frame, and an overflowing candidate list had no scrollbar. The listing window is now sized by the terminal alone: short lists blank-pad the remaining rows (the empty state counts as one), the frame never moves while typing, and overflow renders the same scrollbar as the sibling detail mode.

Closes #445

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `src/tui/ui.rs` (`DetailMode::Input` branch): fixed `list_h` window from the terminal height, blank-padding up to it, and a `scrollable_body_area` call over the listing rect — the exact conventions the detail mode below already follows
- `tests/tui_attach_modal_render_tests.rs`: two TestBackend render tests — border-corner rows identical before/after a list-emptying keystroke (frame stability), and a scrollbar thumb present with 40 candidates on a 24-row terminal
- `CHANGELOG.md`: entry under `[Unreleased] > Fixed`

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

TDD note: red run first (both render tests failed against the resizing, scrollbar-less modal), then green. Full suite run under a stripped CI-like PATH (86 harnesses, zero failures).

## Screenshots / TUI captures

Render-level TestBackend tests pin the two behaviours; no visual capture beyond that (the modal keeps its existing look, only its geometry stabilises).

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (schema unchanged)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #445
- Related PR: #435 (agent session pane)

## Notes for reviewers

`picker_window` already handles a window larger than the list (it clamps), so passing the fixed `list_h` instead of `min(len, max)` is safe for short lists; the blank-pad loop accounts for the one-line empty state so the total line count is constant across every filter state.