### PR TITLE
✨ feat(tui): scroll the Working Tree pane from the status context (J/K)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The `Working Tree` pane scrolls. With the status pane focused, `J` / `K`
+  (rebindable as `wt_scroll_down` / `wt_scroll_up` under `[tui.keys]`) move
+  an independent scroll offset over the file tree, clamped against the
+  viewport the layout actually granted the section — on a large change set
+  the entries beyond the pane height were simply unreachable before. The
+  offset resets on worktree navigation and on the commits ↔ stashes mode
+  toggle, mirroring the Recent Commits scroll contract. (#437)
+
 ### Changed
 
 - No workflow checkout persists the auto-injected token any more: the

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -40,6 +40,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 |:------------|:--------------------------------------------------------------------------------------------------|
 | `↑` / `k`   | previous worktree (`up`) — scrolls the sidebar when it has focus                                  |
 | `↓` / `j`   | next worktree (`down`) — scrolls the sidebar when it has focus                                    |
+| `J` / `K`   | scroll the [`Working Tree` pane](/tui/sidebar#working-tree-block) down / up (`wt_scroll_down` / `wt_scroll_up`) — status focus only |
 | `gg`        | jump to the first worktree (`top`)                                                                |
 | `G` / `End` | jump to the last worktree (`bottom`)                                                              |
 | `n`         | new worktree (`create`; form: type → issue → description) · gated by the [TOFU trust ledger](/configuration/trust-ledger) — refuses with a status-bar hint on untrusted `.gwm.toml` |

--- a/docs/2.tui/2.sidebar.md
+++ b/docs/2.tui/2.sidebar.md
@@ -187,5 +187,6 @@ The panel title shows the active mode. In `stashes` mode the bottom hint becomes
 
 - Hit `Tab` to move focus into the sidebar. The currently focused panel's border paints with the theme `focus` role (default `Cyan`).
 - With the sidebar focused, `j` / `k` (or arrow keys) scroll its content — useful for long `Recent Commits` lists.
+- Still focused, `J` / `K` (`wt_scroll_down` / `wt_scroll_up`) scroll the `Working Tree` file tree independently — on a large change set the tree gets clamped by the layout, and the offset makes the overflow reachable. The offset resets when the selection moves to another worktree.
 - Hit `Tab` again to return focus to the worktree list.
 - `V` toggles the entire sidebar on/off (useful when the terminal is narrow but ≥ 120 cols, or when you need maximum table width).

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -44,6 +44,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 |:------------|:--------------------------------------------------------------------------------------------------|
 | `↑` / `k`   | worktree précédent (`up`) — fait défiler la barre latérale quand elle a le focus                  |
 | `↓` / `j`   | worktree suivant (`down`) — fait défiler la barre latérale quand elle a le focus                  |
+| `J` / `K`   | fait défiler le [bloc `Working Tree`](/fr/tui/sidebar#bloc-working-tree) vers le bas / le haut (`wt_scroll_down` / `wt_scroll_up`) — focus status uniquement |
 | `gg`        | sauter au premier worktree (`top`)                                                                |
 | `G` / `End` | sauter au dernier worktree (`bottom`)                                                             |
 | `n`         | nouveau worktree (`create` ; formulaire : type → issue → description) · protégé par le [registre de confiance TOFU](/fr/configuration/trust-ledger) — refuse avec une indication dans la barre de statut sur un `.gwm.toml` non approuvé |

--- a/docs/fr/2.tui/2.sidebar.md
+++ b/docs/fr/2.tui/2.sidebar.md
@@ -195,5 +195,6 @@ Le titre du panneau affiche le mode actif. En mode `stashes`, l'indication du ba
 
 - Appuyez sur `Tab` pour donner le focus à la barre latérale. La bordure du panneau actuellement focalisé est peinte avec le rôle de thème `focus` (par défaut `Cyan`).
 - Avec la barre latérale focalisée, `j` / `k` (ou les flèches) font défiler son contenu — utile pour les longues listes `Recent Commits`.
+- Toujours focalisée, `J` / `K` (`wt_scroll_down` / `wt_scroll_up`) font défiler l'arbre de fichiers `Working Tree` indépendamment — sur un gros change set l'arbre est tronqué par le layout, et l'offset rend le débordement atteignable. L'offset se réinitialise quand la sélection passe à un autre worktree.
 - Appuyez à nouveau sur `Tab` pour rendre le focus à la liste des worktrees.
 - `V` bascule toute la barre latérale on/off (utile quand le terminal est étroit mais ≥ 120 colonnes, ou quand vous avez besoin de la largeur maximale pour la table).

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2244,6 +2244,24 @@ impl App {
     self.sidebar.scroll_up();
   }
 
+  /// Scroll the Working Tree pane down (issue #437, `J`). Gated on the
+  /// status pane holding the navigation focus — the same condition that
+  /// routes `j` / `k` to the sidebar in [`Self::next`] / [`Self::prev`] —
+  /// so the keys stay inert (and reusable) in the worktrees context.
+  pub fn wt_scroll_down(&mut self) {
+    if self.sidebar.open && self.sidebar.focused {
+      self.sidebar.wt_scroll_down();
+    }
+  }
+
+  /// Scroll the Working Tree pane up (issue #437, `K`). Same focus gate
+  /// as [`Self::wt_scroll_down`].
+  pub fn wt_scroll_up(&mut self) {
+    if self.sidebar.open && self.sidebar.focused {
+      self.sidebar.wt_scroll_up();
+    }
+  }
+
   /// Open the Keybindings (help) overlay from the top (#217). Resetting
   /// the scroll offset here keeps re-opens predictable.
   pub fn enter_help(&mut self) {

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -103,6 +103,9 @@ define_actions! {
   Up                => "up",
   Top               => "top",
   Bottom            => "bottom",
+  // #437: Working Tree pane scroll, status context only.
+  WtScrollDown      => "wt_scroll_down",
+  WtScrollUp        => "wt_scroll_up",
   ToggleSidebar     => "toggle_sidebar",
   ToggleSidebarMode => "toggle_sidebar_mode",
   CycleSidebarLayout => "cycle_sidebar_layout",
@@ -487,6 +490,9 @@ impl Keymap {
       def(Action::Up, &["k", "Up"]),
       def(Action::Top, &["g g"]),
       def(Action::Bottom, &["G", "End"]),
+      // #437: `J` / `K` scroll the Working Tree pane from the status context.
+      def(Action::WtScrollDown, &["J"]),
+      def(Action::WtScrollUp, &["K"]),
       // #290: V=toggle show/hide, S=cycle content (Commits↔Stashes),
       // Space=cycle orientation (auto/side-by-side/stacked), v=toggle position.
       def(Action::ToggleSidebar, &["V"]),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -820,6 +820,10 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     Action::Up => app.prev(),
     Action::Top => app.first(),
     Action::Bottom => app.last(),
+    // Issue #437: Working Tree pane scroll — no-ops unless the status
+    // pane holds the focus (gate lives on the `App` methods).
+    Action::WtScrollDown => app.wt_scroll_down(),
+    Action::WtScrollUp => app.wt_scroll_up(),
     Action::ToggleSidebar => app.toggle_sidebar(),
     // Issue #34: cycle the sidebar preview between commits and
     // stashes. Lands here as the merge resolution between #166

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -197,6 +197,16 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "focus the status pane (opens it if hidden)",
     },
     PaletteEntry {
+      action: Action::WtScrollDown,
+      name: "wt-scroll-down",
+      description: "scroll the Working Tree pane down (status focus)",
+    },
+    PaletteEntry {
+      action: Action::WtScrollUp,
+      name: "wt-scroll-up",
+      description: "scroll the Working Tree pane up (status focus)",
+    },
+    PaletteEntry {
       action: Action::Top,
       name: "top",
       description: "jump to the first worktree",

--- a/src/tui/state/sidebar.rs
+++ b/src/tui/state/sidebar.rs
@@ -147,6 +147,17 @@ pub struct SidebarState {
   /// by [`Self::scroll_down`] to clamp so the panel content can never
   /// be pushed entirely off-screen.
   pub max_scroll: u16,
+  /// First-visible line index of the Working Tree section (issue
+  /// #437). Independent from `scroll` — the file tree and the commit
+  /// list overflow at different rates. Bumped by
+  /// [`Self::wt_scroll_down`] / [`Self::wt_scroll_up`]; reset to 0 by
+  /// [`Self::on_navigation`] and [`Self::cycle_mode`].
+  pub wt_scroll: u16,
+  /// Upper bound for `wt_scroll`, republished by the renderer every
+  /// frame against the Working Tree section's clamped viewport (the
+  /// layout solver may hand the section less height than its content
+  /// on a large change set — exactly the case #437 exists for).
+  pub wt_max_scroll: u16,
   /// Cached pre-rendered sections keyed by the selected worktree's
   /// path **and** the active mode (issue #34). `None` = cold cache
   /// (the renderer will rebuild and store). Invalidated on selection
@@ -178,6 +189,8 @@ impl SidebarState {
       focused: false,
       scroll: 0,
       max_scroll: 0,
+      wt_scroll: 0,
+      wt_max_scroll: 0,
       cache: None,
       mode: SidebarMode::Commits,
     }
@@ -242,6 +255,7 @@ impl SidebarState {
       SidebarMode::Stashes => SidebarMode::Commits,
     };
     self.scroll = 0;
+    self.wt_scroll = 0;
     self.cache = None;
   }
 
@@ -260,6 +274,7 @@ impl SidebarState {
   /// itself on the next frame anyway).
   pub fn on_navigation(&mut self) {
     self.scroll = 0;
+    self.wt_scroll = 0;
     self.cache = None;
   }
 
@@ -284,6 +299,19 @@ impl SidebarState {
   /// 0. Matches `k`-on-sidebar; safe to call from `scroll == 0`.
   pub fn scroll_up(&mut self) {
     self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Scroll the Working Tree viewport down by one line, clamped at
+  /// `wt_max_scroll` (issue #437). Same clamp invariant as
+  /// [`Self::scroll_down`], applied to the file-tree section.
+  pub fn wt_scroll_down(&mut self) {
+    self.wt_scroll = self.wt_scroll.saturating_add(1).min(self.wt_max_scroll);
+  }
+
+  /// Scroll the Working Tree viewport up by one line, saturating at 0
+  /// (issue #437).
+  pub fn wt_scroll_up(&mut self) {
+    self.wt_scroll = self.wt_scroll.saturating_sub(1);
   }
 
   /// Flip `open`. When closing, also drops `focused` — a hidden

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -302,6 +302,7 @@ fn draw_body(f: &mut Frame, area: Rect, app: &mut App) {
     None => {
       // Sidebar not rendered → no scrollable surface → no max scroll to track.
       app.sidebar.max_scroll = 0;
+      app.sidebar.wt_max_scroll = 0;
       draw_list(f, area, app);
       return;
     }
@@ -639,6 +640,8 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       .split(area);
     app.sidebar.max_scroll = 0;
     app.sidebar.scroll = 0;
+    app.sidebar.wt_max_scroll = 0;
+    app.sidebar.wt_scroll = 0;
     render_section(
       f,
       chunks[0],
@@ -784,6 +787,18 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
   }
   let scroll = app.sidebar.scroll;
 
+  // Working Tree scroll (issue #437). The section asks for
+  // `Length(content + 2)` but the layout solver may hand it less when
+  // the sidebar column is shorter than the sum of its sections — the
+  // exact case where entries used to be unreachable. Republish the max
+  // against the clamped viewport, same contract as Recent Commits.
+  let wt_visible = chunks[3].height.saturating_sub(2);
+  app.sidebar.wt_max_scroll = (working_tree_len as u16).saturating_sub(wt_visible);
+  if app.sidebar.wt_scroll > app.sidebar.wt_max_scroll {
+    app.sidebar.wt_scroll = app.sidebar.wt_max_scroll;
+  }
+  let wt_scroll = app.sidebar.wt_scroll;
+
   // Issue #34: surface the active mode in the bottom-scrollable
   // panel title. The footer keeps the `i of N` counter; the bottom
   // hint switches to "Enter: copy stash@{N}" in stashes mode.
@@ -875,7 +890,7 @@ fn draw_sidebar(f: &mut Frame, area: Rect, app: &mut App) {
       working_tree_title,
       SectionBody::new(&sections.working_tree),
       border_color,
-      0,
+      wt_scroll,
       working_tree_footer,
     );
   }
@@ -2071,6 +2086,7 @@ impl HintContext {
       HintContext::Status => &[
         // Read the status pane.
         Hint::Key(Down, "scroll"),
+        Hint::Key(WtScrollDown, "wt scroll"),
         Hint::Key(FetchGithub, "fetch"),
         // Sidebar mode / layout.
         Hint::Key(ToggleSidebarMode, "mode"),
@@ -2731,6 +2747,8 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
     HelpRow::Blank,
     entry(Action::Down, "next (scrolls sidebar when focused)"),
     entry(Action::Up, "prev (scrolls sidebar when focused)"),
+    entry(Action::WtScrollDown, "scroll the Working Tree pane down (status focus)"),
+    entry(Action::WtScrollUp, "scroll the Working Tree pane up (status focus)"),
     entry(Action::Top, "jump to first worktree"),
     entry(Action::Bottom, "jump to last worktree"),
   ];

--- a/tests/keymap_tests.rs
+++ b/tests/keymap_tests.rs
@@ -232,6 +232,23 @@ fn default_keymap_binds_sync_to_lowercase_s() {
 }
 
 #[test]
+fn default_keymap_binds_working_tree_scroll() {
+  // Issue #437: `J` / `K` (Shift+j / Shift+k) scroll the Working Tree
+  // pane from the status context. Rebindable as `wt_scroll_down` /
+  // `wt_scroll_up` under `[tui.keys]`.
+  let km = Keymap::defaults();
+
+  let down = KeyStroke::parse_chord("J").unwrap();
+  assert!(matches!(
+    km.lookup(&down),
+    ChordResolution::Matched(Action::WtScrollDown)
+  ));
+
+  let up = KeyStroke::parse_chord("K").unwrap();
+  assert!(matches!(km.lookup(&up), ChordResolution::Matched(Action::WtScrollUp)));
+}
+
+#[test]
 fn default_keymap_binds_open_docs_to_dot() {
   // Issue #233: `.` opens the gwm documentation in the browser, reusing the
   // OpenMenu browser-spawn path. Rebindable as `open_docs` under `[tui.keys]`.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -919,6 +919,73 @@ fn sidebar_scroll_clamps_at_max() {
 }
 
 #[test]
+fn wt_scroll_requires_status_focus() {
+  // Issue #437: `J` / `K` scroll the Working Tree pane only while the
+  // status pane holds the navigation focus — same gate as `j` / `k`
+  // routing in `next()` / `prev()`. Unfocused, the keys are inert so
+  // they stay free for future list-view use.
+  let (_dir, mut app) = make_app();
+  app.sidebar.wt_max_scroll = 5;
+  assert!(!app.sidebar.focused);
+  app.wt_scroll_down();
+  assert_eq!(
+    app.sidebar.wt_scroll, 0,
+    "unfocused sidebar must not scroll the Working Tree"
+  );
+
+  app.focus_status();
+  app.wt_scroll_down();
+  assert_eq!(app.sidebar.wt_scroll, 1);
+}
+
+#[test]
+fn wt_scroll_clamps_between_zero_and_max() {
+  // The renderer republishes `wt_max_scroll` every frame; scrolling must
+  // clamp against it (down) and saturate at zero (up) exactly like the
+  // Recent Commits offset.
+  let (_dir, mut app) = make_app();
+  app.focus_status();
+  app.wt_scroll_up();
+  assert_eq!(app.sidebar.wt_scroll, 0, "scrolling up from 0 stays at 0");
+
+  app.sidebar.wt_max_scroll = 2;
+  app.wt_scroll_down();
+  app.wt_scroll_down();
+  app.wt_scroll_down();
+  assert_eq!(app.sidebar.wt_scroll, 2, "scrolling beyond max must clamp");
+  app.wt_scroll_up();
+  assert_eq!(app.sidebar.wt_scroll, 1);
+}
+
+#[test]
+fn navigation_resets_wt_scroll() {
+  // Selection change → new worktree → the previous Working Tree offset is
+  // meaningless. Same reset contract as the Recent Commits scroll.
+  let (_dir, mut app) = make_app();
+  app.sidebar.wt_max_scroll = 5;
+  app.sidebar.wt_scroll = 3;
+  app.on_navigation();
+  assert_eq!(
+    app.sidebar.wt_scroll, 0,
+    "navigation must reset the Working Tree scroll"
+  );
+}
+
+#[test]
+fn cycle_mode_resets_wt_scroll() {
+  // Stashes mode renders no Working Tree section; a stale offset would
+  // land on unrelated content when toggling back to Commits.
+  let (_dir, mut app) = make_app();
+  app.sidebar.wt_max_scroll = 5;
+  app.sidebar.wt_scroll = 3;
+  app.sidebar.cycle_mode();
+  assert_eq!(
+    app.sidebar.wt_scroll, 0,
+    "mode toggle must reset the Working Tree scroll"
+  );
+}
+
+#[test]
 fn focus_routes_navigation_to_sidebar() {
   // When sidebar is focused, next()/prev() should NOT move the list selection.
   let (_dir, mut app) = make_app();

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -365,7 +365,8 @@ fn status_hints_are_grouped_read_then_sidebar_then_navigate_then_global() {
     labels,
     vec![
       "scroll",
-      "fetch", // read the status pane
+      "wt scroll", // #437: Working Tree pane scroll
+      "fetch",     // read the status pane
       "mode",
       "layout", // sidebar mode / layout
       "worktrees",


### PR DESCRIPTION
## Description

An independent scroll offset for the Working Tree section of the Status pane. With the status pane focused, `J` / `K` (rebindable `wt_scroll_down` / `wt_scroll_up` under `[tui.keys]`) move the file tree viewport, clamped against the height the layout solver actually granted the section — on a large change set the entries beyond the pane height were simply unreachable from the keyboard. The offset resets on worktree navigation and on the commits ↔ stashes mode toggle, mirroring the Recent Commits scroll contract.

Closes #437

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `SidebarState` gains `wt_scroll` / `wt_max_scroll` plus `wt_scroll_down()` / `wt_scroll_up()`, with resets wired into `on_navigation()` and `cycle_mode()`
- Two new rebindable actions `wt_scroll_down` / `wt_scroll_up`, bound to `J` / `K` by default (both keys were free); dispatch is gated on the status pane holding the navigation focus, the same condition that routes `j` / `k` to the sidebar
- The renderer republishes `wt_max_scroll` every frame against the clamped Working Tree viewport and feeds the offset to `render_section` (previously hard-coded `0`); the hidden-sidebar and no-selection paths zero the new fields like the existing ones
- Advertised in the status footer hints (`wt scroll`), the command palette and the help overlay
- Docs EN/FR (keybindings table + sidebar focus-and-scrolling) and CHANGELOG under `[Unreleased] > Added`

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Red-first: the five new tests were run before the implementation and failed on the missing API (E0609/E0599 confined to the new test code), then went green with the feature in place. Full gate re-run chained on exit codes: green.

## Screenshots / TUI captures

Behaviour is a one-line viewport shift inside the existing Working Tree block; no visual change beyond the scrolled content and the new `wt scroll` footer hint.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no CLI surface change)
- [x] `examples/gwm.toml.example` updated if config schema changed (no schema change — the example defers the action list to `gwm tui keys`)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #437
- Related PR: none (pairs with #438, which will consume this scroll once the responsive heights land)

## Notes for reviewers

The focus gate lives on the `App` methods (not the dispatch match) so the state-machine tests can pin it without an event loop. `wt_max_scroll` is renderer-owned exactly like `max_scroll` — a stale value self-corrects on the next frame.