### PR TITLE
👷 ci: stop persisting credentials on ci.yml and pre-release.yml checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -51,6 +55,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: configure git identity (libgit2 commit needs one)
@@ -69,6 +75,8 @@ jobs:
     # the heavy `test` job — no Rust toolchain needed, just shell + git.
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: shellcheck pre-commit hook
         uses: ludeeus/action-shellcheck@master
         with:
@@ -109,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-audit
@@ -136,6 +146,8 @@ jobs:
       (github.event_name == 'pull_request' && github.base_ref == 'dev')
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: configure git identity

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ steps.tag.outputs.name }}
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -142,6 +143,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ steps.tag.outputs.name }}
+          persist-credentials: false
 
       - name: download all artifacts
         uses: actions/download-artifact@v8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- No workflow checkout persists the auto-injected token any more: the
+  read-only checkouts of `ci.yml` (all six) and `pre-release.yml` (both) now
+  set `persist-credentials: false`, extending the `release.yml` split from
+  #429 to every workflow. The invariant is pinned per file by a YAML-parsing
+  test, with a stricter rule than release.yml: these workflows never push, so
+  no checkout may pass a token at all. (#433)
+
 ### Removed
 
 - The `winget-publish` job. `WINGET_TOKEN` was never provisioned, so the

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -50,16 +50,21 @@ fn stable_release_publish_uses_github_cli_with_workflow_token() {
 }
 
 /// Every `actions/checkout` in `release.yml`, paired with its `with:` block.
+fn release_workflow_checkout_steps() -> Vec<(String, serde_yaml_ng::Value)> {
+  workflow_checkout_steps(".github/workflows/release.yml")
+}
+
+/// Every `actions/checkout` in the given workflow, paired with its `with:`
+/// block.
 ///
-/// Parsing the YAML rather than grepping the text keeps the invariant below
+/// Parsing the YAML rather than grepping the text keeps the invariants below
 /// honest: a step that spells its inputs differently, or a job that grows a
 /// second checkout, is still seen.
-fn release_workflow_checkout_steps() -> Vec<(String, serde_yaml_ng::Value)> {
-  let workflow: serde_yaml_ng::Value =
-    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/release.yml").unwrap()).unwrap();
+fn workflow_checkout_steps(path: &str) -> Vec<(String, serde_yaml_ng::Value)> {
+  let workflow: serde_yaml_ng::Value = serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap()).unwrap();
 
   let mut steps = Vec::new();
-  for (job_name, job) in workflow["jobs"].as_mapping().expect("release.yml must define jobs") {
+  for (job_name, job) in workflow["jobs"].as_mapping().expect("workflow must define jobs") {
     let job_name = job_name.as_str().unwrap_or_default().to_string();
     let Some(job_steps) = job["steps"].as_sequence() else {
       continue;
@@ -104,6 +109,42 @@ fn release_workflow_checkouts_without_a_token_do_not_persist_credentials() {
     "expected at least 4 credential-free checkouts in release.yml, found {audited} — the parser is \
      probably no longer seeing the steps"
   );
+}
+
+/// #433, the follow-up to #429/#432: the sibling workflows carry the same
+/// shape, and none of their checkouts pushes — `ci.yml` is entirely read-only
+/// and `pre-release.yml` publishes through `gh` with an env token, never
+/// `git push`. No checkout here has any business passing `token:`, so the rule
+/// is stricter than in release.yml: every checkout opts out, no exceptions.
+#[test]
+fn ci_and_prerelease_checkouts_do_not_persist_credentials() {
+  for (path, floor) in [
+    (".github/workflows/ci.yml", 6),
+    (".github/workflows/pre-release.yml", 2),
+  ] {
+    let mut audited = 0;
+
+    for (job, with) in workflow_checkout_steps(path) {
+      assert!(
+        with["token"].is_null(),
+        "the checkout in `{path}` job `{job}` passes an explicit token, but nothing in this \
+         workflow pushes — drop it or move the job behind release.yml's audited split"
+      );
+      audited += 1;
+      assert_eq!(
+        with["persist-credentials"].as_bool(),
+        Some(false),
+        "the checkout in `{path}` job `{job}` does not push, so it must set \
+         `persist-credentials: false`"
+      );
+    }
+
+    assert!(
+      audited >= floor,
+      "expected at least {floor} checkouts in `{path}`, found {audited} — the parser is probably \
+       no longer seeing the steps"
+    );
+  }
 }
 
 /// The mirror of the invariant above: the two checkouts that push must keep the


### PR DESCRIPTION
## Description

Extends the `release.yml` credential split from #429/#432 to the two sibling workflows. All six `ci.yml` checkouts and both `pre-release.yml` checkouts are read-only (`ci.yml` never pushes; `pre-release.yml` publishes through `gh` with an env token, never `git push`), so none of them needs the auto-injected token `actions/checkout` persists into `.git/config`.

Closes #433

## Type of change

- [x] 🔧 Chore / CI / build
- [x] ✅ Tests

## Changes

- `persist-credentials: false` on all six `ci.yml` checkouts and both `pre-release.yml` checkouts
- The #432 YAML-parsing test helper is generalised over a file path; a new test pins the invariant per file with a stricter rule than `release.yml`: these workflows never push, so a checkout passing any `token:` at all fails the test (red-first against the unpatched workflows)

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

## Screenshots / TUI captures

Not a TUI change.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)

https://claude.ai/code/session_015Qi26p2xftSSWKCuy7ko9p