### PR TITLE
🐛 fix(tui): the row arithmetic budgets the columns its content takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The header, footer and statusbar stay inside the terminal**
+  ([#563](https://github.com/kbrdn1/gwm-cli/issues/563)). The rows that pin
+  something to their right edge computed the padding before it by counting
+  characters, so anything wider than one column per character under-counted by
+  half and pushed that pinned element off the terminal. The header carries the
+  repo directory name and the working path, the footer and statusbar carry the
+  action log, and none of those three is a value gwm picks: they are wherever
+  you cloned, and whatever the last command had to say. Measured, an 80-column
+  header painted 102 cells and the version chip went with the overflow; the
+  footer painted 100.
+
+  Table columns are sized the same way now. #560 made the cell cut in cells and
+  left the column it is cut to sized in characters, so a branch of wide glyphs
+  got a column half the width it needed and rendered as nine glyphs, an
+  ellipsis, and eleven blank columns. With a wide name and a wide branch both
+  claiming their ceiling, the path column gives up the width they take, which
+  is the intended trade and a better one than spending it on blanks.
+
+  The row arithmetic joins the three truncators (#554, #560, #562) on
+  ratatui's own `CellWidth` per grapheme. ASCII renders exactly as before,
+  which is what kept this standing for so long.
+
+- **The statusbar no longer paints one column past its width**
+  ([#563](https://github.com/kbrdn1/gwm-cli/issues/563)). Unrelated to the
+  measure and visible on plain ASCII: the `…` marking a cut hint list is drawn
+  as a space then the glyph, so it costs two columns wherever anything precedes
+  it, and only one was ever reserved. Any terminal narrow enough to truncate
+  its hints overflowed. Where the context chip alone fills the row, the marker
+  is now dropped rather than drawn past the edge, its leading space first.
+
 - **Table cells and pane headers are cut by the room their text takes**
   ([#560](https://github.com/kbrdn1/gwm-cli/issues/560),
   [#562](https://github.com/kbrdn1/gwm-cli/issues/562)). The two width funnels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ratatui's own `CellWidth` per grapheme. ASCII renders exactly as before,
   which is what kept this standing for so long.
 
+- **The header, footer and statusbar neutralise bidi control characters**
+  ([#563](https://github.com/kbrdn1/gwm-cli/issues/563)). All three replaced
+  what `char::is_control` matches, which is the `Cc` block only. The
+  `Bidi_Control` characters are `Cf`, which is why they had to be named
+  explicitly in the first place: they reorder how a terminal renders the text
+  around them, so a row can read in an order its bytes do not have. The
+  sanitiser sits at the funnel every width-constrained cell passes through, and
+  these three rows reach the terminal without going through it whenever their
+  text fits, which is the ordinary case.
+
+  Neither vector is exotic. The header shows the repo directory name and the
+  working path, and a directory on disk can carry one of these without anyone
+  fetching anything. The action log carries branch names and paths, and git's
+  ref rules refuse the ASCII controls and `~^:?*[` but not the format
+  characters, so a ref carrying one arrives with a fetch. All three call the
+  same sanitiser as the rest of the codebase now, so the replacement shows as
+  `?` rather than a blank.
+
 - **The statusbar no longer paints one column past its width**
   ([#563](https://github.com/kbrdn1/gwm-cli/issues/563)). Unrelated to the
   measure and visible on plain ASCII: the `…` marking a cut hint list is drawn

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2267,8 +2267,15 @@ pub fn branch_status_color(s: &BranchStatus, theme: &Theme) -> Color {
 }
 
 /// Constraint-friendly column width based on observed content, clamped to [min, max].
+///
+/// Observed in CELLS (issue #563). `min`, `max` and the `Constraint` this
+/// feeds are all column counts, so a character count was the odd one out: a
+/// 20-ideograph branch asked for 20 where it needs 40, `trunc` then cut the
+/// cell to that under-sized budget, and the row showed nine glyphs and an
+/// ellipsis inside a column the solver had grown wider than the ask. The
+/// ceiling is what bounds the greed, not the unit.
 fn column_width<'a>(items: impl Iterator<Item = &'a str>, min: u16, max: u16) -> u16 {
-  let observed = items.map(|s| s.chars().count() as u16).max().unwrap_or(min);
+  let observed = items.map(|s| cells(s) as u16).max().unwrap_or(min);
   observed.clamp(min, max)
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3185,7 +3185,7 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &T
   // must stay one visual line.
   let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
   let status_text = format!("[{}]", status);
-  let status_w = status_text.chars().count();
+  let status_w = cells(&status_text);
 
   // Priority floor: if even the status cannot fit, show a clipped status
   // alone — never a hint at the log's expense.
@@ -3206,7 +3206,7 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &T
   for (i, (key, label)) in hints.iter().enumerate() {
     let sep = if i > 0 { 2 } else { 0 }; // two spaces between hint groups (#279)
                                          // flat bind `key` + ` label` (label + 1 leading space)
-    let badge_w = key.chars().count() + 1 + label.chars().count();
+    let badge_w = cells(key) + 1 + cells(label);
     if used + sep + badge_w > hint_budget {
       truncated = true;
       break;
@@ -3272,7 +3272,7 @@ pub fn status_line(
 
   let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
   let status_text = format!("[{}]", status);
-  let status_w = status_text.chars().count();
+  let status_w = cells(&status_text);
 
   // Priority floor: if even the status cannot fit, show a clipped status
   // alone — never a chip or hint at the log's expense.
@@ -3286,7 +3286,7 @@ pub fn status_line(
 
   // Context chip — load-bearing, kept whenever it fits at all.
   let ctx_chip = format!(" {} ", context);
-  let ctx_w = ctx_chip.chars().count();
+  let ctx_w = cells(&ctx_chip);
   if ctx_w <= avail {
     spans.push(Span::styled(ctx_chip, context_style));
     used += ctx_w;
@@ -3296,7 +3296,7 @@ pub fn status_line(
   // and there is room.
   if let Some(glyph) = spinner {
     let padded = format!(" {} ", glyph);
-    let gw = padded.chars().count();
+    let gw = cells(&padded);
     if used + gw <= avail {
       spans.push(Span::styled(padded, spinner_style));
       used += gw;
@@ -3316,7 +3316,7 @@ pub fn status_line(
     // Two spaces between hint groups (#279); a single space after the left
     // cluster (context chip / spinner) before the first hint.
     let sep = if i > 0 { 2 } else { usize::from(used > 0) };
-    let badge_w = key.chars().count() + 1 + label.chars().count();
+    let badge_w = cells(key) + 1 + cells(label);
     if hint_used + sep + badge_w > hint_budget {
       truncated = true;
       break;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -237,9 +237,9 @@ pub fn header_line(
   let path_style = Style::default().fg(theme.muted);
 
   let version_text = format!(" gwm {} ", env!("CARGO_PKG_VERSION"));
-  let version_w = version_text.chars().count();
+  let version_w = cells(&version_text);
   let dir_text = format!(" {} ", repo);
-  let dir_w = dir_text.chars().count();
+  let dir_w = cells(&dir_text);
 
   // Priority floor: if even the right-pinned version chip cannot fit, show it
   // clipped alone — never an empty header.
@@ -259,7 +259,7 @@ pub fn header_line(
     used += dir_w;
   } else if dir_budget > 0 {
     let clipped = trunc(&dir_text, dir_budget);
-    used += clipped.chars().count();
+    used += cells(&clipped);
     spans.push(Span::styled(clipped, dir_badge_style));
   }
 
@@ -267,7 +267,7 @@ pub fn header_line(
   // badge when there is room.
   if picker_mode {
     let picker_text = " picker ".to_string();
-    let need = 1 + picker_text.chars().count(); // leading space + chip
+    let need = 1 + cells(&picker_text); // leading space + chip
     if used + need + version_w < width {
       spans.push(Span::raw(" "));
       spans.push(Span::styled(picker_text, picker_style));
@@ -283,7 +283,7 @@ pub fn header_line(
     let avail = width - used - path_gap - version_w;
     let path_disp = trunc(&path, avail);
     if !path_disp.is_empty() {
-      let w = path_disp.chars().count();
+      let w = cells(&path_disp);
       spans.push(Span::raw("  "));
       spans.push(Span::styled(path_disp, path_style));
       used += path_gap + w;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -224,9 +224,14 @@ pub fn header_line(
     return Line::default();
   }
 
-  let sanitize = |s: &str| -> String { s.chars().map(|c| if c.is_control() { ' ' } else { c }).collect() };
-  let repo = sanitize(repo_name);
-  let path = sanitize(workdir_display);
+  // `sanitise_for_terminal`, not a local `is_control` pass: that one is `Cc`
+  // only, so the `Bidi_Control` format characters went straight through and
+  // the row could read in an order its bytes do not have (#502 / #506). A
+  // directory on disk can carry one, and this row shows both its name and the
+  // working path. Still keeps a control from splitting the single row, which
+  // is what the local pass was for.
+  let repo = crate::naming::sanitise_for_terminal(repo_name);
+  let path = crate::naming::sanitise_for_terminal(workdir_display);
 
   let version_style = chip_style(theme.accent);
   let dir_badge_style = chip_style(theme.name);
@@ -3200,7 +3205,11 @@ pub fn footer_line(hints: &[(&str, &str)], status: &str, width: usize, theme: &T
   // tabs. `Wrap` is disabled, but a raw `\n` would still split the row in
   // two, so collapse every control char to a single space first — the footer
   // must stay one visual line.
-  let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
+  // Same sink as the header (#502 / #506): the action log carries branch names
+  // and paths, and git's ref rules refuse the ASCII controls but not the
+  // format characters, so one arrives with a fetch. `is_control` is `Cc` only
+  // and never matched them.
+  let status: String = crate::naming::sanitise_for_terminal(status);
   let status_text = format!("[{}]", status);
   let status_w = cells(&status_text);
 
@@ -3287,7 +3296,11 @@ pub fn status_line(
     return Line::default();
   }
 
-  let status: String = status.chars().map(|c| if c.is_control() { ' ' } else { c }).collect();
+  // Same sink as the header (#502 / #506): the action log carries branch names
+  // and paths, and git's ref rules refuse the ASCII controls but not the
+  // format characters, so one arrives with a fetch. `is_control` is `Cc` only
+  // and never matched them.
+  let status: String = crate::naming::sanitise_for_terminal(status);
   let status_text = format!("[{}]", status);
   let status_w = cells(&status_text);
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2274,8 +2274,18 @@ pub fn branch_status_color(s: &BranchStatus, theme: &Theme) -> Color {
 /// cell to that under-sized budget, and the row showed nine glyphs and an
 /// ellipsis inside a column the solver had grown wider than the ask. The
 /// ceiling is what bounds the greed, not the unit.
+///
+/// Sanitised before being measured, in that order, because that is the order
+/// `trunc` uses on the cell this sizes (#506): a `Bidi_Control` character
+/// measures zero columns and the `?` replacing it measures one, so measuring
+/// the raw text under-counts by one per neutralised character and the cell is
+/// then cut inside a column that had the room. The character count this
+/// replaced happened to get it right, one char in for one column out.
 fn column_width<'a>(items: impl Iterator<Item = &'a str>, min: u16, max: u16) -> u16 {
-  let observed = items.map(|s| cells(s) as u16).max().unwrap_or(min);
+  let observed = items
+    .map(|s| cells(&crate::naming::sanitise_for_terminal(s)) as u16)
+    .max()
+    .unwrap_or(min);
   observed.clamp(min, max)
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3303,8 +3303,13 @@ pub fn status_line(
     }
   }
 
-  // Hint badges fill whatever is left, minus one column for the `…` marker.
-  let hint_budget = avail.saturating_sub(used).saturating_sub(1);
+  // Hint badges fill whatever is left, minus the `…` marker. The marker is
+  // TWO columns whenever anything precedes it, since it is pushed as a space
+  // then the glyph, and only one was reserved here — so the row painted one
+  // column past its width on every terminal narrow enough to truncate, ASCII
+  // included. `footer_line` reserves both, which is why it never showed this.
+  let marker_w = 1 + usize::from(used > 0);
+  let hint_budget = avail.saturating_sub(used).saturating_sub(marker_w);
   let mut truncated = false;
   let mut hint_used = 0usize;
   for (i, (key, label)) in hints.iter().enumerate() {
@@ -3325,8 +3330,12 @@ pub fn status_line(
     hint_used += badge_w;
   }
   used += hint_used;
-  if truncated {
-    if used > 0 {
+  // The reservation above is not enough on its own: when the chip alone eats
+  // `avail`, the budget saturates to zero, no hint fits, and the marker was
+  // still pushed — two columns past the row. It is only worth drawing if it
+  // fits, and its leading space is the half to drop first.
+  if truncated && used < avail {
+    if used > 0 && used + 1 < avail {
       spans.push(Span::raw(" "));
       used += 1;
     }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6143,7 +6143,16 @@ fn tilde_compress_falls_back_when_path_outside_home() {
 use gwm::tui::{issue_summary_line, pr_summary_line};
 
 fn line_visible_width(line: &ratatui::text::Line<'static>) -> usize {
-  line.spans.iter().map(|s| s.content.chars().count()).sum()
+  // The cells `set_stringn` paints, span by span, which is how ratatui draws a
+  // `Line`. Not `chars().count()`, the measure the builders under test use:
+  // that would agree with them whatever they did (issue #563).
+  line.spans.iter().map(|s| painted(&s.content)).sum()
+}
+
+fn painted(s: &str) -> usize {
+  let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 200, 1));
+  let (x, _) = buf.set_stringn(0, 0, s, 200, ratatui::style::Style::default());
+  usize::from(x)
 }
 
 #[test]

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -571,3 +571,43 @@ fn neither_footer_nor_statusbar_paints_past_its_width_on_wide_glyphs() {
     }
   }
 }
+
+/// Every character carrying the Unicode `Bidi_Control` property. They are
+/// `Cf`, not `Cc`, so `char::is_control` matches none of them, which is the
+/// whole reason they need naming (#502).
+const BIDI_CONTROLS: &[char] = &[
+  '\u{061C}', '\u{200E}', '\u{200F}', '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', '\u{2066}',
+  '\u{2067}', '\u{2068}', '\u{2069}',
+];
+
+#[test]
+fn a_bidi_control_in_the_action_log_never_reaches_the_row() {
+  // Both rows neutralised `char::is_control`, which is `Cc` only, so the
+  // format characters that reorder how a terminal *renders* the text around
+  // them went straight through. The log carries branch names and paths, and
+  // git's ref rules refuse the ASCII controls but not these, so one arrives
+  // with a fetch rather than being typed. The row can then read in an order
+  // the bytes do not have, which is the guarantee #506 exists to give at every
+  // width-constrained sink.
+  //
+  // Pre-dates this branch: `dev` leaks the same characters at the same widths.
+  // Found by a Codex review of #563 and fixed here rather than left behind,
+  // since the fix is the sanitiser these rows already had half of.
+  for c in BIDI_CONTROLS {
+    let status = format!("opened feat/{c}danger");
+    for w in [30usize, 60, 120] {
+      let footer = footer_line(HINTS, &status, w, &Theme::default());
+      assert!(
+        !plain_line(&footer).contains(*c),
+        "the footer replayed U+{:04X} from the action log at {w} columns",
+        *c as u32
+      );
+      let bar = status_line("worktrees", HINTS, &status, None, w, &Theme::default());
+      assert!(
+        !plain_line(&bar).contains(*c),
+        "the statusbar replayed U+{:04X} from the action log at {w} columns",
+        *c as u32
+      );
+    }
+  }
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -498,3 +498,42 @@ fn help_close_hint_resolves_user_rebinding() {
     "the stale literal `Esc/q` must not linger after the rebind: {resolved:?}"
   );
 }
+
+// --- the row never paints past its width (issue #563) ----------------------
+
+/// Cells the renderer paints for `s`: the cursor `set_stringn` leaves behind.
+/// The oracle for every budget assertion below, because the builders measure
+/// with `chars().count()` and asserting on that would agree with them whatever
+/// they did.
+fn painted(s: &str) -> usize {
+  let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 400, 1));
+  let (x, _) = buf.set_stringn(0, 0, s, 400, ratatui::style::Style::default());
+  usize::from(x)
+}
+
+fn painted_line(line: &Line<'_>) -> usize {
+  line.spans.iter().map(|s| painted(&s.content)).sum()
+}
+
+fn plain_line(line: &Line<'_>) -> String {
+  line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+fn the_statusbar_never_paints_past_its_width_on_ascii() {
+  // Pure ASCII, so this is not about the measure: the `…` marker costs two
+  // columns whenever anything precedes it (a space, then the glyph), and the
+  // hint budget only ever reserved one. `footer_line` reserves both, which is
+  // why it does not have this. Asserted as an invariant over a band of widths
+  // rather than one case, since the overflow only shows where the truncation
+  // lands.
+  for w in 20usize..=60 {
+    let line = status_line("worktrees", HINTS, "plain message", None, w, &Theme::default());
+    assert!(
+      painted_line(&line) <= w,
+      "at {w} columns the statusbar painted {} cells: {:?}",
+      painted_line(&line),
+      plain_line(&line)
+    );
+  }
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -537,3 +537,37 @@ fn the_statusbar_never_paints_past_its_width_on_ascii() {
     );
   }
 }
+
+#[test]
+fn neither_footer_nor_statusbar_paints_past_its_width_on_wide_glyphs() {
+  // The action log is the segment that arrives wide: it carries branch names,
+  // paths and error blobs. Both rows budget in characters and pin the log
+  // right, so a CJK log under-counted by half and pushed itself off the
+  // terminal. Measured before the fix: 100 cells into an 80-column row.
+  //
+  // CJK, halfwidth katakana and emoji are the fixtures because the measure at
+  // fault is `chars().count()`; the discriminant is columns per character.
+  let theme = Theme::default();
+  for status in [
+    "作業作業作業作業作業作業作業作業作業作業",
+    "created ｶﾞｶﾞｶﾞｶﾞｶﾞ",
+    "pushed 🚀🚀🚀🚀🚀🚀",
+  ] {
+    for w in [40usize, 60, 80, 120] {
+      let footer = footer_line(HINTS, status, w, &theme);
+      assert!(
+        painted_line(&footer) <= w,
+        "footer at {w} columns painted {} cells: {:?}",
+        painted_line(&footer),
+        plain_line(&footer)
+      );
+      let bar = status_line("worktrees", HINTS, status, None, w, &theme);
+      assert!(
+        painted_line(&bar) <= w,
+        "statusbar at {w} columns painted {} cells: {:?}",
+        painted_line(&bar),
+        plain_line(&bar)
+      );
+    }
+  }
+}

--- a/tests/tui_header_tests.rs
+++ b/tests/tui_header_tests.rs
@@ -169,3 +169,43 @@ fn control_chars_never_break_the_single_line_contract() {
   assert!(!plain(&line).contains('\n'), "newline leaked into header row");
   assert!(!plain(&line).contains('\t'), "tab leaked into header row");
 }
+
+// --- the row never paints past its width (issue #563) ----------------------
+
+/// Cells the renderer paints for `s`. The oracle here, because the builder
+/// budgets with `chars().count()` and asserting on that would agree with it
+/// whatever it did.
+fn painted(s: &str) -> usize {
+  let mut buf = ratatui::buffer::Buffer::empty(ratatui::layout::Rect::new(0, 0, 400, 1));
+  let (x, _) = buf.set_stringn(0, 0, s, 400, ratatui::style::Style::default());
+  usize::from(x)
+}
+
+fn painted_line(line: &Line<'_>) -> usize {
+  line.spans.iter().map(|s| painted(&s.content)).sum()
+}
+
+#[test]
+fn the_header_never_paints_past_its_width_on_wide_glyphs() {
+  // A repo directory named in CJK is 1 character and 2 columns per glyph, and
+  // the row budgets in characters: at 80 columns the header painted 102, so
+  // the version chip it pins right went off the terminal. The discriminant is
+  // width per character, not the `unicode-width` divergence #562 chased, so
+  // Arabic is not a fixture here: it reads one column per letter both ways.
+  let theme = Theme::default();
+  for (repo, path) in [
+    ("作業作業作業作業作業", "~/dev/作業作業作業作業作業作業"),
+    ("plain", "~/dev/ｶﾞｶﾞｶﾞｶﾞｶﾞｶﾞｶﾞｶﾞｶﾞｶﾞ"),
+    ("🚀🚀🚀🚀🚀", "~/dev/🚀🚀🚀🚀🚀🚀🚀🚀"),
+  ] {
+    for w in [80usize, 100, 120] {
+      let line = header_line(repo, path, false, w, &theme);
+      assert!(
+        painted_line(&line) <= w,
+        "{repo:?} at {w} columns: header painted {} cells: {:?}",
+        painted_line(&line),
+        plain(&line)
+      );
+    }
+  }
+}

--- a/tests/tui_header_tests.rs
+++ b/tests/tui_header_tests.rs
@@ -209,3 +209,35 @@ fn the_header_never_paints_past_its_width_on_wide_glyphs() {
     }
   }
 }
+
+/// See `tests/tui_footer_tests.rs` for the same set and the same reasoning:
+/// `Cf`, not `Cc`, so `char::is_control` matches none of them (#502).
+const BIDI_CONTROLS: &[char] = &[
+  '\u{061C}', '\u{200E}', '\u{200F}', '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', '\u{2066}',
+  '\u{2067}', '\u{2068}', '\u{2069}',
+];
+
+#[test]
+fn a_bidi_control_in_the_repo_or_path_never_reaches_the_row() {
+  // The header neutralised `char::is_control` only, so a directory named with
+  // a format character reordered how the row reads. Unlike a ref name this
+  // needs no fetch: a directory on disk can carry one, and the header shows
+  // both its name and the working path.
+  //
+  // Pre-dates this branch, `dev` leaks the same characters. Found by a Codex
+  // review of #563.
+  for c in BIDI_CONTROLS {
+    for (repo, path) in [
+      (format!("re{c}po"), "~/dev/x".to_string()),
+      ("repo".into(), format!("~/dev/x{c}y")),
+    ] {
+      let line = header_line(&repo, &path, false, 120, &Theme::default());
+      assert!(
+        !plain(&line).contains(*c),
+        "the header replayed U+{:04X} from {:?}",
+        *c as u32,
+        (&repo, &path)
+      );
+    }
+  }
+}

--- a/tests/tui_table_render_tests.rs
+++ b/tests/tui_table_render_tests.rs
@@ -374,3 +374,36 @@ fn a_column_of_wide_glyphs_is_sized_by_its_columns_not_its_characters() {
     "the branch column is sized in characters, so it wastes what it was given: {row:?}"
   );
 }
+
+#[test]
+fn a_column_is_sized_on_the_text_that_reaches_the_terminal() {
+  // `trunc` sanitises *before* it measures, on purpose: a `Bidi_Control`
+  // character measures zero columns and the `?` replacing it measures one, so
+  // what is measured has to be what is drawn (#506). `column_width` sizes the
+  // column that same `trunc` then cuts to, so it has to sanitise first too, or
+  // the two disagree by one column per neutralised character and the cell is
+  // truncated inside a column that had the room.
+  //
+  // The character count this replaced got that right by accident: a
+  // `Bidi_Control` is one char and its replacement is one column.
+  let branch = format!("feat/{}danger-branch-name", '\u{202E}');
+  let sanitised = gwm::naming::sanitise_for_terminal(&branch);
+  assert!(
+    sanitised.chars().count() < 38,
+    "the fixture must fit under the column ceiling, or nothing is proven"
+  );
+  let dir = repo_on_branch(&branch);
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  let rows = rows(&terminal);
+  let row = rows
+    .iter()
+    .find(|r| r.starts_with('\u{25B6}'))
+    .unwrap_or_else(|| panic!("no cursor row:\n{}", rows.join("\n")));
+  assert!(
+    row.contains(&sanitised),
+    "the branch fits its column and must render whole: {row:?}"
+  );
+}

--- a/tests/tui_table_render_tests.rs
+++ b/tests/tui_table_render_tests.rs
@@ -344,3 +344,33 @@ fn the_note_marker_is_only_on_the_rows_that_carry_one() {
     "exactly one row carries a note: {text}"
   );
 }
+
+// --- a column is sized by the room its content takes (issue #563) ----------
+
+#[test]
+fn a_column_of_wide_glyphs_is_sized_by_its_columns_not_its_characters() {
+  // #560 made the cell cut in cells; the column it is cut to was still sized
+  // in characters. A 20-ideograph branch is 20 characters and 40 columns, so
+  // `column_width` asked for 20, `trunc` cut to 19, and the cell then sat
+  // inside a column the solver had grown past that: nine glyphs, an ellipsis,
+  // and eleven blank columns before STATUS.
+  let branch = "作".repeat(20);
+  let dir = repo_on_branch(&branch);
+  let mut app = App::new_at_layered(Some(dir.path()), None).unwrap();
+  let backend = TestBackend::new(120, 40);
+  let mut terminal = Terminal::new(backend).unwrap();
+  terminal.draw(|f| draw(f, &mut app)).unwrap();
+  let rows = rows(&terminal);
+  let row = rows
+    .iter()
+    .find(|r| r.starts_with('▶'))
+    .unwrap_or_else(|| panic!("no cursor row:\n{}", rows.join("\n")));
+
+  // The ceiling is 38 columns, so 18 glyphs plus the ellipsis is what fits.
+  // Asserted as a count rather than a slice: it is the gap that was the
+  // defect, and a count is what shrinks when the column is under-sized.
+  assert!(
+    row.matches('作').count() >= 18,
+    "the branch column is sized in characters, so it wastes what it was given: {row:?}"
+  );
+}


### PR DESCRIPTION
## Description

The rows that pin something to their right edge computed the padding before it
by counting characters. Anything wider than one column per character therefore
under-counted by half and pushed that pinned element off the terminal. The
header carries the repo directory name and the working path, the footer and
statusbar carry the action log; none of the three is a value gwm picks, they
are wherever you cloned and whatever the last command had to say.

Table columns are sized the same way now. #560 made the cell cut in cells and
left the column it is cut to sized in characters, which is the eleven-column
gap visible in #564's own green capture.

Plus one defect the issue did not predict, on plain ASCII: `status_line` paints
a column past its width at every width narrow enough to truncate its hints.

Closes #563

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `status_line`: the `…` marker costs two columns whenever anything precedes it
  (a space, then the glyph) and the hint budget reserved one. Reserves both
  now, and drops the marker rather than drawing it past the edge when the
  context chip alone fills the row.
- `header_line`: repo badge, picker chip, path and the pinned version chip all
  measured with `cells`.
- `footer_line` and `status_line`: the action log, the hint badges, the context
  chip and the spinner likewise.
- `column_width`: sizes in cells, so `min`, `max` and the `Constraint` it feeds
  are finally the same unit as the observation.
- `tests/tui_app_tests.rs`'s `line_visible_width` reads back what
  `Buffer::set_stringn` paints instead of summing `chars()`.

Two more, both from the Codex review of this branch:

- `column_width` sanitises **before** it measures, the order `trunc` uses on
  the cell it sizes. Moving to cells lost what the character count had by
  accident: a `Bidi_Control` measures zero columns and its `?` replacement
  measures one, so the raw text under-counted and the cell was cut inside a
  column that had the room.
- The header, footer and statusbar neutralise `Bidi_Control` characters. All
  three replaced `char::is_control`, which is `Cc` only, so the `Cf` format
  characters that reorder a row went straight through.

## Tests

- [x] `cargo test` passes locally (97 binaries, 2948 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

Red proven first for each, and each green capture read rather than trusted to
its exit code:

| red | before |
|:--|:--|
| `the_header_never_paints_past_its_width_on_wide_glyphs` | 102 cells into 80 columns |
| `neither_footer_nor_statusbar_paints_past_its_width_on_wide_glyphs` | 100 into 80 |
| `a_column_of_wide_glyphs_is_sized_by_its_columns_not_its_characters` | 9 glyphs + `…` + 11 blanks |
| `the_statusbar_never_paints_past_its_width_on_ascii` | 22 into 21, 28 into 26 |
| `a_column_is_sized_on_the_text_that_reaches_the_terminal` | `feat/?danger-branch-na…` at 24 columns of content |
| `a_bidi_control_in_the_action_log_never_reaches_the_row` | all 12 characters replayed |
| `a_bidi_control_in_the_repo_or_path_never_reaches_the_row` | all 12 replayed |

The ASCII one is asserted as an invariant over 20..=60 columns rather than one
width: the overflow only appears where the truncation lands, and that moves
with the hint list.

**The fixtures are CJK, halfwidth katakana and emoji, deliberately not Arabic.**
The measure at fault here is `chars().count()`, so the discriminant is
columns-per-character. Arabic reads one column per letter under both measures
and passed every probe untouched; it only separated `unicode-width` from the
renderer in #562 because *that* one measured whole strings. Reusing #562's
fixtures here would have proven nothing.

## Screenshots / TUI captures

Header at 80 columns, before and after, with a CJK directory name:

```
before (102 cells)
 作業作業作業作業作業   ~/dev/作業作業作業作業作業作業                                      gwm 1.7.1

after (80 cells)
 作業作業作業作業作業   ~/dev/作業作業作業作業作業作業                gwm 1.7.1
```

The statusbar's ASCII overflow, and what it degrades to instead:

```
before          after
w=21 -> 22      w=21 -> 21   |n new…[plain message]|
w=26 -> 28      w=26 -> 26   | worktrees [plain message]|
w=40 -> 41      w=40 -> 40   | worktrees  n new  d del …      [plain message]|
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #563
- Related PR: #564 (#560 / #562, the truncators), #561 (#554, the first)

## Notes for reviewers

**The bidi leak is not a regression from this branch.** The review read it as
one. Verified the other way: `git checkout dev -- src/tui/ui.rs`, same probe,
and `dev` replays the same characters on the same three rows at 30, 60 and 120
columns. It is a pre-existing gap in the #506 sweep, fixed here rather than
left behind, since the fix is the sanitiser those rows already had half of.

**Two sites the issue listed as defects are not, and I wrote that issue.**
Probing before coding is what caught it; the body has been corrected and the
measurements are in a comment on #563.

`issue_summary_line` already holds its budget: `fixed` is built from ASCII
constants where a character count *is* a cell count, and the variable part is
the title, which goes through `trunc`, in cells since #560. At a 30-column
budget it paints 29, 30 and 29 for CJK, Arabic and halfwidth katakana. Nothing
to fix.

`flatten_if_overflow` I can only call unreachable by the path I measured, not
sane. It is private, every caller I probed hands it a line that already fits,
and I did not probe it directly.

**The trade in `column_width` is worth a look.** With a wide NAME *and* a wide
BRANCH both claiming the 38-column ceiling, PATH gives up what they take: on a
120-column terminal it drops from ~30 columns to ~14. I took that as the
intended behaviour of a `Fill(1)` column behind two `Min`s that are finally
asking for what they need, and a better trade than the previous row, which
spent 24 columns on blanks inside those two. Say so if you would rather cap it.

**Out of scope, on purpose.** `ui.rs` still counts characters in ~25 other
places: fixed `{:<N}` label padding, `field_input_line`, `badge_group_width`,
the palette / agents / exec overlays. All are either ASCII constants, where the
two measures are equal by construction, or surfaces the issue did not name. I
did not sweep them, and I did not measure them either, so I am not claiming
they are fine.

The sidebar's Status block is also untouched, and the issue used to call it a
third truncation funnel. It is not one: `worktree_identity_lines` is handed no
width at all, so it has no funnel rather than one in the wrong unit, and #547
documents the clipping as the policy. Giving it one means changing those
signatures, which is a design change and belongs in its own issue.
