### PR TITLE
♻️ refactor(worktree,config): close the remaining TOCTOU windows in the removal sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,12 +97,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all `post_create` runs nothing on a delete and is never asked. Hook output
   lands on the Command Logs transcript (`3`) as it does everywhere else.
 - **A refused removal is no longer recorded as undoable**
-  ([#521](https://github.com/kbrdn1/gwm-cli/issues/521)). `gwm remove` wrote
-  its journal entry before the destructive call, so a target that then got
-  refused (its path moved since it was resolved, git declining the removal)
-  still showed up in `gwm history` as something `gwm undo` would replay. The
-  branch OID is still captured beforehand, which is what the entry needs; only
-  the write moved after the removal succeeds.
+  ([#521](https://github.com/kbrdn1/gwm-cli/issues/521),
+  [#531](https://github.com/kbrdn1/gwm-cli/issues/531)). `gwm remove` wrote its
+  journal entry before the destructive call, so a target that then got refused
+  (its path moved since it was resolved, git declining the removal) still
+  showed up in `gwm history` as something `gwm undo` would replay. That is not
+  a cosmetic leftover: `gwm undo` saves the journal only once the resurrection
+  succeeds, and the resurrection fails on a worktree that is still on disk, so
+  the stale entry came back on every retry and no later removal in that repo
+  could be undone until `history.toml` was edited by hand. The removal now
+  records itself at its point of no return, with the worktree gone and the
+  branch not yet, which is both after everything that can still refuse and
+  before the one step that destroys something unrecoverable: a refusal writes
+  nothing, and a partial failure still leaves the branch OID `gwm undo` needs.
+- **The delete reads `.gwm.toml` once**
+  ([#531](https://github.com/kbrdn1/gwm-cli/issues/531)). A TUI delete asked
+  the same file four separate times: for the config whose hooks run, for the
+  repo layer that says whether it runs any, for the bytes the trust ledger
+  rules on, and again to parse the branch for `{type}` / `{issue}` / `{desc}`.
+  A `.gwm.toml` rewritten between two of those could be approved as one thing
+  and executed as another. All four now answer from one snapshot. Same for the
+  branch a removal deletes and the branch it records: one read of HEAD, so a
+  checkout landing mid-removal can no longer have `gwm undo` restore a ref that
+  was never deleted while the deleted one stays lost.
 - **`cycle_sidebar_layout` moved from `Space` to `z`**
   ([#484](https://github.com/kbrdn1/gwm-cli/issues/484)), to make room for the
   row mark. Space-to-mark is the convention in lazygit, k9s and fzf, so the

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -457,7 +457,7 @@ gwm history --all              # every op across every repo (forensic / multi-re
 | `--limit N`    | Maximum entries to print, newest first. Default `20`                                      |
 | `--all`        | List ops across every repo, not just the current one                                      |
 
-By default it filters to the current repo's canonicalised workdir; `--all` surfaces every entry. An empty result prints `no operations recorded` as a stable scripted signal. The journal lives at `$XDG_DATA_HOME/gwm/history.toml` (override with `$GWM_HISTORY_FILE`; macOS falls back under `Application Support`, Windows under `%LOCALAPPDATA%`) and is capped at 100 entries: the oldest is dropped on overflow. Every `gwm remove` (with or without `--delete-branch`) appends an entry; `gwm remove --dry-run` does **not** write the journal, so previewing a destruction can never let you "undo" something that never happened.
+By default it filters to the current repo's canonicalised workdir; `--all` surfaces every entry. An empty result prints `no operations recorded` as a stable scripted signal. The journal lives at `$XDG_DATA_HOME/gwm/history.toml` (override with `$GWM_HISTORY_FILE`; macOS falls back under `Application Support`, Windows under `%LOCALAPPDATA%`) and is capped at 100 entries: the oldest is dropped on overflow. Every `gwm remove` that actually removes something (with or without `--delete-branch`) appends an entry; a refused one appends nothing, and `gwm remove --dry-run` does **not** write the journal, so previewing a destruction can never let you "undo" something that never happened.
 
 ## `gwm completions <shell>`
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -460,7 +460,7 @@ gwm history --all              # every op across every repo (forensic / multi-re
 | `--limit N`    | Nombre maximum d'entrées à afficher, les plus récentes en premier. Défaut `20`           |
 | `--all`        | Liste les opérations de tous les dépôts, pas seulement le courant                         |
 
-Par défaut il filtre sur le workdir canonicalisé du dépôt courant ; `--all` fait remonter chaque entrée. Un résultat vide affiche `no operations recorded` comme signal scripté stable. Le journal vit à `$XDG_DATA_HOME/gwm/history.toml` (à surcharger avec `$GWM_HISTORY_FILE` ; macOS retombe sous `Application Support`, Windows sous `%LOCALAPPDATA%`) et est plafonné à 100 entrées : la plus ancienne est supprimée en cas de débordement. Chaque `gwm remove` (avec ou sans `--delete-branch`) ajoute une entrée ; `gwm remove --dry-run` n'écrit **pas** dans le journal, donc prévisualiser une destruction ne peut jamais vous laisser « annuler » quelque chose qui n'a jamais eu lieu.
+Par défaut il filtre sur le workdir canonicalisé du dépôt courant ; `--all` fait remonter chaque entrée. Un résultat vide affiche `no operations recorded` comme signal scripté stable. Le journal vit à `$XDG_DATA_HOME/gwm/history.toml` (à surcharger avec `$GWM_HISTORY_FILE` ; macOS retombe sous `Application Support`, Windows sous `%LOCALAPPDATA%`) et est plafonné à 100 entrées : la plus ancienne est supprimée en cas de débordement. Chaque `gwm remove` qui supprime effectivement quelque chose (avec ou sans `--delete-branch`) ajoute une entrée ; un refus n'en ajoute aucune, et `gwm remove --dry-run` n'écrit **pas** dans le journal, donc prévisualiser une destruction ne peut jamais vous laisser « annuler » quelque chose qui n'a jamais eu lieu.
 
 ## `gwm completions <shell>`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2686,7 +2686,7 @@ fn cmd_create(
   // (Codex review on PR #474).
   let pre_ctx = match &wt_name {
     WorktreeName::Structured(spec) => HookContext::for_create(&repo, &workdir, &workdir, &target, &branch, spec),
-    WorktreeName::Freeform(_) => HookContext::for_worktree(&repo, &workdir, &workdir, &target, Some(&branch)),
+    WorktreeName::Freeform(_) => HookContext::for_worktree(&repo, &workdir, &workdir, &target, Some(&branch), &config),
   };
   let report = lifecycle::run_phase(&config, HookPhase::PreCreate, &pre_ctx, &skips, false)?;
   print_lifecycle_report(&report);
@@ -3285,6 +3285,7 @@ fn cmd_bootstrap(target: Option<String>, skip_hooks: Option<String>, trust_mode:
     &worktree_path,
     &worktree_path,
     worktree_branch.as_deref(),
+    &config,
   );
   let report = lifecycle::run_phase(&config, HookPhase::PreBootstrap, &hook_ctx, &skips, false)?;
   print_lifecycle_report(&report);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1162,6 +1162,16 @@ fn read_config_value(path: &Path) -> Result<toml::Value> {
   Ok(val)
 }
 
+/// [`read_config_value`] for bytes a caller already read (issue #531). The
+/// UTF-8 check is explicit here because `read_to_string` does it on the file
+/// path and a snapshot must fail the same way rather than lossily.
+fn parse_config_bytes(bytes: &[u8]) -> Result<toml::Value> {
+  let raw = std::str::from_utf8(bytes)
+    .map_err(|e| crate::error::GwmError::Config(format!("{} is not valid UTF-8: {}", CONFIG_FILE, e)))?;
+  let val: toml::Value = toml::from_str(raw)?;
+  Ok(val)
+}
+
 /// Deep-merge `over` onto `base`: two tables merge key-by-key
 /// recursively (so disjoint sections from both files coexist and a
 /// nested table override keeps the untouched sibling keys); for every
@@ -1607,16 +1617,38 @@ impl Config {
   /// the merge contract can be pinned by a test without touching the
   /// runner's real `$HOME` / `$XDG_CONFIG_HOME`.
   pub fn load_layered(repo_root: &Path, global_path: Option<&Path>) -> Result<Self> {
-    let cfg = Self::merge_layered(repo_root, global_path)?;
-    cfg.validate_branch_types()?;
-    cfg.validate_bootstrap_paths()?;
-    cfg.validate_bootstrap_guards()?;
-    cfg.validate_labels()?;
-    cfg.validate_aliases()?;
-    cfg.validate_tui_keys()?;
-    cfg.validate_theme()?;
-    cfg.validate_profiles()?;
-    Ok(cfg)
+    Self::merge_layered(repo_root, global_path)?.validated()
+  }
+
+  /// [`Self::load_layered`] for a caller that has already read the repo's
+  /// `.gwm.toml` and must not have it read again (issue #531).
+  ///
+  /// A delete asks the same file three questions — which hooks run, whether
+  /// the repo declares any remove hook at all, and whether the ledger
+  /// approved it — and each answer used to come from its own `open`. A
+  /// `.gwm.toml` rewritten between two of them had the trust gate rule on a
+  /// file that is not the one whose hooks then execute. One read, one
+  /// snapshot, three answers about the same bytes.
+  ///
+  /// `None` is "this repo has no `.gwm.toml`", the same answer an absent
+  /// file gives through [`Self::load_layered`].
+  pub fn load_layered_from_bytes(repo_bytes: Option<&[u8]>, global_path: Option<&Path>) -> Result<Self> {
+    Self::merge_layered_from_bytes(repo_bytes, global_path)?.validated()
+  }
+
+  /// The semantic validators, in one place, so both load forms run the same
+  /// set — a snapshot must never become a way in for a config the path form
+  /// rejects.
+  fn validated(self) -> Result<Self> {
+    self.validate_branch_types()?;
+    self.validate_bootstrap_paths()?;
+    self.validate_bootstrap_guards()?;
+    self.validate_labels()?;
+    self.validate_aliases()?;
+    self.validate_tui_keys()?;
+    self.validate_theme()?;
+    self.validate_profiles()?;
+    Ok(self)
   }
 
   /// Reject semantically invalid `[exec.profiles.*]` / `[clean.profiles.*]`
@@ -1646,14 +1678,29 @@ impl Config {
   /// (issue #219 review).
   pub(crate) fn merge_layered(repo_root: &Path, global_path: Option<&Path>) -> Result<Self> {
     let repo_path = repo_root.join(CONFIG_FILE);
-    let global_val = match global_path {
-      Some(p) if p.exists() => Some(read_config_value(p)?),
-      _ => None,
-    };
     let repo_val = if repo_path.exists() {
       Some(read_config_value(&repo_path)?)
     } else {
       None
+    };
+    Self::merge_values(repo_val, global_path)
+  }
+
+  /// [`Self::merge_layered`] from a snapshot of the repo layer's bytes
+  /// (issue #531). See [`Self::load_layered_from_bytes`].
+  pub(crate) fn merge_layered_from_bytes(repo_bytes: Option<&[u8]>, global_path: Option<&Path>) -> Result<Self> {
+    let repo_val = match repo_bytes {
+      Some(b) => Some(parse_config_bytes(b)?),
+      None => None,
+    };
+    Self::merge_values(repo_val, global_path)
+  }
+
+  /// Deep-merge an already-parsed repo layer over the global file.
+  fn merge_values(repo_val: Option<toml::Value>, global_path: Option<&Path>) -> Result<Self> {
+    let global_val = match global_path {
+      Some(p) if p.exists() => Some(read_config_value(p)?),
+      _ => None,
     };
 
     Ok(match (global_val, repo_val) {

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -115,13 +115,25 @@ impl HookContext {
     }
   }
 
-  pub fn for_worktree(repo: &Repository, main_repo: &Path, cwd: &Path, path: &Path, branch: Option<&str>) -> Self {
+  /// `config` is the caller's effective config, not one this function loads:
+  /// `BranchParser::for_repo` opens `.gwm.toml` again — a fourth read inside
+  /// one delete, past the bytes the trust gate ruled on — and re-resolves the
+  /// global config path a caller may have deliberately overridden (#194,
+  /// issue #531).
+  pub fn for_worktree(
+    repo: &Repository,
+    main_repo: &Path,
+    cwd: &Path,
+    path: &Path,
+    branch: Option<&str>,
+    config: &crate::config::Config,
+  ) -> Self {
     let meta = RepoMeta::from_repo(repo);
     // Issue #417: the remove / bootstrap hook context rebuilds `{type}` /
     // `{issue}` / `{desc}` by re-reading the branch, so it reads it with the
     // pattern that wrote it. `for_create` does not come through here — it
     // carries the original `BranchSpec` straight through.
-    let parser = crate::naming::BranchParser::for_repo(repo);
+    let parser = crate::naming::BranchParser::from_config(config, &crate::worktree::repo_name(repo));
     let parsed = branch.and_then(|b| parser.parse(b));
     Self {
       main_repo: main_repo.to_path_buf(),

--- a/src/removal.rs
+++ b/src/removal.rs
@@ -104,35 +104,29 @@ pub fn remove_with_lifecycle(
     }
   }
 
-  // Issue #29: capture the branch OID via libgit2 BEFORE the destructive
-  // call so `gwm undo` can resurrect the branch at the tip that was deleted.
+  // Issue #29: capture the branch OID via libgit2 BEFORE the branch is
+  // deleted, so `gwm undo` can resurrect it at the tip that was dropped.
   //
-  // Written here, after every refusal has had its say and before the first
-  // destructive effect. `worktree::remove` prunes the admin entry BEFORE
-  // deleting the directory (#98), so a filesystem failure mid-removal leaves
-  // the repo mutated, and with `--delete-branch` the branch tip gone: writing
-  // the entry afterwards would leave that case with no recovery anchor at all
-  // (Codex review on PR #526). Everything that refuses without mutating
-  // anything — the path check above, a `pre_remove` hook, the trust gate —
-  // happens earlier, so a refusal still records nothing.
-  // Checked again, because the hooks just ran and one of them can move the
-  // very worktree it was given: the advance check above passed, so without
-  // this the entry would claim a removal `remove_verified` is about to refuse,
-  // and `gwm undo` would pop that instead of a recoverable one (Codex review
-  // on PR #526).
-  if let Err(e) = worktree::verify_path(repo, &found.id, expected_path) {
-    return Err(Box::new(RemovalFailure { outcome, error: e }));
-  }
-
-  let entry = journal_entry(repo, found, delete_branch);
-  if let Err(e) = history::record(entry) {
-    outcome.journal_warning = Some(format!(
-      "failed to record undo journal entry: {} (continuing with the removal anyway)",
-      e
-    ));
-  }
-
-  if let Err(e) = worktree::remove_verified(repo, &found.id, expected_path, delete_branch) {
+  // The removal itself decides *when*: `remove_verified_recording` calls back
+  // at its point of no return, once the worktree is gone and before the
+  // branch delete. Nothing between the last thing that can refuse and the
+  // write, which is what a second `verify_path` here used to be — it narrowed
+  // the window rather than closing it, and an entry that slipped through
+  // wedges `gwm undo` for the whole repo until `history.toml` is edited by
+  // hand (issue #531). The `HeadBranch` handed back is the observation the
+  // deletion acts on, so the entry cannot name a different branch.
+  let mut journal_warning = None;
+  let removal = worktree::remove_verified_recording(repo, &found.id, expected_path, delete_branch, |head| {
+    let entry = journal_entry(repo, found, head, delete_branch);
+    if let Err(e) = history::record(entry) {
+      journal_warning = Some(format!(
+        "failed to record undo journal entry: {} (continuing with the removal anyway)",
+        e
+      ));
+    }
+  });
+  outcome.journal_warning = journal_warning;
+  if let Err(e) = removal {
     return Err(Box::new(RemovalFailure { outcome, error: e }));
   }
   outcome.removed = true;
@@ -152,38 +146,33 @@ pub fn remove_with_lifecycle(
   Ok(outcome)
 }
 
-/// The branch a removal will actually delete: the one checked out in the
-/// worktree right now, which is what `worktree::remove` reads.
+/// The branch to record, from the observation the removal itself acted on.
 ///
 /// Not `WorktreeInfo::branch`, which comes from a listing the caller may have
-/// taken a while ago. A batch resolves its listing once, so a `pre_remove`
+/// taken a while ago: a batch resolves its listing once, so a `pre_remove`
 /// hook on an earlier target can check out another branch in a later one
-/// without moving it; recording the stale name would have `gwm undo` restore
-/// a ref that was never deleted while the deleted one stayed lost (Codex
-/// review on PR #526). Falls back to the listing when the worktree cannot be
-/// opened, and yields `None` on a detached HEAD, matching what the removal
-/// does with it.
-fn branch_at_removal_time(found: &WorktreeInfo) -> Option<String> {
-  // "Opened it and HEAD is detached" and "could not open it" are different
-  // answers and must not collapse into the same `None`: the first one means
-  // there is no branch, so falling back to the listing would have the entry
-  // name a branch the removal deletes nothing of (Codex review on PR #526).
-  match Repository::open(&found.path) {
-    Ok(wt_repo) => match wt_repo.head() {
-      Ok(head) if head.is_branch() => head.shorthand().ok().map(String::from),
-      // Detached: `worktree::remove` reads the same HEAD, gets a bare OID,
-      // finds no branch by that name and deletes none.
-      Ok(_) => None,
-      // Unborn or unreadable HEAD: nothing observed, so keep the listing's.
-      Err(_) => found.branch.clone(),
-    },
-    Err(_) => found.branch.clone(),
+/// without moving it, and recording the stale name would have `gwm undo`
+/// restore a ref that was never deleted while the deleted one stayed lost
+/// (Codex review on PR #526).
+///
+/// The three answers stay distinct. `Detached` records no branch, because the
+/// removal deleted none and `gwm undo` refuses such an entry rather than
+/// re-attaching the worktree to a branch it was never on. `Unreadable` is the
+/// only case that falls back to the listing: nothing was observed, so the
+/// caller's older name is better than no name at all — it is what `gwm undo`
+/// re-attaches to, and no branch was deleted for it to contradict.
+fn branch_to_record(found: &WorktreeInfo, head: &worktree::HeadBranch) -> Option<String> {
+  match head {
+    worktree::HeadBranch::Attached(b) => Some(b.clone()),
+    worktree::HeadBranch::Detached => None,
+    worktree::HeadBranch::Unreadable => found.branch.clone(),
   }
 }
 
-/// The undo-journal entry for a removal that is about to happen.
-fn journal_entry(repo: &Repository, found: &WorktreeInfo, delete_branch: bool) -> OpEntry {
-  let branch = branch_at_removal_time(found);
+/// The undo-journal entry for a removal that has just passed its point of no
+/// return, built from the same `head` the removal acted on.
+fn journal_entry(repo: &Repository, found: &WorktreeInfo, head: &worktree::HeadBranch, delete_branch: bool) -> OpEntry {
+  let branch = branch_to_record(found, head);
   let branch_oid = branch.as_deref().and_then(|b| {
     repo
       .find_branch(b, git2::BranchType::Local)

--- a/src/removal.rs
+++ b/src/removal.rs
@@ -92,7 +92,7 @@ pub fn remove_with_lifecycle(
     return Err(Box::new(RemovalFailure { outcome, error: e }));
   }
 
-  let pre_ctx = HookContext::for_worktree(repo, workdir, &found.path, &found.path, found.branch.as_deref());
+  let pre_ctx = HookContext::for_worktree(repo, workdir, &found.path, &found.path, found.branch.as_deref(), config);
   match lifecycle::run_phase_quiet(config, HookPhase::PreRemove, &pre_ctx, skips, false) {
     Ok(report) => outcome.pre = report,
     Err(f) => {

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -234,11 +234,29 @@ pub fn record_config(workdir: &Path, origin: &str, actor: &str) -> Result<Option
 pub fn evaluate(workdir: &Path, origin: &str, mode: TrustMode) -> Result<TrustOutcome> {
   let cfg_path = workdir.join(CONFIG_FILE);
   let bytes = match fs::read(&cfg_path) {
-    Ok(b) => b,
-    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(TrustOutcome::Proceed),
+    Ok(b) => Some(b),
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
     Err(e) => return Err(e.into()),
   };
-  let sha = hash_config(&bytes);
+  evaluate_bytes(&cfg_path, bytes.as_deref(), origin, mode)
+}
+
+/// [`evaluate`] on bytes the caller already read (issue #531).
+///
+/// The decision has to be about the very bytes that get merged into the
+/// config whose hooks then run. Re-opening `.gwm.toml` here made the gate and
+/// the execution two observations of a file another process can rewrite in
+/// between, so a config could be approved as harmless and executed as
+/// something else. `None` is "no `.gwm.toml`", which is nothing to execute.
+///
+/// `cfg_path` is carried only to name the file in the prompt and the refusal;
+/// nothing reads it.
+pub fn evaluate_bytes(cfg_path: &Path, bytes: Option<&[u8]>, origin: &str, mode: TrustMode) -> Result<TrustOutcome> {
+  let Some(bytes) = bytes else {
+    return Ok(TrustOutcome::Proceed);
+  };
+  let cfg_path = cfg_path.to_path_buf();
+  let sha = hash_config(bytes);
 
   if mode == TrustMode::Deny {
     let short_sha: String = sha.chars().take(12).collect();
@@ -252,7 +270,7 @@ pub fn evaluate(workdir: &Path, origin: &str, mode: TrustMode) -> Result<TrustOu
 
   // Empty surface short-circuit (defence-in-depth fallthrough on
   // parse error — a broken parser must not open a bypass).
-  if let Ok(body_str) = std::str::from_utf8(&bytes) {
+  if let Ok(body_str) = std::str::from_utf8(bytes) {
     if let Ok(cfg) = toml::from_str::<Config>(body_str) {
       let bs = &cfg.bootstrap;
       if bs.copy.is_empty()
@@ -281,7 +299,7 @@ pub fn evaluate(workdir: &Path, origin: &str, mode: TrustMode) -> Result<TrustOu
 
   Ok(TrustOutcome::Prompt {
     cfg_path,
-    body: bytes,
+    body: bytes.to_vec(),
     sha,
     origin: origin.to_string(),
     ledger,
@@ -303,17 +321,38 @@ pub const APPROVE_VIA_TRUST_ADD: &str = "run `gwm trust add` from a CLI in anoth
 /// A `Prompt` outcome becomes a refusal here — the alternate screen has
 /// nowhere to ask — with `approve_hint` naming the command that grants it.
 pub fn evaluate_silent(workdir: &Path, origin: &str, mode: TrustMode, approve_hint: &str) -> Result<Option<String>> {
-  match evaluate(workdir, origin, mode)? {
-    TrustOutcome::Proceed => Ok(None),
-    TrustOutcome::Refuse { message } => Ok(Some(message)),
+  Ok(refusal_for(evaluate(workdir, origin, mode)?, approve_hint))
+}
+
+/// [`evaluate_silent`] on bytes the caller already read — see
+/// [`evaluate_bytes`] for why a delete has to gate the snapshot it merged
+/// rather than whatever the file says by now (issue #531).
+pub fn evaluate_silent_bytes(
+  cfg_path: &Path,
+  bytes: Option<&[u8]>,
+  origin: &str,
+  mode: TrustMode,
+  approve_hint: &str,
+) -> Result<Option<String>> {
+  Ok(refusal_for(
+    evaluate_bytes(cfg_path, bytes, origin, mode)?,
+    approve_hint,
+  ))
+}
+
+/// Turn an outcome into what a caller that cannot prompt shows the user.
+fn refusal_for(outcome: TrustOutcome, approve_hint: &str) -> Option<String> {
+  match outcome {
+    TrustOutcome::Proceed => None,
+    TrustOutcome::Refuse { message } => Some(message),
     TrustOutcome::Prompt { cfg_path, sha, .. } => {
       let short_sha: String = sha.chars().take(12).collect();
-      Ok(Some(format!(
+      Some(format!(
         ".gwm.toml at {} not in trust ledger (hash {}) — {}",
         cfg_path.display(),
         short_sha,
         approve_hint
-      )))
+      ))
     }
   }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6373,15 +6373,20 @@ impl RepoBatch {
   /// `None` precisely to avoid it (#194).
   fn open(workdir: &Path, global_path: Option<&Path>, trust_mode: crate::trust::TrustMode) -> Result<Self> {
     let repo = worktree::discover_repo(Some(workdir))?;
-    let config = Config::load_layered(workdir, global_path)?;
-    // Read back to back with the one above, before the `worktree::list` below,
-    // which walks every worktree's git status and is the expensive part. The
-    // two reads still are not atomic — `trust::evaluate` opens the file a
-    // third time to hash it — but a `.gwm.toml` rewritten between them can no
-    // longer land in a window measured in hundreds of milliseconds (Codex
-    // review on PR #526). Closing it fully means handing `evaluate` bytes
-    // already read, which is a change to the trust surface, not to this one.
-    let repo_only = Config::load_layered(workdir, None)?;
+    // One read of `.gwm.toml`, three answers (issue #531): the config whose
+    // hooks run, the repo layer that says whether this operation runs any,
+    // and the bytes the ledger rules on. Three separate opens meant a file
+    // rewritten in between could be approved as one thing and executed as
+    // another; they are now the same snapshot by construction, so no window
+    // is left to narrow.
+    let cfg_path = workdir.join(crate::config::CONFIG_FILE);
+    let repo_bytes = match std::fs::read(&cfg_path) {
+      Ok(b) => Some(b),
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+      Err(e) => return Err(e.into()),
+    };
+    let config = Config::load_layered_from_bytes(repo_bytes.as_deref(), global_path)?;
+    let repo_only = Config::load_layered_from_bytes(repo_bytes.as_deref(), None)?;
     let worktrees = worktree::list(&repo)?;
     // Gate on the phases this operation actually runs, asked of the file the
     // trust decision is about. Two narrowings, both load-bearing:
@@ -6398,7 +6403,13 @@ impl RepoBatch {
       lifecycle::has_steps(&repo_only, HookPhase::PreRemove) || lifecycle::has_steps(&repo_only, HookPhase::PostRemove);
     let trust_refusal = if runs_hooks {
       let origin = crate::trust::origin_key_for_repo(&repo, workdir);
-      crate::trust::evaluate_silent(workdir, &origin, trust_mode, crate::trust::APPROVE_VIA_TRUST_ADD)?
+      crate::trust::evaluate_silent_bytes(
+        &cfg_path,
+        repo_bytes.as_deref(),
+        &origin,
+        trust_mode,
+        crate::trust::APPROVE_VIA_TRUST_ADD,
+      )?
     } else {
       None
     };

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -499,12 +499,87 @@ fn branch_created_age(repo: &Repository, branch: &str) -> Option<Duration> {
 /// may be gone by now, which would make `canonicalize` fail rather than
 /// disagree.
 pub fn remove_verified(repo: &Repository, name: &str, expected_path: &Path, delete_branch: bool) -> Result<()> {
-  remove_inner(repo, name, Some(expected_path), delete_branch)
+  remove_inner(repo, name, Some(expected_path), delete_branch, |_| {})
+}
+
+/// [`remove_verified`], recording the removal at its point of no return
+/// (issue #531).
+///
+/// `record` fires once the worktree is gone and before the branch delete —
+/// the last instant at which nothing irreversible has happened, and the first
+/// at which the removal is committed. That placement is the whole point:
+///
+/// - **Nothing earlier**, because everything that can still refuse runs
+///   before it. An undo-journal entry written ahead of the path check
+///   described a removal that never happened, and `gwm undo` cannot get past
+///   one — it saves the journal only after the resurrection succeeds, and the
+///   resurrection fails on a worktree that is still on disk, so the stale
+///   entry comes back on every retry until someone edits `history.toml` by
+///   hand (Codex review on PR #526, issue #531).
+/// - **Nothing later**, because the branch delete is the only step that
+///   destroys something git cannot rebuild from the reflog alone (issue #29),
+///   so the recovery anchor has to exist before it.
+///
+/// The [`HeadBranch`] handed to `record` is the same observation the deletion
+/// below acts on, read once. Reading it twice let a concurrent checkout have
+/// the journal name one branch while another was deleted.
+pub fn remove_verified_recording(
+  repo: &Repository,
+  name: &str,
+  expected_path: &Path,
+  delete_branch: bool,
+  record: impl FnOnce(&HeadBranch),
+) -> Result<()> {
+  remove_inner(repo, name, Some(expected_path), delete_branch, record)
 }
 
 /// Remove a worktree directory and prune its admin files. Optionally delete the branch.
 pub fn remove(repo: &Repository, name: &str, delete_branch: bool) -> Result<()> {
-  remove_inner(repo, name, None, delete_branch)
+  remove_inner(repo, name, None, delete_branch, |_| {})
+}
+
+/// What a worktree's HEAD says, as three answers that must not collapse into
+/// one another (issue #531).
+///
+/// A removal deletes a branch only in the [`Attached`](HeadBranch::Attached)
+/// case, so whoever records the removal has to be able to tell "there is no
+/// branch" from "I could not look".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeadBranch {
+  /// HEAD is on a branch: the one a removal deletes and a journal records.
+  Attached(String),
+  /// Detached HEAD. There is no branch to delete, and none to restore
+  /// either — `gwm undo` refuses such an entry rather than inventing one.
+  Detached,
+  /// The worktree could not be opened, or its HEAD not read (unborn, already
+  /// gone). Nothing was observed, so nothing is deleted; a caller with an
+  /// older listing may still prefer its own name for the record.
+  Unreadable,
+}
+
+impl HeadBranch {
+  /// The branch name, when one was actually observed.
+  pub fn name(&self) -> Option<&str> {
+    match self {
+      Self::Attached(b) => Some(b),
+      Self::Detached | Self::Unreadable => None,
+    }
+  }
+}
+
+/// Read the branch checked out in the worktree at `path`, once.
+pub fn head_branch(path: &Path) -> HeadBranch {
+  match Repository::open(path) {
+    Ok(wt) => match wt.head() {
+      Ok(head) if head.is_branch() => match head.shorthand() {
+        Ok(b) => HeadBranch::Attached(b.to_string()),
+        Err(_) => HeadBranch::Unreadable,
+      },
+      Ok(_) => HeadBranch::Detached,
+      Err(_) => HeadBranch::Unreadable,
+    },
+    Err(_) => HeadBranch::Unreadable,
+  }
 }
 
 /// The refusal a path mismatch produces, shared so the two check sites word
@@ -550,7 +625,13 @@ pub fn verify_path(repo: &Repository, name: &str, expected_path: &Path) -> Resul
 /// would have the first handle validated and the second one destroyed (Codex
 /// review on PR #520, then again on #526). `expected_path = None` is the
 /// historical, unverified removal.
-fn remove_inner(repo: &Repository, name: &str, expected_path: Option<&Path>, delete_branch: bool) -> Result<()> {
+fn remove_inner(
+  repo: &Repository,
+  name: &str,
+  expected_path: Option<&Path>,
+  delete_branch: bool,
+  record: impl FnOnce(&HeadBranch),
+) -> Result<()> {
   let wt = repo
     .find_worktree(name)
     .map_err(|_| GwmError::WorktreeNotFound(name.into()))?;
@@ -561,11 +642,11 @@ fn remove_inner(repo: &Repository, name: &str, expected_path: Option<&Path>, del
   }
   let path = wt.path().to_path_buf();
 
-  // Capture the branch (if any) so we can drop it after pruning.
-  let branch_name = match Repository::open(&path) {
-    Ok(sub) => sub.head().ok().and_then(|r| r.shorthand().ok().map(|s| s.to_string())),
-    Err(_) => None,
-  };
+  // The one observation of HEAD: it names what `record` writes down and what
+  // the branch delete below removes. Read twice, a concurrent checkout landed
+  // between them and the record named a branch the removal never touched
+  // (issue #531).
+  let head = head_branch(&path);
 
   // Prune admin files (.git/worktrees/<name>) FIRST so a subsequent
   // filesystem failure cannot leave a "phantom worktree" (issue #98):
@@ -581,9 +662,15 @@ fn remove_inner(repo: &Repository, name: &str, expected_path: Option<&Path>, del
     std::fs::remove_dir_all(&path)?;
   }
 
+  // The point of no return, and the only place a record belongs: every
+  // refusal is behind us, and the branch delete — the one step that destroys
+  // something the caller cannot rebuild from what is left on disk — is still
+  // ahead. See [`remove_verified_recording`].
+  record(&head);
+
   if delete_branch {
-    if let Some(b) = branch_name {
-      if let Ok(mut branch) = repo.find_branch(&b, git2::BranchType::Local) {
+    if let Some(b) = head.name() {
+      if let Ok(mut branch) = repo.find_branch(b, git2::BranchType::Local) {
         let _ = branch.delete();
       }
     }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2675,3 +2675,62 @@ fn a_repo_path_without_a_parent_resolves_only_the_path_token() {
   let out = expand_placeholders("{repo_path}|{repo_parent}", "r", None, None, None, Some(root)).unwrap();
   assert_eq!(out, "/|{repo_parent}");
 }
+
+/// Issue #531: the layered load must be able to work from bytes the caller
+/// already read, so a delete can hash, merge and gate one single snapshot of
+/// `.gwm.toml` instead of opening it once per question.
+#[test]
+fn the_layered_config_merges_the_repo_bytes_it_was_handed() {
+  let handed = br#"
+[worktree]
+branch_pattern = "handed/{desc}"
+"#;
+  let cfg = Config::load_layered_from_bytes(Some(handed), None).unwrap();
+  assert_eq!(cfg.worktree.branch_pattern, "handed/{desc}");
+}
+
+/// `None` repo bytes is "this repo has no `.gwm.toml`" — the global layer
+/// alone, exactly what an absent file produces through the path-based form.
+#[test]
+fn no_repo_bytes_leaves_the_global_layer_alone() {
+  let dir = TempDir::new().unwrap();
+  let global = dir.path().join("config.toml");
+  std::fs::write(&global, "[worktree]\nbranch_pattern = \"global/{desc}\"\n").unwrap();
+
+  let cfg = Config::load_layered_from_bytes(None, Some(&global)).unwrap();
+  assert_eq!(cfg.worktree.branch_pattern, "global/{desc}");
+}
+
+/// The handed bytes are still a repo layer, so they win over the global one
+/// key by key — same merge rule as the path-based form (#190).
+#[test]
+fn handed_repo_bytes_override_the_global_layer() {
+  let dir = TempDir::new().unwrap();
+  let global = dir.path().join("config.toml");
+  std::fs::write(
+    &global,
+    "[worktree]\nbranch_pattern = \"global/{desc}\"\nbase = \"develop\"\n",
+  )
+  .unwrap();
+
+  let cfg =
+    Config::load_layered_from_bytes(Some(b"[worktree]\nbranch_pattern = \"repo/{desc}\"\n"), Some(&global)).unwrap();
+  assert_eq!(cfg.worktree.branch_pattern, "repo/{desc}");
+  assert_eq!(
+    cfg.worktree.base, "develop",
+    "an untouched sibling key survives the merge"
+  );
+}
+
+/// The validators run on the handed bytes as they do on the file, so the
+/// snapshot form cannot become a way to smuggle a config the path-based form
+/// rejects.
+#[test]
+fn handed_repo_bytes_go_through_the_same_validators() {
+  let out = Config::load_layered_from_bytes(Some(b"[exec.profiles.bad]\ncommand = []\n"), None);
+  let err = out.expect_err("an empty exec profile command must be rejected");
+  assert!(
+    format!("{err}").contains("empty `command`"),
+    "the semantic validator has to run on handed bytes too, got: {err}"
+  );
+}

--- a/tests/lifecycle_tests.rs
+++ b/tests/lifecycle_tests.rs
@@ -246,3 +246,36 @@ fn an_empty_placeholder_expands_to_nothing_not_to_an_empty_argument() {
   let out = run_one_hook(dir.path(), &hostile, "set -- {issue}; echo $#", HashMap::new());
   assert_eq!(out.trim(), "1", "a non-empty value stays a single quoted argument");
 }
+
+/// Issue #531: the removal hook context must parse the branch with the config
+/// the caller already loaded, not with a fresh read of `.gwm.toml`.
+///
+/// `HookContext::for_worktree` used to build its parser through
+/// `BranchParser::for_repo`, which calls `Config::load_for_repo` — a fourth
+/// open of the same file inside one delete, and one that re-resolves the
+/// global config path the caller may have deliberately overridden (#194).
+#[test]
+fn the_hook_context_parses_the_branch_with_the_config_it_was_given() {
+  let dir = tempfile::tempdir().unwrap();
+  let repo = git2::Repository::init(dir.path()).unwrap();
+  // On disk: a pattern no `feat/#531-x` branch can match, so a re-read
+  // leaves every derived placeholder empty.
+  std::fs::write(
+    dir.path().join(".gwm.toml"),
+    "[worktree]\nbranch_pattern = \"wt/{desc}\"\n",
+  )
+  .unwrap();
+
+  let ctx = HookContext::for_worktree(
+    &repo,
+    dir.path(),
+    dir.path(),
+    dir.path(),
+    Some("feat/#531-x"),
+    &Config::default(),
+  );
+
+  assert_eq!(ctx.branch_type, "feat", "{{type}} must come from the given config");
+  assert_eq!(ctx.issue, "531", "{{issue}} must come from the given config");
+  assert_eq!(ctx.desc, "x", "{{desc}} must come from the given config");
+}

--- a/tests/trust_tests.rs
+++ b/tests/trust_tests.rs
@@ -259,3 +259,76 @@ fn load_malformed_toml_returns_error_not_empty() {
     msg
   );
 }
+
+/// Issue #531: the trust decision must be about the bytes the caller merged
+/// into the config it is going to execute, not about whatever `.gwm.toml`
+/// holds by the time `evaluate` gets around to opening it.
+///
+/// `TrustMode::Deny` is the seam that needs no ledger: it reports the hash it
+/// decided on, so a differing on-disk file proves which bytes were weighed.
+#[test]
+fn the_trust_decision_hashes_the_bytes_it_was_handed() {
+  use gwm::trust::{evaluate_bytes, TrustMode, TrustOutcome};
+
+  // `evaluate_bytes` can reach `$GWM_TRUST_LEDGER`, and "this call short-
+  // circuits before it does" is not something a reader — or the #507 guard —
+  // can check from the call site. Lock like every other reader.
+  let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+  let dir = TempDir::new().unwrap();
+  let cfg_path = dir.path().join(".gwm.toml");
+  std::fs::write(&cfg_path, b"[hooks]\n").unwrap();
+
+  let handed: &[u8] = b"[[hooks.pre_remove]]\nname = \"guard\"\nrun = \"exit 1\"\n";
+  let outcome = evaluate_bytes(&cfg_path, Some(handed), "origin", TrustMode::Deny).unwrap();
+
+  let expected: String = hash_config(handed).chars().take(12).collect();
+  match outcome {
+    TrustOutcome::Refuse { message } => assert!(
+      message.contains(&expected),
+      "the refusal must name the hash of the handed bytes ({expected}), got: {message}"
+    ),
+    other => panic!("--deny-bootstrap must refuse, got {other:?}"),
+  }
+}
+
+/// The empty-surface short-circuit reads the handed bytes too: a repo whose
+/// `.gwm.toml` grew a hook after the caller read it must not turn a delete
+/// the caller already resolved as hook-free into a ledger question.
+#[test]
+fn an_empty_surface_in_the_handed_bytes_proceeds_whatever_the_file_says() {
+  use gwm::trust::{evaluate_bytes, TrustMode, TrustOutcome};
+
+  let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+  let dir = TempDir::new().unwrap();
+  let cfg_path = dir.path().join(".gwm.toml");
+  std::fs::write(&cfg_path, b"[[hooks.pre_remove]]\nname = \"guard\"\nrun = \"exit 1\"\n").unwrap();
+
+  // Reaching the ledger would mean touching `$GWM_TRUST_LEDGER`; `Proceed`
+  // here is precisely the assertion that it short-circuits before that.
+  let outcome = evaluate_bytes(&cfg_path, Some(b"[hooks]\n"), "origin", TrustMode::Prompt).unwrap();
+  assert!(
+    matches!(outcome, TrustOutcome::Proceed),
+    "an empty surface in the handed bytes must proceed, got {outcome:?}"
+  );
+}
+
+/// `None` is "there is no `.gwm.toml`", and it must stay that answer even
+/// when one appeared on disk after the caller looked.
+#[test]
+fn no_handed_bytes_means_no_config_whatever_the_file_says() {
+  use gwm::trust::{evaluate_bytes, TrustMode, TrustOutcome};
+
+  let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+  let dir = TempDir::new().unwrap();
+  let cfg_path = dir.path().join(".gwm.toml");
+  std::fs::write(&cfg_path, b"[[hooks.pre_remove]]\nname = \"guard\"\nrun = \"exit 1\"\n").unwrap();
+
+  let outcome = evaluate_bytes(&cfg_path, None, "origin", TrustMode::Deny).unwrap();
+  assert!(
+    matches!(outcome, TrustOutcome::Proceed),
+    "no config means nothing to execute, got {outcome:?}"
+  );
+}

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -2121,9 +2121,25 @@ fn the_recorded_branch_is_the_one_the_removal_deletes() {
     .path;
 
   let mut seen = None;
-  worktree::remove_verified_recording(&repo, "feat-531-b", &expected, true, |head| seen = Some(head.clone())).unwrap();
+  let mut oid_at_record = None;
+  worktree::remove_verified_recording(&repo, "feat-531-b", &expected, true, |head| {
+    seen = Some(head.clone());
+    // What the undo journal does at this instant. The callback fires after
+    // the prune and after the directory is gone, so the ref has to still
+    // resolve here or `gwm undo` loses the tip it would resurrect, and it is
+    // the last instant at which it can: the branch delete is next.
+    oid_at_record = head
+      .name()
+      .and_then(|b| repo.find_branch(b, git2::BranchType::Local).ok())
+      .and_then(|br| br.into_reference().target());
+  })
+  .unwrap();
 
   assert_eq!(seen, Some(worktree::HeadBranch::Attached("feat/#531-b".into())));
+  assert!(
+    oid_at_record.is_some(),
+    "the branch tip must still resolve when the removal reports itself"
+  );
   assert!(
     repo.find_branch("feat/#531-b", git2::BranchType::Local).is_err(),
     "the branch the callback was handed is the one that got deleted"

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -2070,3 +2070,93 @@ fn remove_verified_refuses_an_id_that_now_points_elsewhere() {
   worktree::remove_verified(&repo, &live.id, &live.path, false).unwrap();
   assert!(!second.exists(), "a target that still matches is removed");
 }
+
+/// Issue #531: the removal records itself at the point of no return, so a
+/// refusal leaves nothing behind.
+///
+/// The check that can still refuse sits on the handle the prune acts on, and
+/// it runs before the callback. An entry written earlier would describe a
+/// removal that never happened, and `gwm undo` cannot get past one: it saves
+/// the journal only after the resurrection succeeds (`cli.rs`), and the
+/// resurrection fails on a worktree that is still on disk, so the stale entry
+/// comes back every single time until someone edits `history.toml` by hand.
+#[test]
+fn a_refused_removal_records_nothing() {
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-531-a");
+  worktree::add(&repo, "feat-531-a", &target, "feat/#531-a", false).unwrap();
+
+  let mut recorded = false;
+  let err = worktree::remove_verified_recording(
+    &repo,
+    "feat-531-a",
+    &wt_root.path().join("somewhere-else"),
+    false,
+    |_| recorded = true,
+  )
+  .expect_err("a path that no longer matches must refuse");
+
+  assert!(!recorded, "a refused removal must not record anything");
+  assert!(format!("{err}").contains("changed since it was confirmed"));
+  assert!(target.exists(), "the worktree must survive its own refusal");
+}
+
+/// One observation of HEAD, handed to whoever records the removal and used by
+/// the deletion itself — the journal cannot name a branch other than the one
+/// that goes.
+#[test]
+fn the_recorded_branch_is_the_one_the_removal_deletes() {
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-531-b");
+  worktree::add(&repo, "feat-531-b", &target, "feat/#531-b", false).unwrap();
+  let expected = worktree::list(&repo)
+    .unwrap()
+    .into_iter()
+    .find(|w| w.name == "feat-531-b")
+    .expect("the new worktree is listed")
+    .path;
+
+  let mut seen = None;
+  worktree::remove_verified_recording(&repo, "feat-531-b", &expected, true, |head| seen = Some(head.clone())).unwrap();
+
+  assert_eq!(seen, Some(worktree::HeadBranch::Attached("feat/#531-b".into())));
+  assert!(
+    repo.find_branch("feat/#531-b", git2::BranchType::Local).is_err(),
+    "the branch the callback was handed is the one that got deleted"
+  );
+}
+
+/// A detached HEAD is its own answer, not "could not read it": the removal
+/// deletes no branch, so the record must not name one either — `gwm undo`
+/// refuses a detached-HEAD entry outright rather than restoring the wrong
+/// branch.
+#[test]
+fn a_detached_head_is_recorded_as_such_and_deletes_no_branch() {
+  let (dir, _) = init_repo();
+  let repo = worktree::discover_repo(Some(dir.path())).unwrap();
+  let wt_root = TempDir::new().unwrap();
+  let target = wt_root.path().join("feat-531-c");
+  worktree::add(&repo, "feat-531-c", &target, "feat/#531-c", false).unwrap();
+  let expected = worktree::list(&repo)
+    .unwrap()
+    .into_iter()
+    .find(|w| w.name == "feat-531-c")
+    .expect("the new worktree is listed")
+    .path;
+
+  let head = Repository::open(&target).unwrap().head().unwrap().target().unwrap();
+  Repository::open(&target).unwrap().set_head_detached(head).unwrap();
+
+  let mut seen = None;
+  worktree::remove_verified_recording(&repo, "feat-531-c", &expected, true, |h| seen = Some(h.clone())).unwrap();
+
+  assert_eq!(seen, Some(worktree::HeadBranch::Detached));
+  assert!(
+    repo.find_branch("feat/#531-c", git2::BranchType::Local).is_ok(),
+    "a detached removal deletes no branch, whatever --delete-branch says"
+  );
+}


### PR DESCRIPTION
## Description

Three findings the Codex review loop on #526 left open, closed together because they are one shape: the removal sequence observed the same state several times (the config bytes, the path, HEAD) and acted on those observations, so every pair of consecutive observations was a window.

Closes #531

One correction to what #531 says. Its body claims the orphan journal entry is harmless because "`gwm undo` only consumes an entry on success, so nothing is silently lost". The first half is true and the conclusion does not follow. `cmd_undo` saves the journal only after the resurrection succeeds (`src/cli.rs:5189`) and `pop_last_for_repo` pops in memory only, so an entry describing a removal that never happened fails at `worktree::add` (the directory is still there), returns early, and is still on disk for the next run. It comes back on every `gwm undo` in that repo, and no later removal can be undone until `history.toml` is edited by hand. That moved the finding from cosmetic to blocking, and it is why the ordering fix is the one that shipped rather than a compensating write.

## Type of change

- [x] ♻️ Refactor (no behaviour change)
- [x] 🐛 Fix (bug fix)

## Changes

- **One snapshot of `.gwm.toml` per delete.** `RepoBatch::open` read it three times (layered config, repo layer, trust hash) and `HookContext::for_worktree` a fourth, through `BranchParser::for_repo`. `Config::load_layered_from_bytes` and `trust::evaluate_bytes` take bytes the caller already read; the path-based forms stay as wrappers so no other caller changes. `for_worktree` now takes the caller's config, which also closes a #194 hazard the surrounding code forbids two lines higher: `for_repo` re-resolves the global config path, so a caller that injected one had it ignored.
- **The removal records itself at its point of no return.** `remove_verified_recording` calls back from inside `remove_inner`, once the worktree is gone and before the branch delete. That is after everything that can still refuse, so a refusal writes nothing, and before the only step that destroys something unrecoverable, so the #29 / #98 anchor still exists on a partial failure. The second `verify_path` in `removal.rs` is gone: it stood in for "nothing refuses after this", which is now true by construction.
- **One observation of HEAD.** It was read twice, once to name the branch in the entry and once to decide which branch to delete. `HeadBranch` is read once in `remove_inner` and handed to both, and keeps the three answers apart: `Attached`, `Detached` (no branch to delete, and `gwm undo` refuses such an entry), `Unreadable` (the only case that falls back to the caller's older listing).
- **A stale changelog claim, corrected.** The `[Unreleased]` bullet from #521 said the journal write "moved after the removal succeeds". The #526 review moved it back in front of the destructive call and the bullet was never updated, so `dev` ships a claim the code does not make. Rewritten around what is true now. The CLI reference said every `gwm remove` appends an entry; a refused one appends none.

## Tests

- [x] `cargo test` passes locally (93 test binaries, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Nine new tests. Each was probed red by reverting the production change rather than by reading the test:

| test | goes red when |
|:--|:--|
| `trust_tests::the_trust_decision_hashes_the_bytes_it_was_handed` (+2 siblings) | `evaluate_bytes` re-opens the file instead of weighing its argument |
| `lifecycle_tests::the_hook_context_parses_the_branch_with_the_config_it_was_given` | `for_worktree` goes back to `BranchParser::for_repo` |
| `worktree_integration::a_refused_removal_records_nothing` | the callback fires before the path check |
| `worktree_integration::the_recorded_branch_is_the_one_the_removal_deletes` | the callback is handed anything other than the observation the deletion uses, **or** it fires below the branch delete instead of above it (the entry's `branch_oid` is looked up in there, after the prune and after the directory is gone) |
| `worktree_integration::a_detached_head_is_recorded_as_such_and_deletes_no_branch` | `Detached` collapses back into `Attached("HEAD")` |
| `config_tests::*_handed_*` (4) | the bytes form stops merging, or skips the validators |

The two tests #526 added on this exact surface (`removal_tests::the_journal_names_the_branch_the_removal_actually_deletes`, `::a_detached_head_is_recorded_as_no_branch`) both still go red under the HEAD-observation probe, so the refactor did not leave them exercising a function nothing calls.

Also run under a CI-like stripped `PATH` (`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin"`) for the five touched binaries.

## What is not covered, and why

None of the three windows is reachable without a concurrent writer timed to a gap between two adjacent statements, so no test here reproduces a race. What the tests pin is the property that makes the race impossible: one snapshot, one observation, and a write that cannot happen before the last refusal. Where a claim is structural rather than behavioural, it is called out above rather than dressed up as coverage.

The ordering change has a window of its own, and it is smaller than the one it replaces. Killed between the directory removal and the record: the worktree is gone, the branch intact, no entry, recoverable by hand. Before, the same kill left a spurious entry that wedged every later undo. The alternatives were both worse: holding the prune's handle across the write widens the #520 window (the handle caches its paths, so a worktree recreated at that id in between gets its admin entry destroyed), and a compensating delete puts a write on a failure path.

## Screenshots / TUI captures

None. No rendered surface changes; the TUI path is the same delete worker, exercised by `removal_tests`.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #531
- Follows: #526 (the loop that found all three), #520 (the invariant that the path check sits on the prune's handle)

## Notes for reviewers

Three things worth a second pair of eyes.

`remove_inner` taking a callback is the part to argue with. It exists to express "between these two statements" and nothing else; `remove` and `remove_verified` pass a no-op and every existing caller is untouched. If there is a way to pin the write to that instant without it, it is better than this.

`Unreadable` falling back to the caller's listing is the one place the sequence still prefers an older observation to none. The reasoning is in `branch_to_record`: nothing was observed, no branch was deleted, and `gwm undo` needs a name to re-attach to. `Detached` deliberately does not fall back.

The trust surface grew two functions rather than changing `evaluate`'s signature, so `create`, `bootstrap` and `review` are byte-for-byte on the old path. That was the reason #531 was filed separately from #526; it turned out to be affordable.
