### PR TITLE
🐛 fix(cli): read the branch from the checkout the command was run in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gwm pr`, `gwm commit-prefix` and `gwm bootstrap` read the branch of the
+  worktree they were pointed at, instead of the main checkout's.
+  `worktree::discover_repo` walks back to the main working directory when it
+  lands inside a linked worktree, which is what `list` / `remove` / `switch` /
+  `prune` need, since they operate on the whole worktree set. Asking that
+  handle "which branch am I on" answered for the main checkout.
+
+  `gwm commit-prefix` was the one that hurt: the bundled `commit-msg` hook
+  calls it and git invokes that hook with the working directory inside the
+  worktree, so every commit made from a worktree took its prefix from whatever
+  the main checkout happened to be sitting on. `gwm pr` had a quieter symptom,
+  falling back to the `chore` template because the main branch did not parse.
+
+  A third site turned up on the sweep, with a different symptom: `gwm
+  bootstrap` only ever resolved a branch when its target came from a fuzzy
+  pattern, so hooks got an **empty** `{branch}` / `{type}` / `{issue}` rather
+  than the wrong one. Two of its three target paths were affected, no argument
+  and an argument that is already a directory.
+
+  Only the branch moves. `.gwm.toml`, the workdir and the repo name still come
+  from the main checkout, which is where the config lives and what `{repo}`
+  expands to, so a branch written with `{repo}` in `branch_pattern` keeps
+  being read back correctly from inside a worktree. `gwm status` was right all
+  along, and its `resolve_target_repo` is the shape the fix follows.
+
+  Pre-existing rather than a regression, measured against the published 1.5.0
+  binary. ([#477](https://github.com/kbrdn1/gwm-cli/issues/477))
+
 - A free-form worktree name is validated against Windows path rules, on every
   platform. `gwm create --name 'foo|bar'` or `--name CON` used to pass every
   check and fail inside `worktree::add`, after `pre_create` hooks had run and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2902,7 +2902,10 @@ const PR_FILES_CHANGED_MAX_LINES: usize = 30;
 
 fn cmd_pr(render_only: bool, draft: bool, base_override: Option<String>) -> Result<()> {
   let RepoContext { repo, workdir, config } = repo_context(None)?;
-  let head_name = current_branch(&repo)?;
+  // Issue #477: from the invoking checkout, not from `repo` — that handle
+  // has walked back to the main working directory. Everything else below
+  // keeps using `repo`, which is what it wants.
+  let head_name = current_branch_at(None)?;
   // Issue #417: `[pr_template.by_type]` selection and the body placeholders
   // read the branch back, so they read it with this repo's own pattern.
   let branch_spec = crate::naming::BranchParser::from_config(&config, &worktree::repo_name(&repo)).parse(&head_name);
@@ -3208,6 +3211,14 @@ fn cmd_bootstrap(target: Option<String>, skip_hooks: Option<String>, trust_mode:
     }
     None => std::env::current_dir()?,
   };
+  // Issue #477: only the fuzzy arm above resolves a branch, off the worktree
+  // record. The other two left it `None`, so hooks received an empty
+  // `{branch}` / `{type}` / `{issue}` — the same defect as `pr` and
+  // `commit-prefix` with a quieter symptom. Read it from the target itself,
+  // which covers a path that was given outright as well as the CWD.
+  if worktree_branch.is_none() {
+    worktree_branch = current_branch_at(Some(&worktree_path)).ok();
+  }
   let skips = HookSkips::parse(skip_hooks.as_deref())?;
 
   trust_or_prompt(&workdir, Some(&repo), trust_mode)?;
@@ -3553,7 +3564,13 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
     None => {
       let repo = worktree::discover_repo(None)?;
       let wd = repo.workdir().map(|w| w.to_path_buf());
-      let name = current_branch(&repo)?;
+      // Issue #477: the workdir and the repo name come from the main
+      // checkout, because that is where `.gwm.toml` lives and what `{repo}`
+      // expands to. The branch does not: the bundled `commit-msg` hook runs
+      // this with git's working directory inside the worktree, so reading
+      // `repo`'s HEAD prefixed every commit made from a worktree with
+      // whatever the main checkout happened to be sitting on.
+      let name = current_branch_at(None)?;
       (wd, Some(worktree::repo_name(&repo)), name)
     }
   };
@@ -3777,6 +3794,36 @@ fn resolve_target_repo(worktree: Option<String>) -> Result<(Repository, String, 
   let repo = Repository::discover(&path).map_err(|_| GwmError::NotInGitRepo)?;
   let branch = current_branch(&repo)?;
   Ok((repo, branch, path))
+}
+
+/// The branch checked out *at* `start`, or at the current directory when
+/// `start` is `None`.
+///
+/// Issue #477. [`worktree::discover_repo`] deliberately walks back to the
+/// main working directory when it lands inside a linked worktree, which is
+/// what every command operating on the whole worktree **set** needs: `list`,
+/// `remove`, `switch`, `prune` all want the one handle that knows about all
+/// of them. Asking that handle "which branch am I on" answers for the main
+/// checkout instead, so `gwm commit-prefix` run by the bundled `commit-msg`
+/// hook — which git invokes with the working directory inside the worktree —
+/// derived its prefix from whatever the main checkout was sitting on.
+///
+/// So this discovers without the walk-back. It is deliberately *not* a
+/// replacement for `repo_context`: `.gwm.toml`, the workdir and
+/// [`worktree::repo_name`] all still want the main repo, and `{repo}` is a
+/// legal token in `branch_pattern`, so widening this to the whole context
+/// would compile the branch parser with the worktree directory's name and
+/// stop reading branches gwm itself wrote. Only the branch moves.
+///
+/// [`resolve_target_repo`] already had the right shape, which is why
+/// `gwm status` reported the right branch from the same directory all along.
+fn current_branch_at(start: Option<&Path>) -> Result<String> {
+  let from = match start {
+    Some(p) => p.to_path_buf(),
+    None => std::env::current_dir()?,
+  };
+  let repo = Repository::discover(&from).map_err(|_| GwmError::NotInGitRepo)?;
+  current_branch(&repo)
 }
 
 fn current_branch(repo: &Repository) -> Result<String> {

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -6885,3 +6885,176 @@ fn pr_falls_back_to_chore_when_the_pattern_carries_no_type() {
     .success()
     .stdout(predicate::str::contains("chore body for tidy-up (#42)"));
 }
+
+// ---------------------------------------------------------------------
+// Issue #477 — `worktree::discover_repo` walks back to the main working
+// directory when it lands inside a linked worktree, which is right for
+// every command operating on the whole worktree *set* (`list`, `remove`,
+// `switch`, `prune`). Commands that instead ask "which branch am I on"
+// were reading that handle's HEAD, so from inside a worktree they
+// answered with the main checkout's branch.
+//
+// `gwm commit-prefix` is the one that hurts: the bundled `commit-msg`
+// hook calls it, and git invokes that hook with the working directory
+// inside the worktree, so committing from a worktree derived the prefix
+// from whatever the main checkout happened to be sitting on.
+//
+// Pre-existing, measured against the published 1.5.0 binary in the issue
+// and re-measured against this branch's build before the fix.
+// ---------------------------------------------------------------------
+
+/// The reproduction from the issue, as a test. `repo_with_one_worktree`
+/// leaves the main checkout on its default branch and the worktree on
+/// `feat/#1-wt`; before the fix this errored out saying the *main*
+/// branch carried no type to read.
+#[test]
+fn commit_prefix_reads_the_branch_of_the_worktree_it_runs_in() {
+  let (_dir, _base, wt) = repo_with_one_worktree();
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(&wt)
+    .args(["commit-prefix", "--unicode"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat(#1):"));
+}
+
+/// Same handle, same defect, different symptom: `cmd_pr` falls back to
+/// the `chore` template when the branch does not parse, so reading the
+/// main checkout's branch surfaced as "no pr_template configured for
+/// branch type 'chore'" rather than as a wrong branch name.
+#[test]
+fn pr_reads_the_branch_of_the_worktree_it_runs_in() {
+  let (dir, _base, wt) = repo_with_one_worktree();
+  let cfg = dir.path().join(".gwm.toml");
+  let mut body = std::fs::read_to_string(&cfg).expect("seeded config");
+  body.push_str("\n[pr_template.by_type.feat]\nbody = \"GWM_PROBE head={head} type={type} issue={issue}\\n\"\n");
+  std::fs::write(&cfg, body).expect("append a template");
+
+  // Selecting the `feat` entry at all is half the assertion: before the fix
+  // the main checkout's branch did not parse, the type fell back to `chore`,
+  // and this errored with "no pr_template configured for branch type
+  // 'chore'". `{head}` then pins the branch itself, not just its type.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(&wt)
+    .args(["pr", "--render"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("GWM_PROBE head=feat/#1-wt type=feat issue=1"));
+}
+
+/// 🔴 The over-correction guard. Only the *branch* comes from the
+/// invoking checkout. `.gwm.toml`, the workdir and `worktree::repo_name`
+/// all legitimately want the main repo, and `{repo}` is a legal token in
+/// `branch_pattern`, so a fix that discovered from the current directory
+/// everywhere would compile the parser with the *worktree directory's*
+/// name and stop reading a branch gwm itself wrote.
+///
+/// Under `{type}/#{issue}-{desc}-{repo}` the worktree directory is named
+/// `feat-1-wt` while the repo is not, so the two names cannot be
+/// confused: this passes only if the parser was handed the main repo's.
+///
+/// `{repo}` sits at the end rather than leading the branch because
+/// `init_repo` builds on `TempDir`, whose basename starts with `.` on
+/// macOS, and git refuses a ref component that does. Inside a component
+/// the same character is fine.
+#[test]
+fn only_the_branch_comes_from_the_worktree_the_repo_name_still_comes_from_the_main_checkout() {
+  let (dir, _repo) = init_repo();
+  let base = tempfile::TempDir::new().unwrap();
+  let repo_name = dir.path().file_name().unwrap().to_string_lossy().to_string();
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    format!(
+      "[worktree]\nbase = \"{base}\"\n\
+       path_pattern = \"{{type}}-{{issue}}-{{desc}}\"\n\
+       branch_pattern = \"{{type}}/#{{issue}}-{{desc}}-{{repo}}\"\n",
+      base = toml_basic_string(base.path()),
+    ),
+  )
+  .expect("seed .gwm.toml");
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["create", "feat", "1", "wt"])
+    .assert()
+    .success();
+  let wt = base.path().join("feat-1-wt");
+  assert!(
+    wt.join(".git").exists(),
+    "precondition: the worktree exists and is named after `path_pattern`, not the repo"
+  );
+  assert_ne!(
+    repo_name, "feat-1-wt",
+    "precondition: the two names differ, or the assertion below proves nothing"
+  );
+
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(&wt)
+    .args(["commit-prefix", "--unicode"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("feat(#1):"));
+}
+
+/// The sweep the issue asked for ("worth checking whether the same
+/// handle is used for anything else that is position-dependent") found a
+/// third site with a *different* symptom: `cmd_bootstrap` never resolved
+/// a branch at all unless the target came from a fuzzy pattern, so hooks
+/// received an empty `{branch}` / `{type}` / `{issue}` rather than the
+/// wrong one. Two of its three target paths were affected, measured
+/// against this branch's build: no argument (the worktree is the CWD),
+/// and an argument that is already a directory. Only the fuzzy path,
+/// which reads the branch off the worktree record, was correct.
+#[test]
+fn bootstrap_gives_hooks_the_branch_of_the_worktree_it_targets() {
+  let (dir, _base, wt) = repo_with_one_worktree();
+  let cfg = dir.path().join(".gwm.toml");
+  let mut body = std::fs::read_to_string(&cfg).expect("seeded config");
+  body.push_str(
+    "\n[[hooks.post_bootstrap]]\nname = \"probe\"\n\
+     run = \"echo GWM_PROBE branch=[{branch}] type=[{type}] issue=[{issue}]\"\n",
+  );
+  std::fs::write(&cfg, body).expect("append a hook");
+
+  let expected = "GWM_PROBE branch=[feat/#1-wt] type=[feat] issue=[1]";
+
+  // No argument: the worktree is the current directory.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(&wt)
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .arg("bootstrap")
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(expected));
+
+  // An argument that is already a directory, from the main checkout.
+  // This one is not about where the command runs: the path was given
+  // outright and its branch was simply never looked up.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .arg("bootstrap")
+    .arg(&wt)
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(expected));
+
+  // The fuzzy path already worked; it is here so a future change cannot
+  // fix the two above by breaking the one that was right.
+  Command::cargo_bin("gwm")
+    .unwrap()
+    .current_dir(dir.path())
+    .env("GWM_ALLOW_BOOTSTRAP", "1")
+    .args(["bootstrap", "feat-1"])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(expected));
+}


### PR DESCRIPTION
## Description

`worktree::discover_repo` walks back to the main working directory when it lands inside a linked worktree. That is right for every command operating on the whole worktree **set**: `list`, `remove`, `switch` and `prune` all want the one handle that knows about all of them. Three commands then asked that handle "which branch am I on" and got the main checkout's `HEAD`.

`gwm commit-prefix` is the one that hurts. The bundled `commit-msg` hook calls it, and git invokes that hook with the working directory inside the worktree, so every commit made from a worktree derived its prefix from whatever the main checkout happened to be sitting on.

Pre-existing, not a regression: measured against the published 1.5.0 binary in the issue, and re-measured against this branch's build before the fix.

Closes #477

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `current_branch_at(start: Option<&Path>)` in `src/cli.rs`: discovers without the walk-back. Same `Option<&Path>` shape as `discover_repo` / `repo_context`, so it is testable without the test process changing directory.
- `cmd_pr` and `cmd_commit_prefix` read the branch through it. Everything else in both keeps using the main-repo handle.
- `cmd_bootstrap` resolves the branch from its target path when the fuzzy arm did not supply one.
- Four end-to-end tests in `tests/cli_binary.rs`, reusing the existing `repo_with_one_worktree` helper.
- `CHANGELOG.md` under `[Unreleased]`.

## Measured before and after, against this branch's build

The issue names two commands. The sweep it asks for ("worth checking whether the same handle is used for anything else that is position-dependent rather than set-wide") found a third, with a different symptom. All five cases run against a repo whose main checkout is on `main` and whose worktree is on `feat/#42-probe`:

| case | before | after |
|---|---|---|
| `gwm commit-prefix`, from the worktree | `error: branch 'main' … carries no branch type` | `✨ feat(#42):` |
| `gwm pr --render`, from the worktree | `error: no pr_template configured for branch type 'chore'` | renders the `feat` template |
| `gwm bootstrap`, no argument, from the worktree | `branch=[] type=[] issue=[]` | `branch=[feat/#42-probe] type=[feat] issue=[42]` |
| `gwm bootstrap <dir path>` | `branch=[] type=[] issue=[]` | same, correct |
| `gwm bootstrap <fuzzy pattern>` | `branch=[feat/#42-probe]` | unchanged |

`chore` is `cmd_pr`'s fallback when the branch does not parse, which is how that one confirms it read `main` too.

The `bootstrap` sites are a **different symptom** and worth calling out rather than folding in silently: the branch was not wrong, it was never resolved. Only the fuzzy arm reads a branch, off the worktree record; the other two left it `None` and hooks received an empty `{branch}` / `{type}` / `{issue}`. One of those two paths is not even about where the command runs, since the directory was given outright. The same helper covers both because the question is the same one, asked of the target rather than of the current directory.

## The decision a reviewer should check

**Only the branch moves.** In both `cmd_pr` and `cmd_commit_prefix`, `.gwm.toml`, the workdir and `worktree::repo_name` all legitimately want the main repo: the config lives there, and `{repo}` is a legal token in `branch_pattern` that expands to the main repo's name. Discovering from the current directory for the whole `RepoContext` would compile the branch parser with the **worktree directory's** name and stop reading branches gwm itself wrote.

That is the obvious wrong fix, so it gets a test rather than a comment. `only_the_branch_comes_from_the_worktree_the_repo_name_still_comes_from_the_main_checkout` sets `branch_pattern = "{type}/#{issue}-{desc}-{repo}"`, creates a worktree, and asserts from inside it that `commit-prefix` still resolves. It carries two preconditions, that the worktree exists and that its directory name differs from the repo name, because without them it would pass for the wrong reason.

`discover_repo` itself is untouched. Its walk-back is deliberate and load-bearing.

## Tests

- [x] `cargo test` passes locally (2498 passed, 0 failed, up from 2494)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (four, in `tests/cli_binary.rs`)

Per CLAUDE.md's rule on environment-dependent tests, these were also run under a stripped CI-like environment before pushing, since a worktree end-to-end test is exactly the shape that passes locally and fails on a bare runner:

```
PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test --locked --test cli_binary
test result: ok. 262 passed; 0 failed
```

## Screenshots / TUI captures

None. No TUI surface changed.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (not needed: no flag or subcommand changed, only which branch three of them read)
- [ ] `examples/gwm.toml.example` updated if config schema changed (not needed)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #477
- Related: #417, during whose end-to-end verification this was found and from whose PR it was deliberately kept out

## Notes for reviewers

The `{repo}` token sits at the **end** of the pattern in the fourth test rather than leading the branch. `init_repo` builds on `TempDir`, whose basename starts with `.` on macOS, and git refuses a ref component that starts with `.` while accepting the character inside one. The first draft put it first and failed on `refs/heads/.tmpXXXX/feat/#1-wt` being an invalid spec, which is a fixture problem rather than a finding, but it is the kind of thing worth knowing before writing another test around `{repo}`.

No documentation page states which checkout these three commands read, so there is nothing to correct in `docs/`. The behaviour they now have is the one the docs already imply.
