### PR TITLE
♻️ refactor(tui): one width policy for every modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   49 columns wide there and its hint row read `Enter activa`, cut mid-word with
   no ellipsis and the `n cancel` hint entirely off screen.
 
-  The PTY overlay, the command-log transcript and the note editor keep spending
-  a percentage of the frame: they are text canvases, and the width is content.
+  The PTY overlay, the command-log transcript, the note editor and the
+  bootstrap report keep spending a percentage of the frame: they are text
+  canvases, and the width is content. `render_section` hard-clips by design
+  (one logical row, one visual row), so on those surfaces every column the
+  frame gives up is a column of a hook's error nobody can reach.
 
 - **The TUI is compact by default** ([#545](https://github.com/kbrdn1/gwm-cli/issues/545)).
   Panes and sidebar sections no longer draw box rules; each is delimited by a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branched on `term_width <= 80` to spend a bigger percentage on a small
   terminal. Width was therefore **not monotonic**: dragging a pane past 80
   columns made the link prompt 16 columns *narrower* and the exec / clean /
-  detail overlay 22. Two others sized on a bare percentage with no ceiling, so
-  the bootstrap report reached 160 columns on a 200-column terminal for a step
-  list around 30 characters long, and the delete confirmation 124 for a
-  four-row detail grid.
+  detail overlay 22. Four others sized on a bare percentage with no ceiling, so
+  on a 200-column terminal the delete confirmation reached 124 columns for a
+  four-row detail grid, and the help, config and command-palette overlays 120.
 
   Every bounded overlay now resolves its width through a single
   `modal_width(term_width, pct, min, max)`: its own knobs, one rule. Never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One width policy for every modal** ([#550](https://github.com/kbrdn1/gwm-cli/issues/550)).
+  Overlays used to size themselves with four different rules, two of which
+  branched on `term_width <= 80` to spend a bigger percentage on a small
+  terminal. Width was therefore **not monotonic**: dragging a pane past 80
+  columns made the link prompt 16 columns *narrower* and the exec / clean /
+  detail overlay 22. Two others sized on a bare percentage with no ceiling, so
+  the bootstrap report reached 160 columns on a 200-column terminal for a step
+  list around 30 characters long, and the delete confirmation 124 for a
+  four-row detail grid.
+
+  Every bounded overlay now resolves its width through a single
+  `modal_width(term_width, pct, min, max)`: its own knobs, one rule. Never
+  narrower as the terminal widens, never past its ceiling, always two columns
+  of margin per side. The floor also makes 80 columns, the width the docs
+  advertise, a size the surfaces were actually sized for. The confirm modal was
+  49 columns wide there and its hint row read `Enter activa`, cut mid-word with
+  no ellipsis and the `n cancel` hint entirely off screen.
+
+  The PTY overlay, the command-log transcript and the note editor keep spending
+  a percentage of the frame: they are text canvases, and the width is content.
+
 - **The TUI is compact by default** ([#545](https://github.com/kbrdn1/gwm-cli/issues/545)).
   Panes and sidebar sections no longer draw box rules; each is delimited by a
   filled one-line header instead, which buys back two rows and two columns per

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -78,13 +78,13 @@ pub use ui::{
   header_line, help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
   hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
   link_prompt_modal_width, link_target_keys, link_target_line, list_pane_counter, modal_hint_for_context,
-  modal_hint_for_context_with_fields, modal_hint_line, overlay_modal_width, palette_name_style, pane_counter,
-  panel_border_color, picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title,
-  reclaim_size_color, rename_buttons_line, status_line, status_pane_title, table_marker, tilde_compress_with_home,
-  type_selector_line, working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts,
-  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
-  SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
-  WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
+  modal_hint_for_context_with_fields, modal_hint_line, modal_width, overlay_modal_width, palette_name_style,
+  pane_counter, panel_border_color, picker_window, pr_badge_color, pr_summary_line, recent_commits_lines,
+  recent_items_pane_title, reclaim_size_color, rename_buttons_line, status_line, status_pane_title, table_marker,
+  tilde_compress_with_home, type_selector_line, working_tree_counts_footer, working_tree_pane_title,
+  working_tree_status_counts, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
+  HelpRow, HintContext, SidebarSections, WorkingTreeCounts, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON,
+  RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3833,7 +3833,7 @@ pub fn help_entry_line(keys: &str, label: &str, max_group_w: usize, theme: &Them
 }
 
 fn draw_help(f: &mut Frame, app: &mut App) {
-  let area = centered(60, 60, f.area());
+  let area = centered_viewport(60, 64, 96, 60, f.area());
   // Use the underlying pane context, not the view-priority `hint_context`
   // (which would be `Help` while this overlay is up) — `?` documents the
   // pane you opened it from, and the picker gating depends on it.
@@ -4236,7 +4236,7 @@ fn settings_keys_lines(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
 /// herdr-style scrollbar, and a fixed footer hint. The renderer republishes
 /// `config_panel.max_scroll` against the live body viewport.
 fn draw_config_panel(f: &mut Frame, app: &mut App) {
-  let area = centered(60, 60, f.area());
+  let area = centered_viewport(60, 64, 96, 60, f.area());
   let accent = app.theme.accent;
   let muted = app.theme.muted;
   let muted_style = Style::default().fg(muted);
@@ -4517,7 +4517,7 @@ fn draw_create(f: &mut Frame, app: &App) {
     clean,
   );
   let term = f.area();
-  let outer = centered_box(70, 72, 1, term);
+  let outer = centered_content(70, 56, 72, 1, term);
   let inner_w = block.inner(outer).width as usize;
 
   // Width of the background-filled value field: the inner width minus the
@@ -4567,7 +4567,7 @@ fn draw_create(f: &mut Frame, app: &App) {
   }
 
   let height = lines.len() as u16 + 4 + 2 /* border */ + 2 /* vertical padding */;
-  let area = centered_box(70, 72, height, term);
+  let area = centered_content(70, 56, 72, height, term);
   let inner = Layout::default()
     .direction(Direction::Vertical)
     .constraints([
@@ -4736,25 +4736,43 @@ pub fn link_target_line(key: &str, label: &str, selected: bool, accent: Color, m
   Line::from(vec![Span::raw("  "), Span::styled(button, idle)])
 }
 
-/// Modal width for the Link prompt. Pure so the visual budget remains pinned
-/// without a terminal renderer in `tests/tui_ui_helpers_tests.rs`.
-pub fn link_prompt_modal_width(term_width: u16) -> u16 {
-  let width = if term_width <= 80 {
-    term_width.saturating_mul(80) / 100
-  } else {
-    term_width.saturating_mul(60) / 100
-  };
-  width.min(72).min(term_width)
+/// **The** modal width policy (issue #550): `pct` % of the terminal, never
+/// below `min_cols`, never above `max_cols`, always leaving two columns of
+/// margin on each side.
+///
+/// Every bounded overlay resolves its width through here, with its own knobs —
+/// the surfaces genuinely want different widths (a clean report uses the room,
+/// a link prompt does not), but they no longer want different *rules*. Two
+/// properties the ad-hoc sizings did not have, both pinned in
+/// `tests/tui_ui_helpers_tests.rs`:
+///
+/// - **Monotonic.** The old helpers branched on `term_width <= 80` to spend a
+///   bigger percentage on a small terminal, so crossing 80 columns made the
+///   modal *narrower*: the link prompt lost 16 columns and the exec/clean
+///   overlay 22, live, while dragging a pane edge. A floor buys the same
+///   "small terminals still get a usable box" without the seam.
+/// - **Bounded.** A bare percentage stretches forever; the report modal was
+///   160 columns wide at 200 for a step list ~30 characters long.
+///
+/// The `min` against the frame comes last so the floor can never push a modal
+/// past the edge on a terminal narrower than `min_cols`.
+pub fn modal_width(term_width: u16, pct: u16, min_cols: u16, max_cols: u16) -> u16 {
+  let ideal = term_width.saturating_mul(pct) / 100;
+  ideal.clamp(min_cols, max_cols).min(term_width.saturating_sub(4).max(1))
 }
 
-/// Modal width for the exec / clean overlays (issue #334 polish). A bit wider
-/// than the link-prompt modal so the full-width clean report (icon + dir name
-/// pinned left, size pinned right) uses the horizontal space — but capped so
-/// the name↔size gap never stretches absurdly on an ultra-wide terminal.
-/// ~62 % of the width (90 % when ≤ 80 cols), clamped to `[48, 88]`.
+/// Modal width for the Link / Open prompts: wide enough for an issue or PR
+/// summary, capped so it stays a prompt rather than a page.
+pub fn link_prompt_modal_width(term_width: u16) -> u16 {
+  modal_width(term_width, 60, 64, 72)
+}
+
+/// Modal width for the exec / clean / detail overlays (issue #334 polish).
+/// Wider than the link-prompt modal so the full-width clean report (icon + dir
+/// name pinned left, size pinned right) uses the horizontal space — but capped
+/// so the name↔size gap never stretches absurdly on an ultra-wide terminal.
 pub fn overlay_modal_width(term_width: u16) -> u16 {
-  let pct = if term_width <= 80 { 90 } else { 62 };
-  (term_width.saturating_mul(pct) / 100).clamp(48, 88).min(term_width)
+  modal_width(term_width, 62, 72, 88)
 }
 
 /// Section-heading style for the Keybindings overlay body. Kept pure so the
@@ -4872,7 +4890,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     let block = overlay_block_titled(delete_worktree_title(), danger);
     let lines: Vec<Line<'static>> = vec![Line::from("nothing selected").centered()];
     let height = lines.len() as u16 + 2 /* border */ + 2 /* padding */;
-    let area = centered_h(40, height, f.area());
+    let area = centered_content(40, 40, 64, height, f.area());
     f.render_widget(Clear, area);
     f.render_widget(Paragraph::new(lines).block(block), area);
     return;
@@ -4960,7 +4978,7 @@ fn draw_confirm(f: &mut Frame, app: &App) {
   // shared interior padding — no more fixed 44%-tall box that dwarfed its
   // few lines (#187 review).
   let height = content.len() as u16 + 4 + 2 /* border */ + 2 /* padding */;
-  let area = centered_h(62, height, term);
+  let area = centered_content(62, 64, 88, height, term);
   f.render_widget(Clear, area);
 
   // Five stacked regions inside the padded frame: the title + description,
@@ -5159,7 +5177,7 @@ fn draw_report(f: &mut Frame, app: &App) {
   // into the top rule.
   let height =
     (logs_height + 2 /* gap + hint */ + 2 /* border */ + 2/* padding */).min(term.height.saturating_mul(80) / 100);
-  let area = centered_h(80, height, term);
+  let area = centered_content(80, 64, 96, height, term);
   let block = overlay_block_titled("Bootstrap Report", accent);
   let inner = block.inner(area);
   let layout = Layout::default()
@@ -5280,6 +5298,26 @@ fn draw_pty_overlay(f: &mut Frame, app: &mut App) {
   }
 }
 
+/// The `pct_y` % slice of `area`'s height, the way a ratatui percentage layout
+/// rounds it. Shared by [`centered`] and [`centered_viewport`] so the two
+/// families agree on what "60 % tall" means to the row.
+fn viewport_height(pct_y: u16, area: Rect) -> u16 {
+  Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([
+      Constraint::Percentage((100 - pct_y) / 2),
+      Constraint::Percentage(pct_y),
+      Constraint::Percentage((100 - pct_y) / 2),
+    ])
+    .split(area)[1]
+    .height
+}
+
+/// A **full-bleed** surface: a percentage of both axes, unbounded. Reserved for
+/// the three text canvases that genuinely spend whatever width the terminal
+/// has — the PTY overlay, the command-log transcript and the note editor. Every
+/// other overlay goes through [`centered_viewport`] or [`modal_width`], which
+/// bound the width (issue #550).
 fn centered(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
   let v = Layout::default()
     .direction(Direction::Vertical)
@@ -5299,6 +5337,15 @@ fn centered(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
     .split(v[1])[1]
 }
 
+/// A scrolling overlay: the height is a viewport (a percentage of the frame —
+/// these surfaces own a scroll cursor, so they do not size to their content),
+/// the width goes through the [`modal_width`] policy so it keeps a floor and a
+/// ceiling. Used by the help, config and command-palette overlays.
+fn centered_viewport(pct_x: u16, min_x: u16, max_x: u16, pct_y: u16, area: Rect) -> Rect {
+  let height = viewport_height(pct_y, area);
+  centered_abs(modal_width(area.width, pct_x, min_x, max_x), height, area)
+}
+
 /// Center a box of an **absolute** `width`/`height` (in cells) inside `area`,
 /// clamping each dimension to the area so an oversized modal cannot overflow
 /// the frame. Shared by the open-menu and link-prompt modals (issue #243) and
@@ -5311,27 +5358,16 @@ pub fn centered_abs(width: u16, height: u16, area: Rect) -> Rect {
   Rect { x, y, width, height }
 }
 
-/// Centre a box of `width_pct`% width and a fixed `height` (rows) in
-/// `area`. Unlike [`centered`], the height is absolute so an overlay can
-/// size itself to its content rather than a fixed percentage of the
-/// screen (#187 — the confirm modal was far taller than its few lines).
-/// Delegates the centering arithmetic to [`centered_abs`].
-fn centered_h(width_pct: u16, height: u16, area: Rect) -> Rect {
-  let width = area.width.saturating_mul(width_pct) / 100;
-  centered_abs(width, height, area)
-}
-
-/// Like [`centered_h`] but also caps the width at `max_width` columns so a
-/// form modal does not stretch edge-to-edge on a wide terminal (issue #217
-/// — the create overlay's input surfaces spanned the whole screen).
-fn centered_box(width_pct: u16, max_width: u16, height: u16, area: Rect) -> Rect {
-  let height = height.min(area.height);
-  let width = (area.width.saturating_mul(width_pct) / 100)
-    .min(max_width)
-    .min(area.width);
-  let x = area.x + area.width.saturating_sub(width) / 2;
-  let y = area.y + area.height.saturating_sub(height) / 2;
-  Rect { x, y, width, height }
+/// A content-sized overlay: the height is absolute so the modal fits its own
+/// lines rather than a percentage of the screen (#187 — the confirm modal was
+/// far taller than its few lines), the width goes through the [`modal_width`]
+/// policy.
+///
+/// This replaces the two helpers that used to do the same job with different
+/// rules (issue #550): `centered_h`, a bare percentage with no ceiling, and
+/// `centered_box`, a percentage with a ceiling but no floor.
+fn centered_content(pct_x: u16, min_x: u16, max_x: u16, height: u16, area: Rect) -> Rect {
+  centered_abs(modal_width(area.width, pct_x, min_x, max_x), height, area)
 }
 
 /// A modal overlay frame: a rounded border in `color` with interior
@@ -6053,7 +6089,7 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
 
   let block = overlay_block_titled("Rename Worktree", clean);
   let term = f.area();
-  let outer = centered_box(70, 72, 1, term);
+  let outer = centered_content(70, 56, 72, 1, term);
   let inner_w = block.inner(outer).width as usize;
   let label_w = 5usize;
   let gutter = 2 + label_w + 2;
@@ -6114,7 +6150,7 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
   }
 
   let height = lines.len() as u16 + 4 + 2 /* border */ + 2 /* vertical padding */;
-  let area = centered_box(70, 72, height, term);
+  let area = centered_content(70, 56, 72, height, term);
   let inner = Layout::default()
     .direction(Direction::Vertical)
     .constraints([
@@ -6169,7 +6205,7 @@ fn draw_edit_worktree(f: &mut Frame, app: &App) {
 }
 
 fn draw_command_palette(f: &mut Frame, app: &App) {
-  let area = centered(60, 50, f.area());
+  let area = centered_viewport(60, 64, 96, 50, f.area());
   f.render_widget(Clear, area);
 
   let accent = app.theme.accent;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5186,7 +5186,19 @@ fn draw_report(f: &mut Frame, app: &App) {
   // into the top rule.
   let height =
     (logs_height + 2 /* gap + hint */ + 2 /* border */ + 2/* padding */).min(term.height.saturating_mul(80) / 100);
-  let area = centered_content(80, 64, 96, height, term);
+  // A text canvas, so a bare percentage rather than the bounded
+  // [`modal_width`] policy (issue #550) — the same call the PTY overlay, the
+  // command-log transcript and the note editor make, and for the same
+  // reason: what it displays is arbitrary external text (hook stdout, error
+  // messages, paths), and `render_section` hard-clips by design (one logical
+  // row = one visual row, no wrap, no horizontal scroll), so every column
+  // the frame gives up is a column of a hook's error nobody can reach.
+  //
+  // #550 briefly capped it at 96 columns because 160 looked wasteful for a
+  // list of short step labels. That is the best case, not the one that
+  // matters: the worst case is a compiler error, and the cap cut 64 cells
+  // off it at 200 columns. No defect ever motivated the cap.
+  let area = centered_abs(term.width.saturating_mul(80) / 100, height, term);
   let block = overlay_block_titled("Bootstrap Report", accent);
   let inner = block.inner(area);
   let layout = Layout::default()

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4896,18 +4896,27 @@ fn draw_confirm(f: &mut Frame, app: &App) {
     return;
   }
 
-  // Width first (a fixed % of the terminal) so a long path / name can be
-  // middle-ellipsized to one line instead of wrapping mid-path (#187
-  // review). `text_w` is the room inside the border + padding.
+  // Title stays centred; details use an aligned label/value grid so the
+  // destructive target is easier to scan (#220 visual follow-up).
   let term = f.area();
-  let outer_w = term.width.saturating_mul(62) / 100;
-  let text_w = outer_w.saturating_sub(6) as usize;
+  let block = overlay_block_titled(&delete_batch_title(targets.len()), danger);
+
+  // Width first so a long path / name can be middle-ellipsized to one line
+  // instead of wrapping mid-path (#187 review). Measured on a throwaway
+  // one-row frame from the *same* `centered_content` call the real frame
+  // below uses (the idiom `draw_create` already follows), so the ellipsis
+  // budget cannot drift from the width the block ends up with.
+  //
+  // It used to recompute `term.width * 62 / 100` by hand: one rule written
+  // twice. Harmless while the frame was that same bare percentage, but the
+  // moment the width policy gained an 88-column ceiling (#550) the two
+  // disagreed — at 200 columns the text was sized for 124 columns inside an
+  // 88-column frame, so nothing was ellipsized and the path wrapped across
+  // three rows, breaking the very alignment #187 built this grid for.
+  let text_w = block.inner(centered_content(62, 64, 88, 1, term)).width as usize;
   let label_w = "Delete Branch".chars().count();
   let value_w = text_w.saturating_sub(label_w + 2).max(1);
 
-  // Title stays centred; details use an aligned label/value grid so the
-  // destructive target is easier to scan (#220 visual follow-up).
-  let block = overlay_block_titled(&delete_batch_title(targets.len()), danger);
   let mut content: Vec<Line> = Vec::new();
   if targets.len() > 1 {
     // A batch reports its size, not its members (#484): the user picked the

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1331,3 +1331,315 @@ fn modal_frames_are_not_taller_than_their_content() {
     rows.join("\n")
   );
 }
+
+// ---------------------------------------------------------------------------
+// Responsive sizing matrix (issue #550)
+// ---------------------------------------------------------------------------
+
+/// The modal's rect, located by the rounded corners its frame draws
+/// (`overlay_block` uses `BorderType::Rounded`). Returns `(x, y, w, h)`.
+///
+/// The oracle is only sound while the surfaces *behind* a modal draw no
+/// rounded corner of their own — `the_background_paints_no_rounded_corner`
+/// below is what keeps that honest.
+fn modal_rect(buf: &Buffer) -> Option<(u16, u16, u16, u16)> {
+  let area = *buf.area();
+  let mut top_left = None;
+  'outer: for y in 0..area.height {
+    for x in 0..area.width {
+      if buf[(x, y)].symbol() == "╭" {
+        top_left = Some((x, y));
+        break 'outer;
+      }
+    }
+  }
+  let (x0, y0) = top_left?;
+  let x1 = (x0 + 1..area.width)
+    .find(|&x| buf[(x, y0)].symbol() == "╮")
+    .unwrap_or(x0);
+  let y1 = (y0 + 1..area.height)
+    .find(|&y| buf[(x0, y)].symbol() == "╰")
+    .unwrap_or(y0);
+  Some((x0, y0, x1 - x0 + 1, y1 - y0 + 1))
+}
+
+/// The rendered rows *inside* the modal frame. Needles asserted against the
+/// whole buffer can be satisfied by the statusbar or the worktree table behind
+/// the modal; these rows can only come from the modal itself.
+fn modal_rows(buf: &Buffer) -> Vec<String> {
+  let Some((x, y, w, h)) = modal_rect(buf) else {
+    return Vec::new();
+  };
+  (y..(y + h).min(buf.area().height))
+    .map(|row| {
+      (x..(x + w).min(buf.area().width))
+        .map(|col| buf[(col, row)].symbol())
+        .collect()
+    })
+    .collect()
+}
+
+fn modal_width_at(setup: &dyn Fn() -> (tempfile::TempDir, App), w: u16, h: u16) -> u16 {
+  let (_dir, mut app) = setup();
+  let buf = render_at(&mut app, w, h);
+  modal_rect(&buf)
+    .unwrap_or_else(|| panic!("no modal rendered at {w}x{h} — rows:\n{}", row_strings(&buf).join("\n")))
+    .2
+}
+
+type ModalSetup = Box<dyn Fn() -> (tempfile::TempDir, App)>;
+
+/// Every modal, with the width it must resolve to at the advertised 80-column
+/// floor and on an ultra-wide terminal. Exact values, deliberately: this is a
+/// characterisation matrix, so a refactor that moves a number has to say so.
+fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
+  vec![
+    (
+      "help",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_help();
+        (d, a)
+      }) as ModalSetup,
+      64,
+      96,
+    ),
+    (
+      "config-panel",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_config_panel();
+        (d, a)
+      }),
+      64,
+      96,
+    ),
+    (
+      "command-palette",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.open_command_palette();
+        (d, a)
+      }),
+      64,
+      96,
+    ),
+    (
+      "create",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_create();
+        (d, a)
+      }),
+      56,
+      72,
+    ),
+    (
+      "edit/rename",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.worktrees.push(deletable_worktree("feat-550-rename"));
+        a.list_state.select(Some(a.worktrees.len() - 1));
+        a.enter_edit_worktree();
+        (d, a)
+      }),
+      56,
+      72,
+    ),
+    (
+      "confirm",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.worktrees.push(deletable_worktree("feat-550-one"));
+        a.list_state.select(Some(a.worktrees.len() - 1));
+        a.enter_confirm_delete();
+        (d, a)
+      }),
+      64,
+      88,
+    ),
+    (
+      "report",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.report = Some(BootstrapReport {
+          steps: vec![StepResult::ok("copy env file"), StepResult::skipped("npm i", "no pkg")],
+        });
+        a.view = View::Report;
+        (d, a)
+      }),
+      64,
+      96,
+    ),
+    (
+      "open-menu",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_open_menu();
+        (d, a)
+      }),
+      64,
+      72,
+    ),
+    (
+      "link-prompt",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_link_prompt();
+        (d, a)
+      }),
+      64,
+      72,
+    ),
+    (
+      "exec-picker",
+      Box::new(|| {
+        let (d, _) = init_repo();
+        std::fs::write(
+          d.path().join(".gwm.toml"),
+          "[exec.profiles.build]\ncommand = [\"cargo\", \"build\"]\n",
+        )
+        .unwrap();
+        let mut a = App::new_at_layered(Some(d.path()), None).unwrap();
+        a.sidebar.open = false;
+        a.enter_exec_picker();
+        (d, a)
+      }),
+      72,
+      88,
+    ),
+    (
+      "detail/agents",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.worktrees.push(deletable_worktree("feat-550-agents"));
+        a.list_state.select(Some(a.worktrees.len() - 1));
+        a.open_agent_overlay();
+        (d, a)
+      }),
+      72,
+      88,
+    ),
+    // Full-bleed surfaces: the log transcript and the note editor are text
+    // canvases, so they keep spending a percentage of the frame rather than
+    // capping. Pinned here anyway — an exemption nobody measures is how a
+    // matrix goes green while missing a surface.
+    (
+      "command-logs",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.view = View::CommandLogs;
+        (d, a)
+      }),
+      72,
+      180,
+    ),
+    (
+      "note-editor",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.worktrees.push(deletable_worktree("feat-550-note"));
+        a.list_state.select(Some(a.worktrees.len() - 1));
+        a.open_note_editor();
+        (d, a)
+      }),
+      64,
+      160,
+    ),
+  ]
+}
+
+#[test]
+fn the_background_paints_no_rounded_corner() {
+  // The matrix below finds each modal by its rounded top-left corner. That
+  // only works while nothing behind the modal draws one — if the worktree
+  // table or the sidebar ever grows a rounded frame, every measurement below
+  // silently starts describing the wrong rect. Prove the oracle, then use it.
+  for sidebar_open in [false, true] {
+    let (_dir, mut app) = make_app();
+    app.sidebar.open = sidebar_open;
+    let buf = render_at(&mut app, 120, 40);
+    let corners = (0..buf.area().height)
+      .flat_map(|y| (0..buf.area().width).map(move |x| (x, y)))
+      .filter(|&(x, y)| buf[(x, y)].symbol() == "╭")
+      .count();
+    assert_eq!(
+      corners,
+      0,
+      "View::List (sidebar open = {sidebar_open}) must paint no rounded corner, found {corners} — rows:\n{}",
+      row_strings(&buf).join("\n")
+    );
+  }
+}
+
+#[test]
+fn every_modal_resolves_to_its_pinned_width_at_the_80_column_floor() {
+  // The docs advertise the TUI at 80 columns. Pre-#550 the confirm modal was
+  // 49 columns wide there and its hint row read `Enter activa`; help was 48
+  // and its rows lost their tail behind the scrollbar. Each modal now has a
+  // floor, so 80 columns is a size the surfaces were actually sized for.
+  for (name, setup, want_at_80, _) in sizing_matrix() {
+    assert_eq!(
+      modal_width_at(setup.as_ref(), 80, 24),
+      want_at_80,
+      "{name}: width at the 80-column floor"
+    );
+  }
+}
+
+#[test]
+fn no_modal_stretches_without_bound_on_an_ultra_wide_terminal() {
+  // Pre-#550 the report modal was 160 columns wide at 200 (for a step list
+  // ~30 characters long) and the confirm modal 124 (for a four-row detail
+  // grid), because both sized on a bare percentage with no ceiling.
+  for (name, setup, _, want_at_200) in sizing_matrix() {
+    assert_eq!(
+      modal_width_at(setup.as_ref(), 200, 80),
+      want_at_200,
+      "{name}: width on a 200-column terminal"
+    );
+  }
+}
+
+#[test]
+fn no_modal_gets_narrower_as_the_terminal_gets_wider() {
+  // The render-level companion to
+  // `a_modal_never_shrinks_when_the_terminal_grows` in
+  // tests/tui_ui_helpers_tests.rs: the helpers being monotonic is worth
+  // nothing if a call site reintroduces the seam. Sampled across the
+  // 80-column boundary where the old branch lived.
+  const WIDTHS: [u16; 8] = [60, 79, 80, 81, 90, 100, 140, 200];
+  for (name, setup, _, _) in sizing_matrix() {
+    let mut previous = 0u16;
+    for w in WIDTHS {
+      let got = modal_width_at(setup.as_ref(), w, 40);
+      assert!(
+        got >= previous,
+        "{name}: widening the terminal to {w} cols shrank the modal from {previous} to {got}"
+      );
+      previous = got;
+    }
+  }
+}
+
+#[test]
+fn the_confirm_hint_row_is_not_cut_mid_word_at_80_columns() {
+  // The concrete symptom the floor fixes: at 49 columns the confirm modal's
+  // hint row was clipped by ratatui to `Enter activa` — no ellipsis, just a
+  // half-word. The last hint the row advertises must survive intact.
+  let (_dir, mut app) = make_app();
+  app.worktrees.push(deletable_worktree("feat-550-hint"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.enter_confirm_delete();
+
+  let buf = render_at(&mut app, 80, 24);
+  // Scanned INSIDE the modal rect, not over the whole buffer: the bottom
+  // statusbar advertises `Enter activate` too, so a whole-buffer search stays
+  // green with the modal's own hint row cut in half.
+  let rows = modal_rows(&buf);
+  assert!(
+    rows.iter().any(|r| r.contains("Enter activate")),
+    "the confirm hint row must render its last hint in full at 80 columns — modal rows:\n{}",
+    rows.join("\n")
+  );
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1643,3 +1643,40 @@ fn the_confirm_hint_row_is_not_cut_mid_word_at_80_columns() {
     rows.join("\n")
   );
 }
+
+#[test]
+fn the_confirm_modal_ellipsizes_to_the_width_its_frame_actually_gets() {
+  // #550, Codex review (P2). The confirm modal computed its ellipsis budget
+  // from `term.width * 62 / 100` by hand: a second copy of the sizing rule.
+  // Harmless while the frame was the same bare percentage, but once the
+  // policy gained an 88-column ceiling the two drifted, and at 200 columns
+  // the text was sized for 124 columns inside an 88-column frame.
+  // `ellipsize_middle` then left the string untouched and ratatui clipped it
+  // at the border, cutting off the very tail a middle-ellipsis exists to
+  // keep. One rule written twice is what let it drift, so the budget now
+  // comes from the frame itself.
+  let (_dir, mut app) = make_app();
+  let mut long = deletable_worktree("feat-550-long");
+  long.path =
+    PathBuf::from("/tmp/gwm-test/a-deliberately-long-worktree-directory-name/nested/deeper/still-deeper/TAIL-MARKER");
+  app.worktrees.push(long);
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.enter_confirm_delete();
+
+  let rows = modal_rows(&render_at(&mut app, 200, 40));
+  let path_row = rows.iter().find(|r| r.contains("Path")).unwrap_or_else(|| {
+    panic!(
+      "the confirm modal must render its Path row — modal rows:\n{}",
+      rows.join("\n")
+    )
+  });
+  assert!(
+    path_row.contains('…'),
+    "a path this long must be middle-ellipsized, not left for ratatui to clip — modal rows:\n{}",
+    rows.join("\n")
+  );
+  assert!(
+    path_row.contains("TAIL-MARKER"),
+    "the path's tail must survive: the budget has to be the frame's own width — row:\n{path_row}"
+  );
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1459,19 +1459,6 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
       88,
     ),
     (
-      "report",
-      Box::new(|| {
-        let (d, mut a) = make_app();
-        a.report = Some(BootstrapReport {
-          steps: vec![StepResult::ok("copy env file"), StepResult::skipped("npm i", "no pkg")],
-        });
-        a.view = View::Report;
-        (d, a)
-      }),
-      64,
-      160,
-    ),
-    (
       "open-menu",
       Box::new(|| {
         let (d, mut a) = make_app();
@@ -1520,11 +1507,26 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
       72,
       88,
     ),
-    // Full-bleed surfaces: the log transcript and the note editor are text
-    // canvases, so they keep spending a percentage of the frame rather than
-    // capping. The bootstrap report above is one too (it renders hook stdout)
-    // and is pinned at its uncapped 160. Pinned here anyway — an exemption
-    // nobody measures is how a matrix goes green while missing a surface.
+    // Text canvases: the bootstrap report, the log transcript and the note
+    // editor render arbitrary external text, so they keep spending a bare
+    // percentage of the frame rather than going through `modal_width`. They
+    // have NO floor — the report's 64 at 80 columns is `80 * 80 / 100`, which
+    // merely happens to land on the same number the bounded surfaces are
+    // floored at. Pinned here anyway: an exemption nobody measures is how a
+    // matrix goes green while missing a surface.
+    (
+      "report",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.report = Some(BootstrapReport {
+          steps: vec![StepResult::ok("copy env file"), StepResult::skipped("npm i", "no pkg")],
+        });
+        a.view = View::Report;
+        (d, a)
+      }),
+      64,
+      160,
+    ),
     (
       "command-logs",
       Box::new(|| {
@@ -1577,8 +1579,10 @@ fn the_background_paints_no_rounded_corner() {
 fn every_modal_resolves_to_its_pinned_width_at_the_80_column_floor() {
   // The docs advertise the TUI at 80 columns. Pre-#550 the confirm modal was
   // 49 columns wide there and its hint row read `Enter activa`; help was 48
-  // and its rows lost their tail behind the scrollbar. Each modal now has a
-  // floor, so 80 columns is a size the surfaces were actually sized for.
+  // and its rows lost their tail behind the scrollbar. Every *bounded* modal
+  // now has a floor, so 80 columns is a size those surfaces were actually
+  // sized for. The three text canvases have none: their entries below are the
+  // plain percentage, pinned so a change to it still has to be declared.
   for (name, setup, want_at_80, _) in sizing_matrix() {
     assert_eq!(
       modal_width_at(setup.as_ref(), 80, 24),

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1469,7 +1469,7 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
         (d, a)
       }),
       64,
-      96,
+      160,
     ),
     (
       "open-menu",
@@ -1522,8 +1522,9 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
     ),
     // Full-bleed surfaces: the log transcript and the note editor are text
     // canvases, so they keep spending a percentage of the frame rather than
-    // capping. Pinned here anyway — an exemption nobody measures is how a
-    // matrix goes green while missing a surface.
+    // capping. The bootstrap report above is one too (it renders hook stdout)
+    // and is pinned at its uncapped 160. Pinned here anyway — an exemption
+    // nobody measures is how a matrix goes green while missing a surface.
     (
       "command-logs",
       Box::new(|| {
@@ -1588,10 +1589,12 @@ fn every_modal_resolves_to_its_pinned_width_at_the_80_column_floor() {
 }
 
 #[test]
-fn no_modal_stretches_without_bound_on_an_ultra_wide_terminal() {
-  // Pre-#550 the report modal was 160 columns wide at 200 (for a step list
-  // ~30 characters long) and the confirm modal 124 (for a four-row detail
-  // grid), because both sized on a bare percentage with no ceiling.
+fn every_modal_resolves_to_its_pinned_width_on_an_ultra_wide_terminal() {
+  // Pre-#550 the confirm modal was 124 columns wide at 200 for a four-row
+  // detail grid, and help / config / palette 120, because they sized on a
+  // bare percentage with no ceiling. The three text canvases (report,
+  // command-log transcript, note editor) still do, deliberately, and are
+  // pinned at that width rather than exempted from the matrix.
   for (name, setup, _, want_at_200) in sizing_matrix() {
     assert_eq!(
       modal_width_at(setup.as_ref(), 200, 80),
@@ -1678,5 +1681,35 @@ fn the_confirm_modal_ellipsizes_to_the_width_its_frame_actually_gets() {
   assert!(
     path_row.contains("TAIL-MARKER"),
     "the path's tail must survive: the budget has to be the frame's own width — row:\n{path_row}"
+  );
+}
+
+#[test]
+fn the_bootstrap_report_shows_a_long_hook_line_on_a_wide_terminal() {
+  // #550, Codex review (P2). The report displays arbitrary external text:
+  // hook stdout, error messages, paths. `render_section` hard-clips by
+  // design (one logical row = one visual row, no wrap, no horizontal
+  // scroll), so whatever does not fit the frame is simply unreachable.
+  //
+  // Capping the report at 96 columns therefore made a hook's error message
+  // 64 cells shorter at 200 columns than it had been. Nothing had reported
+  // that its 80 % width was a problem; the cap was taste, not a fix, so it
+  // is gone and the report sits with the other text canvases.
+  let (_dir, mut app) = make_app();
+  let detail = format!(
+    "error[E0432]: unresolved import `{}` at the end",
+    "very::long::module::path".repeat(3)
+  );
+  assert!(detail.chars().count() > 96, "the fixture must exceed the old cap");
+  app.report = Some(BootstrapReport {
+    steps: vec![StepResult::skipped("cargo build", &detail)],
+  });
+  app.view = View::Report;
+
+  let rows = modal_rows(&render_at(&mut app, 200, 40));
+  assert!(
+    rows.iter().any(|r| r.contains("at the end")),
+    "the tail of a long hook line must stay reachable on a wide terminal — modal rows:\n{}",
+    rows.join("\n")
   );
 }

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -1192,6 +1192,83 @@ fn overlay_modal_width_is_wider_but_clamped() {
 }
 
 #[test]
+fn a_modal_never_shrinks_when_the_terminal_grows() {
+  // #550. Both helpers used to branch on `term_width <= 80` to spend a bigger
+  // percentage on a small terminal, which made width NON-MONOTONIC: dragging
+  // a pane from 80 to 81 columns collapsed the link prompt by 16 columns and
+  // the exec/clean/detail overlay by 22. A modal may stop growing; it must
+  // never get narrower because the terminal got wider.
+  use gwm::tui::{link_prompt_modal_width, overlay_modal_width};
+  for w in 20u16..300 {
+    for (name, f) in [
+      ("link_prompt_modal_width", link_prompt_modal_width as fn(u16) -> u16),
+      ("overlay_modal_width", overlay_modal_width as fn(u16) -> u16),
+    ] {
+      let (here, next) = (f(w), f(w + 1));
+      assert!(
+        next >= here,
+        "{name}: growing the terminal from {w} to {} cols shrank the modal from {here} to {next} cols",
+        w + 1
+      );
+    }
+  }
+}
+
+#[test]
+fn the_width_policy_is_monotonic_and_bounded_for_any_knobs() {
+  // The two wrappers above only exercise two of the eight knob sets in use.
+  // The property belongs to the policy, not to its callers: whatever
+  // (pct, min, max) a future overlay picks, its width must never shrink as the
+  // terminal grows, never break its ceiling, and never reach the frame edge.
+  use gwm::tui::modal_width;
+  for (pct, min_cols, max_cols) in [
+    (40, 40, 64),
+    (60, 64, 72),
+    (60, 64, 96),
+    (62, 64, 88),
+    (70, 56, 72),
+    (80, 64, 96),
+  ] {
+    let mut previous = 0u16;
+    for w in 20u16..=300 {
+      let got = modal_width(w, pct, min_cols, max_cols);
+      assert!(
+        got >= previous,
+        "({pct}%, [{min_cols}, {max_cols}]): {w} cols gave {got}, narrower than the {previous} before it"
+      );
+      assert!(
+        got <= max_cols,
+        "({pct}%, [{min_cols}, {max_cols}]): {w} cols broke the ceiling with {got}"
+      );
+      assert!(
+        got <= w.saturating_sub(4),
+        "({pct}%, [{min_cols}, {max_cols}]): {w} cols gave {got}, under 2 columns of margin per side"
+      );
+      previous = got;
+    }
+  }
+}
+
+#[test]
+fn a_modal_always_leaves_a_margin_inside_the_frame() {
+  // #550: the floor that kills the seam above must not let a modal grow into
+  // the frame edge on a narrow terminal — the border would hug column 0.
+  use gwm::tui::{link_prompt_modal_width, overlay_modal_width};
+  for w in 20u16..=300 {
+    for (name, f) in [
+      ("link_prompt_modal_width", link_prompt_modal_width as fn(u16) -> u16),
+      ("overlay_modal_width", overlay_modal_width as fn(u16) -> u16),
+    ] {
+      let got = f(w);
+      assert!(
+        got <= w.saturating_sub(4),
+        "{name}: at {w} cols the modal is {got} wide, leaving under 2 columns of margin per side"
+      );
+    }
+  }
+}
+
+#[test]
 fn compact_header_line_measures_in_terminal_cells_not_chars() {
   // Codex review, PR #546: the header was padded with `chars().count()`,
   // which counts one for a wide character that ratatui draws in two

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -1216,18 +1216,20 @@ fn a_modal_never_shrinks_when_the_terminal_grows() {
 
 #[test]
 fn the_width_policy_is_monotonic_and_bounded_for_any_knobs() {
-  // The two wrappers above only exercise two of the eight knob sets in use.
-  // The property belongs to the policy, not to its callers: whatever
-  // (pct, min, max) a future overlay picks, its width must never shrink as the
-  // terminal grows, never break its ceiling, and never reach the frame edge.
+  // Every one of the seven distinct knob sets in use, the two the wrappers
+  // above cover included. The property belongs to the policy, not to its
+  // callers: whatever (pct, min, max) a future overlay picks, its width must
+  // never shrink as the terminal grows, never break its ceiling, and never
+  // reach the frame edge.
   use gwm::tui::modal_width;
   for (pct, min_cols, max_cols) in [
-    (40, 40, 64),
-    (60, 64, 72),
-    (60, 64, 96),
-    (62, 64, 88),
-    (70, 56, 72),
-    (80, 64, 96),
+    (40, 40, 64), // confirm, nothing-selected fallback
+    (60, 64, 72), // open-menu / link prompt
+    (60, 64, 96), // help, config, command palette
+    (62, 64, 88), // confirm, destructive summary
+    (62, 72, 88), // exec picker, clean, detail
+    (70, 56, 72), // create, rename
+    (80, 64, 96), // bootstrap report
   ] {
     let mut previous = 0u16;
     for w in 20u16..=300 {


### PR DESCRIPTION
## Description

The fifteen overlays sized themselves with four distinct rules. Two branched on `term_width <= 80` to spend a more generous percentage on a small terminal, which made width **non-monotonic**: dragging a pane from 80 to 81 columns shrank the Link prompt by 16 columns and the exec / clean / detail overlay by 22, live under the cursor. Four others sized on a bare percentage with no ceiling.

One rule now for the **bounded** surfaces, `modal_width(term_width, pct, min, max)`, with knobs of their own. The four surfaces displaying arbitrary external text (PTY, log transcript, note editor, bootstrap report) keep their bare percentage: they are not bounded, and that is deliberate.

Closes #550

## Type of change

- [x] ♻️ Refactor (no behaviour change)

Functionally unchanged, but **the geometry of fifteen modals moves**. See the validation section below.

## Changes

- `modal_width(term_width, pct, min, max)`: the single policy. Never narrower as the terminal widens, never past its ceiling, always two columns of margin per side.
- `centered_h` and `centered_box` dropped in favour of `centered_content`; `centered_viewport` covers the three scrolling overlays (help, config, palette), whose height stays a viewport.
- `link_prompt_modal_width` and `overlay_modal_width` become thin wrappers over the policy.
- The PTY, the log transcript, the note editor **and the bootstrap report** keep their percentage: they are text canvases, and width is content there. `render_section` hard-clips by design (one logical row, one visual row), so on those surfaces every column given up is a column of an error nobody can reach.
- Characterisation matrix: each modal's rect measured at six sizes, located by the frame's rounded corners.

## What it fixes, measured

Full characterisation (method, oracle, before tables) in [the comment on #550](https://github.com/kbrdn1/gwm-cli/issues/550#issuecomment-5273247935).

**The 80-column seam.** The helpers, sweeping terminal width:

```
before                                after
  term  79  link 63  overlay 71         term  79  link 64  overlay 72
  term  80  link 64  overlay 72         term  80  link 64  overlay 72
  term  81  link 48  overlay 50         term  81  link 64  overlay 72
  term 100  link 60  overlay 62         term 100  link 64  overlay 72
```

**The unbounded widths.** At 200 columns: the delete confirmation goes from 124 to 88, help / config / palette from 120 to 96. The bootstrap report had been capped too in the first version of this PR; the review caught it and the cap is removed (see the loop report in the comments), so it keeps its pre-PR width at any terminal width.

**The 80 columns the docs advertise.** The confirmation was 49 columns there, its hint row cut mid-word by ratatui's clip, with no ellipsis, and the `n cancel` hint entirely off screen:

```
before, 49 columns                       after, 64 columns
│  y confirm  D branch  ←/→ move  Enter activa  │
│    y confirm  D branch  ←/→ move  Enter activate  n cancel   │
```

At 52 columns and above, no modal is narrower than before outside its ceiling. Old against new, swept over 10..400 columns, for the seven knob sets:

| surface | narrower on | max delta |
|---|---|---|
| exec / clean / detail | 10..51 | -4 |
| link / open | 10..15 | -2 |
| create / rename | 10 | -1 |
| confirmation | 144..400 | ceiling |
| help / config / palette | 162..400 | ceiling |
| confirmation, "nothing selected" case | 163..400 | ceiling |

The first three rows are not regressions but the margin invariant: below 52 columns the exec/clean/detail overlay took the space it owed the frame. At 40 columns it was exactly 40 wide, border on column 0; it is now 36 and leaves two columns per side. The last three are the intended ceilings. The bootstrap report no longer appears in that table: it is identical to `dev` at any width.

## Tests

- [x] `cargo test` passes locally (whole suite, green)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Six tests written **red first**, each failing on an assertion rather than a compile error:

| test | red before |
|---|---|
| `a_modal_never_shrinks_when_the_terminal_grows` | `growing the terminal from 80 to 81 cols shrank the modal from 64 to 48 cols` |
| `a_modal_always_leaves_a_margin_inside_the_frame` | margin under two columns |
| `the_width_policy_is_monotonic_and_bounded_for_any_knobs` | the general property, over the seven knob sets in use |
| `every_modal_resolves_to_its_pinned_width_at_the_80_column_floor` | exact values, fifteen surfaces |
| `no_modal_stretches_without_bound_on_an_ultra_wide_terminal` | same at 200 columns |
| `the_confirm_hint_row_is_not_cut_mid_word_at_80_columns` | `Enter activa` |

Two traps hit while building the harness, both handled:

- **The oracle is proven before it is used.** The matrix finds each modal by its frame's rounded corner. `the_background_paints_no_rounded_corner` verifies that `View::List` paints none, sidebar open **and** closed: without it, a measurement could describe the wrong rect and never go red.
- **Needle collision.** `the_confirm_hint_row_…` first searched for `Enter activate` across the whole buffer and passed **vacuously**: the bottom statusline advertises the same text. The assertion now covers only the rows inside the modal's rect.

Environment: the modal suite was also replayed with `PATH=/usr/bin:/bin`, a dummy `HOME` and `GWM_NO_GLOBAL_CONFIG=1`, green. Measurements are identical with and without the user's global config, so no ambient state leaks into the runners.

## Screenshots / TUI captures

⚠️ **Not eyeballed yet.** The change moves the geometry of fifteen modals; no test judges whether the result is *good-looking*, only whether it is consistent. To be validated by installing the branch before merge.

**No `docs/_capture/` capture needs regenerating**, verified surface by surface rather than assumed. vhs's real column count was measured by running a tape that prints `tput cols` with the capture geometry: `Set Width 1500` + `Set Padding 22` + `Set FontSize 15` gives **159 columns**, not the 100 or 120 I first assumed, which made the question far less obvious: at the time the bootstrap report was still capped, and its cap bit from 122 columns. It no longer is, which only widens the margin on this conclusion.

The six tapes that actually open a modal, at their measured width:

| tape | columns | modal | before | after |
|---|---|---|---|---|
| `keybindings` | 159 | help | 95 | 95 |
| `config-panel`, `keymap` | 159 | config | 95 | 95 |
| `palette` | 159 | palette | 95 | 95 |
| `agents` | 159 | detail | 88 | 88 |
| `github-linking` | 159 | link prompt | 72 | 72 |
| `countdown` (gif) | 139 | confirmation | 86 | 86 |

`bootstrap` and `trust-ledger` show the **CLI** report from `gwm create`, not the TUI's Report modal. `launchers` and `open-dispatch` open a PTY, whose sizing is untouched. Nothing else shows a modal.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (not applicable)
- [x] `examples/gwm.toml.example` updated if config schema changed (not applicable, no knob exposed)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #550
- Related: #545 (compact, where this surfaced), #549 (titles in the rule, prerequisite, merged)

## Notes for reviewers

**What this PR does not do.** The issue asked four questions; all four have a measured answer in the comment, but only the width half is fixed here.

**Vertical** overflow stays open. `centered_abs` does `height.min(area.height)` and ratatui throws the rest away with no indicator: at 120x16 the rename modal **loses its `Desc` field**, an editable field that disappears with no recourse. That is a form problem (drop the spacer rows, or scroll the field list), not a shared-sizing one, and it only affects create and rename. A follow-up issue to open rather than widening this PR.

On the "one policy?" question: for width, yes. For height, **no**, and merging them would flatten a real distinction. Scrolling surfaces size a viewport, non-scrolling ones size their content. A single `modal_area(content, min, max)` would have collapsed the two.
