### PR TITLE
🐛 fix(tui): returning from a fullscreen surface no longer queries the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `selection_bg` — which is also what separates a focused header from an
   unfocused one.
 
+### Fixed
+
+- **Returning from a fullscreen surface no longer ends the session when the
+  terminal is slow to answer** ([#548](https://github.com/kbrdn1/gwm-cli/issues/548)).
+  Coming back from the PTY overlay, an `exec` run or a review launch, gwm could
+  exit with `error: io error: The cursor position could not be read within a
+  normal duration`. That message is crossterm giving up on a DSR report:
+  `Terminal::clear` snapshots the cursor with `ESC [ 6 n` before wiping the
+  screen, and the return path from a fullscreen child is exactly when the
+  terminal is least likely to answer in time.
+
+  The three call sites now clear without asking. The snapshot was dead weight
+  here — each one repaints the whole frame on the next loop iteration, so the
+  position it restored was overwritten before anyone could see it. What the
+  callers needed was the other half of `clear`, wiping the screen *and*
+  resetting the back buffer so the next `draw` is a full repaint rather than a
+  diff against stale content; a fix that only wiped would have traded the crash
+  for a blank TUI.
+
 ## Past releases
 
 In reverse chronological order:

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -184,8 +184,10 @@ fn enter_terminal() -> Result<Terminal<CrosstermBackend<io::Stderr>>> {
 /// diff against stale content. `Terminal::resize` does precisely that pair for a
 /// `Fullscreen` viewport (`clear_region(All)` + back-buffer reset) and never
 /// touches the cursor, and gwm only ever builds a fullscreen terminal
-/// (`enter_terminal` above). `backend.size()` is an ioctl, not a round-trip, so
-/// nothing left under the `?` can time out.
+/// (`enter_terminal` above). Nothing left under the `?` can time out either:
+/// `backend.size()` is a `TIOCGWINSZ` ioctl (falling back to a `tput` spawn),
+/// never a request the terminal has to answer — and `Terminal::draw` already
+/// calls it on every frame through `autoresize`.
 pub fn clear_without_cursor_query<B: ratatui::backend::Backend>(
   terminal: &mut Terminal<B>,
 ) -> std::result::Result<(), B::Error> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -166,6 +166,33 @@ fn enter_terminal() -> Result<Terminal<CrosstermBackend<io::Stderr>>> {
   Ok(Terminal::new(CrosstermBackend::new(stderr))?)
 }
 
+/// Clear the whole screen and force a full repaint on the next `draw`,
+/// **without** asking the terminal where the cursor is (issue #548).
+///
+/// `Terminal::clear` snapshots the cursor first — `backend.get_cursor_position()`
+/// writes `ESC [ 6 n` and blocks until the terminal answers with a DSR report.
+/// Returning from a fullscreen surface (PTY overlay, `exec` run, review launch)
+/// is exactly the moment that answer is most likely to be late: crossterm then
+/// returns `The cursor position could not be read within a normal duration` and
+/// the `?` ended the whole session over a cosmetic operation.
+///
+/// Dropping the snapshot costs nothing here: every caller repaints the entire
+/// frame on the very next loop iteration, so the position `Terminal::clear`
+/// would have restored is overwritten before anyone could see it. What the
+/// callers actually need from `clear` is the other half — wiping the screen and
+/// resetting the back buffer so the next `draw` is a full repaint rather than a
+/// diff against stale content. `Terminal::resize` does precisely that pair for a
+/// `Fullscreen` viewport (`clear_region(All)` + back-buffer reset) and never
+/// touches the cursor, and gwm only ever builds a fullscreen terminal
+/// (`enter_terminal` above). `backend.size()` is an ioctl, not a round-trip, so
+/// nothing left under the `?` can time out.
+pub fn clear_without_cursor_query<B: ratatui::backend::Backend>(
+  terminal: &mut Terminal<B>,
+) -> std::result::Result<(), B::Error> {
+  let area = terminal.size()?.into();
+  terminal.resize(area)
+}
+
 /// Inverse of `enter_terminal`. Always called from the same scope as
 /// `enter_terminal` so the order of teardown matches the order of setup.
 fn leave_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>) -> Result<()> {
@@ -358,7 +385,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // resize that never reached it would leave the rows wrapped for the
       // previous terminal and the renderer would ellipsise the overflow.
       app.set_term_width(cols);
-      terminal.clear()?;
+      clear_without_cursor_query(terminal)?;
       continue;
     }
     let Event::Key(key) = ev else { continue };
@@ -1199,7 +1226,7 @@ fn run_launcher(
 
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
-    terminal.clear()?;
+    clear_without_cursor_query(terminal)?;
 
     match spawn {
       Ok(s) if s.success() => app.status = format!("{} exited ok", bin),
@@ -1277,7 +1304,7 @@ fn run_subshell(
   // Always restore the TUI, even if the child failed to spawn or exited non-zero.
   enable_raw_mode()?;
   execute!(terminal.backend_mut(), EnterAlternateScreen, EnableMouseCapture)?;
-  terminal.clear()?;
+  clear_without_cursor_query(terminal)?;
 
   match spawn {
     Ok(s) if s.success() => app.status = format!("{} exited ok ({})", label, cmd),

--- a/tests/tui_clear_tests.rs
+++ b/tests/tui_clear_tests.rs
@@ -1,0 +1,170 @@
+//! Issue #548 — returning from a fullscreen surface must not depend on the
+//! terminal answering a cursor-position query.
+//!
+//! `Terminal::clear` snapshots the cursor via `ESC [ 6 n` and waits for the
+//! DSR report. On the return path from the PTY overlay / an `exec` run / a
+//! review launch that answer can be late, crossterm gives up with
+//! `The cursor position could not be read within a normal duration`, and the
+//! `?` in `run_app` used to end the session over it.
+//!
+//! The race itself is timing-dependent and not reproducible on demand, so what
+//! is pinned here is the error path: a backend whose `get_cursor_position`
+//! always fails the way crossterm fails on a timeout. Two properties are
+//! asserted, and both are needed:
+//!
+//!   1. the replacement survives a backend that cannot report the cursor —
+//!      guarded by first asserting that `Terminal::clear` *does* fail on the
+//!      same terminal, otherwise the fixture could be passing vacuously;
+//!   2. it still forces a full repaint. A fix that only wiped the screen
+//!      (`clear_region(All)`) without resetting the back buffer would leave the
+//!      next `draw` diffing the frame against itself, writing nothing, and the
+//!      screen would stay blank — a plausible-looking fix that trades a crash
+//!      for an empty TUI.
+
+use gwm::tui::clear_without_cursor_query;
+use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
+use ratatui::buffer::{Buffer, Cell};
+use ratatui::layout::{Position, Size};
+use ratatui::widgets::Paragraph;
+use ratatui::Terminal;
+use std::io;
+
+/// A `TestBackend` that never answers the DSR query, the way a terminal that
+/// is still mid-stream on the return path from a fullscreen child does not.
+/// Every other operation is delegated untouched.
+struct DsrTimeout {
+  inner: TestBackend,
+}
+
+impl DsrTimeout {
+  fn new(width: u16, height: u16) -> Self {
+    Self {
+      inner: TestBackend::new(width, height),
+    }
+  }
+
+  fn buffer(&self) -> &Buffer {
+    self.inner.buffer()
+  }
+}
+
+/// `TestBackend::Error` is `Infallible`; widen it to the `io::Error` a real
+/// crossterm backend reports so the fixture can fail the one method it must.
+fn widen<T>(result: std::result::Result<T, core::convert::Infallible>) -> io::Result<T> {
+  match result {
+    Ok(value) => Ok(value),
+    Err(never) => match never {},
+  }
+}
+
+impl Backend for DsrTimeout {
+  type Error = io::Error;
+
+  fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+  where
+    I: Iterator<Item = (u16, u16, &'a Cell)>,
+  {
+    widen(self.inner.draw(content))
+  }
+
+  fn hide_cursor(&mut self) -> io::Result<()> {
+    widen(self.inner.hide_cursor())
+  }
+
+  fn show_cursor(&mut self) -> io::Result<()> {
+    widen(self.inner.show_cursor())
+  }
+
+  fn get_cursor_position(&mut self) -> io::Result<Position> {
+    // Verbatim the message crossterm produces when the DSR report is late.
+    Err(io::Error::other(
+      "The cursor position could not be read within a normal duration",
+    ))
+  }
+
+  fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+    widen(self.inner.set_cursor_position(position))
+  }
+
+  fn clear(&mut self) -> io::Result<()> {
+    widen(self.inner.clear())
+  }
+
+  fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+    widen(self.inner.clear_region(clear_type))
+  }
+
+  fn size(&self) -> io::Result<Size> {
+    widen(self.inner.size())
+  }
+
+  fn window_size(&mut self) -> io::Result<WindowSize> {
+    widen(self.inner.window_size())
+  }
+
+  fn flush(&mut self) -> io::Result<()> {
+    widen(self.inner.flush())
+  }
+}
+
+/// Flatten the backend buffer into one string so a row's text can be found
+/// without caring which column it starts at.
+fn buffer_text(buffer: &Buffer) -> String {
+  buffer
+    .content()
+    .iter()
+    .map(|cell| cell.symbol())
+    .collect::<Vec<_>>()
+    .join("")
+}
+
+#[test]
+fn clear_without_cursor_query_survives_a_dsr_timeout() {
+  let mut terminal = Terminal::new(DsrTimeout::new(20, 5)).expect("terminal");
+
+  // The fixture must actually bite: if `Terminal::clear` succeeded here, the
+  // assertion below would prove nothing about the DSR path.
+  let via_clear = terminal.clear();
+  assert!(
+    via_clear.is_err(),
+    "fixture is vacuous: Terminal::clear did not fail on a backend that cannot report the cursor"
+  );
+  assert!(
+    via_clear
+      .unwrap_err()
+      .to_string()
+      .contains("cursor position could not be read"),
+    "fixture failed for the wrong reason"
+  );
+
+  clear_without_cursor_query(&mut terminal).expect("clearing must not depend on a DSR report");
+}
+
+#[test]
+fn clear_without_cursor_query_forces_a_full_repaint() {
+  let mut terminal = Terminal::new(DsrTimeout::new(20, 5)).expect("terminal");
+
+  terminal
+    .draw(|frame| frame.render_widget(Paragraph::new("worktrees"), frame.area()))
+    .expect("first draw");
+  assert!(
+    buffer_text(terminal.backend().buffer()).contains("worktrees"),
+    "sanity: the first frame should have painted"
+  );
+
+  clear_without_cursor_query(&mut terminal).expect("clear");
+  assert!(
+    !buffer_text(terminal.backend().buffer()).contains("worktrees"),
+    "the screen should have been wiped"
+  );
+
+  // Same frame as before. Without the back-buffer reset this diffs against
+  // itself and paints nothing, leaving the wiped screen blank.
+  terminal
+    .draw(|frame| frame.render_widget(Paragraph::new("worktrees"), frame.area()))
+    .expect("repaint");
+  assert!(
+    buffer_text(terminal.backend().buffer()).contains("worktrees"),
+    "the frame after the clear must be a full repaint, not a diff against stale content"
+  );
+}


### PR DESCRIPTION
## Description

Returning from the PTY overlay, an `exec` run or a review launch, gwm could exit
with `error: io error: The cursor position could not be read within a normal
duration`. That message is crossterm giving up on a DSR report:
`Terminal::clear` snapshots the cursor with `ESC [ 6 n` before wiping, and the
return path from a fullscreen surface is exactly when the terminal is least
likely to answer in time.

Closes #548

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `clear_without_cursor_query` replaces `terminal.clear()` at the three sites in
  `src/tui/mod.rs` (the `Event::Resize` handler, `run_launcher`, `run_subshell`).
- The helper goes through `Terminal::resize(terminal.size()?.into())`, the only
  public door that does `clear_region(All)` **plus** the back-buffer reset
  without ever querying the cursor. True for a `Fullscreen` viewport, the only
  one `enter_terminal` builds.
- `tests/tui_clear_tests.rs`: a `DsrTimeout` backend failing
  `get_cursor_position` with crossterm's exact message.
- CHANGELOG entry under `[Unreleased] > Fixed`.

## Why the issue's direction 1 and not 2

The issue also suggested "make the failure non-fatal". With no DSR request there
is no timeout left to swallow: what remains under the `?` is `backend.size()`
and a write. Verified against the source rather than inferred:
`crossterm::terminal::size()` is a `TIOCGWINSZ`, with a fallback that spawns
`tput cols` / `tput lines`; never a request the terminal has to honour. And
`Terminal::draw` already calls it every frame through `autoresize`, so adding it
to the clear path opens no new risk. A failure there means the terminal is gone,
and the next `draw()` would fail anyway: a `let _ =` on top would mask real io
errors for a cosmetic operation, so they keep propagating.

## Why removing the snapshot is not removing a safety net

Every caller repaints the whole frame on the next loop iteration: the position
`Terminal::clear` restored is overwritten before anyone can see it. What the
callers need is the other half of `clear`, wiping *and* resetting the back
buffer, without which the next `draw` diffs the frame against stale content. The
helper's doc comment carries that reasoning.

## Tests

- [x] `cargo test` passes locally (97 green binaries, exit 0)
- [x] `cargo fmt --all --check` passes (exit 0)
- [x] `cargo clippy --all-targets -- -D warnings` passes (exit 0)
- [x] New tests under `tests/tui_clear_tests.rs`
- [x] `cargo clippy --all-targets -- -W clippy::incompatible_msrv`: 0 hits

Two properties pinned, and **the red was proven for each**:

| helper body | `survives_a_dsr_timeout` | `forces_a_full_repaint` |
|---|---|---|
| `terminal.clear()` (before) | ❌ | ❌ |
| `clear_region(All)` alone | ✅ | ❌ |
| `resize(size)` (chosen) | ✅ | ✅ |

The middle row is the one that matters: a fix that only wiped the screen would
trade the crash for a blank TUI, and only the repaint test tells them apart. The
first test starts by asserting that `Terminal::clear` **does** fail on that
backend, without which the fixture would pass vacuously.

Note: `PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin" cargo test` fails
here at link time (`ld: library 'iconv' not found`), before any test runs. That
is the local environment, not the change: `clippy --all-targets` compiles the
same targets fine.

## Screenshots / TUI captures

None: the change touches nothing that is drawn, only how the screen is cleared
before the repaint.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed: not applicable
- [ ] `examples/gwm.toml.example` updated if config schema changed: not applicable
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #548

## Notes for reviewers

Caller census: `grep -rnE "cursor::position|get_cursor(_position)?\(|window_size\(" src/`
returns only the helper's doc comment, so no fourth site queries the cursor
anywhere else in the code.

The race itself is not reproducible on demand (it depends on terminal timing),
so what is tested is the error path, as the issue suggested. The point to
challenge if you see one: `Terminal::resize` is DSR-free for `Fullscreen` and
`Fixed`, but **not** for `Inline` (the inline arm calls `compute_inline_size`,
which needs the cursor). gwm only builds `Terminal::new(CrosstermBackend)`, so
always `Fullscreen`, verified by grepping `Terminal::new` / `with_options` /
`Viewport::`, a single site. If an inline viewport ever appeared, the helper's
contract would need revisiting.
