### PR TITLE
🐛 fix(config): warn when branch_pattern is customised (parser ignores it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `gwm doctor` and `gwm config validate` now warn when
-  `worktree.branch_pattern` differs from the default `{type}/#{issue}-{desc}`.
+  `worktree.branch_pattern` does not survive a format-then-parse round-trip.
   The pattern drives how a branch name is *written* but not how one is *read
-  back* — the parser is still a hardcoded regex — so customising it silently
-  disabled issue/PR auto-linking, gitmoji selection and the branch-convention
-  check. The warning names those consequences instead of leaving the user to
-  discover them. `gwm config validate` prints it on stderr and still exits `0`:
-  a custom pattern is valid configuration, not an error. This states the
-  limitation, it does not remove it — deriving the parser from the pattern is
-  tracked by #417. ([#415](https://github.com/kbrdn1/gwm-cli/issues/415))
+  back* — the parser is still a hardcoded regex — so a mismatched pattern
+  silently broke issue/PR auto-linking, gitmoji selection, lifecycle hook
+  placeholders and the branch-convention check. The warning names whichever
+  segments actually break: a custom pattern is not automatically a broken one
+  (`{type}/#{issue}-prefix-{desc}` still recovers `type` and `issue`, only
+  `desc` comes back wrong), and claiming otherwise would defeat the point of a
+  warning whose whole value is accuracy. `gwm config validate` prints it on
+  stderr, reads the *effective* pattern so one set only in the global
+  `~/.config/gwm/config.toml` is caught too, and still exits `0`: a custom
+  pattern is valid configuration, not an error. This states the limitation, it
+  does not remove it — deriving the parser from the pattern is tracked by #417.
+  ([#415](https://github.com/kbrdn1/gwm-cli/issues/415))
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   segments actually break: a custom pattern is not automatically a broken one
   (`{type}/#{issue}-prefix-{desc}` still recovers `type` and `issue`, only
   `desc` comes back wrong), and claiming otherwise would defeat the point of a
-  warning whose whole value is accuracy. `gwm config validate` prints it on
+  warning whose whole value is accuracy. The probe enumerates the value space
+  `gwm create` admits rather than sampling it — every configured branch type,
+  a single- and a multi-digit issue, a desc with and without the `-` it
+  allows, and the real repo name for `{repo}` — so a pattern that breaks on
+  only some values is reported as breaking on only some values. `gwm config validate` prints it on
   stderr, reads the *effective* pattern so one set only in the global
   `~/.config/gwm/config.toml` is caught too, and still exits `0`: a custom
   pattern is valid configuration, not an error. This states the limitation, it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `gwm doctor` and `gwm config validate` now warn when
+  `worktree.branch_pattern` differs from the default `{type}/#{issue}-{desc}`.
+  The pattern drives how a branch name is *written* but not how one is *read
+  back* — the parser is still a hardcoded regex — so customising it silently
+  disabled issue/PR auto-linking, gitmoji selection and the branch-convention
+  check. The warning names those consequences instead of leaving the user to
+  discover them. `gwm config validate` prints it on stderr and still exits `0`:
+  a custom pattern is valid configuration, not an error. This states the
+  limitation, it does not remove it — deriving the parser from the pattern is
+  tracked by #417. ([#415](https://github.com/kbrdn1/gwm-cli/issues/415))
+
 ### Docs
 
 - `changelogs/1.5.0.md` was corrected after the `v1.5.0` tag: its caveat said

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only some values is reported as breaking on only some values. `gwm config validate` prints it on
   stderr, reads the *effective* pattern so one set only in the global
   `~/.config/gwm/config.toml` is caught too, and still exits `0`: a custom
-  pattern is valid configuration, not an error. This states the limitation, it
+  pattern is valid configuration, not an error (`gwm doctor` reports it as a
+  `!` check, so that command exits `1` like any other Warning). The
+  config-supplied pattern is neutralised for control characters before it is
+  echoed — neither command goes through the trust gate, so an unvetted
+  `.gwm.toml` must not get a terminal escape channel out of a health check. This states the limitation, it
   does not remove it — deriving the parser from the pattern is tracked by #417.
   ([#415](https://github.com/kbrdn1/gwm-cli/issues/415))
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -62,6 +62,32 @@ Custom does not mean broken, though. `{type}/#{issue}-prefix-{desc}` still produ
 
 `path_pattern` is unaffected: it is generation-only, and a worktree's name comes from its directory rather than from re-parsing the pattern.
 
+#### which patterns actually work today
+
+The field stays free-form — set whatever you want, nothing is blocked. But until the parser is derived from the pattern ([#417](https://github.com/kbrdn1/gwm-cli/issues/417)) it is the fixed regex `^([a-z]+)/#(\d+)-([a-z0-9-]+)$`, so only one skeleton reads back. The table below is verified against the real check, not assumed — a test pins it so it cannot drift.
+
+**Round-trips fully:**
+
+| Pattern | Condition |
+|:--------|:----------|
+| `{type}/#{issue}-{desc}` | the default — works with any `[[branch_types]]` |
+| `feat/#{issue}-{desc}` | only when `feat` is the **only** configured branch type, since the parser reads the literal back as the type |
+
+**Parses, but hands back the wrong `desc`** — issue/PR auto-linking and gitmoji keep working; lifecycle hook placeholders and the TUI rename see a corrupted description:
+
+- `{type}/#{issue}-prefix-{desc}` — the literal is swallowed into `desc`
+- `{type}/#{issue}-{desc}-{repo}` — anything appended after `{desc}` lands inside it
+
+**Parses back to nothing at all** — auto-linking, gitmoji, hook placeholders, the TUI rename and the branch-convention check all go inactive:
+
+- `{type}/{issue}-{desc}` — the `#` is required
+- `{type}-{issue}-{desc}` — the `/` is required
+- `{type}/#{issue}_{desc}` — the separator must be `-`
+- `{type}/#{issue}` — `{desc}` is required
+- `{repo}/{type}/#{issue}-{desc}`, `wt/{type}/#{issue}-{desc}` — no extra path segment before `{type}`
+
+The rule of thumb: keep the `<type>/#<issue>-<desc>` skeleton and put nothing after `{desc}`. Anything else still creates worktrees perfectly well — you just lose the features that re-read the branch name, and `gwm doctor` tells you which ones.
+
 ### supported branch types
 
 `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Override per repo if your team uses something else.

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -54,7 +54,7 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 ### customising `branch_pattern` has a cost today
 
-`branch_pattern` is honoured when gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. A pattern the parser cannot follow silently disables issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, and the `doctor` branch-convention check.
+`branch_pattern` is honoured when gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. A pattern the parser cannot follow silently disables issue auto-linking from the branch name, gitmoji selection, hook placeholders on the remove / bootstrap paths, and the `doctor` branch-convention check.
 
 Custom does not mean broken, though. `{type}/#{issue}-prefix-{desc}` still produces `feat/#42-…`, so `type` and `issue` are recovered and only `desc` comes back wrong. `{type}-{issue}-{desc}` matches nothing at all and loses everything.
 
@@ -84,12 +84,12 @@ The field stays free-form — set whatever you want, nothing is blocked. But unt
 | `{type}/#{issue}-{desc}` | the default — works with any `[[branch_types]]` |
 | `feat/#{issue}-{desc}` | only when `feat` is the **only** configured branch type, since the parser reads the literal back as the type |
 
-**Parses, but hands back the wrong `desc`** — issue/PR auto-linking and gitmoji keep working; lifecycle hook placeholders and the TUI rename see a corrupted description:
+**Parses, but hands back the wrong `desc`** — issue auto-linking and gitmoji keep working; remove/bootstrap hook placeholders and the TUI rename see a corrupted description:
 
 - `{type}/#{issue}-prefix-{desc}` — the literal is swallowed into `desc`
 - `{type}/#{issue}-{desc}-{repo}` — anything appended after `{desc}` lands inside it
 
-**Parses back to nothing at all** — auto-linking, gitmoji, hook placeholders, the TUI rename and the branch-convention check all go inactive:
+**Parses back to nothing at all** — issue auto-linking, gitmoji, remove/bootstrap hook placeholders, the TUI rename and the branch-convention check all go inactive (PR/MR detection is unaffected):
 
 - `{type}/{issue}-{desc}` — the `#` is required
 - `{type}-{issue}-{desc}` — the `/` is required

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -52,6 +52,14 @@ Placeholders: `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`, `{repo_path}`, 
 base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 ```
 
+### customising `branch_pattern` has a cost today
+
+`branch_pattern` is honoured when gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. Change the pattern and gwm can no longer decompose the branches it creates, which silently disables issue/PR auto-linking, gitmoji selection, and the `doctor` branch-convention check.
+
+`gwm doctor` and `gwm config validate` both say so ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — the config stays valid and the exit code stays `0`, but the limitation is stated rather than silent. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+
+`path_pattern` is unaffected: it is generation-only, and a worktree's name comes from its directory rather than from re-parsing the pattern.
+
 ### supported branch types
 
 `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Override per repo if your team uses something else.

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -54,9 +54,11 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 ### customising `branch_pattern` has a cost today
 
-`branch_pattern` is honoured when gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. Change the pattern and gwm can no longer decompose the branches it creates, which silently disables issue/PR auto-linking, gitmoji selection, and the `doctor` branch-convention check.
+`branch_pattern` is honoured when gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. A pattern the parser cannot follow silently disables issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, and the `doctor` branch-convention check.
 
-`gwm doctor` and `gwm config validate` both say so ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — the config stays valid and the exit code stays `0`, but the limitation is stated rather than silent. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+Custom does not mean broken, though. `{type}/#{issue}-prefix-{desc}` still produces `feat/#42-…`, so `type` and `issue` are recovered and only `desc` comes back wrong. `{type}-{issue}-{desc}` matches nothing at all and loses everything.
+
+`gwm doctor` and `gwm config validate` probe the actual round-trip and name whichever segments break ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — the config stays valid and the exit code stays `0`, but the limitation is stated rather than silent. `config validate` reads the effective pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
 
 `path_pattern` is unaffected: it is generation-only, and a worktree's name comes from its directory rather than from re-parsing the pattern.
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -58,7 +58,18 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 Custom does not mean broken, though. `{type}/#{issue}-prefix-{desc}` still produces `feat/#42-…`, so `type` and `issue` are recovered and only `desc` comes back wrong. `{type}-{issue}-{desc}` matches nothing at all and loses everything.
 
-`gwm doctor` and `gwm config validate` probe the actual round-trip and name whichever segments break ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — the config stays valid and the exit code stays `0`, but the limitation is stated rather than silent. `config validate` reads the effective pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+`gwm doctor` and `gwm config validate` probe the actual round-trip and name whichever segments break ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — the config stays valid, but the limitation is stated rather than silent.
+
+**The two commands differ on exit code, which matters if you gate CI on them:**
+
+| Command | On a pattern that does not round-trip |
+|:--------|:--------------------------------------|
+| `gwm config validate` | prints the warning on stderr, exits **`0`** — a custom pattern is valid configuration, not an error |
+| `gwm doctor` | reports a `!` check, so the run exits **`1`** like any other Warning ([exit codes](/integrations/doctor#exit-codes)) |
+
+A CI job that runs `gwm doctor` and tolerates Warnings should use `gwm doctor; [ $? -le 1 ]`.
+
+`config validate` reads the effective pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
 
 `path_pattern` is unaffected: it is generation-only, and a worktree's name comes from its directory rather than from re-parsing the pattern.
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -136,6 +136,15 @@ Re-runs the same `[tui.keys]` resolution path the TUI itself uses at startup, so
 
 Only actions with at least one chord count toward the `N action(s) bound` figure — an action set to `[]` in `[tui.keys]` is unbound and excluded. See [`.gwm.toml` schema → `[tui.keys]`](/configuration/gwm-toml#tuikeys), [TUI → Keymap & command palette](/tui/keymap-and-palette), and [TUI → Keybindings](/tui/keybindings) for the action slugs and chord grammar.
 
+### 9. `worktree.branch_pattern` round-trips through the parser
+
+`branch_pattern` drives how gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. Customising the pattern therefore produces branches gwm can no longer decompose, and every feature keyed on the parsed segments goes quiet. Added by [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
+
+- **`✓`** — the pattern is the default, so `parse_branch` reads back what `branch_name` writes
+- **`!`** — the pattern differs from the default; issue/PR auto-linking, gitmoji selection and the branch-convention check (#6 above) are inactive on branches created with it. The hint offers the two honest options: restore the default, or keep the custom pattern and attach issues/PRs by hand with `gwm link`
+
+This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error.
+
 ## CI integration
 
 ```yaml

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -138,12 +138,18 @@ Only actions with at least one chord count toward the `N action(s) bound` figure
 
 ### 9. `worktree.branch_pattern` round-trips through the parser
 
-`branch_pattern` drives how gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. Customising the pattern therefore produces branches gwm can no longer decompose, and every feature keyed on the parsed segments goes quiet. Added by [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
+`branch_pattern` drives how gwm **writes** a branch name, but the parser that **reads one back** is a hardcoded regex for the default `{type}/#{issue}-{desc}`. When the two disagree, every feature keyed on the parsed segments reads the wrong thing — silently. Added by [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
 
-- **`✓`** — the pattern is the default, so `parse_branch` reads back what `branch_name` writes
-- **`!`** — the pattern differs from the default; issue/PR auto-linking, gitmoji selection and the branch-convention check (#6 above) are inactive on branches created with it. The hint offers the two honest options: restore the default, or keep the custom pattern and attach issues/PRs by hand with `gwm link`
+The check is a real round-trip probe, not a comparison against the default string: **a custom pattern is not automatically a broken one**. `{type}/#{issue}-prefix-{desc}` still yields `feat/#42-…`, so `type` and `issue` survive and only `desc` comes back wrong.
 
-This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error.
+- **`✓`** — `parse_branch` reads back the segments `branch_name` writes
+- **`!`** — the pattern does not round-trip. Two shapes:
+  - the branch name matches nothing at all → issue/PR auto-linking, gitmoji selection and the branch-convention check (#6 above) are all inactive
+  - it parses but a segment comes back different → the detail names which one and what it breaks: `type` → gitmoji selection, `issue` → issue/PR auto-linking, `desc` → lifecycle hook placeholders and the TUI rename
+
+  The hint offers the two honest options: restore the default, or keep the custom pattern and attach issues/PRs by hand with `gwm link`.
+
+This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error — and reads the **effective** pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too.
 
 ## CI integration
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -144,9 +144,9 @@ The check is a real round-trip probe, not a comparison against the default strin
 
 - **`✓`** — `parse_branch` reads back the segments `branch_name` writes, for every branch the repo can produce
 - **`!`** — the pattern does not round-trip. Three shapes:
-  - **nothing parses** → issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and body placeholders, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive. **PR/MR detection is not affected** — `Forge::find_pr_for_branch` queries the forge with the whole branch name and never parses it
+  - **nothing parses** → issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and body placeholders, hook placeholders on the remove / bootstrap paths, the TUI rename and the branch-convention check (#6 above) are all inactive. **PR/MR detection is not affected** — `Forge::find_pr_for_branch` queries the forge with the whole branch name and never parses it
   - **only some values parse** → the detail names a failing example and scopes the loss to the branches that come out like it. `{desc}/#{issue}-{type}` is unreadable for a desc carrying a `-` and perfectly readable for one without; calling the whole pattern dead would be false for half the branches it produces
-  - **everything parses but a segment comes back different** → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue/PR auto-linking, and both → lifecycle hook placeholders and the TUI rename, which consume all three segments
+  - **everything parses but a segment comes back different** → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue auto-linking, and both → remove/bootstrap hook placeholders and the TUI rename, which consume all three segments
 
   The hint stays neutral — restore the default, or keep the pattern and accept exactly the loss the detail names. Which workaround applies depends on which segment broke, so recommending one unconditionally would be wrong.
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -151,6 +151,8 @@ The check is a real round-trip probe, not a comparison against the default strin
 
 The probe runs twice with no value shared between the runs. One run is not enough: `feat/#{issue}-{desc}` hardcodes the type and would round-trip perfectly against a probe that happened to use `feat`, while `gwm create fix …` writes a `feat/` branch and reads the wrong type back.
 
+`{repo}` is expanded with the **real** repo name, because the verdict depends on it: `{repo}/#{issue}-{desc}` is fine in a repo called `gwm` and completely unparseable in one called `gwm-cli`, whose dash the `[a-z]+` type charset rejects.
+
 This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error — and reads the **effective** pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too.
 
 ## CI integration

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -161,7 +161,7 @@ Round-trip is value-dependent, so probing a couple of arbitrary values proves no
 | `desc`   | one with a `-`, one without, one all-digits | the dash is the only character that collides with a literal separator; digits-only is the only desc `BRANCH_RE`'s `\d+` issue group can swallow (`{type}/#{desc}-{issue}` parses for `123` and for nothing else) |
 | `{repo}` | the **real** repo name               | the verdict depends on it: `{repo}/#{issue}-{desc}` is fine in a repo called `gwm` and unparseable in one called `gwm-cli`, whose dash the `[a-z]+` type charset rejects |
 
-A pattern that survives all of it is the strongest claim this check can make short of deriving the parser from the pattern.
+A pattern that survives all of it is the strongest claim this check can make short of deriving the parser from the pattern. And the verdict never quantifies beyond what the probes saw: when only part of the probed shapes lose something, the detail counts them (`on 27 of the 30 branch shapes probed, …`) rather than claiming every branch is affected.
 
 This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error — and reads the **effective** pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too.
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -144,7 +144,7 @@ The check is a real round-trip probe, not a comparison against the default strin
 
 - **`✓`** — `parse_branch` reads back the segments `branch_name` writes, for every branch the repo can produce
 - **`!`** — the pattern does not round-trip. Three shapes:
-  - **nothing parses** → issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive
+  - **nothing parses** → issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and body placeholders, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive. **PR/MR detection is not affected** — `Forge::find_pr_for_branch` queries the forge with the whole branch name and never parses it
   - **only some values parse** → the detail names a failing example and scopes the loss to the branches that come out like it. `{desc}/#{issue}-{type}` is unreadable for a desc carrying a `-` and perfectly readable for one without; calling the whole pattern dead would be false for half the branches it produces
   - **everything parses but a segment comes back different** → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue/PR auto-linking, and both → lifecycle hook placeholders and the TUI rename, which consume all three segments
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -1,6 +1,6 @@
 ---
 title: gwm doctor
-description: 8 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
+description: 9 health checks with ✓ / ! / ✗ reporting and 0 / 1 / 2 exit codes for CI.
 ---
 
 # `gwm doctor`
@@ -158,7 +158,7 @@ Round-trip is value-dependent, so probing a couple of arbitrary values proves no
 |:---------|:-------------------------------------|:----------------------------|
 | `type`   | every configured branch type         | finite, so this is exhaustive — and a type your `[[branch_types]]` forbids must not raise a warning about branches that cannot exist |
 | `issue`  | one single-digit, one multi-digit    | `\d+` is the only distinction `BRANCH_RE` can split on |
-| `desc`   | one with a `-`, one without          | the dash is the only character that collides with a literal separator in the pattern |
+| `desc`   | one with a `-`, one without, one all-digits | the dash is the only character that collides with a literal separator; digits-only is the only desc `BRANCH_RE`'s `\d+` issue group can swallow (`{type}/#{desc}-{issue}` parses for `123` and for nothing else) |
 | `{repo}` | the **real** repo name               | the verdict depends on it: `{repo}/#{issue}-{desc}` is fine in a repo called `gwm` and unparseable in one called `gwm-cli`, whose dash the `[a-z]+` type charset rejects |
 
 A pattern that survives all of it is the strongest claim this check can make short of deriving the parser from the pattern.

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -144,10 +144,12 @@ The check is a real round-trip probe, not a comparison against the default strin
 
 - **`✓`** — `parse_branch` reads back the segments `branch_name` writes
 - **`!`** — the pattern does not round-trip. Two shapes:
-  - the branch name matches nothing at all → issue/PR auto-linking, gitmoji selection and the branch-convention check (#6 above) are all inactive
-  - it parses but a segment comes back different → the detail names which one and what it breaks: `type` → gitmoji selection, `issue` → issue/PR auto-linking, `desc` → lifecycle hook placeholders and the TUI rename
+  - the branch name matches nothing at all → issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive
+  - it parses but a segment comes back different → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue/PR auto-linking, and both → lifecycle hook placeholders and the TUI rename, which consume all three segments
 
-  The hint offers the two honest options: restore the default, or keep the custom pattern and attach issues/PRs by hand with `gwm link`.
+  The hint stays neutral — restore the default, or keep the pattern and accept exactly the loss the detail names. Which workaround applies depends on which segment broke, so recommending one unconditionally would be wrong.
+
+The probe runs twice with no value shared between the runs. One run is not enough: `feat/#{issue}-{desc}` hardcodes the type and would round-trip perfectly against a probe that happened to use `feat`, while `gwm create fix …` writes a `feat/` branch and reads the wrong type back.
 
 This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error — and reads the **effective** pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too.
 

--- a/docs/5.integrations/2.doctor.md
+++ b/docs/5.integrations/2.doctor.md
@@ -142,16 +142,26 @@ Only actions with at least one chord count toward the `N action(s) bound` figure
 
 The check is a real round-trip probe, not a comparison against the default string: **a custom pattern is not automatically a broken one**. `{type}/#{issue}-prefix-{desc}` still yields `feat/#42-…`, so `type` and `issue` survive and only `desc` comes back wrong.
 
-- **`✓`** — `parse_branch` reads back the segments `branch_name` writes
-- **`!`** — the pattern does not round-trip. Two shapes:
-  - the branch name matches nothing at all → issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive
-  - it parses but a segment comes back different → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue/PR auto-linking, and both → lifecycle hook placeholders and the TUI rename, which consume all three segments
+- **`✓`** — `parse_branch` reads back the segments `branch_name` writes, for every branch the repo can produce
+- **`!`** — the pattern does not round-trip. Three shapes:
+  - **nothing parses** → issue/PR auto-linking, gitmoji selection, lifecycle hook placeholders, the TUI rename and the branch-convention check (#6 above) are all inactive
+  - **only some values parse** → the detail names a failing example and scopes the loss to the branches that come out like it. `{desc}/#{issue}-{type}` is unreadable for a desc carrying a `-` and perfectly readable for one without; calling the whole pattern dead would be false for half the branches it produces
+  - **everything parses but a segment comes back different** → the detail names which one and every feature reading it: `type` → gitmoji selection, `issue` → issue/PR auto-linking, and both → lifecycle hook placeholders and the TUI rename, which consume all three segments
 
   The hint stays neutral — restore the default, or keep the pattern and accept exactly the loss the detail names. Which workaround applies depends on which segment broke, so recommending one unconditionally would be wrong.
 
-The probe runs twice with no value shared between the runs. One run is not enough: `feat/#{issue}-{desc}` hardcodes the type and would round-trip perfectly against a probe that happened to use `feat`, while `gwm create fix …` writes a `feat/` branch and reads the wrong type back.
+### how the probe space is chosen
 
-`{repo}` is expanded with the **real** repo name, because the verdict depends on it: `{repo}/#{issue}-{desc}` is fine in a repo called `gwm` and completely unparseable in one called `gwm-cli`, whose dash the `[a-z]+` type charset rejects.
+Round-trip is value-dependent, so probing a couple of arbitrary values proves nothing either way. The probe enumerates the value space `gwm create` actually admits, by construction rather than by sampling:
+
+| Segment  | Probed with                          | Why that is the whole space |
+|:---------|:-------------------------------------|:----------------------------|
+| `type`   | every configured branch type         | finite, so this is exhaustive — and a type your `[[branch_types]]` forbids must not raise a warning about branches that cannot exist |
+| `issue`  | one single-digit, one multi-digit    | `\d+` is the only distinction `BRANCH_RE` can split on |
+| `desc`   | one with a `-`, one without          | the dash is the only character that collides with a literal separator in the pattern |
+| `{repo}` | the **real** repo name               | the verdict depends on it: `{repo}/#{issue}-{desc}` is fine in a repo called `gwm` and unparseable in one called `gwm-cli`, whose dash the `[a-z]+` type charset rejects |
+
+A pattern that survives all of it is the strongest claim this check can make short of deriving the parser from the pattern.
 
 This check states the limitation rather than fixing it. Deriving the parser from the pattern is tracked by [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` prints the same message on stderr and still exits `0` — a custom pattern is valid configuration, not an error — and reads the **effective** pattern, so one set only in the global `~/.config/gwm/config.toml` is caught too.
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -54,7 +54,7 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 ### personnaliser `branch_pattern` a un coût aujourd'hui
 
-`branch_pattern` est respecté quand gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Un motif que le parseur ne sait pas suivre désactive silencieusement l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie et le contrôle de convention de branche du `doctor`.
+`branch_pattern` est respecté quand gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Un motif que le parseur ne sait pas suivre désactive silencieusement l'auto-liaison de l'issue depuis le nom de branche, la sélection du gitmoji, les placeholders des hooks sur les chemins remove / bootstrap et le contrôle de convention de branche du `doctor`.
 
 Personnalisé ne veut pas dire cassé pour autant. `{type}/#{issue}-prefix-{desc}` produit encore `feat/#42-…`, donc `type` et `issue` sont récupérés et seul `desc` revient faux. `{type}-{issue}-{desc}` ne correspond à rien du tout et perd tout.
 
@@ -84,12 +84,12 @@ Le champ reste libre — mettez ce que vous voulez, rien n'est bloqué. Mais tan
 | `{type}/#{issue}-{desc}` | le défaut — fonctionne avec n'importe quels `[[branch_types]]` |
 | `feat/#{issue}-{desc}` | uniquement si `feat` est le **seul** type de branche configuré, puisque le parseur relit le littéral comme le type |
 
-**Se parse, mais rend un `desc` faux** — l'auto-liaison issue/PR et le gitmoji continuent de marcher ; les placeholders des hooks de cycle de vie et le renommage TUI voient une description corrompue :
+**Se parse, mais rend un `desc` faux** — l'auto-liaison de l'issue et le gitmoji continuent de marcher ; les placeholders des hooks remove/bootstrap et le renommage TUI voient une description corrompue :
 
 - `{type}/#{issue}-prefix-{desc}` — le littéral est avalé dans `desc`
 - `{type}/#{issue}-{desc}-{repo}` — tout ce qui est ajouté après `{desc}` atterrit dedans
 
-**Ne se parse pas du tout** — auto-liaison, gitmoji, placeholders de hooks, renommage TUI et contrôle de convention de branche deviennent tous inactifs :
+**Ne se parse pas du tout** — auto-liaison de l'issue, gitmoji, placeholders des hooks remove/bootstrap, renommage TUI et contrôle de convention de branche deviennent tous inactifs (la détection PR/MR n'est pas touchée) :
 
 - `{type}/{issue}-{desc}` — le `#` est obligatoire
 - `{type}-{issue}-{desc}` — le `/` est obligatoire

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -52,6 +52,14 @@ Placeholders : `{home}`, `{repo}`, `{type}`, `{issue}`, `{desc}`, `{repo_path}`,
 base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 ```
 
+### personnaliser `branch_pattern` a un coût aujourd'hui
+
+`branch_pattern` est respecté quand gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Changez le motif et gwm ne sait plus décomposer les branches qu'il crée, ce qui désactive silencieusement l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche du `doctor`.
+
+`gwm doctor` et `gwm config validate` le disent tous les deux ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — la config reste valide et le code de sortie reste `0`, mais la limitation est énoncée au lieu d'être muette. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+
+`path_pattern` n'est pas concerné : il ne sert qu'à la génération, et le nom d'un worktree vient de son répertoire, pas d'un re-parsing du motif.
+
 ### types de branche supportés
 
 `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Surchargez par dépôt si votre équipe utilise autre chose.

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -62,6 +62,32 @@ Personnalisé ne veut pas dire cassé pour autant. `{type}/#{issue}-prefix-{desc
 
 `path_pattern` n'est pas concerné : il ne sert qu'à la génération, et le nom d'un worktree vient de son répertoire, pas d'un re-parsing du motif.
 
+#### quels motifs fonctionnent réellement aujourd'hui
+
+Le champ reste libre — mettez ce que vous voulez, rien n'est bloqué. Mais tant que le parseur n'est pas dérivé du motif ([#417](https://github.com/kbrdn1/gwm-cli/issues/417)), c'est la regex figée `^([a-z]+)/#(\d+)-([a-z0-9-]+)$`, donc un seul squelette se relit. Le tableau ci-dessous est vérifié contre le contrôle réel, pas supposé — un test l'épingle pour qu'il ne dérive pas.
+
+**Fait l'aller-retour complet :**
+
+| Motif | Condition |
+|:------|:----------|
+| `{type}/#{issue}-{desc}` | le défaut — fonctionne avec n'importe quels `[[branch_types]]` |
+| `feat/#{issue}-{desc}` | uniquement si `feat` est le **seul** type de branche configuré, puisque le parseur relit le littéral comme le type |
+
+**Se parse, mais rend un `desc` faux** — l'auto-liaison issue/PR et le gitmoji continuent de marcher ; les placeholders des hooks de cycle de vie et le renommage TUI voient une description corrompue :
+
+- `{type}/#{issue}-prefix-{desc}` — le littéral est avalé dans `desc`
+- `{type}/#{issue}-{desc}-{repo}` — tout ce qui est ajouté après `{desc}` atterrit dedans
+
+**Ne se parse pas du tout** — auto-liaison, gitmoji, placeholders de hooks, renommage TUI et contrôle de convention de branche deviennent tous inactifs :
+
+- `{type}/{issue}-{desc}` — le `#` est obligatoire
+- `{type}-{issue}-{desc}` — le `/` est obligatoire
+- `{type}/#{issue}_{desc}` — le séparateur doit être `-`
+- `{type}/#{issue}` — `{desc}` est obligatoire
+- `{repo}/{type}/#{issue}-{desc}`, `wt/{type}/#{issue}-{desc}` — pas de segment de chemin supplémentaire avant `{type}`
+
+La règle empirique : gardez le squelette `<type>/#<issue>-<desc>` et ne mettez rien après `{desc}`. Tout le reste crée parfaitement des worktrees — vous perdez seulement les fonctionnalités qui relisent le nom de branche, et `gwm doctor` vous dit lesquelles.
+
 ### types de branche supportés
 
 `feat`, `fix`, `hotfix`, `docs`, `test`, `refactor`, `chore`, `perf`, `ci`, `build`. Surchargez par dépôt si votre équipe utilise autre chose.

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -54,9 +54,11 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 ### personnaliser `branch_pattern` a un coût aujourd'hui
 
-`branch_pattern` est respecté quand gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Changez le motif et gwm ne sait plus décomposer les branches qu'il crée, ce qui désactive silencieusement l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche du `doctor`.
+`branch_pattern` est respecté quand gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Un motif que le parseur ne sait pas suivre désactive silencieusement l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie et le contrôle de convention de branche du `doctor`.
 
-`gwm doctor` et `gwm config validate` le disent tous les deux ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — la config reste valide et le code de sortie reste `0`, mais la limitation est énoncée au lieu d'être muette. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+Personnalisé ne veut pas dire cassé pour autant. `{type}/#{issue}-prefix-{desc}` produit encore `feat/#42-…`, donc `type` et `issue` sont récupérés et seul `desc` revient faux. `{type}-{issue}-{desc}` ne correspond à rien du tout et perd tout.
+
+`gwm doctor` et `gwm config validate` testent l'aller-retour réel et nomment les segments qui cassent ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — la config reste valide et le code de sortie reste `0`, mais la limitation est énoncée au lieu d'être muette. `config validate` lit le motif effectif, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
 
 `path_pattern` n'est pas concerné : il ne sert qu'à la génération, et le nom d'un worktree vient de son répertoire, pas d'un re-parsing du motif.
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -58,7 +58,18 @@ base = "{repo_parent}/worktrees/{repo}"   # a sibling `worktrees/` dir
 
 Personnalisé ne veut pas dire cassé pour autant. `{type}/#{issue}-prefix-{desc}` produit encore `feat/#42-…`, donc `type` et `issue` sont récupérés et seul `desc` revient faux. `{type}-{issue}-{desc}` ne correspond à rien du tout et perd tout.
 
-`gwm doctor` et `gwm config validate` testent l'aller-retour réel et nomment les segments qui cassent ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — la config reste valide et le code de sortie reste `0`, mais la limitation est énoncée au lieu d'être muette. `config validate` lit le motif effectif, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
+`gwm doctor` et `gwm config validate` testent l'aller-retour réel et nomment les segments qui cassent ([#415](https://github.com/kbrdn1/gwm-cli/issues/415)) — la config reste valide, mais la limitation est énoncée au lieu d'être muette.
+
+**Les deux commandes diffèrent sur le code de sortie, ce qui compte si vous gatez la CI dessus :**
+
+| Commande | Sur un motif qui ne fait pas l'aller-retour |
+|:---------|:--------------------------------------------|
+| `gwm config validate` | affiche l'avertissement sur stderr, sort en **`0`** — un motif personnalisé est une configuration valide, pas une erreur |
+| `gwm doctor` | rapporte un contrôle `!`, donc le run sort en **`1`** comme tout autre Avertissement ([codes de sortie](/fr/integrations/doctor#codes-de-sortie)) |
+
+Un job CI qui lance `gwm doctor` et tolère les Avertissements devrait utiliser `gwm doctor; [ $? -le 1 ]`.
+
+`config validate` lit le motif effectif, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417).
 
 `path_pattern` n'est pas concerné : il ne sert qu'à la génération, et le nom d'un worktree vient de son répertoire, pas d'un re-parsing du motif.
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -151,6 +151,8 @@ Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîn
 
 La sonde tourne deux fois, sans aucune valeur partagée entre les deux passes. Une seule passe ne suffit pas : `feat/#{issue}-{desc}` fige le type et ferait un aller-retour parfait face à une sonde utilisant justement `feat`, alors que `gwm create fix …` écrit une branche `feat/` et relit le mauvais type.
 
+`{repo}` est étendu avec le **vrai** nom du dépôt, parce que le verdict en dépend : `{repo}/#{issue}-{desc}` va très bien dans un dépôt nommé `gwm` et devient totalement illisible dans un dépôt nommé `gwm-cli`, dont le tiret est rejeté par la classe `[a-z]+` du type.
+
 Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur — et lit le motif **effectif**, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi.
 
 ## intégration CI

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -144,7 +144,7 @@ Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîn
 
 - **`✓`** — `parse_branch` relit les segments que `branch_name` écrit, pour toutes les branches que le dépôt peut produire
 - **`!`** — le motif ne fait pas l'aller-retour. Trois formes :
-  - **rien ne se parse** → l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
+  - **rien ne se parse** → l'auto-liaison de l'issue depuis le nom de branche, le gitmoji / `gwm commit-prefix`, la sélection de template et les placeholders de `gwm pr`, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs. **La détection PR/MR n'est pas touchée** — `Forge::find_pr_for_branch` interroge la forge avec le nom de branche entier et ne le parse jamais
   - **seules certaines valeurs se parsent** → le détail nomme un exemple qui échoue et limite la perte aux branches qui lui ressemblent. `{desc}/#{issue}-{type}` est illisible pour un desc portant un `-` et parfaitement lisible pour un desc sans ; déclarer tout le motif mort serait faux pour la moitié des branches qu'il produit
   - **tout se parse mais un segment revient différent** → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, et les deux → placeholders des hooks de cycle de vie et renommage TUI, qui consomment les trois segments
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -161,7 +161,7 @@ L'aller-retour dépend des valeurs, donc sonder deux valeurs arbitraires ne prou
 | `desc`   | un avec `-`, un sans, un tout en chiffres  | le tiret est le seul caractère qui entre en collision avec un séparateur littéral ; le tout-chiffres est le seul desc que le groupe `\d+` de `BRANCH_RE` peut avaler (`{type}/#{desc}-{issue}` se parse pour `123` et pour rien d'autre) |
 | `{repo}` | le **vrai** nom du dépôt                   | le verdict en dépend : `{repo}/#{issue}-{desc}` va très bien dans un dépôt nommé `gwm` et devient illisible dans un dépôt nommé `gwm-cli`, dont le tiret est rejeté par la classe `[a-z]+` du type |
 
-Un motif qui survit à tout cela, c'est l'affirmation la plus forte que ce contrôle peut faire sans dériver le parseur du motif.
+Un motif qui survit à tout cela, c'est l'affirmation la plus forte que ce contrôle peut faire sans dériver le parseur du motif. Et le verdict ne quantifie jamais au-delà de ce que les sondes ont observé : quand seule une partie des formes sondées perd quelque chose, le détail les compte (`on 27 of the 30 branch shapes probed, …`) au lieu d'affirmer que toutes les branches sont touchées.
 
 Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur — et lit le motif **effectif**, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi.
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -144,9 +144,9 @@ Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîn
 
 - **`✓`** — `parse_branch` relit les segments que `branch_name` écrit, pour toutes les branches que le dépôt peut produire
 - **`!`** — le motif ne fait pas l'aller-retour. Trois formes :
-  - **rien ne se parse** → l'auto-liaison de l'issue depuis le nom de branche, le gitmoji / `gwm commit-prefix`, la sélection de template et les placeholders de `gwm pr`, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs. **La détection PR/MR n'est pas touchée** — `Forge::find_pr_for_branch` interroge la forge avec le nom de branche entier et ne le parse jamais
+  - **rien ne se parse** → l'auto-liaison de l'issue depuis le nom de branche, le gitmoji / `gwm commit-prefix`, la sélection de template et les placeholders de `gwm pr`, les placeholders des hooks sur les chemins remove / bootstrap, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs. **La détection PR/MR n'est pas touchée** — `Forge::find_pr_for_branch` interroge la forge avec le nom de branche entier et ne le parse jamais
   - **seules certaines valeurs se parsent** → le détail nomme un exemple qui échoue et limite la perte aux branches qui lui ressemblent. `{desc}/#{issue}-{type}` est illisible pour un desc portant un `-` et parfaitement lisible pour un desc sans ; déclarer tout le motif mort serait faux pour la moitié des branches qu'il produit
-  - **tout se parse mais un segment revient différent** → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, et les deux → placeholders des hooks de cycle de vie et renommage TUI, qui consomment les trois segments
+  - **tout se parse mais un segment revient différent** → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison de l'issue, et les deux → placeholders des hooks remove/bootstrap et renommage TUI, qui consomment les trois segments
 
   L'indication reste neutre — restaurer le défaut, ou garder le motif et accepter exactement la perte que le détail nomme. Le contournement applicable dépend du segment cassé, donc en recommander un inconditionnellement serait faux.
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -144,10 +144,12 @@ Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîn
 
 - **`✓`** — `parse_branch` relit les segments que `branch_name` écrit
 - **`!`** — le motif ne fait pas l'aller-retour. Deux formes :
-  - le nom de branche ne correspond à rien du tout → l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
-  - il se parse mais un segment revient différent → le détail nomme lequel et ce qu'il casse : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, `desc` → placeholders des hooks de cycle de vie et renommage TUI
+  - le nom de branche ne correspond à rien du tout → l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
+  - il se parse mais un segment revient différent → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, et les deux → placeholders des hooks de cycle de vie et renommage TUI, qui consomment les trois segments
 
-  L'indication propose les deux options honnêtes : restaurer le défaut, ou garder le motif personnalisé et attacher les issues/PR à la main avec `gwm link`.
+  L'indication reste neutre — restaurer le défaut, ou garder le motif et accepter exactement la perte que le détail nomme. Le contournement applicable dépend du segment cassé, donc en recommander un inconditionnellement serait faux.
+
+La sonde tourne deux fois, sans aucune valeur partagée entre les deux passes. Une seule passe ne suffit pas : `feat/#{issue}-{desc}` fige le type et ferait un aller-retour parfait face à une sonde utilisant justement `feat`, alors que `gwm create fix …` écrit une branche `feat/` et relit le mauvais type.
 
 Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur — et lit le motif **effectif**, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi.
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -1,6 +1,6 @@
 ---
 title: gwm doctor
-description: 8 vérifications de santé avec un rapport ✓ / ! / ✗ et des codes de sortie 0 / 1 / 2 pour la CI.
+description: 9 vérifications de santé avec un rapport ✓ / ! / ✗ et des codes de sortie 0 / 1 / 2 pour la CI.
 ---
 
 # `gwm doctor`
@@ -158,7 +158,7 @@ L'aller-retour dépend des valeurs, donc sonder deux valeurs arbitraires ne prou
 |:---------|:------------------------------------------|:-------------------------------|
 | `type`   | chaque type de branche configuré           | fini, donc exhaustif — et un type interdit par vos `[[branch_types]]` ne doit pas déclencher d'avertissement sur des branches qui ne peuvent pas exister |
 | `issue`  | un à un chiffre, un à plusieurs chiffres   | `\d+` est la seule distinction sur laquelle `BRANCH_RE` peut découper |
-| `desc`   | un avec `-`, un sans                       | le tiret est le seul caractère qui entre en collision avec un séparateur littéral du motif |
+| `desc`   | un avec `-`, un sans, un tout en chiffres  | le tiret est le seul caractère qui entre en collision avec un séparateur littéral ; le tout-chiffres est le seul desc que le groupe `\d+` de `BRANCH_RE` peut avaler (`{type}/#{desc}-{issue}` se parse pour `123` et pour rien d'autre) |
 | `{repo}` | le **vrai** nom du dépôt                   | le verdict en dépend : `{repo}/#{issue}-{desc}` va très bien dans un dépôt nommé `gwm` et devient illisible dans un dépôt nommé `gwm-cli`, dont le tiret est rejeté par la classe `[a-z]+` du type |
 
 Un motif qui survit à tout cela, c'est l'affirmation la plus forte que ce contrôle peut faire sans dériver le parseur du motif.

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -138,12 +138,18 @@ Seules les actions ayant au moins un chord comptent dans le chiffre `N action(s)
 
 ### 9. `worktree.branch_pattern` fait l'aller-retour via le parseur
 
-`branch_pattern` pilote la façon dont gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Personnaliser le motif produit donc des branches que gwm ne sait plus décomposer, et toutes les fonctionnalités reposant sur les segments parsés deviennent muettes. Ajouté par [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
+`branch_pattern` pilote la façon dont gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Quand les deux divergent, toutes les fonctionnalités reposant sur les segments parsés lisent la mauvaise valeur — silencieusement. Ajouté par [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
 
-- **`✓`** — le motif est celui par défaut, donc `parse_branch` relit ce que `branch_name` écrit
-- **`!`** — le motif diffère du défaut ; l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche (#6 ci-dessus) sont inactifs sur les branches créées avec. L'indication propose les deux options honnêtes : restaurer le défaut, ou garder le motif personnalisé et attacher les issues/PR à la main avec `gwm link`
+Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîne par défaut : **un motif personnalisé n'est pas automatiquement cassé**. `{type}/#{issue}-prefix-{desc}` produit encore `feat/#42-…`, donc `type` et `issue` survivent et seul `desc` revient faux.
 
-Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur.
+- **`✓`** — `parse_branch` relit les segments que `branch_name` écrit
+- **`!`** — le motif ne fait pas l'aller-retour. Deux formes :
+  - le nom de branche ne correspond à rien du tout → l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
+  - il se parse mais un segment revient différent → le détail nomme lequel et ce qu'il casse : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, `desc` → placeholders des hooks de cycle de vie et renommage TUI
+
+  L'indication propose les deux options honnêtes : restaurer le défaut, ou garder le motif personnalisé et attacher les issues/PR à la main avec `gwm link`.
+
+Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur — et lit le motif **effectif**, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi.
 
 ## intégration CI
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -142,16 +142,26 @@ Seules les actions ayant au moins un chord comptent dans le chiffre `N action(s)
 
 Le contrôle est un vrai test d'aller-retour, pas une comparaison avec la chaîne par défaut : **un motif personnalisé n'est pas automatiquement cassé**. `{type}/#{issue}-prefix-{desc}` produit encore `feat/#42-…`, donc `type` et `issue` survivent et seul `desc` revient faux.
 
-- **`✓`** — `parse_branch` relit les segments que `branch_name` écrit
-- **`!`** — le motif ne fait pas l'aller-retour. Deux formes :
-  - le nom de branche ne correspond à rien du tout → l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
-  - il se parse mais un segment revient différent → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, et les deux → placeholders des hooks de cycle de vie et renommage TUI, qui consomment les trois segments
+- **`✓`** — `parse_branch` relit les segments que `branch_name` écrit, pour toutes les branches que le dépôt peut produire
+- **`!`** — le motif ne fait pas l'aller-retour. Trois formes :
+  - **rien ne se parse** → l'auto-liaison issue/PR, la sélection du gitmoji, les placeholders des hooks de cycle de vie, le renommage TUI et le contrôle de convention de branche (#6 ci-dessus) sont tous inactifs
+  - **seules certaines valeurs se parsent** → le détail nomme un exemple qui échoue et limite la perte aux branches qui lui ressemblent. `{desc}/#{issue}-{type}` est illisible pour un desc portant un `-` et parfaitement lisible pour un desc sans ; déclarer tout le motif mort serait faux pour la moitié des branches qu'il produit
+  - **tout se parse mais un segment revient différent** → le détail nomme lequel et toutes les fonctionnalités qui le lisent : `type` → sélection du gitmoji, `issue` → auto-liaison issue/PR, et les deux → placeholders des hooks de cycle de vie et renommage TUI, qui consomment les trois segments
 
   L'indication reste neutre — restaurer le défaut, ou garder le motif et accepter exactement la perte que le détail nomme. Le contournement applicable dépend du segment cassé, donc en recommander un inconditionnellement serait faux.
 
-La sonde tourne deux fois, sans aucune valeur partagée entre les deux passes. Une seule passe ne suffit pas : `feat/#{issue}-{desc}` fige le type et ferait un aller-retour parfait face à une sonde utilisant justement `feat`, alors que `gwm create fix …` écrit une branche `feat/` et relit le mauvais type.
+### comment l'espace de sonde est choisi
 
-`{repo}` est étendu avec le **vrai** nom du dépôt, parce que le verdict en dépend : `{repo}/#{issue}-{desc}` va très bien dans un dépôt nommé `gwm` et devient totalement illisible dans un dépôt nommé `gwm-cli`, dont le tiret est rejeté par la classe `[a-z]+` du type.
+L'aller-retour dépend des valeurs, donc sonder deux valeurs arbitraires ne prouve rien, ni dans un sens ni dans l'autre. La sonde énumère l'espace de valeurs que `gwm create` accepte réellement, par construction et non par échantillonnage :
+
+| Segment  | Sondé avec                                | Pourquoi c'est l'espace entier |
+|:---------|:------------------------------------------|:-------------------------------|
+| `type`   | chaque type de branche configuré           | fini, donc exhaustif — et un type interdit par vos `[[branch_types]]` ne doit pas déclencher d'avertissement sur des branches qui ne peuvent pas exister |
+| `issue`  | un à un chiffre, un à plusieurs chiffres   | `\d+` est la seule distinction sur laquelle `BRANCH_RE` peut découper |
+| `desc`   | un avec `-`, un sans                       | le tiret est le seul caractère qui entre en collision avec un séparateur littéral du motif |
+| `{repo}` | le **vrai** nom du dépôt                   | le verdict en dépend : `{repo}/#{issue}-{desc}` va très bien dans un dépôt nommé `gwm` et devient illisible dans un dépôt nommé `gwm-cli`, dont le tiret est rejeté par la classe `[a-z]+` du type |
+
+Un motif qui survit à tout cela, c'est l'affirmation la plus forte que ce contrôle peut faire sans dériver le parseur du motif.
 
 Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur — et lit le motif **effectif**, donc un motif posé uniquement dans le `~/.config/gwm/config.toml` global est détecté aussi.
 

--- a/docs/fr/5.integrations/2.doctor.md
+++ b/docs/fr/5.integrations/2.doctor.md
@@ -136,6 +136,15 @@ Réexécute le même chemin de résolution `[tui.keys]` que le TUI lui-même uti
 
 Seules les actions ayant au moins un chord comptent dans le chiffre `N action(s) bound` — une action définie à `[]` dans `[tui.keys]` est déliée et exclue. Voir [schéma `.gwm.toml` → `[tui.keys]`](/fr/configuration/gwm-toml#tuikeys), [TUI → Keymap et palette de commandes](/fr/tui/keymap-and-palette), et [TUI → Raccourcis](/fr/tui/keybindings) pour les slugs d'action et la grammaire des chords.
 
+### 9. `worktree.branch_pattern` fait l'aller-retour via le parseur
+
+`branch_pattern` pilote la façon dont gwm **écrit** un nom de branche, mais le parseur qui en **relit** un est une regex codée en dur pour le défaut `{type}/#{issue}-{desc}`. Personnaliser le motif produit donc des branches que gwm ne sait plus décomposer, et toutes les fonctionnalités reposant sur les segments parsés deviennent muettes. Ajouté par [#415](https://github.com/kbrdn1/gwm-cli/issues/415).
+
+- **`✓`** — le motif est celui par défaut, donc `parse_branch` relit ce que `branch_name` écrit
+- **`!`** — le motif diffère du défaut ; l'auto-liaison issue/PR, la sélection du gitmoji et le contrôle de convention de branche (#6 ci-dessus) sont inactifs sur les branches créées avec. L'indication propose les deux options honnêtes : restaurer le défaut, ou garder le motif personnalisé et attacher les issues/PR à la main avec `gwm link`
+
+Ce contrôle énonce la limitation, il ne la corrige pas. La dérivation du parseur depuis le motif est suivie par [#417](https://github.com/kbrdn1/gwm-cli/issues/417). `gwm config validate` affiche le même message sur stderr et sort quand même en `0` — un motif personnalisé est une configuration valide, pas une erreur.
+
 ## intégration CI
 
 ```yaml

--- a/src/config.rs
+++ b/src/config.rs
@@ -338,7 +338,10 @@ fn default_path_pattern() -> String {
   "{type}-{issue}-{desc}".into()
 }
 
-fn default_branch_pattern() -> String {
+/// `pub(crate)` rather than private so [`crate::naming::branch_pattern_warning`]
+/// can compare a configured pattern against the one the hardcoded parser
+/// actually understands (issue #415).
+pub(crate) fn default_branch_pattern() -> String {
   "{type}/#{issue}-{desc}".into()
 }
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -155,7 +155,11 @@ pub fn list(prefix: Option<&str>) -> Result<()> {
 }
 
 pub fn validate() -> Result<()> {
-  let root = repo_root()?;
+  // Discover once: the warning below needs the repo *name* too (`{repo}` is
+  // a supported `branch_pattern` token and the verdict depends on it), and
+  // `repo_root` drops the handle it opened.
+  let repo = worktree::discover_repo(None)?;
+  let root = repo.workdir().ok_or(GwmError::NotInGitRepo)?.to_path_buf();
   let path = config_path(&root);
   let cfg = validate_file(&path)?;
   println!("{} is valid", path.display());
@@ -171,7 +175,9 @@ pub fn validate() -> Result<()> {
   // broken global layer is not this command's business — it reports on
   // `path` — so fall back to the repo-only value it just validated.
   let effective = Config::merge_layered(&root, crate::config::global_config_path().as_deref()).unwrap_or(cfg);
-  if let Some(warning) = crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern) {
+  if let Some(warning) =
+    crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern, &worktree::repo_name(&repo))
+  {
     eprintln!("warning: {}", warning);
   }
   Ok(())

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -175,8 +175,9 @@ pub fn validate() -> Result<()> {
   // broken global layer is not this command's business — it reports on
   // `path` — so fall back to the repo-only value it just validated.
   let effective = Config::merge_layered(&root, crate::config::global_config_path().as_deref()).unwrap_or(cfg);
+  let types = effective.resolved_branch_types().types;
   if let Some(warning) =
-    crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern, &worktree::repo_name(&repo))
+    crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern, &worktree::repo_name(&repo), &types)
   {
     eprintln!("warning: {}", warning);
   }

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -159,10 +159,19 @@ pub fn validate() -> Result<()> {
   let path = config_path(&root);
   let cfg = validate_file(&path)?;
   println!("{} is valid", path.display());
-  // Issue #415: a customised `branch_pattern` is *valid* — it just silently
-  // disables everything that re-parses a branch name. Stated on stderr so
-  // the exit code stays 0 and piped consumers of stdout are unaffected.
-  if let Some(warning) = crate::naming::branch_pattern_warning(&cfg.worktree.branch_pattern) {
+  // Issue #415: a `branch_pattern` the parser cannot read back is *valid*
+  // config — it just silently breaks everything keyed on the re-parsed
+  // segments. Stated on stderr so the exit code stays 0 and piped
+  // consumers of stdout are unaffected.
+  //
+  // Read the *effective* pattern, not the repo file's: `branch_pattern`
+  // set only in the user-level global config still applies at runtime
+  // through `merge_layered`, and validating `path` alone would stay quiet
+  // about it while `gwm doctor` (which sees the merged view) warns. A
+  // broken global layer is not this command's business — it reports on
+  // `path` — so fall back to the repo-only value it just validated.
+  let effective = Config::merge_layered(&root, crate::config::global_config_path().as_deref()).unwrap_or(cfg);
+  if let Some(warning) = crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern) {
     eprintln!("warning: {}", warning);
   }
   Ok(())

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -157,8 +157,14 @@ pub fn list(prefix: Option<&str>) -> Result<()> {
 pub fn validate() -> Result<()> {
   let root = repo_root()?;
   let path = config_path(&root);
-  validate_file(&path)?;
+  let cfg = validate_file(&path)?;
   println!("{} is valid", path.display());
+  // Issue #415: a customised `branch_pattern` is *valid* — it just silently
+  // disables everything that re-parses a branch name. Stated on stderr so
+  // the exit code stays 0 and piped consumers of stdout are unaffected.
+  if let Some(warning) = crate::naming::branch_pattern_warning(&cfg.worktree.branch_pattern) {
+    eprintln!("warning: {}", warning);
+  }
   Ok(())
 }
 
@@ -211,7 +217,7 @@ fn write_and_validate(path: &Path, doc: &DocumentMut) -> Result<()> {
   let rendered = doc.to_string();
   match validate_rendered(path, &rendered) {
     // The edit is valid — write it.
-    Ok(()) => {
+    Ok(_) => {
       std::fs::write(path, rendered)?;
       Ok(())
     }
@@ -232,9 +238,12 @@ fn write_and_validate(path: &Path, doc: &DocumentMut) -> Result<()> {
   }
 }
 
-fn validate_file(path: &Path) -> Result<()> {
+/// Returns the validated `Config` so callers can inspect the resolved
+/// values without re-parsing the file — an absent config yields the
+/// defaults, which is exactly what the loader would have produced.
+fn validate_file(path: &Path) -> Result<Config> {
   if !path.exists() {
-    return Ok(());
+    return Ok(Config::default());
   }
   let raw = std::fs::read_to_string(path)?;
   validate_rendered(path, &raw)
@@ -244,7 +253,7 @@ fn validate_file(path: &Path) -> Result<()> {
 /// checks `gwm config validate` runs). `path` is only used for error
 /// coordinates. Shared by [`validate_file`] (on-disk) and the
 /// validate-before-write path in [`write_and_validate`].
-fn validate_rendered(path: &Path, raw: &str) -> Result<()> {
+fn validate_rendered(path: &Path, raw: &str) -> Result<Config> {
   let cfg = toml::from_str::<Config>(raw).map_err(|e| config_de_error(path, raw, e))?;
   cfg.validate_branch_types()?;
   cfg.validate_bootstrap_paths()?;
@@ -263,7 +272,7 @@ fn validate_rendered(path: &Path, raw: &str) -> Result<()> {
   // check `load_for_repo` does — otherwise `gwm config validate` greenlights a
   // profile the loader and the new commands reject (issue #324 review).
   cfg.validate_profiles()?;
-  Ok(())
+  Ok(cfg)
 }
 
 fn resolved_value(cfg: &Config, key: &str) -> Result<toml::Value> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -439,12 +439,17 @@ fn check_branch_pattern(ctx: &DoctorCtx<'_>) -> Check {
   // file on disk carries a broken one — a false `✓` from the one check
   // whose whole job is catching a silent failure. Fall back to `ctx.config`
   // only when the *merge* fails, which `check_config_parses` already flags.
-  let pattern = match Config::merge_layered(ctx.repo_workdir, ctx.global_config_path) {
-    Ok(cfg) => cfg.worktree.branch_pattern,
-    Err(_) => ctx.config.worktree.branch_pattern.clone(),
+  let effective = match Config::merge_layered(ctx.repo_workdir, ctx.global_config_path) {
+    Ok(cfg) => cfg,
+    Err(_) => ctx.config.clone(),
   };
+  let types = effective.resolved_branch_types().types;
 
-  match branch_pattern_warning(&pattern, &worktree::repo_name(ctx.repo)) {
+  match branch_pattern_warning(
+    &effective.worktree.branch_pattern,
+    &worktree::repo_name(ctx.repo),
+    &types,
+  ) {
     // The hint stays neutral on purpose: which workaround applies depends
     // on which segment broke, and the detail above already names it.
     // Recommending `gwm link` unconditionally was wrong for a pattern

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -419,9 +419,11 @@ fn extract_launcher_binary(command: &str) -> Option<String> {
 /// added to the same set so the user gets one consolidated warning.
 ///
 /// Issue #415: `worktree.branch_pattern` is honoured when a branch name is
-/// *written* and ignored when one is *read back*, so customising it quietly
-/// turns off issue/PR auto-linking, gitmoji selection and the
-/// branch-convention check below.
+/// *written* and ignored when one is *read back*, so a pattern the parser
+/// cannot follow quietly turns off issue/PR auto-linking, gitmoji selection
+/// and the branch-convention check above. [`branch_pattern_warning`] probes
+/// the round-trip and names whichever segments actually break — a custom
+/// pattern is not automatically a broken one.
 ///
 /// Warning rather than Failed: the config is valid and the worktrees it
 /// produces are perfectly usable — only the structured extras go silent.
@@ -433,7 +435,7 @@ fn check_branch_pattern(ctx: &DoctorCtx<'_>) -> Check {
     Some(detail) => Check::warning(name, detail).with_hint(
       "restore the default `{type}/#{issue}-{desc}`, or keep the custom pattern and attach issues/PRs by hand with `gwm link`",
     ),
-    None => Check::ok(name, "default pattern — `parse_branch` reads back what `branch_name` writes"),
+    None => Check::ok(name, "`parse_branch` reads back the segments `branch_name` writes"),
   }
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -431,9 +431,27 @@ fn extract_launcher_binary(command: &str) -> Option<String> {
 /// derived from the pattern in #417.
 fn check_branch_pattern(ctx: &DoctorCtx<'_>) -> Check {
   let name = "worktree.branch_pattern round-trips through the parser";
-  match branch_pattern_warning(&ctx.config.worktree.branch_pattern) {
+
+  // Re-derive from disk for the same reason `check_tui_keymap` does:
+  // `repo_context_lenient` substitutes `Config::default()` when the user's
+  // file fails to load for an unrelated semantic reason, and reading
+  // `ctx.config` there would report the default pattern as fine while the
+  // file on disk carries a broken one — a false `✓` from the one check
+  // whose whole job is catching a silent failure. Fall back to `ctx.config`
+  // only when the *merge* fails, which `check_config_parses` already flags.
+  let pattern = match Config::merge_layered(ctx.repo_workdir, ctx.global_config_path) {
+    Ok(cfg) => cfg.worktree.branch_pattern,
+    Err(_) => ctx.config.worktree.branch_pattern.clone(),
+  };
+
+  match branch_pattern_warning(&pattern) {
+    // The hint stays neutral on purpose: which workaround applies depends
+    // on which segment broke, and the detail above already names it.
+    // Recommending `gwm link` unconditionally was wrong for a pattern
+    // whose `issue` survives — auto-linking works there, and `gwm link`
+    // fixes neither the hook placeholders nor the TUI rename.
     Some(detail) => Check::warning(name, detail).with_hint(
-      "restore the default `{type}/#{issue}-{desc}`, or keep the custom pattern and attach issues/PRs by hand with `gwm link`",
+      "restore the default `{type}/#{issue}-{desc}`, or keep the pattern and accept exactly the loss named above",
     ),
     None => Check::ok(name, "`parse_branch` reads back the segments `branch_name` writes"),
   }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -444,7 +444,7 @@ fn check_branch_pattern(ctx: &DoctorCtx<'_>) -> Check {
     Err(_) => ctx.config.worktree.branch_pattern.clone(),
   };
 
-  match branch_pattern_warning(&pattern) {
+  match branch_pattern_warning(&pattern, &worktree::repo_name(ctx.repo)) {
     // The hint stays neutral on purpose: which workaround applies depends
     // on which segment broke, and the detail above already names it.
     // Recommending `gwm link` unconditionally was wrong for a pattern

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -4,7 +4,7 @@
 
 use crate::config::{expand_placeholders, Config, CONFIG_FILE};
 use crate::error::Result;
-use crate::naming::parse_branch;
+use crate::naming::{branch_pattern_warning, parse_branch};
 use crate::worktree;
 use git2::BranchType;
 use std::collections::BTreeSet;
@@ -140,6 +140,7 @@ pub fn run(ctx: &DoctorCtx<'_>) -> Result<DoctorReport> {
 
   report.checks.push(check_base_dir_writable(ctx));
   report.checks.push(check_tui_keymap(ctx));
+  report.checks.push(check_branch_pattern(ctx));
   Ok(report)
 }
 
@@ -417,6 +418,25 @@ fn extract_launcher_binary(command: &str) -> Option<String> {
 /// users. Configured launchers ([git_tui], [review] — issue #75) are
 /// added to the same set so the user gets one consolidated warning.
 ///
+/// Issue #415: `worktree.branch_pattern` is honoured when a branch name is
+/// *written* and ignored when one is *read back*, so customising it quietly
+/// turns off issue/PR auto-linking, gitmoji selection and the
+/// branch-convention check below.
+///
+/// Warning rather than Failed: the config is valid and the worktrees it
+/// produces are perfectly usable — only the structured extras go silent.
+/// This check does not fix the divergence, it states it; the parser is
+/// derived from the pattern in #417.
+fn check_branch_pattern(ctx: &DoctorCtx<'_>) -> Check {
+  let name = "worktree.branch_pattern round-trips through the parser";
+  match branch_pattern_warning(&ctx.config.worktree.branch_pattern) {
+    Some(detail) => Check::warning(name, detail).with_hint(
+      "restore the default `{type}/#{issue}-{desc}`, or keep the custom pattern and attach issues/PRs by hand with `gwm link`",
+    ),
+    None => Check::ok(name, "default pattern — `parse_branch` reads back what `branch_name` writes"),
+  }
+}
+
 /// Missing binaries are surfaced as Warning, not Failed — the user may not
 /// rely on that step at all, but the visibility matters.
 fn check_binaries_on_path(ctx: &DoctorCtx<'_>) -> Check {

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -173,24 +173,61 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 
 /// Issue #415 — `worktree.branch_pattern` drives [`BranchSpec::branch_name`]
 /// (formatting) but not [`parse_branch`], which matches the hardcoded
-/// `BRANCH_RE`. A pattern that differs from the default therefore writes
-/// branch names the parser cannot read back, and every feature keyed on the
-/// re-parsed segments — issue/PR auto-linking, gitmoji selection, the
-/// `doctor` branch-convention check, lifecycle placeholders — silently
-/// becomes a no-op.
+/// `BRANCH_RE`. When the two disagree, every feature keyed on the re-parsed
+/// segments quietly reads the wrong thing: gitmoji selection off `type`
+/// (`cli.rs` commit prefix), issue/PR auto-linking off `issue`, lifecycle
+/// hook placeholders and the TUI rename off `desc`, plus the `doctor`
+/// branch-convention check which only asks whether the name parses at all.
 ///
-/// Returns the user-facing warning when the pattern diverges, `None` when
-/// the parser follows it. This is the single predicate both `gwm doctor`
-/// and `gwm config validate` consume; issue #417 derives the parser from
-/// the pattern and replaces this body without moving either call site.
+/// The check is an actual round-trip probe, not a comparison against the
+/// default string: "differs from the default" and "breaks the parser" are
+/// not the same set. `{type}/#{issue}-prefix-{desc}` is customised yet
+/// still yields `feat/#42-…`, so `type` and `issue` survive and only
+/// `desc` comes back wrong — claiming auto-linking is dead there would be
+/// false, and a warning whose whole value is accuracy cannot afford that.
+///
+/// Returns the user-facing warning naming what actually breaks, or `None`
+/// when the pattern round-trips. This is the single predicate both
+/// `gwm doctor` and `gwm config validate` consume; issue #417 derives the
+/// parser from the pattern and replaces this body without moving either
+/// call site.
 pub fn branch_pattern_warning(pattern: &str) -> Option<String> {
-  let default = crate::config::default_branch_pattern();
-  if pattern == default {
+  // Probe values chosen to exercise every segment's charset: a real branch
+  // type, a multi-digit issue, and a desc that already contains the `-`
+  // that `DESC_RE` allows (so a greedy-adjacency bug shows up here).
+  const TYPE: &str = "feat";
+  const ISSUE: &str = "42";
+  const DESC: &str = "probe-desc";
+
+  // A pattern that does not expand at all is a different, *loud* failure:
+  // `gwm create` errors on it outright. Not this warning's business.
+  let formatted = expand_placeholders(pattern, "repo", Some(TYPE), Some(ISSUE), Some(DESC), None).ok()?;
+
+  let Some(back) = parse_branch(&formatted) else {
+    return Some(format!(
+      "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji and the branch-convention check will be inactive on branches created with this pattern",
+      pattern, formatted
+    ));
+  };
+
+  let mut broken: Vec<&str> = Vec::new();
+  if back.type_ != TYPE {
+    broken.push("`type`, so gitmoji selection reads the wrong branch type");
+  }
+  if back.issue != ISSUE {
+    broken.push("`issue`, so issue/PR auto-linking targets the wrong issue");
+  }
+  if back.desc != DESC {
+    broken.push("`desc`, so lifecycle hook placeholders and the TUI rename see the wrong description");
+  }
+  if broken.is_empty() {
     return None;
   }
   Some(format!(
-    "worktree.branch_pattern `{}` differs from the default `{}`; structured parsing does not follow it, so issue/PR auto-linking, gitmoji and the branch-convention check will be inactive on branches created with this pattern",
-    pattern, default
+    "worktree.branch_pattern `{}` does not round-trip: gwm writes `{}` and reads back {}",
+    pattern,
+    formatted,
+    broken.join("; ")
   ))
 }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -208,8 +208,11 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// - `issue` — `ISSUE_RE` is `\d+`: one single-digit, one multi-digit, the
 ///   only distinction `BRANCH_RE`'s `\d+` can split on.
 /// - `desc` — `DESC_RE` is `[a-z0-9][a-z0-9-]*`: one with the `-` it allows,
-///   one without. The dash is the only character that makes a desc collide
-///   with a literal separator in the pattern.
+///   one without, and one all-digits. The dash is the only character that
+///   makes a desc collide with a literal separator; the digits-only case is
+///   the only one that can be swallowed by `BRANCH_RE`'s `\d+` issue group
+///   (`{type}/#{desc}-{issue}` parses for `desc = "123"` and for nothing
+///   else, which is a partial round-trip, not a total loss).
 ///
 /// A pattern that round-trips over all of it is the strongest claim this
 /// check can make without deriving the parser from the pattern (#417), and
@@ -217,7 +220,7 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// never generalised to every branch.
 pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -> Option<String> {
   const ISSUES: [&str; 2] = ["7", "42"];
-  const DESCS: [&str; 2] = ["probe", "probe-desc"];
+  const DESCS: [&str; 3] = ["probe", "probe-desc", "123"];
 
   let (mut unparseable, mut parsed) = (None::<String>, 0usize);
   let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -192,41 +192,61 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// parser from the pattern and replaces this body without moving either
 /// call site.
 pub fn branch_pattern_warning(pattern: &str) -> Option<String> {
-  // Probe values chosen to exercise every segment's charset: a real branch
-  // type, a multi-digit issue, and a desc that already contains the `-`
-  // that `DESC_RE` allows (so a greedy-adjacency bug shows up here).
-  const TYPE: &str = "feat";
-  const ISSUE: &str = "42";
-  const DESC: &str = "probe-desc";
+  // Two probes, no value shared between them. One is not enough: a pattern
+  // that hardcodes a segment — `feat/#{issue}-{desc}` — round-trips
+  // perfectly against a probe that happens to use `feat`, while
+  // `gwm create fix …` writes a `feat/` branch and reads back the wrong
+  // type. Distinct values on every segment collapse that false negative.
+  // Each desc carries the `-` that `DESC_RE` allows, so a greedy-adjacency
+  // split shows up here rather than in the user's branch names.
+  const PROBES: [(&str, &str, &str); 2] = [("feat", "42", "probe-desc"), ("chore", "7", "other-slug")];
 
-  // A pattern that does not expand at all is a different, *loud* failure:
-  // `gwm create` errors on it outright. Not this warning's business.
-  let formatted = expand_placeholders(pattern, "repo", Some(TYPE), Some(ISSUE), Some(DESC), None).ok()?;
+  let mut unparseable: Option<String> = None;
+  let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);
 
-  let Some(back) = parse_branch(&formatted) else {
+  for (type_, issue, desc) in PROBES {
+    // A pattern that does not expand at all is a different, *loud* failure:
+    // `gwm create` errors on it outright. Not this warning's business.
+    let formatted = expand_placeholders(pattern, "repo", Some(type_), Some(issue), Some(desc), None).ok()?;
+    match parse_branch(&formatted) {
+      None => unparseable.get_or_insert(formatted),
+      Some(back) => {
+        bad_type |= back.type_ != type_;
+        bad_issue |= back.issue != issue;
+        bad_desc |= back.desc != desc;
+        continue;
+      }
+    };
+  }
+
+  if let Some(formatted) = unparseable {
     return Some(format!(
-      "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji and the branch-convention check will be inactive on branches created with this pattern",
+      "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check will be inactive on branches created with this pattern",
       pattern, formatted
     ));
-  };
+  }
 
+  // Every segment feeds `HookContext::for_worktree` (hook placeholders) and
+  // the TUI rename, on top of its own headline consumer — naming only the
+  // headline would under-report exactly what this warning promises to name.
   let mut broken: Vec<&str> = Vec::new();
-  if back.type_ != TYPE {
-    broken.push("`type`, so gitmoji selection reads the wrong branch type");
+  if bad_type {
+    broken
+      .push("`type`, so gitmoji selection, lifecycle hook placeholders and the TUI rename read the wrong branch type");
   }
-  if back.issue != ISSUE {
-    broken.push("`issue`, so issue/PR auto-linking targets the wrong issue");
+  if bad_issue {
+    broken
+      .push("`issue`, so issue/PR auto-linking, lifecycle hook placeholders and the TUI rename target the wrong issue");
   }
-  if back.desc != DESC {
+  if bad_desc {
     broken.push("`desc`, so lifecycle hook placeholders and the TUI rename see the wrong description");
   }
   if broken.is_empty() {
     return None;
   }
   Some(format!(
-    "worktree.branch_pattern `{}` does not round-trip: gwm writes `{}` and reads back {}",
+    "worktree.branch_pattern `{}` does not round-trip: gwm reads back {}",
     pattern,
-    formatted,
     broken.join("; ")
   ))
 }

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -195,39 +195,91 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// placeholder: `{repo}` is a supported token, and a name carrying a `-`
 /// (`gwm-cli`) is rejected by `BRANCH_RE`'s `[a-z]+` type charset while a
 /// dummy `repo` sails through. The verdict is genuinely repo-dependent.
-pub fn branch_pattern_warning(pattern: &str, repo: &str) -> Option<String> {
-  // Two probes, no value shared between them. One is not enough: a pattern
-  // that hardcodes a segment — `feat/#{issue}-{desc}` — round-trips
-  // perfectly against a probe that happens to use `feat`, while
-  // `gwm create fix …` writes a `feat/` branch and reads back the wrong
-  // type. Distinct values on every segment collapse that false negative.
-  // Each desc carries the `-` that `DESC_RE` allows, so a greedy-adjacency
-  // split shows up here rather than in the user's branch names.
-  const PROBES: [(&str, &str, &str); 2] = [("feat", "42", "probe-desc"), ("chore", "7", "other-slug")];
+/// `types` must be the repo's [`crate::config::Config::resolved_branch_types`]
+/// for the same reason: a type gwm would refuse to create must not produce a
+/// warning about branches that cannot exist.
+///
+/// **Invariant.** Round-trip is value-dependent, so a probe at a handful of
+/// arbitrary values proves nothing either way. The probe space here is the
+/// value space `BranchSpec::validate_against` actually admits, enumerated by
+/// construction rather than sampled:
+///
+/// - `type` — every configured branch type. Finite, so this is exhaustive.
+/// - `issue` — `ISSUE_RE` is `\d+`: one single-digit, one multi-digit, the
+///   only distinction `BRANCH_RE`'s `\d+` can split on.
+/// - `desc` — `DESC_RE` is `[a-z0-9][a-z0-9-]*`: one with the `-` it allows,
+///   one without. The dash is the only character that makes a desc collide
+///   with a literal separator in the pattern.
+///
+/// A pattern that round-trips over all of it is the strongest claim this
+/// check can make without deriving the parser from the pattern (#417), and
+/// a pattern that breaks on part of it is reported as breaking on *part* —
+/// never generalised to every branch.
+pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -> Option<String> {
+  const ISSUES: [&str; 2] = ["7", "42"];
+  const DESCS: [&str; 2] = ["probe", "probe-desc"];
 
-  let mut unparseable: Option<String> = None;
+  let (mut unparseable, mut parsed) = (None::<String>, 0usize);
   let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);
+  let mut probes = 0usize;
 
-  for (type_, issue, desc) in PROBES {
-    // A pattern that does not expand at all is a different, *loud* failure:
-    // `gwm create` errors on it outright. Not this warning's business.
-    let formatted = expand_placeholders(pattern, repo, Some(type_), Some(issue), Some(desc), None).ok()?;
-    match parse_branch(&formatted) {
-      None => unparseable.get_or_insert(formatted),
-      Some(back) => {
-        bad_type |= back.type_ != type_;
-        bad_issue |= back.issue != issue;
-        bad_desc |= back.desc != desc;
-        continue;
+  for type_ in types.iter().map(|t| t.name.as_str()) {
+    for issue in ISSUES {
+      for desc in DESCS {
+        // A pattern that does not expand at all is a different, *loud*
+        // failure: `gwm create` errors on it outright. Not our business.
+        let formatted = expand_placeholders(pattern, repo, Some(type_), Some(issue), Some(desc), None).ok()?;
+        probes += 1;
+        match parse_branch(&formatted) {
+          None => {
+            unparseable.get_or_insert(formatted);
+          }
+          Some(back) => {
+            parsed += 1;
+            bad_type |= back.type_ != type_;
+            bad_issue |= back.issue != issue;
+            bad_desc |= back.desc != desc;
+          }
+        }
       }
-    };
+    }
+  }
+
+  // No configured types at all would leave the verdict unprobed — say
+  // nothing rather than guess. `resolved_branch_types` never yields this
+  // (it falls back to the built-ins), so it is a guard, not a path.
+  if probes == 0 {
+    return None;
   }
 
   if let Some(formatted) = unparseable {
-    return Some(format!(
-      "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check will be inactive on branches created with this pattern",
+    if parsed == 0 {
+      return Some(format!(
+        "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check will be inactive on branches created with this pattern",
+        pattern, formatted
+      ));
+    }
+    // Some values parse and some do not — say exactly that. Claiming the
+    // whole pattern is unreadable would be as wrong as claiming it is fine.
+    let mut msg = format!(
+      "worktree.branch_pattern `{}` round-trips only for some values: `{}` matches nothing, so issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on the branches that come out like it",
       pattern, formatted
-    ));
+    );
+    if bad_type || bad_issue || bad_desc {
+      msg.push_str("; and on the ones that do parse, gwm reads back the wrong ");
+      msg.push_str(
+        &[
+          bad_type.then_some("`type`"),
+          bad_issue.then_some("`issue`"),
+          bad_desc.then_some("`desc`"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" / "),
+      );
+    }
+    return Some(msg);
   }
 
   // Every segment feeds `HookContext::for_worktree` (hook placeholders) and

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -287,37 +287,57 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   let mut parts: Vec<String> = Vec::new();
   if let Some(example) = unparseable {
     parts.push(format!(
-      "{} match nothing at all (e.g. `{}`), so issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on those",
-      unparsed, example
+      "{} match nothing at all (e.g. `{}`), so issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and placeholders, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on those (PR/MR detection is unaffected — it queries the forge with the full branch name)",
+      unparsed,
+      sanitise_for_terminal(&example)
     ));
   }
   if lossy > 0 {
-    // Every segment feeds `HookContext::for_worktree` (hook placeholders) and
-    // the TUI rename, on top of its own headline consumer — naming only the
-    // headline would under-report exactly what this warning promises to name.
+    // Every segment feeds `HookContext::for_worktree` (hook placeholders),
+    // the TUI rename and `cmd_pr`'s template context, on top of its own
+    // headline consumer — naming only the headline would under-report
+    // exactly what this warning promises to name. `issue` is specifically
+    // *issue* linking: PR/MR detection goes through
+    // `Forge::find_pr_for_branch`, which takes the whole branch name and
+    // never parses it, so it keeps working whatever the pattern.
     let mut broken: Vec<&str> = Vec::new();
     if bad_type {
       broken.push(
-        "`type`, so gitmoji selection, lifecycle hook placeholders and the TUI rename read the wrong branch type",
+        "`type`, so gitmoji / `gwm commit-prefix`, `[pr_template.by_type]` selection, lifecycle hook placeholders and the TUI rename read the wrong branch type",
       );
     }
     if bad_issue {
       broken.push(
-        "`issue`, so issue/PR auto-linking, lifecycle hook placeholders and the TUI rename target the wrong issue",
+        "`issue`, so issue auto-linking from the branch name, `gwm pr` body placeholders, lifecycle hook placeholders and the TUI rename target the wrong issue",
       );
     }
     if bad_desc {
-      broken.push("`desc`, so lifecycle hook placeholders and the TUI rename see the wrong description");
+      broken.push(
+        "`desc`, so `gwm pr` body placeholders, lifecycle hook placeholders and the TUI rename see the wrong description",
+      );
     }
     parts.push(format!("{} parse but read back {}", lossy, broken.join("; ")));
   }
 
   Some(format!(
     "worktree.branch_pattern `{}` does not round-trip: of the {} branch shapes probed, {}",
-    pattern,
+    sanitise_for_terminal(pattern),
     probes,
     parts.join("; and ")
   ))
+}
+
+/// Neutralise control characters before echoing a config-supplied value.
+///
+/// `branch_pattern` comes from a repo's `.gwm.toml`, and neither `gwm doctor`
+/// nor `gwm config validate` goes through the TOFU trust gate — running
+/// either inside a repo you have not vetted is meant to be safe. Echoing the
+/// raw value would hand an untrusted `.gwm.toml` a terminal escape channel
+/// (an OSC 52 clipboard write, a title rewrite, cursor games). Same idiom as
+/// [`crate::tui::wt_tree::sanitize_name`]: replace, don't strip, so the value
+/// stays recognisable and its length is not silently altered.
+fn sanitise_for_terminal(s: &str) -> String {
+  s.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
 }
 
 pub fn kebab(input: &str) -> String {

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -226,7 +226,19 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);
   let mut probes = 0usize;
 
-  for type_ in types.iter().map(|t| t.name.as_str()) {
+  // Probe only types `gwm create` would actually accept. `merge_layered`
+  // deserialises `[[branch_types]]` without running `validate_branch_types`,
+  // so the effective list can carry a name like `Feat` that the config
+  // validator rejects outright — probing it would report the *default*
+  // pattern as broken, because `BRANCH_RE`'s `[a-z]+` cannot match it. The
+  // invalid config is reported by its own check; this one stays quiet
+  // rather than blaming the pattern for it.
+  let usable = types
+    .iter()
+    .map(|t| t.name.as_str())
+    .filter(|n| !n.is_empty() && n.chars().all(|c| c.is_ascii_lowercase()));
+
+  for type_ in usable {
     for issue in ISSUES {
       for desc in DESCS {
         // A pattern that does not expand at all is a different, *loud*

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -199,28 +199,28 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// for the same reason: a type gwm would refuse to create must not produce a
 /// warning about branches that cannot exist.
 ///
-/// **Invariant.** Round-trip is value-dependent, so a probe at a handful of
-/// arbitrary values proves nothing either way. The probe space here is the
-/// value space `BranchSpec::validate_against` actually admits, enumerated by
-/// construction rather than sampled:
+/// **Invariant: this function reports what it observed, and never
+/// generalises.** Whether a pattern round-trips depends on the values put
+/// through it, and which values matter depends on the pattern — the
+/// separator ambiguity of `{desc}-{issue}` is not the ambiguity of
+/// `{issue}{desc}`. That space cannot be closed by any fixed value set, only
+/// by deriving the parser from the pattern (#417). So the probe set is
+/// deliberately described as *classes worth probing*, not as exhaustive, and
+/// every message is phrased over "the N branch shapes probed". A class this
+/// set happens to miss can only make the counts smaller — it can never make
+/// the statement false.
 ///
-/// - `type` — every configured branch type. Finite, so this is exhaustive.
-/// - `issue` — `ISSUE_RE` is `\d+`: one single-digit, one multi-digit, the
-///   only distinction `BRANCH_RE`'s `\d+` can split on.
-/// - `desc` — `DESC_RE` is `[a-z0-9][a-z0-9-]*`: one with the `-` it allows,
-///   one without, and one all-digits. The dash is the only character that
-///   makes a desc collide with a literal separator; the digits-only case is
-///   the only one that can be swallowed by `BRANCH_RE`'s `\d+` issue group
-///   (`{type}/#{desc}-{issue}` parses for `desc = "123"` and for nothing
-///   else, which is a partial round-trip, not a total loss).
-///
-/// A pattern that round-trips over all of it is the strongest claim this
-/// check can make without deriving the parser from the pattern (#417), and
-/// a pattern that breaks on part of it is reported as breaking on *part* —
-/// never generalised to every branch.
+/// - `type` — every configured branch type. Finite, so this one *is*
+///   exhaustive, and a type gwm would refuse to create is excluded.
+/// - `issue` — `ISSUE_RE` is `\d+`: single-digit and multi-digit.
+/// - `desc` — `DESC_RE` is `[a-z0-9][a-z0-9-]*`: a plain word, one carrying
+///   the `-` it allows, one all-digits, and one that starts with digits and
+///   then carries a `-`. The dash collides with a literal separator; leading
+///   digits get swallowed by `BRANCH_RE`'s `\d+` issue group
+///   (`{type}/#{issue}{desc}` parses only for a desc starting with digits).
 pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -> Option<String> {
   const ISSUES: [&str; 2] = ["7", "42"];
-  const DESCS: [&str; 3] = ["probe", "probe-desc", "123"];
+  const DESCS: [&str; 4] = ["probe", "probe-desc", "123", "123-probe"];
 
   let (mut unparseable, mut parsed, mut lossy) = (None::<String>, 0usize, 0usize);
   let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);
@@ -264,82 +264,48 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
     return None;
   }
 
-  if let Some(formatted) = unparseable {
-    if parsed == 0 {
-      return Some(format!(
-        "worktree.branch_pattern `{}` produces branch names gwm cannot parse back (`{}` matches nothing); issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check will be inactive on branches created with this pattern",
-        pattern, formatted
-      ));
-    }
-    // Some values parse and some do not — say exactly that. Claiming the
-    // whole pattern is unreadable would be as wrong as claiming it is fine.
-    let mut msg = format!(
-      "worktree.branch_pattern `{}` round-trips only for some values: `{}` matches nothing, so issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on the branches that come out like it",
-      pattern, formatted
-    );
-    if lossy > 0 {
-      msg.push_str(&format!(
-        "; and on {} of the {} that do parse, gwm reads back the wrong {}",
-        lossy,
-        parsed,
-        segment_list(bad_type, bad_issue, bad_desc)
-      ));
-    }
-    return Some(msg);
-  }
-
-  // Every segment feeds `HookContext::for_worktree` (hook placeholders) and
-  // the TUI rename, on top of its own headline consumer — naming only the
-  // headline would under-report exactly what this warning promises to name.
-  let mut broken: Vec<&str> = Vec::new();
-  if bad_type {
-    broken
-      .push("`type`, so gitmoji selection, lifecycle hook placeholders and the TUI rename read the wrong branch type");
-  }
-  if bad_issue {
-    broken
-      .push("`issue`, so issue/PR auto-linking, lifecycle hook placeholders and the TUI rename target the wrong issue");
-  }
-  if bad_desc {
-    broken.push("`desc`, so lifecycle hook placeholders and the TUI rename see the wrong description");
-  }
-  if broken.is_empty() {
+  let unparsed = probes - parsed;
+  if unparsed == 0 && lossy == 0 {
     return None;
   }
-  // Scope to the probes that actually lost something. `lossy == probes` is
-  // the universal case and reads as one; anything less is quantified, never
-  // generalised to every branch the pattern can produce.
-  Some(if lossy == probes {
-    format!(
-      "worktree.branch_pattern `{}` does not round-trip: gwm reads back {}",
-      pattern,
-      broken.join("; ")
-    )
-  } else {
-    format!(
-      "worktree.branch_pattern `{}` does not round-trip for every branch it can produce: on {} of the {} branch shapes probed, gwm reads back {}",
-      pattern,
-      lossy,
-      probes,
-      broken.join("; ")
-    )
-  })
-}
 
-/// Render the set of segments that came back wrong somewhere, for the
-/// count-scoped clause. Kept separate from the prose list above because the
-/// mixed verdict names segments without repeating each one's consumers —
-/// the sentence already carries them.
-fn segment_list(bad_type: bool, bad_issue: bool, bad_desc: bool) -> String {
-  [
-    bad_type.then_some("`type`"),
-    bad_issue.then_some("`issue`"),
-    bad_desc.then_some("`desc`"),
-  ]
-  .into_iter()
-  .flatten()
-  .collect::<Vec<_>>()
-  .join(" / ")
+  // One message shape, always a count over the probed shapes. There is no
+  // branch that says "every branch created with this pattern", because that
+  // is precisely the claim the probe set cannot support.
+  let mut parts: Vec<String> = Vec::new();
+  if let Some(example) = unparseable {
+    parts.push(format!(
+      "{} match nothing at all (e.g. `{}`), so issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on those",
+      unparsed, example
+    ));
+  }
+  if lossy > 0 {
+    // Every segment feeds `HookContext::for_worktree` (hook placeholders) and
+    // the TUI rename, on top of its own headline consumer — naming only the
+    // headline would under-report exactly what this warning promises to name.
+    let mut broken: Vec<&str> = Vec::new();
+    if bad_type {
+      broken.push(
+        "`type`, so gitmoji selection, lifecycle hook placeholders and the TUI rename read the wrong branch type",
+      );
+    }
+    if bad_issue {
+      broken.push(
+        "`issue`, so issue/PR auto-linking, lifecycle hook placeholders and the TUI rename target the wrong issue",
+      );
+    }
+    if bad_desc {
+      broken.push("`desc`, so lifecycle hook placeholders and the TUI rename see the wrong description");
+    }
+    parts.push(format!("{} parse but read back {}", lossy, broken.join("; ")));
+  }
+
+  Some(format!(
+    "worktree.branch_pattern `{}` does not round-trip: of the {} branch shapes probed, {}",
+    pattern,
+    probes,
+    parts.join("; and ")
+  ))
 }
 
 pub fn kebab(input: &str) -> String {

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -287,33 +287,40 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   let mut parts: Vec<String> = Vec::new();
   if let Some(example) = unparseable {
     parts.push(format!(
-      "{} match nothing at all (e.g. `{}`), so issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and placeholders, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on those (PR/MR detection is unaffected — it queries the forge with the full branch name)",
+      "{} match nothing at all (e.g. `{}`), so issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and placeholders, remove/bootstrap hook placeholders, the TUI rename and the branch-convention check are inactive on those (PR/MR detection is unaffected — it queries the forge with the full branch name)",
       unparsed,
       sanitise_for_terminal(&example)
     ));
   }
   if lossy > 0 {
-    // Every segment feeds `HookContext::for_worktree` (hook placeholders),
-    // the TUI rename and `cmd_pr`'s template context, on top of its own
-    // headline consumer — naming only the headline would under-report
-    // exactly what this warning promises to name. `issue` is specifically
-    // *issue* linking: PR/MR detection goes through
-    // `Forge::find_pr_for_branch`, which takes the whole branch name and
-    // never parses it, so it keeps working whatever the pattern.
+    // Every segment feeds the TUI rename and `cmd_pr`'s template context on
+    // top of its own headline consumer — naming only the headline would
+    // under-report exactly what this warning promises to name. Two
+    // boundaries keep the claim honest:
+    //
+    // - `issue` is specifically *issue* linking. PR/MR detection goes through
+    //   `Forge::find_pr_for_branch`, which takes the whole branch name and
+    //   never parses it, so it keeps working whatever the pattern.
+    // - hook placeholders break on the **remove / bootstrap** paths only.
+    //   Those rebuild the context with `HookContext::for_worktree`, which
+    //   re-parses the branch. `gwm create` uses `HookContext::for_create` and
+    //   passes the original `BranchSpec` straight through, so its own hooks
+    //   keep the right `type` / `issue` / `desc` however unreadable the
+    //   pattern is.
     let mut broken: Vec<&str> = Vec::new();
     if bad_type {
       broken.push(
-        "`type`, so gitmoji / `gwm commit-prefix`, `[pr_template.by_type]` selection, lifecycle hook placeholders and the TUI rename read the wrong branch type",
+        "`type`, so gitmoji / `gwm commit-prefix`, `[pr_template.by_type]` selection, remove/bootstrap hook placeholders and the TUI rename read the wrong branch type",
       );
     }
     if bad_issue {
       broken.push(
-        "`issue`, so issue auto-linking from the branch name, `gwm pr` body placeholders, lifecycle hook placeholders and the TUI rename target the wrong issue",
+        "`issue`, so issue auto-linking from the branch name, `gwm pr` body placeholders, remove/bootstrap hook placeholders and the TUI rename target the wrong issue",
       );
     }
     if bad_desc {
       broken.push(
-        "`desc`, so `gwm pr` body placeholders, lifecycle hook placeholders and the TUI rename see the wrong description",
+        "`desc`, so `gwm pr` body placeholders, remove/bootstrap hook placeholders and the TUI rename see the wrong description",
       );
     }
     parts.push(format!("{} parse but read back {}", lossy, broken.join("; ")));

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -191,7 +191,11 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
 /// `gwm doctor` and `gwm config validate` consume; issue #417 derives the
 /// parser from the pattern and replaces this body without moving either
 /// call site.
-pub fn branch_pattern_warning(pattern: &str) -> Option<String> {
+/// `repo` must be the real repo name ([`crate::worktree::repo_name`]), not a
+/// placeholder: `{repo}` is a supported token, and a name carrying a `-`
+/// (`gwm-cli`) is rejected by `BRANCH_RE`'s `[a-z]+` type charset while a
+/// dummy `repo` sails through. The verdict is genuinely repo-dependent.
+pub fn branch_pattern_warning(pattern: &str, repo: &str) -> Option<String> {
   // Two probes, no value shared between them. One is not enough: a pattern
   // that hardcodes a segment — `feat/#{issue}-{desc}` — round-trips
   // perfectly against a probe that happens to use `feat`, while
@@ -207,7 +211,7 @@ pub fn branch_pattern_warning(pattern: &str) -> Option<String> {
   for (type_, issue, desc) in PROBES {
     // A pattern that does not expand at all is a different, *loud* failure:
     // `gwm create` errors on it outright. Not this warning's business.
-    let formatted = expand_placeholders(pattern, "repo", Some(type_), Some(issue), Some(desc), None).ok()?;
+    let formatted = expand_placeholders(pattern, repo, Some(type_), Some(issue), Some(desc), None).ok()?;
     match parse_branch(&formatted) {
       None => unparseable.get_or_insert(formatted),
       Some(back) => {

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -171,6 +171,29 @@ pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
   })
 }
 
+/// Issue #415 — `worktree.branch_pattern` drives [`BranchSpec::branch_name`]
+/// (formatting) but not [`parse_branch`], which matches the hardcoded
+/// `BRANCH_RE`. A pattern that differs from the default therefore writes
+/// branch names the parser cannot read back, and every feature keyed on the
+/// re-parsed segments — issue/PR auto-linking, gitmoji selection, the
+/// `doctor` branch-convention check, lifecycle placeholders — silently
+/// becomes a no-op.
+///
+/// Returns the user-facing warning when the pattern diverges, `None` when
+/// the parser follows it. This is the single predicate both `gwm doctor`
+/// and `gwm config validate` consume; issue #417 derives the parser from
+/// the pattern and replaces this body without moving either call site.
+pub fn branch_pattern_warning(pattern: &str) -> Option<String> {
+  let default = crate::config::default_branch_pattern();
+  if pattern == default {
+    return None;
+  }
+  Some(format!(
+    "worktree.branch_pattern `{}` differs from the default `{}`; structured parsing does not follow it, so issue/PR auto-linking, gitmoji and the branch-convention check will be inactive on branches created with this pattern",
+    pattern, default
+  ))
+}
+
 pub fn kebab(input: &str) -> String {
   // Lowercase, then collapse every non-alphanumeric run into a single `-`.
   let lower = input.to_lowercase();

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -222,7 +222,7 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   const ISSUES: [&str; 2] = ["7", "42"];
   const DESCS: [&str; 3] = ["probe", "probe-desc", "123"];
 
-  let (mut unparseable, mut parsed) = (None::<String>, 0usize);
+  let (mut unparseable, mut parsed, mut lossy) = (None::<String>, 0usize, 0usize);
   let (mut bad_type, mut bad_issue, mut bad_desc) = (false, false, false);
   let mut probes = 0usize;
 
@@ -239,9 +239,18 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
           }
           Some(back) => {
             parsed += 1;
-            bad_type |= back.type_ != type_;
-            bad_issue |= back.issue != issue;
-            bad_desc |= back.desc != desc;
+            let (t, i, d) = (back.type_ != type_, back.issue != issue, back.desc != desc);
+            // `lossy` counts probes, the flags accumulate across them. The
+            // distinction matters: the flags say *which* segments can come
+            // back wrong somewhere, `lossy` says *how many* shapes they came
+            // back wrong on. Reporting the flags as if they held for every
+            // parsed probe is the over-claim this counter exists to stop —
+            // `{desc}/#{issue}-{type}` has probes that round-trip perfectly
+            // alongside probes that swap two segments.
+            lossy += usize::from(t || i || d);
+            bad_type |= t;
+            bad_issue |= i;
+            bad_desc |= d;
           }
         }
       }
@@ -268,19 +277,13 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
       "worktree.branch_pattern `{}` round-trips only for some values: `{}` matches nothing, so issue/PR auto-linking, gitmoji, lifecycle hook placeholders, the TUI rename and the branch-convention check are inactive on the branches that come out like it",
       pattern, formatted
     );
-    if bad_type || bad_issue || bad_desc {
-      msg.push_str("; and on the ones that do parse, gwm reads back the wrong ");
-      msg.push_str(
-        &[
-          bad_type.then_some("`type`"),
-          bad_issue.then_some("`issue`"),
-          bad_desc.then_some("`desc`"),
-        ]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join(" / "),
-      );
+    if lossy > 0 {
+      msg.push_str(&format!(
+        "; and on {} of the {} that do parse, gwm reads back the wrong {}",
+        lossy,
+        parsed,
+        segment_list(bad_type, bad_issue, bad_desc)
+      ));
     }
     return Some(msg);
   }
@@ -303,11 +306,40 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   if broken.is_empty() {
     return None;
   }
-  Some(format!(
-    "worktree.branch_pattern `{}` does not round-trip: gwm reads back {}",
-    pattern,
-    broken.join("; ")
-  ))
+  // Scope to the probes that actually lost something. `lossy == probes` is
+  // the universal case and reads as one; anything less is quantified, never
+  // generalised to every branch the pattern can produce.
+  Some(if lossy == probes {
+    format!(
+      "worktree.branch_pattern `{}` does not round-trip: gwm reads back {}",
+      pattern,
+      broken.join("; ")
+    )
+  } else {
+    format!(
+      "worktree.branch_pattern `{}` does not round-trip for every branch it can produce: on {} of the {} branch shapes probed, gwm reads back {}",
+      pattern,
+      lossy,
+      probes,
+      broken.join("; ")
+    )
+  })
+}
+
+/// Render the set of segments that came back wrong somewhere, for the
+/// count-scoped clause. Kept separate from the prose list above because the
+/// mixed verdict names segments without repeating each one's consumers —
+/// the sentence already carries them.
+fn segment_list(bad_type: bool, bad_issue: bool, bad_desc: bool) -> String {
+  [
+    bad_type.then_some("`type`"),
+    bad_issue.then_some("`issue`"),
+    bad_desc.then_some("`desc`"),
+  ]
+  .into_iter()
+  .flatten()
+  .collect::<Vec<_>>()
+  .join(" / ")
 }
 
 pub fn kebab(input: &str) -> String {

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -493,6 +493,11 @@ branch_pattern = "{type}-{issue}-{desc}"
     .unwrap()
     .current_dir(dir.path())
     .env("XDG_CONFIG_HOME", xdg.path())
+    // CI sets `GWM_NO_GLOBAL_CONFIG=1` workflow-wide (ci.yml) so the suite
+    // ignores the runner's own config. This test is *about* the global
+    // layer, so it has to opt back in explicitly — inheriting the flag made
+    // it pass locally and fail on all three runners.
+    .env_remove("GWM_NO_GLOBAL_CONFIG")
     .args(["config", "validate"])
     .assert()
     .success()

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -419,3 +419,49 @@ fn write_windows_editor_script(root: &Path) -> std::path::PathBuf {
   .unwrap();
   script
 }
+
+/// Issue #415: `gwm config validate` still exits 0 for a customised
+/// `worktree.branch_pattern` — it is a valid config — but it says on stderr
+/// that structured parsing will not follow it.
+#[test]
+fn config_validate_warns_when_branch_pattern_is_customised() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[worktree]
+branch_pattern = "{type}-{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .success()
+    .stderr(predicate::str::contains("branch_pattern"))
+    .stderr(predicate::str::contains("auto-linking"));
+}
+
+#[test]
+fn config_validate_is_quiet_for_the_default_branch_pattern() {
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    r#"
+[worktree]
+branch_pattern = "{type}/#{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .args(["config", "validate"])
+    .assert()
+    .success()
+    .stderr(predicate::str::contains("branch_pattern").not());
+}

--- a/tests/config_cli_tests.rs
+++ b/tests/config_cli_tests.rs
@@ -460,8 +460,42 @@ branch_pattern = "{type}/#{issue}-{desc}"
   Command::cargo_bin("gwm")
     .unwrap()
     .current_dir(dir.path())
+    // The warning reads the *effective* (repo over global) pattern, so a
+    // runner whose own `~/.config/gwm/config.toml` customises it would
+    // flip this assertion. Pin repo-only loading.
+    .env("GWM_NO_GLOBAL_CONFIG", "1")
     .args(["config", "validate"])
     .assert()
     .success()
     .stderr(predicate::str::contains("branch_pattern").not());
+}
+
+/// Issue #415 (Codex review): `branch_pattern` set only in the user-level
+/// global config still applies at runtime through `Config::merge_layered`,
+/// so `gwm config validate` has to warn on the *effective* pattern, not
+/// just on what the repo file happens to carry.
+#[test]
+fn config_validate_warns_for_a_globally_set_branch_pattern() {
+  let (dir, _repo) = init_repo();
+  let xdg = tempfile::tempdir().unwrap();
+  let gwm_dir = xdg.path().join("gwm");
+  fs::create_dir_all(&gwm_dir).unwrap();
+  fs::write(
+    gwm_dir.join("config.toml"),
+    r#"
+[worktree]
+branch_pattern = "{type}-{issue}-{desc}"
+"#,
+  )
+  .unwrap();
+  // No repo-level `.gwm.toml` at all: the global layer is the only source.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("XDG_CONFIG_HOME", xdg.path())
+    .args(["config", "validate"])
+    .assert()
+    .success()
+    .stderr(predicate::str::contains("branch_pattern"))
+    .stderr(predicate::str::contains("auto-linking"));
 }

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -1226,3 +1226,48 @@ fn the_forge_cli_probe_honours_the_gwm_gh_override() {
     c.detail
   );
 }
+
+/// Issue #415: `worktree.branch_pattern` drives the formatter but not the
+/// parser, so customising it silently disables every feature that re-parses
+/// a branch name. Until the parser is derived from the pattern (#417),
+/// `gwm doctor` states the limitation instead of leaving it silent.
+#[test]
+fn custom_branch_pattern_warns_that_the_parser_ignores_it() {
+  let (dir, repo) = init_repo();
+  let mut config = Config::default();
+  config.worktree.branch_pattern = "{type}-{issue}-{desc}".into();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+
+  let check = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("branch_pattern"))
+    .expect("expected a `branch_pattern` check in the report");
+
+  assert_eq!(check.status, CheckStatus::Warning);
+  // The message has to name the consequence, not just the divergence —
+  // the whole point is connecting cause to effect.
+  for expected in ["auto-linking", "gitmoji", "branch-convention"] {
+    assert!(
+      check.detail.contains(expected),
+      "warning should name the '{}' consequence, got: {}",
+      expected,
+      check.detail
+    );
+  }
+}
+
+#[test]
+fn default_branch_pattern_does_not_warn() {
+  let (dir, repo) = init_repo();
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+
+  let check = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("branch_pattern"))
+    .expect("expected a `branch_pattern` check in the report");
+
+  assert_eq!(check.status, CheckStatus::Ok);
+}

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -1234,8 +1234,12 @@ fn the_forge_cli_probe_honours_the_gwm_gh_override() {
 #[test]
 fn custom_branch_pattern_warns_that_the_parser_ignores_it() {
   let (dir, repo) = init_repo();
-  let mut config = Config::default();
-  config.worktree.branch_pattern = "{type}-{issue}-{desc}".into();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[worktree]\nbranch_pattern = \"{type}-{issue}-{desc}\"\n",
+  )
+  .unwrap();
+  let config = Config::default();
   let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
 
   let check = report
@@ -1270,4 +1274,31 @@ fn default_branch_pattern_does_not_warn() {
     .expect("expected a `branch_pattern` check in the report");
 
   assert_eq!(check.status, CheckStatus::Ok);
+}
+
+/// Issue #415 (Codex review): `repo_context_lenient` hands `doctor` a
+/// `Config::default()` when the on-disk config fails to load for an
+/// unrelated semantic reason. Reading `ctx.config` would then report the
+/// default pattern as fine while the file on disk carries a broken one —
+/// a false `✓` from the very check that exists to stop silent failures.
+/// Re-derive from disk, as `check_tui_keymap` already does.
+#[test]
+fn branch_pattern_check_reads_the_on_disk_config_not_the_lenient_fallback() {
+  let (dir, repo) = init_repo();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[worktree]\nbranch_pattern = \"{type}-{issue}-{desc}\"\n",
+  )
+  .unwrap();
+  // What `repo_context_lenient` would have handed us after a load failure.
+  let config = Config::default();
+  let report = doctor::run(&ctx_for(&repo, dir.path(), &config)).unwrap();
+
+  let check = report
+    .checks
+    .iter()
+    .find(|c| c.name.contains("branch_pattern"))
+    .expect("expected a `branch_pattern` check in the report");
+
+  assert_eq!(check.status, CheckStatus::Warning);
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -186,12 +186,16 @@ fn worktree_path_resolves_repo_parent_base() {
 
 #[test]
 fn the_default_pattern_round_trips_so_no_warning() {
-  assert_eq!(branch_pattern_warning("{type}/#{issue}-{desc}", "gwm-cli"), None);
+  assert_eq!(
+    branch_pattern_warning("{type}/#{issue}-{desc}", "gwm-cli", &default_branch_types()),
+    None
+  );
 }
 
 #[test]
 fn an_unparseable_pattern_warns_that_everything_is_inactive() {
-  let w = branch_pattern_warning("{type}-{issue}-{desc}", "gwm-cli").expect("an unparseable pattern must warn");
+  let w = branch_pattern_warning("{type}-{issue}-{desc}", "gwm-cli", &default_branch_types())
+    .expect("an unparseable pattern must warn");
   assert!(w.contains("branch_pattern"), "the warning must name the key: {}", w);
   for expected in ["auto-linking", "gitmoji", "branch-convention"] {
     assert!(
@@ -209,7 +213,8 @@ fn an_unparseable_pattern_warns_that_everything_is_inactive() {
 /// Claiming auto-linking and gitmoji are inactive here would be false.
 #[test]
 fn a_pattern_whose_type_and_issue_survive_warns_only_about_desc() {
-  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}", "gwm-cli").expect("a lossy pattern must still warn");
+  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}", "gwm-cli", &default_branch_types())
+    .expect("a lossy pattern must still warn");
   assert!(
     w.contains("desc"),
     "the warning must name the segment that breaks: {}",
@@ -224,7 +229,8 @@ fn a_pattern_whose_type_and_issue_survive_warns_only_about_desc() {
 
 #[test]
 fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
-  let w = branch_pattern_warning("{type}/#1-{desc}", "gwm-cli").expect("a pattern with a frozen issue must warn");
+  let w = branch_pattern_warning("{type}/#1-{desc}", "gwm-cli", &default_branch_types())
+    .expect("a pattern with a frozen issue must warn");
   assert!(
     w.contains("auto-linking"),
     "a pattern that hardcodes the issue breaks auto-linking: {}",
@@ -239,7 +245,8 @@ fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
 /// type. Two probes with distinct values close that false negative.
 #[test]
 fn a_pattern_that_hardcodes_the_type_is_not_a_false_negative() {
-  let w = branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli").expect("a hardcoded type must warn");
+  let w = branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &default_branch_types())
+    .expect("a hardcoded type must warn");
   assert!(
     w.contains("type"),
     "the warning must name `type` as the broken segment: {}",
@@ -249,7 +256,8 @@ fn a_pattern_that_hardcodes_the_type_is_not_a_false_negative() {
 
 #[test]
 fn a_pattern_that_hardcodes_the_desc_is_not_a_false_negative() {
-  let w = branch_pattern_warning("{type}/#{issue}-fixed", "gwm-cli").expect("a hardcoded desc must warn");
+  let w = branch_pattern_warning("{type}/#{issue}-fixed", "gwm-cli", &default_branch_types())
+    .expect("a hardcoded desc must warn");
   assert!(
     w.contains("desc"),
     "the warning must name `desc` as the broken segment: {}",
@@ -261,7 +269,8 @@ fn a_pattern_that_hardcodes_the_desc_is_not_a_false_negative() {
 /// placeholders and the TUI rename, not only gitmoji / auto-linking.
 #[test]
 fn the_warning_names_every_consumer_of_a_broken_segment() {
-  let w = branch_pattern_warning("{type}/#1-{desc}", "gwm-cli").expect("a frozen issue must warn");
+  let w =
+    branch_pattern_warning("{type}/#1-{desc}", "gwm-cli", &default_branch_types()).expect("a frozen issue must warn");
   assert!(w.contains("auto-linking"), "issue feeds auto-linking: {}", w);
   assert!(
     w.contains("hook placeholders") && w.contains("rename"),
@@ -277,7 +286,8 @@ fn the_warning_names_every_consumer_of_a_broken_segment() {
 /// `[a-z]+` does not match a name carrying a dash.
 #[test]
 fn the_probe_expands_repo_with_the_real_repo_name() {
-  let w = branch_pattern_warning("{repo}/#{issue}-{desc}", "gwm-cli").expect("must warn for this repo");
+  let w = branch_pattern_warning("{repo}/#{issue}-{desc}", "gwm-cli", &default_branch_types())
+    .expect("must warn for this repo");
   assert!(
     w.contains("matches nothing"),
     "in a repo whose name has a dash this pattern parses back to nothing: {}",
@@ -286,6 +296,41 @@ fn the_probe_expands_repo_with_the_real_repo_name() {
   assert!(
     w.contains("auto-linking"),
     "so every consumer is inactive, not just type: {}",
+    w
+  );
+}
+
+/// Issue #415 (Codex review): a type gwm would refuse to create must not
+/// produce a warning about branches that cannot exist. With
+/// `[[branch_types]]` narrowed to `feat`, `feat/#{issue}-{desc}` round-trips
+/// for every branch gwm accepts, so there is nothing to warn about.
+#[test]
+fn a_hardcoded_type_is_fine_when_it_is_the_only_configured_type() {
+  let only_feat = vec![BranchType {
+    name: "feat".into(),
+    description: "New feature implementation".into(),
+  }];
+  assert_eq!(
+    branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &only_feat),
+    None
+  );
+  // …and it is still a real problem once a second type can be created.
+  assert!(branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &default_branch_types()).is_some());
+}
+
+/// Issue #415 (Codex review): parsability is value-dependent. With
+/// `{desc}/#{issue}-{type}` a desc carrying a `-` yields
+/// `probe-desc/#42-feat`, which `[a-z]+` rejects, while a plain `probe`
+/// yields `probe/#42-feat`, which parses and keeps the issue. Reporting
+/// "everything is inactive on this pattern" would be false for half the
+/// branches it produces.
+#[test]
+fn a_partially_parseable_pattern_is_not_generalised_to_every_branch() {
+  let w = branch_pattern_warning("{desc}/#{issue}-{type}", "gwm-cli", &default_branch_types())
+    .expect("a lossy pattern must warn");
+  assert!(
+    w.contains("round-trips only for some values"),
+    "the warning must scope itself to the values that break: {}",
     w
   );
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -186,12 +186,12 @@ fn worktree_path_resolves_repo_parent_base() {
 
 #[test]
 fn the_default_pattern_round_trips_so_no_warning() {
-  assert_eq!(branch_pattern_warning("{type}/#{issue}-{desc}"), None);
+  assert_eq!(branch_pattern_warning("{type}/#{issue}-{desc}", "gwm-cli"), None);
 }
 
 #[test]
 fn an_unparseable_pattern_warns_that_everything_is_inactive() {
-  let w = branch_pattern_warning("{type}-{issue}-{desc}").expect("an unparseable pattern must warn");
+  let w = branch_pattern_warning("{type}-{issue}-{desc}", "gwm-cli").expect("an unparseable pattern must warn");
   assert!(w.contains("branch_pattern"), "the warning must name the key: {}", w);
   for expected in ["auto-linking", "gitmoji", "branch-convention"] {
     assert!(
@@ -209,7 +209,7 @@ fn an_unparseable_pattern_warns_that_everything_is_inactive() {
 /// Claiming auto-linking and gitmoji are inactive here would be false.
 #[test]
 fn a_pattern_whose_type_and_issue_survive_warns_only_about_desc() {
-  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}").expect("a lossy pattern must still warn");
+  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}", "gwm-cli").expect("a lossy pattern must still warn");
   assert!(
     w.contains("desc"),
     "the warning must name the segment that breaks: {}",
@@ -224,7 +224,7 @@ fn a_pattern_whose_type_and_issue_survive_warns_only_about_desc() {
 
 #[test]
 fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
-  let w = branch_pattern_warning("{type}/#1-{desc}").expect("a pattern with a frozen issue must warn");
+  let w = branch_pattern_warning("{type}/#1-{desc}", "gwm-cli").expect("a pattern with a frozen issue must warn");
   assert!(
     w.contains("auto-linking"),
     "a pattern that hardcodes the issue breaks auto-linking: {}",
@@ -239,7 +239,7 @@ fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
 /// type. Two probes with distinct values close that false negative.
 #[test]
 fn a_pattern_that_hardcodes_the_type_is_not_a_false_negative() {
-  let w = branch_pattern_warning("feat/#{issue}-{desc}").expect("a hardcoded type must warn");
+  let w = branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli").expect("a hardcoded type must warn");
   assert!(
     w.contains("type"),
     "the warning must name `type` as the broken segment: {}",
@@ -249,7 +249,7 @@ fn a_pattern_that_hardcodes_the_type_is_not_a_false_negative() {
 
 #[test]
 fn a_pattern_that_hardcodes_the_desc_is_not_a_false_negative() {
-  let w = branch_pattern_warning("{type}/#{issue}-fixed").expect("a hardcoded desc must warn");
+  let w = branch_pattern_warning("{type}/#{issue}-fixed", "gwm-cli").expect("a hardcoded desc must warn");
   assert!(
     w.contains("desc"),
     "the warning must name `desc` as the broken segment: {}",
@@ -261,11 +261,31 @@ fn a_pattern_that_hardcodes_the_desc_is_not_a_false_negative() {
 /// placeholders and the TUI rename, not only gitmoji / auto-linking.
 #[test]
 fn the_warning_names_every_consumer_of_a_broken_segment() {
-  let w = branch_pattern_warning("{type}/#1-{desc}").expect("a frozen issue must warn");
+  let w = branch_pattern_warning("{type}/#1-{desc}", "gwm-cli").expect("a frozen issue must warn");
   assert!(w.contains("auto-linking"), "issue feeds auto-linking: {}", w);
   assert!(
     w.contains("hook placeholders") && w.contains("rename"),
     "issue also feeds lifecycle hook placeholders and the TUI rename: {}",
+    w
+  );
+}
+
+/// Issue #415 (Codex review): `{repo}` is a supported placeholder, so the
+/// probe has to expand it with the real repo name. A dummy value makes the
+/// verdict repo-dependent: `{repo}/#{issue}-{desc}` parses fine as `repo/…`
+/// but produces `gwm-cli/#42-…`, which `BRANCH_RE` rejects outright because
+/// `[a-z]+` does not match a name carrying a dash.
+#[test]
+fn the_probe_expands_repo_with_the_real_repo_name() {
+  let w = branch_pattern_warning("{repo}/#{issue}-{desc}", "gwm-cli").expect("must warn for this repo");
+  assert!(
+    w.contains("matches nothing"),
+    "in a repo whose name has a dash this pattern parses back to nothing: {}",
+    w
+  );
+  assert!(
+    w.contains("auto-linking"),
+    "so every consumer is inactive, not just type: {}",
     w
   );
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -536,4 +536,9 @@ fn the_consumer_mapping_matches_the_call_sites() {
     "`gwm pr` parses the branch and must be named as broken: {}",
     w
   );
+  assert!(
+    w.contains("remove/bootstrap hook placeholders") && !w.contains("lifecycle hook placeholders"),
+    "`gwm create` passes the original BranchSpec to its hooks — only remove/bootstrap re-parse: {}",
+    w
+  );
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -334,3 +334,19 @@ fn a_partially_parseable_pattern_is_not_generalised_to_every_branch() {
     w
   );
 }
+
+/// Issue #415 (Codex review): `DESC_RE` accepts an all-digits desc, and it
+/// is the only desc class `BRANCH_RE`'s `\d+` issue group can swallow. With
+/// `{type}/#{desc}-{issue}` a word desc never parses while `123` yields
+/// `feat/#123-42`, which parses with the segments swapped — a partial
+/// round-trip, not a total loss.
+#[test]
+fn a_digits_only_desc_is_probed_so_the_verdict_stays_partial() {
+  let w = branch_pattern_warning("{type}/#{desc}-{issue}", "gwm-cli", &default_branch_types())
+    .expect("a swapped pattern must warn");
+  assert!(
+    w.contains("round-trips only for some values"),
+    "a digits-only desc parses, so the loss is partial, not total: {}",
+    w
+  );
+}

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -453,3 +453,37 @@ fn the_documented_pattern_table_matches_reality() {
     );
   }
 }
+
+/// Issue #415 (Codex review): `Config::merge_layered` deserialises
+/// `[[branch_types]]` without running `validate_branch_types`, so the
+/// effective list can carry a name `gwm create` would refuse. Probing it
+/// would report the *default* pattern as broken — `BRANCH_RE`'s `[a-z]+`
+/// cannot match `Feat` — which blames the pattern for a config error that
+/// has its own diagnostic.
+#[test]
+fn an_unusable_branch_type_never_makes_the_default_pattern_look_broken() {
+  let invalid = vec![
+    BranchType {
+      name: "Feat".into(), // rejected by `validate_branch_types` (^[a-z]+$)
+      description: String::new(),
+    },
+    BranchType {
+      name: "fix".into(),
+      description: String::new(),
+    },
+  ];
+  assert_eq!(
+    branch_pattern_warning("{type}/#{issue}-{desc}", "gwm-cli", &invalid),
+    None
+  );
+
+  // Nothing probeable at all: stay quiet rather than guess.
+  let all_invalid = vec![BranchType {
+    name: "Feat".into(),
+    description: String::new(),
+  }];
+  assert_eq!(
+    branch_pattern_warning("{type}-{issue}-{desc}", "gwm-cli", &all_invalid),
+    None
+  );
+}

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -487,3 +487,53 @@ fn an_unusable_branch_type_never_makes_the_default_pattern_look_broken() {
     None
   );
 }
+
+/// Issue #415 (Codex review, P1): `branch_pattern` is repo-supplied and
+/// neither `gwm doctor` nor `gwm config validate` goes through the TOFU
+/// trust gate, so running either in an unvetted repo must not hand its
+/// `.gwm.toml` a terminal escape channel (OSC 52 clipboard write, title
+/// rewrite). Both the pattern and the formatted example are echoed, so both
+/// have to be neutralised.
+#[test]
+fn control_characters_in_the_pattern_never_reach_the_terminal() {
+  // OSC 52 clipboard-write shape: ESC ] 52 ; c ; <payload> BEL
+  let hostile = "{type}/#{issue}-{desc}\u{1b}]52;c;cHduZWQ=\u{7}";
+  let w = branch_pattern_warning(hostile, "gwm-cli", &default_branch_types())
+    .expect("a pattern carrying control bytes must warn");
+  assert!(
+    !w.chars().any(|c| c.is_control()),
+    "no control character may survive into the message: {:?}",
+    w
+  );
+  // The value stays recognisable — neutralised, not silently dropped.
+  assert!(w.contains("{type}/#{issue}-{desc}"), "got: {}", w);
+
+  // Same for the formatted example, which is built from the pattern.
+  let w = branch_pattern_warning("{type}\u{1b}[2J{issue}", "gwm-cli", &default_branch_types()).expect("must warn");
+  assert!(
+    !w.chars().any(|c| c.is_control()),
+    "the `e.g.` example is echoed too: {:?}",
+    w
+  );
+}
+
+/// Issue #415 (Codex review): PR/MR detection goes through
+/// `Forge::find_pr_for_branch`, which queries the forge with the *whole*
+/// branch name and never parses it — it keeps working whatever the pattern.
+/// `gwm pr` does call `parse_branch`, for `[pr_template.by_type]` and its
+/// body placeholders, and that consumer has to be named.
+#[test]
+fn the_consumer_mapping_matches_the_call_sites() {
+  let w = branch_pattern_warning("{type}-{issue}-{desc}", "gwm-cli", &default_branch_types())
+    .expect("an unparseable pattern must warn");
+  assert!(
+    w.contains("PR/MR detection is unaffected"),
+    "PR detection survives an unreadable pattern — do not claim otherwise: {}",
+    w
+  );
+  assert!(
+    w.contains("`gwm pr` template selection and placeholders"),
+    "`gwm pr` parses the branch and must be named as broken: {}",
+    w
+  );
+}

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -231,3 +231,41 @@ fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
     w
   );
 }
+
+/// A single probe value collides with a pattern that hardcodes that same
+/// value: `feat/#{issue}-{desc}` formats `feat/#42-…` and parses back
+/// `type = "feat"`, which matches a probe that also used `feat`. But
+/// `gwm create fix 42 …` writes a `feat/` branch and reads back the wrong
+/// type. Two probes with distinct values close that false negative.
+#[test]
+fn a_pattern_that_hardcodes_the_type_is_not_a_false_negative() {
+  let w = branch_pattern_warning("feat/#{issue}-{desc}").expect("a hardcoded type must warn");
+  assert!(
+    w.contains("type"),
+    "the warning must name `type` as the broken segment: {}",
+    w
+  );
+}
+
+#[test]
+fn a_pattern_that_hardcodes_the_desc_is_not_a_false_negative() {
+  let w = branch_pattern_warning("{type}/#{issue}-fixed").expect("a hardcoded desc must warn");
+  assert!(
+    w.contains("desc"),
+    "the warning must name `desc` as the broken segment: {}",
+    w
+  );
+}
+
+/// Issue #415 (Codex review): `type` and `issue` also feed lifecycle hook
+/// placeholders and the TUI rename, not only gitmoji / auto-linking.
+#[test]
+fn the_warning_names_every_consumer_of_a_broken_segment() {
+  let w = branch_pattern_warning("{type}/#1-{desc}").expect("a frozen issue must warn");
+  assert!(w.contains("auto-linking"), "issue feeds auto-linking: {}", w);
+  assert!(
+    w.contains("hook placeholders") && w.contains("rename"),
+    "issue also feeds lifecycle hook placeholders and the TUI rename: {}",
+    w
+  );
+}

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -350,3 +350,32 @@ fn a_digits_only_desc_is_probed_so_the_verdict_stays_partial() {
     w
   );
 }
+
+/// Issue #415 (Codex review): the per-segment flags accumulate across probes,
+/// so reporting them as if they held for every parsed branch over-claims.
+/// `feat/#{issue}-{desc}` round-trips for the `feat` probes and loses the
+/// type for every other configured type — the verdict has to be quantified,
+/// not universal.
+#[test]
+fn a_partly_lossy_pattern_quantifies_instead_of_generalising() {
+  let w = branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &default_branch_types())
+    .expect("a hardcoded type must warn");
+  assert!(
+    w.contains("does not round-trip for every branch it can produce") && w.contains(" of the "),
+    "the warning must count the shapes that lose something, not claim all of them do: {}",
+    w
+  );
+}
+
+/// The universal case still reads as one: every probe loses `desc` here, so
+/// there is nothing to quantify.
+#[test]
+fn a_wholly_lossy_pattern_states_it_plainly() {
+  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}", "gwm-cli", &default_branch_types())
+    .expect("a lossy pattern must warn");
+  assert!(
+    !w.contains("of the") && w.contains("does not round-trip: "),
+    "every probe loses `desc`, so no count is needed: {}",
+    w
+  );
+}

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -1,5 +1,5 @@
 use gwm::config::{BranchType, WorktreeConfig};
-use gwm::naming::{default_branch_types, kebab, parse_branch, BranchSpec, BRANCH_TYPES};
+use gwm::naming::{branch_pattern_warning, default_branch_types, kebab, parse_branch, BranchSpec, BRANCH_TYPES};
 
 #[test]
 fn naming_regexes_compile_at_first_use() {
@@ -174,5 +174,60 @@ fn worktree_path_resolves_repo_parent_base() {
   assert_eq!(
     p,
     std::path::Path::new("/Users/me/Projects/Perso/worktrees/feat-175-repo-path")
+  );
+}
+
+// ---------------------------------------------------------------------
+// Issue #415 — `branch_pattern_warning` probes an actual format/parse
+// round-trip rather than comparing the pattern to the default string.
+// A pattern can differ from the default and still be readable, and the
+// warning must not claim otherwise.
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_default_pattern_round_trips_so_no_warning() {
+  assert_eq!(branch_pattern_warning("{type}/#{issue}-{desc}"), None);
+}
+
+#[test]
+fn an_unparseable_pattern_warns_that_everything_is_inactive() {
+  let w = branch_pattern_warning("{type}-{issue}-{desc}").expect("an unparseable pattern must warn");
+  assert!(w.contains("branch_pattern"), "the warning must name the key: {}", w);
+  for expected in ["auto-linking", "gitmoji", "branch-convention"] {
+    assert!(
+      w.contains(expected),
+      "warning should name the '{}' consequence: {}",
+      expected,
+      w
+    );
+  }
+}
+
+/// The finding that killed the string-equality version: this pattern
+/// differs from the default, yet `feat/#42-…` still matches `BRANCH_RE`,
+/// so `type` and `issue` ARE recovered. Only `desc` comes back wrong.
+/// Claiming auto-linking and gitmoji are inactive here would be false.
+#[test]
+fn a_pattern_whose_type_and_issue_survive_warns_only_about_desc() {
+  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}").expect("a lossy pattern must still warn");
+  assert!(
+    w.contains("desc"),
+    "the warning must name the segment that breaks: {}",
+    w
+  );
+  assert!(
+    !w.contains("auto-linking") && !w.contains("gitmoji"),
+    "type and issue are recovered from this pattern — the warning must not claim otherwise: {}",
+    w
+  );
+}
+
+#[test]
+fn a_pattern_that_drops_the_issue_warns_about_auto_linking() {
+  let w = branch_pattern_warning("{type}/#1-{desc}").expect("a pattern with a frozen issue must warn");
+  assert!(
+    w.contains("auto-linking"),
+    "a pattern that hardcodes the issue breaks auto-linking: {}",
+    w
   );
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -289,7 +289,7 @@ fn the_probe_expands_repo_with_the_real_repo_name() {
   let w = branch_pattern_warning("{repo}/#{issue}-{desc}", "gwm-cli", &default_branch_types())
     .expect("must warn for this repo");
   assert!(
-    w.contains("matches nothing"),
+    w.contains("match nothing at all"),
     "in a repo whose name has a dash this pattern parses back to nothing: {}",
     w
   );
@@ -329,8 +329,8 @@ fn a_partially_parseable_pattern_is_not_generalised_to_every_branch() {
   let w = branch_pattern_warning("{desc}/#{issue}-{type}", "gwm-cli", &default_branch_types())
     .expect("a lossy pattern must warn");
   assert!(
-    w.contains("round-trips only for some values"),
-    "the warning must scope itself to the values that break: {}",
+    w.contains("match nothing at all") && w.contains("parse but read back"),
+    "both outcomes occur here, so both must be reported: {}",
     w
   );
 }
@@ -345,8 +345,8 @@ fn a_digits_only_desc_is_probed_so_the_verdict_stays_partial() {
   let w = branch_pattern_warning("{type}/#{desc}-{issue}", "gwm-cli", &default_branch_types())
     .expect("a swapped pattern must warn");
   assert!(
-    w.contains("round-trips only for some values"),
-    "a digits-only desc parses, so the loss is partial, not total: {}",
+    w.contains("match nothing at all") && w.contains("parse but read back"),
+    "a digits-only desc parses, so the verdict carries both counts, not a total loss: {}",
     w
   );
 }
@@ -361,21 +361,95 @@ fn a_partly_lossy_pattern_quantifies_instead_of_generalising() {
   let w = branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &default_branch_types())
     .expect("a hardcoded type must warn");
   assert!(
-    w.contains("does not round-trip for every branch it can produce") && w.contains(" of the "),
-    "the warning must count the shapes that lose something, not claim all of them do: {}",
+    w.contains("of the ") && w.contains("branch shapes probed"),
+    "the warning must count the shapes it probed, not claim all branches lose something: {}",
     w
   );
 }
 
-/// The universal case still reads as one: every probe loses `desc` here, so
-/// there is nothing to quantify.
+/// The verdict is observational in *every* shape. No message may claim
+/// anything about branches outside the probe set: which values matter
+/// depends on the pattern, so that set cannot be closed without deriving
+/// the parser from the pattern (#417). A class the probes miss can only
+/// make the counts smaller — never make the statement false.
 #[test]
-fn a_wholly_lossy_pattern_states_it_plainly() {
-  let w = branch_pattern_warning("{type}/#{issue}-prefix-{desc}", "gwm-cli", &default_branch_types())
-    .expect("a lossy pattern must warn");
-  assert!(
-    !w.contains("of the") && w.contains("does not round-trip: "),
-    "every probe loses `desc`, so no count is needed: {}",
-    w
+fn every_verdict_is_scoped_to_the_shapes_actually_probed() {
+  for pattern in [
+    "{type}-{issue}-{desc}",
+    "{type}/#{issue}-prefix-{desc}",
+    "feat/#{issue}-{desc}",
+    "{desc}/#{issue}-{type}",
+    "{type}/#{issue}{desc}",
+  ] {
+    let w = branch_pattern_warning(pattern, "gwm-cli", &default_branch_types())
+      .unwrap_or_else(|| panic!("`{}` must warn", pattern));
+    assert!(
+      w.contains("of the ") && w.contains("branch shapes probed"),
+      "`{}` produced an unquantified verdict: {}",
+      pattern,
+      w
+    );
+  }
+}
+
+/// Guard for the "which patterns actually work today" table in
+/// `docs/4.configuration/1.gwm-toml.md` (EN + FR). The docs make concrete
+/// promises about specific patterns; this pins them so the table cannot
+/// drift away from the code. Every expectation below was read off the real
+/// `branch_pattern_warning` output, not assumed.
+#[test]
+fn the_documented_pattern_table_matches_reality() {
+  // Round-trips: the default, for any set of configured types.
+  assert_eq!(
+    branch_pattern_warning("{type}/#{issue}-{desc}", "gwm-cli", &default_branch_types()),
+    None
   );
+
+  // Round-trips: a literal type, but only when it is the *only* configured
+  // branch type — `BRANCH_RE` reads the literal back as the type.
+  let only_feat = vec![BranchType {
+    name: "feat".into(),
+    description: "New feature implementation".into(),
+  }];
+  assert_eq!(
+    branch_pattern_warning("feat/#{issue}-{desc}", "gwm-cli", &only_feat),
+    None
+  );
+
+  // Documented as "nothing parses": any change to the `<type>/#<issue>-<desc>`
+  // skeleton the hardcoded parser expects.
+  for pattern in [
+    "{type}/{issue}-{desc}",         // no `#`
+    "{type}-{issue}-{desc}",         // no `/`
+    "{type}/#{issue}_{desc}",        // `_` instead of `-`
+    "{type}/#{issue}",               // no desc
+    "{repo}/{type}/#{issue}-{desc}", // extra leading segment
+    "wt/{type}/#{issue}-{desc}",     // extra leading segment
+  ] {
+    let w = branch_pattern_warning(pattern, "gwm-cli", &default_branch_types())
+      .unwrap_or_else(|| panic!("`{}` is documented as fully broken but did not warn", pattern));
+    assert!(
+      w.contains("match nothing at all"),
+      "`{}` is documented as fully unparseable: {}",
+      pattern,
+      w
+    );
+  }
+
+  // Documented as "parses, wrong desc": anything glued after `{desc}`, or a
+  // literal wedged between the `-` and `{desc}`.
+  for pattern in [
+    "{type}/#{issue}-{desc}-{repo}",
+    "{type}/#{issue}-{desc}{desc}",
+    "{type}/#{issue}-prefix-{desc}",
+  ] {
+    let w = branch_pattern_warning(pattern, "gwm-cli", &default_branch_types())
+      .unwrap_or_else(|| panic!("`{}` is documented as lossy but did not warn", pattern));
+    assert!(
+      w.contains("parse but read back `desc`") && !w.contains("match nothing at all"),
+      "`{}` is documented as parseable-but-wrong-desc: {}",
+      pattern,
+      w
+    );
+  }
 }


### PR DESCRIPTION
## Description

`worktree.branch_pattern` is honoured when gwm **writes** a branch name (`BranchSpec::branch_name`) and ignored when it **reads one back** (`parse_branch` still matches the hardcoded `BRANCH_RE`). Customising the pattern — including live from the TUI Settings panel — therefore produces branches gwm can no longer decompose, and every feature keyed on the parsed segments silently becomes a no-op: issue/PR auto-linking, gitmoji selection, the doctor branch-convention check, lifecycle placeholders.

This PR does not fix that. It states it: `gwm doctor` and `gwm config validate` now name the pattern and its consequences, so the failure stops being silent.

Closes #415

## Type of change

- [x] 🐛 Fix (bug fix)
- [x] 📝 Docs

## Changes

- `naming::branch_pattern_warning(pattern) -> Option<String>` — the single predicate, returning the user-facing message when the pattern diverges from the default. #417 swaps its body for the real pattern-to-regex round-trip check without touching either call site.
- `gwm doctor` — new check `worktree.branch_pattern round-trips through the parser`, registered **last** in the report so the existing 1-8 numbering in the docs stays valid. Warning, not Failed: the config is valid and the worktrees it produces work, only the structured extras go quiet.
- `gwm config validate` — prints the same message on **stderr** and still exits `0`. `validate_rendered` / `validate_file` now return the parsed `Config` so `validate()` reads the resolved value without a second parse.
- `config::default_branch_pattern` lifted to `pub(crate)` so the comparison has a single source of truth.
- Docs: doctor page check #9 and a `.gwm.toml` schema section on the cost of customising, both EN + FR.

Explicitly out of scope, per the issue: no `path_pattern` guard (generation-only, `WorktreeInfo.name` comes from the directory basename — no round-trip to break), and no TUI change.

## Tests

- [x] `cargo test` passes locally (full suite, run under a CI-like minimal `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Written red-first; both new doctor tests failed on `expected a 'branch_pattern' check in the report` and the config-validate test on an empty stderr before the implementation landed.

- `tests/doctor_tests.rs` — a custom pattern yields `CheckStatus::Warning` whose detail names all three consequences (`auto-linking`, `gitmoji`, `branch-convention`); the default yields `Ok`. Deliberately does **not** assert `report.exit_code()`, which is env-dependent (missing binaries also warn).
- `tests/config_cli_tests.rs` — a custom pattern exits `0` with the warning on stderr; the default exits `0` with no `branch_pattern` mention.

## Screenshots / TUI captures

n/a — no TUI change.

Verified against this repo with the built binary:

```
✓ worktree.branch_pattern round-trips through the parser
    default pattern — `parse_branch` reads back what `branch_name` writes
```

`gwm doctor` on gwm-cli itself stays exit `0`: `.gwm.toml` sets `branch_pattern` explicitly, but to the default value, so the CI advisory doctor job is unaffected.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed — no new command or flag
- [ ] `examples/gwm.toml.example` updated if config schema changed — no schema change, the key already existed
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #415
- Follow-ups in the same sequence: #416 (free-form `--name`), #417 (derive the parser from the pattern, removes the cause), #418 (token-driven create form)

## Notes for reviewers

Two things worth a look:

1. **Check ordering.** The new check is registered after `check_tui_keymap` rather than next to the other config checks, purely so `docs/5.integrations/2.doctor.md` keeps its 1-8 numbering. Say the word if you'd rather have it grouped logically and pay the doc renumber.
2. **`validate_rendered` now returns `Config`.** `write_and_validate` matches on `Ok(_)` instead of `Ok(())`; nothing else consumed the value. The alternative was a second `toml::from_str` in `validate()`.