### PR TITLE
📝 docs(integrations): document the herdr plugin (EN + FR)

### DIFF
--- a/docs/5.integrations/6.herdr.md
+++ b/docs/5.integrations/6.herdr.md
@@ -1,0 +1,86 @@
+---
+title: herdr (plugin)
+description: Drive gwm from inside the herdr multiplexer — the actions shipped by herdr-plugin-gwm, its adopt-only rule, install and configuration.
+---
+
+# herdr (plugin)
+
+[herdr](https://herdr.dev) is a terminal multiplexer with workspaces, panes and a plugin API. [`herdr-plugin-gwm`](https://github.com/kbrdn1/herdr-plugin-gwm) wires gwm into it: create, switch, remove, review a PR, exec and clean across worktrees, and gwm's own TUI in a pane — each worktree reflected as a herdr workspace.
+
+The plugin is glue-only bash. It holds no worktree logic of its own: every script is `gwm <cmd> --format=json` → `jq` → a herdr CLI call, riding the frozen 1.0 JSON contract of [`list`, `path` and `doctor`](/cli/reference).
+
+## the one rule
+
+> The plugin never calls `herdr worktree create` or `worktree open --branch`. Creation and removal always go through gwm; herdr only reflects, via `worktree open --path` (adopt) and `workspace close` / `workspace focus`.
+
+That is what keeps a single source of truth. Break it and herdr starts creating git worktrees outside gwm's control — two writers on the same repo, drifting apart on the first `gwm remove`. The plugin enforces it rather than documenting it: one helper (`adopt_worktree`) is the only path to herdr, and a grep-assert in its test suite fails the build if any script reaches around it.
+
+## install
+
+| Channel | Command |
+|---|---|
+| herdr marketplace | `herdr plugin install kbrdn1/herdr-plugin-gwm` |
+| Local checkout | `herdr plugin link "$PWD"` |
+
+There is no build step — plain bash, nothing to compile.
+
+**Requirements:** herdr ≥ 0.7.4 (popup panes) · `gwm` on `PATH` · `jq` · `fzf` · bash · macOS or Linux.
+
+## the actions
+
+Invoke from any pane inside a herdr workspace sitting in a gwm-managed repo:
+
+```bash
+herdr plugin action invoke gwm.switch
+```
+
+| Action | What it does | Opens as |
+|---|---|---|
+| `gwm.create` | branch type → issue number → description → `gwm create`, then adopts the new worktree, resolved by its linked issue | split pane |
+| `gwm.switch` | fzf over `gwm list --format=json` with live badges (issue `#N`, `PR#N`, dirty `±`, ahead `↑`, behind `↓`) — focuses the workspace if herdr already reflects the pick, adopts otherwise | popup |
+| `gwm.remove` | fzf over removable worktrees (never the main checkout) → confirm gate → `gwm remove` (branch kept) → `workspace close` | popup |
+| `gwm.review` | fzf over `gh pr list` → `gwm review <N>` materialises the PR as its own worktree → adopt | split pane |
+| `gwm.exec` | `gwm exec -- <cmd>` across every worktree, with a `✓/✗` rollup | split pane |
+| `gwm.clean` | `gwm clean` reports reclaimable build artifacts, deletes after a confirm | split pane |
+| `gwm.dashboard` | gwm's TUI, as-is | zoomed pane |
+
+Pick-and-go pickers are session-modal popups so the tiled layout does not move; the panes whose *output* is the point (`exec`, `clean`) or that run long git or network work (`create`, `review`) stay split — a modal that blocks the session for a 30-second clone reads as frozen.
+
+Two things happen without being invoked:
+
+- **A clicked GitHub PR URL** (`https://github.com/<owner>/<repo>/pull/<N>`) triggers `gwm.review`. The pattern is anchored and the script re-extracts the number itself, so only an integer ever reaches gwm — never a raw URL.
+- **`worktree.created`**, fired when a worktree is created on the herdr side, outside gwm, runs `gwm bootstrap` on its path so it gets the same file copies, hooks and preset as a `gwm create` one. Adopts fire `worktree.opened`, not `.created`, so this never double-runs on the plugin's own work.
+
+## binding a key
+
+In `~/.config/herdr/config.toml`, then `herdr server reload-config`:
+
+```toml
+[[keys.command]]
+key = "prefix+ctrl+shift+g"
+type = "plugin_action"
+command = "gwm.switch"
+description = "gwm: switch worktree"
+```
+
+## configuration
+
+Presentation only — the plugin has no behaviour to configure, since gwm owns the behaviour. Create `~/.config/herdr/plugins/config/gwm/config.toml` (or run `herdr plugin config-dir gwm`):
+
+```toml
+# "workspace" (default) → adopt as a nested worktree workspace in the sidebar.
+# "tab"                 → lighter: open a tab with the worktree cwd.
+open_mode = "workspace"
+
+# "user" (default) → inherit your FZF_DEFAULT_OPTS (colors, borders); the picker
+#                    only neutralizes file-browser bits that would garble
+#                    non-file lines or rebind keys.
+# "clean"          → drop FZF_DEFAULT_OPTS entirely for a bare picker.
+fzf_theme = "user"
+```
+
+Worktrees are adopted under the repo's *root* workspace, so invoking an action from inside a linked-worktree pane does not hit herdr's `linked_worktree_source` rejection.
+
+## limits
+
+Multi-repo mode (`gwm --workspace`) is not wired through the actions yet: the plugin operates on the single repo of the current workspace. Everything else — create, switch, remove, review, exec, clean, dashboard, bootstrap-on-create — is implemented.

--- a/docs/5.integrations/index.md
+++ b/docs/5.integrations/index.md
@@ -13,6 +13,7 @@ gwm is small on purpose — it shells out to the tools you already use rather th
 - **[GitLab (multi-forge)](/integrations/gitlab)** — point gwm at GitLab instead of GitHub: the `forge` key, the `glab` backend, and the CI-state and terminology differences.
 - **[`gwm doctor`](/integrations/doctor)** — the 8 health checks, exit-code semantics (`0 / 1 / 2`), the launcher-binary probe added in v0.6, and the `[tui.keys]` keymap check added in v0.8.
 - **[Homebrew & Nix](/integrations/homebrew-nix)** — the packaging surface: the Homebrew tap, the Nix flake, `cargo binstall`, and the prebuilt release archives.
+- **[herdr (plugin)](/integrations/herdr)** — `herdr-plugin-gwm` drives gwm from inside the herdr multiplexer: create, switch, remove, review, exec, clean and the TUI in a pane, with herdr adopting what gwm creates.
 - **[Daemon consumers](/integrations/daemon-consumers)** — the first consumers of `gwm daemon`: the bundled `gwm statusline` for shell prompts, the raw JSON-RPC one-liner, and an editor recipe (Zed / VS Code).
 
 For CI runners that spin up worktrees via `gwm create`, set `GWM_ALLOW_BOOTSTRAP=1` (or pass `--allow-bootstrap` on the gwm invocation) so the [TOFU trust gate](/configuration/trust-ledger) bypasses the interactive prompt — required since the gate's default-deny policy aborts on non-tty stdin to prevent silent execution of attacker-controlled bootstrap lines.

--- a/docs/fr/5.integrations/6.herdr.md
+++ b/docs/fr/5.integrations/6.herdr.md
@@ -1,0 +1,87 @@
+---
+title: herdr (plugin)
+description: Piloter gwm depuis le multiplexeur herdr : les actions livrées par herdr-plugin-gwm, sa règle d'adoption, l'installation et la configuration.
+---
+
+# herdr (plugin)
+
+[herdr](https://herdr.dev) est un multiplexeur de terminal avec workspaces, panes et une API de plugins. [`herdr-plugin-gwm`](https://github.com/kbrdn1/herdr-plugin-gwm) y branche gwm : créer, changer de worktree, supprimer, matérialiser une PR, lancer `exec` et `clean` sur tous les worktrees, et afficher la TUI de gwm dans un pane — chaque worktree étant reflété comme un workspace herdr.
+
+Le plugin n'est que de la glu bash. Il ne porte aucune logique de worktree : chaque script est `gwm <cmd> --format=json` → `jq` → un appel à la CLI herdr, en s'appuyant sur le contrat JSON figé en 1.0 de [`list`, `path` et `doctor`](/fr/cli/reference).
+
+## la règle unique
+
+> Le plugin n'appelle jamais `herdr worktree create` ni `worktree open --branch`. La création et la suppression passent toujours par gwm ; herdr ne fait que refléter, via `worktree open --path` (adoption) et `workspace close` / `workspace focus`.
+
+C'est ce qui garantit une source de vérité unique. Enfreignez-la et herdr se met à créer des worktrees git hors du contrôle de gwm — deux écrivains sur le même dépôt, qui divergent dès le premier `gwm remove`. Le plugin l'applique plutôt que de la documenter : un seul helper (`adopt_worktree`) mène à herdr, et une assertion grep dans sa suite de tests fait échouer le build si un script le contourne.
+
+## installation
+
+| Canal | Commande |
+|---|---|
+| Marketplace herdr | `herdr plugin install kbrdn1/herdr-plugin-gwm` |
+| Checkout local | `herdr plugin link "$PWD"` |
+
+Aucune étape de build : c'est du bash, il n'y a rien à compiler.
+
+**Prérequis :** herdr ≥ 0.7.4 (panes popup) · `gwm` dans le `PATH` · `jq` · `fzf` · bash · macOS ou Linux.
+
+## les actions
+
+À invoquer depuis n'importe quel pane d'un workspace herdr placé dans un dépôt géré par gwm :
+
+```bash
+herdr plugin action invoke gwm.switch
+```
+
+| Action | Ce qu'elle fait | Ouverture |
+|---|---|---|
+| `gwm.create` | type de branche → numéro d'issue → description → `gwm create`, puis adoption du nouveau worktree, résolu par son issue liée | pane splitté |
+| `gwm.switch` | fzf sur `gwm list --format=json` avec les badges à jour (issue `#N`, `PR#N`, modifié `±`, en avance `↑`, en retard `↓`) — focus du workspace si herdr reflète déjà la sélection, adoption sinon | popup |
+| `gwm.remove` | fzf sur les worktrees supprimables (jamais le checkout principal) → confirmation explicite → `gwm remove` (branche conservée) → `workspace close` | popup |
+| `gwm.review` | fzf sur `gh pr list` → `gwm review <N>` matérialise la PR dans son propre worktree → adoption | pane splitté |
+| `gwm.exec` | `gwm exec -- <cmd>` sur chaque worktree, avec un récapitulatif `✓/✗` | pane splitté |
+| `gwm.clean` | `gwm clean` liste les artefacts de build récupérables, et ne supprime qu'après confirmation | pane splitté |
+| `gwm.dashboard` | la TUI de gwm, telle quelle | pane zoomé |
+
+Les sélecteurs « je choisis et j'y vais » s'ouvrent en popup modal pour ne pas déplacer la disposition en tuiles ; les panes dont la *sortie* est l'objet même (`exec`, `clean`) ou qui lancent un travail git/réseau long (`create`, `review`) restent splittés — un modal qui bloque la session pendant un clone de 30 secondes se lit comme un gel.
+
+Deux choses se déclenchent sans invocation :
+
+- **Un clic sur une URL de PR GitHub** (`https://github.com/<owner>/<repo>/pull/<N>`) déclenche `gwm.review`. Le motif est ancré et le script ré-extrait lui-même le numéro : seul un entier atteint gwm, jamais une URL brute.
+- **`worktree.created`**, émis quand un worktree est créé côté herdr, hors gwm, lance `gwm bootstrap` sur son chemin pour qu'il reçoive les mêmes copies de fichiers, hooks et preset qu'un worktree issu de `gwm create`. Les adoptions émettent `worktree.opened`, pas `.created`, donc ce hook ne se déclenche jamais deux fois sur le travail du plugin.
+
+## associer une touche
+
+Dans `~/.config/herdr/config.toml`, puis `herdr server reload-config` :
+
+```toml
+[[keys.command]]
+key = "prefix+ctrl+shift+g"
+type = "plugin_action"
+command = "gwm.switch"
+description = "gwm: switch worktree"
+```
+
+## configuration
+
+Purement présentationnelle : le plugin n'a pas de comportement à configurer, puisque c'est gwm qui le porte. Créez `~/.config/herdr/plugins/config/gwm/config.toml` (ou lancez `herdr plugin config-dir gwm`) :
+
+```toml
+# "workspace" (défaut) → adopte comme workspace de worktree imbriqué dans la barre latérale.
+# "tab"                → plus léger : ouvre un onglet sur le cwd du worktree.
+open_mode = "workspace"
+
+# "user" (défaut) → hérite de vos FZF_DEFAULT_OPTS (couleurs, bordures) ; le
+#                   sélecteur ne neutralise que les réglages orientés navigateur
+#                   de fichiers, qui brouilleraient les lignes non-fichier ou
+#                   réassigneraient des touches.
+# "clean"         → abandonne complètement FZF_DEFAULT_OPTS pour un sélecteur nu.
+fzf_theme = "user"
+```
+
+Les worktrees sont adoptés sous le workspace *racine* du dépôt : invoquer une action depuis un pane de worktree lié ne bute donc pas sur le refus `linked_worktree_source` de herdr.
+
+## limites
+
+Le mode multi-dépôts (`gwm --workspace`) n'est pas encore câblé dans les actions : le plugin travaille sur le dépôt unique du workspace courant. Tout le reste — create, switch, remove, review, exec, clean, dashboard, bootstrap à la création — est implémenté.

--- a/docs/fr/5.integrations/index.md
+++ b/docs/fr/5.integrations/index.md
@@ -13,6 +13,7 @@ gwm est volontairement minimal — il délègue aux outils que vous utilisez dé
 - **[GitLab (multi-forge)](/fr/integrations/gitlab)** — pointer gwm vers GitLab plutôt que GitHub : la clé `forge`, le backend `glab`, et les différences d'état CI et de terminologie.
 - **[`gwm doctor`](/fr/integrations/doctor)** — les 8 vérifications de santé, la sémantique des codes de sortie (`0 / 1 / 2`), la sonde du binaire de lancement ajoutée en v0.6, et la vérification du keymap `[tui.keys]` ajoutée en v0.8.
 - **[Homebrew & Nix](/fr/integrations/homebrew-nix)** — la surface de packaging : le tap Homebrew, le flake Nix, `cargo binstall`, et les archives de release pré-compilées.
+- **[herdr (plugin)](/fr/integrations/herdr)** — `herdr-plugin-gwm` pilote gwm depuis le multiplexeur herdr : create, switch, remove, review, exec, clean et la TUI dans un pane, herdr adoptant ce que gwm crée.
 - **[Consommateurs du daemon](/fr/integrations/daemon-consumers)** — les premiers consommateurs de `gwm daemon` : le `gwm statusline` embarqué pour les prompts shell, le one-liner JSON-RPC brut, et une recette éditeur (Zed / VS Code).
 
 Pour les runners CI qui créent des worktrees via `gwm create`, définissez `GWM_ALLOW_BOOTSTRAP=1` (ou passez `--allow-bootstrap` à l'invocation gwm) afin que la [barrière de confiance TOFU](/fr/configuration/trust-ledger) contourne l'invite interactive — requis car la politique « refus par défaut » de la barrière avorte sur un stdin non-tty pour empêcher l'exécution silencieuse de lignes de bootstrap contrôlées par un attaquant.


### PR DESCRIPTION
## Description

`kbrdn1/herdr-plugin-gwm` is public and drives gwm from inside the herdr
multiplexer; the integrations section did not mention it.

Closes #511

## Type of change

- [x] 📝 Docs

## Changes

- `docs/5.integrations/6.herdr.md` and its French counterpart: the adopt-only
  rule, the seven actions and how each opens, install, key binding,
  configuration, and the one known limit.
- One line in each integrations index.

## Tests

- [x] `cargo test` passes locally
- [ ] New tests added under `tests/`

No test: documentation pages carry no behaviour. The two that do read `docs/`
(`msrv_tests`) pin specific MSRV sentences in five other files and are
unaffected; both suites were run.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no CLI surface change)

No CHANGELOG entry: nothing shipped in the binary changed.

## Linked issues / docs

- Issue: #511
- Related PR: #510 (the docs-sync pipeline), deliberately kept separate

## Notes for reviewers

**There is an ordering constraint between this PR and #510, and it is silent
if broken.** The site's sync script deletes the section it regenerates
(`rm(..., { recursive: true, force: true })` in `sync-gwm-docs.mjs`) and reads
`main` of this repo, not `dev`. So if the generated page is committed on the
site side while this page is still only on `dev`, the first dispatch removes
it and the sync job commits that removal as legitimate drift: green job,
missing page, no error anywhere.

Landing this on `dev` before the `dev` → `main` merge that first fires
`docs-sync.yml` closes the window. Travelling in that same merge closes it
too, and is simpler.

**Checked rather than assumed:** `kbrdn1/herdr-plugin-gwm` exists and is
public, so the links resolve; the EN and FR pages carry the same seven
sections in the same order.
