### PR TITLE
🐛 fix(worktree): roll back a branch `add` created when the worktree fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `gwm create` that fails while making the worktree no longer leaves the
+  branch behind. `worktree::add` has to create the branch before it calls
+  `repo.worktree`, because libgit2's `WorktreeAddOptions::reference` takes a
+  reference that already exists, so any failure past that point left a branch
+  nobody asked for, pointing at the old HEAD, surfaced only by `gwm doctor`'s
+  orphan check or by a `git branch -D` on a name the error printed in passing.
+
+  It is now deleted on the failure path, and only when that same call created
+  it: a branch attached with `--reuse-branch` predates the command, and
+  deleting it would destroy work. The predicate is "this call created it"
+  rather than "reuse was off", because `gwm undo` and `gwm review` both pass
+  the reuse flag against a branch that is usually absent, and then create it.
+  libgit2 drops the `branch.<name>` config section along with the ref, so the
+  creation stamp goes with it instead of ageing the next branch to take that
+  name.
+
+  The error stays the underlying failure rather than a cleanup message. One
+  residue is out of reach and remains `gwm doctor`'s job: libgit2 refuses to
+  delete a branch that is already the HEAD of a linked repository, which is
+  the state it leaves when the failure came from the checkout itself rather
+  than from either mkdir.
+
+  This bounds the class that #474 (the 255-byte cap) and #475 (the Windows
+  character and device set) each closed one input set of. Refusing a name up
+  front is worth having on its own, but a full disk is not an input set.
+
 - Config values no longer reach the terminal with their control bytes intact.
   A `.gwm.toml` comes from a repo nobody has vetted, and the commands that read
   it back skip the trust gate on purpose, because inspecting an unfamiliar repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,9 +185,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deleting it would destroy work. The predicate is "this call created it"
   rather than "reuse was off", because `gwm undo` and `gwm review` both pass
   the reuse flag against a branch that is usually absent, and then create it.
-  libgit2 drops the `branch.<name>` config section along with the ref, so the
-  creation stamp goes with it instead of ageing the next branch to take that
-  name.
+  The creation stamp `add` wrote goes too, so it cannot age the next branch to
+  take that name, but the rest of the `branch.<name>` section stays put: that
+  section outlives its ref easily, and deleting the branch rather than the ref
+  would have taken an upstream setting the command never wrote.
 
   The error stays the underlying failure rather than a cleanup message. One
   residue is out of reach and remains `gwm doctor`'s job: libgit2 refuses to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,10 +191,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would have taken an upstream setting the command never wrote.
 
   The error stays the underlying failure rather than a cleanup message. One
-  residue is out of reach and remains `gwm doctor`'s job: libgit2 refuses to
-  delete a branch that is already the HEAD of a linked repository, which is
-  the state it leaves when the failure came from the checkout itself rather
-  than from either mkdir.
+  window is left alone on purpose: once libgit2 has bound the worktree to the
+  branch, which it does just before the checkout, the branch stays. Deleting
+  it there leaves a worktree pointing at a ref that no longer exists, and
+  unlike an orphan branch that residue is reported by nothing, so a failure
+  that late behaves as it did before.
 
   This bounds the class that #474 (the 255-byte cap) and #475 (the Windows
   character and device set) each closed one input set of. Refusing a name up

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -385,9 +385,17 @@ pub fn add(
     // from either mkdir; `gwm doctor` still catches that residue. The
     // caller gets the underlying error in every case, since the rollback
     // is not the story.
+    //
+    // The tip is re-checked because "what this call created" is a claim
+    // about an OID, not about a name: another process is free to move the
+    // ref while `repo.worktree` runs, and a branch that no longer points
+    // where this call put it is somebody else's now. Leaving an orphan is
+    // the smaller harm of the two.
     if created_branch {
       if let Ok(mut b) = repo.find_branch(branch_name, git2::BranchType::Local) {
-        let _ = b.delete();
+        if b.get().target() == Some(head_commit.id()) {
+          let _ = b.delete();
+        }
       }
     }
     return Err(e.into());

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -379,12 +379,13 @@ pub fn add(
     // asked for (#487). Roll back only what *this* call created: a reused
     // branch predates the command, and deleting it would destroy work.
     //
-    // Best effort, and deliberately so. Once libgit2 has bound the
-    // worktree to the branch, which it does just before the checkout, the
-    // branch stays: deleting it there leaves a worktree pointing at
-    // nothing, and that residue is reported by nothing at all, unlike an
-    // orphan branch. The caller gets the underlying error in every case,
-    // since the rollback is not the story.
+    // Best effort, and deliberately so. Once some checkout has the branch
+    // as its HEAD, the branch stays: deleting it leaves a worktree
+    // pointing at nothing, and that residue is reported by nothing at all,
+    // unlike an orphan branch. That covers both the worktree this call was
+    // binding, since libgit2 writes its HEAD just before the checkout, and
+    // any other one already standing on the name. The caller gets the
+    // underlying error in every case, since the rollback is not the story.
     //
     // The tip is re-checked because "what this call created" is a claim
     // about an OID, not about a name: another process is free to move the
@@ -397,7 +398,7 @@ pub fn add(
     // outlives its ref easily: `git update-ref -d` leaves it, and an
     // upstream can be configured before the branch exists. Dropping the
     // stamp `add` wrote is enough, and it is all this call put there.
-    if created_branch && !worktree_head_points_at(repo, name, branch_name) {
+    if created_branch && !branch_is_checked_out_anywhere(repo, branch_name) {
       if let Ok(b) = repo.find_branch(branch_name, git2::BranchType::Local) {
         if b.get().target() == Some(head_commit.id()) {
           let mut r = b.into_reference();
@@ -431,16 +432,26 @@ fn write_branch_created_at(repo: &Repository, branch: &str, unix_secs: i64) -> R
   Ok(())
 }
 
-/// True when the worktree admin entry `name` is already bound to `branch`,
-/// which is `git_branch_delete`'s "current HEAD of a linked repository"
-/// condition. git2 exposes no binding for that check and the rollback deletes
-/// the reference rather than the branch, so it is spelled out here.
-/// `commondir` rather than `path`, since the latter is the per-worktree gitdir
-/// when gwm is run from inside a linked worktree.
-fn worktree_head_points_at(repo: &Repository, name: &str, branch: &str) -> bool {
-  let head = repo.commondir().join("worktrees").join(name).join("HEAD");
-  match std::fs::read_to_string(head) {
-    Ok(s) => s.trim() == format!("ref: refs/heads/{}", branch),
+/// True when any checkout, main or linked, already has `branch` as its HEAD.
+/// That is `git_branch_is_checked_out`: what `git_worktree_add` refuses on and
+/// what `git_branch_delete` guards against. git2 binds neither, and the
+/// rollback deletes the reference rather than the branch, so it is spelled out
+/// here.
+///
+/// The admin directory is read from disk rather than through
+/// `repo.worktrees()`, because an entry a failed run left half-written has no
+/// `gitdir` file and libgit2 will not list it, while its `HEAD` still names a
+/// branch. `commondir` rather than `path`, since the latter is the
+/// per-worktree gitdir when gwm runs from inside a linked worktree.
+fn branch_is_checked_out_anywhere(repo: &Repository, branch: &str) -> bool {
+  let want = format!("ref: refs/heads/{}", branch);
+  let names_branch = |p: PathBuf| std::fs::read_to_string(p).map(|s| s.trim() == want).unwrap_or(false);
+  let common = repo.commondir().to_path_buf();
+  if names_branch(common.join("HEAD")) {
+    return true;
+  }
+  match std::fs::read_dir(common.join("worktrees")) {
+    Ok(entries) => entries.flatten().any(|e| names_branch(e.path().join("HEAD"))),
     Err(_) => false,
   }
 }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -391,10 +391,19 @@ pub fn add(
     // ref while `repo.worktree` runs, and a branch that no longer points
     // where this call put it is somebody else's now. Leaving an orphan is
     // the smaller harm of the two.
+    //
+    // The ref goes rather than the branch, because `git_branch_delete`
+    // drops the whole `branch.<name>` config section and that section
+    // outlives its ref easily: `git update-ref -d` leaves it, and an
+    // upstream can be configured before the branch exists. Dropping the
+    // stamp `add` wrote is enough, and it is all this call put there.
     if created_branch {
-      if let Ok(mut b) = repo.find_branch(branch_name, git2::BranchType::Local) {
+      if let Ok(b) = repo.find_branch(branch_name, git2::BranchType::Local) {
         if b.get().target() == Some(head_commit.id()) {
-          let _ = b.delete();
+          let mut r = b.into_reference();
+          if r.delete().is_ok() {
+            let _ = remove_branch_created_at(repo, branch_name);
+          }
         }
       }
     }
@@ -419,6 +428,12 @@ fn write_branch_created_at(repo: &Repository, branch: &str, unix_secs: i64) -> R
     &branch_config_key(branch, BRANCH_CREATED_AT_CONFIG_KEY),
     &unix_secs.to_string(),
   )?;
+  Ok(())
+}
+
+fn remove_branch_created_at(repo: &Repository, branch: &str) -> Result<()> {
+  let mut cfg = repo.config()?;
+  cfg.remove(&branch_config_key(branch, BRANCH_CREATED_AT_CONFIG_KEY))?;
   Ok(())
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -443,16 +443,28 @@ fn write_branch_created_at(repo: &Repository, branch: &str, unix_secs: i64) -> R
 /// `gitdir` file and libgit2 will not list it, while its `HEAD` still names a
 /// branch. `commondir` rather than `path`, since the latter is the
 /// per-worktree gitdir when gwm runs from inside a linked worktree.
+///
+/// A read that fails answers nothing, and folding that into "no" would make
+/// the rollback delete a ref on the strength of a failed read, which is the
+/// one outcome this check exists to prevent. So: absent is "no", unreadable is
+/// "assume yes".
 fn branch_is_checked_out_anywhere(repo: &Repository, branch: &str) -> bool {
   let want = format!("ref: refs/heads/{}", branch);
-  let names_branch = |p: PathBuf| std::fs::read_to_string(p).map(|s| s.trim() == want).unwrap_or(false);
+  let names_branch = |p: PathBuf| match std::fs::read_to_string(p) {
+    Ok(s) => s.trim() == want,
+    Err(e) => e.kind() != std::io::ErrorKind::NotFound,
+  };
   let common = repo.commondir().to_path_buf();
   if names_branch(common.join("HEAD")) {
     return true;
   }
   match std::fs::read_dir(common.join("worktrees")) {
-    Ok(entries) => entries.flatten().any(|e| names_branch(e.path().join("HEAD"))),
-    Err(_) => false,
+    Ok(mut entries) => entries.any(|e| match e {
+      Ok(entry) => names_branch(entry.path().join("HEAD")),
+      Err(_) => true,
+    }),
+    // No linked worktrees at all is the ordinary case, and it is a "no".
+    Err(e) => e.kind() != std::io::ErrorKind::NotFound,
   }
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -379,12 +379,12 @@ pub fn add(
     // asked for (#487). Roll back only what *this* call created: a reused
     // branch predates the command, and deleting it would destroy work.
     //
-    // Best effort, and deliberately so. libgit2 refuses to delete a branch
-    // that is already the HEAD of a linked repository, which is the state
-    // it leaves behind when the failure came from the checkout rather than
-    // from either mkdir; `gwm doctor` still catches that residue. The
-    // caller gets the underlying error in every case, since the rollback
-    // is not the story.
+    // Best effort, and deliberately so. Once libgit2 has bound the
+    // worktree to the branch, which it does just before the checkout, the
+    // branch stays: deleting it there leaves a worktree pointing at
+    // nothing, and that residue is reported by nothing at all, unlike an
+    // orphan branch. The caller gets the underlying error in every case,
+    // since the rollback is not the story.
     //
     // The tip is re-checked because "what this call created" is a claim
     // about an OID, not about a name: another process is free to move the
@@ -397,7 +397,7 @@ pub fn add(
     // outlives its ref easily: `git update-ref -d` leaves it, and an
     // upstream can be configured before the branch exists. Dropping the
     // stamp `add` wrote is enough, and it is all this call put there.
-    if created_branch {
+    if created_branch && !worktree_head_points_at(repo, name, branch_name) {
       if let Ok(b) = repo.find_branch(branch_name, git2::BranchType::Local) {
         if b.get().target() == Some(head_commit.id()) {
           let mut r = b.into_reference();
@@ -429,6 +429,20 @@ fn write_branch_created_at(repo: &Repository, branch: &str, unix_secs: i64) -> R
     &unix_secs.to_string(),
   )?;
   Ok(())
+}
+
+/// True when the worktree admin entry `name` is already bound to `branch`,
+/// which is `git_branch_delete`'s "current HEAD of a linked repository"
+/// condition. git2 exposes no binding for that check and the rollback deletes
+/// the reference rather than the branch, so it is spelled out here.
+/// `commondir` rather than `path`, since the latter is the per-worktree gitdir
+/// when gwm is run from inside a linked worktree.
+fn worktree_head_points_at(repo: &Repository, name: &str, branch: &str) -> bool {
+  let head = repo.commondir().join("worktrees").join(name).join("HEAD");
+  match std::fs::read_to_string(head) {
+    Ok(s) => s.trim() == format!("ref: refs/heads/{}", branch),
+    Err(_) => false,
+  }
 }
 
 fn remove_branch_created_at(repo: &Repository, branch: &str) -> Result<()> {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -372,7 +372,26 @@ pub fn add(
   let mut opts = WorktreeAddOptions::new();
   opts.reference(Some(&reference));
 
-  repo.worktree(name, target_path, Some(&opts))?;
+  if let Err(e) = repo.worktree(name, target_path, Some(&opts)) {
+    // The branch has to exist before this call, because
+    // `WorktreeAddOptions::reference` takes a live reference, so every
+    // failure here lands with a branch already on disk that the user never
+    // asked for (#487). Roll back only what *this* call created: a reused
+    // branch predates the command, and deleting it would destroy work.
+    //
+    // Best effort, and deliberately so. libgit2 refuses to delete a branch
+    // that is already the HEAD of a linked repository, which is the state
+    // it leaves behind when the failure came from the checkout rather than
+    // from either mkdir; `gwm doctor` still catches that residue. The
+    // caller gets the underlying error in every case, since the rollback
+    // is not the story.
+    if created_branch {
+      if let Ok(mut b) = repo.find_branch(branch_name, git2::BranchType::Local) {
+        let _ = b.delete();
+      }
+    }
+    return Err(e.into());
+  }
 
   // Record the parent ref for the launcher's base resolution chain.
   if let Some(parent_ref) = head_short {

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -1891,3 +1891,39 @@ fn add_rolls_back_after_a_permission_denial_on_the_target_parent() {
 
   std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
+
+#[test]
+fn add_rollback_keeps_branch_config_it_did_not_write() {
+  // Codex review on PR #497 (P2, iter 2). "Roll back what this call
+  // created" has to hold for config too. A `branch.<name>` section
+  // outlives its ref easily (`git update-ref -d` leaves it behind, and an
+  // upstream can be configured before the branch exists), and
+  // `git_branch_delete` drops the whole section. Only the stamp `add`
+  // itself wrote is this call's to remove.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  {
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str("branch.feat/#487-cfg.remote", "origin").unwrap();
+  }
+  wedge_admin_entry(&repo, "feat-487-cfg");
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-cfg");
+  worktree::add(&repo, "feat-487-cfg", &target, "feat/#487-cfg", false).unwrap_err();
+
+  let cfg = repo.config().unwrap();
+  assert_eq!(
+    cfg.get_string("branch.feat/#487-cfg.remote").ok().as_deref(),
+    Some("origin"),
+    "settings that predate the command must survive its rollback"
+  );
+  assert!(
+    cfg.get_string("branch.feat/#487-cfg.gwm-created-at").is_err(),
+    "the stamp this call wrote is still this call's to remove"
+  );
+  assert!(
+    !branch_exists(&repo, "feat/#487-cfg"),
+    "and the branch itself must still be rolled back"
+  );
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -1720,3 +1720,174 @@ fn find_fuzzy_duplicate_names_stay_ambiguous_even_when_an_id_matches() {
   // The non-colliding worktree is still reachable by its unique id.
   assert_eq!(worktree::find_fuzzy(&repo, "idb").unwrap().id, "idb");
 }
+
+// ---------------------------------------------------------------------
+// Issue #487. `add` creates the branch before it creates the worktree,
+// because `WorktreeAddOptions::reference` needs a reference that already
+// exists. Every late failure therefore lands with a branch already on
+// disk that the user never asked for. #474 (255-byte cap) and #475 (the
+// Windows character and device set) each refused one input set up front;
+// a full disk is not an input set, so the ordering is what bounds the
+// class.
+//
+// Measured boundary of the rollback: `git_branch_delete` refuses a branch
+// that is "the current HEAD of a linked repository", and libgit2 writes
+// `.git/worktrees/<name>/HEAD` late in `git_worktree_add`, after both
+// mkdirs. So a failure during the checkout itself is still recoverable
+// only through `gwm doctor` / `gwm prune`. Everything before that point,
+// which is where the disk-full and permission classes land, is covered:
+// the permission test below asserts it with the admin entry already
+// written.
+
+/// Leave the `.git/worktrees/<name>` entry a crashed earlier run leaves
+/// behind. libgit2 mkdirs that path with `EXCL`, so the next `repo.worktree`
+/// under the same name fails without the test going near a name a validator
+/// could reject up front.
+fn wedge_admin_entry(repo: &Repository, name: &str) {
+  std::fs::create_dir_all(repo.path().join("worktrees").join(name)).unwrap();
+}
+
+fn branch_exists(repo: &Repository, name: &str) -> bool {
+  repo.find_branch(name, git2::BranchType::Local).is_ok()
+}
+
+#[test]
+fn add_rolls_back_the_branch_it_created_when_the_worktree_fails() {
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  wedge_admin_entry(&repo, "feat-487-late");
+  assert!(
+    !branch_exists(&repo, "feat/#487-late"),
+    "precondition: the branch must not exist before the call under test"
+  );
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-late");
+  let err = worktree::add(&repo, "feat-487-late", &target, "feat/#487-late", false).unwrap_err();
+
+  // The rollback is not the story, the failure is: the caller must still
+  // get the underlying libgit2 error to act on.
+  assert!(
+    matches!(err, gwm::error::GwmError::Git(_)),
+    "the underlying failure must reach the caller, got: {err:?}"
+  );
+  assert!(
+    !format!("{err}").to_lowercase().contains("roll"),
+    "the error must describe the failure, not the cleanup: {err}"
+  );
+
+  assert!(
+    !branch_exists(&repo, "feat/#487-late"),
+    "a branch this call created must not outlive the call that failed"
+  );
+  assert!(
+    repo
+      .config()
+      .unwrap()
+      .get_string("branch.feat/#487-late.gwm-created-at")
+      .is_err(),
+    "the created-at stamp must go with the branch, otherwise the next branch \
+     to take this name reads a timestamp older than itself in `gwm list`"
+  );
+}
+
+#[test]
+fn add_leaves_a_reused_branch_alone_when_the_worktree_fails() {
+  // `--reuse-branch` attaches to a branch that existed before the command
+  // ran. Deleting that one on failure would destroy work this call never
+  // created.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  let tip = repo
+    .branch("feat/#487-reused", &head, false)
+    .unwrap()
+    .into_reference()
+    .target()
+    .unwrap();
+  wedge_admin_entry(&repo, "feat-487-reused");
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-reused");
+  worktree::add(&repo, "feat-487-reused", &target, "feat/#487-reused", true).unwrap_err();
+
+  let still = repo
+    .find_branch("feat/#487-reused", git2::BranchType::Local)
+    .expect("a pre-existing branch must survive a failed add")
+    .into_reference()
+    .target()
+    .unwrap();
+  assert_eq!(still, tip, "the reused branch tip must be untouched");
+}
+
+#[test]
+fn add_rolls_back_a_branch_it_created_even_when_reuse_was_asked_for() {
+  // The predicate is "did this call create the branch", not "was reuse
+  // off". `gwm undo` and `gwm review` both pass `reuse_branch: true`
+  // against a branch that is frequently absent, and `add` then creates
+  // it. A rollback keyed on `!reuse_branch` would leave exactly those two
+  // paths orphaning branches.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  wedge_admin_entry(&repo, "feat-487-reuse-absent");
+  assert!(
+    !branch_exists(&repo, "feat/#487-reuse-absent"),
+    "precondition: reuse was asked for, but there is nothing to reuse"
+  );
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-reuse-absent");
+  worktree::add(&repo, "feat-487-reuse-absent", &target, "feat/#487-reuse-absent", true).unwrap_err();
+
+  assert!(
+    !branch_exists(&repo, "feat/#487-reuse-absent"),
+    "reuse_branch: true does not make a branch this call created someone else's"
+  );
+}
+
+#[cfg(unix)]
+#[test]
+fn add_rolls_back_after_a_permission_denial_on_the_target_parent() {
+  // The class the issue is actually about: a failure that no validator can
+  // refuse up front. This one also gets *further* into `git_worktree_add`
+  // than the wedged-entry fixture does, since libgit2 has already created
+  // its admin entry by the time the worktree directory mkdir is denied.
+  use std::os::unix::fs::PermissionsExt;
+
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let parent = wt_root.path().join("read-only");
+  std::fs::create_dir_all(&parent).unwrap();
+  std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+  // Root ignores the mode bits, so the denial never happens and the test
+  // would assert against a *successful* add. Skip explicitly rather than
+  // let it pass or fail for the wrong reason.
+  if std::fs::create_dir(parent.join(".writable-probe")).is_ok() {
+    std::fs::remove_dir(parent.join(".writable-probe")).ok();
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+    eprintln!("skipping: this process can write to a 0555 directory (running as root?)");
+    return;
+  }
+
+  let target = parent.join("feat-487-denied");
+  let err = worktree::add(&repo, "feat-487-denied", &target, "feat/#487-denied", false).unwrap_err();
+
+  let admin = repo.path().join("worktrees").join("feat-487-denied");
+  assert!(
+    admin.exists(),
+    "precondition: libgit2 must have written its admin entry before failing, \
+     otherwise this fixture is not testing a later failure point than the wedge one"
+  );
+  assert!(
+    matches!(err, gwm::error::GwmError::Git(_)),
+    "the underlying failure must reach the caller, got: {err:?}"
+  );
+  assert!(
+    !branch_exists(&repo, "feat/#487-denied"),
+    "a disk or permission failure must not leave a branch behind either"
+  );
+
+  std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -1986,3 +1986,38 @@ fn add_keeps_a_branch_another_worktree_is_bound_to() {
     "the rollback must not delete a ref another worktree is standing on"
   );
 }
+
+#[cfg(unix)]
+#[test]
+fn add_keeps_the_branch_when_the_checkouts_cannot_be_inspected() {
+  // Codex review on PR #497 (P1, iter 5). The bound check answers "is this
+  // branch someone's HEAD", and a read that fails answers nothing at all.
+  // Folding that into "no" makes the rollback delete a ref on the strength
+  // of a failed read, which is the one outcome the check exists to
+  // prevent. Absent is still "no", unreadable is "assume yes".
+  use std::os::unix::fs::PermissionsExt;
+
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  wedge_admin_entry(&repo, "feat-487-blind");
+  let admin_root = repo.path().join("worktrees");
+  std::fs::set_permissions(&admin_root, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+  // Root reads through the mode bits, so the inspection would succeed and
+  // the test would assert against a case it never produced.
+  if std::fs::read_dir(&admin_root).is_ok() {
+    std::fs::set_permissions(&admin_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+    eprintln!("skipping: this process can read a 0000 directory (running as root?)");
+    return;
+  }
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-blind");
+  worktree::add(&repo, "feat-487-blind", &target, "feat/#487-blind", false).unwrap_err();
+  std::fs::set_permissions(&admin_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+  assert!(
+    branch_exists(&repo, "feat/#487-blind"),
+    "an unreadable admin directory must hold the rollback back, not wave it through"
+  );
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -1960,3 +1960,29 @@ fn add_keeps_the_branch_when_the_worktree_is_already_bound_to_it() {
      at nothing that no check reports"
   );
 }
+
+#[test]
+fn add_keeps_a_branch_another_worktree_is_bound_to() {
+  // Codex review on PR #497 (P1, iter 4). The bound check is about the
+  // branch, not about the name this call happened to try. A *different*
+  // checkout can hold the branch as its HEAD while the ref itself is
+  // absent, which is what deleting a ref under a live worktree leaves, and
+  // `git_worktree_add` then refuses with "reference is already checked
+  // out". Rolling back there deletes the ref that other worktree is
+  // standing on.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let other = repo.path().join("worktrees").join("someone-else");
+  std::fs::create_dir_all(&other).unwrap();
+  std::fs::write(other.join("HEAD"), "ref: refs/heads/feat/#487-shared\n").unwrap();
+  wedge_admin_entry(&repo, "feat-487-shared");
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-shared");
+  worktree::add(&repo, "feat-487-shared", &target, "feat/#487-shared", false).unwrap_err();
+
+  assert!(
+    branch_exists(&repo, "feat/#487-shared"),
+    "the rollback must not delete a ref another worktree is standing on"
+  );
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -1927,3 +1927,36 @@ fn add_rollback_keeps_branch_config_it_did_not_write() {
     "and the branch itself must still be rolled back"
   );
 }
+
+#[test]
+fn add_keeps_the_branch_when_the_worktree_is_already_bound_to_it() {
+  // Codex review on PR #497 (P2, iter 3). `git_branch_delete` refuses a
+  // branch that is "the current HEAD of a linked repository";
+  // `git_reference_delete`, which the rollback moved to in order to spare
+  // the config section, carries no such check. Measured on a live
+  // worktree: the ref goes, `find_worktree` still resolves the entry and
+  // `prunable_worktrees` does not list it, so the residue is a worktree
+  // bound to a branch that no longer exists and nothing reports it. That
+  // is worse than the orphan branch this whole change is about.
+  //
+  // libgit2 writes `.git/worktrees/<name>/HEAD` near the end of
+  // `git_worktree_add`, right before the checkout, and a checkout failure
+  // is not reachable from an integration test. The fixture writes the
+  // binding directly, which is the state that failure leaves behind.
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let admin = repo.path().join("worktrees").join("feat-487-bound");
+  std::fs::create_dir_all(&admin).unwrap();
+  std::fs::write(admin.join("HEAD"), "ref: refs/heads/feat/#487-bound\n").unwrap();
+
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-487-bound");
+  worktree::add(&repo, "feat-487-bound", &target, "feat/#487-bound", false).unwrap_err();
+
+  assert!(
+    branch_exists(&repo, "feat/#487-bound"),
+    "a branch a worktree is already bound to must survive the rollback, \
+     otherwise the rollback trades an orphan branch for a worktree pointing \
+     at nothing that no check reports"
+  );
+}


### PR DESCRIPTION
## Description

`worktree::add` creates the branch before it creates the worktree, because
`WorktreeAddOptions::reference` takes a reference that already exists. Every
failure past that point therefore left a branch nobody asked for, pointing at
the old HEAD, surfaced only by `gwm doctor`'s orphan check or by a
`git branch -D` on a name the error printed in passing.

The branch is now deleted on the failure path, and only when this call created
it, still points where this call put it, and no checkout is standing on it.

Closes #487

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `worktree::add` rolls the branch back when `repo.worktree` fails, keyed on
  the `created_branch` flag the function already tracks for its created-at
  stamp. A reused branch predates the command and is left alone.
- The rollback deletes the reference and removes its own `gwm-created-at`
  stamp, rather than deleting the branch, which would take the whole
  `branch.<name>` config section with it.
- `branch_is_checked_out_anywhere` holds the rollback back when any checkout
  has the branch as its HEAD, which is the protection `git_branch_delete`
  carries and `git_reference_delete` does not.
- Eight integration tests in `tests/worktree_integration.rs`, red first.
- CHANGELOG entry under `[Unreleased] > Fixed`.

## Tests

- [x] `cargo test` passes locally (under a CI-like minimal PATH:
      `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

## Screenshots / TUI captures

Not applicable, no TUI surface touched.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no CLI surface change)
- [x] `examples/gwm.toml.example` updated if config schema changed (no schema
      change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #487
- Related PR: #486 (#475, where this was deliberately left out as the wider
  fix), #474

## Notes for reviewers

**Three conditions gate the delete, and each one is a test.** The rollback
fires only when this call created the branch, the tip still matches the commit
it was created at, and no checkout has it as HEAD. The three came from three
different failure modes, all of them worse than the orphan branch the PR is
about.

**The predicate is `created_branch`, not `!reuse_branch`.** `gwm undo`
(`src/cli.rs`) and `gwm review` (`src/review.rs`) both call `add` with
`reuse_branch: true` against a branch that is usually absent, so `add` creates
it. A rollback keyed on `!reuse_branch` would leave exactly those two paths
orphaning branches, and it would pass a test pair built from "reuse off,
created" plus "reuse on, pre-existing".
`add_rolls_back_a_branch_it_created_even_when_reuse_was_asked_for` is the third
case that separates them.

**The ref goes, not the branch.** `git_branch_delete` drops the whole
`branch.<name>` config section, and that section outlives its ref easily:
`git update-ref -d` leaves it behind, and an upstream can be configured before
the branch exists. So the rollback deletes the reference and removes only the
`gwm-created-at` key `add` itself wrote. Verified: libgit2 does remove the
section on `git_branch_delete` (branch.c, `git_config_rename_section` right
before `git_reference_delete`), which is why this had to change.

**That trade cost a protection, and the third condition buys it back.**
`git_branch_delete` refuses a branch that is "the current HEAD of a linked
repository"; `git_reference_delete` does not, and git2 binds neither the check
nor `git_branch_is_checked_out`. Measured on a live worktree rather than
assumed: the ref goes, `find_worktree` still resolves the entry, and
`prunable_worktrees` lists nothing, so the residue is a worktree bound to a ref
that no longer exists and nothing reports it. `branch_is_checked_out_anywhere`
reads the main `HEAD` and every `worktrees/*/HEAD` under `commondir`, from disk
rather than through `repo.worktrees()`, because a half-written entry has no
`gitdir` file and libgit2 will not list it while its `HEAD` still names a
branch. A read that fails counts as in use; only a missing file counts as free.

**Where the rollback stops.** libgit2 writes `.git/worktrees/<name>/HEAD` near
the end of `git_worktree_add`, just before the checkout, so a checkout failure
lands with the worktree already bound and the branch is deliberately kept.
Behaviour for that window is exactly what it was before this PR. Everything
earlier is rolled back, which is where the disk-full and permission classes
land.

**Why the fixtures are what they are.** None of them uses an input a validator
could refuse up front, since that is the shape #474 and #475 already closed
twice and the point of this issue is the ordering. They are a
`.git/worktrees/<name>` entry left by a crashed earlier run (libgit2 mkdirs it
with `EXCL`), a permission denial on the target's parent, and hand-written
admin `HEAD` files for the bound cases, since a checkout failure is not
reachable from an integration test. The two permission-based tests are
`#[cfg(unix)]` and skip explicitly, with a message, when the process can write
to a `0555` directory or read a `0000` one, so running as root does not turn
them into silent passes.

**Prove-red.** Every one of the eight tests was run against the code without
its fix and failed on the assertion it is named for, not on a precondition. The
three original rollback tests failed on "branch left behind" specifically,
which rules out a fixture short-circuiting before the branch is created.
`add_leaves_a_reused_branch_alone_when_the_worktree_fails` was green from the
start, as it should be.

**One thing is untestable from the public surface**: the tip comparison needs
the ref to move *inside* `repo.worktree`, and there is no seam for that. It is
argued here under the narrow exception in CLAUDE.md rather than left silent.

**Not in scope.** libgit2 leaves its own `.git/worktrees/<name>` admin entry
behind on the failure paths that get that far. `gwm prune` and
`prunable_worktrees` already handle orphaned admin entries, and cleaning it
here would mean deciding what to do with a half-created worktree directory too.
Worth a separate issue if it bites.
