### PR TITLE
🐛 fix(tui): cut table cells and pane headers by the columns they take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Table cells and pane headers are cut by the room their text takes**
+  ([#560](https://github.com/kbrdn1/gwm-cli/issues/560),
+  [#562](https://github.com/kbrdn1/gwm-cli/issues/562)). The two width funnels
+  left standing after #554, now on the same measure as the ellipsizer.
+
+  `trunc` clips every width-constrained table cell, and it counted characters
+  where its callers hand it a column width. A branch of 20 ideographs is 20
+  characters and 40 columns, so it was judged short and passed through whole,
+  and the table then hard-clipped it at the column edge: the tail vanished with
+  no `…` to say the name shown is not the branch you are on. That marker is the
+  reason the funnel exists.
+
+  `compact_header_line` budgeted its title through `Span::width`, which is
+  `unicode-width` over the whole string, and that is not the measure ratatui
+  applies when it paints. The two agree on CJK, which is where #546 was
+  measured, and disagree on text that is not exotic: a title reading `لالالا`
+  is 3 columns to `unicode-width` and 6 on screen, `ｶﾞｶﾞｶﾞ` likewise. An
+  undercounted title means padding computed against the undercount, so the
+  right-aligned counter was pushed off the pane. A filter query reaches this
+  directly, being arbitrary typed text. The truncation branch stepped
+  character by character on top of that, where a variation selector reads zero
+  and the sequence it completes paints two, so every one of those was free.
+
+  Both now measure with ratatui's own `CellWidth` per extended grapheme, the
+  walk `Buffer::set_stringn` performs, through the `cells` helper #554 left
+  behind; the prefix walk the three of them share is one function rather than
+  three. Nothing in `src/` measures with `unicode-width` any more, so it moves
+  to a dev-dependency, where the width tests keep it as the contrast measure
+  that proves a fixture is one the two disagree on.
+
 - **A path of wide glyphs is ellipsized by the room it actually takes**
   ([#554](https://github.com/kbrdn1/gwm-cli/issues/554)). `ellipsize_middle`
   counted characters while all eleven of its callers hand it a budget in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,9 +132,6 @@ daemon = []
 clap = { version = "4.5", features = ["derive", "color"] }
 clap_complete = "4.5"
 ratatui = "0.30"
-# Terminal cell widths for the compact header (#545). Already in the tree via
-# ratatui; taken directly so the header can budget a wide glyph per char.
-unicode-width = "0.2"
 # Grapheme boundaries for the middle-ellipsizer (#554). Already in the tree via
 # crossterm and nucleo-matcher; taken directly so a slice is cut where a glyph
 # ends rather than between a base and its combining mark, and so the walk costs
@@ -201,6 +198,11 @@ interprocess = "2.4.2"
 assert_cmd = "2"
 criterion = "0.8"
 predicates = "3"
+# Was a runtime dependency until #560/#562: the crate measured widths with it.
+# Nothing in `src/` does any more — the renderer's own `CellWidth` is the only
+# measure now — so it stays only as the *contrast* measure the width tests
+# assert against, to keep proving a fixture is one the two disagree on.
+unicode-width = "0.2"
 # Parse our own Cargo.toml in tests/binstall_metadata_tests.rs (#27) so
 # the `[package.metadata.binstall]` contract is asserted structurally,
 # not by string-matching. Same `toml` major as the runtime dependency.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -34,7 +34,6 @@ use ratatui::{
 };
 use std::time::{Duration, Instant};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
 
 /// Per-section content of the worktree details sidebar. Rendered by
 /// [`draw_sidebar`] into separate rounded-border blocks (no outer
@@ -696,9 +695,16 @@ pub fn compact_header_line(
   // Measured in terminal CELLS, not chars: a CJK glyph or an emoji in a
   // filter query counts one char and draws two columns, and padding
   // computed against the undercount pushed the right-aligned counter off
-  // the pane (Codex review, PR #546). `Span::width` is the same measure
-  // ratatui uses when it draws.
-  let span_w = |s: &Span<'static>| s.width();
+  // the pane (Codex review, PR #546).
+  //
+  // Through `cells`, not `Span::width` (issue #562). `Span::width` is
+  // `UnicodeWidthStr::width`, which is *not* what ratatui applies when it
+  // draws: `Buffer::set_stringn` walks graphemes and calls `CellWidth` on
+  // each. The two agree on CJK, which is where #546 was measured, and part
+  // company on text that is not exotic — a title of `لالالا` reads 3 and
+  // paints 6, `ｶﾞｶﾞｶﾞ` likewise. A filter query is arbitrary typed text, so
+  // it reaches this directly.
+  let span_w = |s: &Span<'static>| cells(&s.content);
   let title_w: usize = spans.iter().map(span_w).sum();
   // Truncate the title when it alone overflows. Cutting from the tail
   // keeps the leading chord — the actionable half — visible longest. A
@@ -711,16 +717,11 @@ pub fn compact_header_line(
       if w <= left {
         left -= w;
       } else {
-        let mut kept = String::new();
-        let mut used = 0usize;
-        for ch in s.content.chars() {
-          let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
-          if used + cw > left {
-            break;
-          }
-          kept.push(ch);
-          used += cw;
-        }
+        // `head_end`, shared with `ellipsize_middle` and `trunc`: one
+        // grapheme at a time, so a sequence is weighed whole. The per-char
+        // `UnicodeWidthChar` step this replaces read a variation selector as
+        // zero and let every sequence through for free.
+        let kept = s.content[..head_end(&s.content, left)].to_string();
         *s = Span::styled(kept, s.style);
         left = 0;
       }
@@ -5601,6 +5602,28 @@ fn grapheme_cells(g: &str) -> usize {
   }
 }
 
+/// Byte index ending the longest prefix of `s` that fits in `max` cells.
+///
+/// One pass, one grapheme at a time — not a per-char sum, which undercounts
+/// every sequence (`"*\u{FE0F}"` reads 1 + 0 per char and paints 2), and not a
+/// rescan of each prefix, which is the same walk done `n` times. A glyph that
+/// would straddle the budget is left out whole, so the prefix is `<= max`
+/// cells and the cut lands where a glyph ends rather than between a base and
+/// its combining mark.
+fn head_end(s: &str, max: usize) -> usize {
+  let mut end = 0usize;
+  let mut used = 0usize;
+  for (i, g) in s.grapheme_indices(true) {
+    let w = grapheme_cells(g);
+    if used + w > max {
+      break;
+    }
+    used += w;
+    end = i + g.len();
+  }
+  end
+}
+
 /// Middle-ellipsize `s` to at most `max` terminal cells, keeping the head
 /// and tail so a long path keeps both its root and the worktree name
 /// (e.g. `~/Projects/…/feat-187-modal`). Returns `s` unchanged when it
@@ -5631,23 +5654,10 @@ pub fn ellipsize_middle(s: &str, max: usize) -> String {
   let head = keep.div_ceil(2);
   let tail = keep - head;
   // Walked one GRAPHEME at a time from each end, each measured through
-  // `cells` (Codex review, PR #561). Not per char: `unicode-width` reads
-  // `"*\u{FE0F}"` as 2 cells but its two chars in isolation as 1 and 0, so a
-  // per-char sum undercounts every variation-selector sequence — measured, a
-  // 20-sequence string budgeted at 30 cells came back 59 wide. Not per byte
-  // index either: an index is not a column. A grapheme is the unit the
-  // renderer walks, so the cut lands where a glyph ends instead of between a
-  // base and its combining mark.
-  let mut head_end = 0usize;
-  let mut used = 0usize;
-  for (i, g) in s.grapheme_indices(true) {
-    let w = grapheme_cells(g);
-    if used + w > head {
-      break;
-    }
-    used += w;
-    head_end = i + g.len();
-  }
+  // `cells` (Codex review, PR #561). The head half is `head_end`, shared with
+  // `trunc` and `compact_header_line` — all three cut a string to a cell
+  // budget, and one walk is one place to be wrong.
+  let head_end = head_end(s, head);
   let mut tail_start = s.len();
   let mut used = 0usize;
   for (i, g) in s.grapheme_indices(true).rev() {
@@ -5693,12 +5703,24 @@ pub fn pad_cells(s: &str, width: usize) -> String {
 /// It runs **before** the width count, so what is measured is what is drawn: a
 /// replacement is one char for one char, but a `Bidi_Control` character can
 /// measure zero columns where `?` measures one.
+///
+/// Measured in CELLS, not chars (issue #560), the same unit and the same walk
+/// as `ellipsize_middle`. Every caller hands it a column width: a branch of 20
+/// ideographs is 20 characters and 40 columns, so a character count called it
+/// short and returned it whole, and the `Table` then hard-clipped it at the
+/// column edge — silently, where this funnel exists to leave an `…` saying the
+/// value is not all there. On the truncating branch a char count was the same
+/// error in the other direction, keeping `max` characters where `max` columns
+/// were free.
 fn trunc(s: &str, max: usize) -> String {
   let s = crate::naming::sanitise_for_terminal(s);
-  if s.chars().count() <= max {
+  if cells(&s) <= max {
     s
   } else {
-    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    // One column goes to the `…`, and a glyph that would straddle what is
+    // left is dropped whole, so the result is `<= max` cells rather than
+    // exactly `max`.
+    let mut out = s[..head_end(&s, max.saturating_sub(1))].to_string();
     out.push('…');
     out
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -201,10 +201,16 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 ///
 /// Priority when the terminal is narrow: the version chip survives (clipped
 /// only if it alone exceeds `width`), then the current-dir badge, then the
-/// picker chip, and the path is sacrificed first. Pure and measured with
-/// `chars().count()` so the contract is pinned by `tests/tui_header_tests.rs`
-/// without a ratatui backend; control chars are collapsed to spaces so a
-/// pathological path can never split the single row.
+/// picker chip, and the path is sacrificed first. Pure, so the contract is
+/// pinned by `tests/tui_header_tests.rs` without a ratatui backend; control
+/// chars are collapsed to spaces so a pathological path can never split the
+/// single row.
+///
+/// Its own arithmetic still counts `chars()`, which is a cell count only for
+/// the ASCII these segments carry in practice. The path is the one value a
+/// user can make wide, and an undercount there pushes the pinned version chip
+/// past the row. Tracked as #563 with the rest of the row arithmetic; the
+/// three truncators it calls into measure cells since #554 / #560 / #562.
 pub fn header_line(
   repo_name: &str,
   workdir_display: &str,
@@ -3156,8 +3162,12 @@ fn push_modal_hint(
 ///
 /// Pure and width-driven so the contract is pinned by
 /// `tests/tui_footer_tests.rs` without spinning up a ratatui backend. Widths
-/// are measured with `chars().count()` to match the rest of `ui.rs` (keys,
-/// labels and the bracketed status are ASCII / single-width in practice).
+/// are measured with `chars().count()`, which is a cell count for the ASCII
+/// keys, labels and bracketed status this carries in practice. Not the rest
+/// of `ui.rs` any more: the three truncators measure cells since #554 / #560
+/// / #562, and the row arithmetic that has not followed is tracked as #563.
+/// The status message is an action log, so it is the segment that can arrive
+/// wide.
 pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &Theme) -> Line<'static> {
   let key_style = hint_key_style(theme);
   let label_style = hint_label_style(theme);

--- a/tests/tui_table_render_tests.rs
+++ b/tests/tui_table_render_tests.rs
@@ -174,6 +174,54 @@ fn a_worktree_path_cannot_carry_a_bidi_control_into_the_table() {
   }
 }
 
+// --- wide glyphs in a table cell (issue #560) ------------------------------
+
+/// The rendered rows, one string per terminal line — `buffer_text` flattens
+/// the whole buffer, so a needle found in it may come from any row.
+fn rows(terminal: &Terminal<TestBackend>) -> Vec<String> {
+  let buf = terminal.backend().buffer();
+  let area = *buf.area();
+  (0..area.height)
+    .map(|y| (0..area.width).map(|x| buf[(x, y)].symbol()).collect())
+    .collect()
+}
+
+#[test]
+fn a_branch_of_wide_glyphs_is_truncated_by_gwm_not_clipped_by_ratatui() {
+  // 20 ideographs: 20 characters, 40 columns. The BRANCH column is sized off
+  // the same character count, so it is 20 cells wide — `trunc` measuring
+  // characters called the name short and handed it over whole, and the
+  // `Table` then hard-clipped it at the column edge. A clip drops the tail
+  // with no marker, which is the whole difference: nothing on the row says
+  // the branch shown is not the branch it is on.
+  let branch = "作".repeat(20);
+  let dir = repo_on_branch(&branch);
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  let rows = rows(&terminal);
+
+  // The cursor row, not the sidebar's Status block, which shows the same
+  // branch through a funnel of its own.
+  let row = rows
+    .iter()
+    .find(|r| r.starts_with('▶'))
+    .unwrap_or_else(|| panic!("no cursor row in the table:\n{}", rows.join("\n")));
+  assert!(
+    row.matches('作').count() >= 5,
+    "the fixture never reached the BRANCH column: {row:?}"
+  );
+  // Whatever follows the last ideograph is what the cell ended on. A wide
+  // glyph owns a second buffer cell the renderer leaves blank, so the
+  // ellipsis is reached past that blank rather than glued to the glyph.
+  let last = row.rfind('作').unwrap() + '作'.len_utf8();
+  assert!(
+    row[last..].trim_start().starts_with('…'),
+    "the branch cell must end on gwm's ellipsis, not on a ratatui clip: {row:?}"
+  );
+}
+
 // --- mark column (issue #484) ---------------------------------------------
 //
 // Same conditional-column contract as AGENT above: a user who never presses

--- a/tests/tui_ui_helpers_tests.rs
+++ b/tests/tui_ui_helpers_tests.rs
@@ -32,6 +32,14 @@ fn painted(s: &str) -> usize {
   usize::from(x)
 }
 
+/// Same oracle for a whole `Line`, span by span — which is how ratatui draws
+/// one. Not `Line::width()`: that sums `Span::width()`, i.e.
+/// `UnicodeWidthStr::width`, which is the measure under test rather than the
+/// one the renderer applies (issue #562).
+fn painted_line(line: &ratatui::text::Line<'_>) -> usize {
+  line.spans.iter().map(|s| painted(&s.content)).sum()
+}
+
 #[test]
 fn ellipsize_middle_returns_input_when_it_fits() {
   assert_eq!(ellipsize_middle("short", 10), "short");
@@ -1464,15 +1472,16 @@ fn compact_header_line_measures_in_terminal_cells_not_chars() {
   // line wider than the pane — the right-aligned counter fell off the
   // edge — because the padding was computed against an undercount.
   //
-  // `Line::width()` is the same measure ratatui uses when it draws, so
-  // asserting on it is asserting on what lands in the buffer.
+  // Asserted against what `set_stringn` paints, not against `Line::width()`
+  // — that one sums `Span::width()`, the measure the helper itself uses, so
+  // it would agree with a wrong implementation (issue #562).
   let title = ratatui::text::Line::from(" [1] WORKTREES /界 ");
   let line = compact_header_line(title, Some(ratatui::text::Line::from(" 3 of 5 ")), 40, Color::Cyan);
   assert_eq!(
-    line.width(),
+    painted_line(&line),
     40,
     "the header must span exactly the pane width in cells, got {}: {:?}",
-    line.width(),
+    painted_line(&line),
     title_text(&line)
   );
 }
@@ -1485,8 +1494,85 @@ fn compact_header_line_truncates_wide_glyphs_by_cell_budget() {
   let title = ratatui::text::Line::from("界界界界界界界界");
   let line = compact_header_line(title, None, 9, Color::Cyan);
   assert!(
-    line.width() <= 9,
+    painted_line(&line) <= 9,
     "must never exceed the pane width in cells, got {}",
-    line.width()
+    painted_line(&line)
+  );
+}
+
+/// Titles `unicode-width` reads narrower than the renderer paints them, with
+/// the two measures spelled out. CJK is deliberately absent: `UnicodeWidthStr`
+/// and `CellWidth` agree on it, which is why #546 shipped `Span::width()` and
+/// why every fixture above stays green either way.
+const UNDERCOUNTED: &[(&str, usize, usize)] = &[
+  // Lam-alef is a ligature to `unicode-width`; the renderer walks graphemes
+  // and paints both letters.
+  ("لالالالالا", 5, 10),
+  // U+FF9E carries `Grapheme_Extend`, so `unicode-width` gives it no cell,
+  // but a terminal draws the halfwidth dakuten in one and ratatui adds it back.
+  ("ｶﾞｶﾞｶﾞｶﾞｶﾞ", 5, 10),
+];
+
+#[test]
+fn compact_header_line_pads_against_the_cells_the_renderer_paints() {
+  for (title, narrow, wide) in UNDERCOUNTED {
+    assert_eq!(
+      (UnicodeWidthStr::width(*title), painted(title)),
+      (*narrow, *wide),
+      "{title:?} must be a case the two measures disagree on, or this proves nothing"
+    );
+    let counter = ratatui::text::Line::from(" 3 of 5 ");
+    let line = compact_header_line(
+      ratatui::text::Line::from(title.to_string()),
+      Some(counter),
+      20,
+      Color::Cyan,
+    );
+    // Padding computed against the undercount leaves the line wider than the
+    // pane, which pushes the right-aligned counter off it.
+    assert_eq!(
+      painted_line(&line),
+      20,
+      "{title:?}: header painted {} cells into a 20-cell pane: {:?}",
+      painted_line(&line),
+      title_text(&line)
+    );
+  }
+}
+
+#[test]
+fn compact_header_line_truncates_by_the_cells_the_renderer_paints() {
+  for (title, narrow, wide) in UNDERCOUNTED {
+    // Narrower than what gets painted, wider than what `unicode-width` reads:
+    // the truncation branch is only entered at all once the measure is right.
+    let width = (narrow + wide) / 2;
+    let line = compact_header_line(
+      ratatui::text::Line::from(title.to_string()),
+      None,
+      width as u16,
+      Color::Cyan,
+    );
+    assert!(
+      painted_line(&line) <= width,
+      "{title:?}: title painted {} cells into a {width}-cell pane: {:?}",
+      painted_line(&line),
+      title_text(&line)
+    );
+  }
+}
+
+#[test]
+fn compact_header_line_truncates_sequences_whole_not_char_by_char() {
+  // The truncation branch used to step `UnicodeWidthChar::width` per char. A
+  // variation selector reads 0 there while the sequence it completes paints 2,
+  // so every one of these was free and the whole title survived its budget.
+  let title = "*\u{FE0F}*\u{FE0F}*\u{FE0F}*\u{FE0F}*\u{FE0F}";
+  assert_eq!(painted(title), 10, "fixture must paint two cells per sequence");
+  let line = compact_header_line(ratatui::text::Line::from(title), None, 5, Color::Cyan);
+  assert!(
+    painted_line(&line) <= 5,
+    "title painted {} cells into a 5-cell pane: {:?}",
+    painted_line(&line),
+    title_text(&line)
   );
 }


### PR DESCRIPTION
## Description

The two width funnels left standing after #554, both moved onto the measure
ratatui actually paints with.

`trunc` clips every width-constrained table cell and counted characters, where
its callers hand it a column width. A branch of 20 ideographs is 20 characters
and 40 columns, so it was judged short and passed through whole, and the
`Table` hard-clipped it at the column edge: the tail went with no `…` to say
the name shown is not the branch you are on. That marker is the reason the
funnel exists.

`compact_header_line` budgeted through `Span::width`, i.e.
`UnicodeWidthStr::width` over the whole string, which is not what
`Buffer::set_stringn` applies. The two agree on CJK, where #546 was measured,
and part company on text that is not exotic: `لالالا` reads 3 columns and
paints 6, `ｶﾞｶﾞｶﾞ` likewise. Padding computed against the undercount pushed the
right-aligned counter off the pane, and a filter query reaches this directly,
being arbitrary typed text. Its truncation branch stepped per character on top
of that, where a variation selector reads zero while the sequence it completes
paints two.

Closes #560
Closes #562

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `trunc` measures cells (#560), and cuts on a grapheme boundary. Its
  sanitisation still runs **before** the measurement, unchanged: what is
  measured has to be what is drawn, and a `Bidi_Control` character measures
  zero columns where the `?` replacing it measures one.
- `compact_header_line` measures cells through `CellWidth` (#562), title and
  counter alike, and its truncation branch walks graphemes.
- The prefix walk all three funnels do is one `head_end` instead of three
  copies; `ellipsize_middle` loses its inline version to it.
- `unicode-width` becomes a dev-dependency. Nothing under `src/` measures with
  it any more, and the tests keep it as the deliberately different measure a
  fixture is asserted against.
- `header_line` and `footer_line` doc comments corrected: `footer_line`
  claimed its character count was "to match the rest of `ui.rs`", which is no
  longer true.

## Tests

- [x] `cargo test` passes locally (97 binaries, 2941 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Every new assertion reads back the cursor `Buffer::set_stringn` returns, via
the `painted()` helper #554 left and a `painted_line()` added here. The two
existing `compact_header_line` width tests asserted on `Line::width()`, the
same measure the code used, so they agreed with the implementation whatever it
did; they now use the renderer as their oracle too.

The wide-glyph fixtures are asserted to be cases the two measures disagree on,
so the pair cannot silently become vacuous. That guard is why they are Arabic
and halfwidth katakana rather than CJK, which `UnicodeWidthStr` and `CellWidth`
agree on. Red proven first for each:

- `a_branch_of_wide_glyphs_is_truncated_by_gwm_not_clipped_by_ratatui`
  rendered 15 ideographs running flush into the `clean` column, no ellipsis.
- `compact_header_line_pads_against_the_cells_the_renderer_paints` painted 25
  cells into a 20-cell pane.
- `compact_header_line_truncates_sequences_whole_not_char_by_char` painted 10
  cells into a 5-cell pane, the whole title having been free.

## Screenshots / TUI captures

The red, from the render test's own failure output. The BRANCH cell ends flush
against STATUS, cut by ratatui with nothing saying so:

```
       I/P NAME                           BRANCH                         STATUS           PATH
▶ -    ★   .tmpf801o8                     作 作 作 作 作 作 作 作 作 作 作 作 作 作 作  clean            /private/var/folders/q1/7spjwg
```

And the green, same fixture:

```
▶ -    ★   .tmpSO4hBN                     作 作 作 作 作 作 作 作 作 …            clean            /private/var/folders/q1/7spjwg
```

(The rows are 120 columns of `TestBackend`; a wide glyph owns a second buffer
cell the renderer leaves blank, which is the space between each pair.)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issues: #560, #562
- Filed here: #563
- Related PR: #561 (#554, the first of the family), #546 (where `Span::width`
  came from)

## Notes for reviewers

**What was deliberately left out, and why it is not a silent loss.** The row
arithmetic *around* these funnels still counts characters: `header_line`,
`footer_line` and the statusbar line, `flatten_if_overflow`, the
`issue_summary_line` family, and `column_width`, which sizes NAME / BRANCH in
characters while the `Constraint` it feeds is cells. Filed as #563 rather than
folded in, per the repo's "follow-up issues beat scope creep" rule.

None of it is made worse by this change, and the render is strictly better or
equal at every one of those sites. `cells(s) == s.chars().count()` for ASCII,
which is what they all carry today. Where a value can be wide, the previous
behaviour was the same error in the *larger* direction: `trunc` handed back up
to twice the budget, so a caller adding its character count under-counted by
more than it does now.

**The gap in the green capture is that report, made visible.** The BRANCH
column paints 30 cells there while `trunc` is handed `branch_w`, which is 20:
the constraint is `Constraint::Min(branch_w)`, so the column absorbs slack and
ends up wider than the budget the cell was cut to. Hence 9 ideographs, an `…`,
and 11 empty columns. That mismatch is not introduced here, `trunc` has always
been called with the minimum rather than the painted width; it was invisible
because `column_width` returns the exact character count for ASCII, so nothing
was ever cut. Fixing `column_width` to measure cells is #563, and it makes the
column 40 wide, at which point the branch is not truncated at all.

Worth weighing while reviewing: the previous render filled the column with 15
ideographs and no marker, which reads as a complete branch name and is not
one. This one is short of the column and says so. I took the honest-but-stingy
side, and the stinginess has a filed fix.

#563 also names a third truncation funnel this sweep did not touch: the
sidebar's Status block shows the same 20-ideograph branch whole, visible in
the red capture above.

`let head_end = head_end(s, head);` shadows the function with its own result.
Deliberate: the binding is what the call returns, and both are immediately
local.
