### PR TITLE
👷 ci: ring the docs site bell when main moves

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -26,6 +26,12 @@ on:
     paths:
       - 'docs/**'
       - 'changelogs/**'
+      # Not documentation, but the site reads it: the sync script pulls the
+      # `[package]` version out of it for the release badge in the header.
+      # A release usually moves `changelogs/` in the same push, so this only
+      # matters when a version bump travels alone, which is exactly the case
+      # nobody would think to check.
+      - 'Cargo.toml'
   workflow_dispatch:
 
 # The dispatch authenticates with a PAT scoped to the docs repository; the

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,65 @@
+name: docs-sync
+
+# The published documentation follows `main`, never `dev`.
+#
+# `main` is reached exclusively through a `dev` → `main` pull request, so what
+# lands here is what was delivered — which is exactly what the site should
+# serve. Triggering on `dev` would publish pages describing behaviour nobody
+# can install yet; triggering on tags would be worse still, since GitHub's
+# `v*.*.*` glob also matches `v0.8.0-rc.4` (the trap `release.yml` guards
+# against by hand) and every release candidate's docs would go live as stable.
+#
+# The split of work is deliberate: this repo owns the documentation sources
+# (`docs/`, `changelogs/`) and nothing else. The conversion script, the
+# Starlight site and the deploy live in `kbrdn1/kbrdn-docs`, so this workflow
+# only rings the bell. Doing the sync here would drag a Bun monorepo into the
+# CLI's CI for a build this repo cannot verify.
+#
+# Bootstrap: see CONTRIBUTING.md > Releases > Documentation site.
+
+on:
+  push:
+    branches: [main]
+    # Kept in step with the roots the site's sync script reads. A root dropped
+    # here fails silently — the site just stops refreshing — so
+    # `tests/release_workflow_tests.rs` pins the list.
+    paths:
+      - 'docs/**'
+      - 'changelogs/**'
+  workflow_dispatch:
+
+# The dispatch authenticates with a PAT scoped to the docs repository; the
+# workflow token needs nothing at all.
+permissions: {}
+
+jobs:
+  notify:
+    name: notify kbrdn-docs
+    runs-on: ubuntu-latest
+    # While DOCS_SITE_TOKEN is being provisioned the first time, a missing
+    # secret would paint the merge to `main` red for a docs refresh that can be
+    # re-driven by hand at any time (`gh workflow run docs-sync.yml`). Flip to
+    # false once the first dispatch has succeeded.
+    continue-on-error: true
+    steps:
+      - name: verify DOCS_SITE_TOKEN is configured
+        env:
+          DOCS_SITE_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
+        run: |
+          if [ -z "${DOCS_SITE_TOKEN:-}" ]; then
+            echo "::error::DOCS_SITE_TOKEN secret is not configured."
+            echo "Bootstrap: see CONTRIBUTING.md > Releases > Documentation site."
+            exit 1
+          fi
+
+      # No checkout: the docs repository reads this repo itself, at the commit
+      # `main` points to when it runs. Two merges in quick succession therefore
+      # converge on the later one instead of racing, and this job stays a
+      # single API call with nothing on disk to leak.
+      - name: dispatch the docs sync
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
+        run: |
+          gh api repos/kbrdn1/kbrdn-docs/dispatches \
+            --method POST \
+            -f event_type=gwm-docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -603,6 +603,40 @@ The tag's `v` prefix is stripped to match the winget `PackageVersion`, and the m
 
 If the channel is unblocked and the manual flow proves routine, the job can come back — deleting the pin test is the first step of that change, and the removed job (pinned, digest-anchored komac; see the git history of `release.yml` at #448) is the starting point.
 
+### Documentation site (<https://gwm-docs.kbrdn.dev>)
+
+The published documentation follows `main`, not `dev`. Every push to `main` that touches `docs/` or `changelogs/` fires [`docs-sync.yml`](.github/workflows/docs-sync.yml), which sends a `repository_dispatch` to [`kbrdn1/kbrdn-docs`](https://github.com/kbrdn1/kbrdn-docs); that repo replays the conversion into its Starlight site, commits the drift and deploys.
+
+`main` is the right trigger precisely because it is only ever reached through a `dev` → `main` pull request: what lands there is what was delivered. `dev` would publish pages describing behaviour nobody can install yet, and a tag trigger would be worse still, since GitHub's `v*.*.*` glob matches `-rc.N` too and every release candidate's docs would go live as if they were stable. [`tests/release_workflow_tests.rs`](tests/release_workflow_tests.rs) pins both the branch and the watched paths.
+
+Nothing about the site lives in this repo: the conversion script, the Starlight theme and the Cloudflare Pages deploy all belong to `kbrdn-docs`. This side owns the Markdown sources and the bell.
+
+One asymmetry is worth knowing before you go looking for it: `docs/index.md` and `docs/fr/index.md` are **not** ported. The site has its own hand-written landing pages, which the sync deliberately preserves. Editing either file therefore fires the workflow, produces no drift and finishes green without changing anything online. Every other page under `docs/`, plus `changelogs/`, does travel.
+
+#### One-time bootstrap (maintainer)
+
+Same shape as the Homebrew tap, with a token scoped to the docs repo:
+
+1. Generate a fine-grained PAT at <https://github.com/settings/personal-access-tokens/new>:
+   - **Repository access**: select `kbrdn1/kbrdn-docs` only.
+   - **Permissions**: Contents → **Read and write**. Nothing else: that is the documented requirement for `POST /repos/{owner}/{repo}/dispatches`.
+   - **Expiration**: ≥ 1 year (set a calendar reminder to rotate).
+2. Add it as the `DOCS_SITE_TOKEN` secret on `gwm-cli`: <https://github.com/kbrdn1/gwm-cli/settings/secrets/actions/new>.
+3. Flip `continue-on-error: true` to `false` on the `notify` job in [`docs-sync.yml`](.github/workflows/docs-sync.yml) after the first successful dispatch.
+
+Note that this is a write credential for a **private** repository, held in a public repository's secrets. It sits at the same trust level as `HOMEBREW_TAP_TOKEN` and `SCOOP_BUCKET_TOKEN`, which push to repositories of their own.
+
+The deploy itself needs three more settings, all on `kbrdn-docs` and none of them here: the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets, the `DEPLOY_ENABLED` repository variable, and a Cloudflare Pages project named `gwm-docs`. Until they exist the sync still runs and commits, but the deploy job skips. The custom domain is attached to the Pages project itself; `gwm-docs.pages.dev` stays served alongside it and cannot be removed, which is why `site:` in `sites/gwm/astro.config.mjs` pins the custom one: that value is what ships in the sitemap and the canonical URLs.
+
+#### Re-running a missed sync
+
+The dispatch is a single API call with no state, so re-drive it from either end:
+
+```bash
+gh workflow run docs-sync.yml --ref main                       # from gwm-cli
+gh workflow run sync-gwm.yml --ref main -R kbrdn1/kbrdn-docs   # or straight at the site
+```
+
 ---
 
 By contributing, you agree your changes are licensed under the MIT License (see `LICENSE.md`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -622,7 +622,8 @@ Same shape as the Homebrew tap, with a token scoped to the docs repo:
    - **Permissions**: Contents → **Read and write**. Nothing else: that is the documented requirement for `POST /repos/{owner}/{repo}/dispatches`.
    - **Expiration**: ≥ 1 year (set a calendar reminder to rotate).
 2. Add it as the `DOCS_SITE_TOKEN` secret on `gwm-cli`: <https://github.com/kbrdn1/gwm-cli/settings/secrets/actions/new>.
-3. Flip `continue-on-error: true` to `false` on the `notify` job in [`docs-sync.yml`](.github/workflows/docs-sync.yml) after the first successful dispatch.
+3. Land `sync-gwm.yml` on the **default branch** of `kbrdn-docs`. This one is easy to miss because nothing reports it: GitHub only ever runs a `repository_dispatch` receiver from the default branch, so while that file sits on a feature branch the API call returns `204`, this workflow goes green, and nothing syncs. There is no failure anywhere to notice.
+4. Flip `continue-on-error: true` to `false` on the `notify` job in [`docs-sync.yml`](.github/workflows/docs-sync.yml) after the first successful dispatch.
 
 Note that this is a write credential for a **private** repository, held in a public repository's secrets. It sits at the same trust level as `HOMEBREW_TAP_TOKEN` and `SCOOP_BUCKET_TOKEN`, which push to repositories of their own.
 

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -138,12 +138,21 @@ fn workflow_paths() -> Vec<String> {
 /// (it owns the audited token split above), everything else is swept.
 #[test]
 fn sibling_workflow_checkouts_do_not_persist_credentials() {
-  let release = ".github/workflows/release.yml";
   let mut swept = 0;
   let mut audited = 0;
 
   for path in workflow_paths() {
-    if path == release {
+    // By file name, not by path: `read_dir` joins with the platform separator,
+    // so a full-path comparison against `.github/workflows/release.yml` misses
+    // on Windows, and the one workflow that is *supposed* to carry a token
+    // gets swept with the rest. Caught by `test (windows-latest)`, green on
+    // the other two runners.
+    //
+    // And by the whole name, not a suffix: `pre-release.yml` ends with
+    // `release.yml`, so `ends_with` would drop a workflow that must be
+    // audited. The `swept` floor below is what would catch that.
+    let is_release = Path::new(&path).file_name().and_then(|f| f.to_str()) == Some("release.yml");
+    if is_release {
       continue;
     }
     swept += 1;

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -111,20 +111,44 @@ fn release_workflow_checkouts_without_a_token_do_not_persist_credentials() {
   );
 }
 
-/// #433, the follow-up to #429/#432: the sibling workflows carry the same
-/// shape, and none of their checkouts pushes — `ci.yml` is entirely read-only
-/// and `pre-release.yml` publishes through `gh` with an env token, never
-/// `git push`. No checkout here has any business passing `token:`, so the rule
-/// is stricter than in release.yml: every checkout opts out, no exceptions.
-#[test]
-fn ci_and_prerelease_checkouts_do_not_persist_credentials() {
-  for (path, floor) in [
-    (".github/workflows/ci.yml", 6),
-    (".github/workflows/pre-release.yml", 2),
-  ] {
-    let mut audited = 0;
+/// Every workflow in the directory, so a file added later is audited by
+/// construction rather than by remembering to extend a hand-written list. The
+/// three sweeps below all enumerate from here: naming files individually is
+/// how a new workflow silently escapes an invariant that was supposed to be
+/// repo-wide.
+fn workflow_paths() -> Vec<String> {
+  let mut paths: Vec<String> = fs::read_dir(".github/workflows")
+    .expect("the workflows directory must exist")
+    .map(|e| e.unwrap().path())
+    .filter(|p| p.extension().is_some_and(|e| e == "yml" || e == "yaml"))
+    .map(|p| p.to_str().unwrap().to_string())
+    .collect();
+  paths.sort();
+  paths
+}
 
-    for (job, with) in workflow_checkout_steps(path) {
+/// #433, the follow-up to #429/#432: the sibling workflows carry the same
+/// shape, and none of their checkouts pushes — `ci.yml` is entirely read-only,
+/// `pre-release.yml` publishes through `gh` with an env token, never
+/// `git push`, and `docs-sync.yml` only calls an API. No checkout outside
+/// release.yml has any business passing `token:`, so the rule is stricter
+/// there: every checkout opts out, no exceptions.
+///
+/// The set is discovered, not listed: release.yml is the single exception
+/// (it owns the audited token split above), everything else is swept.
+#[test]
+fn sibling_workflow_checkouts_do_not_persist_credentials() {
+  let release = ".github/workflows/release.yml";
+  let mut swept = 0;
+  let mut audited = 0;
+
+  for path in workflow_paths() {
+    if path == release {
+      continue;
+    }
+    swept += 1;
+
+    for (job, with) in workflow_checkout_steps(&path) {
       assert!(
         with["token"].is_null(),
         "the checkout in `{path}` job `{job}` passes an explicit token, but nothing in this \
@@ -138,13 +162,21 @@ fn ci_and_prerelease_checkouts_do_not_persist_credentials() {
          `persist-credentials: false`"
       );
     }
-
-    assert!(
-      audited >= floor,
-      "expected at least {floor} checkouts in `{path}`, found {audited} — the parser is probably \
-       no longer seeing the steps"
-    );
   }
+
+  // A glob that matches nothing passes vacuously, and so does one that stops
+  // seeing the steps inside the files it matched. Both floors are the counts
+  // at the time of writing, minus release.yml.
+  assert!(
+    swept >= 3,
+    "expected at least 3 workflows besides release.yml, found {swept} — the directory listing is \
+     probably no longer seeing them"
+  );
+  assert!(
+    audited >= 8,
+    "expected at least 8 credential-free checkouts outside release.yml, found {audited} — the \
+     parser is probably no longer seeing the steps"
+  );
 }
 
 /// The mirror of the invariant above: the two checkouts that push must keep the
@@ -254,6 +286,74 @@ fn prerelease_workflow_does_not_match_stable_tags() {
     !workflow.contains("\n      - \"v*.*.*\""),
     "pre-release.yml must not trigger on stable tags"
   );
+}
+
+const DOCS_SYNC: &str = ".github/workflows/docs-sync.yml";
+
+fn docs_sync_triggers() -> serde_yaml_ng::Value {
+  let workflow: serde_yaml_ng::Value = serde_yaml_ng::from_str(&fs::read_to_string(DOCS_SYNC).unwrap()).unwrap();
+  workflow["on"].clone()
+}
+
+/// The published docs must only ever show what was *delivered*. `main` is the
+/// delivered state — it is reached exclusively through a `dev` → `main` PR —
+/// so the sync fires on pushes to `main` and on nothing else.
+///
+/// A `dev` trigger would publish pages describing unreleased behaviour. A tag
+/// trigger would be worse: GitHub's `v*.*.*` glob also matches `v0.8.0-rc.4`,
+/// the exact trap `release.yml` has to guard against by hand, so the docs of
+/// every release candidate would go live as if they were stable.
+#[test]
+fn docs_sync_fires_on_pushes_to_main_only() {
+  let on = docs_sync_triggers();
+  let push = &on["push"];
+
+  let branches: Vec<&str> = push["branches"]
+    .as_sequence()
+    .expect("docs-sync.yml must restrict its push trigger to a branch list")
+    .iter()
+    .filter_map(|b| b.as_str())
+    .collect();
+  assert_eq!(
+    branches,
+    ["main"],
+    "docs-sync.yml must fire on `main` alone: any other branch publishes undelivered docs"
+  );
+
+  assert!(
+    push["tags"].is_null(),
+    "docs-sync.yml must not trigger on tags: the `v*.*.*` glob matches pre-release tags too"
+  );
+  assert!(
+    on["pull_request"].is_null(),
+    "docs-sync.yml must not trigger on pull requests: it publishes, it does not check"
+  );
+}
+
+/// The paths filter is the one half of the contract this repo cannot see: the
+/// conversion script lives in `kbrdn1/kbrdn-docs` and reads exactly two roots
+/// of this repo. A root dropped here does not break anything loudly — it just
+/// stops waking the sync, and the site quietly serves stale pages.
+///
+/// So the list is pinned literally. If the site starts reading a third root,
+/// this test is where that gets recorded.
+#[test]
+fn docs_sync_watches_every_root_the_site_reads() {
+  let on = docs_sync_triggers();
+  let paths: Vec<&str> = on["push"]["paths"]
+    .as_sequence()
+    .expect("docs-sync.yml must filter its push trigger by path")
+    .iter()
+    .filter_map(|p| p.as_str())
+    .collect();
+
+  for root in ["docs/**", "changelogs/**"] {
+    assert!(
+      paths.contains(&root),
+      "docs-sync.yml must watch `{root}`: the site's sync script reads it, so a change there \
+       has to wake the sync (paths = {paths:?})"
+    );
+  }
 }
 
 #[test]

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -151,7 +151,11 @@ fn sibling_workflow_checkouts_do_not_persist_credentials() {
     // And by the whole name, not a suffix: `pre-release.yml` ends with
     // `release.yml`, so `ends_with` would drop a workflow that must be
     // audited. The `swept` floor below is what would catch that.
-    let is_release = Path::new(&path).file_name().and_then(|f| f.to_str()) == Some("release.yml");
+    // Fully qualified: `Path` is imported under `#[cfg(unix)]` in this file,
+    // next to the `Command` the shell-script tests need, and this test is not
+    // conditional. Reaching for the short name would have failed to compile on
+    // the very runner the line above exists for.
+    let is_release = std::path::Path::new(&path).file_name().and_then(|f| f.to_str()) == Some("release.yml");
     if is_release {
       continue;
     }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -340,12 +340,19 @@ fn docs_sync_fires_on_pushes_to_main_only() {
 }
 
 /// The paths filter is the one half of the contract this repo cannot see: the
-/// conversion script lives in `kbrdn1/kbrdn-docs` and reads exactly two roots
-/// of this repo. A root dropped here does not break anything loudly — it just
-/// stops waking the sync, and the site quietly serves stale pages.
+/// conversion script lives in `kbrdn1/kbrdn-docs` and reads a fixed set of
+/// roots out of this repo. A root dropped here does not break anything loudly
+/// — it just stops waking the sync, and the site quietly serves stale pages.
 ///
-/// So the list is pinned literally. If the site starts reading a third root,
+/// So the list is pinned literally. If the site starts reading another root,
 /// this test is where that gets recorded.
+///
+/// `Cargo.toml` is in the set and is the reason this test exists rather than
+/// being obvious: it is not documentation, but `sync-gwm-docs.mjs` reads the
+/// `[package]` version out of it for the release badge in the site header.
+/// A release moves `changelogs/` in the same push, so the omission only shows
+/// when a version bump travels alone, and the failure is a stale badge rather
+/// than an error.
 #[test]
 fn docs_sync_watches_every_root_the_site_reads() {
   let on = docs_sync_triggers();
@@ -356,7 +363,7 @@ fn docs_sync_watches_every_root_the_site_reads() {
     .filter_map(|p| p.as_str())
     .collect();
 
-  for root in ["docs/**", "changelogs/**"] {
+  for root in ["docs/**", "changelogs/**", "Cargo.toml"] {
     assert!(
       paths.contains(&root),
       "docs-sync.yml must watch `{root}`: the site's sync script reads it, so a change there \


### PR DESCRIPTION
## Description

The `gwm-cli` half of #423: this repo owns the Markdown sources and tells the
docs site when they move. The conversion, the Starlight build and the deploy
all live in `kbrdn1/kbrdn-docs`.

**This does nothing on its own.** The dispatch it sends is only acted on once
`sync-gwm.yml` is on `main` of `kbrdn-docs`. Merging this early is deliberate:
the two halves are independent, and an unanswered dispatch is a no-op.

refs #423

## Type of change

- [x] 🔧 Chore / CI / build

## Changes

- `.github/workflows/docs-sync.yml`: on a push to `main` touching `docs/` or
  `changelogs/`, sends a `repository_dispatch` to `kbrdn1/kbrdn-docs`. No
  checkout, no permissions, one API call.
- `tests/release_workflow_tests.rs`: the credential sweep discovers the
  workflow files instead of naming two of them, and two new tests pin the
  trigger and the paths filter.
- `CONTRIBUTING.md`: a `Documentation site` section under Releases, with the
  one-time token bootstrap.

## Tests

- [x] `cargo test` passes locally (91 binaries green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]`
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

No CHANGELOG entry: nothing here changes the CLI, its output or its config.
Say the word if you would rather see it under Added anyway.

## Linked issues / docs

- Issue: #423 (this closes the `gwm-cli` half only, so `refs` rather than
  `Closes`)

## Notes for reviewers

**Why `main` and not a tag.** GitHub's `v*.*.*` glob matches `v0.8.0-rc.4`
too. `release.yml` already has to guard against that by hand, and a docs
trigger with the same glob would put every release candidate's pages online as
if they were stable. `main` is only ever reached through a `dev` → `main` PR,
so it *is* the delivered state.

**The two new tests were watched failing**, each on its own assertion: pointing
`branches` at `dev` fails the trigger test and leaves the paths test green;
deleting `changelogs/**` does the reverse.

**The sweep now has a floor that bites.** Deleting `docs-sync.yml` drops the
workflow count to 2 and fails the test, which is the difference between a sweep
and a loop that happens to find nothing. Without this change the new workflow
would have been outside a credential invariant meant to be repo-wide, and so
would the one after it.

**One credential note.** `DOCS_SITE_TOKEN` is a write credential for a private
repository, held in a public repository's secrets. Same trust level as
`HOMEBREW_TAP_TOKEN` and `SCOOP_BUCKET_TOKEN`; it is scoped to
`kbrdn1/kbrdn-docs` with Contents: write and nothing else. It is already
configured, so the `continue-on-error: true` on the notify job should come off
once the first dispatch is seen green.
