### PR TITLE
🔒 fix(tui): neutralise the bidi controls the table and sidebar render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A branch name no longer reaches the TUI table with its bidi controls intact.
+  The sinks the CLI goes through are not on the TUI's path, and what protected
+  the TUI so far was incidental: measured on ratatui 0.30, every render path
+  drops the zero-width control bytes, but `List` and `Table` keep the
+  `Bidi_Control` characters. The worktrees table renders through `Table`, and
+  git's ref rules refuse the ASCII controls and `~^:?*[` but not the Unicode
+  format characters, so a fetched ref could carry one and its row could read
+  in an order the ref is not stored in.
+
+  The neutralisation goes in the width-clipping funnel every constrained cell
+  already passes through, rather than at each cell, so a column added later
+  inherits it. It runs before the width count, so what is measured is what is
+  drawn: a `Bidi_Control` character can measure zero columns where its `?`
+  measures one. The path column, which is not width-constrained, says so
+  itself. `tui::wt_tree::sanitize_name` now delegates to the shared predicate
+  instead of keeping a copy that had drifted: a filename out of `git status -z`
+  reorders a sidebar row exactly as a ref name reorders a table row.
+  ([#506](https://github.com/kbrdn1/gwm-cli/issues/506))
+
 - A config value no longer reaches the terminal with its Unicode bidi controls
   intact. The neutralisation added in 1.6.0 replaces control characters, and
   `char::is_control` covers C0, DEL and C1: it does not cover the twelve

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1896,7 +1896,11 @@ fn build_row(
 
   // The path column paints with the `path` role (issue #210; default
   // `Gray`) — a structural mid-grey distinct from `muted`/`DarkGray`.
-  let path_cell = Cell::from(w.path.to_string_lossy().to_string()).style(worktree_path_style(theme));
+  // Not width-constrained, so it does not pass through `trunc`'s funnel and
+  // has to say so itself: a path carries the worktree directory name, which is
+  // as unvetted as the branch (issue #506).
+  let path_cell =
+    Cell::from(crate::naming::sanitise_for_terminal(&w.path.to_string_lossy())).style(worktree_path_style(theme));
 
   let mut cells = vec![age_cell];
   if let Some((repo_name, repo_w)) = repo {
@@ -4766,9 +4770,27 @@ pub fn ellipsize_middle(s: &str, max: usize) -> String {
   format!("{head_str}…{tail_str}")
 }
 
+/// Clip `s` to `max` columns, neutralising what must never reach the terminal
+/// first (issue #506).
+///
+/// The sanitisation is here rather than at each call site because this is the
+/// one funnel every width-constrained cell already goes through, table rows
+/// included, so a cell added later inherits it instead of having to remember
+/// it. It is a no-op on ordinary text.
+///
+/// Measured, ratatui 0.30 drops zero-width control bytes on every render path,
+/// but `List` and `Table` keep the `Bidi_Control` characters, which is exactly
+/// where a branch name lands: git's ref rules refuse the ASCII controls and
+/// `~^:?*[`, not the Unicode format characters, so a fetched ref can carry one
+/// and a row can then read in an order the ref is not stored in.
+///
+/// It runs **before** the width count, so what is measured is what is drawn: a
+/// replacement is one char for one char, but a `Bidi_Control` character can
+/// measure zero columns where `?` measures one.
 fn trunc(s: &str, max: usize) -> String {
+  let s = crate::naming::sanitise_for_terminal(s);
   if s.chars().count() <= max {
-    s.to_string()
+    s
   } else {
     let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
     out.push('…');

--- a/src/tui/wt_tree.rs
+++ b/src/tui/wt_tree.rs
@@ -135,8 +135,14 @@ pub fn file_icon(name: &str) -> &'static str {
 /// otherwise break the sidebar layout or inject terminal escape sequences;
 /// the real bytes still live in git, this only guards what reaches the
 /// screen.
+///
+/// Delegates rather than keeping its own copy of the rule (issue #506): this
+/// had the same body as [`crate::naming::sanitise_for_terminal`] until that
+/// one grew the `Bidi_Control` characters, and a filename carrying one
+/// reorders a sidebar row exactly as it reorders a config value. A second copy
+/// is a second thing to forget.
 pub fn sanitize_name(name: &str) -> String {
-  name.chars().map(|c| if c.is_control() { '?' } else { c }).collect()
+  crate::naming::sanitise_for_terminal(name)
 }
 
 /// A node in the Working Tree file-explorer model. A `Dir` carries its

--- a/tests/tui_table_render_tests.rs
+++ b/tests/tui_table_render_tests.rs
@@ -85,3 +85,44 @@ fn agent_column_appears_once_a_session_lands() {
   assert!(text.contains("AGENT"), "a landed session must surface the column");
   assert!(text.contains("claude"), "the top session's agent must show");
 }
+
+// --- Bidi controls in a ref name (issue #506) ------------------------------
+
+/// Every character carrying the Unicode `Bidi_Control` property. Not
+/// `char::is_control`, which by construction matches none of them: they are
+/// `Cf`, and that is the whole point.
+const BIDI_CONTROLS: &[char] = &[
+  '\u{061C}', '\u{200E}', '\u{200F}', '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', '\u{2066}',
+  '\u{2067}', '\u{2068}', '\u{2069}',
+];
+
+/// A repo whose checked-out branch is `name`.
+fn repo_on_branch(name: &str) -> TempDir {
+  let dir = repo();
+  let repo = git2::Repository::open(dir.path()).unwrap();
+  let head = repo.head().unwrap().peel_to_commit().unwrap();
+  repo.branch(name, &head, false).unwrap();
+  repo.set_head(&format!("refs/heads/{name}")).unwrap();
+  dir
+}
+
+#[test]
+fn a_branch_name_cannot_carry_a_bidi_control_into_the_table() {
+  // Git's ref rules refuse the ASCII controls, space and `~^:?*[`, but not
+  // the Unicode format characters, so this name is a legal ref that can
+  // arrive with a fetch rather than being typed locally. The table renders
+  // through `Table`, which (measured on ratatui 0.30) drops zero-width
+  // control bytes but keeps these, so the row can read in an order the ref
+  // is not stored in.
+  for c in BIDI_CONTROLS {
+    let dir = repo_on_branch(&format!("feat/{c}danger"));
+    let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+    let text = draw_once(&mut app);
+    let leaked: Vec<char> = text.chars().filter(|x| BIDI_CONTROLS.contains(x)).collect();
+    assert!(
+      leaked.is_empty(),
+      "the table replayed U+{:04X} from the branch name",
+      *c as u32
+    );
+  }
+}

--- a/tests/tui_table_render_tests.rs
+++ b/tests/tui_table_render_tests.rs
@@ -126,3 +126,50 @@ fn a_branch_name_cannot_carry_a_bidi_control_into_the_table() {
     );
   }
 }
+
+/// A repo living in a directory whose own name carries `c`.
+///
+/// The path column is the one cell that is not width-constrained, so it does
+/// not pass through `trunc`'s funnel and needs its own sink. A hostile segment
+/// therefore has to arrive through the path rather than through the ref name.
+fn repo_under_segment(c: char) -> (TempDir, std::path::PathBuf) {
+  let outer = TempDir::new().unwrap();
+  let inner = outer.path().join(format!("wt{c}x"));
+  std::fs::create_dir(&inner).unwrap();
+  let repo = git2::Repository::init(&inner).unwrap();
+  repo.set_head("refs/heads/main").ok();
+  let sig = git2::Signature::now("gwm-test", "gwm@test").unwrap();
+  std::fs::write(inner.join("file.txt"), "seed").unwrap();
+  repo.index().unwrap().add_path(Path::new("file.txt")).unwrap();
+  repo.index().unwrap().write().unwrap();
+  let tree_id = repo.index().unwrap().write_tree().unwrap();
+  let tree = repo.find_tree(tree_id).unwrap();
+  repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[]).unwrap();
+  (outer, inner)
+}
+
+#[test]
+fn a_worktree_path_cannot_carry_a_bidi_control_into_the_table() {
+  // Wide enough that a `TempDir` path reaches the PATH column intact: at 120
+  // cells the interesting segment is truncated away and the test would pass
+  // without ever rendering it.
+  for c in BIDI_CONTROLS {
+    let (_outer, inner) = repo_under_segment(*c);
+    let mut app = App::new_at_layered(Some(inner.as_path()), None).unwrap();
+    let backend = TestBackend::new(300, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| draw(f, &mut app)).unwrap();
+    let text = buffer_text(&terminal);
+    assert!(
+      text.contains("wt?x"),
+      "the fixture must actually reach the PATH column, got {:?}",
+      text.lines().next().unwrap_or_default()
+    );
+    let leaked: Vec<char> = text.chars().filter(|x| BIDI_CONTROLS.contains(x)).collect();
+    assert!(
+      leaked.is_empty(),
+      "the table replayed U+{:04X} from the worktree path",
+      *c as u32
+    );
+  }
+}

--- a/tests/tui_wt_tree_tests.rs
+++ b/tests/tui_wt_tree_tests.rs
@@ -211,3 +211,21 @@ fn file_icon_maps_known_extensions_and_falls_back() {
   assert_eq!(file_icon("Makefile"), WT_FILE_ICON);
   assert_eq!(file_icon(".gitignore"), WT_FILE_ICON);
 }
+
+#[test]
+fn sanitize_name_replaces_bidi_controls() {
+  // Issue #506: `-z` emits filenames verbatim and a `Bidi_Control` character
+  // is legal in one, so a name can render in an order the bytes do not have.
+  // They are `Cf`, so the control-character rule above never saw them.
+  for c in [
+    '\u{061C}', '\u{200E}', '\u{200F}', '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', '\u{2066}',
+    '\u{2067}', '\u{2068}', '\u{2069}',
+  ] {
+    assert_eq!(
+      sanitize_name(&format!("a{c}b.rs")),
+      "a?b.rs",
+      "U+{:04X} must be neutralised like a control character",
+      c as u32
+    );
+  }
+}


### PR DESCRIPTION
## Description

The TUI leg of #502. The CLI sinks are not on the TUI's render path, and what
kept the TUI safe so far turned out to be incidental rather than intended.

Closes #506

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `src/tui/ui.rs`: `trunc` neutralises before it clips. That is the funnel
  every width-constrained cell already passes through, so the name, branch and
  repo columns are covered and a column added later inherits the rule instead
  of having to remember it. It runs before the width count, so what is
  measured is what is drawn.
- The path cell is not width-constrained, so it calls the sanitiser itself.
- `src/tui/wt_tree.rs`: `sanitize_name` delegates to
  `naming::sanitise_for_terminal` rather than keeping the copy that drifted
  when the shared predicate grew the `Bidi_Control` characters.
- Tests: a render-level test through the real `Table` and `TestBackend`, one
  branch name per `Bidi_Control` character, and a unit test on `sanitize_name`
  covering the same twelve.

## Tests

- [x] `cargo test` passes locally (90 binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #506
- Follows #505, which closed the CLI half (#502).

## Notes for reviewers

**The ratatui behaviour this rests on, measured rather than assumed.** Writing
`ab<ESC>]0;Xcd` and `ab<RLO>cd` into a buffer and reading the cells back on
ratatui 0.30:

| render path | ESC (`Cc`) | RLO (`Cf`) |
|---|---|---|
| `Paragraph` | dropped | dropped |
| `Buffer::set_string` | dropped | dropped |
| `List` | dropped | **kept** |
| `Table` | dropped | **kept** |

That is why the Settings panel was never the hole (it renders through
`Paragraph`, so the reviewer finding that pointed there does not reproduce)
and why the worktrees table was.

**Red proven for both halves, separately.** With the fix reverted, the render
test fails with `the table replayed U+061C from the branch name` and the
`sanitize_name` test fails on its first character; with it, 90 test binaries
are green.

**A caveat worth stating.** The test asserts that no `Bidi_Control` character
reaches the ratatui buffer. It does not assert what an emulator would do with
one, which is unobservable from a test and is why the rule is "do not emit"
rather than "emit and hope".

**A worktree name can still carry one on disk.** This PR is about what is
rendered. Refusing such a name at creation is a different decision, on a
different surface, and is not made here.
