### PR TITLE
✨ feat(cli,tui): free-form worktree naming (gwm create --name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   positionals, so a partial triple is still the typo it always was; the mode
   is chosen explicitly, never inferred from how many arguments arrived.
 
-  The name becomes the branch verbatim. `branch_pattern` / `path_pattern` do
-  not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`,
+  The name becomes the branch verbatim, and is validated verbatim: `--name
+  " spike"` is refused rather than trimmed into `spike`, which would be a
+  different branch from the one asked for. `branch_pattern` / `path_pattern`
+  do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`,
   and a free-form name has none of them — while `[worktree].base` still does,
-  so free-form worktrees land beside the structured ones.
+  so free-form worktrees land beside the structured ones. `base` is only
+  expanded with the placeholders it documents, though: the structured path
+  feeds `{type}` / `{issue}` / `{desc}` through `base` too, and since an
+  unfed placeholder is left *literal*, a base written with one of them is
+  refused here rather than turned into a directory called `{type}`.
 
   What a free-form worktree gives up is stated rather than discovered: issue
   auto-linking goes inactive (`gwm link` remains), `gwm commit-prefix` errors
@@ -32,9 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treats the branch as user-managed and never flags it.
 
   Names are validated against libgit2's own branch-name rules rather than a
-  hand-written list, plus two rules of our own: no `.` / `..` path component
-  (a worktree directory named `..` would escape the base) and no leading `-`
-  (git accepts it; `gwm remove` and `git branch -d` would not).
+  hand-written list, plus three rules of our own: no `.` / `..` path component
+  (a worktree directory named `..` would escape the base), no leading `-`
+  (git accepts it; `gwm remove` and `git branch -d` would not), and a 255-byte
+  cap — a branch name is a *path* of components while the worktree directory
+  is a single one, so `a×130/b×130` is a legal ref and an illegal directory
+  name, and without the cap the branch is created before the directory fails,
+  leaving it orphaned.
   No `SCHEMA_VERSION` bump — `JsonWorktree` carries no `type` / `desc`, so
   the wire format is unchanged.
   ([#416](https://github.com/kbrdn1/gwm-cli/issues/416))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Free-form worktree naming. `gwm create --name spike-redis` skips the
+  `<type> <issue> <desc>` triple entirely — not every worktree corresponds to
+  an issue. In the TUI, `Ctrl-T` toggles the create form between the
+  structured triple and a single `Name` field. The flag is exclusive with the
+  positionals, so a partial triple is still the typo it always was; the mode
+  is chosen explicitly, never inferred from how many arguments arrived.
+
+  The name becomes the branch verbatim. `branch_pattern` / `path_pattern` do
+  not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`,
+  and a free-form name has none of them — while `[worktree].base` still does,
+  so free-form worktrees land beside the structured ones.
+
+  What a free-form worktree gives up is stated rather than discovered: issue
+  auto-linking goes inactive (`gwm link` remains), `gwm commit-prefix` errors
+  because a prefix is derived from the branch type and there is none, and
+  remove/bootstrap hook placeholders resolve empty. PR/MR detection is
+  unaffected — it queries the forge with the whole branch name. `doctor`
+  treats the branch as user-managed and never flags it.
+
+  Names are validated against libgit2's own branch-name rules rather than a
+  hand-written list, plus two rules of our own: no `.` / `..` path component
+  (a worktree directory named `..` would escape the base) and no leading `-`
+  (git accepts it; `gwm remove` and `git branch -d` would not).
+  No `SCHEMA_VERSION` bump — `JsonWorktree` carries no `type` / `desc`, so
+  the wire format is unchanged.
+  ([#416](https://github.com/kbrdn1/gwm-cli/issues/416))
+
 ### Fixed
 
 - `gwm doctor` and `gwm config validate` now warn when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,18 +33,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   What a free-form worktree gives up is stated rather than discovered: issue
   auto-linking goes inactive (`gwm link` remains), `gwm commit-prefix` errors
   because a prefix is derived from the branch type and there is none, and
-  remove/bootstrap hook placeholders resolve empty. PR/MR detection is
+  create/remove/bootstrap hook placeholders resolve empty. PR/MR detection is
   unaffected — it queries the forge with the whole branch name. `doctor`
-  treats the branch as user-managed and never flags it.
+  treats the branch as user-managed and never flags it. All of which applies
+  to a name that does *not* match the branch convention: nothing records how
+  a worktree was named, only what its branch is, so `--name 'feat/#42-x'` is
+  read back as structured and keeps every one of those.
 
-  Names are validated against libgit2's own branch-name rules rather than a
-  hand-written list, plus three rules of our own: no `.` / `..` path component
-  (a worktree directory named `..` would escape the base), no leading `-`
-  (git accepts it; `gwm remove` and `git branch -d` would not), and a 255-byte
-  cap — a branch name is a *path* of components while the worktree directory
-  is a single one, so `a×130/b×130` is a legal ref and an illegal directory
-  name, and without the cap the branch is created before the directory fails,
-  leaving it orphaned.
+  The accepted-name rules are enumerated from the three things a free-form
+  name has to be at once, rather than accreted one example at a time. It is a
+  **git branch** — validated with libgit2's branch-level oracle, which is
+  stricter than the reference-level one (`refs/heads/HEAD` is a valid
+  reference name, `HEAD` is not a usable branch name). It is a **single
+  filesystem path component**, which a branch name is not: no `.` / `..`
+  component, and at most 255 bytes, since `a×130/b×130` is a legal ref and an
+  illegal directory name and without the cap the branch is created before the
+  directory fails, leaving it orphaned. And it is a **literal value during
+  hook expansion**, so no `{` / `}`: placeholders are substituted in sequence,
+  and `spike-{issue}` would have its own name rewritten inside the `{branch}`
+  value a hook receives. Plus one rule belonging to none of them: no leading
+  `-`, which git accepts but `gwm remove` and `git branch -d` read as a flag.
+  Windows-specific path rules are deliberately **not** covered — they cannot
+  be measured from a Unix machine, and the gap is tracked by
+  [#475](https://github.com/kbrdn1/gwm-cli/issues/475) rather than guessed at
+  here.
   No `SCHEMA_VERSION` bump — `JsonWorktree` carries no `type` / `desc`, so
   the wire format is unchanged.
   ([#416](https://github.com/kbrdn1/gwm-cli/issues/416))

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -120,13 +120,15 @@ Both the New Worktree form (`n`) and the rename form (`c`) share the same
 | `BackTab` (`Shift+Tab`)   | previous field (`prev_field`)                           |
 | `↑` / `←` / `h`           | previous worktree type (`prev_type`; on the type field) |
 | `↓` / `→` / `l`           | next worktree type (`next_type`; on the type field)     |
-| `Ctrl+t`                  | toggle structured ↔ free-form naming (`toggle_mode`)    |
+| `Ctrl+t`                  | toggle structured ↔ free-form naming (`toggle_mode`; New Worktree form only) |
 | `Enter`                   | submit and bootstrap / rename (`submit`; subject to the [TOFU trust gate](/configuration/trust-ledger)) |
 | `Esc`                     | cancel (`cancel`)                                       |
 
 `Ctrl+t` flips the New Worktree form between the `<type>/#<issue>-<desc>` triple and a single free-form `Name` field ([#416](https://github.com/kbrdn1/gwm-cli/issues/416)). Free-form mode drops the type selector and the issue field — it has no notion of either — and validates the name on submit rather than per keystroke, so an intermediate state can be typed through. Both sides keep what you typed, so toggling to look at the other form loses nothing. What a free-form worktree gives up is listed in [CLI → free-form naming](/cli/reference#free-form-naming---name).
 
 The binding is Ctrl-modified on purpose: the create overlay reserves unmodified printable keys for its text fields, so a bare letter would be swallowed while typing a description.
+
+It is inert in the rename form, which shares this keymap but renders and submits the triple only — toggling there would type into a field the form never shows.
 
 If the repo's `.gwm.toml` isn't trusted, `Enter` lands the form's status bar on a refuse message instead of running the bootstrap — the worktree directory is **not** created in that case, so you can fix the trust state in another terminal (`gwm bootstrap` from CLI, or set `GWM_ALLOW_BOOTSTRAP=1` and relaunch) and retry. See [Configuration → TOFU trust ledger](/configuration/trust-ledger#tui-behaviour) for the exact wording and full decision tree.
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -120,8 +120,13 @@ Both the New Worktree form (`n`) and the rename form (`c`) share the same
 | `BackTab` (`Shift+Tab`)   | previous field (`prev_field`)                           |
 | `↑` / `←` / `h`           | previous worktree type (`prev_type`; on the type field) |
 | `↓` / `→` / `l`           | next worktree type (`next_type`; on the type field)     |
+| `Ctrl+t`                  | toggle structured ↔ free-form naming (`toggle_mode`)    |
 | `Enter`                   | submit and bootstrap / rename (`submit`; subject to the [TOFU trust gate](/configuration/trust-ledger)) |
 | `Esc`                     | cancel (`cancel`)                                       |
+
+`Ctrl+t` flips the New Worktree form between the `<type>/#<issue>-<desc>` triple and a single free-form `Name` field ([#416](https://github.com/kbrdn1/gwm-cli/issues/416)). Free-form mode drops the type selector and the issue field — it has no notion of either — and validates the name on submit rather than per keystroke, so an intermediate state can be typed through. Both sides keep what you typed, so toggling to look at the other form loses nothing. What a free-form worktree gives up is listed in [CLI → free-form naming](/cli/reference#free-form-naming---name).
+
+The binding is Ctrl-modified on purpose: the create overlay reserves unmodified printable keys for its text fields, so a bare letter would be swallowed while typing a description.
 
 If the repo's `.gwm.toml` isn't trusted, `Enter` lands the form's status bar on a refuse message instead of running the bootstrap — the worktree directory is **not** created in that case, so you can fix the trust state in another terminal (`gwm bootstrap` from CLI, or set `GWM_ALLOW_BOOTSTRAP=1` and relaunch) and retry. See [Configuration → TOFU trust ledger](/configuration/trust-ledger#tui-behaviour) for the exact wording and full decision tree.
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -150,9 +150,37 @@ gwm create feat 123 foo --no-bootstrap     # skip the bootstrap pipeline
 | `--no-bootstrap`        | Skip the `.gwm.toml` bootstrap stages (copies / guards / commands / hooks)                    |
 | `--reuse-branch`        | Attach to an already-existing local branch of the same name instead of refusing (issue #99)  |
 | `--skip-hooks <PHASES>` | Skip the comma-separated lifecycle hook phases (e.g. `pre_create,post_create`)                |
+| `--name <NAME>`         | Name the worktree freely instead of the `<type> <issue> <desc>` triple (issue #416). Exclusive with the positionals |
 | `--repo <NAME>`         | In [workspace mode](#workspace-mode-global---workspace-issue-36), which child repo gets the worktree — required there to disambiguate; ignored in single-repo mode (issue #36) |
 
 By default `gwm create` refuses to silently reuse a stale local branch — it ends with an error naming the stale tip so you can audit it; `--reuse-branch` is the opt-in escape hatch.
+
+### free-form naming (`--name`)
+
+Not every worktree is an issue. `--name` skips the convention entirely:
+
+```bash
+gwm create --name spike-redis
+#   → branch spike-redis
+#   → worktree ~/cc-worktree/<repo>/spike-redis
+```
+
+The name becomes the branch **verbatim**. `branch_pattern` and `path_pattern` do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`, and a free-form name has none of them. `[worktree].base` still applies, so free-form worktrees land beside the structured ones. A `/` is legal in the branch and flattens to `-` in the directory name, the same relationship the default pattern pair already has.
+
+**What you give up.** Everything that reads the branch name back goes quiet — that is the deal, not a bug:
+
+| Feature | On a free-form worktree |
+|:--------|:------------------------|
+| issue auto-linking | inactive — use `gwm link --issue <N>` to attach one by hand |
+| PR/MR detection | **still works** — it queries the forge with the whole branch name |
+| gitmoji / `gwm commit-prefix` | errors: a prefix is derived from the branch *type*, and there is none |
+| `doctor` orphan check | treats it as a user-managed branch and never flags it |
+| hook placeholders (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` resolve empty |
+| TUI edit form | not applicable — that form rebuilds the triple; rename with git |
+
+**Accepted names.** Anything git accepts as a branch, checked against libgit2's own rule set rather than a hand-written list, plus two rules of our own: no `.` or `..` as a path component (a worktree directory named `..` would escape the base), and no leading `-` (git accepts it, but the name would be unusable as an argument to `gwm remove` or `git branch -d`). `Spike_Redis`, `2026.07.27` and `réécriture` are all fine.
+
+In the TUI, `Ctrl-T` toggles the create form between the structured triple and a single free-form `Name` field.
 
 End-to-end walkthrough lives in [Getting Started → First worktree](/getting-started/first-worktree).
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -167,7 +167,7 @@ gwm create --name spike-redis
 
 The name becomes the branch **verbatim** — it is validated exactly as typed, so `--name " spike"` is refused rather than trimmed into a different branch than the one you asked for. `branch_pattern` and `path_pattern` do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`, and a free-form name has none of them. `[worktree].base` still applies, so free-form worktrees land beside the structured ones, for the placeholders it documents (`{home}`, `{repo}`, `{repo_path}`, `{repo_parent}`); a base written with `{type}` / `{issue}` / `{desc}` is refused instead, since there is nothing to resolve it against and it would otherwise end up literal in the path. A `/` is legal in the branch and flattens to `-` in the directory name, the same relationship the default pattern pair already has.
 
-**What you give up.** Everything that reads the branch name back goes quiet — that is the deal, not a bug:
+**What you give up.** Everything that reads the branch name back goes quiet — that is the deal, not a bug. This table describes a name that does **not** match the branch convention; nothing records *how* a worktree was named, only what its branch is, so a free-form name that happens to look structured (`--name 'feat/#42-x'`) is read back as structured and keeps every row below:
 
 | Feature | On a free-form worktree |
 |:--------|:------------------------|
@@ -175,16 +175,20 @@ The name becomes the branch **verbatim** — it is validated exactly as typed, s
 | PR/MR detection | **still works** — it queries the forge with the whole branch name |
 | gitmoji / `gwm commit-prefix` | errors: a prefix is derived from the branch *type*, and there is none |
 | `doctor` orphan check | treats it as a user-managed branch and never flags it |
-| hook placeholders (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` resolve empty |
+| hook placeholders (create / remove / bootstrap) | `{type}` / `{issue}` / `{desc}` resolve empty |
 | TUI edit form | not applicable — that form rebuilds the triple; rename with git |
 
-**Accepted names.** Anything git accepts as a branch, checked against libgit2's own rule set rather than a hand-written list, plus three rules of our own:
+**Accepted names.** A free-form name has to be three things at once, and the rules follow from that rather than from a hand-written list of bad examples.
 
-- no `.` or `..` as a path component — a worktree directory named `..` would escape the base;
-- no leading `-` — git accepts it, but the name would be unusable as an argument to `gwm remove` or `git branch -d`;
-- at most 255 bytes — a branch name is a *path* of components while the worktree directory is a single one, so `a×130/b×130` is a legal ref and an illegal directory name. Without the cap the branch gets created and the directory then fails, leaving the branch orphaned.
+It is **a git branch** — checked against libgit2's own branch-level rule set, which is stricter than the reference-level one (`refs/heads/HEAD` is a valid *reference* name, `HEAD` is not a usable *branch* name). It is **a single filesystem path component**, the worktree directory, which a branch name is not: no `.` or `..` component (a directory named `..` would escape the base), and at most 255 bytes — `a×130/b×130` is a legal ref and an illegal directory name, and without the cap the branch gets created before the directory fails, leaving it orphaned. And it is **a literal value during hook expansion**, so no `{` or `}`: placeholders are substituted in sequence, and a branch called `spike-{issue}` would have its own name rewritten inside the `{branch}` value a hook receives.
+
+One more rule belongs to none of those: no leading `-`. Git accepts it; `gwm remove` and `git branch -d` would read it as a flag.
 
 `Spike_Redis`, `2026.07.27` and `réécriture` are all fine.
+
+:::: warning Windows path rules are not validated yet
+`< > " |` and reserved device names (`CON`, `NUL`, `COM1`…) pass every check above but cannot become a directory on Windows, so such a name fails when the worktree is created rather than up front — after `pre_create` hooks, leaving the branch behind. Tracked in [#475](https://github.com/kbrdn1/gwm-cli/issues/475).
+::::
 
 In the TUI, `Ctrl-T` toggles the create form — and only that form — between the structured triple and a single free-form `Name` field.
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -165,7 +165,7 @@ gwm create --name spike-redis
 #   → worktree ~/cc-worktree/<repo>/spike-redis
 ```
 
-The name becomes the branch **verbatim**. `branch_pattern` and `path_pattern` do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`, and a free-form name has none of them. `[worktree].base` still applies, so free-form worktrees land beside the structured ones. A `/` is legal in the branch and flattens to `-` in the directory name, the same relationship the default pattern pair already has.
+The name becomes the branch **verbatim** — it is validated exactly as typed, so `--name " spike"` is refused rather than trimmed into a different branch than the one you asked for. `branch_pattern` and `path_pattern` do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`, and a free-form name has none of them. `[worktree].base` still applies, so free-form worktrees land beside the structured ones, for the placeholders it documents (`{home}`, `{repo}`, `{repo_path}`, `{repo_parent}`); a base written with `{type}` / `{issue}` / `{desc}` is refused instead, since there is nothing to resolve it against and it would otherwise end up literal in the path. A `/` is legal in the branch and flattens to `-` in the directory name, the same relationship the default pattern pair already has.
 
 **What you give up.** Everything that reads the branch name back goes quiet — that is the deal, not a bug:
 
@@ -178,9 +178,15 @@ The name becomes the branch **verbatim**. `branch_pattern` and `path_pattern` do
 | hook placeholders (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` resolve empty |
 | TUI edit form | not applicable — that form rebuilds the triple; rename with git |
 
-**Accepted names.** Anything git accepts as a branch, checked against libgit2's own rule set rather than a hand-written list, plus two rules of our own: no `.` or `..` as a path component (a worktree directory named `..` would escape the base), and no leading `-` (git accepts it, but the name would be unusable as an argument to `gwm remove` or `git branch -d`). `Spike_Redis`, `2026.07.27` and `réécriture` are all fine.
+**Accepted names.** Anything git accepts as a branch, checked against libgit2's own rule set rather than a hand-written list, plus three rules of our own:
 
-In the TUI, `Ctrl-T` toggles the create form between the structured triple and a single free-form `Name` field.
+- no `.` or `..` as a path component — a worktree directory named `..` would escape the base;
+- no leading `-` — git accepts it, but the name would be unusable as an argument to `gwm remove` or `git branch -d`;
+- at most 255 bytes — a branch name is a *path* of components while the worktree directory is a single one, so `a×130/b×130` is a legal ref and an illegal directory name. Without the cap the branch gets created and the directory then fails, leaving the branch orphaned.
+
+`Spike_Redis`, `2026.07.27` and `réécriture` are all fine.
+
+In the TUI, `Ctrl-T` toggles the create form — and only that form — between the structured triple and a single free-form `Name` field.
 
 End-to-end walkthrough lives in [Getting Started → First worktree](/getting-started/first-worktree).
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -124,8 +124,13 @@ partagent les mêmes verbes `[tui.keys.modal.create]` :
 | `BackTab` (`Shift+Tab`)   | champ précédent (`prev_field`)                          |
 | `↑` / `←` / `h`           | type de worktree précédent (`prev_type` ; sur le champ type) |
 | `↓` / `→` / `l`           | type de worktree suivant (`next_type` ; sur le champ type) |
+| `Ctrl+t`                  | bascule nommage structuré ↔ libre (`toggle_mode`)       |
 | `Enter`                   | soumettre et bootstrapper / renommer (`submit` ; soumis à la [barrière de confiance TOFU](/fr/configuration/trust-ledger)) |
 | `Esc`                     | annuler (`cancel`)                                      |
+
+`Ctrl+t` bascule le formulaire Nouveau worktree entre le triplet `<type>/#<issue>-<desc>` et un unique champ `Name` libre ([#416](https://github.com/kbrdn1/gwm-cli/issues/416)). Le mode libre retire le sélecteur de type et le champ issue — il n'en a aucune notion — et valide le nom à la soumission plutôt qu'à chaque frappe, pour qu'on puisse taper à travers un état intermédiaire. Les deux côtés conservent ce qui a été saisi, donc basculer pour regarder l'autre formulaire ne perd rien. Ce qu'un worktree libre abandonne est listé dans [CLI → nommage libre](/fr/cli/reference#nommage-libre---name).
+
+La liaison est modifiée par Ctrl à dessein : la surcouche de création réserve les touches imprimables non modifiées à ses champs texte, donc une lettre seule serait avalée pendant la saisie d'une description.
 
 Si le `.gwm.toml` du dépôt n'est pas approuvé, `Enter` place la barre de statut du formulaire sur un message de refus au lieu de lancer le bootstrap — le répertoire du worktree n'est **pas** créé dans ce cas, donc vous pouvez corriger l'état de confiance dans un autre terminal (`gwm bootstrap` depuis le CLI, ou définir `GWM_ALLOW_BOOTSTRAP=1` et relancer) puis réessayer. Voir [Configuration → registre de confiance TOFU](/fr/configuration/trust-ledger#comportement-de-la-tui) pour la formulation exacte et l'arbre de décision complet.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -124,13 +124,15 @@ partagent les mêmes verbes `[tui.keys.modal.create]` :
 | `BackTab` (`Shift+Tab`)   | champ précédent (`prev_field`)                          |
 | `↑` / `←` / `h`           | type de worktree précédent (`prev_type` ; sur le champ type) |
 | `↓` / `→` / `l`           | type de worktree suivant (`next_type` ; sur le champ type) |
-| `Ctrl+t`                  | bascule nommage structuré ↔ libre (`toggle_mode`)       |
+| `Ctrl+t`                  | bascule nommage structuré ↔ libre (`toggle_mode` ; formulaire Nouveau worktree uniquement) |
 | `Enter`                   | soumettre et bootstrapper / renommer (`submit` ; soumis à la [barrière de confiance TOFU](/fr/configuration/trust-ledger)) |
 | `Esc`                     | annuler (`cancel`)                                      |
 
 `Ctrl+t` bascule le formulaire Nouveau worktree entre le triplet `<type>/#<issue>-<desc>` et un unique champ `Name` libre ([#416](https://github.com/kbrdn1/gwm-cli/issues/416)). Le mode libre retire le sélecteur de type et le champ issue — il n'en a aucune notion — et valide le nom à la soumission plutôt qu'à chaque frappe, pour qu'on puisse taper à travers un état intermédiaire. Les deux côtés conservent ce qui a été saisi, donc basculer pour regarder l'autre formulaire ne perd rien. Ce qu'un worktree libre abandonne est listé dans [CLI → nommage libre](/fr/cli/reference#nommage-libre---name).
 
 La liaison est modifiée par Ctrl à dessein : la surcouche de création réserve les touches imprimables non modifiées à ses champs texte, donc une lettre seule serait avalée pendant la saisie d'une description.
+
+Elle est inerte dans le formulaire de renommage, qui partage ce keymap mais n'affiche et ne soumet que le triplet — y basculer écrirait dans un champ que le formulaire ne montre jamais.
 
 Si le `.gwm.toml` du dépôt n'est pas approuvé, `Enter` place la barre de statut du formulaire sur un message de refus au lieu de lancer le bootstrap — le répertoire du worktree n'est **pas** créé dans ce cas, donc vous pouvez corriger l'état de confiance dans un autre terminal (`gwm bootstrap` depuis le CLI, ou définir `GWM_ALLOW_BOOTSTRAP=1` et relancer) puis réessayer. Voir [Configuration → registre de confiance TOFU](/fr/configuration/trust-ledger#comportement-de-la-tui) pour la formulation exacte et l'arbre de décision complet.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -167,7 +167,7 @@ gwm create --name spike-redis
 
 Le nom devient la branche **tel quel** — il est validé exactement comme il a été saisi, donc `--name " spike"` est refusé plutôt que rogné en une branche différente de celle demandée. `branch_pattern` et `path_pattern` ne s'appliquent pas — ils sont écrits en `{type}` / `{issue}` / `{desc}`, dont un nom libre n'a aucun. `[worktree].base` s'applique toujours, donc les worktrees libres atterrissent à côté des structurés, pour les placeholders qu'il documente (`{home}`, `{repo}`, `{repo_path}`, `{repo_parent}`) ; une base écrite avec `{type}` / `{issue}` / `{desc}` est refusée à la place, puisqu'il n'y a rien pour les résoudre et qu'ils finiraient littéralement dans le chemin. Un `/` est légal dans la branche et devient `-` dans le nom de répertoire, exactement le rapport qu'ont déjà les deux motifs par défaut.
 
-**Ce que vous perdez.** Tout ce qui relit le nom de branche devient muet — c'est le contrat, pas un bug :
+**Ce que vous perdez.** Tout ce qui relit le nom de branche devient muet — c'est le contrat, pas un bug. Ce tableau décrit un nom qui ne **correspond pas** à la convention de branche ; rien n'enregistre *comment* un worktree a été nommé, seulement quelle est sa branche, donc un nom libre qui ressemble par hasard à un nom structuré (`--name 'feat/#42-x'`) est relu comme structuré et conserve toutes les lignes ci-dessous :
 
 | Fonctionnalité | Sur un worktree libre |
 |:---------------|:----------------------|
@@ -175,16 +175,20 @@ Le nom devient la branche **tel quel** — il est validé exactement comme il a 
 | détection PR/MR | **fonctionne toujours** — elle interroge la forge avec le nom de branche entier |
 | gitmoji / `gwm commit-prefix` | erreur : le préfixe est dérivé du *type* de branche, et il n'y en a pas |
 | contrôle des orphelines du `doctor` | la traite comme une branche gérée par l'utilisateur, jamais signalée |
-| placeholders des hooks (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` sont vides |
+| placeholders des hooks (create / remove / bootstrap) | `{type}` / `{issue}` / `{desc}` sont vides |
 | formulaire d'édition TUI | sans objet — ce formulaire reconstruit le triplet ; renommez avec git |
 
-**Noms acceptés.** Tout ce que git accepte comme branche, vérifié contre le jeu de règles de libgit2 lui-même plutôt qu'une liste écrite à la main, plus trois règles maison :
+**Noms acceptés.** Un nom libre doit être trois choses à la fois, et les règles en découlent plutôt que d'une liste de mauvais exemples écrite à la main.
 
-- ni `.` ni `..` comme composant de chemin — un répertoire de worktree nommé `..` sortirait de la base ;
-- pas de `-` en tête — git l'accepte, mais le nom serait inutilisable comme argument de `gwm remove` ou `git branch -d` ;
-- 255 octets au maximum — un nom de branche est un *chemin* de composants alors que le répertoire du worktree n'en est qu'un seul, donc `a×130/b×130` est une ref légale et un nom de répertoire illégal. Sans ce plafond, la branche est créée puis le répertoire échoue, laissant la branche orpheline.
+C'est **une branche git** — vérifié contre le jeu de règles de libgit2 au niveau *branche*, plus strict que celui au niveau *référence* (`refs/heads/HEAD` est un nom de référence valide, `HEAD` n'est pas un nom de branche utilisable). C'est **un composant de chemin unique**, le répertoire du worktree, ce qu'un nom de branche n'est pas : ni `.` ni `..` comme composant (un répertoire nommé `..` sortirait de la base), et 255 octets au maximum — `a×130/b×130` est une ref légale et un nom de répertoire illégal, et sans ce plafond la branche est créée avant que le répertoire n'échoue, la laissant orpheline. Et c'est **une valeur littérale pendant l'expansion des hooks**, donc ni `{` ni `}` : les placeholders sont substitués en séquence, et une branche nommée `spike-{issue}` verrait son propre nom réécrit à l'intérieur de la valeur `{branch}` reçue par un hook.
+
+Une dernière règle n'appartient à aucune des trois : pas de `-` en tête. Git l'accepte ; `gwm remove` et `git branch -d` le liraient comme un flag.
 
 `Spike_Redis`, `2026.07.27` et `réécriture` passent tous.
+
+:::: warning Les règles de chemin Windows ne sont pas encore validées
+`< > " |` et les noms de périphériques réservés (`CON`, `NUL`, `COM1`…) passent toutes les vérifications ci-dessus mais ne peuvent pas devenir un répertoire sous Windows, donc un tel nom échoue à la création du worktree plutôt qu'en amont — après les hooks `pre_create`, en laissant la branche derrière lui. Suivi dans [#475](https://github.com/kbrdn1/gwm-cli/issues/475).
+::::
 
 Dans la TUI, `Ctrl-T` bascule le formulaire de création — et lui seul — entre le triplet structuré et un unique champ `Name`.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -165,7 +165,7 @@ gwm create --name spike-redis
 #   → worktree ~/cc-worktree/<repo>/spike-redis
 ```
 
-Le nom devient la branche **tel quel**. `branch_pattern` et `path_pattern` ne s'appliquent pas — ils sont écrits en `{type}` / `{issue}` / `{desc}`, dont un nom libre n'a aucun. `[worktree].base` s'applique toujours, donc les worktrees libres atterrissent à côté des structurés. Un `/` est légal dans la branche et devient `-` dans le nom de répertoire, exactement le rapport qu'ont déjà les deux motifs par défaut.
+Le nom devient la branche **tel quel** — il est validé exactement comme il a été saisi, donc `--name " spike"` est refusé plutôt que rogné en une branche différente de celle demandée. `branch_pattern` et `path_pattern` ne s'appliquent pas — ils sont écrits en `{type}` / `{issue}` / `{desc}`, dont un nom libre n'a aucun. `[worktree].base` s'applique toujours, donc les worktrees libres atterrissent à côté des structurés, pour les placeholders qu'il documente (`{home}`, `{repo}`, `{repo_path}`, `{repo_parent}`) ; une base écrite avec `{type}` / `{issue}` / `{desc}` est refusée à la place, puisqu'il n'y a rien pour les résoudre et qu'ils finiraient littéralement dans le chemin. Un `/` est légal dans la branche et devient `-` dans le nom de répertoire, exactement le rapport qu'ont déjà les deux motifs par défaut.
 
 **Ce que vous perdez.** Tout ce qui relit le nom de branche devient muet — c'est le contrat, pas un bug :
 
@@ -178,9 +178,15 @@ Le nom devient la branche **tel quel**. `branch_pattern` et `path_pattern` ne s'
 | placeholders des hooks (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` sont vides |
 | formulaire d'édition TUI | sans objet — ce formulaire reconstruit le triplet ; renommez avec git |
 
-**Noms acceptés.** Tout ce que git accepte comme branche, vérifié contre le jeu de règles de libgit2 lui-même plutôt qu'une liste écrite à la main, plus deux règles maison : ni `.` ni `..` comme composant de chemin (un répertoire de worktree nommé `..` sortirait de la base), et pas de `-` en tête (git l'accepte, mais le nom serait inutilisable comme argument de `gwm remove` ou `git branch -d`). `Spike_Redis`, `2026.07.27` et `réécriture` passent tous.
+**Noms acceptés.** Tout ce que git accepte comme branche, vérifié contre le jeu de règles de libgit2 lui-même plutôt qu'une liste écrite à la main, plus trois règles maison :
 
-Dans la TUI, `Ctrl-T` bascule le formulaire de création entre le triplet structuré et un unique champ `Name`.
+- ni `.` ni `..` comme composant de chemin — un répertoire de worktree nommé `..` sortirait de la base ;
+- pas de `-` en tête — git l'accepte, mais le nom serait inutilisable comme argument de `gwm remove` ou `git branch -d` ;
+- 255 octets au maximum — un nom de branche est un *chemin* de composants alors que le répertoire du worktree n'en est qu'un seul, donc `a×130/b×130` est une ref légale et un nom de répertoire illégal. Sans ce plafond, la branche est créée puis le répertoire échoue, laissant la branche orpheline.
+
+`Spike_Redis`, `2026.07.27` et `réécriture` passent tous.
+
+Dans la TUI, `Ctrl-T` bascule le formulaire de création — et lui seul — entre le triplet structuré et un unique champ `Name`.
 
 Le déroulé de bout en bout vit dans [Premiers pas → Premier worktree](/fr/getting-started/first-worktree).
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -150,9 +150,37 @@ gwm create feat 123 foo --no-bootstrap     # skip the bootstrap pipeline
 | `--no-bootstrap`        | Saute les étapes de bootstrap de `.gwm.toml` (copies / guards / commands / hooks)            |
 | `--reuse-branch`        | Se rattache à une branche locale existante du même nom au lieu de refuser (issue #99)        |
 | `--skip-hooks <PHASES>` | Saute les phases de hook de cycle de vie séparées par des virgules (par ex. `pre_create,post_create`) |
+| `--name <NAME>`         | Nomme le worktree librement au lieu du triplet `<type> <issue> <desc>` (issue #416). Exclusif des positionnels |
 | `--repo <NAME>`         | En [mode workspace](#mode-workspace-global---workspace-issue-36), quel dépôt enfant reçoit le worktree — requis là pour lever l'ambiguïté ; ignoré en mode mono-dépôt (issue #36) |
 
 Par défaut `gwm create` refuse de réutiliser silencieusement une branche locale obsolète — il se termine par une erreur nommant le tip obsolète pour que vous puissiez l'auditer ; `--reuse-branch` est l'échappatoire opt-in.
+
+### nommage libre (`--name`)
+
+Tous les worktrees ne correspondent pas à une issue. `--name` contourne entièrement la convention :
+
+```bash
+gwm create --name spike-redis
+#   → branche spike-redis
+#   → worktree ~/cc-worktree/<repo>/spike-redis
+```
+
+Le nom devient la branche **tel quel**. `branch_pattern` et `path_pattern` ne s'appliquent pas — ils sont écrits en `{type}` / `{issue}` / `{desc}`, dont un nom libre n'a aucun. `[worktree].base` s'applique toujours, donc les worktrees libres atterrissent à côté des structurés. Un `/` est légal dans la branche et devient `-` dans le nom de répertoire, exactement le rapport qu'ont déjà les deux motifs par défaut.
+
+**Ce que vous perdez.** Tout ce qui relit le nom de branche devient muet — c'est le contrat, pas un bug :
+
+| Fonctionnalité | Sur un worktree libre |
+|:---------------|:----------------------|
+| auto-liaison de l'issue | inactive — utilisez `gwm link --issue <N>` pour en attacher une à la main |
+| détection PR/MR | **fonctionne toujours** — elle interroge la forge avec le nom de branche entier |
+| gitmoji / `gwm commit-prefix` | erreur : le préfixe est dérivé du *type* de branche, et il n'y en a pas |
+| contrôle des orphelines du `doctor` | la traite comme une branche gérée par l'utilisateur, jamais signalée |
+| placeholders des hooks (remove / bootstrap) | `{type}` / `{issue}` / `{desc}` sont vides |
+| formulaire d'édition TUI | sans objet — ce formulaire reconstruit le triplet ; renommez avec git |
+
+**Noms acceptés.** Tout ce que git accepte comme branche, vérifié contre le jeu de règles de libgit2 lui-même plutôt qu'une liste écrite à la main, plus deux règles maison : ni `.` ni `..` comme composant de chemin (un répertoire de worktree nommé `..` sortirait de la base), et pas de `-` en tête (git l'accepte, mais le nom serait inutilisable comme argument de `gwm remove` ou `git branch -d`). `Spike_Redis`, `2026.07.27` et `réécriture` passent tous.
+
+Dans la TUI, `Ctrl-T` bascule le formulaire de création entre le triplet structuré et un unique champ `Name`.
 
 Le déroulé de bout en bout vit dans [Premiers pas → Premier worktree](/fr/getting-started/first-worktree).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ use crate::milestones::{self, MilestoneDiff};
 use crate::multiplexer::{
   build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
 };
-use crate::naming::{parse_branch, BranchSpec};
+use crate::naming::{parse_branch, BranchSpec, WorktreeName};
 use crate::pr_templates::{self, PrTemplateContext};
 use crate::presets;
 use crate::review;
@@ -182,14 +182,25 @@ pub enum Command {
   /// Create a new worktree (and matching branch).
   Create {
     /// Branch type (feat, fix, hotfix, docs, test, refactor, chore, perf, ci, build).
-    #[arg()]
-    branch_type: String,
+    #[arg(required_unless_present = "name", conflicts_with = "name")]
+    branch_type: Option<String>,
     /// Issue number (digits only).
-    #[arg()]
-    issue: String,
+    #[arg(required_unless_present = "name", conflicts_with = "name")]
+    issue: Option<String>,
     /// Short description (kebab-case, will be normalized).
-    #[arg()]
-    desc: String,
+    #[arg(required_unless_present = "name", conflicts_with = "name")]
+    desc: Option<String>,
+    /// Name the worktree freely instead of using the <TYPE> <ISSUE> <DESC>
+    /// triple (issue #416), e.g. `gwm create --name spike-redis`. The name
+    /// becomes the branch verbatim; `branch_pattern` / `path_pattern` do not
+    /// apply because it has no `{type}` / `{issue}` / `{desc}` to expand.
+    /// Features that read the branch name back (issue auto-linking, gitmoji)
+    /// stay inactive on it — `gwm link` remains available.
+    ///
+    /// Exclusive with the positional triple: the mode is chosen explicitly,
+    /// never inferred from how many arguments were supplied.
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["branch_type", "issue", "desc"])]
+    name: Option<String>,
     /// Skip bootstrap after creation.
     #[arg(long)]
     no_bootstrap: bool,
@@ -1038,6 +1049,7 @@ pub fn run(cli: Cli) -> Result<()> {
       branch_type,
       issue,
       desc,
+      name,
       no_bootstrap,
       reuse_branch,
       skip_hooks,
@@ -1051,6 +1063,7 @@ pub fn run(cli: Cli) -> Result<()> {
         branch_type,
         issue,
         desc,
+        name,
         no_bootstrap,
         reuse_branch,
         skip_hooks,
@@ -2604,9 +2617,10 @@ fn resolve_workspace_create_repo(root: &Path, repo: Option<String>) -> Result<Pa
 // of this dispatcher follows, so the arg count is deliberate here.
 #[allow(clippy::too_many_arguments)]
 fn cmd_create(
-  branch_type: String,
-  issue: String,
-  desc: String,
+  branch_type: Option<String>,
+  issue: Option<String>,
+  desc: Option<String>,
+  name: Option<String>,
   no_bootstrap: bool,
   reuse_branch: bool,
   skip_hooks: Option<String>,
@@ -2616,11 +2630,34 @@ fn cmd_create(
   let RepoContext { repo, workdir, config } = repo_context(start)?;
   let repo_name = worktree::repo_name(&repo);
 
-  let resolved_types = config.resolved_branch_types();
-  let spec = BranchSpec::new_with_types(branch_type, issue, desc, &resolved_types.types)?;
-  let branch = spec.branch_name(&config.worktree, &repo_name)?;
-  let dirname = spec.worktree_dirname(&config.worktree, &repo_name)?;
-  let target = spec.worktree_path(&config.worktree, &repo_name, &workdir)?;
+  // clap guarantees exactly one of the two shapes reaches here:
+  // `--name` conflicts with all three positionals, and each positional is
+  // `required_unless_present = "name"`, so a partial triple is rejected
+  // before dispatch rather than silently read as a free-form request.
+  let wt_name = match name {
+    Some(name) => WorktreeName::freeform(&name)?,
+    None => {
+      let resolved_types = config.resolved_branch_types();
+      let (branch_type, issue, desc) = match (branch_type, issue, desc) {
+        (Some(t), Some(i), Some(d)) => (t, i, d),
+        _ => {
+          return Err(GwmError::Other(
+            "`gwm create` needs <TYPE> <ISSUE> <DESC> or --name".into(),
+          ))
+        }
+      };
+      WorktreeName::Structured(BranchSpec::new_with_types(
+        branch_type,
+        issue,
+        desc,
+        &resolved_types.types,
+      )?)
+    }
+  };
+
+  let branch = wt_name.branch_name(&config.worktree, &repo_name)?;
+  let dirname = wt_name.worktree_dirname(&config.worktree, &repo_name)?;
+  let target = wt_name.worktree_path(&config.worktree, &repo_name, &workdir)?;
   let skips = HookSkips::parse(skip_hooks.as_deref())?;
 
   // Gate the bootstrap RCE primitive on the TOFU ledger BEFORE
@@ -2633,7 +2670,14 @@ fn cmd_create(
     trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
   }
 
-  let pre_ctx = HookContext::for_create(&repo, &workdir, &workdir, &target, &branch, &spec);
+  // A free-form worktree genuinely has no type / issue / desc, so its hook
+  // placeholders resolve empty. That is the honest value, not a degradation:
+  // `for_worktree` derives exactly what a later `gwm remove` on the same
+  // worktree would see, so the two phases agree.
+  let pre_ctx = match &wt_name {
+    WorktreeName::Structured(spec) => HookContext::for_create(&repo, &workdir, &workdir, &target, &branch, spec),
+    WorktreeName::Freeform(_) => HookContext::for_worktree(&repo, &workdir, &workdir, &target, Some(&branch)),
+  };
   let report = lifecycle::run_phase(&config, HookPhase::PreCreate, &pre_ctx, &skips, false)?;
   print_lifecycle_report(&report);
 
@@ -2832,9 +2876,12 @@ fn cmd_new(
   println!("creating linked worktree for {}", branch);
 
   cmd_create(
-    spec.type_,
-    issue,
-    spec.desc,
+    Some(spec.type_),
+    Some(issue),
+    Some(spec.desc),
+    // `gwm new` always produces a structured worktree — it has just created
+    // the issue whose number the branch carries.
+    None,
     no_bootstrap,
     reuse_branch,
     skip_hooks,
@@ -3497,10 +3544,16 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
     }
   };
 
+  // Issue #416: a free-form branch reaches here legitimately. This command
+  // exists solely to derive a prefix from the branch *type*, and a name the
+  // user chose has none — there is no honest default to fall back to, so it
+  // stays an error. The message says the shape is unavailable rather than
+  // implying the branch is wrong.
   let spec = parse_branch(&branch_name).ok_or_else(|| {
     GwmError::Other(format!(
-      "branch '{}' does not follow the gwm convention <type>/#<issue>-<slug> — \
-       cannot derive a commit prefix from it",
+      "branch '{}' carries no <type>/#<issue>-<slug> to read — a commit prefix is derived from the \
+       branch type, so a free-form branch has none. Pass --branch <structured-name>, or write the \
+       prefix by hand",
       branch_name
     ))
   })?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2670,10 +2670,13 @@ fn cmd_create(
     trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
   }
 
-  // A free-form worktree genuinely has no type / issue / desc, so its hook
-  // placeholders resolve empty. That is the honest value, not a degradation:
-  // `for_worktree` derives exactly what a later `gwm remove` on the same
-  // worktree would see, so the two phases agree.
+  // `for_worktree` derives the context by re-parsing the branch, exactly as
+  // a later `gwm remove` on the same worktree would, so the two phases
+  // agree. Note what that means: the placeholders resolve empty only when
+  // the name does not match the branch convention. `--name 'feat/#42-x'`
+  // parses, so its context populates — and that is right, because nothing
+  // downstream knows how a worktree was named, only what its branch is
+  // (Codex review on PR #474).
   let pre_ctx = match &wt_name {
     WorktreeName::Structured(spec) => HookContext::for_create(&repo, &workdir, &workdir, &target, &branch, spec),
     WorktreeName::Freeform(_) => HookContext::for_worktree(&repo, &workdir, &workdir, &target, Some(&branch)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,13 @@ pub enum GwmError {
   #[error("invalid description '{0}' (kebab-case alphanumeric)")]
   InvalidDescription(String),
 
+  /// A `gwm create --name` value git or the filesystem would refuse
+  /// (issue #416). Free-form names skip the `<type>/#<issue>-<desc>`
+  /// convention entirely, so the only bar left is "can this be a branch
+  /// and a directory" — `{reason}` says which of the two objected.
+  #[error("invalid worktree name '{name}': {reason}")]
+  InvalidWorktreeName { name: String, reason: String },
+
   #[error("worktree '{0}' not found")]
   WorktreeNotFound(String),
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -161,6 +161,115 @@ impl BranchSpec {
   }
 }
 
+/// How a worktree got its name (issue #416).
+///
+/// [`Self::Structured`] is the canonical `<type>/#<issue>-<desc>` triple that
+/// `branch_pattern` / `path_pattern` expand. [`Self::Freeform`] is a name the
+/// user simply chose — `gwm create --name spike-redis` — and it deliberately
+/// escapes the convention: no branch type, no issue, no `DESC_RE`.
+///
+/// The patterns do not apply to a free-form name, because they are written in
+/// terms of `{type}` / `{issue}` / `{desc}` and it has none of them. `base`
+/// still applies (it only uses `{home}` / `{repo}`), so a free-form worktree
+/// lands beside the structured ones rather than somewhere else.
+#[derive(Debug, Clone)]
+pub enum WorktreeName {
+  Structured(BranchSpec),
+  /// Already validated by [`WorktreeName::freeform`] — constructing this
+  /// variant directly bypasses the ref/path checks.
+  Freeform(String),
+}
+
+impl WorktreeName {
+  /// Validate a user-supplied free-form name.
+  ///
+  /// The bar is deliberately low: git-ref legality and single-path-component
+  /// safety, nothing else. `Spike_Redis`, `2026.07.27` and `réécriture` are
+  /// all fine — refusing them would defeat the point of the flag.
+  ///
+  /// Ref legality is delegated to libgit2's own
+  /// [`git2::Reference::is_valid_name`] against the real `refs/heads/<name>`
+  /// the branch will occupy, rather than a hand-written rule list: the
+  /// authority on what git accepts is git.
+  pub fn freeform(input: &str) -> Result<Self> {
+    let name = input.trim();
+    let reject = |reason: &str| {
+      Err(GwmError::InvalidWorktreeName {
+        name: input.to_string(),
+        reason: reason.to_string(),
+      })
+    };
+
+    if name.is_empty() {
+      return reject("empty");
+    }
+    // Checked before the ref oracle so the message points at the real
+    // problem: git happily accepts `..` inside a longer component, but a
+    // worktree directory named `..` would escape the base directory.
+    if name.split('/').any(|part| part == "." || part == "..") {
+      return reject("`.` and `..` are not usable as a directory name");
+    }
+    if name.contains('\0') {
+      return reject("contains a NUL byte");
+    }
+    // Not a git rule: libgit2 accepts `refs/heads/-x` quite happily
+    // (verified — the ref oracle below lets it through). It is an
+    // *ergonomics* rule. A leading `-` makes the name unusable as an
+    // argument to every command that would take it back: `gwm remove -x`,
+    // `git branch -d -x`, `cd -x` all read it as a flag.
+    if name.starts_with('-') {
+      return reject("a leading `-` makes the name unusable as a command argument");
+    }
+
+    // The branch will live at `refs/heads/<name>`; validate exactly that.
+    if !git2::Reference::is_valid_name(&format!("refs/heads/{}", name)) {
+      return reject(
+        "not a valid git branch name — git rejects spaces, `~ ^ : ? * [ \\`, `@{`, `..`, \
+         leading/trailing `/`, a trailing `.` and a `.lock` suffix",
+      );
+    }
+
+    Ok(Self::Freeform(name.to_string()))
+  }
+
+  /// The branch this worktree gets. Structured names expand
+  /// `branch_pattern`; free-form names are the branch.
+  pub fn branch_name(&self, cfg: &WorktreeConfig, repo: &str) -> Result<String> {
+    match self {
+      Self::Structured(spec) => spec.branch_name(cfg, repo),
+      Self::Freeform(name) => Ok(name.clone()),
+    }
+  }
+
+  /// The worktree directory name. A branch may carry `/`; a directory is a
+  /// single path component, so it flattens to `-` — the same relationship
+  /// the default `branch_pattern` / `path_pattern` pair already has
+  /// (`feat/#42-x` on disk is `feat-42-x`).
+  pub fn worktree_dirname(&self, cfg: &WorktreeConfig, repo: &str) -> Result<String> {
+    match self {
+      Self::Structured(spec) => spec.worktree_dirname(cfg, repo),
+      Self::Freeform(name) => Ok(name.replace('/', "-")),
+    }
+  }
+
+  /// Absolute worktree path: `base` (expanded) joined with the directory
+  /// name. `base` applies in both modes.
+  pub fn worktree_path(
+    &self,
+    cfg: &WorktreeConfig,
+    repo: &str,
+    repo_path: &std::path::Path,
+  ) -> Result<std::path::PathBuf> {
+    match self {
+      Self::Structured(spec) => spec.worktree_path(cfg, repo, repo_path),
+      Self::Freeform(_) => {
+        let base = expand_placeholders(&cfg.base, repo, None, None, None, Some(repo_path))?;
+        Ok(std::path::PathBuf::from(base).join(self.worktree_dirname(cfg, repo)?))
+      }
+    }
+  }
+}
+
 /// Try to recover a BranchSpec from a free-form branch name like `feat/#123-my-desc`.
 pub fn parse_branch(branch: &str) -> Option<BranchSpec> {
   let cap = BRANCH_RE.captures(branch)?;

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -170,8 +170,23 @@ impl BranchSpec {
 ///
 /// The patterns do not apply to a free-form name, because they are written in
 /// terms of `{type}` / `{issue}` / `{desc}` and it has none of them. `base`
-/// still applies (it only uses `{home}` / `{repo}`), so a free-form worktree
-/// lands beside the structured ones rather than somewhere else.
+/// still applies, so a free-form worktree lands beside the structured ones
+/// rather than somewhere else — but only for the placeholders it documents
+/// (`{home}` / `{repo}` / `{repo_path}` / `{repo_parent}`). The structured
+/// path also feeds `{type}` / `{issue}` / `{desc}` through `base`; a `base`
+/// written with one of those is refused here rather than expanded literally.
+/// Max bytes in a single path component. `NAME_MAX` is 255 on every
+/// filesystem gwm targets; git's own ref check is silent about length,
+/// so the worktree directory is the binding constraint.
+const MAX_DIR_COMPONENT_BYTES: usize = 255;
+
+/// The `base` placeholders only the structured triple can supply. A
+/// free-form name has no value for any of them, and `expand_placeholders`
+/// leaves an unfed placeholder literal, so a `base` written with one of
+/// these has to be refused rather than turned into a directory called
+/// `{type}`.
+const STRUCTURED_BASE_PLACEHOLDERS: [&str; 3] = ["{type}", "{issue}", "{desc}"];
+
 #[derive(Debug, Clone)]
 pub enum WorktreeName {
   Structured(BranchSpec),
@@ -191,8 +206,13 @@ impl WorktreeName {
   /// [`git2::Reference::is_valid_name`] against the real `refs/heads/<name>`
   /// the branch will occupy, rather than a hand-written rule list: the
   /// authority on what git accepts is git.
+  ///
+  /// The name is validated exactly as typed. Trimming would accept
+  /// `--name " spike"` and create `spike` instead — a different branch from
+  /// the one that was asked for, which the "the name becomes the branch"
+  /// contract does not allow.
   pub fn freeform(input: &str) -> Result<Self> {
-    let name = input.trim();
+    let name = input;
     let reject = |reason: &str| {
       Err(GwmError::InvalidWorktreeName {
         name: input.to_string(),
@@ -219,6 +239,18 @@ impl WorktreeName {
     // `git branch -d -x`, `cd -x` all read it as a flag.
     if name.starts_with('-') {
       return reject("a leading `-` makes the name unusable as a command argument");
+    }
+    // A ref is a *path* of components, a worktree directory is a single one,
+    // so `a×130/b×130` is a legal ref and an illegal directory name. Without
+    // this check `worktree::add` creates the branch, then fails on the
+    // directory and leaves the branch orphaned. `/` → `-` is 1:1, so the
+    // flattened dirname has exactly the name's byte length.
+    if name.len() > MAX_DIR_COMPONENT_BYTES {
+      return reject(&format!(
+        "{} bytes long — a worktree directory is a single path component, capped at {}",
+        name.len(),
+        MAX_DIR_COMPONENT_BYTES
+      ));
     }
 
     // The branch will live at `refs/heads/<name>`; validate exactly that.
@@ -263,6 +295,14 @@ impl WorktreeName {
     match self {
       Self::Structured(spec) => spec.worktree_path(cfg, repo, repo_path),
       Self::Freeform(_) => {
+        if let Some(ph) = STRUCTURED_BASE_PLACEHOLDERS.iter().find(|ph| cfg.base.contains(**ph)) {
+          return Err(GwmError::Config(format!(
+            "worktree.base `{}` uses `{}`, which a free-form name has no value for \
+             (it would be left literal in the path) — drop it from base, or create \
+             the worktree with <type> <issue> <desc>",
+            cfg.base, ph
+          )));
+        }
         let base = expand_placeholders(&cfg.base, repo, None, None, None, Some(repo_path))?;
         Ok(std::path::PathBuf::from(base).join(self.worktree_dirname(cfg, repo)?))
       }

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -198,14 +198,32 @@ pub enum WorktreeName {
 impl WorktreeName {
   /// Validate a user-supplied free-form name.
   ///
-  /// The bar is deliberately low: git-ref legality and single-path-component
-  /// safety, nothing else. `Spike_Redis`, `2026.07.27` and `réécriture` are
-  /// all fine — refusing them would defeat the point of the flag.
+  /// The bar is deliberately low. `Spike_Redis`, `2026.07.27` and
+  /// `réécriture` are all fine — refusing them would defeat the point of the
+  /// flag. The rules are enumerated from the three things the name has to be
+  /// at once, rather than accreted one reviewer example at a time:
   ///
-  /// Ref legality is delegated to libgit2's own
-  /// [`git2::Reference::is_valid_name`] against the real `refs/heads/<name>`
-  /// the branch will occupy, rather than a hand-written rule list: the
-  /// authority on what git accepts is git.
+  /// 1. **A git branch.** Delegated to libgit2's own
+  ///    [`git2::Branch::name_is_valid`] — the branch-level oracle, not the
+  ///    reference-level one, because they disagree: `refs/heads/HEAD` is a
+  ///    syntactically valid *reference* name while `HEAD` is not a usable
+  ///    *branch* name. The authority on what git accepts is git.
+  /// 2. **A single filesystem path component** — the worktree directory. A
+  ///    branch name is a *path* of components, so the two have different
+  ///    limits: bounded at [`MAX_DIR_COMPONENT_BYTES`], and no `.` / `..`.
+  /// 3. **A literal value in placeholder expansion.**
+  ///    `lifecycle::expand_placeholders` substitutes sequentially, so a name
+  ///    that itself contains a token gets rewritten inside its own
+  ///    substituted value.
+  ///
+  /// Plus one rule that belongs to none of them: no leading `-`, which is a
+  /// CLI-ergonomics rule (git accepts it).
+  ///
+  /// What is deliberately **not** checked is the Windows-specific character
+  /// and reserved-device-name set (`< > " |`, `CON`, `NUL`, `COM1`…). That
+  /// gap is real and tracked separately — it cannot be verified from a Unix
+  /// machine, and a rule that only runs on one platform's CI is a rule
+  /// nobody can pre-validate.
   ///
   /// The name is validated exactly as typed. Trimming would accept
   /// `--name " spike"` and create `spike` instead — a different branch from
@@ -232,13 +250,22 @@ impl WorktreeName {
     if name.contains('\0') {
       return reject("contains a NUL byte");
     }
-    // Not a git rule: libgit2 accepts `refs/heads/-x` quite happily
-    // (verified — the ref oracle below lets it through). It is an
-    // *ergonomics* rule. A leading `-` makes the name unusable as an
-    // argument to every command that would take it back: `gwm remove -x`,
-    // `git branch -d -x`, `cd -x` all read it as a flag.
+    // Not a git rule: libgit2 accepts `-x` as a branch name quite happily
+    // (verified — the oracle below lets it through). It is an *ergonomics*
+    // rule. A leading `-` makes the name unusable as an argument to every
+    // command that would take it back: `gwm remove -x`, `git branch -d -x`,
+    // `cd -x` all read it as a flag.
     if name.starts_with('-') {
       return reject("a leading `-` makes the name unusable as a command argument");
+    }
+    // Consumer (3): `lifecycle::expand_placeholders` replaces `{branch}`
+    // first and `{type}` / `{issue}` / `{desc}` / `{repo}` after, so a hook
+    // asking for `{branch}` on `spike-{issue}` receives `spike-` — the
+    // second pass rewrites the value the first one just substituted.
+    // `DESC_RE` kept structured names out of this; free-form names reach it,
+    // so the boundary is where it gets closed.
+    if name.contains('{') || name.contains('}') {
+      return reject("`{` and `}` would be re-substituted when a lifecycle hook expands its placeholders");
     }
     // A ref is a *path* of components, a worktree directory is a single one,
     // so `a×130/b×130` is a legal ref and an illegal directory name. Without
@@ -253,11 +280,13 @@ impl WorktreeName {
       ));
     }
 
-    // The branch will live at `refs/heads/<name>`; validate exactly that.
-    if !git2::Reference::is_valid_name(&format!("refs/heads/{}", name)) {
+    // Consumer (1). The branch-level oracle, not `Reference::is_valid_name`
+    // on `refs/heads/<name>`: that one accepts `HEAD`, which `git branch`
+    // refuses and which would collide with the HEAD pseudo-ref.
+    if !git2::Branch::name_is_valid(name).unwrap_or(false) {
       return reject(
         "not a valid git branch name — git rejects spaces, `~ ^ : ? * [ \\`, `@{`, `..`, \
-         leading/trailing `/`, a trailing `.` and a `.lock` suffix",
+         leading/trailing `/`, a trailing `.`, a `.lock` suffix and `HEAD`",
       );
     }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -178,7 +178,12 @@ impl BranchSpec {
 /// Max bytes in a single path component. `NAME_MAX` is 255 on every
 /// filesystem gwm targets; git's own ref check is silent about length,
 /// so the worktree directory is the binding constraint.
-const MAX_DIR_COMPONENT_BYTES: usize = 255;
+///
+/// Public because the TUI create form has to stop typing at exactly this
+/// number: a form that stopped short would silently truncate a name the
+/// validator would have accepted, and submit a different branch than the
+/// one that was typed.
+pub const MAX_DIR_COMPONENT_BYTES: usize = 255;
 
 /// The `base` placeholders only the structured triple can supply. A
 /// free-form name has no value for any of them, and `expand_placeholders`

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -185,6 +185,11 @@ impl BranchSpec {
 /// one that was typed.
 pub const MAX_DIR_COMPONENT_BYTES: usize = 255;
 
+/// Bytes git tacks onto the ref's **final** component while creating it:
+/// `refs/heads/<name>.lock` has to exist before `refs/heads/<name>` does.
+/// Earlier components are plain directories and carry no suffix.
+const GIT_REF_LOCK_SUFFIX_BYTES: usize = ".lock".len();
+
 /// The `base` placeholders only the structured triple can supply. A
 /// free-form name has no value for any of them, and `expand_placeholders`
 /// leaves an unfed placeholder literal, so a `base` written with one of
@@ -282,6 +287,20 @@ impl WorktreeName {
         "{} bytes long — a worktree directory is a single path component, capped at {}",
         name.len(),
         MAX_DIR_COMPONENT_BYTES
+      ));
+    }
+    // The ref side of the same limit, five bytes tighter on the final
+    // component only: git creates `refs/heads/<name>.lock` first, and
+    // `Branch::name_is_valid` checks syntax, never length. Measured: a
+    // 250-byte final segment creates, 251 fails — after `pre_create` hooks
+    // have run. Earlier segments are plain directories, so they keep the
+    // full budget; capping them too would refuse names git accepts.
+    let last = name.rsplit('/').next().unwrap_or(name);
+    if last.len() + GIT_REF_LOCK_SUFFIX_BYTES > MAX_DIR_COMPONENT_BYTES {
+      return reject(&format!(
+        "its last segment is {} bytes — git writes `refs/heads/<name>.lock` first, leaving {} for it",
+        last.len(),
+        MAX_DIR_COMPONENT_BYTES - GIT_REF_LOCK_SUFFIX_BYTES
       ));
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2323,7 +2323,7 @@ impl App {
   pub fn hint_context(&self) -> super::ui::HintContext {
     use super::ui::HintContext;
     match self.view {
-      View::Create => HintContext::Create,
+      View::Create => self.create_hint_context(),
       View::Confirm => HintContext::Confirm,
       View::OpenMenu => HintContext::OpenMenu,
       // #219: the two link-prompt stages advertise different keys — the
@@ -2359,6 +2359,20 @@ impl App {
         }
       }
       View::List => self.pane_hint_context(),
+    }
+  }
+
+  /// Which hint row the create overlay advertises (issue #416). The two
+  /// modes present different inputs, so they advertise different verbs:
+  /// free-form has one field and no type selector, and `toggle_mode` is the
+  /// only way between them — a verb a user cannot guess from the visible
+  /// inputs, unlike Tab or the arrows. Both the statusbar and the overlay's
+  /// own footer read this, so the two can never disagree.
+  pub fn create_hint_context(&self) -> super::ui::HintContext {
+    use super::ui::HintContext;
+    match self.create_form.mode {
+      Mode::Freeform => HintContext::CreateFreeform,
+      Mode::Structured => HintContext::Create,
     }
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4133,6 +4133,15 @@ impl App {
       Some(ModalAction::CreateCancel) => return CreateKey::Cancel,
       Some(ModalAction::CreateNextField) => self.create_next_field(),
       Some(ModalAction::CreatePrevField) => self.create_prev_field(),
+      // Scoped to the create modal: `View::Edit` (rename, #290) routes its
+      // keys through this same handler, but it renders and submits the
+      // structured triple only — a free-form toggle there would send
+      // keystrokes into an invisible buffer and make Enter submit the
+      // untouched values (Codex review on PR #474).
+      // Swallowed outside the create modal — an explicit empty arm, not a
+      // guard on the arm below, because a failing guard would fall through
+      // to the literal-input fallback and type `t` into the description.
+      Some(ModalAction::CreateToggleMode) if self.view != View::Create => {}
       Some(ModalAction::CreateToggleMode) => {
         self.create_form.toggle_mode();
         self.status = match self.create_form.mode {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4144,11 +4144,19 @@ impl App {
       Some(ModalAction::CreateToggleMode) if self.view != View::Create => {}
       Some(ModalAction::CreateToggleMode) => {
         self.create_form.toggle_mode();
+        // Name the LIVE binding, and drop the clause when the verb is
+        // unbound — same contract as the confirm countdown above: never
+        // advertise a key that does nothing (Codex review on PR #474).
+        let back = self
+          .modal_keymap
+          .primary_key(ModalAction::CreateToggleMode)
+          .map(|k| format!(" — {k}: "))
+          .unwrap_or_default();
         self.status = match self.create_form.mode {
-          Mode::Freeform => {
-            "free-form: name the worktree anything git accepts — ctrl-t: back to type/issue/desc".into()
-          }
-          Mode::Structured => "tab/shift-tab: switch field — enter on desc: submit — ctrl-t: free-form".into(),
+          Mode::Freeform if back.is_empty() => "free-form: name the worktree anything git accepts".into(),
+          Mode::Freeform => format!("free-form: name the worktree anything git accepts{back}back to type/issue/desc"),
+          Mode::Structured if back.is_empty() => "tab/shift-tab: switch field — enter on desc: submit".into(),
+          Mode::Structured => format!("tab/shift-tab: switch field — enter on desc: submit{back}free-form"),
         };
       }
       Some(ModalAction::CreateSubmit) => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use super::state::clean_overlay::CleanOverlay;
 use super::state::command_logs::CommandLogs;
 use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
-use super::state::create_form::{CreateForm, Field};
+use super::state::create_form::{CreateForm, Field, Mode};
 use super::state::exec_picker::ExecPicker;
 use super::state::filter::{fuzzy_match_indices, FilterState};
 use super::state::github_fetch::{FetchKey, GitHubFetch};
@@ -21,7 +21,7 @@ use crate::config::{CleanConfig, Config, ExecConfig, TuiOpenConfig, TuiOpenMode}
 use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, PrStatus};
 use crate::launcher::{self, ExpandedCommand, LauncherContext};
-use crate::naming::BranchSpec;
+use crate::naming::{BranchSpec, WorktreeName};
 use crate::worktree::{self, WorktreeInfo};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::Repository;
@@ -4133,8 +4133,19 @@ impl App {
       Some(ModalAction::CreateCancel) => return CreateKey::Cancel,
       Some(ModalAction::CreateNextField) => self.create_next_field(),
       Some(ModalAction::CreatePrevField) => self.create_prev_field(),
+      Some(ModalAction::CreateToggleMode) => {
+        self.create_form.toggle_mode();
+        self.status = match self.create_form.mode {
+          Mode::Freeform => {
+            "free-form: name the worktree anything git accepts — ctrl-t: back to type/issue/desc".into()
+          }
+          Mode::Structured => "tab/shift-tab: switch field — enter on desc: submit — ctrl-t: free-form".into(),
+        };
+      }
       Some(ModalAction::CreateSubmit) => {
-        if self.create_form.field == Field::Desc {
+        // The submit field is the last one of the active mode: `Desc` in
+        // the structured triple, `Name` in free-form (its only field).
+        if matches!(self.create_form.field, Field::Desc | Field::Name) {
           return CreateKey::Submit;
         }
         self.create_next_field();
@@ -4154,20 +4165,36 @@ impl App {
   }
 
   pub fn submit_create(&mut self) -> Result<()> {
-    let type_ = self
-      .branch_types
-      .get(self.create_form.type_index)
-      .map(|t| t.name.clone())
-      .unwrap_or_default();
-    let spec = BranchSpec::new_with_types(
-      type_,
-      self.create_form.issue.clone(),
-      self.create_form.desc.clone(),
-      &self.branch_types,
-    )?;
-    let branch = spec.branch_name(&self.config.worktree, &self.repo_name)?;
-    let dirname = spec.worktree_dirname(&self.config.worktree, &self.repo_name)?;
-    let target = spec.worktree_path(&self.config.worktree, &self.repo_name, &self.workdir)?;
+    // Issue #416: free-form validation lands here rather than per keystroke,
+    // so the user can type through an intermediate state. A rejected name
+    // keeps the form open with the reason in the status bar — same shape as
+    // the trust refusal below, and for the same reason (an `Err` would tear
+    // down the alternate screen).
+    let wt_name = match self.create_form.mode {
+      Mode::Freeform => match WorktreeName::freeform(&self.create_form.name) {
+        Ok(n) => n,
+        Err(e) => {
+          self.status = format!("{}", e);
+          return Ok(());
+        }
+      },
+      Mode::Structured => {
+        let type_ = self
+          .branch_types
+          .get(self.create_form.type_index)
+          .map(|t| t.name.clone())
+          .unwrap_or_default();
+        WorktreeName::Structured(BranchSpec::new_with_types(
+          type_,
+          self.create_form.issue.clone(),
+          self.create_form.desc.clone(),
+          &self.branch_types,
+        )?)
+      }
+    };
+    let branch = wt_name.branch_name(&self.config.worktree, &self.repo_name)?;
+    let dirname = wt_name.worktree_dirname(&self.config.worktree, &self.repo_name)?;
+    let target = wt_name.worktree_path(&self.config.worktree, &self.repo_name, &self.workdir)?;
 
     // Gate the bootstrap RCE primitive on the TOFU ledger BEFORE
     // creating the worktree on disk (issue #95). A refusal here

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3846,8 +3846,12 @@ impl App {
       return;
     };
     let Some(spec) = crate::naming::parse_branch(&branch) else {
+      // Issue #416: a free-form worktree lands here by design, not by
+      // mistake. The edit form rebuilds a `<type>/#<issue>-<desc>` triple,
+      // which a name the user chose on purpose has none of — so state that
+      // this form does not apply rather than implying a malformed branch.
       self.status = format!(
-        "branch '{}' doesn't match <type>/#<issue>-<desc>; can't rename here",
+        "'{}' is a free-form branch — the edit form rebuilds <type>/#<issue>-<desc>; rename it with git",
         branch
       );
       return;

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -380,6 +380,10 @@ impl ModalAction {
         | ModalAction::CreateCancel
         | ModalAction::CreateNextField
         | ModalAction::CreatePrevField
+        // #416: free-form mode has `Name` as its only field, so a bare
+        // printable bound here would be swallowed as typing with no way
+        // back to the structured form.
+        | ModalAction::CreateToggleMode
     ) && !stroke.modifiers.intersects(KM::CONTROL | KM::ALT)
       && matches!(stroke.code, KC::Char(_) | KC::Backspace)
   }

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -244,6 +244,10 @@ define_modal_actions! {
     CreateSubmit    => "submit"     [ "Enter" ],
     CreatePrevType  => "prev_type"  [ "Up", "Left", "h" ],
     CreateNextType  => "next_type"  [ "Down", "Right", "l" ],
+    // Issue #416. Ctrl-modified on purpose: the create overlay reserves
+    // unmodified printable keys for the text fields, so a bare letter here
+    // would be swallowed while typing a description.
+    CreateToggleMode => "toggle_mode" [ "Ctrl+t" ],
   }
   Confirm {
     ConfirmConfirm      => "confirm"       [ "y" ],

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -18,26 +18,51 @@ pub const MAX_ISSUE_LEN: usize = 7;
 /// limit even with the longest configured branch type (#217).
 pub const MAX_DESC_LEN: usize = 200;
 
+/// Max characters accepted in the free-form name field (issue #416).
+/// Same bound as the slug: git's ref limit is 255 bytes and the name IS
+/// the branch, so 200 leaves room for multi-byte characters — free-form
+/// names are not restricted to ASCII.
+pub const MAX_NAME_LEN: usize = 200;
+
+/// Which naming shape the form is collecting (issue #416). Toggled with
+/// the `toggle_mode` verb; `Structured` is the default so the canonical
+/// triple stays the path of least resistance.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum Mode {
+  #[default]
+  Structured,
+  Freeform,
+}
+
 /// Which input is currently focused inside the create overlay. Selected
 /// via Tab / Shift-Tab; the Type field is special — it's cycled via
-/// `next_type` / `prev_type` rather than typed into.
+/// `next_type` / `prev_type` rather than typed into. `Name` is the sole
+/// field of [`Mode::Freeform`] and is never reachable from the structured
+/// rotation.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub enum Field {
   #[default]
   Type,
   Issue,
   Desc,
+  Name,
 }
 
 /// Input state for the create-worktree overlay. `Default` opens the form
-/// in the initial state (Type field focused, first type selected, both
-/// string fields empty).
+/// in the initial state (structured mode, Type field focused, first type
+/// selected, every string field empty).
+///
+/// Both modes' buffers are kept side by side rather than sharing one:
+/// toggling is exploratory, and a user flipping across to look at the
+/// other form must not lose what they already typed.
 #[derive(Debug, Default)]
 pub struct CreateForm {
+  pub mode: Mode,
   pub field: Field,
   pub type_index: usize,
   pub issue: String,
   pub desc: String,
+  pub name: String,
 }
 
 impl CreateForm {
@@ -48,26 +73,53 @@ impl CreateForm {
   /// Return to the freshly-opened state. Called by the orchestrator when
   /// the form opens or cancels.
   pub fn reset(&mut self) {
+    self.mode = Mode::Structured;
     self.field = Field::Type;
     self.type_index = 0;
     self.issue.clear();
     self.desc.clear();
+    self.name.clear();
   }
 
-  /// Rotate field focus forward (Type → Issue → Desc → Type).
+  /// Flip between the structured triple and a free-form name (issue #416),
+  /// landing focus on the target mode's entry field: `Name` is free-form's
+  /// only field, `Issue` is where `enter_create` opens the structured form.
+  /// Typed values on both sides survive, so a round trip loses nothing.
+  pub fn toggle_mode(&mut self) {
+    match self.mode {
+      Mode::Structured => {
+        self.mode = Mode::Freeform;
+        self.field = Field::Name;
+      }
+      Mode::Freeform => {
+        self.mode = Mode::Structured;
+        self.field = Field::Issue;
+      }
+    }
+  }
+
+  /// Rotate field focus forward (Type → Issue → Desc → Type). Free-form
+  /// mode has a single field, so rotation stays put rather than walking
+  /// focus onto inputs that mode does not present.
   pub fn next_field(&mut self) {
+    if self.mode == Mode::Freeform {
+      return;
+    }
     self.field = match self.field {
       Field::Type => Field::Issue,
       Field::Issue => Field::Desc,
-      Field::Desc => Field::Type,
+      Field::Desc | Field::Name => Field::Type,
     };
   }
 
   /// Rotate field focus backward (Type → Desc → Issue → Type).
   pub fn prev_field(&mut self) {
+    if self.mode == Mode::Freeform {
+      return;
+    }
     self.field = match self.field {
       Field::Type => Field::Desc,
-      Field::Issue => Field::Type,
+      Field::Issue | Field::Name => Field::Type,
       Field::Desc => Field::Issue,
     };
   }
@@ -99,10 +151,14 @@ impl CreateForm {
   /// drops non-digits to match the `<type>/#<digits>-<slug>` branch
   /// convention; Desc accepts any character (slug normalisation happens
   /// downstream in `BranchSpec`). Type is no-op (cycled, not typed).
+  /// Name accepts anything printable: git-ref and path legality are
+  /// checked once on submit by `WorktreeName::freeform`, not per keystroke,
+  /// so the user can type through an intermediate state (issue #416).
   pub fn push_char(&mut self, c: char) {
     match self.field {
       Field::Issue if c.is_ascii_digit() && self.issue.chars().count() < MAX_ISSUE_LEN => self.issue.push(c),
       Field::Desc if self.desc.chars().count() < MAX_DESC_LEN => self.desc.push(c),
+      Field::Name if self.name.chars().count() < MAX_NAME_LEN => self.name.push(c),
       _ => {}
     }
   }
@@ -116,6 +172,9 @@ impl CreateForm {
       }
       Field::Desc => {
         self.desc.pop();
+      }
+      Field::Name => {
+        self.name.pop();
       }
       _ => {}
     }

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -18,11 +18,16 @@ pub const MAX_ISSUE_LEN: usize = 7;
 /// limit even with the longest configured branch type (#217).
 pub const MAX_DESC_LEN: usize = 200;
 
-/// Max characters accepted in the free-form name field (issue #416).
-/// Same bound as the slug: git's ref limit is 255 bytes and the name IS
-/// the branch, so 200 leaves room for multi-byte characters — free-form
-/// names are not restricted to ASCII.
-pub const MAX_NAME_LEN: usize = 200;
+/// Max **bytes** accepted in the free-form name field (issue #416).
+///
+/// Deliberately the validator's own limit rather than a form-local number:
+/// the name IS the branch, so a form that stopped short of what
+/// `WorktreeName::freeform` accepts would silently truncate a legal name
+/// and submit a different branch than the one typed (Codex review on
+/// PR #474). Counted in bytes for the same reason the validator does —
+/// free-form names are not restricted to ASCII, and it is the worktree
+/// directory's byte length that has to fit.
+pub const MAX_NAME_LEN: usize = crate::naming::MAX_DIR_COMPONENT_BYTES;
 
 /// Which naming shape the form is collecting (issue #416). Toggled with
 /// the `toggle_mode` verb; `Structured` is the default so the canonical
@@ -158,7 +163,7 @@ impl CreateForm {
     match self.field {
       Field::Issue if c.is_ascii_digit() && self.issue.chars().count() < MAX_ISSUE_LEN => self.issue.push(c),
       Field::Desc if self.desc.chars().count() < MAX_DESC_LEN => self.desc.push(c),
-      Field::Name if self.name.chars().count() < MAX_NAME_LEN => self.name.push(c),
+      Field::Name if self.name.len() + c.len_utf8() <= MAX_NAME_LEN => self.name.push(c),
       _ => {}
     }
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2011,8 +2011,13 @@ pub enum HintContext {
   Status,
   /// `gwm switch` picker — mutating verbs are inert, Enter/Esc pick/cancel.
   Picker,
-  /// Create-worktree form modal.
+  /// Create-worktree form modal, structured `<type> <issue> <desc>` mode.
   Create,
+  /// Create-worktree form modal, free-form mode (issue #416). A separate
+  /// context because the two modes present different inputs: free-form has
+  /// one field and no type selector, so the `field` / `type` hints would
+  /// name verbs that do nothing there.
+  CreateFreeform,
   /// Confirm-delete modal.
   Confirm,
   /// Open issue/PR URL menu.
@@ -2057,7 +2062,7 @@ impl HintContext {
       HintContext::Worktrees => "worktrees",
       HintContext::Status => "status",
       HintContext::Picker => "switch",
-      HintContext::Create => "create",
+      HintContext::Create | HintContext::CreateFreeform => "create",
       HintContext::Confirm => "confirm",
       HintContext::OpenMenu => "open",
       HintContext::LinkPrompt => "link",
@@ -2147,6 +2152,17 @@ impl HintContext {
       HintContext::Create => &[
         Hint::Modal(ModalAction::CreateNextField, "field"),
         Hint::Lit("↑/↓", "type"),
+        Hint::Modal(ModalAction::CreateToggleMode, "free-form"),
+        Hint::Modal(ModalAction::CreateSubmit, "submit"),
+        Hint::Modal(ModalAction::CreateCancel, "cancel"),
+      ],
+      // Free-form has one field and no type selector, so `field` and `type`
+      // are dropped rather than shown inert — the same reason `draw_create`
+      // stops rendering those rows. `toggle_mode` leads the row: it is the
+      // only way back, and unlike the create form's other verbs it is not
+      // guessable from the visible inputs.
+      HintContext::CreateFreeform => &[
+        Hint::Modal(ModalAction::CreateToggleMode, "structured"),
         Hint::Modal(ModalAction::CreateSubmit, "submit"),
         Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
@@ -2271,7 +2287,7 @@ impl HintContext {
   /// hint key shadowed by a modal binding in the same context.
   fn modal_context(self) -> Option<KeyContext> {
     Some(match self {
-      HintContext::Create | HintContext::Rename => KeyContext::Create,
+      HintContext::Create | HintContext::CreateFreeform | HintContext::Rename => KeyContext::Create,
       HintContext::Confirm => KeyContext::Confirm,
       HintContext::OpenMenu => KeyContext::OpenMenu,
       HintContext::LinkPrompt => KeyContext::LinkChooseTarget,
@@ -3867,7 +3883,7 @@ fn draw_create(f: &mut Frame, app: &App) {
     );
     f.render_widget(
       Paragraph::new(modal_hint_for_context(
-        HintContext::Create,
+        app.create_hint_context(),
         &app.keymap,
         &app.modal_keymap,
         &app.theme,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4,7 +4,7 @@ use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::state::async_task::TaskKind;
 use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
-use super::state::create_form::Field;
+use super::state::create_form::{Field, Mode};
 use super::state::pty_overlay::PtyKind;
 use super::state::sidebar::SidebarMode;
 use super::state::spinner::DOT_FRAMES;
@@ -2953,10 +2953,11 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       modal_entry(ModalAction::CreateNextType, "next branch type"),
       modal_entry(ModalAction::CreateNextField, "next field"),
       modal_entry(ModalAction::CreatePrevField, "previous field"),
-      modal_entry(ModalAction::CreateSubmit, "submit (on description) / next field"),
+      modal_entry(ModalAction::CreateSubmit, "submit (on description / name) / next field"),
+      modal_entry(ModalAction::CreateToggleMode, "toggle type/issue/desc ↔ free-form name"),
       modal_entry(ModalAction::CreateCancel, "cancel"),
       fixed("0-9", "type into the issue field (digits only)"),
-      fixed("any char", "type into the description field"),
+      fixed("any char", "type into the description / name field"),
       fixed("Backspace", "delete the last character"),
       HelpRow::Blank,
       HelpRow::Section("Delete Worktree".to_string()),
@@ -3746,28 +3747,43 @@ fn draw_create(f: &mut Frame, app: &App) {
   let value_w = inner_w.saturating_sub(gutter);
 
   let label = |s: &str| format!("{:<label_w$}", s);
-  let branch = ellipsize_middle(
-    &format!("{}/#{}-{}", type_str, app.create_form.issue, app.create_form.desc),
-    inner_w.saturating_sub("  Branch : ".len()),
-  );
-  let dirname = ellipsize_middle(
-    &format!("{}-{}-{}", type_str, app.create_form.issue, app.create_form.desc),
-    inner_w.saturating_sub("  Dir    : ".len()),
-  );
+  let freeform = app.create_form.mode == Mode::Freeform;
+  // Issue #416: a free-form name IS the branch, and the directory is that
+  // name with `/` flattened — mirroring `WorktreeName::worktree_dirname`.
+  let (branch_raw, dir_raw) = if freeform {
+    (app.create_form.name.clone(), app.create_form.name.replace('/', "-"))
+  } else {
+    (
+      format!("{}/#{}-{}", type_str, app.create_form.issue, app.create_form.desc),
+      format!("{}-{}-{}", type_str, app.create_form.issue, app.create_form.desc),
+    )
+  };
+  let branch = ellipsize_middle(&branch_raw, inner_w.saturating_sub("  Branch : ".len()));
+  let dirname = ellipsize_middle(&dir_raw, inner_w.saturating_sub("  Dir    : ".len()));
 
-  let mut lines = overlay_title_lines("New Worktree", clean);
+  let mut lines = overlay_title_lines(
+    if freeform {
+      "New Worktree — free-form"
+    } else {
+      "New Worktree"
+    },
+    clean,
+  );
   // Type selector first, then the live preview, then the editable fields —
   // the preview sits above the inputs so the resulting names stay in view
-  // while typing (issue #217 follow-up).
-  lines.push(type_selector_line(
-    &label("Type"),
-    type_str,
-    type_desc,
-    app.create_form.field == Field::Type,
-    accent,
-    muted,
-  ));
-  lines.push(Line::from(String::new()));
+  // while typing (issue #217 follow-up). Free-form mode has no branch type,
+  // so the selector is absent rather than shown inert.
+  if !freeform {
+    lines.push(type_selector_line(
+      &label("Type"),
+      type_str,
+      type_desc,
+      app.create_form.field == Field::Type,
+      accent,
+      muted,
+    ));
+    lines.push(Line::from(String::new()));
+  }
   lines.push(Line::from(vec![
     Span::raw("  Branch : "),
     Span::styled(branch, Style::default().fg(app.theme.branch)),
@@ -3777,25 +3793,37 @@ fn draw_create(f: &mut Frame, app: &App) {
     Span::styled(dirname, Style::default().fg(app.theme.dirty)),
   ]));
   lines.push(Line::from(String::new()));
-  lines.push(field_input_line(
-    &label("Issue"),
-    &app.create_form.issue,
-    app.create_form.field == Field::Issue,
-    value_w,
-    accent,
-    muted,
-    surface,
-  ));
-  lines.push(Line::from(String::new()));
-  lines.push(field_input_line(
-    &label("Desc"),
-    &app.create_form.desc,
-    app.create_form.field == Field::Desc,
-    value_w,
-    accent,
-    muted,
-    surface,
-  ));
+  if freeform {
+    lines.push(field_input_line(
+      &label("Name"),
+      &app.create_form.name,
+      app.create_form.field == Field::Name,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+  } else {
+    lines.push(field_input_line(
+      &label("Issue"),
+      &app.create_form.issue,
+      app.create_form.field == Field::Issue,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+    lines.push(Line::from(String::new()));
+    lines.push(field_input_line(
+      &label("Desc"),
+      &app.create_form.desc,
+      app.create_form.field == Field::Desc,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+  }
 
   let height = lines.len() as u16 + 4 + 2 /* border */ + 2 /* vertical padding */;
   let area = centered_box(70, 72, height, term);

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -6703,3 +6703,80 @@ fn trust_add_satisfies_the_gate_that_bootstrap_checks() {
   run(&["open", "issue", "--print-url"]).success();
   run(&["bootstrap"]).success();
 }
+
+// --- create --name (issue #416) -----------------------------------------
+
+#[test]
+fn create_name_flag_appears_in_help() {
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["create", "--help"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("--name"));
+}
+
+/// The mode is chosen by an explicit flag, never inferred from how many
+/// positionals were supplied — two of the three is a typo, not a request
+/// for free-form naming.
+#[test]
+fn create_rejects_a_partial_triple() {
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["create", "feat", "42"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("<DESC>").or(predicate::str::contains("required")));
+}
+
+#[test]
+fn create_name_conflicts_with_the_structured_triple() {
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["create", "--name", "spike-redis", "feat", "42", "x"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("cannot be used with").or(predicate::str::contains("conflict")));
+}
+
+#[test]
+fn create_name_makes_a_worktree_whose_branch_is_the_name() {
+  let (dir, repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "--name", "spike-redis"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("spike-redis"))
+    .stdout(predicate::str::contains("worktree created"));
+
+  // `path_pattern` is `{type}-{issue}-{desc}` in the test config and must
+  // NOT have been applied — a free-form name has none of those tokens.
+  let wt_dir = base.path().join("spike-redis");
+  assert!(wt_dir.exists(), "worktree dir must be the name verbatim");
+  assert!(
+    repo.find_branch("spike-redis", git2::BranchType::Local).is_ok(),
+    "the branch must be the name verbatim"
+  );
+}
+
+#[test]
+fn create_name_rejects_a_name_git_would_refuse() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  write_test_config(dir.path(), base.path());
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "--name", "has space"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("has space"));
+}

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -219,6 +219,30 @@ fn cross_context_reuse_is_not_a_conflict() {
 }
 
 #[test]
+fn toggle_mode_refuses_a_bare_printable_the_text_fields_would_swallow() {
+  // #456's contract: `handle_create_key` routes an unmodified printable into
+  // the focused text field BEFORE resolving the modal verb, so `toggle_mode =
+  // ["x"]` would be accepted by config and then never fire — and in free-form
+  // mode, where `Name` is the only field, it would leave no way back to the
+  // structured form. `Ctrl+t` is the default precisely because of this, but
+  // the guard has to cover the verb too (Codex review on PR #474).
+  let mut km = ModalKeymap::defaults();
+  let err = km
+    .apply_override(ModalAction::CreateToggleMode, vec![ch('x')])
+    .expect_err("a bare printable must be refused for toggle_mode");
+  assert!(
+    err.to_string().contains("reserved for typing"),
+    "the message must explain why: {err}"
+  );
+  // Ctrl-modified stays bindable — that is the escape hatch the default uses.
+  km.apply_override(
+    ModalAction::CreateToggleMode,
+    vec![KeyStroke::new(KeyCode::Char('y'), KeyModifiers::CONTROL)],
+  )
+  .expect("a Ctrl-modified stroke is not typing input");
+}
+
+#[test]
 fn override_marks_source_as_user_config() {
   let mut km = ModalKeymap::defaults();
   km.apply_override(ModalAction::ConfirmConfirm, vec![ch('o')]).unwrap();

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -692,9 +692,43 @@ fn a_name_that_would_overflow_a_path_component_is_refused_before_anything_is_cre
     WorktreeName::freeform(&long).is_err(),
     "a 261-byte directory name must be refused up front"
   );
-  // Right at the edge: 255 bytes is a legal component, 256 is not.
-  assert!(WorktreeName::freeform(&"a".repeat(255)).is_ok(), "255 bytes is legal");
-  assert!(WorktreeName::freeform(&"a".repeat(256)).is_err(), "256 bytes is not");
+  // Right at the edge: 255 bytes of directory name is legal, 256 is not.
+  // Split so the *final* ref component stays clear of the `.lock` rule the
+  // next test pins — this one is about the directory, not the ref.
+  let edge = format!("{}/{}", "a".repeat(251), "b".repeat(3));
+  assert_eq!(edge.len(), 255);
+  assert!(WorktreeName::freeform(&edge).is_ok(), "255 bytes is legal");
+  assert!(
+    WorktreeName::freeform(&format!("{}b", edge)).is_err(),
+    "256 bytes is not"
+  );
+}
+
+/// The other five bytes. Git writes `refs/heads/<name>.lock` *before* the
+/// ref itself, so the ref's final path component carries a suffix the
+/// directory name never sees — and `Branch::name_is_valid` only checks
+/// syntax, never length. Measured against the branch binary: a 250-byte
+/// final segment creates, 251 fails, and it fails after `pre_create` hooks
+/// have already run (Codex review on PR #474).
+///
+/// Only the final segment: an earlier one gets no suffix, so it may use the
+/// full directory budget. Capping every segment would refuse names git and
+/// the filesystem both accept.
+#[test]
+fn the_final_segment_leaves_room_for_git_s_lock_file() {
+  assert!(
+    WorktreeName::freeform(&"a".repeat(250)).is_ok(),
+    "250 + `.lock` is exactly 255 — legal"
+  );
+  assert!(
+    WorktreeName::freeform(&"a".repeat(251)).is_err(),
+    "251 + `.lock` overflows the component git has to create first"
+  );
+  let front_heavy = format!("{}/{}", "a".repeat(251), "b".repeat(3));
+  assert!(
+    WorktreeName::freeform(&front_heavy).is_ok(),
+    "a 251-byte segment is fine when it is not the one carrying `.lock`"
+  );
 }
 
 /// A free-form name has to survive three consumers, and the rules are

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -1,5 +1,7 @@
 use gwm::config::{BranchType, WorktreeConfig};
-use gwm::naming::{branch_pattern_warning, default_branch_types, kebab, parse_branch, BranchSpec, BRANCH_TYPES};
+use gwm::naming::{
+  branch_pattern_warning, default_branch_types, kebab, parse_branch, BranchSpec, WorktreeName, BRANCH_TYPES,
+};
 
 #[test]
 fn naming_regexes_compile_at_first_use() {
@@ -541,4 +543,101 @@ fn the_consumer_mapping_matches_the_call_sites() {
     "`gwm create` passes the original BranchSpec to its hooks — only remove/bootstrap re-parse: {}",
     w
   );
+}
+
+// ---------------------------------------------------------------------
+// Issue #416 — free-form worktree naming. `WorktreeName` splits the
+// structured triple from a name the user simply chose. Free-form names
+// are checked for git-ref and filesystem safety only, never against
+// `DESC_RE` — the whole point is not having to obey the convention.
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_freeform_name_is_kept_as_typed_when_it_is_already_safe() {
+  let n = WorktreeName::freeform("spike-redis").expect("a plain slug is valid");
+  let cfg = WorktreeConfig::default();
+  assert_eq!(n.branch_name(&cfg, "gwm-cli").unwrap(), "spike-redis");
+  assert_eq!(n.worktree_dirname(&cfg, "gwm-cli").unwrap(), "spike-redis");
+}
+
+/// Free-form means free-form: shapes `DESC_RE` rejects are fine here.
+#[test]
+fn a_freeform_name_is_not_held_to_the_desc_convention() {
+  for name in ["Spike_Redis", "2026.07.27", "réécriture", "WIP"] {
+    assert!(
+      WorktreeName::freeform(name).is_ok(),
+      "`{}` is a legal git ref and must be accepted",
+      name
+    );
+  }
+}
+
+/// `branch_pattern` / `path_pattern` are defined in terms of `{type}`,
+/// `{issue}` and `{desc}`, none of which a free-form name has, so they do
+/// not apply. `base` still does — it only uses `{home}` / `{repo}`.
+#[test]
+fn patterns_do_not_apply_to_a_freeform_name_but_base_still_does() {
+  let cfg = WorktreeConfig {
+    base: "/tmp/{repo}".into(),
+    path_pattern: "{type}-{issue}-{desc}".into(),
+    branch_pattern: "{type}/#{issue}-{desc}".into(),
+  };
+  let n = WorktreeName::freeform("spike-redis").unwrap();
+  assert_eq!(n.branch_name(&cfg, "r").unwrap(), "spike-redis");
+  let p = n.worktree_path(&cfg, "r", std::path::Path::new("/repos/r")).unwrap();
+  assert_eq!(p, std::path::Path::new("/tmp/r/spike-redis"));
+}
+
+/// A `/` is legal in a branch name and a common convention, but a worktree
+/// directory is a single path component — same split the structured mode
+/// already makes between `branch_pattern` and `path_pattern`.
+#[test]
+fn a_slash_survives_in_the_branch_and_flattens_in_the_directory() {
+  let n = WorktreeName::freeform("spike/redis").expect("a slash is a legal ref");
+  let cfg = WorktreeConfig::default();
+  assert_eq!(n.branch_name(&cfg, "r").unwrap(), "spike/redis");
+  assert_eq!(n.worktree_dirname(&cfg, "r").unwrap(), "spike-redis");
+}
+
+/// Rejected against libgit2's own `refs/heads/<name>` check rather than a
+/// hand-written rule list, plus the path-component rules a ref check does
+/// not cover.
+#[test]
+fn a_freeform_name_that_git_or_the_filesystem_would_refuse_is_rejected() {
+  for bad in [
+    "",            // empty
+    "   ",         // whitespace only
+    "..",          // path traversal
+    "a..b",        // git: no double dot
+    "-leading",    // git: no leading dash on a ref component
+    "trailing.",   // git: no trailing dot
+    "has space",   // git: no space
+    "tilde~1",     // git: no tilde
+    "caret^",      // git: no caret
+    "colon:",      // git: no colon
+    "quest?",      // git: no question mark
+    "star*",       // git: no asterisk
+    "brack[et",    // git: no open bracket
+    "back\\slash", // git: no backslash
+    "at@{brace",   // git: no @{
+    "ends.lock",   // git: no .lock suffix
+    "ctrl\u{7}x",  // control byte
+    "/leading",    // empty ref component
+    "trailing/",   // empty ref component
+    "double//slash",
+  ] {
+    assert!(
+      WorktreeName::freeform(bad).is_err(),
+      "`{}` must be rejected as a worktree name",
+      bad
+    );
+  }
+}
+
+/// The rejection has to say what is wrong, not just that something is.
+#[test]
+fn the_rejection_names_the_offending_value() {
+  let err = WorktreeName::freeform("has space").unwrap_err();
+  let msg = format!("{}", err);
+  assert!(msg.contains("has space"), "the message must quote the input: {}", msg);
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -574,7 +574,8 @@ fn a_freeform_name_is_not_held_to_the_desc_convention() {
 
 /// `branch_pattern` / `path_pattern` are defined in terms of `{type}`,
 /// `{issue}` and `{desc}`, none of which a free-form name has, so they do
-/// not apply. `base` still does — it only uses `{home}` / `{repo}`.
+/// not apply. `base` still does, for the placeholders it documents
+/// (`{home}` / `{repo}` / `{repo_path}` / `{repo_parent}`).
 #[test]
 fn patterns_do_not_apply_to_a_freeform_name_but_base_still_does() {
   let cfg = WorktreeConfig {
@@ -586,6 +587,28 @@ fn patterns_do_not_apply_to_a_freeform_name_but_base_still_does() {
   assert_eq!(n.branch_name(&cfg, "r").unwrap(), "spike-redis");
   let p = n.worktree_path(&cfg, "r", std::path::Path::new("/repos/r")).unwrap();
   assert_eq!(p, std::path::Path::new("/tmp/r/spike-redis"));
+}
+
+/// `base` is only expanded with the placeholders a free-form name can
+/// supply. The structured path feeds `{type}` / `{issue}` / `{desc}` into
+/// `base` too, so a base written with one of them has nothing to resolve
+/// against here — and `expand_placeholders` leaves an unfed placeholder
+/// *literal*, which would silently create a directory named `{type}`.
+/// Refusing beats creating the wrong path (Codex review on PR #474).
+#[test]
+fn a_base_written_with_the_structured_placeholders_is_refused_not_left_literal() {
+  for base in ["/srv/{type}", "/srv/{repo}-{issue}", "{home}/wt/{desc}"] {
+    let cfg = WorktreeConfig {
+      base: base.into(),
+      ..WorktreeConfig::default()
+    };
+    let n = WorktreeName::freeform("spike-redis").unwrap();
+    let err = n
+      .worktree_path(&cfg, "r", std::path::Path::new("/repos/r"))
+      .expect_err(&format!("`{}` has no value to resolve for a free-form name", base));
+    let msg = format!("{}", err);
+    assert!(msg.contains("base"), "the message must point at worktree.base: {}", msg);
+  }
 }
 
 /// A `/` is legal in a branch name and a common convention, but a worktree
@@ -632,6 +655,46 @@ fn a_freeform_name_that_git_or_the_filesystem_would_refuse_is_rejected() {
       bad
     );
   }
+}
+
+/// The name becomes the branch verbatim, so it has to be validated
+/// verbatim. Trimming would accept `--name " spike"` and quietly create
+/// `spike` — a different branch from the one that was asked for. Git
+/// already refuses the space; letting it say so is the honest answer
+/// (Codex review on PR #474).
+#[test]
+fn surrounding_whitespace_is_refused_rather_than_silently_stripped() {
+  for bad in [" spike", "spike ", "\tspike", "spike\n"] {
+    assert!(
+      WorktreeName::freeform(bad).is_err(),
+      "`{:?}` must be refused, not trimmed into a different branch",
+      bad
+    );
+  }
+}
+
+/// The branch and the directory have different length limits: a ref is a
+/// path of components (each ≤ 255 bytes), a worktree directory is a single
+/// one. `a×130/b×130` is a legal ref and a 261-byte directory name, so the
+/// branch gets created and `repo.worktree` then fails — leaving an orphan
+/// branch behind. Reproduced against the branch binary before the fix
+/// (Codex review on PR #474); the structured path cannot reach it, because
+/// the `.lock` suffix makes git's own limit one byte stricter than the
+/// directory's.
+#[test]
+fn a_name_that_would_overflow_a_path_component_is_refused_before_anything_is_created() {
+  let long = format!("{}/{}", "a".repeat(130), "b".repeat(130));
+  assert!(
+    git2::Reference::is_valid_name(&format!("refs/heads/{}", long)),
+    "precondition: git accepts this ref, so only our own check can stop it"
+  );
+  assert!(
+    WorktreeName::freeform(&long).is_err(),
+    "a 261-byte directory name must be refused up front"
+  );
+  // Right at the edge: 255 bytes is a legal component, 256 is not.
+  assert!(WorktreeName::freeform(&"a".repeat(255)).is_ok(), "255 bytes is legal");
+  assert!(WorktreeName::freeform(&"a".repeat(256)).is_err(), "256 bytes is not");
 }
 
 /// The rejection has to say what is wrong, not just that something is.

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -697,6 +697,51 @@ fn a_name_that_would_overflow_a_path_component_is_refused_before_anything_is_cre
   assert!(WorktreeName::freeform(&"a".repeat(256)).is_err(), "256 bytes is not");
 }
 
+/// A free-form name has to survive three consumers, and the rules are
+/// enumerated from those rather than sampled from whatever a reviewer
+/// happened to try (Codex review on PR #474 raised three findings of this
+/// same class before the invariant got written down):
+///
+/// 1. it is a **git branch** — checked with the branch-level oracle, not the
+///    reference-level one, because they do not agree;
+/// 2. it is a **single filesystem path component** — bounded and free of
+///    `.` / `..`;
+/// 3. it is a **literal value in placeholder expansion** — so it must not
+///    itself look like a placeholder.
+///
+/// This test pins (1): the ref-level oracle accepts `refs/heads/HEAD`, but
+/// `git branch HEAD` is refused and the name collides with the HEAD
+/// pseudo-ref.
+#[test]
+fn a_name_git_refuses_as_a_branch_is_refused_even_when_the_ref_syntax_is_legal() {
+  assert!(
+    git2::Reference::is_valid_name("refs/heads/HEAD"),
+    "precondition: the ref-level oracle lets `HEAD` through, so only the branch-level one can stop it"
+  );
+  assert!(
+    !git2::Branch::name_is_valid("HEAD").unwrap(),
+    "precondition: the branch-level oracle is the one that refuses it"
+  );
+  assert!(WorktreeName::freeform("HEAD").is_err(), "`HEAD` is not a branch name");
+}
+
+/// (3) `lifecycle::expand_placeholders` substitutes sequentially — `{branch}`
+/// first, then `{type}` / `{issue}` / `{desc}` / `{repo}` — so a branch whose
+/// own name contains a token gets that token rewritten inside the value that
+/// was just substituted: a hook receiving `{branch}` for `spike-{issue}` sees
+/// `spike-`. `DESC_RE` made this unreachable for structured names; free-form
+/// names reach it, so they are refused at the boundary.
+#[test]
+fn a_name_that_looks_like_a_placeholder_is_refused() {
+  for bad in ["spike-{issue}", "{repo}-spike", "{branch}", "closing}brace"] {
+    assert!(
+      WorktreeName::freeform(bad).is_err(),
+      "`{}` would be re-substituted during hook expansion",
+      bad
+    );
+  }
+}
+
 /// The rejection has to say what is wrong, not just that something is.
 #[test]
 fn the_rejection_names_the_offending_value() {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -8921,6 +8921,39 @@ fn ctrl_t_does_not_flip_the_rename_modal_into_free_form_mode() {
 }
 
 #[test]
+fn the_mode_status_names_the_live_toggle_key_not_the_default() {
+  // Same contract as the confirm countdown (#219 review): never advertise a
+  // key that is no longer bound. The status hard-coded `ctrl-t`, so rebinding
+  // `toggle_mode = ["Ctrl+y"]` left the overlay telling the user to press a
+  // combination that does nothing (Codex review on PR #474).
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::keymap::KeyStroke;
+  use gwm::tui::modal_keymap::ModalAction;
+  let (_dir, mut app) = make_app();
+  app
+    .modal_keymap
+    .apply_override(
+      ModalAction::CreateToggleMode,
+      vec![KeyStroke::new(KeyCode::Char('y'), KeyModifiers::CONTROL)],
+    )
+    .expect("Ctrl+y is bindable");
+  app.enter_create();
+
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL));
+
+  assert!(
+    app.status.to_lowercase().contains("ctrl-y") || app.status.to_lowercase().contains("ctrl+y"),
+    "the status must name the live binding: {}",
+    app.status
+  );
+  assert!(
+    !app.status.to_lowercase().contains("ctrl-t"),
+    "the status must not advertise the vacated default: {}",
+    app.status
+  );
+}
+
+#[test]
 fn ctrl_t_still_flips_the_create_modal_into_free_form_mode() {
   // The counterpart: scoping the verb to `View::Create` must not disarm it
   // where it belongs.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -8886,6 +8886,57 @@ fn enter_edit_worktree_prefills_create_form_from_branch() {
 }
 
 #[test]
+fn ctrl_t_does_not_flip_the_rename_modal_into_free_form_mode() {
+  // The rename modal reuses `handle_create_key` (`tui/mod.rs`, #290), so
+  // #416's free-form toggle became reachable from it — but `draw_edit_worktree`
+  // never renders the `Name` field and `submit_edit_worktree` never reads it.
+  // Toggling there sent keystrokes into an invisible buffer and made Enter
+  // submit the untouched triple, i.e. "no change" (Codex review on PR #474).
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("foo");
+  wt.branch = Some("fix/#42-broken-thing".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.view, View::Edit);
+
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+  assert_eq!(
+    app.create_form.mode,
+    Mode::Structured,
+    "the rename modal has no free-form mode to switch to"
+  );
+  assert_eq!(
+    app.create_form.field,
+    Field::Desc,
+    "focus must stay on the field the modal actually renders"
+  );
+  assert_eq!(
+    app.create_form.desc, "broken-thing",
+    "swallowing the verb must not leak `t` into the description as literal input"
+  );
+}
+
+#[test]
+fn ctrl_t_still_flips_the_create_modal_into_free_form_mode() {
+  // The counterpart: scoping the verb to `View::Create` must not disarm it
+  // where it belongs.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  assert_eq!(app.view, View::Create);
+
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+  assert_eq!(app.create_form.field, Field::Name);
+}
+
+#[test]
 fn enter_edit_worktree_rejects_unparseable_branch() {
   // A branch that isn't `<type>/#<issue>-<desc>` (e.g. `main`) can't be
   // decomposed into the form, so the modal refuses to open.

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -694,3 +694,30 @@ fn settings_tui_tab_keeps_the_selected_field_visible_on_a_short_terminal() {
     );
   }
 }
+
+/// Issue #416: free-form mode presents a single `Name` field and drops the
+/// inputs it has no notion of — the branch type selector and the issue
+/// number. Showing them inert would suggest they still apply.
+#[test]
+fn create_modal_in_freeform_mode_shows_only_the_name_field() {
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  app.create_form.toggle_mode();
+  let buf = render(&mut app);
+
+  assert_present(&buf, "free-form", "the title states the active mode");
+  assert_present(&buf, "Name", "the free-form name field");
+  // The preview rows survive — they are what makes the resolved branch and
+  // directory legible while typing.
+  assert_present(&buf, "Branch", "branch preview label");
+  assert_present(&buf, "Dir", "dir preview label");
+
+  for absent in ["Issue", "Type"] {
+    assert!(
+      !buffer_contains(&buf, absent),
+      "`{}` has no meaning in free-form mode and must not be rendered — buffer rows:\n{}",
+      absent,
+      row_strings(&buf).join("\n")
+    );
+  }
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -695,6 +695,47 @@ fn settings_tui_tab_keeps_the_selected_field_visible_on_a_short_terminal() {
   }
 }
 
+/// The hint row has to describe the mode that is on screen. Free-form has a
+/// single field and no type selector, so `field` and `type` advertise verbs
+/// that do nothing there — and `toggle_mode`, the only way between the two
+/// modes, was advertised by neither. Caught on the install-and-validate pass:
+/// the verb existed in the keymap and the help overlay but never reached the
+/// footer, which is where a user actually looks.
+#[test]
+fn the_create_hint_row_describes_the_mode_that_is_on_screen() {
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  let (_dir, mut app) = make_app();
+  app.enter_create();
+  let buf = render(&mut app);
+  assert_present(&buf, "free-form", "structured mode must advertise the way across");
+  assert_present(&buf, "field", "structured mode still rotates fields");
+
+  // Through the real key route, not `toggle_mode()` directly: the status
+  // line is part of what the user reads, and only the key handler updates
+  // it. Toggling the form behind its back would leave the structured
+  // message on screen and hide exactly the kind of mismatch this pins.
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  let buf = render(&mut app);
+  assert_present(&buf, "structured", "free-form must advertise the way back");
+
+  // Scoped to the overlay's own hint row — the row inside the modal box that
+  // carries `submit`. The status line legitimately says "back to
+  // type/issue/desc" as prose, and the worktree table behind the modal can
+  // hold anything; neither is the row under test.
+  let hint_row = row_strings(&buf)
+    .into_iter()
+    .find(|r| r.contains("submit") && r.contains('│'))
+    .expect("the create overlay renders a hint row inside its box");
+  for absent in ["field", "type"] {
+    assert!(
+      !hint_row.contains(absent),
+      "`{}` names a verb that does nothing in free-form mode — hint row: {}",
+      absent,
+      hint_row.trim()
+    );
+  }
+}
+
 /// Issue #416: free-form mode presents a single `Name` field and drops the
 /// inputs it has no notion of — the branch type selector and the issue
 /// number. Showing them inert would suggest they still apply.

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -258,8 +258,22 @@ fn the_freeform_name_cap_is_the_validator_s_own_limit_so_nothing_legal_is_trunca
     f.push_char('x');
   }
   assert_eq!(f.name.len(), MAX_NAME_LEN);
+
+  // And a name that uses the whole budget legally must survive the round
+  // trip — the form's job is not to truncate it. (A single 255-byte segment
+  // is refused by the `.lock` rule, which is a *ref* limit, not the
+  // directory one this cap enforces; split it so the final segment is short.)
+  let mut g = CreateForm::new();
+  g.toggle_mode();
+  for _ in 0..251 {
+    g.push_char('x');
+  }
+  for c in "/yyy".chars() {
+    g.push_char(c);
+  }
+  assert_eq!(g.name.len(), MAX_NAME_LEN);
   assert!(
-    gwm::naming::WorktreeName::freeform(&f.name).is_ok(),
+    gwm::naming::WorktreeName::freeform(&g.name).is_ok(),
     "whatever the form let through must still validate"
   );
 }

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -240,13 +240,44 @@ fn freeform_accepts_characters_the_slug_field_would_also_take() {
 }
 
 #[test]
-fn the_freeform_name_is_length_capped_like_the_other_text_fields() {
+fn the_freeform_name_cap_is_the_validator_s_own_limit_so_nothing_legal_is_truncated() {
+  // The form's cap and `WorktreeName::freeform`'s must be the same number:
+  // when the form stopped at 200 characters and the validator accepted 255
+  // bytes, a 201-character name was silently truncated and submitted as a
+  // *different* branch — the one thing "the name becomes the branch verbatim"
+  // rules out (Codex review on PR #474). Counted in bytes, like the
+  // validator, not in characters.
+  assert_eq!(
+    MAX_NAME_LEN,
+    gwm::naming::MAX_DIR_COMPONENT_BYTES,
+    "the form must not stop short of what the validator accepts"
+  );
   let mut f = CreateForm::new();
   f.toggle_mode();
   for _ in 0..(MAX_NAME_LEN + 10) {
     f.push_char('x');
   }
-  assert_eq!(f.name.chars().count(), MAX_NAME_LEN);
+  assert_eq!(f.name.len(), MAX_NAME_LEN);
+  assert!(
+    gwm::naming::WorktreeName::freeform(&f.name).is_ok(),
+    "whatever the form let through must still validate"
+  );
+}
+
+#[test]
+fn a_multibyte_name_is_capped_on_bytes_not_characters() {
+  // `é` is two bytes: counting characters would let the buffer grow past the
+  // 255-byte path component the directory actually has to fit in.
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  for _ in 0..MAX_NAME_LEN {
+    f.push_char('é');
+  }
+  assert!(
+    f.name.len() <= MAX_NAME_LEN,
+    "byte length must stay within the cap, got {}",
+    f.name.len()
+  );
 }
 
 #[test]

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -7,7 +7,7 @@
 //! into `BranchSpec` and dispatches `worktree::add` + `bootstrap::run` on
 //! the async task spine.
 
-use gwm::tui::state::create_form::{CreateForm, Field, MAX_DESC_LEN, MAX_ISSUE_LEN};
+use gwm::tui::state::create_form::{CreateForm, Field, Mode, MAX_DESC_LEN, MAX_ISSUE_LEN, MAX_NAME_LEN};
 
 #[test]
 fn reset_returns_form_to_initial_state() {
@@ -169,4 +169,94 @@ fn push_char_caps_the_desc_field_length() {
     MAX_DESC_LEN,
     "desc must not grow past the cap"
   );
+}
+
+// --- free-form mode (issue #416) ----------------------------------------
+
+#[test]
+fn the_form_opens_in_structured_mode() {
+  let f = CreateForm::new();
+  assert_eq!(f.mode, Mode::Structured);
+}
+
+#[test]
+fn toggling_switches_mode_and_focuses_the_only_field_of_the_target_mode() {
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  assert_eq!(f.mode, Mode::Freeform);
+  assert_eq!(f.field, Field::Name, "free-form has a single field, focus it");
+
+  f.toggle_mode();
+  assert_eq!(f.mode, Mode::Structured);
+  assert_eq!(f.field, Field::Issue, "back to the field `enter_create` opens on");
+}
+
+/// Toggling is exploratory — a user flipping modes to see the other form
+/// must not lose what they already typed.
+#[test]
+fn toggling_preserves_what_was_already_typed_on_both_sides() {
+  let mut f = CreateForm::new();
+  f.field = Field::Desc;
+  for c in "tui-search".chars() {
+    f.push_char(c);
+  }
+  f.toggle_mode();
+  for c in "spike-redis".chars() {
+    f.push_char(c);
+  }
+  assert_eq!(f.name, "spike-redis");
+
+  f.toggle_mode();
+  assert_eq!(f.desc, "tui-search", "the structured slug survived the round trip");
+  f.toggle_mode();
+  assert_eq!(f.name, "spike-redis", "and so did the free-form name");
+}
+
+/// One field means field rotation has nowhere to go — Tab must not walk
+/// focus onto Type or Issue, which free-form mode does not present.
+#[test]
+fn field_rotation_is_a_no_op_in_freeform_mode() {
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  f.next_field();
+  assert_eq!(f.field, Field::Name);
+  f.prev_field();
+  assert_eq!(f.field, Field::Name);
+}
+
+#[test]
+fn freeform_accepts_characters_the_slug_field_would_also_take() {
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  for c in "Spike_Redis 2".chars() {
+    f.push_char(c);
+  }
+  assert_eq!(
+    f.name, "Spike_Redis 2",
+    "validation happens on submit, not per keystroke"
+  );
+  f.pop_char();
+  assert_eq!(f.name, "Spike_Redis ");
+}
+
+#[test]
+fn the_freeform_name_is_length_capped_like_the_other_text_fields() {
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  for _ in 0..(MAX_NAME_LEN + 10) {
+    f.push_char('x');
+  }
+  assert_eq!(f.name.chars().count(), MAX_NAME_LEN);
+}
+
+#[test]
+fn reset_returns_to_structured_mode_and_clears_the_name() {
+  let mut f = CreateForm::new();
+  f.toggle_mode();
+  for c in "spike".chars() {
+    f.push_char(c);
+  }
+  f.reset();
+  assert_eq!(f.mode, Mode::Structured);
+  assert!(f.name.is_empty());
 }


### PR DESCRIPTION
## Description

`gwm create` required the full `<type> <issue> <desc>` triple, and not every worktree corresponds to an issue. `gwm create --name spike-redis` skips the convention; in the TUI, `Ctrl-T` toggles the create form between the structured triple and a single `Name` field.

Closes #416

## Type of change

- [x] ✨ Feature (new functionality)
- [x] 📝 Docs

## Changes

- `WorktreeName::{Structured, Freeform}` in `naming.rs`, with `branch_name` / `worktree_dirname` / `worktree_path` dispatching on the variant.
- `gwm create --name`, exclusive with the positionals via clap (`conflicts_with_all` one way, `required_unless_present` the other) so a partial triple stays the typo it always was.
- TUI: `Ctrl-T` → `toggle_mode`, single `Name` field, mode named in the overlay title, type selector and issue field dropped in free-form rather than shown inert.
- Two refusal messages reworded — a free-form branch now reaches them by design, not by mistake.
- Docs EN + FR: CLI reference section, TUI keybinding row, CHANGELOG.

### Decisions the issue left open

**Patterns do not apply to a free-form name.** `branch_pattern` / `path_pattern` are written in terms of `{type}` / `{issue}` / `{desc}` and a free-form name has none of them, so the name *is* the branch and the directory is the name with `/` flattened to `-` — the same relationship the default pattern pair already has (`feat/#42-x` lives at `feat-42-x`). `[worktree].base` still applies, so free-form worktrees land beside the structured ones.

**`gwm commit-prefix` stays an error** rather than falling back. The issue suggested "a configurable default, or nothing"; that command exists solely to derive a prefix from the branch *type*, so there is no honest default, and a new config key for it is something nobody has asked for. The message now names the missing shape instead of implying the branch is malformed.

**Validation is delegated, not hand-rolled.** Ref legality goes through libgit2's own `Reference::is_valid_name` against the real `refs/heads/<name>`. Two rules sit outside it, kept separate so the reasons stay honest:
- `.` / `..` as a path component — git accepts `..` inside a longer component, but a worktree directory named `..` would escape the base.
- a leading `-` — libgit2 accepts `refs/heads/-x`, **verified** (the test caught my wrong assumption), but the name would be unusable as an argument to `gwm remove`, `git branch -d` or `cd`.

### Degradation

Confirmed at each call site rather than assumed. The `parse_branch` sites needed no `None` handling added — they already treat it as "unstructured, leave alone", including the doctor orphan check.

| Feature | On a free-form worktree |
|:--------|:------------------------|
| issue auto-linking | inactive — `gwm link --issue <N>` remains |
| **PR/MR detection** | **still works** — `Forge::find_pr_for_branch` queries with the whole branch name and never parses it |
| gitmoji / `gwm commit-prefix` | errors, with a message naming the missing shape |
| `doctor` orphan check | user-managed branch, never flagged |
| hook placeholders (remove / bootstrap) | resolve empty — the honest value |
| TUI edit form | says the form rebuilds the triple; rename with git |

## Tests

- [x] `cargo test` passes locally (full suite, CI-like env: `GWM_NO_GLOBAL_CONFIG=1` + minimal `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Written red-first at each layer:

- `naming_tests.rs` — the enum, pattern non-application, `/` flattening, and a rejection table driven through the git oracle. The `-leading` case went green when it should have been red, which is how the wrong assumption surfaced.
- `cli_binary.rs` — `--name` in help, partial-triple rejection, flag conflict, the happy path asserting `path_pattern` was *not* applied, and a rejected name.
- `tui_state_create_form_tests.rs` — toggle, focus landing, buffer preservation across a round trip, rotation no-op, length cap, reset.
- `tui_modal_render_tests.rs` — free-form overlay shows `Name` and does **not** render `Type` / `Issue`.

The help-overlay completeness guard (#334) went red on the new modal verb, as designed.

## Screenshots / TUI captures

None attached — the render is covered by a buffer assertion instead. **This PR touches the TUI, so it needs your local install-and-validate pass before merge.**

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed — the CLI reference under `docs/` carries the flag; README does not enumerate flags
- [ ] `examples/gwm.toml.example` updated if config schema changed — no schema change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #416
- Next in the sequence: #417 (derive the parser from the pattern), which #472 left an acceptance table on; then #418 (token-driven create form), which reshapes the form this PR just extended

## Notes for reviewers

Worth a look:

1. **`MAX_NAME_LEN` is now `naming::MAX_DIR_COMPONENT_BYTES` (255), counted in bytes.** It started at 200 characters, mirroring `MAX_DESC_LEN`, which meant the form silently truncated a 201-character name the validator would have accepted — submitting a different branch than the one typed. Review pass 3 caught it; the form's cap and the validator's are the same constant now, so they cannot drift apart again.
2. **`#418` will rewrite `create_form.rs`.** That issue's own body warns the file will be substantially rewritten. This PR adds a mode dimension the token-driven form will have to carry; the `Mode` enum should survive, the `Field` enum probably will not.
