### PR TITLE
📝 docs: link the published site and bring the roadmap to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/_assets/promo.png">
-    <source media="(prefers-color-scheme: light)" srcset="docs/_assets/promo-light.png">
-    <img alt="gwm — git worktree manager, a CLI + TUI in Rust. One binary, every worktree, setup already done." src="docs/_assets/promo.png" width="100%">
-  </picture>
+  <a href="https://gwm.kbrdn.dev/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/_assets/promo.png">
+      <source media="(prefers-color-scheme: light)" srcset="docs/_assets/promo-light.png">
+      <img alt="gwm — git worktree manager, a CLI + TUI in Rust. One binary, every worktree, setup already done." src="docs/_assets/promo.png" width="100%">
+    </picture>
+  </a>
 </p>
 
 # <picture><source media="(prefers-color-scheme: dark)" srcset="docs/_assets/logo.svg"><source media="(prefers-color-scheme: light)" srcset="docs/_assets/logo-light.svg"><img alt="" src="docs/_assets/logo.svg" width="26" height="26" align="top"></picture> gwm — git worktree manager
@@ -12,6 +14,7 @@
 [![release](https://img.shields.io/github/v/release/kbrdn1/gwm-cli?display_name=tag&sort=semver)](https://github.com/kbrdn1/gwm-cli/releases)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 [![rust](https://img.shields.io/badge/rust-1.95%2B-orange?logo=rust)](https://www.rust-lang.org/)
+[![docs](https://img.shields.io/badge/docs-gwm.kbrdn.dev-d4825d)](https://gwm.kbrdn.dev/)
 
 **One binary to manage every git worktree in every repo, with the setup already done.**
 
@@ -94,7 +97,9 @@ Step-by-step walkthrough: [`docs/getting-started/first-worktree.md`](docs/1.gett
 
 ## documentation
 
-The full tree lives under [`docs/`](docs/): 39 pages in English, with 36 of them translated in French under [`docs/fr/`](docs/fr/). Numeric prefixes drive the sidebar order and every page carries frontmatter, so the tree renders as-is into a static site ([#423](https://github.com/kbrdn1/gwm-cli/issues/423) tracks publishing it). The in-repo tree is the source of truth.
+Published at **<https://gwm.kbrdn.dev>**, and it keeps itself there: a delivery landing on `main` that touches `docs/` fires a resync and a redeploy on its own ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)).
+
+The full tree lives under [`docs/`](docs/): 39 pages in English, with 36 of them translated in French under [`docs/fr/`](docs/fr/). Numeric prefixes drive the sidebar order and every page carries frontmatter, so the tree renders as-is into the static site. The in-repo tree is the source of truth: the site is generated from it, never edited on the other side.
 
 | Section                                                         | Read this when …                                                              |
 |:----------------------------------------------------------------|:------------------------------------------------------------------------------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,11 @@ This document tracks where `gwm` is heading. It complements [CHANGELOG.md](CHANG
 
 Each item below links to its GitHub issue. The scope, alternatives considered, and acceptance criteria live there — this file is the map, not the spec.
 
-## Current state — v1.6.0 stable
+## Current state — v1.6.1 stable
 
-The current **stable** line is **v1.6.0** (2026-08-03), which carries a
-**security fix affecting every earlier version** (see the highlights table). The machine-readable
+The current **stable** line is **v1.6.1** (2026-08-04), a follow-up closing the
+gaps left by the v1.6.0 **security fix affecting every earlier version** (see
+the highlights table). The machine-readable
 contracts frozen at 1.0.0 still hold: the CLI subcommands / flags / exit codes,
 the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml`
 section set will not break without a major bump (see
@@ -153,6 +154,8 @@ For reference (each linked to its closing PR):
 
 | [GHSA-fffq-vg6f-gxqm](https://github.com/kbrdn1/gwm-cli/security/advisories/GHSA-fffq-vg6f-gxqm) + [#415](https://github.com/kbrdn1/gwm-cli/issues/415) / [#416](https://github.com/kbrdn1/gwm-cli/issues/416) / [#417](https://github.com/kbrdn1/gwm-cli/issues/417) / [#418](https://github.com/kbrdn1/gwm-cli/issues/418) / [#479](https://github.com/kbrdn1/gwm-cli/issues/479) + [#491](https://github.com/kbrdn1/gwm-cli/issues/491) | v1.6.0 | **Security fix + naming flexibility.** A branch name could inject a command into a lifecycle hook: placeholders were expanded into `sh -c` unescaped, and git permits `;`, `|`, `&`, `$`, backticks and redirections in a ref name, so a branch someone else pushed ran arbitrary commands as anyone who had trusted their own repo's hooks, with no trust prompt in the path (the gate covers the repo's hooks, never the branch name entering them). Affects every version up to and including 1.5.0, no backport. Values are shell-escaped on expansion, `env` values stay raw because they never see a shell, and hooks additionally get `GWM_*` environment variables that need no quoting. Alongside it: `gwm create --name` drops the `<type> <issue> <desc>` requirement (#416), the TUI create and rename forms present the fields the repo's patterns actually ask for in pattern order, in both directions (#418), and the declared MSRV becomes an honest 1.95 held by a CI job that resolves and compiles the locked graph at the floor (#491). Verifying the sequence produced the Fixed section: terminal-escape neutralisation of echoed config (#473), single-pass placeholder expansion (#494), branch rollback on a failed `gwm create` (#487), Windows path rules on free-form names (#475), and worktree-aware branch reads (#477) |
 
+| [#502](https://github.com/kbrdn1/gwm-cli/issues/502) / [#506](https://github.com/kbrdn1/gwm-cli/issues/506) / [#507](https://github.com/kbrdn1/gwm-cli/issues/507) + [#423](https://github.com/kbrdn1/gwm-cli/issues/423) / [#511](https://github.com/kbrdn1/gwm-cli/issues/511) | v1.6.1 | **Bidi follow-up to the security release, and the documentation pipeline.** The 1.6.0 neutralisation rests on `char::is_control`, which covers C0, DEL and C1: it does not cover the twelve characters carrying the `Bidi_Control` property, which are `Cf`, not `Cc`, and reorder how a terminal renders the text around them without ever being a control byte. The pre-trust bootstrap summary inherited the gap, the one output whose job is to let someone authorise a shell command out of an unvetted repo. The TUI worktrees table was never on the path the CLI sinks protect at all: measured on ratatui 0.30, every render path drops the zero-width bytes but `List` and `Table` keep the `Bidi_Control` ones, so a fetched ref could read in an order it is not stored in. Both closed, the neutralisation landing in the width-clipping funnel so a column added later inherits it, plus an alias expansion refused rather than neutralised because it becomes argv before clap is reached. Alongside: the published documentation now resyncs and redeploys itself when `main` moves ([#423](https://github.com/kbrdn1/gwm-cli/issues/423), <https://gwm.kbrdn.dev>), and `herdr-plugin-gwm` gets an integration page in English and French ([#511](https://github.com/kbrdn1/gwm-cli/issues/511)) |
+
 If an issue still shows `open` on GitHub even though its work shipped, it's a tracking issue waiting for a follow-up audit — check the CHANGELOG and the linked PR before reopening scope work on it.
 
 ## Next up
@@ -269,7 +272,7 @@ worktree → branch → PR → issue chain and can open on the current row direc
 
 ### Maintenance
 
-- [#500](https://github.com/kbrdn1/gwm-cli/issues/500) — `exec_tests` flakes on Linux with `ETXTBSY`: the test writes an executable and runs it, which races against the fork-to-exec window of any other test in the harness that spawns a process. Seen once on a lockfile-only PR, green on a bare re-run. Retry on that one errno, with the reason written next to it so it does not read as flake-hiding later
+- [#500](https://github.com/kbrdn1/gwm-cli/issues/500) ✅ — `exec_tests` flaked on Linux with `ETXTBSY`: the test writes an executable and runs it, which races against the fork-to-exec window of any other test in the harness that spawns a process. Fixed in v1.6.1 by retrying on that one errno, with the reason written next to it so it does not read as flake-hiding later
 - The transitive graph needs a manual `cargo update` from time to time. `.github/dependabot.yml` sets no `allow: dependency-type: all`, so dependabot only ever PRs the direct dependencies. Last full refresh: [#499](https://github.com/kbrdn1/gwm-cli/pull/499), which also took the vendored libgit2 from 1.9.3 to 1.9.6. Do it **after** an MSRV change lands, never before: a lockfile refresh is exactly how a floor moves without anyone deciding to, so it has to be checked against a floor that is already settled
 
 ### Visibility
@@ -278,7 +281,7 @@ Not feature work, but tracked here because it gates whether any of the above is
 seen:
 
 - [#422](https://github.com/kbrdn1/gwm-cli/issues/422) — comparison page covering gwm, gwq and lazyworktree (gwq is the incumbent by star count and has been dormant since May)
-- [#423](https://github.com/kbrdn1/gwm-cli/issues/423) — sync `docs/` to the Astro docs site, with the in-repo tree as the source of truth
+- [#423](https://github.com/kbrdn1/gwm-cli/issues/423) ✅ — the documentation is published at **<https://gwm.kbrdn.dev>** and keeps itself there. A merge into `main` touching `docs/`, `changelogs/` or `Cargo.toml` posts a `repository_dispatch` to `kbrdn1/kbrdn-docs`, which reruns the conversion, commits whatever drifted and redeploys. The in-repo tree stays the source of truth: the site is generated from it, never edited on the other side
 
 ## Ambitious
 

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,17 +1,27 @@
 ---
 title: Roadmap
-description: What's shipped, the v1.6.0 security fix and naming-flexibility line on top of the v1.5.0 multi-forge work, the v1.4.0 help overlay and the frozen v1.0.0 contracts, plus the link to the issue tracker.
+description: What's shipped, the v1.6.1 bidi follow-up and self-maintaining documentation on top of the v1.6.0 security fix, the v1.5.0 multi-forge work and the frozen v1.0.0 contracts, plus the link to the issue tracker.
 ---
 
 # Roadmap
 
 The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
 
-## current state — v1.6.0 stable
+## current state — v1.6.1 stable
 
-The current **stable** line is **v1.6.0** (`Cargo.toml` `version = "1.6.0"`, tagged 2026-08-03). **It carries a security fix and every earlier version is affected**: see [`changelogs/1.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md) and the v1.6.0 section below. The **machine-readable contracts frozen at 1.0.0 are unchanged**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)). The project MSRV is **1.95**.
+The current **stable** line is **v1.6.1** (`Cargo.toml` `version = "1.6.1"`, tagged 2026-08-04), a follow-up closing the gaps left by the v1.6.0 security fix. **That fix affects every version up to and including 1.5.0**: see [`changelogs/1.6.1.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.1.md), [`changelogs/1.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md) and the sections below. The **machine-readable contracts frozen at 1.0.0 are unchanged**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)). The project MSRV is **1.95**.
 
 Since the 1.0.0 milestone (tagged 2026-06-26): three 1.0.x patches hardened the stable line, **v1.1.0** shipped the first outside-report-driven pair ([#363](https://github.com/kbrdn1/gwm-cli/issues/363): persisted sidebar layout + OSC52 clipboard fallback over SSH) with **v1.1.1** fixing global config resolution on macOS, **v1.2.0** shipped the distribution train ([#383](https://github.com/kbrdn1/gwm-cli/issues/383): Scoop, `.deb` / `.rpm`, AUR, aqua, winget automation), **v1.3.0** made gwm agent-aware, **v1.4.0** finished the help overlay and the TUI-polish trio, **v1.5.0** made gwm multi-forge, and **v1.6.0** fixes a command injection through branch names in lifecycle hooks while landing the naming-flexibility line: the section below. Per-version notes live under [`changelogs/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs).
+
+## v1.6.1: bidi follow-up and self-maintaining documentation
+
+The v1.6.1 line closes what the 1.6.0 neutralisation missed and puts the documentation on rails. Consolidated notes: [`changelogs/1.6.1.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.1.md). Key items:
+
+- **The bidi controls the sanitisers missed** ([#502](https://github.com/kbrdn1/gwm-cli/issues/502)): the 1.6.0 rule rests on `char::is_control`, which covers C0, DEL and C1. It does not cover the twelve characters carrying the `Bidi_Control` property, which are `Cf` and not `Cc`: they reorder how a terminal renders the text around them without ever being a control byte. The site that matters is the pre-trust bootstrap summary, whose whole job is to let someone decide whether to authorise a shell command out of a repo they have not vetted; a summary that can be made to misrepresent that command is worse than no summary. An `[aliases]` expansion is refused rather than neutralised, because it becomes argv before clap parses it.
+- **Branch names reaching the TUI table** ([#506](https://github.com/kbrdn1/gwm-cli/issues/506)): the sinks the CLI goes through are not on the TUI's path, and what protected it so far was incidental. Measured on ratatui 0.30, every render path drops the zero-width control bytes, but `List` and `Table` keep the `Bidi_Control` characters, and git's ref rules refuse the ASCII controls but not the Unicode format ones. The neutralisation goes in the width-clipping funnel every constrained cell already passes through, so a column added later inherits it.
+- **The documentation publishes itself** ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)): the tree under `docs/` is served at **<https://gwm.kbrdn.dev>**. A merge into `main` touching `docs/`, `changelogs/` or `Cargo.toml` triggers a resync and a redeploy without anyone asking. The in-repo tree stays the source of truth, the site is generated from it and never edited on the other side.
+- **herdr integration page** ([#511](https://github.com/kbrdn1/gwm-cli/issues/511)): `herdr-plugin-gwm` drives gwm from inside the herdr multiplexer, documented in English and French. The plugin never creates a worktree of its own: gwm creates, herdr adopts, which is what keeps a single source of truth.
+- **Test hardening around the same class of mistake**: a rule about the `$HOME` guard that was stated in a doc comment rather than checked is now derived by construction ([#507](https://github.com/kbrdn1/gwm-cli/issues/507)), and two harness races never reachable from the product are closed ([#500](https://github.com/kbrdn1/gwm-cli/issues/500)).
 
 ## v1.6.0: security fix and naming flexibility
 
@@ -120,8 +130,10 @@ The full v0.8.0 notes live at [`changelogs/0.8.0.md`](https://github.com/kbrdn1/
 
 The active queues, in the order the root [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) lists them:
 
-- **Naming flexibility** ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) / [#416](https://github.com/kbrdn1/gwm-cli/issues/416) / [#417](https://github.com/kbrdn1/gwm-cli/issues/417) / [#418](https://github.com/kbrdn1/gwm-cli/issues/418)) — free-form worktree names (`gwm create --name`), a parser derived from `branch_pattern`, and a token-driven create form with live preview.
-- **Rich PR / Issue view** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)) — metadata, checks, reviews and comments in the TUI.
+- **Rich PR / Issue view** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)) — metadata, checks, reviews and comments in the TUI. It was deliberately queued behind multi-forge so it is born speaking to both forges rather than being rewritten later.
+- **Comparison page** ([#422](https://github.com/kbrdn1/gwm-cli/issues/422)) — gwm against gwq and lazyworktree. Not feature work, but it gates whether any of the above gets seen.
+
+The naming-flexibility line ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) through [#418](https://github.com/kbrdn1/gwm-cli/issues/418), plus [#475](https://github.com/kbrdn1/gwm-cli/issues/475) and [#479](https://github.com/kbrdn1/gwm-cli/issues/479) to [#482](https://github.com/kbrdn1/gwm-cli/issues/482)) shipped in v1.6.0 and is closed. Publishing the documentation ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)) shipped in v1.6.1.
 
 For fresh work, start from the issue tracker:
 


### PR DESCRIPTION
Documentation only, no code. Same shape as #504 after #501: a doc merge landing on `main` right after a release.

Two commits, three files:

| File | Why |
|---|---|
| `README.md` | nothing pointed at the published docs, and the Documentation paragraph still announced #423 as *tracking* the publication, which happened today |
| `ROADMAP.md` | stable line to v1.6.1 with its highlights row; #423 and #500 moved out of the open queues |
| `docs/7.roadmap.md` | same, on the page the site serves |

Three entries had gone from dated to plain wrong rather than merely stale: the "what's next" queue still advertised the naming-flexibility line closed in v1.6.0, Visibility listed #423 as pending, and Maintenance listed the `ETXTBSY` flake that v1.6.1 fixes.

The remaining queue is therefore the rich PR/Issue view (#420) and the comparison page (#422).

### Side effect, intended

`docs/7.roadmap.md` changes, so this merge matches `docs-sync.yml`'s `paths:` filter and fires a second real dispatch. The site will resync and redeploy with the updated roadmap on its own. The first one, at the v1.6.1 cut, went through in 9 seconds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent links and a badge for the published documentation site.
  * Updated documentation guidance to reflect automatic synchronization and deployment.
  * Refreshed roadmap content for the v1.6.1 release, including security improvements, reliability fixes, integrations, and documentation updates.
  * Updated upcoming work to distinguish shipped items from active roadmap priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->