### PR TITLE
✅ test(config): check the env-guard rule by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The rule that a test which can observe a rewritten environment variable must
+  hold its binary's lock is now checked by construction rather than stated in a
+  doc comment. That comment is what #503 was about: it named a boundary
+  narrower than the real one, and five tests were written against the sentence.
+  Its replacement then stated a second wrong boundary, that a layered load
+  reads `$HOME`. It does not: `Config::load_layered` and `resolved_rows` take
+  the global config path as a parameter, and `Config::load_for_repo`, which
+  does resolve it, is called by no test in that binary. A new test walks the
+  four test binaries that rewrite a variable and fails on any test calling an
+  ambient reader of it without the lock, ignoring mentions in comments and
+  identifiers that merely end with the name. Both mistakes came from a search
+  that could not tell those apart.
+  ([#507](https://github.com/kbrdn1/gwm-cli/issues/507))
+
 - A branch name no longer reaches the TUI table with its bidi controls intact.
   The sinks the CLI goes through are not on the TUI's path, and what protected
   the TUI so far was incidental: measured on ratatui 0.30, every render path

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -16,9 +16,18 @@ use tempfile::TempDir;
 /// adding a test can answer, rather than "does this string contain `{home}`?",
 /// which looks answerable and is not.
 ///
-/// A layered load reads it too (`Config::load_layered` → `global_config_path`
-/// → `dirs::home_dir`). Those tests do not take the lock yet; widening it
-/// there would serialise most of the binary, so it is tracked separately.
+/// The other half of that rule is which functions can see `$HOME`, and the
+/// note here used to answer it wrongly (#507): it claimed a layered load reads
+/// it through `Config::load_layered`. It does not. `load_layered` and
+/// `resolved_rows` take the global config path as a **parameter**, so they
+/// resolve nothing; `Config::load_for_repo` is the one that calls
+/// `global_config_path()`, and no test in this binary calls it. So
+/// `expand_placeholders` is the only ambient reader reachable from here, and
+/// #503 covered it completely.
+///
+/// The rule is no longer only stated: `tests/env_guard_invariant_tests.rs`
+/// checks it by construction, for this binary and the three others that
+/// rewrite an environment variable.
 fn env_lock() -> &'static std::sync::Mutex<()> {
   static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
   LOCK.get_or_init(|| std::sync::Mutex::new(()))

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -1,0 +1,148 @@
+//! One invariant, checked by construction rather than stated in a doc
+//! comment (issue #507).
+//!
+//! `std::env::set_var` is `unsafe` because it races a concurrent `getenv`, so
+//! a test binary that mutates a process-global variable has to serialise every
+//! test that can **observe** it. Each such binary keeps its own mutex for that,
+//! and the rule has so far lived in the mutex's doc comment. #503 is what a
+//! doc-comment rule is worth: it said "tests that expand a `{home}` pattern"
+//! while the real boundary was "tests that call `expand_placeholders`", and
+//! five tests were written against the narrower sentence.
+//!
+//! So the rule is checked here instead. For each audited binary: every
+//! function that calls one of the listed **ambient readers** must also take
+//! that binary's lock.
+//!
+//! An *ambient reader* is a function that resolves the variable itself. The
+//! distinction is the whole audit, and getting it wrong in either direction is
+//! easy:
+//!
+//! - `Config::load_layered` and `resolved_rows` take the global config path as
+//!   a **parameter**, so they read nothing. `Config::load_for_repo` calls
+//!   `global_config_path()`, so it does.
+//! - `resolve_global_config_path` takes every path as a parameter;
+//!   `global_config_path` reads `$XDG_CONFIG_HOME` and `dirs::home_dir()`. One
+//!   name contains the other, which is exactly how a substring search reports
+//!   five tests that are in fact clean.
+
+/// A test binary that mutates the environment, and what counts as observing it.
+struct Audited {
+  /// For the failure message.
+  file: &'static str,
+  /// The variable the binary rewrites with `set_var`.
+  var: &'static str,
+  /// Source of the binary, pulled in at compile time so this cannot drift
+  /// from what is on disk or depend on the working directory.
+  source: &'static str,
+  /// Functions that resolve `var` themselves, verified in `src/`.
+  ambient_readers: &'static [&'static str],
+}
+
+const AUDITED: &[Audited] = &[
+  Audited {
+    file: "tests/config_tests.rs",
+    var: "HOME",
+    source: include_str!("config_tests.rs"),
+    // `expand_placeholders` resolves `dirs::home_dir()` before it looks at a
+    // single token, and ends with `shellexpand::tilde`. `load_for_repo`
+    // resolves the global config path, which reads `$HOME` on the way.
+    ambient_readers: &["expand_placeholders", "Config::load_for_repo"],
+  },
+  Audited {
+    file: "tests/config_global_tests.rs",
+    var: "XDG_CONFIG_HOME",
+    source: include_str!("config_global_tests.rs"),
+    ambient_readers: &["global_config_path", "Config::load_for_repo"],
+  },
+  Audited {
+    file: "tests/trust_tests.rs",
+    var: "GWM_TRUST_LEDGER",
+    source: include_str!("trust_tests.rs"),
+    ambient_readers: &["default_ledger_path"],
+  },
+  Audited {
+    file: "tests/history_tests.rs",
+    var: "GWM_HISTORY_FILE",
+    source: include_str!("history_tests.rs"),
+    ambient_readers: &["default_journal_path"],
+  },
+];
+
+/// Split a Rust source into `(name, body)` per top-level `fn`.
+///
+/// CRLF is normalised first: a Windows checkout stores these files with `\r\n`
+/// and every line-anchored match would miss otherwise, leaving the guard green
+/// on exactly one of the three runners.
+fn functions(source: &str) -> Vec<(String, String)> {
+  let normalised = source.replace("\r\n", "\n");
+  let mut out = Vec::new();
+  for chunk in normalised.split("\nfn ").skip(1) {
+    let name = chunk.split('(').next().unwrap_or_default().to_string();
+    out.push((name, chunk.to_string()));
+  }
+  out
+}
+
+/// Does `body` **call** `name`, as opposed to merely mentioning it?
+///
+/// Two exclusions, both learned from a search that got this wrong: a comment
+/// naming the function is not a call (five of the six `load_for_repo` mentions
+/// in `config_tests.rs` are prose), and a longer identifier ending in `name` is
+/// a different function (`resolve_global_config_path` is not
+/// `global_config_path`).
+fn calls(body: &str, name: &str) -> bool {
+  body.lines().filter(|l| !l.trim_start().starts_with("//")).any(|line| {
+    line.match_indices(name).any(|(at, _)| {
+      let before_ok = at == 0
+        || !line[..at]
+          .chars()
+          .next_back()
+          .is_some_and(|c| c.is_alphanumeric() || c == '_');
+      let after_ok = line[at + name.len()..].starts_with('(');
+      before_ok && after_ok
+    })
+  })
+}
+
+#[test]
+fn every_test_that_can_observe_a_mutated_env_var_takes_its_lock() {
+  let mut offenders = Vec::new();
+  for binary in AUDITED {
+    for (name, body) in functions(binary.source) {
+      let reader = binary.ambient_readers.iter().find(|r| calls(&body, r));
+      if let Some(reader) = reader {
+        if !body.contains("lock()") {
+          offenders.push(format!(
+            "{}::{} calls {} (an ambient ${} reader) without taking the binary's lock",
+            binary.file, name, reader, binary.var
+          ));
+        }
+      }
+    }
+  }
+  assert!(
+    offenders.is_empty(),
+    "a test that can observe a rewritten environment variable must be serialised against the rewrite:\n  {}",
+    offenders.join("\n  ")
+  );
+}
+
+#[test]
+fn the_guard_can_actually_fire() {
+  // A guard that never matches passes vacuously, and this one is built from
+  // two exclusions that could each silently swallow every call. So: the same
+  // predicate, against a body written here, in both directions.
+  let guarded = "  let _g = env_lock().lock().unwrap();\n  expand_placeholders(\"{home}\", ...);\n";
+  let bare = "  expand_placeholders(\"{home}\", ...);\n";
+  let commented = "  // expand_placeholders(\"{home}\") would read $HOME\n";
+  let longer_name = "  resolve_expand_placeholders(...);\n";
+
+  assert!(calls(bare, "expand_placeholders"), "a bare call must be seen");
+  assert!(calls(guarded, "expand_placeholders"), "a guarded call is still a call");
+  assert!(guarded.contains("lock()"), "and the guard is what makes it acceptable");
+  assert!(!calls(commented, "expand_placeholders"), "prose is not a call");
+  assert!(
+    !calls(longer_name, "expand_placeholders"),
+    "a longer identifier is a different function"
+  );
+}

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -22,6 +22,18 @@
 //! So all three are derived: the binaries from their own `set_var` calls, the
 //! readers from a transitive walk of `src/`, and the ordering from where the
 //! guard sits relative to the call.
+//!
+//! # What it does not catch, on purpose
+//!
+//! A reader that takes the variable *name* as a parameter. `trust::env_truthy`
+//! calls `std::env::var(key)`, so nothing links it to any particular variable
+//! by reading the source. Seeding on non-literal `env::var` calls was tried
+//! and measured: it marks `env_truthy` a reader of everything, which through
+//! the transitive walk reaches `read_link` and `enter_open_menu`, and demands
+//! a lock from about a third of `forge_tests` and `tui_app_tests` including
+//! binaries whose own rewritten-variable set is empty. That trades a targeted
+//! guard for one whose failures carry no information, so the bound stays and
+//! is written here instead.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -214,30 +226,51 @@ fn ambient_readers(src: &[(String, String)], vars: &BTreeSet<String>) -> BTreeSe
   readers
 }
 
-/// Names of the `-> &'static std::sync::Mutex` helpers a test binary defines.
-/// Its guard is `<name>().lock()`, whatever the binary chose to call it.
-fn lock_helpers(source: &str) -> Vec<String> {
-  functions(source)
-    .into_iter()
-    .filter(|(_, body)| {
-      let head = body.lines().next().unwrap_or_default();
-      head.contains("Mutex")
-    })
-    .map(|(name, _)| name)
-    .collect()
+/// The two shapes a test binary uses to take its lock.
+///
+/// A `-> &'static Mutex<()>` helper hands back the mutex, so the acquisition
+/// is `helper().lock()`. A `-> MutexGuard` helper takes the lock itself and
+/// hands back the guard, so calling it *is* the acquisition. Both are in the
+/// tree (`env_lock` and `clean_env`), and reading only the first shape reports
+/// every `clean_env()` test in `gitlab_tests` and `forge_tests` as unguarded.
+struct Locks {
+  /// Needs `.lock()` chained onto the call.
+  mutexes: Vec<String>,
+  /// The call alone acquires, because the guard is the return value.
+  providers: Vec<String>,
+}
+
+fn lock_helpers(source: &str) -> Locks {
+  let mut mutexes = Vec::new();
+  let mut providers = Vec::new();
+  for (name, body) in functions(source) {
+    let head = body.lines().next().unwrap_or_default();
+    if head.contains("MutexGuard") {
+      providers.push(name);
+    } else if head.contains("Mutex") {
+      mutexes.push(name);
+    }
+  }
+  Locks { mutexes, providers }
 }
 
 /// Byte offset of the first acquisition of one of `helpers`, if any.
-fn guard_at(body: &str, helpers: &[String]) -> Option<usize> {
-  helpers
-    .iter()
-    .filter_map(|h| {
-      let at = call_at(body, h)?;
-      // The acquisition, not just the helper: `env_lock()` alone hands back a
-      // reference and locks nothing.
-      body[at..].find(".lock()").map(|_| at)
-    })
-    .min()
+///
+/// The `.lock()` has to be chained to the helper call, not merely present
+/// somewhere after it: `env_lock(); reader(); other.lock();` returns a
+/// reference, reads unprotected, and then locks something unrelated, which an
+/// "is there a `.lock()` later" test reads as a guarded body.
+fn guard_at(body: &str, locks: &Locks) -> Option<usize> {
+  let chained = locks.mutexes.iter().filter_map(|h| {
+    let at = call_at(body, h)?;
+    let after = &body[at + h.len()..];
+    let after = after.strip_prefix('(')?;
+    let after = after.trim_start().strip_prefix(')')?;
+    // Allow the line break rustfmt inserts on a long chain.
+    after.trim_start().starts_with(".lock()").then_some(at)
+  });
+  let provided = locks.providers.iter().filter_map(|p| call_at(body, p));
+  chained.chain(provided).min()
 }
 
 #[test]
@@ -257,22 +290,41 @@ fn every_test_that_can_observe_a_rewritten_env_var_locks_first() {
     if file.contains("env_guard_invariant") {
       continue; // its own `set_var` strings are the fixture below
     }
-    let vars = mutated_vars(&source);
-    if vars.is_empty() {
+    // Membership is "does this binary rewrite the environment at all", not
+    // "does it name a variable we could parse". `forge_tests::clean_env` loops
+    // over a list and calls `remove_var(v)`, so the literal scan finds nothing
+    // and the binary would drop out of the audit entirely while the count
+    // stayed plausible.
+    if !source.contains("set_var(") && !source.contains("remove_var(") {
       continue;
     }
     audited += 1;
 
+    // Empty when every key is indirect; the readers derived from it are then
+    // empty too, and what still holds for the binary is the rule that the
+    // rewrite itself must be locked.
+    let vars = mutated_vars(&source);
     let readers = ambient_readers(&src, &vars);
     let helpers = lock_helpers(&source);
     for (name, body) in functions(&source) {
-      let Some((reader, read_at)) = readers
+      // The rewrite itself has to be serialised, not only the reads: a test
+      // that only calls `set_var` (seeding the environment for a child
+      // process, say) still races every concurrent reader, and matching no
+      // reader name would otherwise excuse it.
+      let mutation = ["set_var(", "remove_var("]
+        .iter()
+        .filter_map(|m| call_at(&body, m.trim_end_matches('(')))
+        .min();
+      let reader_hit = readers
         .iter()
         .filter(|r| body.contains(r.as_str()))
         .filter_map(|r| call_at(&body, r).map(|at| (r, at)))
-        .min_by_key(|(_, at)| *at)
-      else {
-        continue;
+        .min_by_key(|(_, at)| *at);
+      let (reader, read_at) = match (reader_hit, mutation) {
+        (Some((_, at)), Some(m)) if m < at => ("set_var/remove_var", m),
+        (Some((r, at)), _) => (r.as_str(), at),
+        (None, Some(m)) => ("set_var/remove_var", m),
+        (None, None) => continue,
       };
       match guard_at(&body, &helpers) {
         Some(lock_at) if lock_at < read_at => {}
@@ -286,8 +338,13 @@ fn every_test_that_can_observe_a_rewritten_env_var_locks_first() {
     }
   }
 
+  // A sweep that silently stops finding binaries reports "no offenders" for
+  // the same reason an empty one does. Ten rewrite the environment today,
+  // eleven counting this file, which is skipped because its own fixtures
+  // contain the strings being searched for. The floor moves up when one is
+  // added, never down without saying why.
   assert!(
-    audited >= 8,
+    audited >= 10,
     "expected the sweep to find the env-rewriting binaries, found {audited}"
   );
   assert!(
@@ -328,12 +385,17 @@ fn the_guard_can_actually_fire() {
   );
   assert!(!readers.contains("unrelated"), "and nothing else is");
 
-  let helpers = vec!["env_lock".to_string()];
+  let helpers = Locks {
+    mutexes: vec!["env_lock".to_string()],
+    providers: vec!["clean_env".to_string()],
+  };
   let before = "fn t() {\n  let _g = env_lock().lock().unwrap();\n  record();\n}\n";
   let after = "fn t() {\n  record();\n  let _g = env_lock().lock().unwrap();\n}\n";
   let none = "fn t() {\n  record();\n}\n";
   let prose = "fn t() {\n  // record() would read the journal path\n}\n";
   let longer = "fn t() {\n  wrapped_record();\n}\n";
+  let unchained = "fn t() {\n  env_lock();\n  record();\n  other.lock();\n}\n";
+  let provided = "fn t() {\n  let _g = clean_env();\n  record();\n}\n";
 
   assert!(
     guard_at(before, &helpers) < call_at(before, "record"),
@@ -344,6 +406,14 @@ fn the_guard_can_actually_fire() {
     "locked afterwards serialises nothing and must be caught"
   );
   assert!(guard_at(none, &helpers).is_none(), "no guard at all is caught");
+  assert!(
+    guard_at(unchained, &helpers).is_none(),
+    "the helper without a chained .lock() returns a reference and protects nothing, whatever locks later"
+  );
+  assert!(
+    guard_at(provided, &helpers) < call_at(provided, "record"),
+    "a helper that returns the guard acquires on call"
+  );
   assert!(call_at(prose, "record").is_none(), "prose is not a call");
   assert!(
     call_at(longer, "record").is_none(),

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -100,7 +100,16 @@ fn functions(source: &str) -> Vec<(String, String)> {
   for (i, start) in bytes.iter().enumerate() {
     let end = bytes.get(i + 1).copied().unwrap_or(source.len());
     let chunk = &source[*start..end];
-    let name = chunk[3..].split('(').next().unwrap_or_default().trim().to_string();
+    // Cut at `<` as well as `(`, or a generic function is dropped entirely:
+    // `run_gh<I, S>` reads `$GWM_GH` through `gh_program()`, and rejecting the
+    // name for its type parameters kept every wrapper of it out of the reader
+    // set.
+    let name = chunk[3..]
+      .split(['(', '<'])
+      .next()
+      .unwrap_or_default()
+      .trim()
+      .to_string();
     if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
       out.push((name, chunk.to_string()));
     }

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -2,147 +2,356 @@
 //! comment (issue #507).
 //!
 //! `std::env::set_var` is `unsafe` because it races a concurrent `getenv`, so
-//! a test binary that mutates a process-global variable has to serialise every
-//! test that can **observe** it. Each such binary keeps its own mutex for that,
-//! and the rule has so far lived in the mutex's doc comment. #503 is what a
-//! doc-comment rule is worth: it said "tests that expand a `{home}` pattern"
-//! while the real boundary was "tests that call `expand_placeholders`", and
-//! five tests were written against the narrower sentence.
+//! a test binary that rewrites a process-global variable has to serialise
+//! every test that can **observe** it. Each such binary keeps its own mutex
+//! for that, and the rule has so far lived in the mutex's doc comment. #503 is
+//! what a doc-comment rule is worth: it said "tests that expand a `{home}`
+//! pattern" while the real boundary was "tests that call
+//! `expand_placeholders`", and five tests were written against the sentence.
 //!
-//! So the rule is checked here instead. For each audited binary: every
-//! function that calls one of the listed **ambient readers** must also take
-//! that binary's lock.
+//! Nothing here is a hand-maintained list, because every hand-maintained list
+//! written while fixing #507 was wrong within the hour:
 //!
-//! An *ambient reader* is a function that resolves the variable itself. The
-//! distinction is the whole audit, and getting it wrong in either direction is
-//! easy:
+//! - naming four binaries missed the eight others that also call `set_var`;
+//! - naming the reader functions missed the wrappers that reach them
+//!   (`Config::load_exec_config` and `global_forge_host` both call
+//!   `global_config_path`, `history::record` calls `default_journal_path`);
+//! - looking for the text `lock()` accepts a lock taken *after* the read,
+//!   which serialises nothing.
 //!
-//! - `Config::load_layered` and `resolved_rows` take the global config path as
-//!   a **parameter**, so they read nothing. `Config::load_for_repo` calls
-//!   `global_config_path()`, so it does.
-//! - `resolve_global_config_path` takes every path as a parameter;
-//!   `global_config_path` reads `$XDG_CONFIG_HOME` and `dirs::home_dir()`. One
-//!   name contains the other, which is exactly how a substring search reports
-//!   five tests that are in fact clean.
+//! So all three are derived: the binaries from their own `set_var` calls, the
+//! readers from a transitive walk of `src/`, and the ordering from where the
+//! guard sits relative to the call.
 
-/// A test binary that mutates the environment, and what counts as observing it.
-struct Audited {
-  /// For the failure message.
-  file: &'static str,
-  /// The variable the binary rewrites with `set_var`.
-  var: &'static str,
-  /// Source of the binary, pulled in at compile time so this cannot drift
-  /// from what is on disk or depend on the working directory.
-  source: &'static str,
-  /// Functions that resolve `var` themselves, verified in `src/`.
-  ambient_readers: &'static [&'static str],
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
-const AUDITED: &[Audited] = &[
-  Audited {
-    file: "tests/config_tests.rs",
-    var: "HOME",
-    source: include_str!("config_tests.rs"),
-    // `expand_placeholders` resolves `dirs::home_dir()` before it looks at a
-    // single token, and ends with `shellexpand::tilde`. `load_for_repo`
-    // resolves the global config path, which reads `$HOME` on the way.
-    ambient_readers: &["expand_placeholders", "Config::load_for_repo"],
-  },
-  Audited {
-    file: "tests/config_global_tests.rs",
-    var: "XDG_CONFIG_HOME",
-    source: include_str!("config_global_tests.rs"),
-    ambient_readers: &["global_config_path", "Config::load_for_repo"],
-  },
-  Audited {
-    file: "tests/trust_tests.rs",
-    var: "GWM_TRUST_LEDGER",
-    source: include_str!("trust_tests.rs"),
-    ambient_readers: &["default_ledger_path"],
-  },
-  Audited {
-    file: "tests/history_tests.rs",
-    var: "GWM_HISTORY_FILE",
-    source: include_str!("history_tests.rs"),
-    ambient_readers: &["default_journal_path"],
-  },
-];
-
-/// Split a Rust source into `(name, body)` per top-level `fn`.
+/// Read a source file with CRLF normalised.
 ///
-/// CRLF is normalised first: a Windows checkout stores these files with `\r\n`
-/// and every line-anchored match would miss otherwise, leaving the guard green
-/// on exactly one of the three runners.
-fn functions(source: &str) -> Vec<(String, String)> {
-  let normalised = source.replace("\r\n", "\n");
+/// A Windows checkout stores these with `\r\n`, and every line-anchored match
+/// below would miss, leaving this guard green on exactly one of the three
+/// runners.
+fn read(path: &Path) -> String {
+  std::fs::read_to_string(path)
+    .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+    .replace("\r\n", "\n")
+}
+
+fn rs_files(dir: &Path) -> Vec<PathBuf> {
   let mut out = Vec::new();
-  for chunk in normalised.split("\nfn ").skip(1) {
-    let name = chunk.split('(').next().unwrap_or_default().to_string();
-    out.push((name, chunk.to_string()));
+  let mut stack = vec![dir.to_path_buf()];
+  while let Some(d) = stack.pop() {
+    for entry in std::fs::read_dir(&d).unwrap_or_else(|e| panic!("cannot list {}: {e}", d.display())) {
+      let path = entry.unwrap().path();
+      if path.is_dir() {
+        stack.push(path);
+      } else if path.extension().is_some_and(|e| e == "rs") {
+        out.push(path);
+      }
+    }
+  }
+  out.sort();
+  out
+}
+
+/// Every `(name, body)` pair in a Rust source, where the body runs to the next
+/// `fn`.
+///
+/// Deliberately over-approximating: a body that swallows a nested `fn` makes
+/// the outer one look like it calls what the inner one calls, which can only
+/// ever ask for *more* locking, never less. A guard that errs has to err
+/// towards failing.
+fn functions(source: &str) -> Vec<(String, String)> {
+  let mut out: Vec<(String, String)> = Vec::new();
+  let bytes: Vec<usize> = source
+    .match_indices("fn ")
+    .filter(|(at, _)| {
+      *at == 0
+        || !source[..*at]
+          .chars()
+          .next_back()
+          .is_some_and(|c| c.is_alphanumeric() || c == '_')
+    })
+    .map(|(at, _)| at)
+    .collect();
+  for (i, start) in bytes.iter().enumerate() {
+    let end = bytes.get(i + 1).copied().unwrap_or(source.len());
+    let chunk = &source[*start..end];
+    let name = chunk[3..].split('(').next().unwrap_or_default().trim().to_string();
+    if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+      out.push((name, chunk.to_string()));
+    }
   }
   out
 }
 
-/// Does `body` **call** `name`, as opposed to merely mentioning it?
-///
-/// Two exclusions, both learned from a search that got this wrong: a comment
-/// naming the function is not a call (five of the six `load_for_repo` mentions
-/// in `config_tests.rs` are prose), and a longer identifier ending in `name` is
-/// a different function (`resolve_global_config_path` is not
-/// `global_config_path`).
-fn calls(body: &str, name: &str) -> bool {
-  body.lines().filter(|l| !l.trim_start().starts_with("//")).any(|line| {
-    line.match_indices(name).any(|(at, _)| {
-      let before_ok = at == 0
-        || !line[..at]
-          .chars()
-          .next_back()
-          .is_some_and(|c| c.is_alphanumeric() || c == '_');
-      let after_ok = line[at + name.len()..].starts_with('(');
-      before_ok && after_ok
-    })
-  })
+/// Lines that are not comments. A function named in prose is not called by it,
+/// which is how a first pass counted five comments as calls to
+/// `Config::load_for_repo`.
+fn code_lines(body: &str) -> impl Iterator<Item = &str> {
+  body.lines().filter(|l| !l.trim_start().starts_with("//"))
 }
 
-#[test]
-fn every_test_that_can_observe_a_mutated_env_var_takes_its_lock() {
-  let mut offenders = Vec::new();
-  for binary in AUDITED {
-    for (name, body) in functions(binary.source) {
-      let reader = binary.ambient_readers.iter().find(|r| calls(&body, r));
-      if let Some(reader) = reader {
-        if !body.contains("lock()") {
-          offenders.push(format!(
-            "{}::{} calls {} (an ambient ${} reader) without taking the binary's lock",
-            binary.file, name, reader, binary.var
-          ));
+/// Byte offset of the first **call** to `name` in `body`, if any.
+///
+/// A call, not a mention: the character before must not be part of an
+/// identifier (so `resolve_global_config_path` is not `global_config_path`)
+/// and the next must be `(`.
+fn call_at(body: &str, name: &str) -> Option<usize> {
+  let mut offset = 0usize;
+  for line in body.lines() {
+    let line_len = line.len() + 1;
+    if !line.trim_start().starts_with("//") {
+      for (at, _) in line.match_indices(name) {
+        let before_ok = at == 0
+          || !line[..at]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if before_ok && line[at + name.len()..].starts_with('(') {
+          return Some(offset + at);
+        }
+      }
+    }
+    offset += line_len;
+  }
+  None
+}
+
+/// Environment variables `source` rewrites with `set_var` / `remove_var`.
+fn mutated_vars(source: &str) -> BTreeSet<String> {
+  let mut out = BTreeSet::new();
+  for line in code_lines(source) {
+    for call in ["set_var(\"", "remove_var(\""] {
+      let mut rest = line;
+      while let Some(at) = rest.find(call) {
+        rest = &rest[at + call.len()..];
+        if let Some(end) = rest.find('"') {
+          out.insert(rest[..end].to_string());
         }
       }
     }
   }
+  out
+}
+
+/// Names carried by exactly one function in `src/`.
+///
+/// Matching happens by name, with no scope resolution, so a name several
+/// functions share cannot be attributed: `new` and `default` exist on dozens
+/// of types, one of which reaches `dirs::home_dir()`, and treating that as a
+/// reader made every `TempDir::new()` in the suite an offender. Restricting to
+/// unambiguous names is the honest bound, and it is a bound: a reader whose
+/// name collides with anything is invisible here, so the doc comments still
+/// carry the rule for those.
+fn unambiguous(src: &[(String, String)]) -> BTreeSet<String> {
+  let mut seen: std::collections::BTreeMap<&str, usize> = Default::default();
+  for (name, _) in src {
+    *seen.entry(name.as_str()).or_default() += 1;
+  }
+  seen
+    .into_iter()
+    .filter(|(_, n)| *n == 1)
+    .map(|(name, _)| name.to_string())
+    .collect()
+}
+
+/// Functions in `src/` that can observe any of `vars`, transitively.
+///
+/// Seeded with the ones that read the variable themselves, then closed over
+/// callers until it stops growing: `default_journal_path` reads
+/// `$GWM_HISTORY_FILE`, so `history::record`, which calls it, observes it too,
+/// and so does anything calling *that*.
+///
+/// `$HOME` is seeded differently because nothing reads it by name: it is
+/// reached through `dirs::home_dir()`, and through the `shellexpand::tilde`
+/// pass `expand_placeholders` ends with.
+fn ambient_readers(src: &[(String, String)], vars: &BTreeSet<String>) -> BTreeSet<String> {
+  let unique = unambiguous(src);
+  let mut seeds: Vec<String> = Vec::new();
+  for var in vars {
+    if var == "HOME" {
+      seeds.push("dirs::home_dir(".into());
+      seeds.push("shellexpand::tilde(".into());
+    } else {
+      seeds.push(format!("env::var(\"{var}\""));
+      seeds.push(format!("env::var_os(\"{var}\""));
+    }
+  }
+
+  let mut readers: BTreeSet<String> = src
+    .iter()
+    .filter(|(name, _)| unique.contains(name.as_str()))
+    .filter(|(_, body)| code_lines(body).any(|l| seeds.iter().any(|s| l.contains(s.as_str()))))
+    .map(|(name, _)| name.clone())
+    .collect();
+
+  loop {
+    let mut grew = false;
+    for (name, body) in src {
+      if readers.contains(name) || !unique.contains(name.as_str()) {
+        continue;
+      }
+      // `contains` first: `call_at` walks the body line by line, and skipping
+      // it for the overwhelming majority that do not mention the name at all
+      // is the difference between a second and a minute.
+      if readers
+        .iter()
+        .any(|r| body.contains(r.as_str()) && call_at(body, r).is_some())
+      {
+        readers.insert(name.clone());
+        grew = true;
+      }
+    }
+    if !grew {
+      break;
+    }
+  }
+  readers
+}
+
+/// Names of the `-> &'static std::sync::Mutex` helpers a test binary defines.
+/// Its guard is `<name>().lock()`, whatever the binary chose to call it.
+fn lock_helpers(source: &str) -> Vec<String> {
+  functions(source)
+    .into_iter()
+    .filter(|(_, body)| {
+      let head = body.lines().next().unwrap_or_default();
+      head.contains("Mutex")
+    })
+    .map(|(name, _)| name)
+    .collect()
+}
+
+/// Byte offset of the first acquisition of one of `helpers`, if any.
+fn guard_at(body: &str, helpers: &[String]) -> Option<usize> {
+  helpers
+    .iter()
+    .filter_map(|h| {
+      let at = call_at(body, h)?;
+      // The acquisition, not just the helper: `env_lock()` alone hands back a
+      // reference and locks nothing.
+      body[at..].find(".lock()").map(|_| at)
+    })
+    .min()
+}
+
+#[test]
+fn every_test_that_can_observe_a_rewritten_env_var_locks_first() {
+  let root = repo_root();
+  let src: Vec<(String, String)> = rs_files(&root.join("src"))
+    .iter()
+    .flat_map(|p| functions(&read(p)))
+    .collect();
+
+  let mut audited = 0usize;
+  let mut offenders = Vec::new();
+
+  for path in rs_files(&root.join("tests")) {
+    let source = read(&path);
+    let file = path.strip_prefix(&root).unwrap_or(&path).display().to_string();
+    if file.contains("env_guard_invariant") {
+      continue; // its own `set_var` strings are the fixture below
+    }
+    let vars = mutated_vars(&source);
+    if vars.is_empty() {
+      continue;
+    }
+    audited += 1;
+
+    let readers = ambient_readers(&src, &vars);
+    let helpers = lock_helpers(&source);
+    for (name, body) in functions(&source) {
+      let Some((reader, read_at)) = readers
+        .iter()
+        .filter(|r| body.contains(r.as_str()))
+        .filter_map(|r| call_at(&body, r).map(|at| (r, at)))
+        .min_by_key(|(_, at)| *at)
+      else {
+        continue;
+      };
+      match guard_at(&body, &helpers) {
+        Some(lock_at) if lock_at < read_at => {}
+        Some(_) => offenders.push(format!(
+          "{file}::{name} takes its lock AFTER calling {reader}, which serialises nothing (vars: {vars:?})"
+        )),
+        None => offenders.push(format!(
+          "{file}::{name} calls {reader}, which can observe {vars:?}, without taking the binary's lock"
+        )),
+      }
+    }
+  }
+
+  assert!(
+    audited >= 8,
+    "expected the sweep to find the env-rewriting binaries, found {audited}"
+  );
   assert!(
     offenders.is_empty(),
-    "a test that can observe a rewritten environment variable must be serialised against the rewrite:\n  {}",
+    "a test that can observe a rewritten environment variable must hold the lock across the read:\n  {}",
     offenders.join("\n  ")
   );
 }
 
 #[test]
 fn the_guard_can_actually_fire() {
-  // A guard that never matches passes vacuously, and this one is built from
-  // two exclusions that could each silently swallow every call. So: the same
-  // predicate, against a body written here, in both directions.
-  let guarded = "  let _g = env_lock().lock().unwrap();\n  expand_placeholders(\"{home}\", ...);\n";
-  let bare = "  expand_placeholders(\"{home}\", ...);\n";
-  let commented = "  // expand_placeholders(\"{home}\") would read $HOME\n";
-  let longer_name = "  resolve_expand_placeholders(...);\n";
+  // A guard built from three exclusions can pass by matching nothing, so each
+  // one is exercised in both directions against bodies written here.
+  let src = vec![
+    (
+      "default_journal_path".to_string(),
+      "fn default_journal_path() {\n  std::env::var(\"GWM_HISTORY_FILE\")\n}\n".to_string(),
+    ),
+    (
+      "record".to_string(),
+      "fn record() {\n  default_journal_path();\n}\n".to_string(),
+    ),
+    (
+      "unrelated".to_string(),
+      "fn unrelated() {\n  something_else();\n}\n".to_string(),
+    ),
+  ];
+  let vars: BTreeSet<String> = ["GWM_HISTORY_FILE".to_string()].into_iter().collect();
+  let readers = ambient_readers(&src, &vars);
 
-  assert!(calls(bare, "expand_placeholders"), "a bare call must be seen");
-  assert!(calls(guarded, "expand_placeholders"), "a guarded call is still a call");
-  assert!(guarded.contains("lock()"), "and the guard is what makes it acceptable");
-  assert!(!calls(commented, "expand_placeholders"), "prose is not a call");
   assert!(
-    !calls(longer_name, "expand_placeholders"),
+    readers.contains("default_journal_path"),
+    "the direct reader is a reader"
+  );
+  assert!(
+    readers.contains("record"),
+    "a wrapper reaching it transitively is one too, which a list of direct names misses"
+  );
+  assert!(!readers.contains("unrelated"), "and nothing else is");
+
+  let helpers = vec!["env_lock".to_string()];
+  let before = "fn t() {\n  let _g = env_lock().lock().unwrap();\n  record();\n}\n";
+  let after = "fn t() {\n  record();\n  let _g = env_lock().lock().unwrap();\n}\n";
+  let none = "fn t() {\n  record();\n}\n";
+  let prose = "fn t() {\n  // record() would read the journal path\n}\n";
+  let longer = "fn t() {\n  wrapped_record();\n}\n";
+
+  assert!(
+    guard_at(before, &helpers) < call_at(before, "record"),
+    "locked first is fine"
+  );
+  assert!(
+    guard_at(after, &helpers) > call_at(after, "record"),
+    "locked afterwards serialises nothing and must be caught"
+  );
+  assert!(guard_at(none, &helpers).is_none(), "no guard at all is caught");
+  assert!(call_at(prose, "record").is_none(), "prose is not a call");
+  assert!(
+    call_at(longer, "record").is_none(),
     "a longer identifier is a different function"
+  );
+  assert_eq!(
+    mutated_vars("  std::env::set_var(\"GWM_HISTORY_FILE\", p);\n"),
+    vars,
+    "the binary's own set_var is what says which variable it rewrites"
   );
 }

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -34,6 +34,13 @@
 //! binaries whose own rewritten-variable set is empty. That trades a targeted
 //! guard for one whose failures carry no information, so the bound stays and
 //! is written here instead.
+//!
+//! The guard's *scope* is also unchecked: the comparison is positional, so a
+//! lock acquired inside an inner block, or dropped before the read, would
+//! satisfy it. Following scope means tracking blocks, which is the next step
+//! towards a parser; measured against the tree, no audited binary takes its
+//! lock in an inner block and the only `drop(` in one drops a repo handle. So
+//! the ordering check is what is claimed here, and no more.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -135,16 +142,56 @@ fn call_at(body: &str, name: &str) -> Option<usize> {
 }
 
 /// Environment variables `source` rewrites with `set_var` / `remove_var`.
+///
+/// Literal keys are read off the call. When a key is *not* a literal, nothing
+/// in the file says which variable it is:
+/// `forge_tests::clean_env` loops over an array and calls `remove_var(v)`, so
+/// reading only literal calls returns nothing and the binary's readers are
+/// never derived, which is the whole audit silently skipped.
+///
+/// The fallback for that case is to take every environment-shaped literal in
+/// the file, `SCREAMING_SNAKE` and at least three characters. It over-collects
+/// (a `"GITLAB_CI"` used for something else joins the set) and that is the
+/// safe direction: a variable that is not really rewritten can only make the
+/// sweep ask for more locking.
 fn mutated_vars(source: &str) -> BTreeSet<String> {
   let mut out = BTreeSet::new();
+  let mut indirect = false;
   for line in code_lines(source) {
-    for call in ["set_var(\"", "remove_var(\""] {
+    for call in ["set_var(", "remove_var("] {
       let mut rest = line;
       while let Some(at) = rest.find(call) {
         rest = &rest[at + call.len()..];
-        if let Some(end) = rest.find('"') {
-          out.insert(rest[..end].to_string());
+        match rest.strip_prefix('"') {
+          Some(after) => {
+            if let Some(end) = after.find('"') {
+              out.insert(after[..end].to_string());
+            }
+          }
+          None => indirect = true,
         }
+      }
+    }
+  }
+  if indirect {
+    out.extend(env_shaped_literals(source));
+  }
+  out
+}
+
+/// Every `"SCREAMING_SNAKE"` string literal in `source`.
+fn env_shaped_literals(source: &str) -> BTreeSet<String> {
+  let mut out = BTreeSet::new();
+  for line in code_lines(source) {
+    for (i, piece) in line.split('"').enumerate() {
+      let inside_quotes = i % 2 == 1;
+      let shaped = piece.len() >= 3
+        && piece
+          .chars()
+          .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && piece.chars().next().is_some_and(|c| c.is_ascii_uppercase());
+      if inside_quotes && shaped {
+        out.insert(piece.to_string());
       }
     }
   }

--- a/tests/env_guard_invariant_tests.rs
+++ b/tests/env_guard_invariant_tests.rs
@@ -195,9 +195,15 @@ fn ambient_readers(src: &[(String, String)], vars: &BTreeSet<String>) -> BTreeSe
     }
   }
 
+  // Direct readers are kept whatever their name collides with. The unique-name
+  // rule below exists to stop the *transitive* walk from reaching `new` and
+  // `default`, and applying it here instead dropped `expand_placeholders`,
+  // which `config.rs` and `lifecycle.rs` both define: the guard then stayed
+  // green with the lock deleted from the very test #503 was about. Measured,
+  // the direct readers are seven specific names, none of them generic, so
+  // there is nothing to protect against here.
   let mut readers: BTreeSet<String> = src
     .iter()
-    .filter(|(name, _)| unique.contains(name.as_str()))
     .filter(|(_, body)| code_lines(body).any(|l| seeds.iter().any(|s| l.contains(s.as_str()))))
     .map(|(name, _)| name.clone())
     .collect();
@@ -295,7 +301,7 @@ fn every_test_that_can_observe_a_rewritten_env_var_locks_first() {
     // over a list and calls `remove_var(v)`, so the literal scan finds nothing
     // and the binary would drop out of the audit entirely while the count
     // stayed plausible.
-    if !source.contains("set_var(") && !source.contains("remove_var(") {
+    if call_at(&source, "set_var").is_none() && call_at(&source, "remove_var").is_none() {
       continue;
     }
     audited += 1;
@@ -339,12 +345,14 @@ fn every_test_that_can_observe_a_rewritten_env_var_locks_first() {
   }
 
   // A sweep that silently stops finding binaries reports "no offenders" for
-  // the same reason an empty one does. Ten rewrite the environment today,
-  // eleven counting this file, which is skipped because its own fixtures
-  // contain the strings being searched for. The floor moves up when one is
-  // added, never down without saying why.
+  // the same reason an empty one does. Nine rewrite the environment today
+  // (this file is skipped: its own fixtures contain the strings being searched
+  // for). The floor moves up when a binary is added, never down without saying
+  // why. It read ten until the membership test became a call rather than a
+  // substring: `bootstrap_when_tests` mutates nothing, and was counted for the
+  // `set_var(` inside `env_set_false_for_unset_var()`.
   assert!(
-    audited >= 10,
+    audited >= 9,
     "expected the sweep to find the env-rewriting binaries, found {audited}"
   );
   assert!(
@@ -423,5 +431,32 @@ fn the_guard_can_actually_fire() {
     mutated_vars("  std::env::set_var(\"GWM_HISTORY_FILE\", p);\n"),
     vars,
     "the binary's own set_var is what says which variable it rewrites"
+  );
+}
+
+#[test]
+fn the_reader_that_started_all_this_is_derived_from_the_real_source() {
+  // #503 was `expand_placeholders` reached without the lock, so a guard that
+  // does not classify *that* function as a reader is worth nothing whatever
+  // else it checks. This is not hypothetical: the unique-name filter dropped
+  // it, because `config.rs` and `lifecycle.rs` both define a function by that
+  // name, and the sweep stayed green with the lock deleted from the very test
+  // the issue was about. Derived from the real tree, not a fixture, because
+  // that is the part that broke.
+  let src: Vec<(String, String)> = rs_files(&repo_root().join("src"))
+    .iter()
+    .flat_map(|p| functions(&read(p)))
+    .collect();
+  let home: BTreeSet<String> = ["HOME".to_string()].into_iter().collect();
+  let readers = ambient_readers(&src, &home);
+
+  assert!(
+    readers.contains("expand_placeholders"),
+    "the function #503 is about must be classified as a $HOME reader, got {} readers",
+    readers.len()
+  );
+  assert!(
+    readers.contains("global_config_path"),
+    "and so must the resolver behind Config::load_for_repo"
   );
 }

--- a/tests/history_tests.rs
+++ b/tests/history_tests.rs
@@ -65,6 +65,7 @@ fn load_returns_empty_on_missing_file() {
 
 #[test]
 fn append_then_load_roundtrips_entry() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // Append an entry, persist to disk, reload. The reloaded journal
   // must contain the exact same entry — TOML round-trip is the IO
   // backbone of the whole feature.
@@ -90,6 +91,7 @@ fn append_then_load_roundtrips_entry() {
 
 #[test]
 fn rotation_caps_at_one_hundred_entries() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // Cap is 100 entries TOTAL across all repos. On append #101, drop
   // the oldest. This pins the rotation contract — the journal must
   // not grow unbounded.
@@ -121,6 +123,7 @@ fn rotation_caps_at_one_hundred_entries() {
 
 #[test]
 fn entries_for_repo_filters_by_repo_root() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // The journal is global (one file across all repos). `entries_for_repo`
   // must return only the ops whose `repo_root` matches verbatim — that
   // is the per-repo separation `gwm undo` and `gwm history` rely on so
@@ -148,6 +151,7 @@ fn entries_for_repo_filters_by_repo_root() {
 
 #[test]
 fn last_for_repo_returns_most_recent_entry() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // `gwm undo` pulls the *most recent* op for the current repo. Pin
   // the ordering contract: entries are listed newest-first via
   // `last_for_repo` regardless of insertion order.
@@ -174,6 +178,7 @@ fn last_for_repo_returns_most_recent_entry() {
 
 #[test]
 fn last_for_repo_returns_none_for_unknown_repo() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // If no ops have been recorded for the current repo, `last_for_repo`
   // returns `None` — `gwm undo` then prints "nothing to undo" rather
   // than crashing.
@@ -192,6 +197,7 @@ fn last_for_repo_returns_none_for_unknown_repo() {
 
 #[test]
 fn pop_last_for_repo_removes_and_returns_entry() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // After a successful undo, `gwm undo` needs to drop the entry so a
   // second `undo` resurfaces the previous op instead of replaying the
   // same one. `pop_last_for_repo` must atomically return-and-remove

--- a/tests/json_api_tests.rs
+++ b/tests/json_api_tests.rs
@@ -11,6 +11,20 @@ use gwm::worktree::{BranchStatus, WorktreeInfo};
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// Process-global lock for this binary's environment rewrite, held across any
+/// read that could observe it (issue #507).
+///
+/// Only one test here rewrites `$GWM_AGENTS_HOME`, and it is also the only
+/// reader, so the lock is uncontended today. It exists so the next test on
+/// either side inherits the rule instead of having to notice it, which is what
+/// `tests/env_guard_invariant_tests.rs` checks. Distinct from the helpers in
+/// the other suites on purpose: separate cargo-test binaries are separate
+/// processes, so a shared one would buy nothing.
+fn env_lock() -> &'static std::sync::Mutex<()> {
+  static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+  LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
 fn sample_worktree() -> WorktreeInfo {
   let mut link = BranchLink::empty();
   link.issue = Some(42);
@@ -206,6 +220,7 @@ fn json_worktree_vec_decodes_from_a_daemon_list_result() {
 /// attach_agents caller, so the env var and the cache stay uncontended.
 #[test]
 fn attach_agents_reuses_detection_within_the_ttl() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let home = tempfile::TempDir::new().unwrap();
   // SAFETY-of-intent: single test touching this var in this binary.
   std::env::set_var("GWM_AGENTS_HOME", home.path());

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6873,6 +6873,7 @@ fn toml_basic_string(path: &std::path::Path) -> String {
 
 #[test]
 fn tui_gate_passes_when_no_gwm_toml_present() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // The CLI gate is a no-op when `.gwm.toml` doesn't exist — same
   // contract on the TUI side. Construction with `init_repo`'s empty
   // workdir already covers this.
@@ -6885,6 +6886,7 @@ fn tui_gate_passes_when_no_gwm_toml_present() {
 
 #[test]
 fn tui_gate_passes_on_empty_bootstrap_surface() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // A `.gwm.toml` with only `[worktree]` (no executable surface)
   // carries no RCE risk. Prompting in that case would just train
   // the user to mash `y` — same UX bug the CLI gate avoids.
@@ -6959,6 +6961,7 @@ run  = "true"
 
 #[test]
 fn tui_gate_clears_under_allow_mode() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // `--allow-bootstrap` (resolved to `TrustMode::Allow` at the
   // entrypoint) bypasses the gate. Threading it through
   // `with_trust_mode` is the whole reason for this PR follow-up —
@@ -6978,6 +6981,7 @@ run  = "true"
 
 #[test]
 fn tui_gate_refuses_under_deny_mode_even_with_safe_config() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // `--deny-bootstrap` is the forensic mode: refuse even if there's
   // nothing scary. The empty-surface short-circuit comes BEFORE the
   // Deny check inside `evaluate`, so a truly empty surface still
@@ -7091,6 +7095,7 @@ fn fill_create_form(app: &mut App, issue: &str, desc: &str) {
 
 #[test]
 fn submit_create_starts_async_create_and_keeps_create_modal_open() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   use gwm::tui::state::async_task::TaskKind;
 
   let base_dir = tempfile::TempDir::new().unwrap();
@@ -7278,6 +7283,7 @@ run  = "echo trapped"
 
 #[test]
 fn bootstrap_selected_with_no_selection_reports_and_does_not_load() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   // The early guard runs before the trust gate and the spawn: with nothing
   // selected there is no worktree to bootstrap, so no generation is claimed.
   let (_dir, mut app) = make_app();
@@ -11397,6 +11403,7 @@ fn enter_submits_from_the_last_field_whatever_the_pattern_calls_it() {
 /// repo still failed with `invalid issue number ''`.
 #[test]
 fn submitting_the_create_form_does_not_demand_a_segment_the_patterns_discard() {
+  let _env = env_lock().lock().unwrap_or_else(|e| e.into_inner());
   let (_d, mut app) = app_with_patterns("{type}/{desc}", "{type}-{desc}", "{repo_parent}/wt");
   app.enter_create();
   for c in "thing".chars() {


### PR DESCRIPTION
## Description

#507 as filed describes a race that does not exist. The premise was verified
before any code was written and it does not hold, so what this PR delivers is
the part that survives: the rule has now been stated wrongly twice in a doc
comment, so it stops being prose and becomes a test.

Closes #507

## Type of change

- [x] ✅ Tests
- [x] 📝 Docs

## Changes

- `tests/env_guard_invariant_tests.rs`: walks the four test binaries that
  rewrite an environment variable and fails on any test that calls an ambient
  reader of that variable without holding the binary's lock. A companion test
  exercises the matcher in both directions so the guard cannot pass by
  matching nothing.
- `tests/config_tests.rs`: `env_lock`'s doc no longer claims a layered load
  reads `$HOME`.
- `CHANGELOG.md` under `## [Unreleased]`.

## Tests

- [x] `cargo test` passes locally (91 binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Run under a CI-like stripped environment too, since this is entirely about
environment-dependent tests:

```
PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test   # exit 0
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #507, with the correction posted as a comment there.
- Follows #505, which is where the wrong doc comment was introduced.

## Notes for reviewers

**Why the issue was wrong, since the PR is shaped by it.**
`Config::load_layered(repo_root, global_path)` takes the global config path as
a parameter and resolves nothing; `Config::load_for_repo` is the one that calls
`global_config_path()`. No test in `config_tests.rs` calls it: of six
occurrences of the name, five are comments and the sixth is a test's own name.

**The audit is the test.** An *ambient reader* is a function that resolves the
variable itself, and telling one from a pure function that takes paths as
parameters is the entire exercise. Both naive searches failed, in opposite
directions:

- substring on `load_for_repo` counts five comments as calls;
- substring on `global_config_path` reports every `resolve_global_config_path`
  test as an offender.

The matcher therefore skips comment lines and requires a non-identifier
character before the name and a `(` after it, and `the_guard_can_actually_fire`
pins both.

**Red proven.** Deleting the `env_lock()` line from one real test makes the
invariant fail naming that test and its file. Restored, 91 binaries are green.

**What it does not do.** It does not detect a reader reached indirectly, only a
direct call to a listed name. That is a deliberate floor: the list of ambient
readers is short, verified against `src/`, and carries a comment saying what
qualifies, so extending it is a one-line change when a new one appears.
