### PR TITLE
🐛 fix(tui): workspace repo naming, rename PR warning, and what a reordered pattern owes a frozen segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The TUI rename modal says when submitting would close an open pull request.
+  The remote half of a rename is `git push --atomic origin :<old> <new>:<new>`,
+  a delete followed by a create, and GitHub closes a pull request whose head
+  branch is renamed. There is no clean fix, only a warning: GitHub's own rename
+  endpoint retargets a pull request whose *base* is the renamed branch and
+  closes one whose *head* it is, and a worktree branch is always the head of its
+  own pull request, so both paths end in the same place; GitLab has no rename
+  operation at all, only create-then-delete. The line is live, appearing the
+  moment the form would write a different branch and going away when the user
+  reverts, and `Esc` is the cancel. It is keyed on the branch rather than on the
+  rename, since an edit that only moves the directory returns before touching a
+  single ref, and it stays quiet on a merged or closed pull request. No extra
+  forge call: the link was already resolved at list time, it is what draws the
+  pastille. ([#481](https://github.com/kbrdn1/gwm-cli/issues/481))
+
 - Free-form worktree naming. `gwm create --name spike-redis` skips the
   `<type> <issue> <desc>` triple entirely — not every worktree corresponds to
   an issue. In the TUI, `Ctrl-T` toggles the create form between the
@@ -62,6 +77,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#416](https://github.com/kbrdn1/gwm-cli/issues/416))
 
 ### Fixed
+
+- The TUI names a workspace repo by its directory, not by its display label.
+  `workspace::discover` suffixes a repo whose basename collides with a sibling,
+  so a second `api` shows as `api-2`, and activating it put that label into the
+  field every formatter call expands `{repo}` with. The parser side reads the
+  directory basename and so does every `gwm create` from the CLI, so in a
+  workspace with such a collision a `{repo}` pattern wrote `api-2/...` that
+  neither could read back: no issue auto-linking, no gitmoji, `commit-prefix`
+  erroring on a branch gwm had just created. The label is a property of the
+  workspace's current membership rather than of the repo, so it changes when a
+  sibling moves while branches already written do not, and a name persisted in
+  git must not depend on what else sits next to it on disk. Naming uses the
+  basename everywhere now; the label stays what it was built for, the header and
+  the `REPO` column. Two repos sharing a basename consequently share a `{repo}`
+  base directory, which is what the CLI has always done, and a collision there
+  is a loud `target path already exists` rather than a silent one.
+  ([#480](https://github.com/kbrdn1/gwm-cli/issues/480))
 
 - `gwm doctor` and `gwm config validate` now warn when
   `worktree.branch_pattern` does not survive a format-then-parse round-trip.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,7 +168,7 @@ deliberately ahead of the rich PR/Issue view so that view is born multi-forge
 instead of being rewritten later. See the table above for both. The remaining
 two are ordered by what they unlock rather than by size.
 
-### 1. Naming flexibility ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) → [#416](https://github.com/kbrdn1/gwm-cli/issues/416) → [#417](https://github.com/kbrdn1/gwm-cli/issues/417) → [#418](https://github.com/kbrdn1/gwm-cli/issues/418) → [#479](https://github.com/kbrdn1/gwm-cli/issues/479))
+### 1. Naming flexibility ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) ✅ → [#416](https://github.com/kbrdn1/gwm-cli/issues/416) ✅ → [#417](https://github.com/kbrdn1/gwm-cli/issues/417) ✅ → [#418](https://github.com/kbrdn1/gwm-cli/issues/418) → [#479](https://github.com/kbrdn1/gwm-cli/issues/479)), plus [#480](https://github.com/kbrdn1/gwm-cli/issues/480) / [#481](https://github.com/kbrdn1/gwm-cli/issues/481) / [#482](https://github.com/kbrdn1/gwm-cli/issues/482)
 
 `gwm create` requires the full `<type> <issue> <desc>` triple, and there is no
 way to name a worktree freely. Working through this surfaced a real defect
@@ -182,24 +182,35 @@ connecting cause to effect.
 
 Sequenced cheapest-first, each step shippable on its own:
 
-- [#415](https://github.com/kbrdn1/gwm-cli/issues/415) — warn in `doctor` / `config validate` when the pattern is customised (turns a silent failure into a stated one)
-- [#416](https://github.com/kbrdn1/gwm-cli/issues/416) — free-form naming via `gwm create --name`, additive and contract-safe
-- [#417](https://github.com/kbrdn1/gwm-cli/issues/417) — derive the parser from the pattern and drop `BRANCH_RE`, which removes the defect at the root
-- [#418](https://github.com/kbrdn1/gwm-cli/issues/418) — token-driven create form with a live branch/path preview
-- [#479](https://github.com/kbrdn1/gwm-cli/issues/479) : rename a free-form worktree, either freely again or into the pattern
+- [x] [#415](https://github.com/kbrdn1/gwm-cli/issues/415) : warn in `doctor` / `config validate` when the pattern is customised (turns a silent failure into a stated one)
+- [x] [#416](https://github.com/kbrdn1/gwm-cli/issues/416) : free-form naming via `gwm create --name`, additive and contract-safe
+- [x] [#417](https://github.com/kbrdn1/gwm-cli/issues/417) : derive the parser from the pattern and drop `BRANCH_RE`, which removes the defect at the root
+- [ ] [#418](https://github.com/kbrdn1/gwm-cli/issues/418) : token-driven create form with a live branch/path preview
+- [ ] [#479](https://github.com/kbrdn1/gwm-cli/issues/479) : rename a free-form worktree, either freely again or into the pattern
 
-The last two came out of building the first three rather than from the original
-read. [#478](https://github.com/kbrdn1/gwm-cli/issues/478) is already closed inside
-#417's PR: `branch_pattern` and `path_pattern` need not carry the same segments, so
-a worktree created as `gwm create fix 42 login` under `feat/#{issue}-{desc}` keeps
-its `fix` only in the directory name, and rebuilding the triple from the branch
-alone silently renamed that component on every edit.
+The first three are on `dev` and unreleased. **#418 is the only step of the original
+sequence still to build**; everything else listed below is follow-up work that came
+out of building the first three, not a widening of the plan.
 
-[#479](https://github.com/kbrdn1/gwm-cli/issues/479) is the other half, still open:
-the rename form refuses a free-form branch outright, so a worktree named for a spike
-can neither be renamed again nor promoted into the convention once it grows an issue
-number. It sits next to #418 because both rewrite the same create form, and running
-them concurrently buys only merge conflicts.
+[#478](https://github.com/kbrdn1/gwm-cli/issues/478) is already closed inside #417's
+PR: `branch_pattern` and `path_pattern` need not carry the same segments, so a
+worktree created as `gwm create fix 42 login` under `feat/#{issue}-{desc}` keeps its
+`fix` only in the directory name, and rebuilding the triple from the branch alone
+silently renamed that component on every edit.
+
+[#479](https://github.com/kbrdn1/gwm-cli/issues/479) is the other half of free-form
+naming, still open: the rename form refuses a free-form branch outright, so a worktree
+named for a spike can neither be renamed again nor promoted into the convention once
+it grows an issue number. It sits next to #418 because both rewrite the same create
+form, and running them concurrently buys only merge conflicts.
+
+Three more came out of reviewing #417 and were split out rather than folded into an
+already large PR. They are independent of #418 and #479 and touch different files, so
+they run in parallel with them:
+
+- [ ] [#480](https://github.com/kbrdn1/gwm-cli/issues/480) : `{repo}` expands to the workspace display name when a branch is written and to the directory basename when one is read, so in a workspace holding two repos that share a basename a `{repo}` pattern writes what it cannot read back
+- [ ] [#481](https://github.com/kbrdn1/gwm-cli/issues/481) : renaming a worktree closes its open pull request without warning, since the remote rename is a delete plus a create and GitHub closes a PR whose head branch is renamed, including through its own rename API
+- [ ] [#482](https://github.com/kbrdn1/gwm-cli/issues/482) : a segment frozen as a literal is lost when the pattern reorders its placeholders, because the recovery bounds each literal by the canonical `type, issue, desc` rank against markers whose real order differs
 
 ### 2. Rich PR/Issue view ([#420](https://github.com/kbrdn1/gwm-cli/issues/420))
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -256,7 +256,23 @@ pub struct WorkspaceState {
 
 pub struct App {
   pub repo: Repository,
+  /// The name `{repo}` expands to, in `branch_pattern`, `path_pattern` and
+  /// `[worktree].base` alike: the repo directory's basename
+  /// ([`worktree::repo_name`]), which is also the name every `gwm create` from
+  /// the CLI uses and the one the parser side reads back
+  /// ([`crate::naming::BranchParser::for_repo`], `github::read_link`,
+  /// `lifecycle`).
+  ///
+  /// Issue #480: deliberately **not** the workspace display label. That label
+  /// is derived from the workspace's current membership (a second `api` becomes
+  /// `api-2`, #304), so it changes when a sibling repo moves while the branches
+  /// already written keep saying `api-2`. A name persisted in git cannot depend
+  /// on what else happens to sit next to it on disk.
   pub repo_name: String,
+  /// The name shown to the user for the active repo: the workspace display
+  /// label when there is one, otherwise identical to [`Self::repo_name`]. Only
+  /// the header reads it; nothing that writes a branch or a path does.
+  pub display_repo_name: String,
   pub workdir: PathBuf,
   pub config: Config,
   /// Workspace-mode state (issue #36); `None` in single-repo mode.
@@ -616,6 +632,7 @@ impl App {
     let (task_tx, task_rx) = mpsc::channel();
     let mut out = Self {
       repo,
+      display_repo_name: repo_name.clone(),
       repo_name,
       workdir,
       config,
@@ -845,8 +862,11 @@ impl App {
     };
     match Repository::open(&meta.workdir) {
       Ok(repo) => {
+        // Issue #480: the naming name comes from the freshly-opened repo's own
+        // directory, never from the workspace label — see `App::repo_name`.
+        self.repo_name = worktree::repo_name(&repo);
         self.repo = repo;
-        self.repo_name = meta.name;
+        self.display_repo_name = meta.name;
         self.workdir = meta.workdir;
         self.config = meta.config;
         self.workspace_active_stale = false;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, Instant};
 
 pub use app::{
   read_pins_from_sources, App, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget,
-  OpenTarget, View,
+  OpenTarget, RepoMeta, View, WorkspaceState,
 };
 pub use state::async_task::{CreateWorktreeResult, TaskKind, TaskMsg, TaskRunner};
 pub use state::clean_overlay::CleanOverlay;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -351,7 +351,9 @@ fn draw_header(f: &mut Frame, area: Rect, app: &App) {
   // line renders flush, mirroring the footer. No `Wrap` — `header_line`
   // guarantees one visual line clipped to `width`.
   let line = header_line(
-    &app.repo_name,
+    // The workspace label, which is what the user is looking at; `repo_name` is
+    // the naming name and can be the same string in a workspace of one (#480).
+    &app.display_repo_name,
     &workdir,
     app.picker_mode,
     area.width as usize,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3756,6 +3756,41 @@ fn draw_config_panel(f: &mut Frame, app: &mut App) {
 /// so this never validates and never refuses: an empty issue expands to
 /// nothing, which is what a preview should show. An expansion that cannot be
 /// resolved at all yields an empty string rather than a stale or invented one.
+/// Issue #481. Whether submitting this rename would close an open pull request,
+/// as a message ready to render, or `None` when nothing is at risk.
+///
+/// The remote half of a rename is `git push --atomic origin :<old> <new>:<new>`,
+/// a delete followed by a create, and GitHub closes a pull request whose head
+/// branch is renamed. gwm cannot route around that. GitHub's own rename
+/// endpoint retargets a pull request whose *base* is the renamed branch and
+/// closes one whose *head* it is, and a worktree branch is always the head of
+/// its own pull request, so both paths end in the same place. GitLab has no
+/// rename operation at all, only create-then-delete. Saying so before the push
+/// is the whole of what is available.
+///
+/// Keyed on the **branch** rather than on the rename: an edit that only moves
+/// the directory returns from `worktree::rename_worktree` before touching a
+/// single ref, so it is never at risk, and warning there would train the user
+/// to ignore the line. Recomputed per frame, so it appears the moment the form
+/// would write a different branch and goes away when the user reverts.
+///
+/// A merged or closed pull request has nothing left to lose, and an unfetched
+/// state says nothing either way: this reports what gwm knows, and claims
+/// nothing about what it has not looked up.
+fn rename_pr_warning(app: &App, new_branch: &str, old_branch: &str) -> Option<String> {
+  if new_branch == old_branch {
+    return None;
+  }
+  let w = app.selected()?;
+  if !matches!(w.pr_state.or(w.link.pr_state)?, PrState::Open | PrState::Draft) {
+    return None;
+  }
+  Some(match w.link.pr {
+    Some(number) => format!("⚠ renaming the branch closes PR #{}", number),
+    None => "⚠ renaming the branch closes its open pull request".into(),
+  })
+}
+
 fn pattern_preview(app: &App, type_str: &str) -> (String, String) {
   let expand = |pattern: &str| {
     crate::config::expand_placeholders(
@@ -5253,6 +5288,15 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
     Span::raw("  Dir    : "),
     Span::styled(dirname, Style::default().fg(app.theme.dirty)),
   ]));
+  if let Some(warning) = rename_pr_warning(app, &branch_raw, old_branch) {
+    lines.push(Line::from(vec![
+      Span::raw("  "),
+      Span::styled(
+        ellipsize_middle(&warning, inner_w.saturating_sub(2)),
+        Style::default().fg(app.theme.prunable),
+      ),
+    ]));
+  }
   lines.push(Line::from(String::new()));
   lines.push(field_input_line(
     &label("Issue"),

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -483,6 +483,102 @@ fn the_documented_pattern_table_matches_reality() {
   assert!(w.contains("match nothing at all"), "got: {}", w);
 }
 
+/// Issue #482. Reordered layouts and frozen segments are each documented as
+/// supported; the two **together** are claimed by no line, and the recovery
+/// bounds every literal by the canonical `type, issue, desc` rank, so a
+/// reordered pattern can leave a segment's region empty and the literal
+/// unread. `{desc}/feat/#{issue}` writes `x/feat/#42` and recovers no type.
+///
+/// Recovering it is not deliverable without a special case, and this is the
+/// measurement that settles it rather than an opinion: `feat/#{issue}-{desc}`
+/// and `wt/{type}/#{issue}` both put a literal before every placeholder, and in
+/// one it is the branch type while in the other it must stay the namespace it
+/// looks like. No rule phrased on position alone separates them, so the
+/// canonical order is doing load-bearing work that a reordered pattern removes.
+/// Keying on "the literal matches a configured branch type" would separate
+/// them, and would be a special case in the one function where three of those
+/// have already been wrong.
+///
+/// So the obligation is not "recover it" but "never be wrong or quiet about
+/// it", and that is enumerated here rather than sampled: every ordering of the
+/// three segments, each of them frozen in turn, across four separators.
+#[test]
+fn a_reordered_pattern_with_a_frozen_segment_is_never_wrong_and_never_quiet() {
+  let types = default_branch_types();
+  let slots = [("{type}", "feat"), ("{issue}", "42"), ("{desc}", "login")];
+  let orders = [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]];
+  let separators = ["/", "-", "/#", "_"];
+
+  let mut wrong: Vec<String> = Vec::new();
+  let mut unstated: Vec<String> = Vec::new();
+  let mut checked = 0;
+
+  for order in orders {
+    for frozen in 0..3 {
+      for separator in separators {
+        let pattern = order
+          .iter()
+          .map(|&i| {
+            if i == frozen {
+              slots[i].1.to_string()
+            } else {
+              slots[i].0.to_string()
+            }
+          })
+          .collect::<Vec<_>>()
+          .join(separator);
+        // A layout the compiler refuses is refused with a reason of its own,
+        // which the ambiguity enumeration already covers.
+        let Ok(parser) = BranchParser::compile(&pattern, "gwm-cli", &types) else {
+          continue;
+        };
+        checked += 1;
+        let segment = ["type", "issue", "desc"][frozen];
+        let expected = slots[frozen].1;
+        let recovered = parser
+          .constants()
+          .iter()
+          .find(|(s, _)| *s == segment)
+          .map(|(_, v)| v.clone());
+
+        match recovered {
+          // Never wrong: a value read back must be the one the pattern writes.
+          Some(value) if value != expected => wrong.push(format!(
+            "`{}` read {} as `{}`, not `{}`",
+            pattern, segment, value, expected
+          )),
+          // Never quiet: a value not read back has to be named by the warning,
+          // which is what turns `commit-prefix` returning nothing into
+          // something the user can act on.
+          None => {
+            let warning = branch_pattern_warning(&pattern, "gwm-cli", &types);
+            let names_it = warning.as_deref().is_some_and(|w| {
+              w.contains(&format!("`{{{}}}`", segment)) || w.contains(&format!("read back `{}`", segment))
+            });
+            if !names_it {
+              unstated.push(format!("`{}` loses {} silently: {:?}", pattern, segment, warning));
+            }
+          }
+          _ => {}
+        }
+      }
+    }
+  }
+
+  assert!(checked >= 60, "the family should be large, got {}", checked);
+  assert!(
+    wrong.is_empty(),
+    "a reordered pattern must never read a frozen segment back as the wrong value:\n{}",
+    wrong.join("\n")
+  );
+  assert!(
+    unstated.is_empty(),
+    "a frozen segment a reordered pattern cannot recover must be named by `branch_pattern_warning`, \
+     since that is the whole of what the user gets:\n{}",
+    unstated.join("\n")
+  );
+}
+
 /// Ambiguity is about the *value*, not about how many places it could have
 /// come from. `feat/feat/#{issue}-{desc}` offers the type two candidates, and
 /// refusing on that count alone reported no type at all for a pattern whose

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -10870,6 +10870,61 @@ fn the_rename_form_still_refuses_to_change_what_neither_pattern_writes() {
 }
 
 #[test]
+fn activating_a_workspace_repo_names_it_by_its_directory_not_its_display_label() {
+  // Issue #480. `workspace::discover` suffixes a repo whose basename collides
+  // with a sibling, so the second `api` is displayed as `api-2` (#304), and
+  // activating it used to put that label straight into `App::repo_name` — the
+  // field every formatter call expands `{repo}` with. The parser side
+  // (`BranchParser::for_repo`, `github::read_link`, `lifecycle`) reads the
+  // *directory* basename, and so does every `gwm create` from the CLI, so a
+  // `{repo}` pattern wrote `api-2/…` that nothing could read back.
+  //
+  // The label is a property of the workspace's current membership, not of the
+  // repo: move the sibling out and this repo becomes `api` again while its
+  // branches still say `api-2`. A name persisted in git cannot depend on what
+  // else sits next to it on disk, so naming uses the basename and the label
+  // stays what it was built for, which is display.
+  let (dir, mut app) = make_app();
+  let sibling = dir.path().join("api");
+  std::fs::create_dir_all(&sibling).unwrap();
+  git2::Repository::init(&sibling).unwrap();
+
+  app.workspace = Some(gwm::tui::WorkspaceState {
+    root: dir.path().to_path_buf(),
+    repos: vec![
+      gwm::tui::RepoMeta {
+        name: app.repo_name.clone(),
+        workdir: app.workdir.clone(),
+        config: app.config.clone(),
+      },
+      gwm::tui::RepoMeta {
+        // The display label, deliberately different from the basename `api`.
+        name: "api-2".into(),
+        workdir: sibling.clone(),
+        config: app.config.clone(),
+      },
+    ],
+    row_repo: vec![0, 1],
+    active: 0,
+  });
+  let mut wt = worktree_fixture("other");
+  wt.branch = Some("api/feat/#42-x".into());
+  app.worktrees = vec![worktree_fixture("own"), wt];
+  app.list_state.select(Some(1));
+
+  app.sync_active_repo();
+
+  assert_eq!(
+    app.repo_name, "api",
+    "`{{repo}}` is expanded with the directory basename, the same name the CLI and the parser use"
+  );
+  assert_eq!(
+    app.display_repo_name, "api-2",
+    "the disambiguated label survives, for the header and the REPO column"
+  );
+}
+
+#[test]
 fn the_rename_form_reads_a_branch_with_the_same_repo_name_it_writes_one_with() {
   // Codex review on PR #476, eighth pass. In a workspace, two repos whose
   // directories share a basename are disambiguated for display — the second

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -121,6 +121,14 @@ fn assert_present(buf: &Buffer, needle: &str, what: &str) {
   );
 }
 
+fn assert_absent(buf: &Buffer, needle: &str, what: &str) {
+  assert!(
+    !buffer_contains(buf, needle),
+    "{what}: expected {needle:?} NOT to be rendered — buffer rows:\n{}",
+    row_strings(buf).join("\n")
+  );
+}
+
 #[test]
 fn worktrees_table_header_labels_the_issue_pr_badge_column() {
   // The worktree table's badge column (the `●/●` issue/PR pastilles) now
@@ -855,4 +863,82 @@ fn the_rename_refusal_fits_in_the_modal() {
 
   let buf = render(&mut app);
   assert_present(&buf, &failure, "the whole refusal, not the part that fits");
+}
+
+/// Issue #481. The remote half of a rename is `git push --atomic origin :<old>
+/// <new>:<new>`, a delete plus a create, and GitHub closes a pull request whose
+/// head branch is renamed. That is not something gwm can route around: GitHub's
+/// own rename endpoint retargets a PR whose *base* is the renamed branch and
+/// closes one whose head it is, and a worktree branch is always the head of its
+/// own PR. So the only honest protection is to say so before the push.
+///
+/// Live rather than one-shot, so it appears the moment the form would write a
+/// different branch and goes away when the user reverts.
+#[test]
+fn the_rename_modal_warns_before_a_branch_change_closes_an_open_pr() {
+  let (_dir, mut app) = make_app();
+  let mut wt = deletable_worktree("login");
+  wt.branch = Some("feat/#42-login".into());
+  wt.link.pr = Some(476);
+  wt.pr_state = Some(gwm::github::PrState::Open);
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.view, View::Edit, "the form must open: {}", app.status);
+
+  // Untouched: the submit would rewrite the same branch, so nothing is at risk.
+  let buf = render(&mut app);
+  assert_absent(&buf, "closes PR #476", "an unchanged branch renames nothing");
+
+  app.create_form.desc = "login-v2".into();
+  let buf = render(&mut app);
+  assert_present(
+    &buf,
+    "closes PR #476",
+    "a branch change deletes the remote branch, which closes the PR",
+  );
+}
+
+/// The counterpart, and the reason the warning is tied to the *branch* rather
+/// than to the rename: an edit that only moves the directory returns from
+/// `rename_worktree` before it touches a single ref, local or remote, so the
+/// PR is never in danger and saying otherwise would train the user to ignore
+/// the line.
+#[test]
+fn the_rename_modal_stays_quiet_when_only_the_directory_moves() {
+  let (_dir, mut app) = make_app();
+  // Freezes every branch segment, so the branch cannot change; `path_pattern`
+  // still writes the description, so the directory can.
+  app.config.worktree.branch_pattern = "feat/#42-login".into();
+  app.config.worktree.path_pattern = "{type}-{issue}-{desc}".into();
+  let mut wt = deletable_worktree("login");
+  wt.branch = Some("feat/#42-login".into());
+  wt.link.pr = Some(476);
+  wt.pr_state = Some(gwm::github::PrState::Open);
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.view, View::Edit, "the form must open: {}", app.status);
+
+  app.create_form.desc = "login-v2".into();
+  let buf = render(&mut app);
+  assert_absent(&buf, "closes PR", "a path-only edit never touches a ref");
+}
+
+/// A merged or closed PR has nothing left to lose, so warning about it would be
+/// noise on the common case of renaming a branch after its PR landed.
+#[test]
+fn the_rename_modal_stays_quiet_about_a_pr_that_is_already_closed() {
+  let (_dir, mut app) = make_app();
+  let mut wt = deletable_worktree("login");
+  wt.branch = Some("feat/#42-login".into());
+  wt.link.pr = Some(476);
+  wt.pr_state = Some(gwm::github::PrState::Merged);
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+
+  app.create_form.desc = "login-v2".into();
+  let buf = render(&mut app);
+  assert_absent(&buf, "closes PR", "a merged PR cannot be closed by a rename");
 }


### PR DESCRIPTION
## Description

The three follow-ups split out of #476's review, plus the ROADMAP entry that records them.

Two are behaviour fixes. The third turned out not to need code, and the measurement that says so ships as a test rather than as an opinion.

Closes #480
Closes #481
Closes #482

## Type of change

- [x] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [x] ✅ Tests
- [x] 📝 Docs

## Changes

**#480, a workspace repo is named by its directory, not by its display label.** `workspace::discover` suffixes a repo whose basename collides with a sibling, so a second `api` shows as `api-2`, and activating it put that label into the field every formatter call expands `{repo}` with. The parser side reads the directory basename and so does every `gwm create` from the CLI, so in a workspace with such a collision a `{repo}` pattern wrote `api-2/...` that neither could read back: no issue auto-linking, no gitmoji, `commit-prefix` erroring on a branch gwm had just created.

The label is a property of the workspace's current membership rather than of the repo, so it changes when a sibling moves while the branches already written do not. A name persisted in git must not depend on what else sits next to it on disk, so naming uses the basename everywhere and `display_repo_name` keeps the label for the header and the `REPO` column.

Deliberate trade-off, since the review that raised this proposed the opposite direction: two repos sharing a basename now also share a `{repo}` base directory. That is what the CLI has always done, and a collision there surfaces as a loud `target path already exists`, not as a silent one.

**#481, the rename modal says when submitting would close an open pull request.** The remote half of a rename is `git push --atomic origin :<old> <new>:<new>`, a delete followed by a create, and GitHub closes a pull request whose head branch is renamed. `rename_worktree` is careful about losing commits and said nothing about the pull request.

There is no clean fix, only a warning, and this is worth stating because the obvious alternative sounds like it would work. From GitHub's docs on renaming a branch: "Branch protection policies are also updated, as well as the base branch for open pull requests (including those for forks) and draft releases. If the renamed branch is the head branch of an open pull request, this pull request is closed." So the native rename endpoint retargets a pull request whose *base* is the branch and closes one whose *head* it is, and a worktree branch is always the head of its own pull request. GitLab has no rename operation at all, only create-then-delete.

The line is live: it appears the moment the form would write a different branch and goes away when the user reverts, and `Esc` is the cancel. Keyed on the branch rather than on the rename, since a path-only edit returns before touching a single ref, and quiet on a merged or closed pull request. No extra forge call, the link was already resolved at list time.

Chose a modal line over a second confirm view on purpose: #418 and #479 both rewrite this form, and a new state machine here would only buy merge conflicts.

**#482 needed no code, and the measurement is the deliverable.** The issue reported that a segment frozen as a literal is lost when the pattern reorders its placeholders, and asked for it to be recovered. Enumerating the family (every ordering of the three segments, each frozen in turn, over four separators) says the loss is real and the framing was not: nothing is ever read back as the wrong value, and nothing is lost without `branch_pattern_warning` naming the segment and the consumers that go with it. `{desc}/feat/#{issue}` already reports that it carries no `{type}`, with the fix in the message. The issue's claim that the code "silently picks the unsupported answer instead of refusing or warning" was wrong, and the issue body has been corrected.

Recovering it is not deliverable without a special case, and the measurement is what settles that: `feat/#{issue}-{desc}` and `wt/{type}/#{issue}` both put a literal before every placeholder, and in one it is the branch type while in the other it must stay the namespace it looks like. No rule phrased on position alone separates them, so the canonical order is load-bearing and a reordered pattern removes it. Keying on "matches a configured branch type" would separate them and would be a special case in the one function where three of those have already been wrong.

So the obligation is not "recover it" but "never be wrong or quiet about it", and that is now enumerated. It is also the fresh enumeration the issue asked for: neither the ambiguity family (all three placeholders present) nor the 1.5.0 parity family (canonical by construction) can reach these shapes.

## Tests

- [x] `cargo test` passes locally (88 suites)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

New tests: `activating_a_workspace_repo_names_it_by_its_directory_not_its_display_label`, `the_rename_modal_warns_before_a_branch_change_closes_an_open_pr` with its two counter-cases (a path-only edit and an already-merged pull request), and `a_reordered_pattern_with_a_frozen_segment_is_never_wrong_and_never_quiet`.

## Screenshots / TUI captures

Not captured. The rename warning is asserted through `gwm::tui::draw` into a `TestBackend` buffer, including the two cases where it must *not* appear, which is the part a screenshot cannot show.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issues: #480, #481, #482
- Related PR: #476, whose review raised all three

## Notes for reviewers

Two things worth your attention rather than the diff.

The **#480 trade-off** is a real one and I picked the side that loses something: worktree paths for two same-basename repos in a workspace can now collide. It aligns the TUI with the CLI and keeps branch names independent of workspace membership, and the failure is loud, but it is a choice rather than a strict improvement.

The **#482 conclusion** contradicts what the issue I filed said to expect. If you would rather have the special case (recover a literal that exactly matches a configured branch type, wherever it sits), say so and it is a small change; I left it out because it is the fourth patch of a class that has been wrong three times in that function.

One commit is not atomic: `dbd480e` carries the ROADMAP update alongside the #480 fix. `src/tui/ui.rs` is touched by both #480 and #481, so splitting it cleanly needed hunk-level surgery on four commits, which seemed a worse trade than the impurity.
