### PR TITLE
📝 docs: reorder the queue and bring the French roadmap along

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document tracks where `gwm` is heading. It complements [CHANGELOG.md](CHANG
 
 Each item below links to its GitHub issue. The scope, alternatives considered, and acceptance criteria live there — this file is the map, not the spec.
 
-## Current state — v1.6.1 stable
+## Current state: v1.6.1 stable
 
 The current **stable** line is **v1.6.1** (2026-08-04), a follow-up closing the
 gaps left by the v1.6.0 **security fix affecting every earlier version** (see
@@ -261,10 +261,30 @@ individual checks, reviews, conversation, and inline review comments. Modelled
 on `snacks.nvim`'s `snacks.gh`, whose key lesson is that inline diff comments are
 reachable only through GraphQL, not through `gh --json`.
 
-Comes last, and inherits both the detail overlay the agent pane (#408) already
-paid for and the `Forge` trait (#419), so it is born reading GitLab too. Where gwm can beat the reference: `snacks.gh` has no notion of a worktree,
-so the user picks from a flat list; gwm already knows the
+Comes first of the two queued features, and inherits both the detail overlay the
+agent pane (#408) already paid for and the `Forge` trait (#419), so it is born
+reading GitLab too. Where gwm can beat the reference: `snacks.gh` has no notion
+of a worktree, so the user picks from a flat list; gwm already knows the
 worktree → branch → PR → issue chain and can open on the current row directly.
+
+### 3. Per-worktree notes ([#515](https://github.com/kbrdn1/gwm-cli/issues/515))
+
+gwm holds everything about a worktree except the part only its author can write:
+where they were. It knows the branch, the linked issue, the diff against base and
+the agent session, but not what had just been figured out, what is blocking, or
+what to check before opening the PR. With eight worktrees open that context lives
+outside gwm, so returning to one after two days means rebuilding it from
+`git log` and memory.
+
+A note attached to the worktree, editable from the TUI and flagged in the table.
+The design decision is storage, and it has no obvious answer: inside the worktree
+it dies with it and is unreadable from the main checkout, in the config dir it
+survives removal but becomes orphaned state that `gwm clean` then has to know
+about. Either way it should be plain text on disk, because a note is something
+one may want to `grep` or open without gwm running.
+
+Comes after the PR/Issue view, which pays for the overlay machinery it would
+reuse.
 
 ### Deferred
 
@@ -280,7 +300,8 @@ worktree → branch → PR → issue chain and can open on the current row direc
 Not feature work, but tracked here because it gates whether any of the above is
 seen:
 
-- [#422](https://github.com/kbrdn1/gwm-cli/issues/422) — comparison page covering gwm, gwq and lazyworktree (gwq is the incumbent by star count and has been dormant since May)
+- [#422](https://github.com/kbrdn1/gwm-cli/issues/422) : comparison page covering gwm, gwq and lazyworktree (gwq is the incumbent by star count and has been dormant since May). Queued **after** the PR/Issue view (#420) and per-worktree notes (#515): a comparison is worth writing once the features it compares are the ones shipping
+- [#516](https://github.com/kbrdn1/gwm-cli/issues/516) : retire the em dash habit across `docs/`, 1500 occurrences over 76 of its 79 files. Now that the tree is published, that is the punctuation the site carries. Worth doing page by page while they are touched for other reasons, not as one unreviewable diff
 - [#423](https://github.com/kbrdn1/gwm-cli/issues/423) ✅ — the documentation is published at **<https://gwm.kbrdn.dev>** and keeps itself there. A merge into `main` touching `docs/`, `changelogs/` or `Cargo.toml` posts a `repository_dispatch` to `kbrdn1/kbrdn-docs`, which reruns the conversion, commits whatever drifted and redeploys. The in-repo tree stays the source of truth: the site is generated from it, never edited on the other side
 
 ## Ambitious

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -7,7 +7,7 @@ description: What's shipped, the v1.6.1 bidi follow-up and self-maintaining docu
 
 The full roadmap (with grouped categories and per-item issue links) lives in [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) at the repo root. The issue tracker is the source of truth for scope details, acceptance criteria, and alternatives considered.
 
-## current state — v1.6.1 stable
+## current state: v1.6.1 stable
 
 The current **stable** line is **v1.6.1** (`Cargo.toml` `version = "1.6.1"`, tagged 2026-08-04), a follow-up closing the gaps left by the v1.6.0 security fix. **That fix affects every version up to and including 1.5.0**: see [`changelogs/1.6.1.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.1.md), [`changelogs/1.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md) and the sections below. The **machine-readable contracts frozen at 1.0.0 are unchanged**: the CLI subcommands / flags / exit codes, the `--format=json` schemas, the daemon JSON-RPC protocol, and the `.gwm.toml` section set will not break without a major bump (see [Stability & compatibility](/development/stability)). The project MSRV is **1.95**.
 
@@ -130,8 +130,9 @@ The full v0.8.0 notes live at [`changelogs/0.8.0.md`](https://github.com/kbrdn1/
 
 The active queues, in the order the root [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) lists them:
 
-- **Rich PR / Issue view** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)) — metadata, checks, reviews and comments in the TUI. It was deliberately queued behind multi-forge so it is born speaking to both forges rather than being rewritten later.
-- **Comparison page** ([#422](https://github.com/kbrdn1/gwm-cli/issues/422)) — gwm against gwq and lazyworktree. Not feature work, but it gates whether any of the above gets seen.
+- **Rich PR / Issue view** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)): metadata, checks, reviews and comments in the TUI. It was deliberately queued behind multi-forge so it is born speaking to both forges rather than being rewritten later.
+- **Per-worktree notes** ([#515](https://github.com/kbrdn1/gwm-cli/issues/515)): gwm knows the branch, the linked issue, the diff and the agent session, but nothing of where you were. A note attached to a worktree, editable from the TUI, closes the gap between holding eight worktrees and remembering what each one was for.
+- **Comparison page** ([#422](https://github.com/kbrdn1/gwm-cli/issues/422)): gwm against gwq and lazyworktree. Content rather than product work, and it comes after the two above, but it is what decides whether any of them gets seen.
 
 The naming-flexibility line ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) through [#418](https://github.com/kbrdn1/gwm-cli/issues/418), plus [#475](https://github.com/kbrdn1/gwm-cli/issues/475) and [#479](https://github.com/kbrdn1/gwm-cli/issues/479) to [#482](https://github.com/kbrdn1/gwm-cli/issues/482)) shipped in v1.6.0 and is closed. Publishing the documentation ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)) shipped in v1.6.1.
 

--- a/docs/fr/7.roadmap.md
+++ b/docs/fr/7.roadmap.md
@@ -1,17 +1,27 @@
 ---
 title: Roadmap
-description: Ce qui est livré, la ligne v1.6.0 (correctif de sécurité + souplesse de nommage) au-dessus du multi-forge v1.5.0, du help overlay v1.4.0 et des contrats v1.0.0 gelés, plus le lien vers le tracker d'issues.
+description: Ce qui est livré, la ligne v1.6.1 (suite bidi + documentation qui se publie seule) au-dessus du correctif de sécurité v1.6.0, du multi-forge v1.5.0 et des contrats v1.0.0 gelés, plus le lien vers le tracker d'issues.
 ---
 
 # Roadmap
 
 La roadmap complète (avec les catégories groupées et les liens d'issues par item) vit dans [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) à la racine du repo. Le tracker d'issues est la source de vérité pour les détails de scope, les critères d'acceptation et les alternatives considérées.
 
-## état courant — stable v1.6.0
+## état courant : stable v1.6.1
 
-La ligne **stable** courante est **v1.6.0** (`Cargo.toml` `version = "1.6.0"`, taguée le 2026-08-03). **Elle porte un correctif de sécurité et toutes les versions antérieures sont affectées** : voir [`changelogs/1.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md) et la section v1.6.0 ci-dessous. Les **contrats lisibles par machine gelés en 1.0.0 sont inchangés** : les sous-commandes / flags / codes de sortie de la CLI, les schémas `--format=json`, le protocole JSON-RPC du daemon et l'ensemble des sections `.gwm.toml` ne casseront pas sans un bump majeur (voir [Stabilité & compatibilité](/fr/development/stability)). Le MSRV du projet est **1.95**.
+La ligne **stable** courante est **v1.6.1** (`Cargo.toml` `version = "1.6.1"`, taguée le 2026-08-04), une suite qui ferme ce que le correctif de sécurité v1.6.0 avait laissé ouvert. **Ce correctif affecte toutes les versions jusqu'à la 1.5.0 incluse** : voir [`changelogs/1.6.1.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.1.md), [`changelogs/1.6.0.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md) et les sections ci-dessous. Les **contrats lisibles par machine gelés en 1.0.0 sont inchangés** : les sous-commandes / flags / codes de sortie de la CLI, les schémas `--format=json`, le protocole JSON-RPC du daemon et l'ensemble des sections `.gwm.toml` ne casseront pas sans un bump majeur (voir [Stabilité & compatibilité](/fr/development/stability)). Le MSRV du projet est **1.95**.
 
 Depuis le jalon 1.0.0 (tagué le 2026-06-26) : trois patchs 1.0.x ont durci la ligne stable, **v1.1.0** a livré la première paire issue d'un rapport externe ([#363](https://github.com/kbrdn1/gwm-cli/issues/363) : layout de sidebar persisté + fallback presse-papier OSC52 en SSH) avec **v1.1.1** corrigeant la résolution de la config globale sur macOS, **v1.2.0** a livré le train de distribution ([#383](https://github.com/kbrdn1/gwm-cli/issues/383) : Scoop, `.deb` / `.rpm`, AUR, aqua, automatisation winget), **v1.3.0** a rendu gwm conscient des agents, **v1.4.0** a complété le help overlay et le trio de polish TUI, **v1.5.0** a rendu gwm multi-forge, et **v1.6.0** corrige une injection de commande via le nom de branche dans les hooks de cycle de vie tout en livrant la ligne souplesse de nommage : la section ci-dessous. Les notes par version vivent sous [`changelogs/`](https://github.com/kbrdn1/gwm-cli/tree/main/changelogs).
+
+## v1.6.1 : suite bidi et documentation qui se publie seule
+
+La ligne v1.6.1 ferme ce que la neutralisation de la 1.6.0 avait manqué et met la documentation sur des rails. Notes consolidées : [`changelogs/1.6.1.md`](https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.1.md). Points clés :
+
+- **Les contrôles bidi que les assainisseurs manquaient** ([#502](https://github.com/kbrdn1/gwm-cli/issues/502)) : la règle de la 1.6.0 repose sur `char::is_control`, qui couvre C0, DEL et C1. Elle ne couvre pas les douze caractères portant la propriété `Bidi_Control`, qui sont des `Cf` et non des `Cc` : ils réordonnent le rendu du texte autour d'eux dans un terminal sans jamais être un octet de contrôle. Le site qui compte est le récapitulatif de bootstrap pré-confiance, dont le rôle entier est de laisser quelqu'un décider d'autoriser une commande shell venant d'un dépôt qu'il n'a pas audité : un récapitulatif qu'on peut faire mentir sur cette commande est pire que pas de récapitulatif. Une expansion d'`[aliases]` est refusée plutôt que neutralisée, parce qu'elle devient argv avant que clap ne la parse.
+- **Les noms de branche atteignant la table de la TUI** ([#506](https://github.com/kbrdn1/gwm-cli/issues/506)) : les puits par lesquels passe la CLI ne sont pas sur le chemin de la TUI, et ce qui la protégeait jusqu'ici était accidentel. Mesuré sur ratatui 0.30, tous les chemins de rendu jettent les octets de contrôle de largeur nulle, mais `List` et `Table` gardent les caractères `Bidi_Control`, et les règles de ref de git refusent les contrôles ASCII mais pas les caractères de format Unicode. La neutralisation va dans l'entonnoir de rognage en largeur que traverse déjà toute cellule contrainte, si bien qu'une colonne ajoutée plus tard en hérite.
+- **La documentation se publie seule** ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)) : l'arborescence sous `docs/` est servie sur **<https://gwm.kbrdn.dev>**. Une livraison sur `main` touchant `docs/`, `changelogs/` ou `Cargo.toml` déclenche resynchro et redéploiement sans que personne le demande. L'arborescence in-repo reste la source de vérité : le site en est généré, jamais édité de l'autre côté.
+- **Page d'intégration herdr** ([#511](https://github.com/kbrdn1/gwm-cli/issues/511)) : `herdr-plugin-gwm` pilote gwm depuis le multiplexeur herdr, documenté en anglais et en français. Le plugin ne crée jamais de worktree lui-même : gwm crée, herdr adopte, ce qui préserve une source de vérité unique.
+- **Durcissement des tests sur la même classe d'erreur** : une règle sur le garde `$HOME` qui était énoncée dans un commentaire plutôt que vérifiée est maintenant dérivée par construction ([#507](https://github.com/kbrdn1/gwm-cli/issues/507)), et deux courses du harnais jamais atteignables depuis le produit sont fermées ([#500](https://github.com/kbrdn1/gwm-cli/issues/500)).
 
 ## v1.6.0 : correctif de sécurité et souplesse de nommage
 
@@ -120,8 +130,11 @@ Les notes complètes de la v0.8.0 vivent dans [`changelogs/0.8.0.md`](https://gi
 
 Les files actives, dans l'ordre où la [`ROADMAP.md`](https://github.com/kbrdn1/gwm-cli/blob/main/ROADMAP.md) racine les liste :
 
-- **Souplesse de nommage** ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) / [#416](https://github.com/kbrdn1/gwm-cli/issues/416) / [#417](https://github.com/kbrdn1/gwm-cli/issues/417) / [#418](https://github.com/kbrdn1/gwm-cli/issues/418)) — noms de worktree libres (`gwm create --name`), un parseur dérivé de `branch_pattern`, et un formulaire de création par tokens avec preview en direct.
-- **Vue PR / Issue riche** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)) — métadonnées, checks, reviews et commentaires dans la TUI.
+- **Vue PR / Issue riche** ([#420](https://github.com/kbrdn1/gwm-cli/issues/420)) : métadonnées, checks, reviews et commentaires dans la TUI. Elle a été délibérément mise derrière le multi-forge pour naître en lisant GitLab aussi, plutôt que d'être réécrite ensuite.
+- **Notes par worktree** ([#515](https://github.com/kbrdn1/gwm-cli/issues/515)) : gwm connaît la branche, l'issue liée, le diff et la session d'agent, mais rien de l'endroit où vous en étiez. Une note attachée au worktree, éditable depuis la TUI, comble l'écart entre tenir huit worktrees et se souvenir de ce que chacun faisait.
+- **Page de comparaison** ([#422](https://github.com/kbrdn1/gwm-cli/issues/422)) : gwm face à gwq et lazyworktree. Du contenu plutôt que du produit, et elle vient après les deux ci-dessus, mais c'est elle qui décide si l'un d'eux sera vu.
+
+La ligne souplesse de nommage ([#415](https://github.com/kbrdn1/gwm-cli/issues/415) à [#418](https://github.com/kbrdn1/gwm-cli/issues/418), plus [#475](https://github.com/kbrdn1/gwm-cli/issues/475) et [#479](https://github.com/kbrdn1/gwm-cli/issues/479) à [#482](https://github.com/kbrdn1/gwm-cli/issues/482)) est livrée en v1.6.0 et close. La publication de la documentation ([#423](https://github.com/kbrdn1/gwm-cli/issues/423)) est livrée en v1.6.1.
 
 Pour démarrer un nouveau travail, partez du tracker d'issues :
 


### PR DESCRIPTION
Documentation only, same shape as #514.

### Queue reordered

The next queue becomes: rich PR/Issue view (#420), then per-worktree notes (#515, opened today), then the comparison page (#422). The last one moves behind the other two on purpose: a comparison is worth writing once the features it compares are the ones actually shipping.

### The French roadmap had been left behind

`docs/fr/7.roadmap.md` was still on v1.6.0 with the stale queue, while the site serves both locales. It now mirrors the English one, v1.6.1 section included. It was missed in the previous commit and `tests/msrv_tests.rs` is what surfaced it, by naming the file among its version anchors.

### Also

- #516 added to Visibility: retire the em dash habit across `docs/`, 1500 occurrences over 76 of its 79 files. Now that the tree is published, that is the punctuation the site carries.
- The three "current state" headings move from ` — ` to ` : `, which recent version headings already did. No anchor pointed at them, checked.

`cargo test --test msrv_tests` stays green: the MSRV claims those files carry were not touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and French roadmaps to reflect the stable v1.6.1 release.
  * Reorganized upcoming work, including per-worktree notes, richer pull request and issue views, and a comparison page.
  * Documented completed improvements to bidirectional text controls, branch-name handling, automated documentation publishing, integrations, and test hardening.
  * Added a deferred item for improved comparison and punctuation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->