### PR TITLE
🐛 fix(config): substitute worktree placeholders in a single pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `worktree` patterns are expanded in a single pass, so an expansion is a value
+  rather than more template. `expand_placeholders` chained `str::replace` calls
+  and each one re-scanned what the previous had written, with `{home}` and
+  `{repo}` going first: on a repo whose own directory is named `api-{type}`,
+  `branch_pattern = "{repo}/{desc}"` wrote `api-fix/foo` and carried a branch
+  type the pattern never mentions.
+
+  Anything that reasons about a pattern by reading it was wrong there, and two
+  things do. The create form derived its fields from the wrong set, and the
+  branch parser could not mirror a formatter that rewrote its own output, so it
+  refused the whole class rather than build a parser recognising none of the
+  branches the pattern creates. Those patterns now compile and round-trip.
+
+  Two behaviours are preserved rather than tidied away: a token with no value
+  stays literal instead of collapsing to empty, which is what lets
+  `{repo_path}` and `{repo_parent}` survive into a branch name; and the token
+  starts at the last `{` before the closing brace, so `{{type}` keeps writing
+  `{feat` as it did in 1.5.0.
+
+  Hook placeholders were already single-pass and are unaffected.
+  ([#494](https://github.com/kbrdn1/gwm-cli/issues/494))
+
 - `gwm pr`, `gwm commit-prefix` and `gwm bootstrap` read the branch of the
   worktree they were pointed at, instead of the main checkout's.
   `worktree::discover_repo` walks back to the main working directory when it

--- a/src/config.rs
+++ b/src/config.rs
@@ -2080,22 +2080,63 @@ pub fn expand_placeholders(
     .ok_or_else(|| GwmError::Config("cannot resolve $HOME".into()))?
     .to_string_lossy()
     .to_string();
-  let mut out = template.replace("{home}", &home).replace("{repo}", repo);
-  if let Some(t) = type_ {
-    out = out.replace("{type}", t);
-  }
-  if let Some(i) = issue {
-    out = out.replace("{issue}", i);
-  }
-  if let Some(d) = desc {
-    out = out.replace("{desc}", d);
-  }
-  if let Some(p) = repo_path {
-    out = out.replace("{repo_path}", &p.to_string_lossy());
-    if let Some(parent) = p.parent() {
-      out = out.replace("{repo_parent}", &parent.to_string_lossy());
+
+  // Resolved value for one `{token}`, or `None` to leave it verbatim.
+  //
+  // The `None` arm carries real weight: `BranchSpec::branch_name` passes no
+  // `repo_path` precisely so the disk-path tokens survive into the branch
+  // name, and `BranchParser::compile` mirrors that by treating them as
+  // literals. Note the asymmetry when a `repo_path` has no parent — `/` is the
+  // case — where `{repo_path}` resolves and `{repo_parent}` does not: the old
+  // nested `if let` fell into that by accident, so it has to be said here.
+  let value_for = |token: &str| -> Option<String> {
+    match token {
+      "{home}" => Some(home.clone()),
+      "{repo}" => Some(repo.to_string()),
+      "{type}" => type_.map(str::to_string),
+      "{issue}" => issue.map(str::to_string),
+      "{desc}" => desc.map(str::to_string),
+      "{repo_path}" => repo_path.map(|p| p.to_string_lossy().into_owned()),
+      "{repo_parent}" => repo_path
+        .and_then(|p| p.parent())
+        .map(|p| p.to_string_lossy().into_owned()),
+      _ => None,
     }
+  };
+
+  // One pass, never re-examining what was written (issue #494). Chained
+  // `str::replace` calls re-scan the previous call's output, so a value that
+  // itself contains a token got rewritten from the inside: on a repo named
+  // `api-{type}`, `{repo}/{desc}` wrote `api-fix/foo` and carried a type the
+  // template never mentions. **An expansion is a value, not more template** —
+  // nothing downstream can reason about a pattern by reading it otherwise, and
+  // `naming::editable_segments` and `BranchParser::compile` both do.
+  //
+  // Same property `lifecycle::expand` has had since the hook-injection patch,
+  // and for the same reason one layer down.
+  let mut out = String::with_capacity(template.len());
+  let mut rest = template;
+  while let Some(open) = rest.find('{') {
+    let Some(close) = rest[open..].find('}').map(|at| open + at) else {
+      // Unbalanced `{` — no token to close, so the remainder is literal.
+      break;
+    };
+    // The token starts at the **last** `{` before this `}`, not the first.
+    // `str::replace` matched `{type}` inside `{{type}` and wrote `{feat`, and
+    // #417 built the compiler to mirror that. Taking the first `{` would leave
+    // `{{type}` literal instead, which is a pattern that worked in 1.5.0
+    // quietly changing meaning — a different bug from the one this fixes.
+    let start = rest[open..close].rfind('{').map(|at| open + at).unwrap_or(open);
+    out.push_str(&rest[..start]);
+    let token = &rest[start..=close];
+    match value_for(token) {
+      Some(value) => out.push_str(&value),
+      None => out.push_str(token),
+    }
+    rest = &rest[close + 1..];
   }
+  out.push_str(rest);
+
   // Tilde expansion in case the template starts with ~/...
   let expanded = shellexpand::tilde(&out).to_string();
   Ok(expanded)

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -91,34 +91,19 @@ const SEGMENTS: [&str; 3] = ["type", "issue", "desc"];
 /// repeated capturing token, but `expand_placeholders` is a chain of
 /// `str::replace` and substitutes every occurrence quite happily.
 ///
-/// Scanned **after** the context placeholders are resolved, because that is what
-/// the formatter does: `expand_placeholders` substitutes `{home}` / `{repo}`
-/// first and then substitutes what those expansions produced. A repo literally
-/// named `api-{type}` therefore makes `{repo}/{desc}` write a type the raw
-/// template never mentions, and reading the raw template hid the field while
-/// silently defaulting it (Codex review on PR #492).
-///
-/// Bounding that by "the compiler refuses this class anyway" was **false**, and
-/// worth recording because the bound looked solid: `branch_pattern_warning` is
-/// only ever called with `worktree.branch_pattern`, so the same repo name
-/// reaches the form through `path_pattern` or `base` with no diagnostic at all.
-/// The multi-pass substitution is still the root cause and still worth removing
-/// (#494); deriving from the same intermediate text is what makes this function
-/// agree with the formatter meanwhile.
-pub fn editable_segments(patterns: &[&str], repo: &str) -> Vec<&'static str> {
-  // `{home}` failing to resolve leaves it literal here, which matches what the
-  // caller is about to hit anyway: `expand_placeholders` errors outright on it.
-  let home = dirs::home_dir().map(|p| p.to_string_lossy().to_string());
+/// Reads the pattern as written, which is only correct because
+/// `expand_placeholders` is single-pass (#494): an expansion is a value, so a
+/// repo named `api-{type}` contributes the text `api-{type}` and not a `{type}`
+/// placeholder. While the formatter re-substituted its own output, #418 had to
+/// resolve `{home}` / `{repo}` here first to stay in step with it; removing the
+/// root removed the need, and leaving that resolution in would now invent a
+/// field for a token the formatter writes literally.
+pub fn editable_segments(patterns: &[&str]) -> Vec<&'static str> {
   let mut out: Vec<&'static str> = Vec::new();
   for pattern in patterns {
-    let mut resolved = (*pattern).to_string();
-    if let Some(home) = &home {
-      resolved = resolved.replace("{home}", home);
-    }
-    let resolved = resolved.replace("{repo}", repo);
     let mut hits: Vec<(usize, &'static str)> = SEGMENTS
       .into_iter()
-      .filter_map(|segment| resolved.find(&format!("{{{}}}", segment)).map(|at| (at, segment)))
+      .filter_map(|segment| pattern.find(&format!("{{{}}}", segment)).map(|at| (at, segment)))
       .collect();
     hits.sort_by_key(|(at, _)| *at);
     for (_, segment) in hits {
@@ -424,10 +409,14 @@ impl WorktreeName {
   /// 2. **A single filesystem path component** — the worktree directory. A
   ///    branch name is a *path* of components, so the two have different
   ///    limits: bounded at [`MAX_DIR_COMPONENT_BYTES`], and no `.` / `..`.
-  /// 3. **A literal value in placeholder expansion.**
-  ///    `lifecycle::expand_placeholders` substitutes sequentially, so a name
-  ///    that itself contains a token gets rewritten inside its own
-  ///    substituted value.
+  /// 3. **A literal value in placeholder expansion.** Defensive now rather
+  ///    than live: both expanders substitute in one pass — `lifecycle::expand`
+  ///    since the hook-injection patch, `config::expand_placeholders` since
+  ///    #494 — so a name containing a token is no longer rewritten inside its
+  ///    own substituted value. The rule is kept because a name is data that
+  ///    reaches two script-adjacent surfaces, but it now stands without the
+  ///    bug that motivated it, which is a naming-surface decision to revisit
+  ///    rather than something this list can settle.
   ///
   /// Plus one rule that belongs to none of them: no leading `-`, which is a
   /// CLI-ergonomics rule (git accepts it).
@@ -475,12 +464,15 @@ impl WorktreeName {
     if name.starts_with('-') {
       return reject("a leading `-` makes the name unusable as a command argument");
     }
-    // Consumer (3): `lifecycle::expand_placeholders` replaces `{branch}`
-    // first and `{type}` / `{issue}` / `{desc}` / `{repo}` after, so a hook
-    // asking for `{branch}` on `spike-{issue}` receives `spike-` — the
-    // second pass rewrites the value the first one just substituted.
-    // `DESC_RE` kept structured names out of this; free-form names reach it,
-    // so the boundary is where it gets closed.
+    // Consumer (3), and the reason has expired: `lifecycle::expand` used to
+    // replace `{branch}` first and `{type}` / `{issue}` / `{desc}` / `{repo}`
+    // after, so a hook asking for `{branch}` on `spike-{issue}` received
+    // `spike-`. Both expanders are single-pass now, so nothing re-substitutes
+    // a name that contains a token. Kept as a defensive rule rather than
+    // dropped, because loosening what a free-form name may contain is a
+    // separate decision from removing the re-substitution — but the stated
+    // cause is no longer live, and a rejection justified by a false cause is
+    // how the next reader removes it for the wrong reason.
     if name.contains('{') || name.contains('}') {
       return reject("`{` and `}` would be re-substituted when a lifecycle hook expands its placeholders");
     }
@@ -810,6 +802,13 @@ impl BranchParser {
   /// the two disagree on is refused rather than compiled into a parser that
   /// recognises none of the branches it creates.
   ///
+  /// Two of those three classes are gone since #494 made the formatter
+  /// single-pass: an expansion is a value now, so it cannot carry a token and
+  /// cannot form one against the text around it. The patterns that used to be
+  /// refused for it compile and round-trip. The check stays because its value
+  /// was never the list of known cases — it is what turns the next unknown one
+  /// into a refusal instead of a parser that reads nothing.
+  ///
   /// Two deliberate exclusions:
   ///
   /// - **A `~` prefix.** `expand_placeholders` ends with `shellexpand::tilde`,
@@ -845,9 +844,7 @@ impl BranchParser {
     }
     Err(GwmError::Config(format!(
       "worktree.branch_pattern `{}` writes `{}`, which the parser derived from it does not read \
-       back, so gwm would recognise none of the branches this pattern creates — a `{{repo}}` or \
-       `{{home}}` that expands to text containing another placeholder does this, because the \
-       formatter substitutes what its own expansions produce",
+       back, so gwm would recognise none of the branches this pattern creates",
       sanitise_for_terminal(pattern),
       sanitise_for_terminal(&written)
     )))

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -409,14 +409,15 @@ impl WorktreeName {
   /// 2. **A single filesystem path component** — the worktree directory. A
   ///    branch name is a *path* of components, so the two have different
   ///    limits: bounded at [`MAX_DIR_COMPONENT_BYTES`], and no `.` / `..`.
-  /// 3. **A literal value in placeholder expansion.** Defensive now rather
-  ///    than live: both expanders substitute in one pass — `lifecycle::expand`
-  ///    since the hook-injection patch, `config::expand_placeholders` since
-  ///    #494 — so a name containing a token is no longer rewritten inside its
-  ///    own substituted value. The rule is kept because a name is data that
-  ///    reaches two script-adjacent surfaces, but it now stands without the
-  ///    bug that motivated it, which is a naming-surface decision to revisit
-  ///    rather than something this list can settle.
+  /// 3. **A literal value in placeholder expansion.** Two of the three
+  ///    expanders substitute in one pass and can no longer rewrite a value
+  ///    from the inside — `lifecycle::expand` since the hook-injection patch,
+  ///    `config::expand_placeholders` since #494. The third,
+  ///    `launcher::expand`, still chains `str::replace` over its own output,
+  ///    and it substitutes the worktree **path** before `{base}` / `{head}`,
+  ///    so a brace reaching that path is re-substituted inside an already
+  ///    shell-quoted value. So this rule is not merely defensive: it is what
+  ///    keeps a chosen name out of that surface.
   ///
   /// Plus one rule that belongs to none of them: no leading `-`, which is a
   /// CLI-ergonomics rule (git accepts it).
@@ -464,15 +465,23 @@ impl WorktreeName {
     if name.starts_with('-') {
       return reject("a leading `-` makes the name unusable as a command argument");
     }
-    // Consumer (3), and the reason has expired: `lifecycle::expand` used to
-    // replace `{branch}` first and `{type}` / `{issue}` / `{desc}` / `{repo}`
-    // after, so a hook asking for `{branch}` on `spike-{issue}` received
-    // `spike-`. Both expanders are single-pass now, so nothing re-substitutes
-    // a name that contains a token. Kept as a defensive rule rather than
-    // dropped, because loosening what a free-form name may contain is a
-    // separate decision from removing the re-substitution — but the stated
-    // cause is no longer live, and a rejection justified by a false cause is
-    // how the next reader removes it for the wrong reason.
+    // Consumer (3). The reason originally written here has expired:
+    // `lifecycle::expand` used to replace `{branch}` first and `{type}` /
+    // `{issue}` / `{desc}` / `{repo}` after, so a hook asking for `{branch}`
+    // on `spike-{issue}` received `spike-`. That expander has been single-pass
+    // since the hook-injection patch and `config::expand_placeholders` is
+    // since #494.
+    //
+    // The rule stays, and not merely as a belt: `launcher::expand` still
+    // chains `str::replace` over its own output, substituting the worktree
+    // path before `{base}` / `{head}`. `kebab` strips braces out of a
+    // structured description, so this check is the only thing keeping them out
+    // of a name that becomes a directory. (`worktree.base` can still put one
+    // there, which is config rather than a chosen name — a separate surface.)
+    //
+    // Worth stating rather than leaving as folklore: a rejection justified by
+    // a cause that has expired is how the next reader removes it for the wrong
+    // reason, and this one nearly was.
     if name.contains('{') || name.contains('}') {
       return reject("`{` and `}` would be re-substituted when a lifecycle hook expands its placeholders");
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -835,14 +835,11 @@ impl App {
   /// rather than round-tripping a `.gwm.toml`, and that shortcut has to be able
   /// to re-derive what construction derives.
   pub fn apply_create_form_fields(&mut self) {
-    self.create_form.set_fields(super::state::create_form::fields_for(
-      &[
-        &self.config.worktree.branch_pattern,
-        &self.config.worktree.path_pattern,
-        &self.config.worktree.base,
-      ],
-      &self.repo_name,
-    ));
+    self.create_form.set_fields(super::state::create_form::fields_for(&[
+      &self.config.worktree.branch_pattern,
+      &self.config.worktree.path_pattern,
+      &self.config.worktree.base,
+    ]));
   }
 
   /// The name of the field Enter submits from, for the status line (#418).
@@ -903,14 +900,11 @@ impl App {
   /// [`crate::naming::BranchSpec::new_with_required`] validates against, so the
   /// form never refuses a submission over a value the patterns discard (#418).
   fn required_segments(&self) -> Vec<&'static str> {
-    crate::naming::editable_segments(
-      &[
-        &self.config.worktree.branch_pattern,
-        &self.config.worktree.path_pattern,
-        &self.config.worktree.base,
-      ],
-      &self.repo_name,
-    )
+    crate::naming::editable_segments(&[
+      &self.config.worktree.branch_pattern,
+      &self.config.worktree.path_pattern,
+      &self.config.worktree.base,
+    ])
   }
 
   /// Mark the workspace selection stale AND close the open CI checks

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -73,10 +73,9 @@ impl Field {
 /// Pass every pattern the triple feeds — `branch_pattern`, `path_pattern` and
 /// `base` — because [`crate::naming::BranchSpec::worktree_path`] expands the
 /// three tokens in `base` too, so a segment only `base` carries still names a
-/// real directory on disk. `repo` is the name `{repo}` expands to, which can
-/// itself contain a token (see [`crate::naming::editable_segments`]).
-pub fn fields_for(patterns: &[&str], repo: &str) -> Vec<Field> {
-  crate::naming::editable_segments(patterns, repo)
+/// real directory on disk.
+pub fn fields_for(patterns: &[&str]) -> Vec<Field> {
+  crate::naming::editable_segments(patterns)
     .into_iter()
     .filter_map(Field::from_segment)
     .collect()

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2585,12 +2585,24 @@ fn a_token_produced_by_expanding_the_repo_name_stays_literal() {
   }
 }
 
-/// The same for `{home}`, which is substituted first of all and is the one
-/// token whose value the user does not choose directly.
+/// The same for `{home}`, which is substituted first of all and is the one token
+/// whose value the user does not choose directly.
+///
+/// **Unix only, and the gate is the point rather than a shortcut.** `dirs 6` on
+/// Windows resolves the home directory through `SHGetKnownFolderPath` and never
+/// reads `$HOME`, so swapping the variable there changes nothing and the
+/// assertion fails on every run. Caught by the `windows-latest` job on PR #495,
+/// which is the CLAUDE.md rule about pre-validating environment-dependent tests
+/// being paid for rather than followed.
+///
+/// The *property* is covered portably by the test above: `{home}` and `{repo}`
+/// are two arms of one `value_for` match, and that one exercises all five tokens
+/// arriving through a value. What this adds is the guarantee that `{home}` is
+/// not special-cased back into a pre-pass, which is exactly how the defect was
+/// shaped, so it is worth keeping on the platform that can express it.
+#[cfg(unix)]
 #[test]
 fn a_token_produced_by_expanding_home_stays_literal() {
-  // `$HOME` is read through `dirs::home_dir`, so drive it via the env var the
-  // way the other environment-sensitive tests in this file do.
   let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let previous = std::env::var("HOME").ok();
   unsafe { std::env::set_var("HOME", "/tmp/h-{issue}") };

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -4,6 +4,16 @@ use gwm::config::{
 };
 use tempfile::TempDir;
 
+/// Process-global lock guarding every test in this binary that reads or
+/// mutates `$HOME`. `expand_placeholders` resolves `{home}` through
+/// `dirs::home_dir` and ends with `shellexpand::tilde`, so a test that swaps
+/// `$HOME` races every other one that expands a `{home}` pattern. `set_var` is
+/// `unsafe` for the same reason the other suites take this lock (#494).
+fn env_lock() -> &'static std::sync::Mutex<()> {
+  static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+  LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
 #[cfg(unix)]
 fn toml_absolute_path(unix: &'static str, _windows: &'static str) -> &'static str {
   unix
@@ -323,6 +333,7 @@ trunks = []
 
 #[test]
 fn placeholders_expand() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let out = expand_placeholders(
     "{home}/cc-worktree/{repo}/{type}-{issue}-{desc}",
     "my-repo",
@@ -339,6 +350,7 @@ fn placeholders_expand() {
 
 #[test]
 fn placeholders_no_optional_args_leave_repo_only() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let out = expand_placeholders("{home}/{repo}", "x", None, None, None, None).unwrap();
   assert!(out.ends_with("/x"));
 }
@@ -2520,4 +2532,110 @@ fn tui_clipboard_invalid_value_errors_at_parse_time() {
   let dir = TempDir::new().unwrap();
   std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nclipboard = \"osc-52\"\n").unwrap();
   assert!(Config::load_layered(dir.path(), None).is_err());
+}
+
+// --- single-pass substitution (issue #494) --------------------------------
+
+/// `expand_placeholders` chained `str::replace` calls, so each one re-scanned
+/// what the previous had just written. `{home}` and `{repo}` go first, which
+/// means a repo whose own name contains `{type}` made `{repo}/{desc}` write a
+/// type the template never mentions.
+///
+/// An expansion is a **value**, not more template. Nothing downstream can
+/// reason about a pattern by reading it otherwise: `naming::editable_segments`
+/// derived the create form's fields from the wrong set, and
+/// `BranchParser::compile` had to refuse the whole class rather than mirror a
+/// formatter it could not predict.
+///
+/// Same property `lifecycle::expand` has had since the security patch
+/// (`97e4e09`), and for the same reason.
+#[test]
+fn a_token_produced_by_expanding_the_repo_name_stays_literal() {
+  let out = expand_placeholders(
+    "{repo}/{desc}",
+    "api-{type}",
+    Some("fix"),
+    Some("42"),
+    Some("foo"),
+    None,
+  )
+  .unwrap();
+  assert_eq!(
+    out, "api-{type}/foo",
+    "the repo name is a value; the `{{type}}` inside it is not a placeholder"
+  );
+
+  // Every token, so no single ordering of the replace chain passes by luck.
+  for token in ["{type}", "{issue}", "{desc}", "{repo}", "{home}"] {
+    let out = expand_placeholders(
+      "{repo}-x",
+      &format!("api-{token}"),
+      Some("fix"),
+      Some("42"),
+      Some("foo"),
+      None,
+    )
+    .unwrap();
+    assert_eq!(
+      out,
+      format!("api-{token}-x"),
+      "`{}` arrived through the repo name, so it is data",
+      token
+    );
+  }
+}
+
+/// The same for `{home}`, which is substituted first of all and is the one
+/// token whose value the user does not choose directly.
+#[test]
+fn a_token_produced_by_expanding_home_stays_literal() {
+  // `$HOME` is read through `dirs::home_dir`, so drive it via the env var the
+  // way the other environment-sensitive tests in this file do.
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+  let previous = std::env::var("HOME").ok();
+  unsafe { std::env::set_var("HOME", "/tmp/h-{issue}") };
+
+  let out = expand_placeholders("{home}/wt/{desc}", "r", Some("fix"), Some("42"), Some("foo"), None);
+
+  match previous {
+    Some(v) => unsafe { std::env::set_var("HOME", v) },
+    None => unsafe { std::env::remove_var("HOME") },
+  }
+
+  assert_eq!(out.unwrap(), "/tmp/h-{issue}/wt/foo");
+}
+
+/// A token with no value is left **literal**, not emptied.
+/// `BranchSpec::branch_name` passes no `repo_path` precisely so the disk-path
+/// tokens survive verbatim into the branch name, and `BranchParser::compile`
+/// mirrors that. Restated here against the rewritten expander, since the old
+/// one got it by not calling `replace` at all.
+#[test]
+fn a_token_with_no_value_survives_the_single_pass_verbatim() {
+  assert_eq!(
+    expand_placeholders("{repo_parent}/{type}/{issue}/{desc}", "r", None, None, None, None).unwrap(),
+    "{repo_parent}/{type}/{issue}/{desc}"
+  );
+  // And an unknown token is not a token.
+  assert_eq!(
+    expand_placeholders("{nope}/{repo}", "r", None, None, None, None).unwrap(),
+    "{nope}/r"
+  );
+  // Nor is an unbalanced brace.
+  assert_eq!(
+    expand_placeholders("{repo}/{unclosed", "r", None, None, None, None).unwrap(),
+    "r/{unclosed"
+  );
+}
+
+/// The asymmetry the old nesting encoded by accident: with `repo_path` set but
+/// its parent `None`, `{repo_path}` resolves and `{repo_parent}` does not. A
+/// token lookup has to state that, where the nested `if let` fell into it.
+#[test]
+fn a_repo_path_without_a_parent_resolves_only_the_path_token() {
+  let root = std::path::Path::new("/");
+  assert!(root.parent().is_none(), "the fixture must actually have no parent");
+
+  let out = expand_placeholders("{repo_path}|{repo_parent}", "r", None, None, None, Some(root)).unwrap();
+  assert_eq!(out, "/|{repo_parent}");
 }

--- a/tests/naming_tests.rs
+++ b/tests/naming_tests.rs
@@ -1336,10 +1336,16 @@ fn the_compiler_handles_every_token_the_formatter_substitutes() {
     .1;
   let body = body.split_once("\n}\n").expect("the function has a body").0;
 
+  // Every `"{token}"` string literal in the body. Matched without the leading
+  // `(` that the first version of this scan assumed: #494 turned the chain of
+  // `replace("{token}", …)` calls into a `match token { "{token}" => … }`, so
+  // anchoring on the paren silently found nothing and the guard passed while
+  // classifying an empty set. The `found.len() >= 5` assertion below is what
+  // caught that, and is why it is written as a floor rather than a comment.
   let mut found: Vec<String> = Vec::new();
   let mut rest = body;
-  while let Some(open) = rest.find("(\"{") {
-    rest = &rest[open + 2..];
+  while let Some(open) = rest.find("\"{") {
+    rest = &rest[open + 1..];
     let Some(close) = rest.find("}\"") else { break };
     found.push(rest[..close + 1].to_string());
     rest = &rest[close + 1..];
@@ -1527,21 +1533,22 @@ fn every_pattern_1_5_0_read_is_read_the_same_way() {
   );
 }
 
-/// Codex review on PR #476, fourth and fifth passes — and the reason the
-/// mirror is now *checked* rather than argued.
+/// Codex review on PR #476, fourth and fifth passes, inverted by #494.
 ///
-/// `expand_placeholders` substitutes in a fixed order (`{home}`, `{repo}`,
-/// then the three capturing tokens) and each `str::replace` runs over what the
-/// previous ones produced, so an expansion can be substituted again. Both
-/// shapes below were reported separately, one review pass apart, because the
-/// first fix inspected the expansion in isolation and the second token was
-/// formed with the literals around it. Replaying the whole chain for inputs
-/// nobody has is not worth it; compiling a parser that recognises none of the
-/// branches the pattern creates is worse. So `compile` writes one probe branch
-/// with the real formatter and refuses the pattern when it cannot read it back
-/// — which closes the class rather than these two instances.
+/// These two patterns used to be **refused**, because `expand_placeholders` was
+/// a chain of `str::replace` in a fixed order and each call ran over what the
+/// previous ones produced, so an expansion could be substituted again. Both
+/// shapes were reported a review pass apart, one with the token inside the
+/// expansion and one with the token formed against the braces the pattern wrote
+/// around it. `compile` could not mirror a formatter that rewrote its own
+/// output, so it refused rather than build a parser recognising none of the
+/// branches the pattern creates.
+///
+/// #494 removed the cause: an expansion is a value, so there is nothing left to
+/// disagree about and the refusal became a restriction with no reason. Both now
+/// compile and round-trip, which is the widening that fix buys.
 #[test]
-fn a_pattern_the_parser_and_the_formatter_disagree_on_is_refused() {
+fn a_pattern_whose_expansion_carries_a_token_now_round_trips() {
   let types = default_branch_types();
   for (pattern, repo) in [
     // The token sits inside the expansion.
@@ -1549,23 +1556,25 @@ fn a_pattern_the_parser_and_the_formatter_disagree_on_is_refused() {
     // The token is formed with the braces the pattern wrote around it.
     ("{{repo}}/#{issue}-{desc}", "type"),
   ] {
-    // The formatter really does substitute twice — assert that rather than
-    // assume it, since the refusal is only correct if it does.
+    // Measured, not assumed: the `{type}` the old formatter substituted a
+    // second time is now written through as the text it is.
     let written =
       gwm::config::expand_placeholders(pattern, repo, Some("feat"), Some("42"), Some("x"), None).expect("formats");
     assert_eq!(
-      written, "feat/#42-x",
-      "`{}` in a repo called `{}` is expected to substitute twice",
+      written, "{type}/#42-x",
+      "`{}` in a repo called `{}` must substitute exactly once",
       pattern, repo
     );
 
-    let err = BranchParser::compile(pattern, repo, &types)
-      .map(|_| String::new())
-      .unwrap_or_else(|e| e.to_string());
-    assert!(
-      err.contains(pattern) && err.contains("does not read back"),
-      "the message must name the pattern and say the parser cannot read it back: {}",
-      err
+    let parser = BranchParser::compile(pattern, repo, &types)
+      .unwrap_or_else(|e| panic!("`{}` must no longer be refused: {}", pattern, e));
+    let back = parser
+      .parse(&written)
+      .expect("the parser reads what the formatter wrote");
+    assert_eq!((back.issue.as_str(), back.desc.as_str()), ("42", "x"));
+    assert_eq!(
+      back.type_, "",
+      "the pattern writes no type — `{{type}}` is literal text here, not a placeholder"
     );
   }
 
@@ -2133,22 +2142,22 @@ fn a_placeholder_between_two_literals_does_not_fuse_them() {
 #[test]
 fn the_editable_segments_come_back_in_the_order_the_pattern_writes_them() {
   assert_eq!(
-    gwm::naming::editable_segments(&["{type}/#{issue}-{desc}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{type}/#{issue}-{desc}"]),
     ["type", "issue", "desc"],
     "the canonical pattern keeps the canonical order"
   );
   assert_eq!(
-    gwm::naming::editable_segments(&["{desc}-{issue}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{desc}-{issue}"]),
     ["desc", "issue"],
     "a pattern that leads with the description is read in its own order"
   );
   assert_eq!(
-    gwm::naming::editable_segments(&["{type}/{desc}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{type}/{desc}"]),
     ["type", "desc"],
     "a pattern that writes no issue number must not ask for one"
   );
   assert!(
-    gwm::naming::editable_segments(&["wip"], "gwm-cli").is_empty(),
+    gwm::naming::editable_segments(&["wip"]).is_empty(),
     "a pattern that is pure literal asks the user for nothing"
   );
 }
@@ -2160,7 +2169,7 @@ fn the_editable_segments_come_back_in_the_order_the_pattern_writes_them() {
 #[test]
 fn a_segment_only_base_carries_is_still_asked_for() {
   assert_eq!(
-    gwm::naming::editable_segments(&["{type}/{desc}", "{type}-{desc}", "{home}/wt/{issue}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{type}/{desc}", "{type}-{desc}", "{home}/wt/{issue}"]),
     ["type", "desc", "issue"],
     "base carries the issue, so the form must still collect it"
   );
@@ -2173,7 +2182,7 @@ fn a_segment_only_base_carries_is_still_asked_for() {
 #[test]
 fn a_token_repeated_across_or_within_patterns_yields_one_field() {
   assert_eq!(
-    gwm::naming::editable_segments(&["{type}/{desc}-{desc}", "{type}-{desc}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{type}/{desc}-{desc}", "{type}-{desc}"]),
     ["type", "desc"]
   );
 }
@@ -2198,10 +2207,16 @@ fn every_substituted_token_is_either_context_resolved_or_a_form_field() {
     .1;
   let body = body.split_once("\n}\n").expect("the function has a body").0;
 
+  // Every `"{token}"` string literal in the body. Matched without the leading
+  // `(` that the first version of this scan assumed: #494 turned the chain of
+  // `replace("{token}", …)` calls into a `match token { "{token}" => … }`, so
+  // anchoring on the paren silently found nothing and the guard passed while
+  // classifying an empty set. The `found.len() >= 5` assertion below is what
+  // caught that, and is why it is written as a floor rather than a comment.
   let mut found: Vec<String> = Vec::new();
   let mut rest = body;
-  while let Some(open) = rest.find("(\"{") {
-    rest = &rest[open + 2..];
+  while let Some(open) = rest.find("\"{") {
+    rest = &rest[open + 1..];
     let Some(close) = rest.find("}\"") else { break };
     found.push(rest[..close + 1].to_string());
     rest = &rest[close + 1..];
@@ -2219,7 +2234,7 @@ fn every_substituted_token_is_either_context_resolved_or_a_form_field() {
 
   for token in &found {
     let segment = token.trim_start_matches('{').trim_end_matches('}');
-    let is_field = !gwm::naming::editable_segments(&[token.as_str()], "gwm-cli").is_empty();
+    let is_field = !gwm::naming::editable_segments(&[token.as_str()]).is_empty();
     assert!(
       FROM_CONTEXT.contains(&token.as_str()) || is_field,
       "`{}` is substituted by expand_placeholders but is neither resolved from context nor \
@@ -2231,24 +2246,21 @@ fn every_substituted_token_is_either_context_resolved_or_a_form_field() {
   }
 }
 
-/// Codex review on PR #492, third and fourth passes. `expand_placeholders`
-/// substitutes `{repo}` / `{home}` first and then substitutes what those
-/// expansions produced, so a repo literally named `api-{type}` makes
-/// `{repo}/{desc}` write `api-fix/foo`: a type the raw template never mentions.
+/// Codex review on PR #492 (passes three and four), then inverted by #494.
 ///
-/// My first answer was to declare the raw scan bounded by a failure that
-/// already ships, since #417's compiler refuses this class and
-/// `branch_pattern_warning` reports it. **That bound was false**, and the fourth
-/// pass is what showed it: the warning is only ever called with
-/// `worktree.branch_pattern` (`doctor.rs`, `config_cli.rs`). Nothing validates
-/// `path_pattern` or `base`, so the same repo name reaches the form through
-/// either of them with no diagnostic at all.
+/// While `expand_placeholders` re-substituted its own output, a repo named
+/// `api-{type}` made `{repo}/{desc}` write `api-fix/foo`, so the create form
+/// had to resolve `{repo}` / `{home}` before scanning or it would hide a field
+/// the formatter was going to fill. #494 removed the cause, and that made the
+/// workaround wrong in the other direction: the pattern now writes the text
+/// `api-{type}` and asks for no type at all, so resolving here would invent a
+/// field for a token nothing substitutes.
 ///
-/// So the scan mirrors the formatter instead: context placeholders first, the
-/// editable ones after.
+/// The rule this leaves is worth stating plainly, because two passes of review
+/// were spent on either side of it: **the field set is read from the pattern as
+/// written, and that is correct exactly because an expansion is a value.**
 #[test]
-fn a_token_produced_by_expanding_the_repo_name_is_still_a_field() {
-  // The mechanism, measured on the formatter itself.
+fn the_field_set_reads_the_pattern_as_written() {
   assert_eq!(
     gwm::config::expand_placeholders(
       "{repo}/{desc}",
@@ -2259,29 +2271,29 @@ fn a_token_produced_by_expanding_the_repo_name_is_still_a_field() {
       None
     )
     .unwrap(),
-    "api-fix/foo"
+    "api-{type}/foo",
+    "the repo name is data, so the `{{type}}` inside it is never substituted"
   );
   assert_eq!(
-    gwm::naming::editable_segments(&["{repo}/{desc}"], "api-{type}"),
-    ["type", "desc"],
-    "the expansion writes a type, so the form has to collect one"
-  );
-
-  // The two patterns no diagnostic covers, which is what made the bound false.
-  assert_eq!(
-    gwm::naming::editable_segments(&["{desc}", "{repo}-{desc}", "~/wt"], "api-{issue}"),
-    ["desc", "issue"],
-    "path_pattern carries it through the repo name"
-  );
-  assert_eq!(
-    gwm::naming::editable_segments(&["{desc}", "{desc}", "~/wt/{repo}"], "api-{type}"),
-    ["desc", "type"],
-    "and so does base"
+    gwm::naming::editable_segments(&["{repo}/{desc}"]),
+    ["desc"],
+    "so the form must not ask for a type the pattern does not write"
   );
 
-  // An ordinary repo name is unaffected.
+  // The two patterns no diagnostic covers, which is what made the #492 bound
+  // false and is still the reason not to depend on one here.
   assert_eq!(
-    gwm::naming::editable_segments(&["{repo}/{type}/#{issue}-{desc}"], "gwm-cli"),
+    gwm::naming::editable_segments(&["{desc}", "{repo}-{desc}", "~/wt"]),
+    ["desc"]
+  );
+  assert_eq!(
+    gwm::naming::editable_segments(&["{desc}", "{desc}", "~/wt/{repo}"]),
+    ["desc"]
+  );
+
+  // An ordinary repo name is unaffected, in the order the pattern writes.
+  assert_eq!(
+    gwm::naming::editable_segments(&["{repo}/{type}/#{issue}-{desc}"]),
     ["type", "issue", "desc"]
   );
 }

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -325,7 +325,7 @@ use gwm::tui::state::create_form::fields_for;
 #[test]
 fn a_pattern_without_an_issue_token_presents_no_issue_field() {
   assert_eq!(
-    fields_for(&["{type}/{desc}", "{type}-{desc}", "{home}/wt"], "gwm-cli"),
+    fields_for(&["{type}/{desc}", "{type}-{desc}", "{home}/wt"]),
     [Field::Type, Field::Desc]
   );
 }
@@ -334,7 +334,7 @@ fn a_pattern_without_an_issue_token_presents_no_issue_field() {
 #[test]
 fn the_field_order_follows_the_pattern_rather_than_the_canonical_triple() {
   let mut form = CreateForm::new();
-  form.set_fields(fields_for(&["{desc}-{issue}", "{desc}-{issue}", "~/wt"], "gwm-cli"));
+  form.set_fields(fields_for(&["{desc}-{issue}", "{desc}-{issue}", "~/wt"]));
   form.reset();
 
   assert_eq!(form.field, Field::Desc, "the pattern leads with the description");
@@ -356,7 +356,7 @@ fn rotation_never_lands_on_a_field_the_pattern_omits() {
     &["#{issue}-{desc}", "{issue}-{desc}", "~/wt"][..],
     &["{type}/#{issue}", "{type}-{issue}", "~/wt"][..],
   ] {
-    let expected = fields_for(patterns, "gwm-cli");
+    let expected = fields_for(patterns);
     let mut form = CreateForm::new();
     form.set_fields(expected.clone());
     form.reset();
@@ -385,7 +385,7 @@ fn every_entry_point_focuses_a_field_the_pattern_actually_presents() {
     &["#{issue}-{desc}", "{issue}-{desc}", "~/wt"][..],
     &["{type}/#{issue}", "{type}-{issue}", "~/wt"][..],
   ] {
-    let expected = fields_for(patterns, "gwm-cli");
+    let expected = fields_for(patterns);
     let mut form = CreateForm::new();
     form.set_fields(expected.clone());
 
@@ -435,11 +435,11 @@ fn the_entry_field_skips_the_cycle_only_type_selector() {
     "the default pattern still opens on Issue"
   );
 
-  form.set_fields(fields_for(&["{type}/{desc}", "{type}-{desc}", "~/wt"], "gwm-cli"));
+  form.set_fields(fields_for(&["{type}/{desc}", "{type}-{desc}", "~/wt"]));
   assert_eq!(form.entry_field(), Field::Desc, "Type is skipped, Desc is next");
 
   // A pattern whose only editable token is the type has nowhere else to go.
-  form.set_fields(fields_for(&["{type}/fixed", "{type}-fixed", "~/wt"], "gwm-cli"));
+  form.set_fields(fields_for(&["{type}/fixed", "{type}-fixed", "~/wt"]));
   assert_eq!(form.entry_field(), Field::Type);
 }
 
@@ -451,7 +451,7 @@ fn the_entry_field_skips_the_cycle_only_type_selector() {
 #[test]
 fn typing_into_a_field_the_pattern_omits_is_a_no_op() {
   let mut form = CreateForm::new();
-  form.set_fields(fields_for(&["{type}/{desc}", "{type}-{desc}", "~/wt"], "gwm-cli"));
+  form.set_fields(fields_for(&["{type}/{desc}", "{type}-{desc}", "~/wt"]));
   form.field = Field::Issue;
   form.push_char('4');
   form.push_char('2');
@@ -471,7 +471,7 @@ fn typing_into_a_field_the_pattern_omits_is_a_no_op() {
 #[test]
 fn a_pattern_set_with_no_editable_token_leaves_the_form_inert_rather_than_panicking() {
   let mut form = CreateForm::new();
-  form.set_fields(fields_for(&["wip", "wip", "~/wt"], "gwm-cli"));
+  form.set_fields(fields_for(&["wip", "wip", "~/wt"]));
   assert!(form.fields().is_empty());
   form.reset();
   form.next_field();
@@ -485,7 +485,7 @@ fn a_pattern_set_with_no_editable_token_leaves_the_form_inert_rather_than_panick
 #[test]
 fn reset_clears_the_buffers_but_keeps_the_configured_field_set() {
   let mut form = CreateForm::new();
-  let expected = fields_for(&["{desc}-{issue}", "{desc}-{issue}", "~/wt"], "gwm-cli");
+  let expected = fields_for(&["{desc}-{issue}", "{desc}-{issue}", "~/wt"]);
   form.set_fields(expected.clone());
   form.desc.push_str("thing");
   form.reset();


### PR DESCRIPTION
## Description

`config::expand_placeholders` chained `str::replace` calls, so each one re-scanned
what the previous had written. `{home}` and `{repo}` go first, which means a repo
whose own directory is named `api-{type}` made `{repo}/{desc}` write `api-fix/foo`:
a branch type the template never mentions.

**An expansion is a value, not more template.** It now substitutes in one pass.

Closes #494

## Type of change

- [x] 🐛 Fix (bug fix)
- [x] ♻️ Refactor (no behaviour change)

## Why it matters beyond the pathological repo name

Two things reason about a pattern by reading it, and both were wrong there:

- `naming::editable_segments` derives the create form's field set (#418).
- `BranchParser::compile` derives the branch parser, and could not mirror a
  formatter that rewrote its own output. It refused the whole class rather than
  build a parser recognising none of the branches the pattern creates.

So this is a **widening**: `{repo}/#{issue}-{desc}` on a repo named `{type}`, and
`{{repo}}/#{issue}-{desc}`, both compile and round-trip now. The test that pinned
their refusal asserts that instead.

## Three things preserved rather than tidied away

1. **A token with no value stays literal**, not emptied. `BranchSpec::branch_name`
   passes no `repo_path` precisely so `{repo_path}` / `{repo_parent}` survive
   verbatim into the branch name, and the compiler mirrors that.
2. **The `repo_path` / `repo_parent` asymmetry.** With `repo_path` set but its
   parent `None` (`/` is the case), `{repo_path}` resolves and `{repo_parent}`
   does not. The old nested `if let` fell into that; a token lookup has to state
   it. Pinned by its own test.
3. **The token starts at the last `{` before the closing brace**, not the first.
   `str::replace` matched `{type}` inside `{{type}` and wrote `{feat`, and #417
   built the compiler to mirror that. My first draft scanned from the first brace,
   which left `{{type}` literal instead: a pattern that worked in 1.5.0 quietly
   changing meaning, which is a different bug from the one being fixed. Caught by
   `the_compiler_finds_placeholders_where_the_formatter_substitutes_them`.

## Corrections to the issue, made before coding

Both were mine, and both changed what the fix had to do. The issue body is updated.

- **`lifecycle` is not affected.** I had written that this reaches hook
  placeholders. `lifecycle::expand` has been single-pass since the hook-injection
  patch, walking the template once and never re-scanning what it wrote, and
  `tests/lifecycle_tests.rs` already pins it with a branch named `spike-{issue}`.
  That expander is the reference implementation for this one.
- **#418's workaround becomes actively wrong.** `editable_segments` resolved
  `{repo}` / `{home}` before scanning so the form would ask for the fields the
  multi-pass formatter was going to fill. Once expansions are values, resolving
  there invents a field for a token nothing substitutes. Reverting it is the point
  of the change rather than a side effect, so it is in its own commit.

## Also stale, found while measuring

`WorktreeName::freeform` rejects `{` and `}` citing
`lifecycle::expand_placeholders` rewriting a name that contains a token. That
cause was already gone before this PR. The rule is **kept** as defensive, since
loosening what a free-form name may contain is a naming-surface decision and not
part of this fix, but its comment now says the reason has expired. A rejection
justified by a false cause is how the next reader removes it for the wrong reason.

## Tests

- [x] `cargo test` passes locally (88 test binaries, exit 0), under a CI-like
      minimal PATH: `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `gwm doctor` clean
- [x] New tests added under `tests/`

**Verified by restoring the defect and confirming red.** A fixture whose values
contain no token passes on the multi-pass code too, so it would otherwise prove
nothing. Both new `config_tests` go red with the replace chain put back.

New coverage:

- `tests/config_tests.rs`: a token arriving through the repo name (all five
  tokens, so no single ordering of the old chain passes by luck), a token
  arriving through `$HOME`, the no-value-stays-literal contract including an
  unknown token and an unbalanced brace, and the `repo_path` / `repo_parent`
  asymmetry.
- `tests/naming_tests.rs`: the two previously-refused patterns now round-trip,
  and the field set reads the pattern as written.

⚠️ Two existing tests in `config_tests.rs` read `{home}`, so the new `$HOME` test
would have raced them. The binary gains the process-global `env_lock` the other
env-touching suites already use, and the three tests take it.

⚠️ The two source-scanning guards in `naming_tests.rs` extracted tokens by
anchoring on `("{`, which found nothing once the replace chain became a `match`.
They passed while classifying an empty set; the `found.len() >= 5` floor is what
caught it, which is why that assertion is written as a floor rather than a
comment.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #494
- Found by Codex review on #492, which is where the symptom was worked around.

## Notes for reviewers

The interesting question is whether the last-brace rule is the right tokenisation
or whether `{{` should mean an escaped brace. This PR keeps 1.5.0's meaning
deliberately; changing it is a separate decision.
