### PR TITLE
🔒 fix(trust): key the ledger on the repo, not on its host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The trust ledger keys on the repo again, not on its host**
+  ([#463](https://github.com/kbrdn1/gwm-cli/issues/463)). The ledger stores
+  `(origin, sha256(.gwm.toml))`, and the `origin` half had come to be built two
+  different ways: the bootstrap gates used the full `origin` remote URL, while
+  the forge host gate and `gwm trust add` (both new in #419) used
+  `RemoteRef::web_origin` — scheme + host only. That degraded the key from "this
+  repo" to "this host", so approval was shared by every repo on that host whose
+  `.gwm.toml` hashed identically. Since that file is normally a template copied
+  across a team's repos, identical hashes are the ordinary case rather than a
+  corner case, and a hostile repo could inherit a sibling's approval by shipping
+  its config verbatim. The two gates also stopped seeing each other's entries, so
+  `gwm trust add` printed `✓ trusted …` and `gwm create` in the same repo still
+  refused. All four call sites now go through one `trust::origin_key_for_repo`
+  helper, so the key cannot drift again. Ledger entries written before this fix
+  by the bootstrap path are unaffected.
 - **A blocking `manual` GitLab pipeline no longer reads as green**
   ([#419](https://github.com/kbrdn1/gwm-cli/issues/419)). It was mapped to
   passing by analogy with GitHub's `SKIPPED`, but a pipeline reports `manual`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4297,10 +4297,8 @@ fn cmd_trust_add() -> Result<()> {
   let cwd = std::env::current_dir()?;
   let repo = Repository::discover(&cwd).map_err(|_| GwmError::NotInGitRepo)?;
   let workdir = repo.workdir().unwrap_or_else(|| repo.path()).to_path_buf();
-  // Same key `forge::resolve` checks: the origin's web origin when there
-  // is one, the canonical workdir otherwise.
-  let origin = forge::origin_ref(&repo).ok().map(|r| r.web_origin);
-  let key = trust::resolve_origin_key(origin.as_deref(), &workdir);
+  // Same key every other gate uses — see `trust::origin_key_for_repo`.
+  let key = trust::origin_key_for_repo(&repo, &workdir);
   match trust::record_config(&workdir, &key, &trust::current_actor())? {
     Some(sha) => {
       let short: String = sha.chars().take(12).collect();
@@ -4350,8 +4348,10 @@ fn cmd_trust_show() -> Result<()> {
 /// the drift-detection half of the feature even when the threat model
 /// is weaker.
 fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -> Result<()> {
-  let origin = origin_url_for_repo(repo);
-  let origin_key = trust::resolve_origin_key(origin.as_deref(), workdir);
+  let origin_key = match repo {
+    Some(r) => trust::origin_key_for_repo(r, workdir),
+    None => trust::resolve_origin_key(None, workdir),
+  };
 
   match trust::evaluate(workdir, &origin_key, mode)? {
     TrustOutcome::Proceed => Ok(()),
@@ -4397,12 +4397,6 @@ fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -
 /// is one. Returns `None` for repos with no `origin` remote — caller
 /// (or `trust::resolve_origin_key`) falls back to the canonical
 /// workdir path in that case.
-fn origin_url_for_repo(repo: Option<&Repository>) -> Option<String> {
-  let r = repo?;
-  let remote = r.find_remote("origin").ok()?;
-  remote.url().ok().map(|s| s.to_string())
-}
-
 /// Interactive y/N/show loop. Prints a one-shot summary of the
 /// bootstrap surface (copy targets, guards, command lines, no-symlink
 /// declarations) so the user has the relevant signal before answering.

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -816,7 +816,9 @@ fn authorised_kind(repo: &Repository, config: &Config, parsed: &RemoteRef) -> Re
     )));
   };
   let workdir = repo.workdir().unwrap_or_else(|| repo.path());
-  let origin_key = crate::trust::resolve_origin_key(Some(&parsed.web_origin), workdir);
+  // The full `origin` URL, not `parsed.web_origin`: the ledger key has to
+  // identify the repo, and scheme+host identifies only the host (#463).
+  let origin_key = crate::trust::origin_key_for_repo(repo, workdir);
   if crate::trust::config_is_trusted(workdir, &origin_key, crate::trust::resolve_mode(false, false))? {
     return Ok(kind);
   }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -78,14 +78,40 @@ pub fn env_truthy(key: &str) -> bool {
   }
 }
 
+/// The trust-ledger key for `repo` — [`resolve_origin_key`] fed from the
+/// `origin` remote.
+///
+/// One helper rather than the extraction repeated at each call site.
+/// That repetition is what broke: the doc below used to argue the module
+/// should stay git2-free because "every caller already holds a
+/// Repository and extracts the URL on their side in three lines", and
+/// three of the four callers wrote the same three lines while the fourth
+/// reached for `RemoteRef::web_origin` instead (issue #463).
+///
+/// The difference is not cosmetic. `web_origin` is scheme + host, so the
+/// key stopped identifying a *repo* and started identifying a *host* —
+/// collapsing `(origin, sha256)` into a pair shared by every repo on
+/// that host with an identically-hashing `.gwm.toml`. Since that file is
+/// normally a template copied across a team's repos, identical hashes
+/// are the ordinary case, and a hostile repo could inherit a sibling's
+/// approval by shipping its config verbatim. The two gates also stopped
+/// seeing each other's entries, so `gwm trust add` reported success and
+/// `gwm create` in the same repo still refused.
+pub fn origin_key_for_repo(repo: &git2::Repository, workdir: &Path) -> String {
+  let url = repo
+    .find_remote("origin")
+    .ok()
+    .and_then(|r| r.url().ok().map(String::from));
+  resolve_origin_key(url.as_deref(), workdir)
+}
+
 /// Resolve the trust-ledger key for the current repo: prefer the
 /// `origin` remote URL (the hostile-clone threat axis), fall back to
 /// the canonicalised workdir path (purely-local repos with no remote
 /// still benefit from the drift-detection half of the feature).
 ///
-/// Takes `origin_url: Option<&str>` rather than a `git2::Repository`
-/// so this module stays git2-free — every caller already holds a
-/// Repository and extracts the URL on their side in three lines.
+/// Prefer [`origin_key_for_repo`] when you hold a `Repository`. This
+/// lower-level form stays for callers that genuinely have only a URL.
 pub fn resolve_origin_key(origin_url: Option<&str>, workdir: &Path) -> String {
   if let Some(url) = origin_url {
     if !url.is_empty() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1033,12 +1033,7 @@ impl App {
   pub fn check_trust_for_bootstrap(&self) -> Result<Option<String>> {
     use crate::trust::{self, TrustOutcome};
 
-    let origin_url = self
-      .repo
-      .find_remote("origin")
-      .ok()
-      .and_then(|r| r.url().ok().map(String::from));
-    let origin = trust::resolve_origin_key(origin_url.as_deref(), &self.workdir);
+    let origin = trust::origin_key_for_repo(&self.repo, &self.workdir);
 
     match trust::evaluate(&self.workdir, &origin, self.trust_mode)? {
       TrustOutcome::Proceed => Ok(None),

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -6624,3 +6624,82 @@ fn a_global_config_authorises_the_hosts_it_names_with_their_kind() {
     "ghe.acme.internal/team/proj/issues/7",
   );
 }
+
+#[test]
+fn approving_one_repo_does_not_approve_its_neighbour_on_the_same_host() {
+  // The ledger is keyed on `(origin, sha256(.gwm.toml))`, and the `origin`
+  // half has to identify the *repo*. Building it from `RemoteRef::web_origin`
+  // degraded it to the *host*, so the pair collapsed to
+  // `(https://code.acme.internal, <hash>)` — shared by every repo on that
+  // host whose config hashes the same.
+  //
+  // That is not a corner case: `.gwm.toml` is normally a template copied
+  // across a team's repos, so byte-identical files are the common shape. A
+  // hostile repo could ship a sibling's config verbatim and inherit its
+  // approval, which is exactly the capability the #419 gate exists to
+  // withhold.
+  let ledger = tempfile::TempDir::new().unwrap();
+  let ledger = ledger.path().join("trust.toml");
+  let config = "forge = \"gitlab\"\n";
+
+  let make = |slug: &str| {
+    let (dir, repo) = init_repo();
+    repo
+      .remote("origin", &format!("https://code.acme.internal/{slug}.git"))
+      .unwrap();
+    fs::write(dir.path().join(".gwm.toml"), config).unwrap();
+    dir
+  };
+  let mine = make("team/mine");
+  let theirs = make("team/theirs");
+
+  let run = |dir: &tempfile::TempDir, args: &[&str]| {
+    let mut c = Command::cargo_bin("gwm").unwrap();
+    c.current_dir(dir.path())
+      .env("GWM_TRUST_LEDGER", &ledger)
+      .env("GWM_NO_GLOBAL_CONFIG", "1")
+      .args(args);
+    c.assert()
+  };
+
+  run(&mine, &["link", "issue", "7"]).success();
+  run(&theirs, &["link", "issue", "7"]).success();
+  run(&mine, &["trust", "add"]).success();
+
+  run(&mine, &["open", "issue", "--print-url"]).success();
+  run(&theirs, &["open", "issue", "--print-url"])
+    .failure()
+    .stderr(predicate::str::contains("trust ledger"));
+}
+
+#[test]
+fn trust_add_satisfies_the_gate_that_bootstrap_checks() {
+  // `gwm trust add` printed `✓ trusted …` and `gwm create` in the same repo
+  // still refused, because the two wrote and read different keys. One helper
+  // now builds both, so approving a repo means the same thing everywhere.
+  let (dir, repo) = init_repo();
+  repo
+    .remote("origin", "https://code.acme.internal/team/proj.git")
+    .unwrap();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "forge = \"gitlab\"\n\n[[bootstrap.command]]\nname = \"noop\"\nrun = \"true\"\n",
+  )
+  .unwrap();
+  let ledger = dir.path().join("trust.toml");
+
+  let run = |args: &[&str]| {
+    let mut c = Command::cargo_bin("gwm").unwrap();
+    c.current_dir(dir.path())
+      .env("GWM_TRUST_LEDGER", &ledger)
+      .env("GWM_NO_GLOBAL_CONFIG", "1")
+      .args(args);
+    c.assert()
+  };
+
+  run(&["trust", "add"]).success();
+  // Both gates, one approval: the forge host gate and the bootstrap gate.
+  run(&["link", "issue", "7"]).success();
+  run(&["open", "issue", "--print-url"]).success();
+  run(&["bootstrap"]).success();
+}


### PR DESCRIPTION
## Description

The TOFU ledger stores `(origin, sha256(.gwm.toml))`. The `origin` half had come to be built two different ways:

| Call site | Key it built |
|---|---|
| `cli::trust_or_prompt` (bootstrap) | full `origin` remote URL |
| `tui::app` (bootstrap from the TUI) | full `origin` remote URL |
| `cli::cmd_trust_add` (new in #419) | `RemoteRef::web_origin` — scheme + host |
| `forge::authorised_kind` (new in #419) | `RemoteRef::web_origin` |

Closes #463

## Why it matters

**The key stopped identifying a repo.** `web_origin` is scheme + host, so `(origin, sha256)` collapsed to a pair shared by every repo on that host with an identically-hashing `.gwm.toml`. That file is normally a template copied across a team's repos, so identical hashes are the ordinary case — a hostile repo could inherit a sibling's approval by shipping its config verbatim. That is precisely the capability the #419 host gate exists to withhold, so this weakened the gate it shipped alongside.

**The gates also stopped seeing each other.** Found by dogfooding rather than review — running `gwm create` on this repo right after merging #419:

```
$ gwm trust add
✓ trusted https://github.com (.gwm.toml 289aabe215b6)
$ gwm create docs 462 skill-refresh
error: .gwm.toml … is not in the trust ledger
```

The ledger ended up holding two entries for one repo.

## Root cause

It is written in the doc comment that argued for it. `trust.rs` deliberately stayed git2-free because *"every caller already holds a Repository and extracts the URL on their side in three lines"* — and three of the four callers wrote the same three lines while the fourth reached for a different field. Duplication at four sites is what let one drift.

## Changes

- **`trust::origin_key_for_repo(repo, workdir)`** — one helper, used by all four gates. `resolve_origin_key` stays for callers that genuinely hold only a URL.
- `cli::origin_url_for_repo` removed; it was the duplicated extraction and had no callers left.
- Ledger entries written by the bootstrap path are unaffected — they already used the URL this restores.

## Tests

- [x] `cargo test` passes locally (**2376 passed, 0 failed**)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Re-run under a CI-like minimal `PATH`
- [x] New tests in `tests/cli_binary.rs`, both red before the fix:
  - `approving_one_repo_does_not_approve_its_neighbour_on_the_same_host` — two repos on one host with a byte-identical `.gwm.toml`; approving one must not approve the other. Failed with *"Unexpected success"* on the neighbour.
  - `trust_add_satisfies_the_gate_that_bootstrap_checks` — `gwm trust add` then `gwm bootstrap` in the same repo. Failed with the exact error reproduced above.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — no new subcommand or flag
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #463
- Introduced by: #458 (#419)