### PR TITLE
🔧 chore(deps): declare the MSRV a build actually reports (1.95) + a CI job that holds it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: cargo check at the declared floor
         run: cargo check --all-targets --locked
+      # `daemon` is default-on, so the check above never compiles the
+      # `#[cfg(not(all(any(unix, windows), feature = "daemon")))]` arms of
+      # `cmd_daemon` / `cmd_statusline`. That build is documented as supported
+      # (docs/3.cli/1.reference.md), so it gets the same floor guarantee.
+      - name: cargo check at the declared floor (no default features)
+        run: cargo check --all-targets --locked --no-default-features
 
   test:
     name: test (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,19 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   msrv:
-    name: msrv (declared floor)
-    runs-on: ubuntu-latest
+    name: msrv (declared floor, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    # Same matrix as `test`, and for the same reason: a single-platform run
+    # sees neither the `[target."cfg(windows)".dependencies]` block nor the
+    # `#[cfg(windows)]` code, so a Windows-only dependency raising its floor
+    # (or a Windows-only use of a newer std API) would keep this job green on
+    # Linux while `cargo install` breaks for those users. That is the #491 bug
+    # again, one axis over.
+    #
     # The clippy job catches a *std API* newer than the declared floor
     # (`clippy::incompatible_msrv`), but nothing covered a **dependency**
     # whose floor is higher than ours: `Cargo.toml` said 1.86 for a whole
@@ -72,6 +83,8 @@ jobs:
           persist-credentials: false
       - name: read the declared MSRV
         id: msrv
+        # `windows-latest` defaults to PowerShell, which has no grep/cut.
+        shell: bash
         run: |
           version=$(grep -m1 '^rust-version = ' Cargo.toml | cut -d'"' -f2)
           [ -n "$version" ] || { echo "::error::no rust-version in Cargo.toml"; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,44 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: msrv (declared floor)
+    runs-on: ubuntu-latest
+    # The clippy job catches a *std API* newer than the declared floor
+    # (`clippy::incompatible_msrv`), but nothing covered a **dependency**
+    # whose floor is higher than ours: `Cargo.toml` said 1.86 for a whole
+    # release line while the graph needed 1.95, silently (issue #491).
+    # This job installs exactly the declared floor and both resolves and
+    # compiles the committed lockfile against it, which is why `--locked`
+    # is load-bearing: cargo's `rust-version` gate fires at resolve time
+    # for the crates that declare a floor, and the compile that follows
+    # is the only thing that catches one declaring nothing at all (which
+    # is what `rusqlite`'s `libsqlite3-sys` does). The toolchain is read
+    # out of `Cargo.toml` rather than hardcoded so the job cannot drift
+    # from the manifest either.
+    env:
+      # Overrides the workflow-wide `-D warnings`. A warning only an older
+      # toolchain emits (or an `unknown_lints` for a lint added after it)
+      # says nothing about the MSRV and must not paint this job red.
+      RUSTFLAGS: ""
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: read the declared MSRV
+        id: msrv
+        run: |
+          version=$(grep -m1 '^rust-version = ' Cargo.toml | cut -d'"' -f2)
+          [ -n "$version" ] || { echo "::error::no rust-version in Cargo.toml"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "declared MSRV: $version"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check at the declared floor
+        run: cargo check --all-targets --locked
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   show a default and submitting would write it over the real value on disk.
   ([#418](https://github.com/kbrdn1/gwm-cli/issues/418))
 
+### Changed
+
+- The declared MSRV is now **1.95**, up from 1.86, and CI holds it from now on.
+
+  `Cargo.toml` claimed 1.86 while nothing verified the claim, and two separate
+  blind spots kept it that way. The clippy job only catches a **std API** used
+  above the declared floor, never a dependency raising its own; and
+  `cargo metadata`, the obvious way to read the graph's floor, only reports
+  crates that declare a `rust-version` at all. Read through metadata, the
+  locked graph asks for 1.88 (the ratatui 0.30 stack, `time 0.3.47`). Compiled,
+  it asks for 1.95: `libsqlite3-sys 0.38.1`, a normal dependency pulled in by
+  `rusqlite` with `bundled`, declares no `rust-version` whatsoever and its
+  build script uses `cfg_select!`, stable only since 1.95.0. A crate that
+  declares nothing is invisible to every metadata-based check. Only a build
+  finds it.
+
+  Both sides were measured against the committed lockfile:
+  `cargo +1.94 check --all-targets --locked` fails with `error[E0658]: use of
+  unstable library feature 'cfg_select'`, and `cargo +1.95 check --all-targets
+  --locked` passes. `libsqlite3-sys 0.38.1` was already locked at the `v1.5.0`
+  tag, so this raises the *declared* floor to what the code has in fact
+  required since before that release; it does not raise the real one.
+
+  Holding a lower floor was considered and dropped: `rusqlite 0.40.1` requires
+  `libsqlite3-sys ^0.38.1`, so it would mean downgrading rusqlite itself.
+  ([#491](https://github.com/kbrdn1/gwm-cli/issues/491))
+
+- A `msrv` job now runs on every push and pull request. It reads `rust-version`
+  out of `Cargo.toml`, installs exactly that toolchain, and runs
+  `cargo check --all-targets --locked`, which both fires cargo's own
+  `rust-version` gate at resolve time and compiles the dependencies that
+  declare no floor at all. The toolchain is derived rather than hardcoded, so
+  the job cannot drift from the manifest the way the manifest drifted from the
+  graph. A companion test pins the ten user-facing places that advertise the
+  MSRV to whatever `Cargo.toml` declares.
+  ([#491](https://github.com/kbrdn1/gwm-cli/issues/491))
+
 ### Fixed
 
 - A `gwm create` that fails while making the worktree no longer leaves the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ All tests live under `tests/` — no inline `#[cfg(test)] mod tests` blocks insi
 
 ### Prerequisites
 
-- Rust toolchain (stable channel, 1.86+ — the MSRV declared in `Cargo.toml`, raised by `tui-term` / `portable-pty` when the PTY overlay landed).
+- Rust toolchain (stable channel, 1.95+ — the MSRV declared in `Cargo.toml`, raised by `rusqlite`'s bundled `libsqlite3-sys` and verified on every PR by CI's `msrv` job).
 - A C compiler (libgit2 is vendored and built from source on first `cargo build`).
 
 ### Build & run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,26 @@
 name = "gwm-cli"
 version = "1.5.0"
 edition = "2021"
-# MSRV is the floor required by every use in the crate, not just the
-# newest one introduced here. `std::sync::LazyLock` (this PR, src/naming.rs)
-# wants 1.80; `std::iter::repeat_n` (existing code in src/tui/ui.rs's
-# countdown bar) wants 1.82; `tui-term 0.3.4` (issue #35 PTY overlay)
-# declares `rust-version = "1.86.0"`. The crate as a whole compiles at
-# 1.86+, so MSRV is set to the higher floor. CI's clippy job catches an
-# accidental *std-API* regression above this floor (`clippy::incompatible_msrv`
-# is warn-by-default, escalated to a hard error by `-D warnings`), but it does
-# NOT cover language/edition features or a dependency raising its own floor —
-# those are verified locally before an MSRV bump with `cargo msrv verify` (or
-# `cargo +1.86.0 build --all-targets --locked`). See
-# `docs/6.development/3.stability.md` §MSRV policy for the full story.
-rust-version = "1.86"
+# MSRV is the floor required by every use in the crate, not just the newest
+# one introduced here. Our own std usage sits far lower: `std::sync::LazyLock`
+# (src/naming.rs) wants 1.80, `std::iter::repeat_n` (src/tui/ui.rs's countdown
+# bar) wants 1.82. The floor comes from the dependency graph, and reading it
+# takes a build rather than `cargo metadata`: the highest *declared*
+# `rust-version` in the locked graph is 1.88 (the ratatui 0.30 stack, `time
+# 0.3.47`), but `libsqlite3-sys 0.38.1`, a normal dependency pulled in by
+# `rusqlite` with `bundled`, declares no `rust-version` at all and its build
+# script uses `cfg_select!`, stable only since 1.95.0. Measured against the
+# committed lockfile: `cargo +1.94 check --all-targets --locked` fails with
+# `error[E0658]`, `cargo +1.95 check --all-targets --locked` passes.
+#
+# Two CI jobs hold this line. The clippy job catches an accidental *std-API*
+# use above it (`clippy::incompatible_msrv` is warn-by-default, escalated to a
+# hard error by `-D warnings`). The `msrv` job (#491) installs the toolchain
+# declared right here and runs `cargo check --all-targets --locked`, which is
+# the only check that sees a language/edition feature or a dependency that
+# declares no floor of its own. See `docs/6.development/3.stability.md`
+# §MSRV policy for the full story.
+rust-version = "1.95"
 description = "git worktree manager — TUI + CLI, native libgit2, per-repo bootstrap"
 authors = ["Kylian Bardini"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![ci](https://github.com/kbrdn1/gwm-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/kbrdn1/gwm-cli/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/kbrdn1/gwm-cli?display_name=tag&sort=semver)](https://github.com/kbrdn1/gwm-cli/releases)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
-[![rust](https://img.shields.io/badge/rust-1.86%2B-orange?logo=rust)](https://www.rust-lang.org/)
+[![rust](https://img.shields.io/badge/rust-1.95%2B-orange?logo=rust)](https://www.rust-lang.org/)
 
 **One binary to manage every git worktree in every repo, with the setup already done.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,8 +47,9 @@ bounded `--jobs`, and `--workspace` fan-out ([#324](https://github.com/kbrdn1/gw
 overlays ([#325](https://github.com/kbrdn1/gwm-cli/issues/325)). See the
 [Shipped highlights](#shipped-highlights) table for the per-issue breakdown and
 [`changelogs/1.0.0.md`](changelogs/1.0.0.md) for the consolidated notes. The
-MSRV is **1.86** (raised by the PTY overlay's `portable-pty` / `tui-term`
-dependencies; MSRV bumps ride a minor per the stability policy).
+MSRV is **1.95** (raised by `rusqlite`'s bundled `libsqlite3-sys`, which
+declares no floor of its own; MSRV bumps ride a minor per the stability
+policy).
 
 The 0.9.x stable line ships:
 

--- a/docs/1.getting-started/1.install.md
+++ b/docs/1.getting-started/1.install.md
@@ -15,7 +15,7 @@ cd gwm-cli
 cargo install --path .
 ```
 
-The binary lands in `~/.cargo/bin/gwm`. Requires a recent stable Rust toolchain — MSRV is **1.86**.
+The binary lands in `~/.cargo/bin/gwm`. Requires a recent stable Rust toolchain — MSRV is **1.95**.
 
 ## from crates.io
 

--- a/docs/6.development/3.stability.md
+++ b/docs/6.development/3.stability.md
@@ -99,26 +99,36 @@ of them.
 
 The Minimum Supported Rust Version is declared as `rust-version` in
 [`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
-(currently **1.86**) — the floor the crate is expected to compile against.
+(currently **1.95**) — the floor the crate is expected to compile against.
 
-CI builds and tests on the *stable* toolchain, so it exercises the code but
-does not compile it *at* 1.86. What it does catch: the clippy job runs with
+Two CI jobs hold that floor. The clippy job runs on the *stable* toolchain with
 `-D warnings`, and `clippy::incompatible_msrv` is warn-by-default, so an
-accidental use of a **std API** newer than the declared floor fails CI. What it
-does **not** catch: a newer **language / edition** feature, or a **dependency**
-raising its own floor — neither surfaces on stable. Those are verified locally
-before an MSRV bump with `cargo msrv verify` (or, without rustup,
-`cargo +1.86.0 build --all-targets --locked`). A dedicated `toolchain@1.86`
-build/test job would close that gap for the exhaustive guarantee; it is not
-wired up yet (its first run has to be confirmed green before it can gate
-merges).
+accidental use of a **std API** newer than the declared floor fails CI. The
+`msrv` job installs the declared toolchain itself (read out of `Cargo.toml`,
+never hardcoded) and runs `cargo check --all-targets --locked`, which covers
+what clippy cannot: a newer **language / edition** feature, or a **dependency**
+whose own floor is higher than ours. `--locked` matters twice over. Cargo's
+`rust-version` gate is evaluated at *resolve* time against the committed
+lockfile, so a dependency that **declares** a higher floor fails before
+anything is built; and the compile that follows is the only thing that catches
+a dependency which declares **nothing at all**.
+
+That last case is not hypothetical, and it is why this section no longer
+recommends reading the floor out of `cargo metadata`. Until
+[#491](https://github.com/kbrdn1/gwm-cli/issues/491) the declared floor read
+`1.86` with nothing enforcing it. Metadata put the real floor at `1.88` (the
+ratatui 0.30 stack, `time 0.3.47`); compiling put it at `1.95`, because
+`libsqlite3-sys 0.38.1` (a normal dependency, via `rusqlite` with `bundled`)
+declares no `rust-version` and its build script uses `cfg_select!`, stable
+since 1.95.0. A crate that declares nothing is invisible to every
+metadata-based check, so the floor is whatever a build says it is.
 
 In practice an MSRV bump rides a **minor** release, not a major one — it has
-historically been driven by a dependency raising its own floor (the `1.86`
-bump came in with `tui-term` / `portable-pty` when the PTY overlay landed),
-and is treated as a routine toolchain update rather than a breaking change to
-the public contract. Bumps are called out in the changelog so packagers are
-not surprised.
+historically been driven by a dependency raising its own floor (the `1.86` bump
+came in with `tui-term` / `portable-pty` when the PTY overlay landed, the
+`1.95` bump with `rusqlite`'s bundled `libsqlite3-sys`), and is treated as a
+routine toolchain update rather than a breaking change to the public contract.
+Bumps are called out in the changelog so packagers are not surprised.
 
 ## Deprecation process
 

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -9,7 +9,7 @@ The full roadmap (with grouped categories and per-item issue links) lives in [`R
 
 ## current state — v1.5.0 stable
 
-The current **stable** line is **v1.5.0** (`Cargo.toml` `version = "1.5.0"`, tagged 2026-07-26). The **machine-readable contracts frozen at 1.0.0 are unchanged**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)). The project MSRV is **1.86**.
+The current **stable** line is **v1.5.0** (`Cargo.toml` `version = "1.5.0"`, tagged 2026-07-26). The **machine-readable contracts frozen at 1.0.0 are unchanged**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)). The project MSRV is **1.95**.
 
 Since the 1.0.0 milestone (tagged 2026-06-26): three 1.0.x patches hardened the stable line, **v1.1.0** shipped the first outside-report-driven pair ([#363](https://github.com/kbrdn1/gwm-cli/issues/363): persisted sidebar layout + OSC52 clipboard fallback over SSH) with **v1.1.1** fixing global config resolution on macOS, **v1.2.0** shipped the distribution train ([#383](https://github.com/kbrdn1/gwm-cli/issues/383): Scoop, `.deb` / `.rpm`, AUR, aqua, winget automation), **v1.3.0** made gwm agent-aware, **v1.4.0** finished the help overlay and the TUI-polish trio, and **v1.5.0** makes gwm multi-forge: the section below. Per-version notes live under [`changelogs/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs).
 
@@ -66,7 +66,7 @@ The v0.9.0 line built on the v0.8.0 configurability cycle and added the TUI trai
 - **Pane-key family `1` / `2` / `3` / `4`** ([#226](https://github.com/kbrdn1/gwm-cli/issues/226) / [#232](https://github.com/kbrdn1/gwm-cli/issues/232)) — direct focus for Worktrees / Status, a Command Logs overlay, and a Configuration panel showing the resolved config with repo / user / default source attribution.
 - **Docs key (`.`)** ([#233](https://github.com/kbrdn1/gwm-cli/issues/233)) — open the documentation from inside the TUI; rebindable as `open_docs`.
 
-The full v0.9.0 release notes live at [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). The project MSRV is **1.86** — raised in the v0.10.0 line by the PTY overlay's `portable-pty` / `tui-term` dependencies (`tui-term` declares `rust-version = "1.86.0"`).
+The full v0.9.0 release notes live at [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). The MSRV was raised to **1.86** in the v0.10.0 line by the PTY overlay's `portable-pty` / `tui-term` dependencies (`tui-term` declares `rust-version = "1.86.0"`); the current floor is stated at the top of this page.
 
 ## v0.10.0 — Settings editability + TUI enrichment
 

--- a/docs/fr/1.getting-started/1.install.md
+++ b/docs/fr/1.getting-started/1.install.md
@@ -15,7 +15,7 @@ cd gwm-cli
 cargo install --path .
 ```
 
-Le binaire arrive dans `~/.cargo/bin/gwm`. Nécessite une toolchain Rust stable récente — le MSRV est **1.86**.
+Le binaire arrive dans `~/.cargo/bin/gwm`. Nécessite une toolchain Rust stable récente — le MSRV est **1.95**.
 
 ## depuis crates.io
 

--- a/docs/fr/6.development/3.stability.md
+++ b/docs/fr/6.development/3.stability.md
@@ -92,19 +92,40 @@ d'automatisation par-dessus.
 
 La version Rust minimale supportée est déclarée via `rust-version` dans
 [`Cargo.toml`](https://github.com/kbrdn1/gwm-cli/blob/main/Cargo.toml)
-(actuellement **1.86**) — le plancher contre lequel la crate est censée
-compiler. La CI build et teste sur la toolchain *stable* ; elle n'épingle pas
-de job 1.86 dédié, donc le MSRV est vérifié localement avant un bump avec
-`cargo clippy --all-targets -- -W clippy::incompatible_msrv` (ou
-`cargo msrv verify`), qui signale l'usage accidentel d'une API plus récente
-que le plancher déclaré.
+(actuellement **1.95**) — le plancher contre lequel la crate est censée
+compiler.
+
+Deux jobs CI tiennent ce plancher. Le job clippy tourne sur la toolchain
+*stable* avec `-D warnings` : `clippy::incompatible_msrv` étant warn-by-default,
+l'usage accidentel d'une **API std** plus récente que le plancher déclaré fait
+échouer la CI. Le job `msrv` installe la toolchain déclarée elle-même (lue dans
+`Cargo.toml`, jamais codée en dur) et lance `cargo check --all-targets
+--locked`, ce qui couvre ce que clippy ne voit pas : une fonctionnalité
+**langage / édition** plus récente, ou une **dépendance** dont le plancher est
+plus haut que le nôtre. `--locked` compte deux fois. Le gate `rust-version` de
+cargo est évalué au moment de la *résolution*, contre le lockfile commité :
+une dépendance qui **déclare** un plancher plus haut échoue avant toute
+compilation. Et la compilation qui suit est la seule chose qui attrape une
+dépendance qui ne déclare **rien du tout**.
+
+Ce dernier cas n'a rien d'hypothétique, et c'est pourquoi cette section ne
+recommande plus de lire le plancher dans `cargo metadata`. Jusqu'à
+[#491](https://github.com/kbrdn1/gwm-cli/issues/491), le plancher déclaré
+affichait `1.86` sans que rien ne le vérifie. Les métadonnées situaient le vrai
+plancher à `1.88` (la stack ratatui 0.30, `time 0.3.47`) ; la compilation le
+situait à `1.95`, parce que `libsqlite3-sys 0.38.1` (dépendance normale, via
+`rusqlite` avec `bundled`) ne déclare aucune `rust-version` et que son build
+script utilise `cfg_select!`, stable seulement depuis 1.95.0. Une crate qui ne
+déclare rien est invisible à toute vérification basée sur les métadonnées : le
+plancher est ce qu'une compilation en dit.
 
 En pratique, un bump MSRV ride une release **mineure**, pas majeure — il a
 historiquement été piloté par une dépendance relevant son propre plancher (le
 bump `1.86` est arrivé avec `tui-term` / `portable-pty` lors de l'ajout de
-l'overlay PTY), et est traité comme une mise à jour de toolchain de routine
-plutôt qu'un changement cassant du contrat public. Les bumps sont signalés
-dans le changelog pour que les packagers ne soient pas surpris.
+l'overlay PTY, le bump `1.95` avec le `libsqlite3-sys` bundled de `rusqlite`),
+et est traité comme une mise à jour de toolchain de routine plutôt qu'un
+changement cassant du contrat public. Les bumps sont signalés dans le
+changelog pour que les packagers ne soient pas surpris.
 
 ## Processus de dépréciation
 

--- a/docs/fr/7.roadmap.md
+++ b/docs/fr/7.roadmap.md
@@ -9,7 +9,7 @@ La roadmap complète (avec les catégories groupées et les liens d'issues par i
 
 ## état courant — stable v1.5.0
 
-La ligne **stable** courante est **v1.5.0** (`Cargo.toml` `version = "1.5.0"`, taguée le 2026-07-26). Les **contrats lisibles par machine gelés en 1.0.0 sont inchangés** : les sous-commandes / flags / codes de sortie de la CLI, les schémas `--format=json`, le protocole JSON-RPC du daemon et l'ensemble des sections `.gwm.toml` ne casseront pas sans un bump majeur (voir [Stabilité & compatibilité](/fr/development/stability)). Le MSRV du projet est **1.86**.
+La ligne **stable** courante est **v1.5.0** (`Cargo.toml` `version = "1.5.0"`, taguée le 2026-07-26). Les **contrats lisibles par machine gelés en 1.0.0 sont inchangés** : les sous-commandes / flags / codes de sortie de la CLI, les schémas `--format=json`, le protocole JSON-RPC du daemon et l'ensemble des sections `.gwm.toml` ne casseront pas sans un bump majeur (voir [Stabilité & compatibilité](/fr/development/stability)). Le MSRV du projet est **1.95**.
 
 Depuis le jalon 1.0.0 (tagué le 2026-06-26) : trois patchs 1.0.x ont durci la ligne stable, **v1.1.0** a livré la première paire issue d'un rapport externe ([#363](https://github.com/kbrdn1/gwm-cli/issues/363) : layout de sidebar persisté + fallback presse-papier OSC52 en SSH) avec **v1.1.1** corrigeant la résolution de la config globale sur macOS, **v1.2.0** a livré le train de distribution ([#383](https://github.com/kbrdn1/gwm-cli/issues/383) : Scoop, `.deb` / `.rpm`, AUR, aqua, automatisation winget), **v1.3.0** a rendu gwm conscient des agents, **v1.4.0** a complété le help overlay et le trio de polish TUI, et **v1.5.0** rend gwm multi-forge : la section ci-dessous. Les notes par version vivent sous [`changelogs/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs).
 
@@ -66,7 +66,7 @@ La ligne v0.9.0 s'est appuyée sur le cycle de configurabilité v0.8.0 et a ajou
 - **Famille de touches de pane `1` / `2` / `3` / `4`** ([#226](https://github.com/kbrdn1/gwm-cli/issues/226) / [#232](https://github.com/kbrdn1/gwm-cli/issues/232)) — focus direct Worktrees / Status, overlay Command Logs et panneau Configuration affichant la config résolue avec attribution de source repo / user / default.
 - **Touche docs (`.`)** ([#233](https://github.com/kbrdn1/gwm-cli/issues/233)) — ouverture de la documentation depuis la TUI ; rebindable via `open_docs`.
 
-Les notes de release complètes de la v0.9.0 vivent dans [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). La MSRV du projet est **1.86** — relevée dans la ligne v0.10.0 par les dépendances `portable-pty` / `tui-term` de l'overlay PTY (`tui-term` déclare `rust-version = "1.86.0"`).
+Les notes de release complètes de la v0.9.0 vivent dans [`changelogs/0.9.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/0.9.0.md). La MSRV a été relevée à **1.86** dans la ligne v0.10.0 par les dépendances `portable-pty` / `tui-term` de l'overlay PTY (`tui-term` déclare `rust-version = "1.86.0"`) ; le plancher courant est indiqué en haut de cette page.
 
 ## v0.10.0 — Éditabilité des Settings + enrichissement TUI
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 Single-binary Rust tool that manages git worktrees with `libgit2`, a ratatui TUI, a declarative per-repo bootstrap (`.gwm.toml`), GitHub issue/PR linking, multiplexer hand-off (tmux / zellij), and a doctor command. Replaces project-specific bash wrappers with one portable binary that works in any git repo.
 
-Source: https://github.com/kbrdn1/gwm-cli — latest stable: **`1.5.0`** (machine contracts frozen since 1.0.0 — MSRV 1.86).
+Source: https://github.com/kbrdn1/gwm-cli — latest stable: **`1.5.0`** (machine contracts frozen since 1.0.0 — MSRV 1.95).
 
 **Multi-forge, shipped in 1.5.0 (#419).** Issue / PR lookups go through a `Forge` trait with two backends — GitHub via `gh`, GitLab via `glab`. `forge = "github" | "gitlab"` in `.gwm.toml` names the backend; `[forge_hosts]` in the **user-level** config authorises a self-hosted host; `gwm trust add` is the per-repo alternative. Worktrees, bootstrap, branch naming and link storage are forge-neutral — only the network layer knows which forge is in play. See [Forge selection](#forge-selection-github--gitlab).
 
@@ -38,7 +38,7 @@ Shipped since 1.0.0: **multi-forge** in 1.5.0 (#419, above); the **help overlay*
 
 ```bash
 command -v gwm           # required — installed by `cargo install --path .` from the gwm-cli repo
-command -v cargo         # required at install time (1.86+ — the crate MSRV)
+command -v cargo         # required at install time (1.95+ — the crate MSRV)
 command -v git           # required at runtime
 command -v gh            # OPTIONAL — the GitHub backend: live `gwm status`, TUI state, `R: review` preset
 command -v glab          # OPTIONAL — the GitLab backend (forge = "gitlab"); $GWM_GLAB overrides it

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -139,4 +139,14 @@ fn ci_verifies_the_declared_msrv_and_derives_it_from_cargo_toml() {
      *resolve* time against the committed lockfile, which is what turns a \
      dependency raising its floor into a red job"
   );
+  for os in ["ubuntu-latest", "macos-latest", "windows-latest"] {
+    assert!(
+      block.contains(os),
+      "the msrv job must run on {os}, like the `test` job. A single-platform \
+       run compiles neither the `[target.\"cfg(windows)\".dependencies]` block \
+       nor the `#[cfg(windows)]` code, so a Windows-only dependency raising \
+       its own floor stays green on Linux while `cargo install` breaks for \
+       those users"
+    );
+  }
 }

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -48,42 +48,6 @@ fn declared_msrv() -> String {
     .to_string()
 }
 
-/// The *executable* lines of the `ci.yml` block belonging to `job`, i.e. from
-/// its 2-space-indented key up to the next one, with YAML comments stripped.
-///
-/// Both halves are load-bearing. Without the slicing, a `--locked` or a
-/// `Cargo.toml` from some *other* job satisfies the assertions below. Without
-/// dropping comments, the job's own prose does: the first draft of this guard
-/// stayed green with `--locked` deleted from the `cargo check` line, because
-/// the comment right above it explains that `--locked` is load-bearing. A
-/// guard that matches its own documentation never fires.
-fn job_block(yaml: &str, job: &str) -> String {
-  let start = yaml
-    .find(&format!("\n  {job}:\n"))
-    .unwrap_or_else(|| panic!("ci.yml must declare a `{job}:` job (2-space indent)"))
-    + 1;
-  let rest = &yaml[start..];
-  let end = rest
-    .match_indices("\n  ")
-    .find(|(i, _)| {
-      let line = rest[i + 3..].lines().next().unwrap_or("");
-      // Next job key: `  <name>:` and nothing after the colon.
-      !line.starts_with(char::is_whitespace)
-        && line.ends_with(':')
-        && line
-          .trim_end_matches(':')
-          .chars()
-          .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    })
-    .map(|(i, _)| i + 1)
-    .unwrap_or(rest.len());
-  rest[..end]
-    .lines()
-    .filter(|line| !line.trim_start().starts_with('#'))
-    .collect::<Vec<_>>()
-    .join("\n")
-}
-
 /// Every *live* MSRV claim, as a pattern with `{msrv}` standing in for the
 /// declared floor. Historical statements are deliberately absent: the v0.10.0
 /// row in `ROADMAP.md`, the v0.9.0 / #35 paragraphs in `docs/7.roadmap.md`,
@@ -119,34 +83,116 @@ fn every_live_msrv_claim_matches_cargo_toml() {
   }
 }
 
+/// The `msrv` job, parsed. Reading the YAML rather than slicing it out of the
+/// text is what makes the assertions below say what they mean: a text search
+/// for `Cargo.toml` and `rust-version` is satisfied by a *leftover* read step
+/// whose output nothing consumes, so swapping the action input for a literal
+/// `toolchain: 1.95` while keeping that step would have kept the old guard
+/// green, reintroducing exactly the drift it exists to block. The value of the
+/// input is now compared to the step output it must reference.
+fn msrv_job() -> serde_yaml_ng::Value {
+  let workflow: serde_yaml_ng::Value =
+    serde_yaml_ng::from_str(&read(".github/workflows/ci.yml")).expect("ci.yml must be valid YAML");
+  workflow["jobs"]["msrv"].clone()
+}
+
+fn steps(job: &serde_yaml_ng::Value) -> Vec<serde_yaml_ng::Value> {
+  job["steps"].as_sequence().cloned().unwrap_or_default()
+}
+
 #[test]
-fn ci_verifies_the_declared_msrv_and_derives_it_from_cargo_toml() {
-  let block = job_block(&read(".github/workflows/ci.yml"), "msrv");
-  assert!(
-    !block.contains("rust-toolchain@1."),
-    "the msrv job must not pin a toolchain literal (`dtolnay/rust-toolchain@1.88`); \
-     read `rust-version` out of Cargo.toml and feed it to \
-     `dtolnay/rust-toolchain@master`, otherwise the job and the manifest drift \
-     apart exactly the way the manifest and the graph did (#491)"
-  );
-  assert!(
-    block.contains("Cargo.toml") && block.contains("rust-version"),
-    "the msrv job must derive its toolchain from Cargo.toml's `rust-version`"
-  );
-  assert!(
-    block.contains("--locked"),
-    "the msrv job must pass `--locked`: cargo's `rust-version` gate fires at \
-     *resolve* time against the committed lockfile, which is what turns a \
-     dependency raising its floor into a red job"
-  );
+fn ci_runs_the_msrv_check_on_every_supported_platform() {
+  let job = msrv_job();
+  let matrix = job["strategy"]["matrix"]["os"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|v| v.as_str().map(str::to_owned))
+    .collect::<Vec<_>>();
   for os in ["ubuntu-latest", "macos-latest", "windows-latest"] {
     assert!(
-      block.contains(os),
-      "the msrv job must run on {os}, like the `test` job. A single-platform \
-       run compiles neither the `[target.\"cfg(windows)\".dependencies]` block \
-       nor the `#[cfg(windows)]` code, so a Windows-only dependency raising \
-       its own floor stays green on Linux while `cargo install` breaks for \
-       those users"
+      matrix.iter().any(|m| m == os),
+      "the msrv job must run on {os}, like the `test` job (matrix is {matrix:?}). \
+       A single-platform run compiles neither the \
+       `[target.\"cfg(windows)\".dependencies]` block nor the `#[cfg(windows)]` \
+       code, so a Windows-only dependency raising its own floor stays green on \
+       Linux while `cargo install` breaks for those users"
     );
   }
+}
+
+#[test]
+fn ci_feeds_the_msrv_job_the_toolchain_declared_in_cargo_toml() {
+  let job = msrv_job();
+  let steps = steps(&job);
+
+  let reader = steps
+    .iter()
+    .find(|s| s["id"].as_str() == Some("msrv"))
+    .expect("the msrv job needs a step with `id: msrv` that reads the declared floor");
+  let script = reader["run"].as_str().unwrap_or_default();
+  assert!(
+    script.contains("rust-version") && script.contains("Cargo.toml"),
+    "the `id: msrv` step must read `rust-version` out of Cargo.toml, got: {script:?}"
+  );
+  assert!(
+    reader["shell"].as_str() == Some("bash"),
+    "the reader step must force `shell: bash`: windows-latest defaults to \
+     PowerShell, which has no grep or cut"
+  );
+
+  let toolchain = steps
+    .iter()
+    .find(|s| {
+      s["uses"]
+        .as_str()
+        .is_some_and(|u| u.starts_with("dtolnay/rust-toolchain@"))
+    })
+    .expect("the msrv job must install a toolchain via dtolnay/rust-toolchain");
+  assert_eq!(
+    toolchain["uses"].as_str(),
+    Some("dtolnay/rust-toolchain@master"),
+    "pin the action at @master and pass the version as an input; a \
+     `rust-toolchain@<version>` ref is a literal that drifts from the manifest"
+  );
+  assert_eq!(
+    toolchain["with"]["toolchain"].as_str(),
+    Some("${{ steps.msrv.outputs.version }}"),
+    "the installed toolchain must be the value read from Cargo.toml, not a \
+     literal. A literal here is the drift this whole job exists to catch (#491)"
+  );
+}
+
+#[test]
+fn ci_checks_the_msrv_locked_and_without_default_features() {
+  let commands = steps(&msrv_job())
+    .iter()
+    .filter_map(|s| s["run"].as_str().map(str::to_owned))
+    .collect::<Vec<_>>()
+    .join("\n");
+
+  let checks: Vec<&str> = commands
+    .lines()
+    .map(str::trim)
+    .filter(|l| l.starts_with("cargo check"))
+    .collect();
+  assert!(
+    !checks.is_empty(),
+    "the msrv job must run `cargo check` at the declared floor"
+  );
+  assert!(
+    checks.iter().all(|c| c.contains("--locked")),
+    "every msrv `cargo check` must pass `--locked`: cargo's `rust-version` gate \
+     fires at *resolve* time against the committed lockfile, which is what turns \
+     a dependency declaring a higher floor into a red job. Got: {checks:?}"
+  );
+  assert!(
+    checks.iter().any(|c| c.contains("--no-default-features")),
+    "the msrv job must also check `--no-default-features`. `daemon` is default-on, \
+     so the default-features check never compiles the \
+     `#[cfg(not(all(any(unix, windows), feature = \"daemon\")))]` arms of \
+     `cmd_daemon` / `cmd_statusline`, and that build is documented as supported. \
+     Got: {checks:?}"
+  );
 }

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -1,0 +1,135 @@
+//! Guards for the declared MSRV (issue #491).
+//!
+//! Two failure modes, two guards:
+//!
+//! 1. **The declared floor drifts below the dependency graph.** `Cargo.toml`
+//!    said `1.86` while the graph required far more, and nothing said a word:
+//!    the clippy job only catches *std-API* regressions, never a dependency
+//!    raising its own floor. Reading the graph through `cargo metadata` is not
+//!    enough either, since it only reports crates that declare a
+//!    `rust-version` at all (metadata said `1.88`, a build said `1.95`). Only
+//!    compiling at the floor settles it, which needs that toolchain actually
+//!    installed, so it is guarded by the `msrv` CI job; what *is* checked here
+//!    is that the job exists and derives its toolchain from `Cargo.toml`
+//!    instead of hardcoding a version that would itself drift.
+//! 2. **The prose drifts from the manifest.** Ten places advertise the MSRV to
+//!    users; the bump has to reach all of them.
+//!
+//! Same shape as `flake_tests.rs`: pin the *mechanism*, and treat `Cargo.toml`
+//! as the single source of truth every other claim mirrors.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_file(rel: &str) -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read(rel: &str) -> String {
+  fs::read_to_string(repo_file(rel))
+    .unwrap_or_else(|err| panic!("{rel} must exist at the repo root; read error: {err}"))
+}
+
+/// The declared floor, read from the left margin of `Cargo.toml` so a
+/// `rust-version` mentioned inside the comment block above it cannot match.
+fn declared_msrv() -> String {
+  read("Cargo.toml")
+    .lines()
+    .find_map(|line| line.strip_prefix("rust-version = \""))
+    .and_then(|rest| rest.split('"').next())
+    .expect("Cargo.toml must declare `rust-version = \"X.Y\"` at the left margin")
+    .to_string()
+}
+
+/// The *executable* lines of the `ci.yml` block belonging to `job`, i.e. from
+/// its 2-space-indented key up to the next one, with YAML comments stripped.
+///
+/// Both halves are load-bearing. Without the slicing, a `--locked` or a
+/// `Cargo.toml` from some *other* job satisfies the assertions below. Without
+/// dropping comments, the job's own prose does: the first draft of this guard
+/// stayed green with `--locked` deleted from the `cargo check` line, because
+/// the comment right above it explains that `--locked` is load-bearing. A
+/// guard that matches its own documentation never fires.
+fn job_block(yaml: &str, job: &str) -> String {
+  let start = yaml
+    .find(&format!("\n  {job}:\n"))
+    .unwrap_or_else(|| panic!("ci.yml must declare a `{job}:` job (2-space indent)"))
+    + 1;
+  let rest = &yaml[start..];
+  let end = rest
+    .match_indices("\n  ")
+    .find(|(i, _)| {
+      let line = rest[i + 3..].lines().next().unwrap_or("");
+      // Next job key: `  <name>:` and nothing after the colon.
+      !line.starts_with(char::is_whitespace)
+        && line.ends_with(':')
+        && line
+          .trim_end_matches(':')
+          .chars()
+          .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    })
+    .map(|(i, _)| i + 1)
+    .unwrap_or(rest.len());
+  rest[..end]
+    .lines()
+    .filter(|line| !line.trim_start().starts_with('#'))
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+/// Every *live* MSRV claim, as a pattern with `{msrv}` standing in for the
+/// declared floor. Historical statements are deliberately absent: the v0.10.0
+/// row in `ROADMAP.md`, the v0.9.0 / #35 paragraphs in `docs/7.roadmap.md`,
+/// the `changelogs/*.md` records and the `set_var`-became-unsafe comments in
+/// `trust_tests.rs` / `history_tests.rs` all say `1.86` about the past and
+/// must keep saying it. That is why this is an allowlist of anchored patterns
+/// and not a repo-wide sweep for the old number.
+const LIVE_CLAIMS: &[(&str, &str)] = &[
+  ("README.md", "badge/rust-{msrv}%2B-orange"),
+  ("CONTRIBUTING.md", "stable channel, {msrv}+"),
+  ("ROADMAP.md", "MSRV is **{msrv}**"),
+  ("docs/1.getting-started/1.install.md", "MSRV is **{msrv}**"),
+  ("docs/fr/1.getting-started/1.install.md", "le MSRV est **{msrv}**"),
+  ("docs/6.development/3.stability.md", "(currently **{msrv}**)"),
+  ("docs/fr/6.development/3.stability.md", "(actuellement **{msrv}**)"),
+  ("docs/7.roadmap.md", "The project MSRV is **{msrv}**."),
+  ("docs/fr/7.roadmap.md", "Le MSRV du projet est **{msrv}**."),
+  ("skills/SKILL.md", "MSRV {msrv})"),
+  ("skills/SKILL.md", "({msrv}+ — the crate MSRV)"),
+];
+
+#[test]
+fn every_live_msrv_claim_matches_cargo_toml() {
+  let msrv = declared_msrv();
+  for (file, pattern) in LIVE_CLAIMS {
+    let expected = pattern.replace("{msrv}", &msrv);
+    assert!(
+      read(file).contains(&expected),
+      "{file} must advertise the declared MSRV: expected to find {expected:?} \
+       (Cargo.toml declares `rust-version = \"{msrv}\"`). An MSRV bump has to \
+       reach every user-facing claim, not just the manifest (#491)"
+    );
+  }
+}
+
+#[test]
+fn ci_verifies_the_declared_msrv_and_derives_it_from_cargo_toml() {
+  let block = job_block(&read(".github/workflows/ci.yml"), "msrv");
+  assert!(
+    !block.contains("rust-toolchain@1."),
+    "the msrv job must not pin a toolchain literal (`dtolnay/rust-toolchain@1.88`); \
+     read `rust-version` out of Cargo.toml and feed it to \
+     `dtolnay/rust-toolchain@master`, otherwise the job and the manifest drift \
+     apart exactly the way the manifest and the graph did (#491)"
+  );
+  assert!(
+    block.contains("Cargo.toml") && block.contains("rust-version"),
+    "the msrv job must derive its toolchain from Cargo.toml's `rust-version`"
+  );
+  assert!(
+    block.contains("--locked"),
+    "the msrv job must pass `--locked`: cargo's `rust-version` gate fires at \
+     *resolve* time against the committed lockfile, which is what turns a \
+     dependency raising its floor into a red job"
+  );
+}

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -25,9 +25,16 @@ fn repo_file(rel: &str) -> PathBuf {
   PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
 }
 
+/// Reads a repo file with line endings normalised to `\n`.
+///
+/// The normalisation is not cosmetic. Windows runners check out with
+/// `core.autocrlf=true`, so every file arrives CRLF, and `job_block`'s
+/// `find("\n  msrv:\n")` matched nothing there while passing on Linux and
+/// macOS: the guard failed on `test (windows-latest)` only.
 fn read(rel: &str) -> String {
   fs::read_to_string(repo_file(rel))
     .unwrap_or_else(|err| panic!("{rel} must exist at the repo root; read error: {err}"))
+    .replace("\r\n", "\n")
 }
 
 /// The declared floor, read from the left margin of `Cargo.toml` so a


### PR DESCRIPTION
## Description

#491 asked for two things: raise the declared MSRV from 1.86 to 1.88, and add a
CI job so it cannot drift silently again. The job is here, and on its first real
run it showed that 1.88 was wrong too. The declared floor is now **1.95**,
measured on both sides.

The issue derived 1.88 from `cargo metadata` over the locked graph (the ratatui
0.30 stack, `time 0.3.47`). `cargo metadata` only reports crates that declare a
`rust-version`. `libsqlite3-sys 0.38.1` declares none at all, and its build
script uses `cfg_select!`, stable only since 1.95.0. It is a normal dependency
(via `rusqlite` with `bundled`), so every consumer compiles it. A crate that
declares nothing is invisible to every metadata-based check; only a build finds
it.

Measured against the committed lockfile:

```
$ cargo +1.94 check --all-targets --locked
error[E0658]: use of unstable library feature `cfg_select`
error: could not compile `libsqlite3-sys` (build script) due to 1 previous error

$ cargo +1.95 check --all-targets --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 14s
```

`libsqlite3-sys 0.38.1` is already in the lockfile at the `v1.5.0` tag, so this
raises the *declared* floor to what the code has required since before that
release. It does not raise the real one.

Closes #491

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `msrv` CI job: reads `rust-version` out of `Cargo.toml`, installs exactly
  that toolchain, runs `cargo check --all-targets --locked`. Derived rather
  than hardcoded, so the job cannot drift from the manifest the way the
  manifest drifted from the graph. `RUSTFLAGS: ""` overrides the workflow-wide
  `-D warnings` for this job only (a warning an older toolchain emits says
  nothing about the MSRV).
- `tests/msrv_tests.rs`: one guard pins the ten user-facing MSRV claims to
  whatever `Cargo.toml` declares, the other pins the CI job's mechanism.
- `Cargo.toml`: `rust-version = "1.95"`, and the comment above it rewritten.
  It credited `tui-term 0.3.4` and claimed a dependency raising its floor is
  "verified locally before an MSRV bump", which is precisely what nobody did.
- Docs, EN + FR: README badge, CONTRIBUTING, ROADMAP, install / stability /
  roadmap pages, plus `skills/SKILL.md` (two claims there, not listed in the
  issue but just as wrong). The stability page's MSRV policy section is
  rewritten: it named "a dedicated `toolchain@1.86` job" as a known unfilled
  gap, and it no longer recommends reading the floor from `cargo metadata`.
- CHANGELOG under `[Unreleased] > Changed`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Both guards were proven red before being made green, not just observed green:

- with `--locked` deleted from the job, `ci_verifies_…` fails on the `--locked`
  assertion (this caught a real bug in the first draft, where the guard matched
  the word `--locked` inside the job's own comment and never fired);
- with `dtolnay/rust-toolchain@1.88` hardcoded, it fails on the literal
  assertion;
- with `Cargo.toml` bumped and the docs untouched, `every_live_msrv_claim_…`
  fails on the README badge.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (badge only, no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #491
- Related: #344 (1.0.x hardening backlog, carried the MSRV doc item), #318
  (stability policy, where the MSRV policy text lives)

## Notes for reviewers

Three deltas from the issue as written, all deliberate:

1. **The number is 1.95, not 1.88.** This is a policy call as much as a fix:
   1.95 is one release behind current stable (1.96.1), and
   `docs/6.development/3.stability.md` says MSRV bumps ride a minor, so this
   one rides 1.6.0. The alternative was downgrading `rusqlite` to hold a lower
   floor (`rusqlite 0.40.1` requires `libsqlite3-sys ^0.38.1`, so the sys crate
   alone cannot be pinned back). Declaring the truth was chosen over carrying a
   dependency downgrade.
2. **Acceptance criterion 1 is not ticked, on purpose.** "`cargo metadata
   --locked` shows no dependency with a `rust_version` above the declared one"
   passes today at 1.88 while the crate does not build. It is a vacuous check
   for exactly the dependency that caused this, and the `msrv` job replaces it.
3. **The job is not added to the seven required status checks on `main`.** That
   is a repo-settings change, left to you.

The job also does not run on the release workflows, only `ci.yml` (push / PR on
`main` and `dev`). Worth a follow-up if you want the floor verified at tag time
too.
