### PR TITLE
✨ feat(tui): rename a free-form worktree, freely or into the pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Toggling seeds only what is still empty, so a round trip never overwrites
   typed input. Leaving structured seeds the name with the current branch
-  verbatim. Leaving free-form seeds the description with `kebab` of the name and
-  leaves type and issue blank, because a free-form name carries neither;
-  `kebab`'s output is by construction either a valid description or empty, so
-  the seed can never dead-end the form on a value it would then refuse.
+  verbatim. Leaving free-form seeds the description with `kebab` of the name,
+  capped at the length the field enforces when typed, and leaves the issue
+  empty; `kebab`'s output is by construction either a valid description or
+  empty, so the seed can never dead-end the form on a value it would then
+  refuse. The type is neither seeded nor blanked, it stays on whatever the
+  selector shows, which is the create form's own contract and is spelled out by
+  the preview.
 
   Names are validated with the same `WorktreeName::freeform` rules as
   `gwm create --name`, so a name one form refuses the other refuses too. Two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The TUI rename form (`c`) now handles free-form worktrees, in both
+  directions. A worktree created with `gwm create --name spike-redis` could
+  not be renamed from the TUI at all: `worktree_spec` starts by parsing the
+  branch, a name chosen on purpose does not parse, and the form refused
+  outright. That left the two ordinary cases impossible, renaming a spike that
+  outlived its name and promoting one into the convention once it acquires an
+  issue number, and both are exactly what the form exists for.
+
+  Such a branch now opens the form in free-form mode with its current name
+  prefilled, and `Ctrl-T` moves between the two shapes in either direction, the
+  same verb and the same two modes the create form has had since #416. All four
+  conversions work: free-form to free-form and structured to free-form write
+  the name verbatim as the branch and flatten `/` to `-` for the directory;
+  free-form to structured applies `branch_pattern` and `path_pattern` to the
+  triple; structured to structured is unchanged.
+
+  The four cells are two code paths, not four. `WorktreeName` already knew how
+  each shape becomes a branch and a directory, so the rename target is composed
+  through it exactly the way the create target is, and the live preview reads
+  the same value the submit will write. That last point is not incidental: the
+  preview and the submit drifting is precisely how both forms came to display a
+  branch they were not going to create, and free-form is the same trap one mode
+  over, since there no pattern is expanded at all.
+
+  Toggling seeds only what is still empty, so a round trip never overwrites
+  typed input. Leaving structured seeds the name with the current branch
+  verbatim. Leaving free-form seeds the description with `kebab` of the name and
+  leaves type and issue blank, because a free-form name carries neither;
+  `kebab`'s output is by construction either a valid description or empty, so
+  the seed can never dead-end the form on a value it would then refuse.
+
+  Names are validated with the same `WorktreeName::freeform` rules as
+  `gwm create --name`, so a name one form refuses the other refuses too. Two
+  guards come along with the change. A `worktree.base` written with `{type}` /
+  `{issue}` / `{desc}` is refused for a free-form target rather than expanded to
+  a literal, since a free-form name has no value for them. And the **main
+  worktree** is now refused explicitly: its branch is normally unparseable
+  (`main`, `dev`), so the old refusal was turning this form away from it by
+  accident, and free-form mode parses nothing, so that side effect had to be
+  replaced by the same stated guard `enter_confirm_delete` uses.
+
+  This inverts a decision from #416, which deliberately kept the rename modal
+  single-mode; the test that pinned it is rewritten rather than deleted, with
+  the original reasoning kept as history.
+  ([#479](https://github.com/kbrdn1/gwm-cli/issues/479))
+
 - The TUI rename modal says when submitting would close an open pull request.
   The remote half of a rename is `git push --atomic origin :<old> <new>:<new>`,
   a delete followed by a create, and GitHub closes a pull request whose head

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -120,7 +120,7 @@ Both the New Worktree form (`n`) and the rename form (`c`) share the same
 | `BackTab` (`Shift+Tab`)   | previous field (`prev_field`)                           |
 | `↑` / `←` / `h`           | previous worktree type (`prev_type`; on the type field) |
 | `↓` / `→` / `l`           | next worktree type (`next_type`; on the type field)     |
-| `Ctrl+t`                  | toggle structured ↔ free-form naming (`toggle_mode`; New Worktree form only) |
+| `Ctrl+t`                  | toggle structured ↔ free-form naming (`toggle_mode`)    |
 | `Enter`                   | submit and bootstrap / rename (`submit`; subject to the [TOFU trust gate](/configuration/trust-ledger)) |
 | `Esc`                     | cancel (`cancel`)                                       |
 
@@ -128,7 +128,20 @@ Both the New Worktree form (`n`) and the rename form (`c`) share the same
 
 The binding is Ctrl-modified on purpose: the create overlay reserves unmodified printable keys for its text fields, so a bare letter would be swallowed while typing a description.
 
-It is inert in the rename form, which shares this keymap but renders and submits the triple only — toggling there would type into a field the form never shows.
+It works in the rename form too ([#479](https://github.com/kbrdn1/gwm-cli/issues/479)). It used to be inert there, because that form rendered and submitted the triple only, so toggling would have typed into a field it never showed; the form now has both modes, so the verb does what its name says.
+
+A worktree created with `gwm create --name` opens the rename form in **free-form mode** with its current branch prefilled, instead of being turned away as it was before. `Ctrl+t` then moves between the two shapes in either direction, which is what makes the four renames possible:
+
+| from | to | branch becomes | directory becomes |
+|:--|:--|:--|:--|
+| free-form | free-form | the name, verbatim | the name, with `/` flattened to `-` |
+| free-form | structured | `branch_pattern` applied to the triple | `path_pattern` applied to the triple |
+| structured | free-form | the name, verbatim | the name, with `/` flattened to `-` |
+| structured | structured | unchanged | unchanged |
+
+Toggling seeds only what is still empty, so a round trip never overwrites what you typed. Leaving structured seeds the name with the current branch verbatim; leaving free-form seeds the description with a kebab-cased form of the name and leaves the type and the issue blank, because a free-form name carries neither and guessing one would be worse than asking.
+
+Names are validated with exactly the rules `gwm create --name` uses, so a name one form refuses the other refuses too. The **main worktree** is never renamed from here: its branch is the repo's default branch, and `git worktree move` cannot move the main checkout anyway.
 
 If the repo's `.gwm.toml` isn't trusted, `Enter` lands the form's status bar on a refuse message instead of running the bootstrap — the worktree directory is **not** created in that case, so you can fix the trust state in another terminal (`gwm bootstrap` from CLI, or set `GWM_ALLOW_BOOTSTRAP=1` and relaunch) and retry. See [Configuration → TOFU trust ledger](/configuration/trust-ledger#tui-behaviour) for the exact wording and full decision tree.
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -139,7 +139,7 @@ A worktree created with `gwm create --name` opens the rename form in **free-form
 | structured | free-form | the name, verbatim | the name, with `/` flattened to `-` |
 | structured | structured | unchanged | unchanged |
 
-Toggling seeds only what is still empty, so a round trip never overwrites what you typed. Leaving structured seeds the name with the current branch verbatim; leaving free-form seeds the description with a kebab-cased form of the name and leaves the type and the issue blank, because a free-form name carries neither and guessing one would be worse than asking.
+Toggling seeds only what is still empty, so a round trip never overwrites what you typed. Leaving structured seeds the name with the current branch verbatim. Leaving free-form seeds the description with a kebab-cased form of the name, capped at the same length the field accepts when typed, and leaves the issue empty because a free-form name carries no issue number. The **type** is neither seeded nor blanked: it stays on whatever the selector shows, which is the first configured type on a form you just opened, exactly as in the New Worktree form. It is visible in the selector and the preview spells out the branch it produces, so read that line before submitting if you are promoting a spike into the pattern.
 
 Names are validated with exactly the rules `gwm create --name` uses, so a name one form refuses the other refuses too. The **main worktree** is never renamed from here: its branch is the repo's default branch, and `git worktree move` cannot move the main checkout anyway.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -143,7 +143,7 @@ Un worktree créé avec `gwm create --name` ouvre le formulaire de renommage en 
 | structuré | libre | le nom, tel quel | le nom, `/` aplati en `-` |
 | structuré | structuré | inchangé | inchangé |
 
-La bascule ne pré-remplit que ce qui est encore vide, donc un aller-retour n'écrase jamais ce que vous avez saisi. En quittant le mode structuré, le nom est pré-rempli avec la branche courante telle quelle ; en quittant le mode libre, la description est pré-remplie avec une forme kebab du nom et le type comme l'issue restent vides, parce qu'un nom libre n'en porte aucun et que deviner vaudrait moins que demander.
+La bascule ne pré-remplit que ce qui est encore vide, donc un aller-retour n'écrase jamais ce que vous avez saisi. En quittant le mode structuré, le nom est pré-rempli avec la branche courante telle quelle. En quittant le mode libre, la description est pré-remplie avec une forme kebab du nom, bornée à la même longueur que le champ accepte à la frappe, et l'issue reste vide parce qu'un nom libre ne porte aucun numéro d'issue. Le **type**, lui, n'est ni pré-rempli ni vidé : il reste sur ce qu'affiche le sélecteur, c'est-à-dire le premier type configuré sur un formulaire qu'on vient d'ouvrir, exactement comme dans le formulaire Nouveau worktree. Il est visible dans le sélecteur et la preview annonce la branche qu'il produit, donc lisez cette ligne avant de soumettre si vous promouvez un spike vers le pattern.
 
 Les noms sont validés avec exactement les règles de `gwm create --name`, donc un nom qu'un formulaire refuse, l'autre le refuse aussi. Le **worktree principal** n'est jamais renommé depuis ici : sa branche est la branche par défaut du dépôt, et `git worktree move` ne sait de toute façon pas déplacer le checkout principal.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -124,7 +124,7 @@ partagent les mêmes verbes `[tui.keys.modal.create]` :
 | `BackTab` (`Shift+Tab`)   | champ précédent (`prev_field`)                          |
 | `↑` / `←` / `h`           | type de worktree précédent (`prev_type` ; sur le champ type) |
 | `↓` / `→` / `l`           | type de worktree suivant (`next_type` ; sur le champ type) |
-| `Ctrl+t`                  | bascule nommage structuré ↔ libre (`toggle_mode` ; formulaire Nouveau worktree uniquement) |
+| `Ctrl+t`                  | bascule nommage structuré ↔ libre (`toggle_mode`)       |
 | `Enter`                   | soumettre et bootstrapper / renommer (`submit` ; soumis à la [barrière de confiance TOFU](/fr/configuration/trust-ledger)) |
 | `Esc`                     | annuler (`cancel`)                                      |
 
@@ -132,7 +132,20 @@ partagent les mêmes verbes `[tui.keys.modal.create]` :
 
 La liaison est modifiée par Ctrl à dessein : la surcouche de création réserve les touches imprimables non modifiées à ses champs texte, donc une lettre seule serait avalée pendant la saisie d'une description.
 
-Elle est inerte dans le formulaire de renommage, qui partage ce keymap mais n'affiche et ne soumet que le triplet — y basculer écrirait dans un champ que le formulaire ne montre jamais.
+Elle fonctionne aussi dans le formulaire de renommage ([#479](https://github.com/kbrdn1/gwm-cli/issues/479)). Elle y était inerte parce que ce formulaire n'affichait et ne soumettait que le triplet, donc y basculer aurait écrit dans un champ qu'il ne montrait jamais ; le formulaire a désormais les deux modes, donc le verbe fait ce que son nom annonce.
+
+Un worktree créé avec `gwm create --name` ouvre le formulaire de renommage en **mode libre**, avec sa branche courante pré-remplie, au lieu d'être refusé comme avant. `Ctrl+t` passe ensuite d'une forme à l'autre dans les deux sens, ce qui rend les quatre renommages possibles :
+
+| depuis | vers | la branche devient | le répertoire devient |
+|:--|:--|:--|:--|
+| libre | libre | le nom, tel quel | le nom, `/` aplati en `-` |
+| libre | structuré | `branch_pattern` appliqué au triplet | `path_pattern` appliqué au triplet |
+| structuré | libre | le nom, tel quel | le nom, `/` aplati en `-` |
+| structuré | structuré | inchangé | inchangé |
+
+La bascule ne pré-remplit que ce qui est encore vide, donc un aller-retour n'écrase jamais ce que vous avez saisi. En quittant le mode structuré, le nom est pré-rempli avec la branche courante telle quelle ; en quittant le mode libre, la description est pré-remplie avec une forme kebab du nom et le type comme l'issue restent vides, parce qu'un nom libre n'en porte aucun et que deviner vaudrait moins que demander.
+
+Les noms sont validés avec exactement les règles de `gwm create --name`, donc un nom qu'un formulaire refuse, l'autre le refuse aussi. Le **worktree principal** n'est jamais renommé depuis ici : sa branche est la branche par défaut du dépôt, et `git worktree move` ne sait de toute façon pas déplacer le checkout principal.
 
 Si le `.gwm.toml` du dépôt n'est pas approuvé, `Enter` place la barre de statut du formulaire sur un message de refus au lieu de lancer le bootstrap — le répertoire du worktree n'est **pas** créé dans ce cas, donc vous pouvez corriger l'état de confiance dans un autre terminal (`gwm bootstrap` depuis le CLI, ou définir `GWM_ALLOW_BOOTSTRAP=1` et relancer) puis réessayer. Voir [Configuration → registre de confiance TOFU](/fr/configuration/trust-ledger#comportement-de-la-tui) pour la formulation exacte et l'arbre de décision complet.
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4070,10 +4070,17 @@ impl App {
     self.view = View::List;
   }
 
-  /// Refuse a change to a segment **nothing writes**, by setting
-  /// `edit_failure` (#417, Codex review on PR #476). Structured mode only:
-  /// see the call site for why free-form has no segments to freeze.
-  fn refuse_unwritable_segment_change(&mut self, type_: &str) {
+  /// Whether this submit changes a segment **nothing writes**, setting
+  /// `edit_failure` with the reason when it does (#417, Codex review on
+  /// PR #476). Structured mode only: see the call site for why free-form has
+  /// no segments to freeze.
+  ///
+  /// Returns its verdict rather than leaving the caller to read `edit_failure`
+  /// back (Codex review on PR #485). That field survives a failed submit, so
+  /// reading it as "did the guard refuse" also caught every *earlier* failure
+  /// and stopped a submit the user had just corrected, wedging the form shut
+  /// until it was closed and reopened.
+  fn refuse_unwritable_segment_change(&mut self, type_: &str) -> bool {
     // Issue #417 / Codex review on PR #476: a segment **nothing writes** is not
     // editable here, because there is nowhere to put the new value. The submit
     // would rebuild the same branch at the same path and close the form having
@@ -4146,10 +4153,11 @@ impl App {
           // validating by hand).
           let _ = was;
           self.edit_failure = Some(format!("branch_pattern has no {{{}}} to write", segment));
-          return;
+          return true;
         }
       }
     }
+    false
   }
 
   /// Submit the rename from the `View::Edit` modal (#290). Composes the new
@@ -4174,11 +4182,8 @@ impl App {
     // guard, and that is right: the guard refuses to change a value the form was
     // opened with when nothing can write it, and a worktree opened free-form was
     // opened with no such value to contradict.
-    if self.create_form.mode == Mode::Structured {
-      self.refuse_unwritable_segment_change(&type_);
-      if self.edit_failure.is_some() {
-        return Ok(());
-      }
+    if self.create_form.mode == Mode::Structured && self.refuse_unwritable_segment_change(&type_) {
+      return Ok(());
     }
     // Issue #479: composed through `WorktreeName`, the same seam
     // `submit_create` uses, so free-form and structured targets are built by

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4032,11 +4032,26 @@ impl App {
   ///
   /// Leaving structured, the free-form name is seeded with the current branch
   /// verbatim: it is the only non-guess available, and the common edit is a
-  /// small one. Leaving free-form, the description is seeded with `kebab` of
-  /// the name while type and issue are left for the user, because a free-form
-  /// name carries neither and inventing one would be a guess. `kebab`'s output
-  /// is by construction either `DESC_RE`-valid or empty, so this seed can never
-  /// dead-end the form on a value it would then refuse to submit.
+  /// small one.
+  ///
+  /// Leaving free-form, the description is seeded with `kebab` of the name and
+  /// the issue is left empty, because a free-form name carries no issue number
+  /// and inventing one would be a guess. `kebab`'s output is by construction
+  /// either `DESC_RE`-valid or empty, so this seed can never dead-end the form
+  /// on a value it would then refuse to submit.
+  ///
+  /// Truncated to `MAX_DESC_LEN` (Codex review on PR #485): a free-form name
+  /// may run to `MAX_DIR_COMPONENT_BYTES`, `push_char` is the only other place
+  /// that bound is applied, and `BranchSpec` has no length check to catch the
+  /// overflow downstream — so seeding unbounded wrote a description no
+  /// keystroke could have produced, and the cap is what keeps
+  /// `<type>/#<issue>-<desc>` inside git's ref limit.
+  ///
+  /// The **type** is not seeded and is not left unset either: it stays on
+  /// whatever the selector shows, which is the first configured type on a form
+  /// that was just opened. That is the create form's own contract, the value is
+  /// on screen in the selector, and the preview spells out the branch it
+  /// produces — so a promotion into the pattern is stated rather than silent.
   fn seed_toggled_mode(&mut self) {
     if self.view != View::Edit {
       return;
@@ -4048,7 +4063,10 @@ impl App {
         }
       }
       Mode::Freeform if self.create_form.desc.is_empty() => {
-        self.create_form.desc = crate::naming::kebab(&self.create_form.name);
+        self.create_form.desc = crate::naming::kebab(&self.create_form.name)
+          .chars()
+          .take(crate::tui::state::create_form::MAX_DESC_LEN)
+          .collect();
       }
       _ => {}
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2369,7 +2369,7 @@ impl App {
       View::Pty => super::ui::HintContext::Pty,
       View::ExecPicker => HintContext::ExecPicker,
       View::CleanReport => HintContext::Clean,
-      View::Edit => HintContext::Rename,
+      View::Edit => self.rename_hint_context(),
       // Issue #408: the detail overlay advertises its close/scroll keys.
       View::DetailOverlay => {
         if self.detail_overlay.kind == crate::tui::state::detail_overlay::DetailKind::CiChecks {
@@ -2393,6 +2393,20 @@ impl App {
     match self.create_form.mode {
       Mode::Freeform => HintContext::CreateFreeform,
       Mode::Structured => HintContext::Create,
+    }
+  }
+
+  /// Which hint row the rename overlay advertises (issue #479). Same shape and
+  /// same reason as [`Self::create_hint_context`]: free-form has one field and
+  /// no type selector, so advertising `field` and `type` there would name keys
+  /// that do nothing. Both the statusbar and the modal's own footer read this,
+  /// so the two can never disagree — which they did when only the footer knew
+  /// about the mode (Codex review on PR #485).
+  pub fn rename_hint_context(&self) -> super::ui::HintContext {
+    use super::ui::HintContext;
+    match self.create_form.mode {
+      Mode::Freeform => HintContext::RenameFreeform,
+      Mode::Structured => HintContext::Rename,
     }
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3872,6 +3872,18 @@ impl App {
   /// not match the `<type>/#<issue>-<desc>` pattern can't be decomposed into
   /// the form, so the modal refuses to open and explains why.
   pub fn enter_edit_worktree(&mut self) {
+    // Issue #479 replaces an accidental protection with a deliberate one. The
+    // main checkout's branch is normally unparseable (`main`, `dev`), so the
+    // refusal below used to turn this modal away from it — for the wrong
+    // reason, but with the right result. Free-form mode parses nothing, so that
+    // side effect is gone: state the guard, the same shape
+    // `enter_confirm_delete` already uses. Renaming the main worktree means
+    // renaming the repo's default branch, and `git worktree move` cannot move
+    // the main checkout anyway.
+    if self.selected().is_some_and(|w| w.is_main) {
+      self.status = "cannot rename the main worktree".into();
+      return;
+    }
     let Some((branch, path)) = self
       .selected()
       .and_then(|w| w.branch.clone().map(|b| (b, w.path.clone())))
@@ -3896,18 +3908,27 @@ impl App {
       &branch,
       path.file_name().and_then(|name| name.to_str()),
     ) else {
-      // Issue #416: a free-form worktree lands here by design, not by
-      // mistake. The edit form rebuilds a `<type>/#<issue>-<desc>` triple,
-      // which a name the user chose on purpose has none of — so state that
-      // this form does not apply rather than implying a malformed branch.
+      // Issue #416 refused here: a name the user chose on purpose has none of
+      // the `<type>/#<issue>-<desc>` triple the form rebuilds, so the form said
+      // it did not apply. Issue #479 supplies the missing mode instead — the
+      // form now collects a free-form name too, which is exactly the shape this
+      // worktree already has, so there is nothing left to turn away.
+      //
+      // Prefilled with the current branch verbatim: the common edit is a small
+      // one (`spike-redis` becoming `spike-valkey`), and it is also the only
+      // non-guess available, since a free-form name carries no segments.
       //
       // Issue #417 deliberately did NOT fold "type not configured" into this
       // arm: `{type}` stays `[a-z]+`, so `zzz/#7-thing` still parses and the
       // type-index lookup below refuses it with the precise reason.
-      self.status = format!(
-        "'{}' is a free-form branch — the edit form rebuilds <type>/#<issue>-<desc>; rename it with git",
-        branch
-      );
+      self.create_form.reset();
+      self.create_form.mode = Mode::Freeform;
+      self.create_form.name = branch.clone();
+      self.create_form.field = Field::Name;
+      self.edit_original_branch = Some(branch);
+      self.edit_original_path = Some(path);
+      self.edit_failure = None;
+      self.view = View::Edit;
       return;
     };
     // A pattern that neither writes nor freezes a segment leaves it empty, and
@@ -3949,6 +3970,90 @@ impl App {
     self.view = View::Edit;
   }
 
+  /// The [`WorktreeName`] the form currently describes, in whichever mode it is
+  /// in (#479). The rename target is built the same way the create target is,
+  /// so the four conversions of issue #479 are two code paths, not four:
+  /// `WorktreeName` already knows how each shape becomes a branch and a
+  /// directory.
+  fn worktree_name_from_form(&self) -> std::result::Result<WorktreeName, String> {
+    match self.create_form.mode {
+      Mode::Freeform => WorktreeName::freeform(&self.create_form.name).map_err(|e| e.to_string()),
+      Mode::Structured => {
+        let type_ = self
+          .branch_types
+          .get(self.create_form.type_index)
+          .map(|t| t.name.clone())
+          .unwrap_or_default();
+        BranchSpec::new_with_types(
+          type_,
+          self.create_form.issue.clone(),
+          self.create_form.desc.clone(),
+          &self.branch_types,
+        )
+        .map(WorktreeName::Structured)
+        .map_err(|e| e.to_string())
+      }
+    }
+  }
+
+  /// What the rename would write: `(branch, directory name)`.
+  ///
+  /// Public because the renderer needs it. The preview and the submit have to
+  /// derive from **one** place or they drift, and drifting is not hypothetical:
+  /// both live previews used to expand a hardcoded `<type>/#<issue>-<desc>`
+  /// while the submit expanded the repo's real patterns, so the modal showed a
+  /// branch it was not going to write (found by hand on #476). Free-form mode
+  /// is the same trap one mode over, since there the branch is the name and no
+  /// pattern is expanded at all.
+  ///
+  /// `Err` carries the reason the form cannot compose a target yet — an
+  /// incomplete triple, a refused free-form name, or a `base` that uses a
+  /// placeholder a free-form name has no value for.
+  pub fn edit_target(&self) -> std::result::Result<(String, String), String> {
+    let name = self.worktree_name_from_form()?;
+    let branch = name
+      .branch_name(&self.config.worktree, &self.repo_name)
+      .map_err(|e| e.to_string())?;
+    let dirname = name
+      .worktree_dirname(&self.config.worktree, &self.repo_name)
+      .map_err(|e| e.to_string())?;
+    Ok((branch, dirname))
+  }
+
+  /// Seed the mode `toggle_mode` is about to switch *into*, for the rename
+  /// modal (#479). Called before the flip, so `self.create_form.mode` is still
+  /// the mode being left.
+  ///
+  /// Only ever fills an **empty** buffer: #416 keeps both modes' buffers side
+  /// by side precisely so a round trip loses nothing, and overwriting what the
+  /// user already typed would defeat that.
+  ///
+  /// Create seeds nothing — there is no worktree to seed from.
+  ///
+  /// Leaving structured, the free-form name is seeded with the current branch
+  /// verbatim: it is the only non-guess available, and the common edit is a
+  /// small one. Leaving free-form, the description is seeded with `kebab` of
+  /// the name while type and issue are left for the user, because a free-form
+  /// name carries neither and inventing one would be a guess. `kebab`'s output
+  /// is by construction either `DESC_RE`-valid or empty, so this seed can never
+  /// dead-end the form on a value it would then refuse to submit.
+  fn seed_toggled_mode(&mut self) {
+    if self.view != View::Edit {
+      return;
+    }
+    match self.create_form.mode {
+      Mode::Structured if self.create_form.name.is_empty() => {
+        if let Some(branch) = self.edit_original_branch.clone() {
+          self.create_form.name = branch;
+        }
+      }
+      Mode::Freeform if self.create_form.desc.is_empty() => {
+        self.create_form.desc = crate::naming::kebab(&self.create_form.name);
+      }
+      _ => {}
+    }
+  }
+
   /// `true` while the async rename worker is in flight (#290). The run loop
   /// swallows input in `View::Edit` while this holds, mirroring create.
   pub fn is_edit_worktree_loading(&self) -> bool {
@@ -3965,18 +4070,10 @@ impl App {
     self.view = View::List;
   }
 
-  /// Submit the rename from the `View::Edit` modal (#290). Composes the new
-  /// branch name + worktree path from the form, then spawns an off-thread
-  /// worker that renames the local branch (`git branch -m`), the remote
-  /// branch when it exists (`git push origin :<old> <new>:<new>` + re-track),
-  /// and moves the worktree directory (`git worktree move`). A no-op rename
-  /// (nothing changed) just closes the modal.
-  pub fn submit_edit_worktree(&mut self) -> Result<()> {
-    let type_ = self
-      .branch_types
-      .get(self.create_form.type_index)
-      .map(|t| t.name.clone())
-      .unwrap_or_default();
+  /// Refuse a change to a segment **nothing writes**, by setting
+  /// `edit_failure` (#417, Codex review on PR #476). Structured mode only:
+  /// see the call site for why free-form has no segments to freeze.
+  fn refuse_unwritable_segment_change(&mut self, type_: &str) {
     // Issue #417 / Codex review on PR #476: a segment **nothing writes** is not
     // editable here, because there is nowhere to put the new value. The submit
     // would rebuild the same branch at the same path and close the form having
@@ -4036,7 +4133,7 @@ impl App {
           continue;
         }
         let (submitted, was) = match segment {
-          "type" => (type_.as_str(), opened_with.type_.as_str()),
+          "type" => (type_, opened_with.type_.as_str()),
           "issue" => (self.create_form.issue.as_str(), opened_with.issue.as_str()),
           _ => (self.create_form.desc.as_str(), opened_with.desc.as_str()),
         };
@@ -4049,27 +4146,68 @@ impl App {
           // validating by hand).
           let _ = was;
           self.edit_failure = Some(format!("branch_pattern has no {{{}}} to write", segment));
-          return Ok(());
+          return;
         }
       }
     }
+  }
 
-    let spec = match BranchSpec::new_with_types(
-      type_,
-      self.create_form.issue.clone(),
-      self.create_form.desc.clone(),
-      &self.branch_types,
-    ) {
-      Ok(s) => s,
+  /// Submit the rename from the `View::Edit` modal (#290). Composes the new
+  /// branch name + worktree path from the form, then spawns an off-thread
+  /// worker that renames the local branch (`git branch -m`), the remote
+  /// branch when it exists (`git push origin :<old> <new>:<new>` + re-track),
+  /// and moves the worktree directory (`git worktree move`). A no-op rename
+  /// (nothing changed) just closes the modal.
+  pub fn submit_edit_worktree(&mut self) -> Result<()> {
+    let type_ = self
+      .branch_types
+      .get(self.create_form.type_index)
+      .map(|t| t.name.clone())
+      .unwrap_or_default();
+    // Issue #479: the frozen-segment guard below is about segments, and a
+    // free-form name has none — the branch is the name, no pattern is expanded,
+    // so nothing can be frozen out of reach. Skipping it is stated here rather
+    // than left to fall out of `opened_with` being `None` for an unparseable
+    // branch, which is how it would happen by accident.
+    //
+    // Converting a free-form worktree *into* the pattern therefore bypasses the
+    // guard, and that is right: the guard refuses to change a value the form was
+    // opened with when nothing can write it, and a worktree opened free-form was
+    // opened with no such value to contradict.
+    if self.create_form.mode == Mode::Structured {
+      self.refuse_unwritable_segment_change(&type_);
+      if self.edit_failure.is_some() {
+        return Ok(());
+      }
+    }
+    // Issue #479: composed through `WorktreeName`, the same seam
+    // `submit_create` uses, so free-form and structured targets are built by
+    // one mechanism and the preview can show exactly what this will write.
+    let name = match self.worktree_name_from_form() {
+      Ok(n) => n,
+      Err(e) => {
+        self.edit_failure = Some(e);
+        return Ok(());
+      }
+    };
+    // Reported in the form rather than returned as `Err`: these are user- and
+    // config-driven refusals (an incomplete triple, a name git will not take, a
+    // `base` a free-form name has no value for), and an `Err` out of here tears
+    // down the alternate screen instead of telling the user what to fix.
+    let (new_branch, new_name) = match self.edit_target() {
+      Ok(target) => target,
+      Err(e) => {
+        self.edit_failure = Some(e);
+        return Ok(());
+      }
+    };
+    let new_path = match name.worktree_path(&self.config.worktree, &self.repo_name, &self.workdir) {
+      Ok(p) => p,
       Err(e) => {
         self.edit_failure = Some(e.to_string());
         return Ok(());
       }
     };
-
-    let new_branch = spec.branch_name(&self.config.worktree, &self.repo_name)?;
-    let new_name = spec.worktree_dirname(&self.config.worktree, &self.repo_name)?;
-    let new_path = spec.worktree_path(&self.config.worktree, &self.repo_name, &self.workdir)?;
 
     let Some(old_branch) = self.edit_original_branch.clone() else {
       self.cancel_edit_worktree();
@@ -4285,16 +4423,17 @@ impl App {
       Some(ModalAction::CreateCancel) => return CreateKey::Cancel,
       Some(ModalAction::CreateNextField) => self.create_next_field(),
       Some(ModalAction::CreatePrevField) => self.create_prev_field(),
-      // Scoped to the create modal: `View::Edit` (rename, #290) routes its
-      // keys through this same handler, but it renders and submits the
-      // structured triple only — a free-form toggle there would send
-      // keystrokes into an invisible buffer and make Enter submit the
-      // untouched values (Codex review on PR #474).
-      // Swallowed outside the create modal — an explicit empty arm, not a
+      // Both modal views that collect a name: create (#416) and rename (#479).
+      // #474 scoped this to create alone because `draw_edit_worktree` did not
+      // render the `Name` field and `submit_edit_worktree` did not read it, so
+      // toggling there sent keystrokes into an invisible buffer; #479 supplies
+      // both halves, so the verb is no longer suppressed.
+      // Swallowed outside those modals — an explicit empty arm, not a
       // guard on the arm below, because a failing guard would fall through
       // to the literal-input fallback and type `t` into the description.
-      Some(ModalAction::CreateToggleMode) if self.view != View::Create => {}
+      Some(ModalAction::CreateToggleMode) if !matches!(self.view, View::Create | View::Edit) => {}
       Some(ModalAction::CreateToggleMode) => {
+        self.seed_toggled_mode();
         self.create_form.toggle_mode();
         // Name the LIVE binding, and drop the clause when the verb is
         // unbound — same contract as the confirm countdown above: never

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5420,11 +5420,9 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
     );
     f.render_widget(
       Paragraph::new(modal_hint_for_context(
-        if freeform {
-          HintContext::RenameFreeform
-        } else {
-          HintContext::Rename
-        },
+        // One source with the statusbar (`App::rename_hint_context`), so the
+        // footer and the bar behind it cannot disagree about the mode.
+        app.rename_hint_context(),
         &app.keymap,
         &app.modal_keymap,
         &app.theme,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2045,8 +2045,13 @@ pub enum HintContext {
   /// Clean reclaim overlay (issue #325): j/k pick a profile, confirm
   /// reclaims (safety countdown), Esc cancels.
   Clean,
-  /// Branch-rename modal (`View::Edit`, #290).
+  /// Branch-rename modal (`View::Edit`, #290), structured triple.
   Rename,
+  /// Branch-rename modal in free-form mode (issue #479). A separate context
+  /// for the same reason `CreateFreeform` is one: the two modes present
+  /// different inputs, so advertising a type selector free-form does not
+  /// render would name a key that does nothing.
+  RenameFreeform,
   /// Generic detail overlay (issue #408): scroll / close. Agent sessions
   /// today, the rich PR/Issue view tomorrow.
   Detail,
@@ -2075,7 +2080,7 @@ impl HintContext {
       HintContext::Pty => "terminal",
       HintContext::ExecPicker => "exec",
       HintContext::Clean => "clean",
-      HintContext::Rename => "rename",
+      HintContext::Rename | HintContext::RenameFreeform => "rename",
       HintContext::Detail => "agents",
       HintContext::CiChecks => "checks",
     }
@@ -2249,8 +2254,16 @@ impl HintContext {
       // Rename reuses the create-form input handler, hence the `create`
       // context's verbs (#290 / #219).
       HintContext::Rename => &[
+        Hint::Modal(ModalAction::CreateToggleMode, "free-form"),
         Hint::Modal(ModalAction::CreateNextField, "field"),
         Hint::Lit("↑/↓", "type"),
+        Hint::Modal(ModalAction::CreateSubmit, "submit"),
+        Hint::Modal(ModalAction::CreateCancel, "cancel"),
+      ],
+      // Free-form has one field and no type selector, so `field` and `type`
+      // are left out rather than advertised inert (issue #479).
+      HintContext::RenameFreeform => &[
+        Hint::Modal(ModalAction::CreateToggleMode, "structured"),
         Hint::Modal(ModalAction::CreateSubmit, "submit"),
         Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
@@ -2289,7 +2302,9 @@ impl HintContext {
   /// hint key shadowed by a modal binding in the same context.
   fn modal_context(self) -> Option<KeyContext> {
     Some(match self {
-      HintContext::Create | HintContext::CreateFreeform | HintContext::Rename => KeyContext::Create,
+      HintContext::Create | HintContext::CreateFreeform | HintContext::Rename | HintContext::RenameFreeform => {
+        KeyContext::Create
+      }
       HintContext::Confirm => KeyContext::Confirm,
       HintContext::OpenMenu => KeyContext::OpenMenu,
       HintContext::LinkPrompt => KeyContext::LinkChooseTarget,
@@ -3791,7 +3806,33 @@ fn rename_pr_warning(app: &App, new_branch: &str, old_branch: &str) -> Option<St
   })
 }
 
+/// The `(branch, directory)` pair the form would produce, for the live preview.
+///
+/// Both modes, because both are reachable from the create form (#416) and now
+/// from the rename modal too (#479) — and a preview that handled only one of
+/// them would show a branch the submit is not going to write. That defect
+/// shipped once already, with the preview hardcoding `<type>/#<issue>-<desc>`
+/// while the submit expanded the repo's patterns; free-form is the same trap
+/// one mode over, since there nothing is expanded at all.
+///
+/// Deliberately **unvalidated**, unlike [`App::edit_target`]: this runs on every
+/// keystroke and has to show what a half-typed form is heading towards. So the
+/// free-form arm builds `WorktreeName::Freeform` directly rather than through
+/// `WorktreeName::freeform`, which would refuse an incomplete name and blank the
+/// preview mid-word. The flattening still comes from `worktree_dirname`, so the
+/// preview and the submit cannot drift on it.
 fn pattern_preview(app: &App, type_str: &str) -> (String, String) {
+  if app.create_form.mode == Mode::Freeform {
+    let name = crate::naming::WorktreeName::Freeform(app.create_form.name.clone());
+    return (
+      name
+        .branch_name(&app.config.worktree, &app.repo_name)
+        .unwrap_or_default(),
+      name
+        .worktree_dirname(&app.config.worktree, &app.repo_name)
+        .unwrap_or_default(),
+    );
+  }
   let expand = |pattern: &str| {
     crate::config::expand_placeholders(
       pattern,
@@ -5265,21 +5306,28 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
   let branch = ellipsize_middle(&branch_raw, inner_w.saturating_sub("  Branch : ".len()));
   let dirname = ellipsize_middle(&dir_raw, inner_w.saturating_sub("  Dir    : ".len()));
 
+  let freeform = app.create_form.mode == Mode::Freeform;
   let mut lines = overlay_title_lines("Rename Worktree", clean);
   lines.push(Line::from(vec![
     Span::raw("  From   : "),
     Span::styled(old_display, Style::default().fg(muted)),
   ]));
   lines.push(Line::from(String::new()));
-  lines.push(type_selector_line(
-    &label("Type"),
-    type_str,
-    type_desc,
-    app.create_form.field == Field::Type,
-    accent,
-    muted,
-  ));
-  lines.push(Line::from(String::new()));
+  // Issue #479: free-form has one field and no type selector, so the rows the
+  // structured triple needs are not rendered rather than rendered inert — the
+  // same shape `draw_create` uses, and the reason #474 suppressed the toggle
+  // here in the first place was that these rows did not exist.
+  if !freeform {
+    lines.push(type_selector_line(
+      &label("Type"),
+      type_str,
+      type_desc,
+      app.create_form.field == Field::Type,
+      accent,
+      muted,
+    ));
+    lines.push(Line::from(String::new()));
+  }
   lines.push(Line::from(vec![
     Span::raw("  Branch : "),
     Span::styled(branch, Style::default().fg(app.theme.branch)),
@@ -5298,25 +5346,37 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
     ]));
   }
   lines.push(Line::from(String::new()));
-  lines.push(field_input_line(
-    &label("Issue"),
-    &app.create_form.issue,
-    app.create_form.field == Field::Issue,
-    value_w,
-    accent,
-    muted,
-    surface,
-  ));
-  lines.push(Line::from(String::new()));
-  lines.push(field_input_line(
-    &label("Desc"),
-    &app.create_form.desc,
-    app.create_form.field == Field::Desc,
-    value_w,
-    accent,
-    muted,
-    surface,
-  ));
+  if freeform {
+    lines.push(field_input_line(
+      &label("Name"),
+      &app.create_form.name,
+      app.create_form.field == Field::Name,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+  } else {
+    lines.push(field_input_line(
+      &label("Issue"),
+      &app.create_form.issue,
+      app.create_form.field == Field::Issue,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+    lines.push(Line::from(String::new()));
+    lines.push(field_input_line(
+      &label("Desc"),
+      &app.create_form.desc,
+      app.create_form.field == Field::Desc,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+  }
 
   let height = lines.len() as u16 + 4 + 2 /* border */ + 2 /* vertical padding */;
   let area = centered_box(70, 72, height, term);
@@ -5360,7 +5420,11 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
     );
     f.render_widget(
       Paragraph::new(modal_hint_for_context(
-        HintContext::Rename,
+        if freeform {
+          HintContext::RenameFreeform
+        } else {
+          HintContext::Rename
+        },
         &app.keymap,
         &app.modal_keymap,
         &app.theme,

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -8989,6 +8989,39 @@ fn the_rename_form_refuses_a_free_form_name_create_would_refuse() {
 }
 
 #[test]
+fn a_corrected_rename_is_not_held_back_by_the_previous_attempt() {
+  // Codex review on PR #485. The frozen-segment guard reports through
+  // `edit_failure`, and the call site read that same field back to decide
+  // whether to stop — so an *earlier* failure still sitting there stopped the
+  // next submit too, whatever the user had just fixed, and the form could only
+  // be unstuck by closing and reopening it. The guard returns its own verdict
+  // now, so the only thing that can stop a submit is that submit.
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("foo");
+  wt.branch = Some("feat/#42-my-desc".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.view, View::Edit);
+
+  // A first submit that fails on its own terms: an empty description is not a
+  // branch `BranchSpec` will build.
+  app.create_form.desc = String::new();
+  app
+    .submit_edit_worktree()
+    .expect("a refusal is a form failure, not an error");
+  assert!(app.edit_failure.is_some(), "an empty description is refused");
+
+  // Fixing it has to be enough.
+  app.create_form.desc = "other-desc".into();
+  app.submit_edit_worktree().expect("submits");
+  assert_eq!(
+    app.edit_failure, None,
+    "a corrected form must not be held back by the previous attempt's message"
+  );
+}
+
+#[test]
 fn the_rename_modal_opens_a_free_form_worktree_in_free_form_mode() {
   // Issue #479. `worktree_spec` starts with `branch_parser.parse(branch)?`, so a
   // name the user chose on purpose does not parse and the modal used to refuse

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -8885,13 +8885,149 @@ fn enter_edit_worktree_prefills_create_form_from_branch() {
   );
 }
 
+/// Issue #479's conversion table, all four cells. `WorktreeName` already knows
+/// how each shape becomes a branch and a directory, so the rename target is
+/// built exactly the way `submit_create` builds the create target, and the
+/// table is two code paths rather than four.
+///
+/// The worker is never reached here — `spawn_edit_worktree` needs a real repo —
+/// so what these assert is the *target* the form composes, read back off the
+/// task the submit requested.
 #[test]
-fn ctrl_t_does_not_flip_the_rename_modal_into_free_form_mode() {
-  // The rename modal reuses `handle_create_key` (`tui/mod.rs`, #290), so
-  // #416's free-form toggle became reachable from it — but `draw_edit_worktree`
-  // never renders the `Name` field and `submit_edit_worktree` never reads it.
-  // Toggling there sent keystrokes into an invisible buffer and made Enter
-  // submit the untouched triple, i.e. "no change" (Codex review on PR #474).
+fn the_rename_form_composes_a_target_for_each_of_the_four_conversions() {
+  use gwm::tui::state::create_form::Mode;
+
+  // free-form → free-form: the name is the branch, verbatim.
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+  app.create_form.name = "spike-valkey".into();
+  assert_eq!(
+    app.edit_target().expect("a legal free-form name composes a target"),
+    ("spike-valkey".to_string(), "spike-valkey".to_string()),
+    "free-form → free-form writes the name verbatim as branch and directory"
+  );
+
+  // free-form → structured: the pattern is applied after the fact.
+  app.create_form.mode = Mode::Structured;
+  app.create_form.type_index = app
+    .branch_types
+    .iter()
+    .position(|t| t.name == "feat")
+    .expect("`feat` is a built-in branch type");
+  app.create_form.issue = "42".into();
+  app.create_form.desc = "cache-layer".into();
+  assert_eq!(
+    app.edit_target().expect("a complete triple composes a target"),
+    ("feat/#42-cache-layer".to_string(), "feat-42-cache-layer".to_string()),
+    "free-form → structured promotes the spike into the convention"
+  );
+
+  // structured → free-form: the name is the branch, verbatim, again.
+  let (_dir2, mut app) = make_app();
+  let mut wt = worktree_fixture("feat-42-cache-layer");
+  wt.branch = Some("feat/#42-cache-layer".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.create_form.mode, Mode::Structured);
+  app.create_form.mode = Mode::Freeform;
+  app.create_form.name = "spike-again".into();
+  assert_eq!(
+    app.edit_target().expect("composes"),
+    ("spike-again".to_string(), "spike-again".to_string()),
+    "structured → free-form drops out of the convention on purpose"
+  );
+
+  // structured → structured: unchanged from before #479.
+  app.create_form.mode = Mode::Structured;
+  app.create_form.desc = "other-desc".into();
+  assert_eq!(
+    app.edit_target().expect("composes"),
+    ("feat/#42-other-desc".to_string(), "feat-42-other-desc".to_string()),
+    "structured → structured is exactly what #290 did"
+  );
+}
+
+#[test]
+fn the_rename_form_refuses_a_free_form_name_create_would_refuse() {
+  // Same validator, so a name one form turns away the other turns away too:
+  // `WorktreeName::freeform` is the single set of rules (#416), and a rename
+  // that accepted more than create would produce worktrees create could never
+  // have made.
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+
+  for refused in ["HEAD", "spike-{issue}", "-spike", "..", " spike"] {
+    app.create_form.name = refused.into();
+    assert!(
+      gwm::naming::WorktreeName::freeform(refused).is_err(),
+      "`{}` is documented as refused by create",
+      refused
+    );
+    app.edit_failure = None;
+    app
+      .submit_edit_worktree()
+      .expect("a refusal is a form failure, not an error");
+    assert_eq!(app.view, View::Edit, "the form stays open on `{}`", refused);
+    assert!(
+      app.edit_failure.is_some(),
+      "`{}` must be refused by rename too, with a reason",
+      refused
+    );
+  }
+}
+
+#[test]
+fn the_rename_modal_opens_a_free_form_worktree_in_free_form_mode() {
+  // Issue #479. `worktree_spec` starts with `branch_parser.parse(branch)?`, so a
+  // name the user chose on purpose does not parse and the modal used to refuse
+  // outright. It is the one shape the rename form exists for and the one shape
+  // it turned away: renaming a spike that outlived its name meant `git branch -m`
+  // plus `git worktree move` by hand, two commands that have to agree.
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+
+  app.enter_edit_worktree();
+
+  assert_eq!(
+    app.view,
+    View::Edit,
+    "the modal opens instead of refusing: {}",
+    app.status
+  );
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+  assert_eq!(
+    app.create_form.name, "spike-redis",
+    "prefilled with the current name, so the common edit is a small one"
+  );
+  assert_eq!(app.create_form.field, Field::Name, "free-form's only field");
+}
+
+#[test]
+fn ctrl_t_flips_the_rename_modal_between_modes() {
+  // Issue #479 inverts a decision from #416, and the reasoning is kept rather
+  // than deleted. The rename modal reuses `handle_create_key` (`tui/mod.rs`,
+  // #290), so #416's free-form toggle was already *reachable* from it — and
+  // was swallowed, because `draw_edit_worktree` did not render the `Name`
+  // field and `submit_edit_worktree` did not read it, so toggling sent
+  // keystrokes into an invisible buffer and made Enter submit the untouched
+  // triple (Codex review on PR #474). #479 supplies the two missing halves, so
+  // the verb does what its name says instead of being suppressed.
   use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   use gwm::tui::state::create_form::Mode;
   let (_dir, mut app) = make_app();
@@ -8901,22 +9037,32 @@ fn ctrl_t_does_not_flip_the_rename_modal_into_free_form_mode() {
   app.list_state.select(Some(0));
   app.enter_edit_worktree();
   assert_eq!(app.view, View::Edit);
+  assert_eq!(app.create_form.mode, Mode::Structured, "a branch the pattern reads");
 
   app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
 
   assert_eq!(
     app.create_form.mode,
-    Mode::Structured,
-    "the rename modal has no free-form mode to switch to"
+    Mode::Freeform,
+    "the verb flips the rename modal now"
   );
   assert_eq!(
     app.create_form.field,
-    Field::Desc,
-    "focus must stay on the field the modal actually renders"
+    Field::Name,
+    "focus lands on the field the target mode renders"
   );
   assert_eq!(
+    app.create_form.name, "fix/#42-broken-thing",
+    "converting to free-form seeds the current branch verbatim, the only obvious answer"
+  );
+
+  // …and back, without losing what the structured side held: #416 keeps both
+  // buffers side by side precisely so a round trip costs nothing.
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  assert_eq!(app.create_form.mode, Mode::Structured);
+  assert_eq!(
     app.create_form.desc, "broken-thing",
-    "swallowing the verb must not leak `t` into the description as literal input"
+    "the structured buffer survives the round trip, and `t` never leaked into it as literal input"
   );
 }
 
@@ -8970,9 +9116,12 @@ fn ctrl_t_still_flips_the_create_modal_into_free_form_mode() {
 }
 
 #[test]
-fn enter_edit_worktree_rejects_unparseable_branch() {
-  // A branch that isn't `<type>/#<issue>-<desc>` (e.g. `main`) can't be
-  // decomposed into the form, so the modal refuses to open.
+fn enter_edit_worktree_opens_an_unparseable_branch_in_free_form() {
+  // Inverted by #479, and the reasoning is kept: a branch that is not
+  // `<type>/#<issue>-<desc>` could not be decomposed into the form, so the
+  // modal refused to open at all. It now has a mode that needs no
+  // decomposition, so the same branch opens in it.
+  use gwm::tui::state::create_form::Mode;
   let (_dir, mut app) = make_app();
   let mut wt = worktree_fixture("foo");
   wt.branch = Some("main".into());
@@ -8981,8 +9130,36 @@ fn enter_edit_worktree_rejects_unparseable_branch() {
 
   app.enter_edit_worktree();
 
-  assert_eq!(app.view, View::List, "unparseable branch must not open the modal");
+  assert_eq!(app.view, View::Edit, "free-form mode needs no decomposition");
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+  assert_eq!(app.edit_original_branch.as_deref(), Some("main"));
+}
+
+#[test]
+fn enter_edit_worktree_refuses_the_main_worktree() {
+  // #479 removes an accidental protection and has to replace it deliberately.
+  // The main checkout's branch is normally unparseable (`main`, `dev`), so the
+  // parse failure used to turn the rename modal away from it — for the wrong
+  // reason, but with the right result. Free-form mode parses nothing, so that
+  // side effect is gone and the guard has to be the explicit one `enter_confirm_delete`
+  // already has: renaming the main worktree means renaming the repo's default
+  // branch, and `git worktree move` cannot move the main checkout anyway.
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("foo");
+  wt.branch = Some("main".into());
+  wt.is_main = true;
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+
+  app.enter_edit_worktree();
+
+  assert_eq!(app.view, View::List, "the main worktree is not renamed from here");
   assert!(app.edit_original_branch.is_none());
+  assert!(
+    app.status.contains("main worktree"),
+    "the refusal names what it is protecting: {}",
+    app.status
+  );
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -8989,6 +8989,37 @@ fn the_rename_form_refuses_a_free_form_name_create_would_refuse() {
 }
 
 #[test]
+fn the_seeded_description_respects_the_bound_typing_it_would_have() {
+  // Codex review on PR #485. A free-form name may run to
+  // `MAX_DIR_COMPONENT_BYTES` (255), while the description field caps typed
+  // input at `MAX_DESC_LEN` (200) — and that cap exists so
+  // `<type>/#<issue>-<desc>` cannot exceed git's ref limit. `push_char` is the
+  // only place it was enforced, so seeding the field wrote past a bound no
+  // keystroke could have crossed, and `BranchSpec` has no length check to
+  // catch it downstream.
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+  use gwm::tui::state::create_form::{Mode, MAX_DESC_LEN};
+  let long = "a".repeat(250);
+  let (_dir, mut app) = make_app();
+  let mut wt = worktree_fixture("spike");
+  wt.branch = Some(long.clone());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+  assert_eq!(app.create_form.name, long, "the whole name is a legal free-form branch");
+
+  app.handle_create_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+  assert_eq!(app.create_form.mode, Mode::Structured);
+  assert!(
+    app.create_form.desc.chars().count() <= MAX_DESC_LEN,
+    "the seed must not write past the bound typing enforces: {} chars",
+    app.create_form.desc.chars().count()
+  );
+}
+
+#[test]
 fn a_corrected_rename_is_not_held_back_by_the_previous_attempt() {
   // Codex review on PR #485. The frozen-segment guard reports through
   // `edit_failure`, and the call site read that same field back to decide

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -802,6 +802,38 @@ fn the_create_preview_expands_this_repo_s_own_patterns() {
 }
 
 #[test]
+fn the_statusbar_follows_the_rename_modal_s_mode() {
+  // Codex review on PR #485. The modal's own footer tracked the mode while
+  // `hint_context()` still returned `Rename` unconditionally for `View::Edit`,
+  // so the statusbar behind it kept advertising `field` and `type` — two verbs
+  // free-form mode neither renders nor can act on, and this codebase's rule is
+  // to never name a key that does nothing. The create overlay already solves
+  // it with one source both read (#416); rename gets the same.
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  let mut wt = deletable_worktree("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+
+  let buf = render(&mut app);
+  assert_absent(&buf, "↑/↓ type", "free-form has no type selector to advertise");
+  // The toggle hint names its *target* mode, so free-form advertises the way back.
+  assert_present(
+    &buf,
+    "structured",
+    "the toggle is the one verb the visible inputs cannot suggest",
+  );
+
+  app.create_form.toggle_mode();
+  let buf = render(&mut app);
+  assert_present(&buf, "↑/↓ type", "structured mode does have a type selector");
+  assert_present(&buf, "free-form", "and advertises the way across");
+}
+
+#[test]
 fn the_rename_preview_shows_a_free_form_name_verbatim() {
   // Issue #479. In free-form mode no pattern is expanded at all: the branch IS
   // the name, and the directory is that name flattened. A preview that kept

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -802,6 +802,61 @@ fn the_create_preview_expands_this_repo_s_own_patterns() {
 }
 
 #[test]
+fn the_rename_preview_shows_a_free_form_name_verbatim() {
+  // Issue #479. In free-form mode no pattern is expanded at all: the branch IS
+  // the name, and the directory is that name flattened. A preview that kept
+  // expanding `branch_pattern` here would show a branch the submit will not
+  // write, which is exactly the defect found by hand on #476 one mode over.
+  // Preview and submit therefore derive from the same `WorktreeName`.
+  use gwm::tui::state::create_form::Mode;
+  let (_dir, mut app) = make_app();
+  let mut wt = deletable_worktree("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+  assert_eq!(app.view, View::Edit, "the form must open: {}", app.status);
+  assert_eq!(app.create_form.mode, Mode::Freeform);
+
+  // A `/` is legal in a free-form branch and has to flatten in the directory.
+  app.create_form.name = "spike/valkey".into();
+  let buf = render(&mut app);
+
+  assert_present(&buf, "spike/valkey", "the branch preview is the name, verbatim");
+  assert_present(&buf, "spike-valkey", "the dir preview is the name, flattened");
+  assert!(
+    !buffer_contains(&buf, "#0-"),
+    "no pattern is expanded in free-form mode — buffer rows:\n{}",
+    row_strings(&buf).join("\n")
+  );
+}
+
+#[test]
+fn the_rename_pr_warning_fires_on_a_free_form_rename_too() {
+  // The warning added for #481 compares the branch the submit would write
+  // against the current one. Free-form renames change the branch just as much
+  // as structured ones, so the comparison has to be fed the free-form target
+  // rather than a pattern expansion that never matches anything.
+  use gwm::github::PrState;
+  let (_dir, mut app) = make_app();
+  let mut wt = deletable_worktree("spike-redis");
+  wt.branch = Some("spike-redis".into());
+  wt.link.pr = Some(77);
+  wt.pr_state = Some(PrState::Open);
+  app.worktrees = vec![wt];
+  app.list_state.select(Some(0));
+  app.enter_edit_worktree();
+
+  // Unchanged name: nothing is being renamed, so nothing is being closed.
+  let buf = render(&mut app);
+  assert_absent(&buf, "closes PR #77", "an unchanged name renames nothing");
+
+  app.create_form.name = "spike-valkey".into();
+  let buf = render(&mut app);
+  assert_present(&buf, "closes PR #77", "a free-form rename closes the PR just the same");
+}
+
+#[test]
 fn the_rename_preview_expands_this_repo_s_own_patterns() {
   let (_dir, mut app) = make_app();
   // Freezes the type: whatever the selector says, the branch stays `feat/`.


### PR DESCRIPTION
## Description

A worktree created with `gwm create --name spike-redis` could not be renamed from the TUI at all. `worktree_spec` starts by parsing the branch, a name chosen on purpose does not parse, and the form refused outright. That left the two ordinary cases impossible: renaming a spike that outlived its name, and promoting one into the convention once it acquires an issue number. Both are what the rename form exists for, and it was the one shape it turned away.

Such a branch now opens the form in **free-form mode** with its current name prefilled, and `Ctrl-T` moves between the two shapes in either direction, the same verb and the same two modes the create form has had since #416.

Closes #479

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- The rename modal opens a branch the pattern cannot read in free-form mode instead of refusing, prefilled with the current branch.
- `Ctrl-T` is live in the rename modal, both directions. It was suppressed there by #474 because the form rendered no `Name` field and read none on submit; this supplies both halves.
- The rename target is composed through `WorktreeName`, the same seam `submit_create` uses, so the four conversions of the issue are two code paths. The live preview reads that same value.
- The frozen-segment guard is extracted and scoped to structured mode explicitly, rather than being skipped by accident because `opened_with` is `None` for an unparseable branch.
- The main worktree is refused explicitly, replacing a protection that was accidental.
- `worktree.base` written with a structured placeholder is refused for a free-form target rather than expanded to a literal (this already existed in `WorktreeName::worktree_path`; the rename path now surfaces it in the form instead of tearing down the alternate screen).

## Tests

- [x] `cargo test` passes locally (88 suites, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

New coverage:

- `the_rename_modal_opens_a_free_form_worktree_in_free_form_mode`
- `ctrl_t_flips_the_rename_modal_between_modes`, rewritten from `ctrl_t_does_not_flip_the_rename_modal_into_free_form_mode`
- `the_rename_form_composes_a_target_for_each_of_the_four_conversions`
- `the_rename_form_refuses_a_free_form_name_create_would_refuse`
- `enter_edit_worktree_opens_an_unparseable_branch_in_free_form`, rewritten from `enter_edit_worktree_rejects_unparseable_branch`
- `enter_edit_worktree_refuses_the_main_worktree`
- `the_rename_preview_shows_a_free_form_name_verbatim`
- `the_rename_pr_warning_fires_on_a_free_form_rename_too`

## Screenshots / TUI captures

Not attached. The rendered output is asserted in `tests/tui_modal_render_tests.rs` against a `TestBackend` buffer, including the two cases a capture would be showing: the free-form preview and the PR warning.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #479
- Docs: `docs/2.tui/1.keybindings.md` and `docs/fr/2.tui/1.keybindings.md`

## Notes for reviewers

**This inverts a decision from #416** and rewrites the two tests that pinned it rather than deleting them, keeping the original reasoning as history. #474 suppressed `Ctrl-T` in the rename modal for a good reason at the time: without a rendered `Name` field, toggling sent keystrokes into an invisible buffer. That reason is gone, not overruled.

**Where to look hardest.** The preview and the submit must derive from one place. Both live previews previously hardcoded `<type>/#<issue>-<desc>` while the submit expanded the repo's real patterns, so the modal showed a branch it was not going to write; free-form is the same trap one mode over, because there nothing is expanded at all. `pattern_preview` handles both modes, and deliberately builds `WorktreeName::Freeform` directly rather than through the validating constructor, so a half-typed name still previews instead of blanking mid-word. The submit uses the validating path.

**The seeding choice was the open question in the issue.** Leaving free-form seeds the description with `kebab` of the name and leaves type and issue blank. `kebab` lowercases, collapses non-alphanumeric runs to a single `-` and trims the edges, so its output is by construction either `DESC_RE`-valid or empty, and empty is exactly what seeding nothing would give. A seed that dead-ends the form was the failure mode worth avoiding, and this one cannot.

**One message is now stale and deliberately untouched.** A branch whose type is not configured (`zzz/#7-thing` with `zzz` absent from `.gwm.toml`) still refuses with "can't rename here", which free-form mode makes false. Changing it means deciding whether that case should fall through to free-form too, which is a separate decision from this issue's, so it is left alone rather than folded in.
