### PR TITLE
♻️ refactor(cli,tui): a message gwm prints reads without an em dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and #543 finished the skills; neither reached `src/`, so a user hitting an
   `exec` error read a dash the documentation for that same feature no longer
   used. 165 of them across 161 string literals, in every error message, status
-  line and TUI hint the binary carries.
+  line and TUI hint the binary carries, and 49 more in `gwm --help`, which
+  `clap` builds out of the doc comments on the CLI types. The completion
+  scripts carried the same text and are fixed with it: `gwm completions zsh`
+  went from 23 to none.
 
   The connector was chosen at each call site rather than substituted. A colon
   where the dash introduced the remedy, a semicolon where the clause already
@@ -29,11 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   create form hints and the loader detail now read the way the segments beside
   them already did.
 
-  Comments and doc comments are untouched, roughly 1900 of them: a doc comment
-  quoting a spec or a command's real output has to stay verbatim. A test
-  enforces the rule from here on, scanning `src/` with a Rust literal scanner
-  rather than a grep, since telling a literal from a doc comment is the whole
-  difference between a guard that holds and one nobody can keep green.
+  Comments are untouched, roughly 1900 of them: a doc comment quoting a spec
+  or a command's real output has to stay verbatim, and it is read in the source
+  rather than printed. Two tests hold the rule from here on. One scans `src/`
+  with a Rust literal scanner rather than a grep, since telling a literal from
+  a doc comment is the whole difference between a guard that holds and one
+  nobody can keep green. The other walks `gwm --help` and every subcommand's,
+  because that is where a doc comment stops being a comment, and no scanner
+  can answer that question as reliably as reading what the binary prints.
 
   Several doc captures still show the old wording and are tracked separately.
   The published site follows `main`, never `dev`, so they go stale at the next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A message gwm prints reads without an em dash**
+  ([#567](https://github.com/kbrdn1/gwm-cli/issues/567)). The rule this
+  project writes under is that published prose does not use the em dash, and
+  the binary's own output is as published as the README. #516 swept `docs/`
+  and #543 finished the skills; neither reached `src/`, so a user hitting an
+  `exec` error read a dash the documentation for that same feature no longer
+  used. 165 of them across 161 string literals, in every error message, status
+  line and TUI hint the binary carries.
+
+  The connector was chosen at each call site rather than substituted. A colon
+  where the dash introduced the remedy, a semicolon where the clause already
+  carried a colon, a full stop where a second colon would have made the
+  sentence unreadable. In the TUI the dash was often not punctuation at all
+  but a separator, and there is already one in use there, so `/ filter`, the
+  create form hints and the loader detail now read the way the segments beside
+  them already did.
+
+  Comments and doc comments are untouched, roughly 1900 of them: a doc comment
+  quoting a spec or a command's real output has to stay verbatim. A test
+  enforces the rule from here on, scanning `src/` with a Rust literal scanner
+  rather than a grep, since telling a literal from a doc comment is the whole
+  difference between a guard that holds and one nobody can keep green.
+
+  Several doc captures still show the old wording and are tracked separately.
+  The published site follows `main`, never `dev`, so they go stale at the next
+  release cut and not before.
+
 - **The Settings panel sizes to its active tab**
   ([#569](https://github.com/kbrdn1/gwm-cli/issues/569)). #550 gave every
   bounded overlay one width policy; height stayed a flat percentage of the

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -439,14 +439,14 @@ pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> R
   for (name, value) in map {
     if built_ins.contains(name) {
       return Err(GwmError::Config(format!(
-        "{}: alias '{}' would shadow a built-in subcommand or alias — pick a different name",
+        "{}: alias '{}' would shadow a built-in subcommand or alias; pick a different name",
         source_label, name
       )));
     }
     let trimmed = value.trim();
     if trimmed.is_empty() {
       return Err(GwmError::Config(format!(
-        "{}: alias '{}' has an empty value — provide a subcommand to expand to",
+        "{}: alias '{}' has an empty value; provide a subcommand to expand to",
         source_label, name
       )));
     }
@@ -457,7 +457,7 @@ pub fn validate_aliases(map: &BTreeMap<String, String>, source_label: &str) -> R
     for pat in SHELL_METACHARS {
       if trimmed.contains(pat) {
         return Err(GwmError::Config(format!(
-          "{}: alias '{}' = {:?} contains shell metachar {:?} — \
+          "{}: alias '{}' = {:?} contains shell metachar {:?}: \
            gwm aliases are argv substitution only (no pipelines); use a shell alias instead",
           source_label, name, value, pat
         )));

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -168,7 +168,7 @@ fn run_copies(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut Bootstr
         report.steps.push(StepResult::failed(
           label,
           format!(
-            "refusing to copy: destination {} is a symlink — would redirect the write outside the worktree (issue #93)",
+            "refusing to copy: destination {} is a symlink; would redirect the write outside the worktree (issue #93)",
             dst.display()
           ),
         ));
@@ -186,7 +186,7 @@ fn run_copies(ctx: &BootstrapCtx<'_>, bs: &BootstrapConfig, report: &mut Bootstr
         report.steps.push(StepResult::failed(
           label,
           format!(
-            "failed to stat destination {}: {} — refusing to proceed with unknown filesystem state",
+            "failed to stat destination {}: {}; refusing to proceed with unknown filesystem state",
             dst.display(),
             e
           ),
@@ -244,7 +244,7 @@ fn resolve_missing(step: &CopyStep, bs: &BootstrapConfig, dst: &Path) -> Option<
       match write_no_follow(dst, fb.content.as_bytes()) {
         Ok(()) => Some(StepResult::warning(
           "",
-          format!("source missing — wrote inline fallback to {}", dst.display()),
+          format!("source missing, wrote inline fallback to {}", dst.display()),
         )),
         Err(e) => Some(StepResult::failed("", format!("inline fallback write failed: {}", e))),
       }
@@ -294,7 +294,7 @@ fn guard_match(step: &CopyStep, bs: &BootstrapConfig, src: &Path) -> std::result
         }
         Err(e) => {
           return Err(format!(
-            "guard '{}' deny_pattern {:?} failed to compile at evaluation time — \
+            "guard '{}' deny_pattern {:?} failed to compile at evaluation time. \
              Config bypassed Config::load_for_repo (#96)? regex: {}",
             guard.name, pat, e
           ));
@@ -337,7 +337,7 @@ fn handle_guard_match(
           Ok(_) => report.steps.push(StepResult::warning(
             label,
             format!(
-              "guard '{}' tripped on {} — seeded {} from {} (edit before use)",
+              "guard '{}' tripped on {}, seeded {} from {} (edit before use)",
               guard.name,
               src.display(),
               dst.display(),
@@ -364,7 +364,7 @@ fn handle_guard_match(
       // abort
       report.steps.push(StepResult::failed(
         label,
-        format!("guard '{}' tripped on {} — abort", guard.name, src.display()),
+        format!("guard '{}' tripped on {}: abort", guard.name, src.display()),
       ));
     }
   }
@@ -732,7 +732,7 @@ fn ensure_within(base: &Path, path: &Path) -> std::io::Result<()> {
     return Err(std::io::Error::new(
       std::io::ErrorKind::InvalidInput,
       format!(
-        "{:?} resolves outside {:?} — '..' traversal, absolute path, or symlinked intermediate component rejected (issue #94)",
+        "{:?} resolves outside {:?}: '..' traversal, absolute path, or symlinked intermediate component rejected (issue #94)",
         path, base_canon
       ),
     ));

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -74,7 +74,7 @@ fn normalized_profile_dirs(profile: &str, dirs: &[String]) -> Result<Vec<String>
   for d in dirs {
     if d.is_empty() {
       return Err(GwmError::Config(format!(
-        "clean: profile `{profile}` has an empty `dirs` entry — list single worktree-relative directory names"
+        "clean: profile `{profile}` has an empty `dirs` entry; list single worktree-relative directory names"
       )));
     }
     let mut comps = Path::new(d).components().filter(|c| !matches!(c, Component::CurDir));
@@ -94,7 +94,7 @@ fn normalized_profile_dirs(profile: &str, dirs: &[String]) -> Result<Vec<String>
       // `.` / `./.` collapse to nothing — they resolve to the worktree root.
       (None, _) => {
         return Err(GwmError::Config(format!(
-          "clean: profile `{profile}` dir `{d}` resolves to the worktree root — name a real subdirectory"
+          "clean: profile `{profile}` dir `{d}` resolves to the worktree root; name a real subdirectory"
         )));
       }
       // Two or more components — a nested path like `a/b`.
@@ -116,7 +116,7 @@ fn normalized_profile_dirs(profile: &str, dirs: &[String]) -> Result<Vec<String>
     // fine — the `--` delimiter in the git calls already neutralises it.
     if name.starts_with(':') || name.contains(['*', '?', '[', ']']) {
       return Err(GwmError::Config(format!(
-        "clean: profile `{profile}` dir `{d}` contains git pathspec metacharacters (`* ? [ ]` or a leading `:`) — name a literal directory"
+        "clean: profile `{profile}` dir `{d}` contains git pathspec metacharacters (`* ? [ ]` or a leading `:`); name a literal directory"
       )));
     }
     out.push(name);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub struct Cli {
   ///
   /// Equivalent to `GWM_ALLOW_BOOTSTRAP=1`. Use in non-interactive
   /// environments (CI runners, scripted workflows) where there is no
-  /// human to answer the prompt. Off by default — the threat model is
+  /// human to answer the prompt. Off by default: the threat model is
   /// arbitrary RCE via `[[bootstrap.command]]` lines from an untrusted
   /// remote, so the safe default is "prompt".
   #[arg(long, global = true)]
@@ -59,7 +59,7 @@ pub struct Cli {
   /// mode: `gwm --workspace ~/Projects` opens the TUI over every
   /// direct-child repo, and `gwm list --workspace ~/Projects` prints
   /// the merged worktree table with a leading `REPO` column.
-  /// `.gwm.toml` stays per-repo — there is no workspace-level config.
+  /// `.gwm.toml` stays per-repo; there is no workspace-level config.
   /// `global = true` so the flag is accepted before or after the
   /// subcommand.
   #[arg(long, global = true, value_name = "DIR")]
@@ -73,7 +73,7 @@ pub struct Cli {
 #[derive(Debug, Clone, clap::Subcommand)]
 pub enum AgentsAction {
   /// Pin session SESSION_ID to the worktree matching PATTERN. The pin
-  /// overlays auto-detection and ACCUMULATES — several sessions can be
+  /// overlays auto-detection and ACCUMULATES: several sessions can be
   /// pinned to one worktree.
   Attach {
     /// Worktree name (substring match), or `.` for the enclosing worktree.
@@ -95,7 +95,7 @@ pub enum AgentsAction {
 pub enum AgentsFormat {
   /// Human-readable listing (default).
   Table,
-  /// Machine-readable JSON — the same worktree rows as
+  /// Machine-readable JSON, the same worktree rows as
   /// `gwm list --format=json` (experimental `agents` field included).
   Json,
 }
@@ -104,7 +104,7 @@ pub enum AgentsFormat {
 pub enum ListFormat {
   /// Human-readable table (default).
   Table,
-  /// One worktree name per line — suitable for shell completion.
+  /// One worktree name per line, suitable for shell completion.
   Names,
   /// Machine-readable JSON array of worktrees (issue #38). Stable schema
   /// documented under `docs/schema/worktree-list.schema.json`.
@@ -153,7 +153,7 @@ pub enum Command {
     /// (writes nothing, needs no git repo).
     #[arg(long)]
     list_presets: bool,
-    /// Print the resolved preset to stdout instead of writing .gwm.toml —
+    /// Print the resolved preset to stdout instead of writing .gwm.toml;
     /// handy for diffing a preset against an existing config.
     #[arg(long)]
     show: bool,
@@ -172,7 +172,7 @@ pub enum Command {
   },
   /// Agent sessions per worktree (issue #408): list what detection found,
   /// or pin/unpin a session manually. Detection reads each agent's on-disk
-  /// session artefacts (Claude Code, Codex, opencode, Mistral Vibe) — a pin
+  /// session artefacts (Claude Code, Codex, opencode, Mistral Vibe); a pin
   /// overlays it for the cases the recorded directory cannot cover.
   Agents {
     #[command(subcommand)]
@@ -197,7 +197,7 @@ pub enum Command {
     /// becomes the branch verbatim; `branch_pattern` / `path_pattern` do not
     /// apply because it has no `{type}` / `{issue}` / `{desc}` to expand.
     /// Features that read the branch name back (issue auto-linking, gitmoji)
-    /// stay inactive on it — `gwm link` remains available.
+    /// stay inactive on it; `gwm link` remains available.
     ///
     /// Exclusive with the positional triple: the mode is chosen explicitly,
     /// never inferred from how many arguments were supplied.
@@ -207,7 +207,7 @@ pub enum Command {
     #[arg(long)]
     no_bootstrap: bool,
     /// Attach the new worktree to an already-existing local branch of the
-    /// same name instead of refusing (issue #99). Off by default — a
+    /// same name instead of refusing (issue #99). Off by default: a
     /// pre-existing branch ends `gwm create` with an error naming the
     /// stale tip so the user can audit it.
     #[arg(long)]
@@ -234,8 +234,8 @@ pub enum Command {
   ///
   /// Placeholders substituted by the template engine:
   ///   `{type}` `{issue}` `{desc}` `{base}` `{head}` `{repo}`
-  ///   `{commits}`        — `git log --pretty='- %s' base..head`
-  ///   `{files_changed}`  — `git diff --stat base..head`, capped 30 lines
+  ///   `{commits}`        = `git log --pretty='- %s' base..head`
+  ///   `{files_changed}`  = `git diff --stat base..head`, capped 30 lines
   Pr {
     /// Render the body to stdout instead of creating the PR. The output
     /// is suitable for piping into `gh pr create --body-file -`.
@@ -253,8 +253,8 @@ pub enum Command {
   /// Materialise an existing GitHub PR into an isolated worktree (issue #308).
   ///
   /// Resolves the PR head via `gh` and fetches origin's universal
-  /// `refs/pull/<N>/head` ref — cross-fork aware, and valid for PRs in any
-  /// state (open / draft / closed / merged) — into a local
+  /// `refs/pull/<N>/head` ref (cross-fork aware, and valid for PRs in any
+  /// state: open, draft, closed or merged) into a local
   /// `review/pr-<N>-<author>-<slug>` branch, attaches a worktree, and links
   /// the PR so the sidebar / CI indicator light up immediately. Tear down
   /// with `gwm remove <dir> --delete-branch` like any worktree.
@@ -262,7 +262,7 @@ pub enum Command {
   /// Safe-by-default: bootstrap and lifecycle hooks are NOT run, because a
   /// review worktree holds a contributor's (possibly fork) code and those
   /// steps execute commands against it (`npm install`, `composer install`,
-  /// `direnv allow`, `post_create` hooks …) — i.e. arbitrary code. Pass
+  /// `direnv allow`, `post_create` hooks …), i.e. arbitrary code. Pass
   /// `--bootstrap` to opt in once you trust the PR enough to set it up.
   Review {
     /// PR number to review (digits only).
@@ -274,7 +274,7 @@ pub enum Command {
     #[arg(long, value_name = "BRANCH")]
     name: Option<String>,
     /// Run bootstrap + lifecycle hooks against the PR's code after creation.
-    /// Off by default — these execute commands the PR can influence, so it's
+    /// Off by default: these execute commands the PR can influence, so it's
     /// opt-in (see the command help for the security rationale).
     #[arg(long)]
     bootstrap: bool,
@@ -314,7 +314,7 @@ pub enum Command {
     /// Print the resolved worktree (name + path + branch + would-delete-branch
     /// flag) without touching anything. Exit code 0. If the pattern is
     /// ambiguous, the same non-zero candidate-list error fires as in the
-    /// destructive form — `--dry-run` only suppresses *destruction*, not
+    /// destructive form: `--dry-run` only suppresses *destruction*, not
     /// resolution failures. Issue #31.
     #[arg(long)]
     dry_run: bool,
@@ -327,7 +327,7 @@ pub enum Command {
   },
   /// Print the on-disk path of a worktree (use `$(gwm path …)` to cd into it).
   ///
-  /// Also available as `gwm cd <pattern>` — same semantics, framed for the
+  /// Also available as `gwm cd <pattern>`: same semantics, framed for the
   /// cd flow. Pair with `gwm shell-init <shell>` for a one-line wrapper.
   #[command(visible_alias = "cd")]
   Path {
@@ -354,7 +354,7 @@ pub enum Command {
   ///
   /// Resolves the target worktree (defaults to the CWD worktree when
   /// no pattern is given), runs `git fetch` for its upstream's remote,
-  /// then rebases the branch onto the upstream — or merges with
+  /// then rebases the branch onto the upstream, or merges with
   /// `--merge`. Reports the outcome with the same ✓ / ! / ✗ sigils as
   /// the rest of gwm.
   ///
@@ -380,7 +380,7 @@ pub enum Command {
   },
   /// Diagnose the gwm setup (config, env, worktree state).
   ///
-  /// Exit code 0 if all green, 1 if any warning, 2 if any failure —
+  /// Exit code 0 if all green, 1 if any warning, 2 if any failure;
   /// suitable for CI / pre-commit hooks.
   Doctor {
     /// Output format. `json` emits the checks array plus aggregate
@@ -394,7 +394,7 @@ pub enum Command {
   ///
   /// Editors, statusbars, and tooling connect once and call `list` /
   /// `doctor` / `path`, or `subscribe` for pushed `worktrees.changed`
-  /// notifications — instead of spawning `gwm` per query (issue #38).
+  /// notifications, instead of spawning `gwm` per query (issue #38).
   /// Newline-delimited JSON, one request and one response per line.
   ///
   /// The transport is a unix domain socket on unix and a named pipe under
@@ -404,7 +404,7 @@ pub enum Command {
   Daemon {
     /// Where to bind. On unix: a socket path, defaulting to
     /// `$XDG_RUNTIME_DIR/gwm.sock`, falling back to `$TMPDIR`, then
-    /// `/tmp` — isolated in a per-user `<base>/gwm-<uid>/gwm.sock` when
+    /// `/tmp`, isolated in a per-user `<base>/gwm-<uid>/gwm.sock` when
     /// the base dir is not owner-only. On Windows: the pipe NAME under
     /// `\\.\pipe\` (not a filesystem path), defaulting to
     /// `gwm-<user>.sock`, restricted to the owner by its security
@@ -423,21 +423,21 @@ pub enum Command {
   ///
   /// The first real consumer of `gwm daemon`: it connects to the daemon's
   /// transport (unix socket, or a named pipe on Windows, issue #439), asks
-  /// for the worktree set, and renders a single line —
-  /// active branch, worktree count, dirty / ahead / behind, linked issue /
-  /// PR — suitable for a tmux / starship / zsh statusline. With `--watch`
+  /// for the worktree set, and renders a single line
+  /// (active branch, worktree count, dirty / ahead / behind, linked issue /
+  /// PR) suitable for a tmux / starship / zsh statusline. With `--watch`
   /// it subscribes to the daemon's `worktrees.changed` stream and reprints
   /// on every change (one line per update).
   ///
   /// Needs a running `gwm daemon` (one per repo). When none is reachable it
   /// prints an empty line and exits 0, so a prompt substitution degrades to
-  /// nothing instead of erroring. A CI rollup is intentionally not shown —
+  /// nothing instead of erroring. A CI rollup is intentionally not shown:
   /// it is not part of the daemon's stable schema.
   Statusline {
     /// Daemon socket path (unix) or pipe name (Windows). Defaults to the
     /// same resolution as `gwm daemon`: `$XDG_RUNTIME_DIR/gwm.sock`, then
-    /// `$TMPDIR`, then `/tmp` — isolated in a per-user
-    /// `<base>/gwm-<uid>/gwm.sock` when the base dir isn't owner-only —
+    /// `$TMPDIR`, then `/tmp`, isolated in a per-user
+    /// `<base>/gwm-<uid>/gwm.sock` when the base dir isn't owner-only,
     /// and `gwm-<user>.sock` under `\\.\pipe\` on Windows.
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
@@ -455,21 +455,21 @@ pub enum Command {
   Types {
     /// Show the resolved emoji + shortcode for each branch type
     /// (issue #85). Without the flag, only `name` + `description`
-    /// are printed — matches the pre-#85 surface.
+    /// are printed; matches the pre-#85 surface.
     #[arg(long)]
     gitmoji: bool,
   },
   /// Print the Gitmoji + Conventional Commits prefix for the current
   /// (or named) branch (issue #85).
   ///
-  /// Output shape: `:sparkles: feat(#41):` — the canonical commit
+  /// Output shape: `:sparkles: feat(#41):`, the canonical commit
   /// prefix used across this repo (see CONTRIBUTING.md §Commits).
   /// `--unicode` substitutes the shortcode for the real emoji
   /// character (e.g. `✨` instead of `:sparkles:`); useful for shell
   /// prompts and the bundled `commit-msg` hook.
   ///
   /// Without `--branch`, reads the current branch from HEAD via
-  /// libgit2 — requires the CWD to be inside a git repo.
+  /// libgit2; requires the CWD to be inside a git repo.
   CommitPrefix {
     /// Branch name to resolve (e.g. `feat/#41-tui-search`). When
     /// omitted, defaults to HEAD of the current repo.
@@ -485,7 +485,7 @@ pub enum Command {
   /// Currently exposes a single hook: `commit-msg`, which
   /// auto-prepends the resolved Gitmoji + Conventional Commits
   /// prefix when the commit message doesn't already start with one.
-  /// Hooks are **opt-in** — `gwm` never installs them implicitly.
+  /// Hooks are **opt-in**: `gwm` never installs them implicitly.
   Hooks {
     #[command(subcommand)]
     action: HooksAction,
@@ -525,7 +525,7 @@ pub enum Command {
   Switch,
   /// Open the matched worktree in a new tmux window (current session).
   ///
-  /// Requires `$TMUX` to be set — i.e. gwm must be invoked from inside an
+  /// Requires `$TMUX` to be set, i.e. gwm must be invoked from inside an
   /// existing tmux session. Outside a tmux session the command exits
   /// non-zero with a clear error rather than spawning a stray server.
   /// Use `--split` to open in a horizontal split of the current pane
@@ -552,7 +552,7 @@ pub enum Command {
   /// Link the current (or named) worktree to a GitHub issue or pull request.
   ///
   /// The link is stored in `git config branch.<name>.gwm-issue` (or
-  /// `gwm-pr`) — local, per-branch, survives worktree moves. Issue
+  /// `gwm-pr`): local, per-branch, survives worktree moves. Issue
   /// numbers are auto-detected from the `<type>/#<N>-<slug>` convention
   /// when no explicit override is set; `gwm link issue <N>` overrides
   /// that. PR numbers are not auto-detected; link them explicitly with
@@ -570,7 +570,7 @@ pub enum Command {
   /// Remove the explicit issue / PR link on the current (or named) worktree.
   ///
   /// After `gwm unlink issue`, auto-detection from the branch name
-  /// resurfaces if the branch follows `<type>/#<N>-<slug>`. Idempotent —
+  /// resurfaces if the branch follows `<type>/#<N>-<slug>`. Idempotent:
   /// safe to run when nothing is linked.
   Unlink {
     /// What to unlink: `issue` or `pr`.
@@ -584,7 +584,7 @@ pub enum Command {
   ///
   /// Uses the OS opener (`open` on macOS, `xdg-open` on Linux,
   /// `explorer` on Windows). Pass `--print-url` to emit the URL on
-  /// stdout instead — useful for piping, testing, and headless shells.
+  /// stdout instead, useful for piping, testing, and headless shells.
   Open {
     /// What to open: `issue` or `pr`.
     #[arg(value_enum)]
@@ -633,12 +633,12 @@ pub enum Command {
   /// Manage the TOFU trust ledger for `.gwm.toml` files (issue #95).
   ///
   /// `gwm` runs `[[bootstrap.command]]` lines from `.gwm.toml` under
-  /// the user's privileges — equivalent to `curl … | sh` against the
+  /// the user's privileges, equivalent to `curl … | sh` against the
   /// repo author. The trust ledger at `~/.config/gwm/trust.toml`
   /// (override via `$GWM_TRUST_LEDGER`) records the `(origin URL,
   /// sha256 of .gwm.toml)` tuples the user has approved, so
   /// subsequent runs skip the prompt. Hash drift (any byte changes
-  /// in `.gwm.toml`) re-prompts — see the module-level comment in
+  /// in `.gwm.toml`) re-prompts; see the module-level comment in
   /// `src/trust.rs` for the threat model.
   Trust {
     #[command(subcommand)]
@@ -665,7 +665,7 @@ pub enum Command {
   /// (issue #29). One line per op, newest first, with timestamp,
   /// kind, and worktree name.
   ///
-  /// Defaults to the current repo only — pass `--all` to list ops
+  /// Defaults to the current repo only; pass `--all` to list ops
   /// across every repo in the journal. The journal file lives at
   /// `$GWM_HISTORY_FILE` if set, otherwise
   /// `$XDG_DATA_HOME/gwm/history.toml`.
@@ -684,7 +684,7 @@ pub enum Command {
   /// entry from the journal.
   ///
   /// Pass `--bootstrap` to re-run the per-worktree bootstrap after
-  /// the resurrection (off by default — bootstrap can be expensive
+  /// the resurrection (off by default, bootstrap can be expensive
   /// and the user often just wants the directory back).
   Undo {
     /// Re-run bootstrap after the worktree is re-added. Off by
@@ -694,7 +694,7 @@ pub enum Command {
   },
   /// TUI introspection / debugging subcommands (issue #87).
   ///
-  /// Today exposes a single child — `keys` — which prints the
+  /// Today exposes a single child, `keys`, which prints the
   /// resolved keymap (built-in defaults layered with `[tui.keys]`
   /// overrides from `.gwm.toml`). Reserved as a sub-tree so future
   /// TUI knobs (`gwm tui themes`, `gwm tui dump-state`, …) have a
@@ -719,7 +719,7 @@ pub enum Command {
   /// Prints a per-worktree ✓ / ✗ rollup and exits non-zero if any
   /// worktree's command failed. Everything after `--` is forwarded
   /// verbatim (flags and all). This is the user's own command against
-  /// their own worktrees — no bootstrap trust gate applies (#95).
+  /// their own worktrees: no bootstrap trust gate applies (#95).
   Exec {
     /// Worktree slugs to target (fuzzy match, before `--`). Empty = all
     /// non-main worktrees.
@@ -748,7 +748,7 @@ pub enum Command {
   /// and prints the reclaimable size per worktree. Report-only by default;
   /// pass `--yes` to actually delete. Scope to a subset with slug
   /// positionals: `gwm clean feat-1`. Deliberately not journaled into
-  /// `gwm history` (#29) — the artifacts are regenerable.
+  /// `gwm history` (#29): the artifacts are regenerable.
   ///
   /// Safety: `--yes` only deletes directories git treats as ignored. A
   /// non-ignored `dist/` / `build/` (tracked or hand-authored, hence
@@ -925,17 +925,17 @@ pub enum LabelsAction {
   /// still reads the remote via `gh label list` to compute the
   /// diff; only create / update / delete calls are skipped).
   /// `--prune` opt-in deletes labels on remote that aren't declared in
-  /// config (off by default — destructive). `--random-colors` picks a
+  /// config (off by default, destructive). `--random-colors` picks a
   /// random pastel for labels with no `color` field instead of the
   /// default deterministic hash.
   Push {
     /// Print the plan without mutating the remote. Still reads remote
-    /// labels via `gh label list` to compute the diff — only the
+    /// labels via `gh label list` to compute the diff; only the
     /// create / update / delete calls are skipped.
     #[arg(long)]
     dry_run: bool,
     /// Delete remote labels that aren't declared in `.gwm.toml`.
-    /// Destructive — off by default.
+    /// Destructive, off by default.
     #[arg(long)]
     prune: bool,
     /// Generate a random pastel for labels with no `color` field
@@ -955,7 +955,7 @@ pub enum TrustAction {
   ///
   /// The prompt on `gwm create` / `gwm bootstrap` only fires when the
   /// file has a bootstrap surface to run, so a `.gwm.toml` that only
-  /// names `forge` could never be approved that way — and since #419
+  /// names `forge` could never be approved that way, and since #419
   /// that key decides which host receives an authenticated call
   /// (Codex review #458). This is how you answer that question
   /// deliberately, without executing anything.
@@ -965,17 +965,17 @@ pub enum TrustAction {
   Add,
   /// List every recorded `(origin, hash)` pair in the active ledger.
   ///
-  /// Empty ledger prints a single line and exits 0 — the no-op fast
+  /// Empty ledger prints a single line and exits 0, the no-op fast
   /// path for fresh installs. The `trusted_at` timestamp is the
   /// audit anchor; revoke entries whose age looks suspicious with
   /// `gwm trust revoke <origin>`.
   List,
   /// Remove every entry whose `origin` matches verbatim. After revoke,
   /// the next `gwm create` / `gwm bootstrap` against that repo
-  /// re-prompts — use this when you change machines, rotate
+  /// re-prompts; use this when you change machines, rotate
   /// credentials, or no longer trust a previously approved repo.
   Revoke {
-    /// Origin URL to revoke (must match the recorded form verbatim —
+    /// Origin URL to revoke (must match the recorded form verbatim;
     /// SSH and HTTPS flavours of the same GitHub repo are recorded as
     /// distinct entries because they ARE distinct trust paths).
     origin: String,
@@ -985,7 +985,7 @@ pub enum TrustAction {
   /// Honours `$GWM_TRUST_LEDGER` if set, falls back to
   /// `$XDG_CONFIG_HOME/gwm/trust.toml` (or the platform-specific
   /// equivalent). Useful when triaging "why is gwm re-prompting?"
-  /// situations — eyeball the recorded hash vs. what `sha256sum
+  /// situations: eyeball the recorded hash vs. what `sha256sum
   /// .gwm.toml` produces.
   Show,
 }
@@ -1009,15 +1009,15 @@ pub enum MilestonesAction {
   /// still reads the remote via `gh api …/milestones` to compute the
   /// diff; only create / update / delete calls are skipped).
   /// `--prune` opt-in deletes milestones on remote that aren't
-  /// declared in config (off by default — destructive).
+  /// declared in config (off by default, destructive).
   Push {
     /// Print the plan without mutating the remote. Still reads remote
-    /// milestones via `gh api` to compute the diff — only the
+    /// milestones via `gh api` to compute the diff; only the
     /// create / update / delete calls are skipped.
     #[arg(long)]
     dry_run: bool,
     /// Delete remote milestones that aren't declared in `.gwm.toml`.
-    /// Destructive — off by default.
+    /// Destructive, off by default.
     #[arg(long)]
     prune: bool,
   },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1952,7 +1952,7 @@ fn cmd_init(preset: Option<String>, list_presets: bool, show: bool) -> Result<()
   let name = preset.as_deref().unwrap_or("generic");
   let resolved = presets::lookup(name).ok_or_else(|| {
     GwmError::Config(format!(
-      "unknown preset {name:?} — run `gwm init --list-presets` to see the built-ins"
+      "unknown preset {name:?}: run `gwm init --list-presets` to see the built-ins"
     ))
   })?;
 
@@ -2069,7 +2069,7 @@ fn cmd_agents(action: Option<AgentsAction>, format: AgentsFormat) -> Result<()> 
       let target = resolve_agents_worktree(&trees, &pattern)?;
       let Some(branch) = github::pinnable_branch(target.branch.as_deref()).map(str::to_string) else {
         return Err(GwmError::Config(format!(
-          "worktree '{}' has no branch (detached HEAD) — a pin lives in branch config",
+          "worktree '{}' has no branch (detached HEAD): a pin lives in branch config",
           target.name
         )));
       };
@@ -2089,7 +2089,7 @@ fn cmd_agents(action: Option<AgentsAction>, format: AgentsFormat) -> Result<()> 
         .is_some_and(|a| a.sessions.iter().any(|s| s.id == session_id));
       if !found {
         return Err(GwmError::Config(format!(
-          "no agent session with id '{session_id}' — run `gwm agents` to see the detected ids"
+          "no agent session with id '{session_id}': run `gwm agents` to see the detected ids"
         )));
       }
       github::add_agent_pin(&repo, &branch, &session_id)?;
@@ -2100,7 +2100,7 @@ fn cmd_agents(action: Option<AgentsAction>, format: AgentsFormat) -> Result<()> 
       let target = resolve_agents_worktree(&trees, &pattern)?;
       let Some(branch) = github::pinnable_branch(target.branch.as_deref()).map(str::to_string) else {
         return Err(GwmError::Config(format!(
-          "worktree '{}' has no branch (detached HEAD) — nothing to detach",
+          "worktree '{}' has no branch (detached HEAD): nothing to detach",
           target.name
         )));
       };
@@ -2108,7 +2108,7 @@ fn cmd_agents(action: Option<AgentsAction>, format: AgentsFormat) -> Result<()> 
         Some(sid) => {
           if !github::remove_agent_pin(&repo, &branch, &sid)? {
             return Err(GwmError::Config(format!(
-              "no pin '{sid}' on {} — run `gwm agents` to see the pinned ids",
+              "no pin '{sid}' on {}: run `gwm agents` to see the pinned ids",
               target.name
             )));
           }
@@ -2941,7 +2941,7 @@ fn cmd_review(
       print_lifecycle_report(&reports.post_create);
     }
     None => {
-      println!("(skipped bootstrap + hooks — pass --bootstrap to run setup against the PR's code)");
+      println!("(skipped bootstrap + hooks; pass --bootstrap to run setup against the PR's code)");
     }
   }
   Ok(())
@@ -3377,7 +3377,7 @@ fn cmd_note_show(slug: Option<String>) -> Result<()> {
   // for the agent pin, restated here so the CLI says why instead of
   // printing nothing.
   let Some(branch) = github::pinnable_branch(branch.as_deref()) else {
-    eprintln!("no branch checked out (detached HEAD) — a note is keyed on the branch");
+    eprintln!("no branch checked out (detached HEAD): a note is keyed on the branch");
     std::process::exit(1);
   };
   match crate::notes::read(&repo, branch) {
@@ -3835,7 +3835,7 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
   let spec = parser.parse(&branch_name).ok_or_else(|| {
     GwmError::Other(format!(
       "branch '{}' does not match this repo's branch pattern `{}`, so it carries no branch type to \
-       read — a commit prefix is derived from one, and a free-form branch has none. Pass --branch \
+       read: a commit prefix is derived from one, and a free-form branch has none. Pass --branch \
        <name written by the pattern>, or write the prefix by hand",
       branch_name, pattern
     ))
@@ -3857,7 +3857,7 @@ fn cmd_commit_prefix(branch_override: Option<String>, unicode: bool) -> Result<(
       _ => "`{issue}`",
     };
     return Err(GwmError::Other(format!(
-      "this repo's branch pattern `{}` carries no {}, so branch '{}' has none to read — a commit \
+      "this repo's branch pattern `{}` carries no {}, so branch '{}' has none to read: a commit \
        prefix is built from the branch type and issue number. Add {} to worktree.branch_pattern, \
        or write the prefix by hand",
       pattern, want, branch_name, want
@@ -3961,7 +3961,7 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool) -> Result<()>
     // backslash escaping). Pre-fix this read `\\${env_name}` and
     // surfaced `\$TMUX` to the user — caught at PR #65 review.
     return Err(GwmError::Other(format!(
-      "{0} session not running (${1} unset) — run `gwm {0} <pattern>` from inside a {0} session",
+      "{0} session not running (${1} unset): run `gwm {0} <pattern>` from inside a {0} session",
       mux.binary(),
       env_name,
     )));
@@ -4374,7 +4374,7 @@ fn cmd_labels(action: LabelsAction) -> Result<()> {
 fn cmd_labels_list() -> Result<()> {
   let config = load_labels_config()?;
   if config.labels.is_empty() {
-    println!("0 labels declared in .gwm.toml — nothing to push.");
+    println!("0 labels declared in .gwm.toml; nothing to push.");
     return Ok(());
   }
   // Resolve (and validate colours) before touching the network, so a
@@ -4391,7 +4391,7 @@ fn cmd_labels_list() -> Result<()> {
 fn cmd_labels_push(dry_run: bool, prune: bool, random_colors: bool) -> Result<()> {
   let config = load_labels_config()?;
   if config.labels.is_empty() {
-    println!("0 labels declared in .gwm.toml — nothing to push.");
+    println!("0 labels declared in .gwm.toml; nothing to push.");
     return Ok(());
   }
   let declared = labels::resolve_labels(&config.labels, random_colors)?;
@@ -4411,7 +4411,7 @@ fn cmd_labels_push(dry_run: bool, prune: bool, random_colors: bool) -> Result<()
           GwmError::Config(msg) => msg,
           other => other.to_string(),
         };
-        GwmError::Config(format!("labels (remote): {inner} — refusing to prune"))
+        GwmError::Config(format!("labels (remote): {inner}; refusing to prune"))
       })?;
     }
   }
@@ -4441,7 +4441,7 @@ fn cmd_labels_push(dry_run: bool, prune: bool, random_colors: bool) -> Result<()
     }
   } else if !diff.extra_on_remote.is_empty() {
     println!(
-      "{} label(s) on remote not in config — pass --prune to delete",
+      "{} label(s) on remote not in config: pass --prune to delete",
       diff.extra_on_remote.len()
     );
   }
@@ -4487,7 +4487,7 @@ pub fn labels_diff_lines(slug: &str, declared: &[labels::LabelSpec], diff: &Labe
   let clean = crate::naming::sanitise_for_terminal;
   let (n_create, n_update, n_match, n_extra) = diff.counts();
   let mut lines = vec![format!(
-    "declared in .gwm.toml: {} labels — diff against {}:",
+    "declared in .gwm.toml: {} labels; diff against {}:",
     declared.len(),
     clean(slug)
   )];
@@ -4528,7 +4528,7 @@ fn cmd_milestones(action: MilestonesAction) -> Result<()> {
 fn cmd_milestones_list() -> Result<()> {
   let config = load_milestones_config()?;
   if config.milestones.is_empty() {
-    println!("0 milestones declared in .gwm.toml — nothing to push.");
+    println!("0 milestones declared in .gwm.toml; nothing to push.");
     return Ok(());
   }
   // Resolve (and validate due_on / state) before touching the network,
@@ -4545,7 +4545,7 @@ fn cmd_milestones_list() -> Result<()> {
 fn cmd_milestones_push(dry_run: bool, prune: bool) -> Result<()> {
   let config = load_milestones_config()?;
   if config.milestones.is_empty() {
-    println!("0 milestones declared in .gwm.toml — nothing to push.");
+    println!("0 milestones declared in .gwm.toml; nothing to push.");
     return Ok(());
   }
   let declared = milestones::resolve_milestones(&config.milestones)?;
@@ -4589,7 +4589,7 @@ fn cmd_milestones_push(dry_run: bool, prune: bool) -> Result<()> {
     }
   } else if !diff.extra_on_remote.is_empty() {
     println!(
-      "{} milestone(s) on remote not in config — pass --prune to delete",
+      "{} milestone(s) on remote not in config: pass --prune to delete",
       diff.extra_on_remote.len()
     );
   }
@@ -4622,7 +4622,7 @@ pub fn milestones_diff_lines(slug: &str, declared: &[milestones::MilestoneSpec],
   let clean = crate::naming::sanitise_for_terminal;
   let (n_create, n_update, n_match, n_extra) = diff.counts();
   let mut lines = vec![format!(
-    "declared in .gwm.toml: {} milestones — diff against {}:",
+    "declared in .gwm.toml: {} milestones; diff against {}:",
     declared.len(),
     clean(slug)
   )];
@@ -4753,7 +4753,7 @@ fn cmd_trust_add() -> Result<()> {
       Ok(())
     }
     None => Err(GwmError::Other(format!(
-      "no .gwm.toml in {} — there is nothing to trust here",
+      "no .gwm.toml in {}: there is nothing to trust here",
       workdir.display()
     ))),
   }
@@ -4775,7 +4775,7 @@ fn cmd_trust_show() -> Result<()> {
       }
     }
     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-      println!("(file does not exist yet — nothing has been trusted on this machine)");
+      println!("(file does not exist yet, nothing has been trusted on this machine)");
     }
     Err(e) => return Err(e.into()),
   }
@@ -4821,7 +4821,7 @@ fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -
       use std::io::IsTerminal;
       if !std::io::stdin().is_terminal() {
         return Err(GwmError::Other(format!(
-          ".gwm.toml at {} is not in the trust ledger and stdin is not interactive — \
+          ".gwm.toml at {} is not in the trust ledger and stdin is not interactive: \
            pass --allow-bootstrap (or set GWM_ALLOW_BOOTSTRAP=1) to bypass, \
            or run interactively to approve",
           cfg_path.display()
@@ -4831,7 +4831,7 @@ fn trust_or_prompt(workdir: &Path, repo: Option<&Repository>, mode: TrustMode) -
       let granted = prompt_user(&cfg_path, &body, &origin, &sha)?;
       if !granted {
         return Err(GwmError::Other(format!(
-          "trust prompt declined for {} — aborting bootstrap",
+          "trust prompt declined for {}, aborting bootstrap",
           cfg_path.display()
         )));
       }
@@ -4875,7 +4875,7 @@ fn prompt_user(cfg_path: &Path, bytes: &[u8], origin: &str, sha: &str) -> Result
   if let Some(cfg) = parsed.as_ref() {
     print_bootstrap_summary(cfg);
   } else {
-    println!("     (could not parse .gwm.toml for summary — see raw via `show` below)");
+    println!("     (could not parse .gwm.toml for summary, see raw via `show` below)");
   }
   println!();
 
@@ -5030,7 +5030,7 @@ fn cmd_aliases_list() -> Result<()> {
   // repo section -------------------------------------------------------
   println!("repo (.gwm.toml):");
   if repo_workdir.is_none() {
-    println!("  (not inside a git repository — repo aliases are read from <repo>/.gwm.toml)");
+    println!("  (not inside a git repository; repo aliases are read from <repo>/.gwm.toml)");
   } else if resolved.repo.is_empty() {
     println!("  (none declared)");
   } else {
@@ -5079,7 +5079,7 @@ pub fn shell_init_script(shell: InitShell) -> &'static str {
   }
 }
 
-const POSIX_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
+const POSIX_SHELL_INIT: &str = r#"# gwm shell helper: wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: eval "$(gwm shell-init bash)"   # or zsh
 #
 # Two paths:
@@ -5106,7 +5106,7 @@ function gcd {
 unalias gcd 2>/dev/null || true
 "#;
 
-const FISH_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
+const FISH_SHELL_INIT: &str = r#"# gwm shell helper: wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: gwm shell-init fish | source   # then persist in ~/.config/fish/config.fish
 #
 # Two paths:
@@ -5129,7 +5129,7 @@ function gcd --description 'cd into a gwm worktree (no arg = interactive picker)
 end
 "#;
 
-const POWERSHELL_SHELL_INIT: &str = r#"# gwm shell helper — wraps `gwm cd` / `gwm switch` so the parent shell can cd.
+const POWERSHELL_SHELL_INIT: &str = r#"# gwm shell helper: wraps `gwm cd` / `gwm switch` so the parent shell can cd.
 # Install: Invoke-Expression (& gwm shell-init powershell | Out-String)
 #
 # Two paths:
@@ -5247,7 +5247,7 @@ fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
 
   let Some(entry) = journal.pop_last_for_repo(&root) else {
     return Err(GwmError::Other(format!(
-      "nothing to undo for {} — the journal is empty for this repo",
+      "nothing to undo for {}: the journal is empty for this repo",
       root.display()
     )));
   };
@@ -5296,7 +5296,7 @@ fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
         &oid_hex[..oid_hex.len().min(8)]
       );
     } else {
-      println!("· branch {} already exists — skipping resurrection", branch_name);
+      println!("· branch {} already exists, skipping resurrection", branch_name);
     }
   }
 
@@ -5317,7 +5317,7 @@ fn cmd_undo(run_bootstrap: bool, trust_mode: TrustMode) -> Result<()> {
   //     (PR #155 Copilot review).
   let branch_name = entry.branch.as_deref().ok_or_else(|| {
     GwmError::Other(format!(
-      "cannot undo remove of detached-HEAD worktree {} — only branch-attached worktrees are supported today",
+      "cannot undo remove of detached-HEAD worktree {}: only branch-attached worktrees are supported today",
       entry.worktree
     ))
   })?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1056,7 +1056,7 @@ const TUI_KEYS_MODAL_NAMESPACE: &str = "modal";
 fn as_chord_list(coord: &str, value: &toml::Value) -> Result<Vec<String>> {
   let arr = value
     .as_array()
-    .expect("as_chord_list called on a non-array — caller must match Value::Array first");
+    .expect("as_chord_list called on a non-array: caller must match Value::Array first");
   let mut out = Vec::with_capacity(arr.len());
   for v in arr {
     let s = v.as_str().ok_or_else(|| {
@@ -1103,7 +1103,7 @@ fn walk_modal_context(
       toml::Value::Array(_) => {
         let ctx = ctx.ok_or_else(|| {
           GwmError::Config(format!(
-            "tui.keys.modal.{path}: {path:?} is a context group, not a leaf — bind under a stage (e.g. {path}.<stage>)",
+            "tui.keys.modal.{path}: {path:?} is a context group, not a leaf; bind under a stage (e.g. {path}.<stage>)",
             path = ctx_path
           ))
         })?;
@@ -1943,7 +1943,7 @@ impl Config {
           // shape used by `validate_bootstrap_paths` (e.g.
           // "bootstrap.copy[0].to").
           GwmError::Config(format!(
-            "bootstrap.guard[{}].deny_patterns[{}] '{}': invalid pattern {:?} — regex: {}",
+            "bootstrap.guard[{}].deny_patterns[{}] '{}': invalid pattern {:?}; regex: {}",
             gi, pi, g.name, pat, e
           ))
         })?;
@@ -2016,13 +2016,13 @@ impl Config {
       if !name_re.is_match(&entry.name) {
         return Err(GwmError::Config(format!(
           "branch_types: invalid `name = \"{}\"`; must match ^[a-z]+$ to be a valid branch-prefix \
-           (lowercase letters only, no digits, no dashes — git refs and the branch parser rely on this)",
+           (lowercase letters only, no digits, no dashes; git refs and the branch parser rely on this)",
           entry.name
         )));
       }
       if !seen.insert(entry.name.as_str()) {
         return Err(GwmError::Config(format!(
-          "branch_types: duplicate entry for `name = \"{}\"` — each branch type must be declared at most once",
+          "branch_types: duplicate entry for `name = \"{}\"`; each branch type must be declared at most once",
           entry.name
         )));
       }
@@ -2180,7 +2180,7 @@ fn check_relative_no_traversal(value: &str, field: &str) -> Result<()> {
   let p = Path::new(value);
   if p.is_absolute() {
     return Err(GwmError::Config(format!(
-      "{}: {:?} is an absolute path — only relative paths under the base directory are allowed",
+      "{}: {:?} is an absolute path; only relative paths under the base directory are allowed",
       field, value
     )));
   }
@@ -2192,13 +2192,13 @@ fn check_relative_no_traversal(value: &str, field: &str) -> Result<()> {
     match comp {
       std::path::Component::ParentDir => {
         return Err(GwmError::Config(format!(
-          "{}: {:?} contains '..' traversal — only relative paths under the base directory are allowed",
+          "{}: {:?} contains '..' traversal; only relative paths under the base directory are allowed",
           field, value
         )));
       }
       std::path::Component::Prefix(_) => {
         return Err(GwmError::Config(format!(
-          "{}: {:?} contains a Windows drive prefix — only relative paths under the base directory are allowed",
+          "{}: {:?} contains a Windows drive prefix; only relative paths under the base directory are allowed",
           field, value
         )));
       }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1163,7 +1163,7 @@ mod server_win {
     options.security_descriptor = Some(owner_only_descriptor()?);
     let listener = options.create_duplex::<pipe_mode::Bytes>().map_err(|e| {
       GwmError::Other(format!(
-        "daemon: failed to bind pipe {} (a name that is already claimed is refused — first-instance guard): {e}",
+        "daemon: failed to bind pipe {} (a name that is already claimed is refused, first-instance guard): {e}",
         opts.socket.display()
       ))
     })?;

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -218,7 +218,7 @@ fn check_tui_keymap(ctx: &DoctorCtx<'_>) -> Check {
   if !quit_has_user_binding {
     return Check::warning(
       name,
-      "`quit` has no binding — Ctrl+C still exits the TUI as a hard-coded fallback, but no discoverable key remains",
+      "`quit` has no binding: Ctrl+C still exits the TUI as a hard-coded fallback, but no discoverable key remains",
     )
     .with_hint("add `quit = [\"q\", \"Esc\"]` (or any other key) to `[tui.keys]`");
   }
@@ -245,7 +245,7 @@ fn check_config_parses(ctx: &DoctorCtx<'_>) -> Check {
   let name = ".gwm.toml parses";
 
   if !path.exists() {
-    return Check::ok(name, "no .gwm.toml present — defaults assumed");
+    return Check::ok(name, "no .gwm.toml present, defaults assumed");
   }
 
   let raw = match std::fs::read_to_string(&path) {
@@ -785,7 +785,7 @@ fn check_orphan_notes(ctx: &DoctorCtx<'_>) -> Check {
     ),
   )
   .with_hint(format!(
-    "the branch is gone — delete the file under {} when the work has landed",
+    "the branch is gone: delete the file under {} when the work has landed",
     crate::notes::notes_dir(ctx.repo).display()
   ))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ pub enum GwmError {
   /// stale ref or rename their request rather than ending up on
   /// whatever commit the stale branch resurrected.
   #[error(
-    "branch '{name}' already exists at {oid} — pass --reuse-branch to attach the worktree to it, or delete the stale branch first"
+    "branch '{name}' already exists at {oid}: pass --reuse-branch to attach the worktree to it, or delete the stale branch first"
   )]
   BranchExists { name: String, oid: String },
 
@@ -154,7 +154,7 @@ pub enum GwmError {
   /// it. Reject it elsewhere rather than silently ignoring it and acting on
   /// the current single repo — a wrong-target footgun for destructive
   /// commands like `gwm remove` (Codex review #303 P2).
-  #[error("--workspace is only supported with `gwm list`, `gwm create`, `gwm exec`, `gwm clean`, or bare `gwm` (the TUI) — refusing to run this subcommand against a single repo")]
+  #[error("--workspace is only supported with `gwm list`, `gwm create`, `gwm exec`, `gwm clean`, or bare `gwm` (the TUI): refusing to run this subcommand against a single repo")]
   WorkspaceUnsupportedCommand,
 
   #[error("{0}")]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -52,7 +52,7 @@ pub type CapturedRun = (ExecOutcome, Vec<u8>);
 pub fn resolve_exec_command(profile: Option<&str>, inline: &[String], cfg: &ExecConfig) -> Result<Vec<String>> {
   match (profile, inline.is_empty()) {
     (Some(_), false) => Err(GwmError::Other(
-      "exec: --profile and an inline `-- <cmd>` are mutually exclusive — the profile carries the command".into(),
+      "exec: --profile and an inline `-- <cmd>` are mutually exclusive; the profile carries the command".into(),
     )),
     (Some(name), true) => {
       let p = cfg
@@ -85,7 +85,7 @@ pub fn validate_exec_profile(profile: &str, entry: &ExecProfile) -> Result<()> {
   } = entry;
   if command.is_empty() {
     return Err(GwmError::Config(format!(
-      "exec: profile `{profile}` has an empty `command` — give it an argv array like `command = [\"cargo\", \"test\"]`"
+      "exec: profile `{profile}` has an empty `command`; give it an argv array like `command = [\"cargo\", \"test\"]`"
     )));
   }
   if let Some(c) = container {
@@ -111,12 +111,12 @@ pub fn validate_container(profile: &str, cfg: &ContainerConfig) -> Result<()> {
   } = cfg;
   if image.trim().is_empty() {
     return Err(GwmError::Config(format!(
-      "exec: profile `{profile}` has a `[container]` with an empty `image` — give it one like `image = \"rust:1.90\"`"
+      "exec: profile `{profile}` has a `[container]` with an empty `image`; give it one like `image = \"rust:1.90\"`"
     )));
   }
   if extra_args.iter().any(|a| a == "--name" || a.starts_with("--name=")) {
     return Err(GwmError::Config(format!(
-      "exec: profile `{profile}` sets `--name` in `[container] extra_args` — gwm owns that flag, \
+      "exec: profile `{profile}` sets `--name` in `[container] extra_args`; gwm owns that flag, \
        because the TUI overlay removes its container by name when it closes. Drop it."
     )));
   }
@@ -167,7 +167,7 @@ pub fn resolve_container_runtime(configured: Option<&str>, available: impl Fn(&s
     .map(|bin| (*bin).to_string())
     .ok_or_else(|| {
       GwmError::Config(format!(
-        "exec: no container runtime found on PATH (looked for {}) — install one or set `runtime` in the profile's `[container]`",
+        "exec: no container runtime found on PATH (looked for {}); install one or set `runtime` in the profile's `[container]`",
         CONTAINER_RUNTIMES.join(", ")
       ))
     })
@@ -202,7 +202,7 @@ impl ContainerPlan {
     // unable to answer — the one thing this feature exists to guarantee.
     if cfg!(windows) {
       return Err(GwmError::Config(
-        "exec: `[container]` is not supported on Windows — the wrapper mirrors host paths, \
+        "exec: `[container]` is not supported on Windows; the wrapper mirrors host paths, \
          and a `C:\\…` path is neither mountable nor resolvable inside a Linux container \
          (the worktree's `.git` file would still name a Windows path). Run the profile on \
          the host, or drive the container from a Linux/macOS checkout."
@@ -354,7 +354,7 @@ pub fn build_container_argv(
   }
   if let Some(bad) = mounted.iter().find(|p| p.contains(':')) {
     return Err(GwmError::Config(format!(
-      "exec: `[container]` cannot mount `{bad}` — a `:` in the path is the separator of \
+      "exec: `[container]` cannot mount `{bad}`; a `:` in the path is the separator of \
        `-v source:destination`, so the mount cannot be expressed. Move the worktree (or the \
        repository) to a path without a colon, or run the profile on the host."
     )));

--- a/src/github.rs
+++ b/src/github.rs
@@ -1766,7 +1766,7 @@ fn validate_remote_label_name(name: &str) -> Result<()> {
       other => other.to_string(),
     };
     GwmError::Config(format!(
-      "labels (remote): {} — refusing to delete via `gh label delete`",
+      "labels (remote): {}; refusing to delete via `gh label delete`",
       inner
     ))
   })

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -997,7 +997,7 @@ fn parse_paginated_array<T: serde::de::DeserializeOwned>(s: &str, kind: &'static
   }
   if pages == 0 {
     return Err(GwmError::Other(format!(
-      "{kind}: glab returned no JSON at all — treating that as an empty \
+      "{kind}: glab returned no JSON at all; treating that as an empty \
        remote would let --prune run against a baseline it never read"
     )));
   }
@@ -1504,7 +1504,7 @@ impl Forge for GitLabForge {
         GwmError::Config(msg) => msg,
         other => other.to_string(),
       };
-      GwmError::Config(format!("labels (remote): {} — refusing to delete via `glab`", inner))
+      GwmError::Config(format!("labels (remote): {}; refusing to delete via `glab`", inner))
     })?;
     self.run_argv(label_delete_argv(self.repo_selector(), name))?;
     Ok(())

--- a/src/history.rs
+++ b/src/history.rs
@@ -226,9 +226,8 @@ pub fn default_journal_path() -> Result<PathBuf> {
       return Ok(PathBuf::from(p).join("gwm").join("history.toml"));
     }
   }
-  let base = dirs::data_dir().ok_or_else(|| {
-    GwmError::Other("could not resolve user data directory — set GWM_HISTORY_FILE to override".into())
-  })?;
+  let base = dirs::data_dir()
+    .ok_or_else(|| GwmError::Other("could not resolve user data directory: set GWM_HISTORY_FILE to override".into()))?;
   Ok(base.join("gwm").join("history.toml"))
 }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -62,7 +62,7 @@ use std::path::{Path, PathBuf};
 pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
   let repo = git2::Repository::discover(repo_root).map_err(|_| {
     GwmError::Other(format!(
-      "no git repository discovered from {} — `gwm hooks install` must be run from inside a git repo",
+      "no git repository discovered from {}: `gwm hooks install` must be run from inside a git repo",
       repo_root.display()
     ))
   })?;
@@ -73,7 +73,7 @@ pub fn install_commit_msg(repo_root: &Path, force: bool) -> Result<PathBuf> {
   let hook_path = hooks_dir.join("commit-msg");
   if hook_path.exists() && !force {
     return Err(GwmError::Other(format!(
-      "commit-msg hook already exists at {} — pass --force to overwrite",
+      "commit-msg hook already exists at {}: pass --force to overwrite",
       hook_path.display()
     )));
   }
@@ -164,18 +164,18 @@ pub fn commit_msg_script() -> String {
   // variable surfaces as a real bug (rather than silently producing
   // empty output).
   r#"#!/bin/sh
-# gwm commit-msg hook — auto-prepends the gitmoji + type prefix when
+# gwm commit-msg hook: auto-prepends the gitmoji + type prefix when
 # the commit message doesn't already start with one. Installed by
 # `gwm hooks install commit-msg` (issue #85). Re-running the installer
 # with --force overwrites this file.
 #
 # Best-effort by design: every filesystem step is guarded so a
 # transient failure (full /tmp, noexec mount, …) never blocks the
-# commit — the user just loses the auto-prefix for that one commit.
+# commit: the user just loses the auto-prefix for that one commit.
 
 set -u
 
-# Skip when `gwm` isn't on $PATH — never block a commit because of us.
+# Skip when `gwm` isn't on $PATH: never block a commit because of us.
 if ! command -v gwm >/dev/null 2>&1; then
   exit 0
 fi
@@ -189,13 +189,13 @@ msg_file="${1:-}"
 # a `#`-prefixed comment; we take the first match. Falling back to an
 # empty string lets the downstream check no-op cleanly when the buffer
 # only contains the git template (i.e. the user aborted with an empty
-# message — git itself will reject that commit, no need for us to).
+# message: git itself will reject that commit, no need for us to).
 first_line="$(grep -nvE '^([[:space:]]*#|[[:space:]]*$)' "$msg_file" 2>/dev/null | sed -n '1s/^[0-9]*://p')"
 [ -n "$first_line" ] || exit 0
 
 # Already-prefixed messages are passed through untouched. We detect
 # both the shortcode form (`:sparkles: feat(…)`) and the unicode form
-# (✨ feat(…)) — any non-space first byte that looks like an emoji
+# (✨ feat(…)). Any non-space first byte that looks like an emoji
 # fence covers the latter. The shortcode check is tighter so common
 # `:foo:` mentions in PR / issue subjects don't false-positive.
 case "$first_line" in

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -218,25 +218,25 @@ fn fnv1a_64(bytes: &[u8]) -> u64 {
 pub fn validate_label_name(name: &str) -> Result<()> {
   if name.is_empty() {
     return Err(GwmError::Config(
-      "entry has empty `name` — GitHub label names must be non-empty".into(),
+      "entry has empty `name`: GitHub label names must be non-empty".into(),
     ));
   }
   if name.starts_with('-') {
     return Err(GwmError::Config(format!(
-      "name {:?} starts with '-' — would be parsed as a flag by `gh label create`; \
+      "name {:?} starts with '-': would be parsed as a flag by `gh label create`; \
        rename or remove the leading dash (issue #100)",
       name
     )));
   }
   if name.contains(',') {
     return Err(GwmError::Config(format!(
-      "name {:?} contains ',' — GitHub uses comma as a label-list separator; rename without commas",
+      "name {:?} contains ',': GitHub uses comma as a label-list separator; rename without commas",
       name
     )));
   }
   if let Some(bad) = name.chars().find(|c| c.is_ascii_control()) {
     return Err(GwmError::Config(format!(
-      "name {:?} contains ASCII control character {:?} — rename without control characters",
+      "name {:?} contains ASCII control character {:?}: rename without control characters",
       name, bad
     )));
   }

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -492,7 +492,7 @@ impl WorktreeName {
     // flattened dirname has exactly the name's byte length.
     if name.len() > MAX_DIR_COMPONENT_BYTES {
       return reject(&format!(
-        "{} bytes long — a worktree directory is a single path component, capped at {}",
+        "{} bytes long: a worktree directory is a single path component, capped at {}",
         name.len(),
         MAX_DIR_COMPONENT_BYTES
       ));
@@ -506,7 +506,7 @@ impl WorktreeName {
     let last = name.rsplit('/').next().unwrap_or(name);
     if last.len() + GIT_REF_LOCK_SUFFIX_BYTES > MAX_DIR_COMPONENT_BYTES {
       return reject(&format!(
-        "its last segment is {} bytes — git writes `refs/heads/<name>.lock` first, leaving {} for it",
+        "its last segment is {} bytes: git writes `refs/heads/<name>.lock` first, leaving {} for it",
         last.len(),
         MAX_DIR_COMPONENT_BYTES - GIT_REF_LOCK_SUFFIX_BYTES
       ));
@@ -517,7 +517,7 @@ impl WorktreeName {
     // refuses and which would collide with the HEAD pseudo-ref.
     if !git2::Branch::name_is_valid(name).unwrap_or(false) {
       return reject(
-        "not a valid git branch name — git rejects spaces, `~ ^ : ? * [ \\`, `@{`, `..`, \
+        "not a valid git branch name: git rejects spaces, `~ ^ : ? * [ \\`, `@{`, `..`, \
          leading/trailing `/`, a trailing `.`, a `.lock` suffix and `HEAD`",
       );
     }
@@ -528,7 +528,7 @@ impl WorktreeName {
     // here is a name git already accepted.
     if let Some(ch) = name.chars().find(|c| WINDOWS_FORBIDDEN_CHARS.contains(c)) {
       return reject(&format!(
-        "`{}` cannot appear in a directory name on Windows — the branch would be \
+        "`{}` cannot appear in a directory name on Windows: the branch would be \
          unusable on a teammate's machine even though git accepts it",
         ch
       ));
@@ -545,7 +545,7 @@ impl WorktreeName {
       // to pass both `Branch::name_is_valid` and `git check-ref-format`.
       if segment.ends_with('.') {
         return reject(&format!(
-          "`{}` ends with `.`, which Windows refuses as a directory name — git only \
+          "`{}` ends with `.`, which Windows refuses as a directory name; git only \
            applies that rule to the last segment of a branch",
           segment
         ));
@@ -553,7 +553,7 @@ impl WorktreeName {
       if is_windows_reserved_segment(segment) {
         return reject(&format!(
           "`{}` is a reserved device name on Windows (`CON`, `PRN`, `AUX`, `NUL`, \
-           `COM1`-`COM9`, `LPT1`-`LPT9`, with or without an extension) — no path \
+           `COM1`-`COM9`, `LPT1`-`LPT9`, with or without an extension): no path \
            component may be one",
           segment
         ));
@@ -597,7 +597,7 @@ impl WorktreeName {
         if let Some(ph) = STRUCTURED_BASE_PLACEHOLDERS.iter().find(|ph| cfg.base.contains(**ph)) {
           return Err(GwmError::Config(format!(
             "worktree.base `{}` uses `{}`, which a free-form name has no value for \
-             (it would be left literal in the path) — drop it from base, or create \
+             (it would be left literal in the path): drop it from base, or create \
              the worktree with <type> <issue> <desc>",
             cfg.base, ph
           )));
@@ -741,7 +741,7 @@ impl BranchParser {
                 format!(
                   "worktree.branch_pattern `{}` puts `{{{}}}` straight after `{{{}}}` with nothing \
                    between them and both can hold the same characters, so a branch it writes cannot \
-                   be read back unambiguously — separate them with a literal (`-`, `_`, `/`, …)",
+                   be read back unambiguously: separate them with a literal (`-`, `_`, `/`, …)",
                   sanitise_for_terminal(pattern),
                   name,
                   left
@@ -749,8 +749,8 @@ impl BranchParser {
               } else {
                 format!(
                   "worktree.branch_pattern `{}` separates `{{{}}}` from `{{{}}}` with `{}`, which \
-                   could be read as part of either, so a branch it writes splits at the wrong place \
-                   — separate them with a character neither can contain (`/`, `_`, `#`, `.`, …)",
+                   could be read as part of either, so a branch it writes splits at the wrong place: \
+                   separate them with a character neither can contain (`/`, `_`, `#`, `.`, …)",
                   sanitise_for_terminal(pattern),
                   left,
                   name,
@@ -1472,7 +1472,7 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
       .map(|seg| format!("{} {}", segment_consumers(seg), segment_absent_verb(seg)))
       .collect::<Vec<_>>();
     parts.push(format!(
-      "it carries no {}, so {} — write {} into the pattern to get them back",
+      "it carries no {}, so {}: write {} into the pattern to get them back",
       tokens.join(" and "),
       losses.join("; "),
       tokens.join(" and ")
@@ -1480,7 +1480,7 @@ pub fn branch_pattern_warning(pattern: &str, repo: &str, types: &[BranchType]) -
   }
   if let Some(example) = unparseable {
     parts.push(format!(
-      "{} of the {} branch shapes probed match nothing at all (e.g. `{}`), so issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and placeholders, remove/bootstrap hook placeholders, the TUI rename and the branch-convention check are inactive on those (PR/MR detection is unaffected — it queries the forge with the full branch name)",
+      "{} of the {} branch shapes probed match nothing at all (e.g. `{}`), so issue auto-linking from the branch name, gitmoji / `gwm commit-prefix`, `gwm pr` template selection and placeholders, remove/bootstrap hook placeholders, the TUI rename and the branch-convention check are inactive on those (PR/MR detection is unaffected, it queries the forge with the full branch name)",
       unparsed,
       probes,
       sanitise_for_terminal(&example)

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -252,7 +252,7 @@ pub fn prepare(repo: &git2::Repository, branch: &str) -> Result<Option<PathBuf>>
   };
   if let Some(rival) = case_fold_rival(repo, branch) {
     return Err(crate::error::GwmError::CommandFailed(format!(
-      "`{branch}` and `{rival}` differ only in case and would share one note file — \
+      "`{branch}` and `{rival}` differ only in case and would share one note file: \
        rename one of the two branches, the filesystem cannot tell their notes apart"
     )));
   }
@@ -267,7 +267,7 @@ pub fn prepare(repo: &git2::Repository, branch: &str) -> Result<Option<PathBuf>>
       .and_then(branch_from_relative)
       .unwrap_or_else(|| other.display().to_string());
     return Err(crate::error::GwmError::CommandFailed(format!(
-      "this filesystem opens `{branch}`'s note and `{owner}`'s as one file — \
+      "this filesystem opens `{branch}`'s note and `{owner}`'s as one file: \
        rename one of the two branches, editing either would rewrite the other"
     )));
   }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -96,7 +96,7 @@ pub fn sync(start: &Path, strategy: SyncStrategy) -> Result<SyncReport> {
   })?;
   if !head.is_branch() {
     return Err(GwmError::UnbornHead {
-      reason: "sync: HEAD is detached — check out a branch first".into(),
+      reason: "sync: HEAD is detached; check out a branch first".into(),
     });
   }
   let branch_short = head

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -348,7 +348,7 @@ fn refusal_for(outcome: TrustOutcome, approve_hint: &str) -> Option<String> {
     TrustOutcome::Prompt { cfg_path, sha, .. } => {
       let short_sha: String = sha.chars().take(12).collect();
       Some(format!(
-        ".gwm.toml at {} not in trust ledger (hash {}) — {}",
+        ".gwm.toml at {} not in trust ledger (hash {}): {}",
         cfg_path.display(),
         short_sha,
         approve_hint
@@ -515,7 +515,7 @@ pub fn default_ledger_path() -> Result<PathBuf> {
     }
   }
   let base = dirs::config_dir().ok_or_else(|| {
-    GwmError::Other("could not resolve user config directory — set GWM_TRUST_LEDGER to override".into())
+    GwmError::Other("could not resolve user config directory: set GWM_TRUST_LEDGER to override".into())
   })?;
   Ok(base.join("gwm").join("trust.toml"))
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -883,7 +883,7 @@ impl App {
     // in one cross-repo bulk pass — see `refresh_linked_github_statuses_for_worktrees`.
     app.refresh_link();
     app.status = format!(
-      "workspace {} — {} repo(s), {} worktree(s) · press ? for help",
+      "workspace {}: {} repo(s), {} worktree(s) · press ? for help",
       root.display(),
       repo_count,
       wt_count
@@ -977,7 +977,7 @@ impl App {
       0 => "enter: submit".into(),
       1 => format!("enter on {}: submit", self.submit_field_label()),
       _ => format!(
-        "tab/shift-tab: switch field — enter on {}: submit",
+        "tab/shift-tab: switch field · enter on {}: submit",
         self.submit_field_label()
       ),
     }
@@ -1094,7 +1094,7 @@ impl App {
         // reachable row (or a refresh drops the dead repo) — #304.
         self.mark_workspace_stale();
         self.status = format!(
-          "workspace: repo '{}' is unavailable ({}) — press r to refresh",
+          "workspace: repo '{}' is unavailable ({}); press r to refresh",
           meta.name, e
         );
       }
@@ -1276,7 +1276,7 @@ impl App {
     let mut app = Self::new_at_layered(start, global_path)?;
     app.picker_mode = true;
     app.filter.open();
-    app.status = "switch picker — type to filter · enter selects · esc cancels".into();
+    app.status = "switch picker: type to filter · enter selects · esc cancels".into();
     Ok(app)
   }
 
@@ -1393,11 +1393,11 @@ impl App {
     }
     self.status = if spawned > 0 {
       format!(
-        "refreshed — {} worktree(s); fetching GitHub status…",
+        "refreshed: {} worktree(s); fetching GitHub status…",
         self.worktrees.len()
       )
     } else {
-      format!("refreshed — {} worktree(s)", self.worktrees.len())
+      format!("refreshed: {} worktree(s)", self.worktrees.len())
     };
   }
 
@@ -2456,7 +2456,7 @@ impl App {
   pub fn open_command_palette(&mut self) {
     self.palette.open();
     self.view = View::CommandPalette;
-    self.status = "command palette — type, Enter to run, Esc to cancel".into();
+    self.status = "command palette: type, Enter to run, Esc to cancel".into();
   }
 
   /// Close the palette without firing anything. Called on `Esc` from
@@ -2814,7 +2814,7 @@ impl App {
     // with a stale selection that path is the *previously* active repo, so
     // refuse rather than rebind keys in the wrong repo (#304).
     if self.workspace_active_stale && self.config_panel.layer == SettingsLayer::Project {
-      self.status = "workspace: selected repo is unavailable — can't edit its project keymap".into();
+      self.status = "workspace: selected repo is unavailable; can't edit its project keymap".into();
       return;
     }
     let path = match self.config_panel.layer {
@@ -2868,7 +2868,7 @@ impl App {
         // roll the file back to its prior state so the config is never left
         // broken on disk, and keep the previous live keymaps.
         Self::restore_file(&path, prior);
-        self.status = format!("keys: rebind rejected — would break the merged config: {}", e);
+        self.status = format!("keys: rebind rejected; would break the merged config: {}", e);
         return;
       }
     }
@@ -2904,7 +2904,7 @@ impl App {
     // it persisted. Warn instead of reporting a clean success (Codex #297
     // review).
     if !self.capture_took_effect(target, &cap.pending) {
-      status.push_str(" — shadowed (a higher layer or legacy alias still binds it)");
+      status.push_str("; shadowed (a higher layer or legacy alias still binds it)");
     }
     self.status = status;
   }
@@ -2994,7 +2994,7 @@ impl App {
     };
     let names: Vec<String> = self.config.exec.profiles.keys().cloned().collect();
     if names.is_empty() {
-      self.status = "no [exec.profiles] configured — add one to .gwm.toml".into();
+      self.status = "no [exec.profiles] configured: add one to .gwm.toml".into();
       return;
     }
     // Capture the target worktree path AND the active repo's `[exec]` config
@@ -3160,7 +3160,7 @@ impl App {
     // checks. Refuse, the same contract as the project-layer keymap
     // editor (#304 / Codex review #455).
     if self.workspace_active_stale {
-      self.status = "workspace: selected repo is unavailable — can't open its CI checks".into();
+      self.status = "workspace: selected repo is unavailable; can't open its CI checks".into();
       return;
     }
     let checks = match self.pr_fetch_state() {
@@ -3169,8 +3169,8 @@ impl App {
         // Resolve the active fetch binding instead of hard-coding `F`
         // (Codex review #455); an unbound action drops the parenthetical.
         self.status = match self.keymap.primary_chord(Action::FetchGithub) {
-          Some(key) => format!("no CI checks to show — link a PR and fetch ({key}) first"),
-          None => "no CI checks to show — link a PR and fetch first".into(),
+          Some(key) => format!("no CI checks to show: link a PR and fetch ({key}) first"),
+          None => "no CI checks to show: link a PR and fetch first".into(),
         };
         return;
       }
@@ -3224,7 +3224,7 @@ impl App {
     // leaves the link and its cache pointing at the previously active
     // repo, and this view would then browse the OLD repo's PR.
     if self.workspace_active_stale {
-      self.status = "workspace: selected repo is unavailable — can't open its PR/issue view".into();
+      self.status = "workspace: selected repo is unavailable; can't open its PR/issue view".into();
       return;
     }
     let width = self.rich_view_width();
@@ -3249,8 +3249,8 @@ impl App {
     // Resolve the active binding rather than hard-coding `F`, the same way
     // `enter_ci_checks` does.
     self.status = match self.keymap.primary_chord(Action::FetchGithub) {
-      Some(key) => format!("nothing to show — link an issue or PR and fetch ({key}) first"),
-      None => "nothing to show — link an issue or PR and fetch first".into(),
+      Some(key) => format!("nothing to show: link an issue or PR and fetch ({key}) first"),
+      None => "nothing to show: link an issue or PR and fetch first".into(),
     };
   }
 
@@ -3351,7 +3351,7 @@ impl App {
   pub fn rich_view_refresh(&mut self) {
     if self.workspace_active_stale {
       self.close_detail_overlay();
-      self.status = "workspace: selected repo is unavailable — PR/issue view closed".into();
+      self.status = "workspace: selected repo is unavailable; PR/issue view closed".into();
       return;
     }
     self.refresh_github_status();
@@ -3403,7 +3403,7 @@ impl App {
   pub fn ci_checks_refresh(&mut self) {
     if self.workspace_active_stale {
       self.close_detail_overlay();
-      self.status = "workspace: selected repo is unavailable — CI checks closed".into();
+      self.status = "workspace: selected repo is unavailable; CI checks closed".into();
       return;
     }
     self.refresh_github_status();
@@ -3549,7 +3549,7 @@ impl App {
       // workspace mode `sync_active_repo` may swap `self.repo` under the
       // open overlay, which would write the pin into the wrong repo's
       // config (Codex review round B).
-      self.status = "agent pins are per-repo — not available in workspace mode".into();
+      self.status = "agent pins are per-repo: not available in workspace mode".into();
       return false;
     }
     let Some((path, _)) = self.detail_overlay_target.clone() else {
@@ -3629,7 +3629,7 @@ impl App {
       .unwrap_or_else(|| self.detail_overlay.input.trim().to_string());
     let known = candidates.iter().any(|s| s.id == sid);
     if sid.is_empty() || !known {
-      self.status = format!("no agent session matching '{sid}' — run gwm agents for ids");
+      self.status = format!("no agent session matching '{sid}': run gwm agents for ids");
       return;
     }
     if self.attach_agent_by_id(&sid) {
@@ -3643,7 +3643,7 @@ impl App {
   /// session's pin is removed, the others stay.
   pub fn detach_selected_agent(&mut self) {
     if self.is_workspace() {
-      self.status = "agent pins are per-repo — not available in workspace mode".into();
+      self.status = "agent pins are per-repo: not available in workspace mode".into();
       return;
     }
     let Some(sid) = self.detail_overlay.selected_meta().map(str::to_string) else {
@@ -3793,7 +3793,7 @@ impl App {
     match action {
       ConfirmKeyAction::Armed => {
         self.status = format!(
-          "armed — reclaiming {} in {}s",
+          "armed: reclaiming {} in {}s",
           crate::clean::human_size(self.clean_overlay.total_bytes()),
           total.as_secs()
         );
@@ -3931,7 +3931,7 @@ impl App {
     // refuse rather than write settings into the wrong repo (#304). Global-layer
     // edits are repo-independent and stay allowed.
     if self.workspace_active_stale && self.config_panel.layer == SettingsLayer::Project {
-      self.status = "workspace: selected repo is unavailable — can't edit its project config".into();
+      self.status = "workspace: selected repo is unavailable; can't edit its project config".into();
       return;
     }
     let path = match self.config_panel.layer {
@@ -4017,7 +4017,7 @@ impl App {
     if self.config_panel.layer == SettingsLayer::Global
       && self.config_panel.field_source(field) == Some(crate::config::ConfigSource::Repo)
     {
-      status.push_str(" — shadowed by .gwm.toml");
+      status.push_str("; shadowed by .gwm.toml");
     }
     self.status = status;
   }
@@ -4132,7 +4132,7 @@ impl App {
     let resolved = match self.config.review.resolved() {
       Some(r) => r,
       None => {
-        self.status = "review tool not configured — set [review] in .gwm.toml".into();
+        self.status = "review tool not configured: set [review] in .gwm.toml".into();
         return None;
       }
     };
@@ -4141,7 +4141,7 @@ impl App {
       return None;
     };
     let Some(head) = wt.branch.clone() else {
-      self.status = "selected worktree has no branch — cannot review".into();
+      self.status = "selected worktree has no branch: cannot review".into();
       return None;
     };
 
@@ -4164,7 +4164,7 @@ impl App {
     match launcher::expand_command(&resolved.command, &ctx) {
       Ok(expanded) => {
         if self.config.review.has_shadowed_tool() {
-          self.status = format!("review: command overrides tool — running {}", base);
+          self.status = format!("review: command overrides tool; running {}", base);
         } else {
           self.status = format!("review: {} vs {}", head, base);
         }
@@ -4237,13 +4237,13 @@ impl App {
       return None;
     };
     let Some(branch) = crate::github::pinnable_branch(selected.branch.as_deref()).map(str::to_string) else {
-      self.status = "detached HEAD — a note is keyed on the branch".into();
+      self.status = "detached HEAD: a note is keyed on the branch".into();
       return None;
     };
     match crate::notes::prepare(&self.repo, &branch) {
       Ok(Some(path)) => Some((branch, path)),
       Ok(None) => {
-        self.status = format!("`{branch}` cannot back a note file — the name is not a portable filename");
+        self.status = format!("`{branch}` cannot back a note file: the name is not a portable filename");
         None
       }
       // `prepare` writes its own message: the directory it could not create,
@@ -4630,7 +4630,7 @@ impl App {
       _ => spec.desc.is_empty(),
     }) {
       self.status = format!(
-        "'{}' carries {{{}}} only where this form cannot read it back (check worktree.base), so renaming would overwrite it — rename with git, or write {{{}}} into worktree.branch_pattern or worktree.path_pattern",
+        "'{}' carries {{{}}} only where this form cannot read it back (check worktree.base), so renaming would overwrite it: rename with git, or write {{{}}} into worktree.branch_pattern or worktree.path_pattern",
         crate::naming::sanitise_for_terminal(&branch),
         missing,
         missing
@@ -5096,7 +5096,7 @@ impl App {
     // writes no issue number, `Field::Issue` focused an input the renderer
     // does not draw, so the first keypress went nowhere at all.
     self.create_form.field = self.create_form.entry_field();
-    self.status = format!("{} — esc: cancel", self.structured_form_instruction());
+    self.status = format!("{} · esc: cancel", self.structured_form_instruction());
   }
 
   pub fn create_next_field(&mut self) {
@@ -5190,7 +5190,7 @@ impl App {
         let back = self
           .modal_keymap
           .primary_key(ModalAction::CreateToggleMode)
-          .map(|k| format!(" — {k}: "))
+          .map(|k| format!(" · {k}: "))
           .unwrap_or_default();
         self.status = match self.create_form.mode {
           Mode::Freeform if back.is_empty() => "free-form: name the worktree anything git accepts".into(),
@@ -5534,7 +5534,7 @@ impl App {
         // #219 review: name the live confirm key, and drop the clause entirely
         // when it is unbound — never advertise a key that no longer re-arms.
         self.status = match self.modal_keymap.primary_key(ModalAction::ConfirmConfirm) {
-          Some(c) => format!("countdown cancelled — press {c} to re-arm ({secs}s safety delay)"),
+          Some(c) => format!("countdown cancelled: press {c} to re-arm ({secs}s safety delay)"),
           None => format!("countdown cancelled ({secs}s safety delay)"),
         };
       }
@@ -5551,7 +5551,7 @@ impl App {
           (None, Some(x)) => format!(" · press {x} to cancel"),
           (None, None) => String::new(),
         };
-        self.status = format!("armed — auto-fires in {secs}s{tail}");
+        self.status = format!("armed: auto-fires in {secs}s{tail}");
       }
     }
     action
@@ -5605,7 +5605,7 @@ impl App {
     self.clear_marks();
     self.sidebar.focused = false;
     self.cancel_pending_motion();
-    self.status = "/ filter — type to narrow · enter confirms · esc clears".into();
+    self.status = "/ filter: type to narrow · enter confirms · esc clears".into();
   }
 
   /// Close the filter bar but keep the query: `Enter` confirms the current
@@ -5741,7 +5741,7 @@ impl App {
         self.picker_should_exit = true;
       }
       None => {
-        self.status = "no worktree selected — adjust the filter and try again".into();
+        self.status = "no worktree selected: adjust the filter and try again".into();
       }
     }
   }
@@ -6071,13 +6071,13 @@ impl App {
 
     if self.github.link.issue.is_none() && self.github.link.pr.is_none() {
       self.status = format!(
-        "nothing linked — press {} to link an issue or PR",
+        "nothing linked: press {} to link an issue or PR",
         self.link_prompt_chord()
       );
       return;
     }
     let Some(slug) = slug else {
-      self.status = "no GitHub remote — cannot fetch status".into();
+      self.status = "no GitHub remote: cannot fetch status".into();
       return;
     };
     // Explicit user-initiated refresh: flush the cache (so the cold-cache
@@ -6265,7 +6265,7 @@ impl App {
       ),
       (false, true) => format!("pr fetch failed: {}", self.pr_error_message().unwrap_or("?".into())),
       (true, true) => format!(
-        "issue + pr fetch failed — issue: {} · pr: {}",
+        "issue + pr fetch failed · issue: {} · pr: {}",
         self.issue_error_message().unwrap_or("?".into()),
         self.pr_error_message().unwrap_or("?".into())
       ),
@@ -6544,7 +6544,7 @@ impl App {
   pub fn open_menu_pick(&mut self, target: LinkTarget) -> Option<String> {
     self.view = View::List;
     let Some(forge) = self.github.forge.clone() else {
-      self.status = "no forge remote — cannot build URL".into();
+      self.status = "no forge remote: cannot build URL".into();
       return None;
     };
     // Whether the URL was built locally rather than read off the server.
@@ -6560,7 +6560,7 @@ impl App {
           forge.issue_url(n)
         }),
         None => {
-          self.status = format!("no issue linked — press {} to link one", self.link_prompt_chord());
+          self.status = format!("no issue linked: press {} to link one", self.link_prompt_chord());
           return None;
         }
       },
@@ -6571,7 +6571,7 @@ impl App {
         }),
         None => {
           self.status = format!(
-            "no {} linked — press {} to link one",
+            "no {} linked: press {} to link one",
             forge.pr_noun(),
             self.link_prompt_chord()
           );
@@ -6580,7 +6580,7 @@ impl App {
       },
     };
     if inferred && !forge.origin_is_authoritative() {
-      self.status = format!("opening a guessed URL — the SSH origin names no web host: {url}");
+      self.status = format!("opening a guessed URL; the SSH origin names no web host: {url}");
     }
     Some(url)
   }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -674,7 +674,7 @@ impl Keymap {
         if all[i].0 == all[j].0 {
           if all[i].1 != all[j].1 {
             return Err(GwmError::Config(format!(
-              "keymap: chord {:?} bound to both {:?} and {:?} — conflict",
+              "keymap: chord {:?} bound to both {:?} and {:?} (conflict)",
               format_chord(all[i].0),
               all[i].1.slug(),
               all[j].1.slug()
@@ -689,7 +689,7 @@ impl Keymap {
         };
         if all[short].0.len() < all[long].0.len() && all[long].0.starts_with(all[short].0) {
           return Err(GwmError::Config(format!(
-            "keymap: chord {:?} (action {:?}) is a prefix of {:?} (action {:?}) — refused at load time so the event loop never has to time out",
+            "keymap: chord {:?} (action {:?}) is a prefix of {:?} (action {:?}); refused at load time so the event loop never has to time out",
             format_chord(all[short].0),
             all[short].1.slug(),
             format_chord(all[long].0),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -951,7 +951,7 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
   // active repo, so the write would hit the wrong repository. Navigation and
   // refresh stay live so the user can recover (a refresh drops the dead repo).
   if app.workspace_active_stale && action.is_repo_mutating() {
-    app.status = "workspace: selected repo is unavailable (moved/deleted?) — press r to refresh".into();
+    app.status = "workspace: selected repo is unavailable (moved/deleted?); press r to refresh".into();
     return Ok(());
   }
 
@@ -1211,7 +1211,7 @@ fn run_launcher(
   // binaries get a clean status-bar error instead of a flicker.
   if which::which(bin).is_err() {
     app.status = format!(
-      "`{}` not on $PATH — install it or change [review]/[git_tui] in .gwm.toml",
+      "`{}` not on $PATH: install it or change [review]/[git_tui] in .gwm.toml",
       bin
     );
     return Ok(());
@@ -1391,7 +1391,7 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
     app.config.tui.macro2.clone()
   };
   let Some(macro_cfg) = cfg else {
-    app.status = format!("macro{} not configured — add [tui.macro{}] to .gwm.toml", n, n);
+    app.status = format!("macro{} not configured: add [tui.macro{}] to .gwm.toml", n, n);
     return Ok(());
   };
   use crate::multiplexer::{build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, SpawnMode};
@@ -1419,7 +1419,7 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
     } else if detect_zellij(std::env::var("ZELLIJ").ok()) {
       Some(build_zellij_command(&label, &path, SpawnMode::Split))
     } else {
-      app.status = format!("macro{}: no multiplexer — falling back to PTY overlay", n);
+      app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
       None
     }
   } else {
@@ -1514,7 +1514,7 @@ fn copy_text_to_clipboard(app: &mut App, text: &str, success: &str) {
       // division renders 65_537 bytes as "64 KiB > 64 KiB", which reads as a
       // bug in the check rather than as a reason for the refusal.
       app.status = format!(
-        "too large for osc52 ({} KiB > {} KiB) — set [tui] clipboard = \"tools\"",
+        "too large for osc52 ({} KiB > {} KiB): set [tui] clipboard = \"tools\"",
         bytes.div_ceil(1024),
         crate::clipboard::MAX_OSC52_BYTES / 1024
       );

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -525,7 +525,7 @@ impl ModalKeymap {
     for k in &keys {
       if action.reserved_typing_stroke(k) {
         return Err(GwmError::Config(format!(
-          "context {}: key {} is reserved for typing input there and cannot be bound to {} — \
+          "context {}: key {} is reserved for typing input there and cannot be bound to {}; \
            the dispatch routes it into the input before the modal resolution",
           ctx.config_path(),
           k,
@@ -552,7 +552,7 @@ impl ModalKeymap {
     for k in &keys {
       if let Some(prev) = map.get(k) {
         return Err(GwmError::Config(format!(
-          "context {}: key {} bound to both {:?} and {:?} — conflict",
+          "context {}: key {} bound to both {:?} and {:?} (conflict)",
           ctx.config_path(),
           k,
           prev.verb(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -135,7 +135,7 @@ impl<'a> LoaderWidget<'a> {
       LoaderWidgetState::Running { detail, .. } | LoaderWidgetState::Failed { detail, .. } => detail,
     };
     if let Some(detail) = detail {
-      spans.push(Span::styled(" — ", Style::default().fg(self.muted)));
+      spans.push(Span::styled(" · ", Style::default().fg(self.muted)));
       spans.push(Span::styled(detail.to_string(), Style::default().fg(self.muted)));
     }
     Line::from(spans)
@@ -3632,7 +3632,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   }
   rows.push(entry(
     Action::TerminalFullscreen,
-    "open per [tui.open] — shell / editor / finder",
+    "open per [tui.open]: shell / editor / finder",
   ));
   rows.push(entry(Action::TerminalPty, "open native $SHELL in embedded PTY overlay"));
   rows.push(entry(Action::OpenDocs, "open the gwm documentation in the browser"));
@@ -3729,7 +3729,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
     let open_desc = if open_picks.is_empty() {
       "open menu".to_string()
     } else {
-      format!("open menu — {}", open_picks.join(" · "))
+      format!("open menu: {}", open_picks.join(" · "))
     };
     rows.push(entry(Action::BrowseLinks, &open_desc));
 
@@ -3753,10 +3753,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       parts.push(format!("or {}", picks.join("/")));
     }
     parts.push("then digits".to_string());
-    rows.push(entry(
-      Action::LinkPrompt,
-      &format!("link prompt — {}", parts.join(", ")),
-    ));
+    rows.push(entry(Action::LinkPrompt, &format!("link prompt: {}", parts.join(", "))));
   }
   rows.push(entry(Action::Help, "this help"));
   if !picker_mode {
@@ -3934,7 +3931,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       modal_entry(ModalAction::ConfigSelectPrev, "previous setting (All tab: scroll up)"),
       modal_entry(
         ModalAction::ConfigActivate,
-        "toggle / edit the selected setting (Keys tab: start a key capture — a modal verb commits on its first stroke)",
+        "toggle / edit the selected setting (Keys tab: start a key capture; a modal verb commits on its first stroke)",
       ),
       modal_entry(ModalAction::ConfigScrollLeft, "pan left (All tab)"),
       modal_entry(ModalAction::ConfigScrollRight, "pan right (All tab)"),
@@ -3947,7 +3944,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       modal_entry(ModalAction::ConfigEditCancel, "cancel the edit / the key capture"),
       fixed(
         "any char",
-        "type the value — free text for text fields, digits for numeric ones",
+        "type the value: free text for text fields, digits for numeric ones",
       ),
       fixed(
         "Backspace",
@@ -3961,7 +3958,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       HelpRow::Blank,
       fixed(
         "Esc",
-        "close the overlay — other keys pass through (any key but Ctrl-C closes a finished exec run)",
+        "close the overlay; other keys pass through (any key but Ctrl-C closes a finished exec run)",
       ),
     ]);
     rows.extend([
@@ -4356,7 +4353,7 @@ fn settings_fields_lines(app: &App, fields: &[SettingField]) -> Vec<Line<'static
     // rather than silently no-op or hard-disable the field.
     if selected && panel.layer.source() == ConfigSource::User && panel.field_source(*field) == Some(ConfigSource::Repo)
     {
-      spans.push(Span::styled("  — set in .gwm.toml; switch to Project", muted_style));
+      spans.push(Span::styled("  (set in .gwm.toml; switch to Project)", muted_style));
     }
     lines.push(Line::from(spans));
   }
@@ -4784,7 +4781,7 @@ fn draw_create(f: &mut Frame, app: &App) {
 
   let block = overlay_block_titled(
     if app.create_form.mode == Mode::Freeform {
-      "New Worktree — free-form"
+      "New Worktree (free-form)"
     } else {
       "New Worktree"
     },
@@ -5640,7 +5637,7 @@ fn draw_pty_overlay(f: &mut Frame, app: &mut App) {
     Some((PtyKind::Review, _)) => "Review",
     Some((PtyKind::Exec, false)) => "Exec",
     // #325: once the one-shot command exits, the title invites dismissal.
-    Some((PtyKind::Exec, true)) => "Exec · done — press any key",
+    Some((PtyKind::Exec, true)) => "Exec · done · press any key",
     None => "Overlay",
   };
   // Already rode the top rule before #549; routed through the shared
@@ -6504,7 +6501,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
   // Gate-preserved names — explain why a visible `target/` was not counted.
   for rel in app.clean_overlay.skipped() {
     lines.push(
-      Line::from(format!("skipped {rel} — not git-ignored / holds tracked files"))
+      Line::from(format!("skipped {rel}: not git-ignored / holds tracked files"))
         .style(Style::default().fg(muted))
         .centered(),
     );
@@ -6515,7 +6512,7 @@ fn draw_clean_overlay(f: &mut Frame, app: &App) {
   if armed {
     lines.push(Line::from(""));
     lines.push(
-      Line::from("⚠ armed — confirm again or cancel to abort")
+      Line::from("⚠ armed: confirm again or cancel to abort")
         .style(Style::default().fg(danger).add_modifier(Modifier::BOLD))
         .centered(),
     );
@@ -6751,7 +6748,7 @@ fn draw_command_palette(f: &mut Frame, app: &App) {
     .collect();
   if lines.is_empty() {
     lines.push(Line::from(Span::styled(
-      "  (no matching command — backspace to broaden)",
+      "  (no matching command, backspace to broaden)",
       Style::default().fg(app.theme.prunable),
     )));
   }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -600,7 +600,7 @@ pub fn head_branch(path: &Path) -> HeadBranch {
 /// it identically whichever one catches the move.
 fn path_changed(name: &str, actual: &Path, expected: &Path) -> GwmError {
   GwmError::Other(format!(
-    "'{}' now points at {} instead of {} — it changed since it was confirmed, nothing removed",
+    "'{}' now points at {} instead of {}: it changed since it was confirmed, nothing removed",
     name,
     actual.display(),
     expected.display()
@@ -783,7 +783,7 @@ pub fn rename_worktree(
       // either (Codex review, PR #530, pass 4).
       if crate::notes::occupied_by(&repo, old_branch).is_some() && crate::notes::relative_path(new_branch).is_none() {
         return Err(GwmError::CommandFailed(format!(
-          "`{old_branch}` carries a note and `{new_branch}` cannot back a note file — \
+          "`{old_branch}` carries a note and `{new_branch}` cannot back a note file: \
            rename to a name a filesystem accepts, or move the note out of {} first",
           crate::notes::notes_dir(&repo).display()
         )));
@@ -799,7 +799,7 @@ pub fn rename_worktree(
       // its report (Codex review, PR #530, pass 5).
       if let Some(note) = crate::notes::move_conflict(&repo, old_branch, new_branch) {
         return Err(GwmError::CommandFailed(format!(
-          "a note already exists for `{new_branch}`: {} — move or delete it first",
+          "a note already exists for `{new_branch}`: {}; move or delete it first",
           note.display()
         )));
       }

--- a/tests/em_dash_guard_tests.rs
+++ b/tests/em_dash_guard_tests.rs
@@ -1,0 +1,341 @@
+//! No string literal under `src/` carries an em dash (issue #567).
+//!
+//! The rule this repo writes under is that published prose does not use the
+//! em dash, and the binary's own output is as published as the README. #516
+//! swept `docs/` and #543 finished `skills/`; neither could reach `src/`,
+//! where the strings a user reads on stderr and in the TUI live. Sweeping
+//! them once fixes today; this is what stops the habit coming back, which is
+//! the follow-up #516 closed without.
+//!
+//! # Why a lexer and not a grep
+//!
+//! `grep -rn '"[^"]*—[^"]*"'` finds 138 lines here and the real figure is
+//! 161 literals: it cannot see a literal that spans lines, and it reads the
+//! quotes inside a doc comment as a literal's delimiters. The opposite error
+//! matters more. Roughly 1900 em dashes in this tree sit in comments and doc
+//! comments, which are **not** in scope: a doc comment quoting a spec or a
+//! command's real output has to stay verbatim. A guard that cannot tell the
+//! two apart is a guard nobody can keep green.
+//!
+//! # Scope, stated
+//!
+//! `src/` only. The fixtures below are in `tests/`, so the sweep cannot
+//! match its own strings and pass by finding itself; assert prose elsewhere
+//! in the suite is not touched either, since a failure message is read by
+//! whoever runs the suite, not published.
+//!
+//! Only U+2014. The en dash appears three times in this tree, all in
+//! comments, all of them the range in `3–5×`, which is a numeral and not a
+//! connector.
+//!
+//! # What it does not catch, on purpose
+//!
+//! A dash assembled at runtime: `format!("{a} {} {b}", '\u{2014}')` reads as
+//! an escape here and nothing links it to the character. Nothing in the tree
+//! does that, and covering it means evaluating const expressions.
+
+use std::path::{Path, PathBuf};
+
+const EM_DASH: char = '\u{2014}';
+
+fn repo_root() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Read a source file with CRLF normalised.
+///
+/// A Windows checkout stores these with `\r\n`. Nothing below is
+/// line-anchored, but the reported line numbers are, and an offender list
+/// pointing at the wrong lines is worse than no list.
+fn read(path: &Path) -> String {
+  std::fs::read_to_string(path)
+    .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+    .replace("\r\n", "\n")
+}
+
+fn rs_files(dir: &Path) -> Vec<PathBuf> {
+  let mut out = Vec::new();
+  let mut stack = vec![dir.to_path_buf()];
+  while let Some(d) = stack.pop() {
+    for entry in std::fs::read_dir(&d).unwrap_or_else(|e| panic!("cannot list {}: {e}", d.display())) {
+      let path = entry.unwrap().path();
+      if path.is_dir() {
+        stack.push(path);
+      } else if path.extension().is_some_and(|e| e == "rs") {
+        out.push(path);
+      }
+    }
+  }
+  out.sort();
+  out
+}
+
+/// A literal, with the 1-based line it opens on.
+#[derive(Debug, PartialEq, Eq)]
+struct Literal {
+  line: usize,
+  text: String,
+}
+
+fn is_ident(c: char) -> bool {
+  c.is_alphanumeric() || c == '_'
+}
+
+/// Every string and character literal in `source`, in order.
+///
+/// A hand-written scanner rather than a regex because the three things that
+/// have to be skipped, both comment forms and the lifetime tick, are exactly
+/// the ones a regex cannot separate from what they contain. It walks `char`s
+/// rather than bytes so an em dash inside a literal cannot land the cursor
+/// mid-sequence.
+fn literals(source: &str) -> Vec<Literal> {
+  let src: Vec<char> = source.chars().collect();
+  let mut out = Vec::new();
+  let mut i = 0usize;
+  let mut line = 1usize;
+
+  while i < src.len() {
+    let c = src[i];
+
+    if c == '\n' {
+      line += 1;
+      i += 1;
+      continue;
+    }
+
+    // `//`, and with it `///` and `//!`.
+    if c == '/' && src.get(i + 1) == Some(&'/') {
+      while i < src.len() && src[i] != '\n' {
+        i += 1;
+      }
+      continue;
+    }
+
+    // `/* */`, which nests in Rust: `/* /* */ */` is one comment, and
+    // stopping at the first `*/` would resume the scan inside it.
+    if c == '/' && src.get(i + 1) == Some(&'*') {
+      let mut depth = 1usize;
+      i += 2;
+      while i < src.len() && depth > 0 {
+        if src[i] == '/' && src.get(i + 1) == Some(&'*') {
+          depth += 1;
+          i += 2;
+        } else if src[i] == '*' && src.get(i + 1) == Some(&'/') {
+          depth -= 1;
+          i += 2;
+        } else {
+          if src[i] == '\n' {
+            line += 1;
+          }
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    // A string, with its optional `b` / `c` / `r` prefixes: `"`, `b"`, `r"`,
+    // `r#"`, `br#"`. The prefix only counts when the character before it is
+    // not part of an identifier, or the `r` ending `for` would open a raw
+    // string on the next quote it meets.
+    let mut p = i;
+    while p < src.len() && p - i < 2 && matches!(src[p], 'b' | 'c' | 'r') {
+      p += 1;
+    }
+    let prefixed = p > i;
+    let raw = prefixed && src[p - 1] == 'r';
+    let mut hashes = 0usize;
+    let mut q = p;
+    if raw {
+      while src.get(q) == Some(&'#') {
+        hashes += 1;
+        q += 1;
+      }
+    }
+    let opens = src.get(q) == Some(&'"') && (!prefixed || i == 0 || !is_ident(src[i - 1]));
+    if opens {
+      let start = line;
+      let mut text = String::new();
+      let mut j = q + 1;
+      loop {
+        match src.get(j) {
+          None => break,
+          Some(&'\\') if !raw => {
+            // The escape is kept verbatim: `\"` must not close the literal,
+            // and no escape in this tree spells an em dash.
+            text.push('\\');
+            if let Some(&e) = src.get(j + 1) {
+              text.push(e);
+              if e == '\n' {
+                line += 1;
+              }
+            }
+            j += 2;
+          }
+          Some(&'"') if closes(&src, j, hashes) => {
+            j += 1 + hashes;
+            break;
+          }
+          Some(&ch) => {
+            if ch == '\n' {
+              line += 1;
+            }
+            text.push(ch);
+            j += 1;
+          }
+        }
+      }
+      out.push(Literal { line: start, text });
+      i = j;
+      continue;
+    }
+
+    // A character literal, which shares its opening tick with a lifetime.
+    // `'a` and `'static` are told apart by what follows: a literal closes on
+    // the character after the one it holds.
+    if c == '\'' {
+      if src.get(i + 1) == Some(&'\\') {
+        // `'\''` closes on the tick after the escape, not on the escaped one.
+        let mut j = i + 2;
+        while j < src.len() && src[j] != '\'' {
+          j += 1;
+        }
+        if j < src.len() {
+          out.push(Literal {
+            line,
+            text: src[i + 1..j].iter().collect(),
+          });
+          i = j + 1;
+          continue;
+        }
+      } else if src.get(i + 2) == Some(&'\'') {
+        out.push(Literal {
+          line,
+          text: src[i + 1..i + 2].iter().collect(),
+        });
+        i += 3;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+
+    i += 1;
+  }
+
+  out
+}
+
+/// Whether the `"` at `at` closes a literal opened with `hashes` hashes.
+fn closes(src: &[char], at: usize, hashes: usize) -> bool {
+  (1..=hashes).all(|n| src.get(at + n) == Some(&'#'))
+}
+
+#[test]
+fn no_string_literal_under_src_carries_an_em_dash() {
+  let root = repo_root();
+  let mut scanned = 0usize;
+  let mut offenders = Vec::new();
+
+  for path in rs_files(&root.join("src")) {
+    let file = path.strip_prefix(&root).unwrap_or(&path).display().to_string();
+    for lit in literals(&read(&path)) {
+      scanned += 1;
+      if lit.text.contains(EM_DASH) {
+        let shown: String = lit.text.chars().take(90).collect();
+        offenders.push(format!("{file}:{} {shown}", lit.line));
+      }
+    }
+  }
+
+  // A scanner that desynchronises reports no offenders for the same reason a
+  // clean tree does, and the two are indistinguishable from the outside. The
+  // tree holds 4867 literals today, so a floor well under it still catches
+  // the failure that matters: one mis-parsed construct swallowing the rest of
+  // a file, or of every file.
+  assert!(
+    scanned >= 4000,
+    "expected the scan to find the literals in src/, found {scanned}"
+  );
+  assert!(
+    offenders.is_empty(),
+    "a string printed by gwm must not carry an em dash (issue #567): use a colon where it \
+     introduces an explanation, a comma for an apposition, a full stop where the clause \
+     already carries a colon. {} offender(s):\n  {}",
+    offenders.len(),
+    offenders.join("\n  ")
+  );
+}
+
+#[test]
+fn the_guard_can_actually_fire() {
+  // Each construct the scanner has to tell apart, in both directions, since
+  // a scanner that skips too much and one that skips nothing both report an
+  // empty offender list.
+  let found = |s: &str| literals(s).iter().any(|l| l.text.contains(EM_DASH));
+
+  assert!(found(r#"let m = "broke — do this";"#), "a plain literal is in scope");
+  assert!(
+    found(r##"let m = r#"broke — do this"#;"##),
+    "and so is a raw one, hashes and all"
+  );
+  assert!(
+    found("let m = \"says \\\" then — this\";"),
+    "an escaped quote does not close the literal, so what follows it is still inside"
+  );
+  assert!(found("let m = \"first\nsecond — third\";"), "a literal may span lines");
+  assert!(found(r#"let c = '—';"#), "a character literal holds one too");
+
+  assert!(!found("// broke — do this"), "a line comment is prose about the code");
+  assert!(
+    !found("/// broke — do this"),
+    "a doc comment quoting output stays verbatim"
+  );
+  assert!(!found("//! broke — do this"), "and so does a module one");
+  assert!(!found("/* broke — do this */"), "a block comment is not output");
+  assert!(
+    !found("/* outer /* inner — dash */ still outer */ let m = \"clean\";"),
+    "block comments nest, and stopping at the first close resumes inside one"
+  );
+  assert!(
+    !found("fn f<'a>(s: &'a str) -> &'a str { s } // — prose"),
+    "a lifetime is not an unterminated character literal"
+  );
+  assert!(!found(r"let c = '\'';"), "an escaped tick closes on the next one");
+
+  // Line numbers are what the offender list is worth.
+  let counted = literals("fn a() {}\n// —\nlet m = \"x — y\";\n");
+  assert_eq!(
+    counted,
+    vec![Literal {
+      line: 3,
+      text: "x — y".into()
+    }],
+    "the comment is skipped and the literal is reported on its own line"
+  );
+}
+
+#[test]
+fn the_hard_constructs_are_read_off_the_real_tree() {
+  // Fixtures prove the scanner handles a construct; only the tree proves it
+  // handles the ones actually in it. Both of these were written before this
+  // guard and neither is a shape the fixtures above invented: the hook
+  // script is a multi-line `r#"..."#` holding `#`, `"` and `'`, and the
+  // shell snippet holds an interior `"$@"`.
+  let hooks = literals(&read(&repo_root().join("src/hooks.rs")));
+  assert!(
+    hooks
+      .iter()
+      .any(|l| l.text.contains("#!/bin/sh") && l.text.contains("gwm commit-prefix --unicode")),
+    "the generated commit-msg hook is one raw literal, start to end"
+  );
+
+  let cli = literals(&read(&repo_root().join("src/cli.rs")));
+  assert!(
+    cli.iter().any(|l| l.text.contains("unalias gcd")),
+    "and so is the generated shell helper"
+  );
+  assert!(
+    cli.iter().any(|l| l.text.contains("\\\"")),
+    "a literal spelling an escaped quote survives the scan"
+  );
+}

--- a/tests/em_dash_guard_tests.rs
+++ b/tests/em_dash_guard_tests.rs
@@ -17,6 +17,25 @@
 //! command's real output has to stay verbatim. A guard that cannot tell the
 //! two apart is a guard nobody can keep green.
 //!
+//! # The exception clap makes, and why the second test is not a scanner
+//!
+//! Excluding doc comments is only sound while a doc comment stays a comment.
+//! `clap`'s derive builds `--help` out of the `///` on every struct, field and
+//! variant, so in `src/cli.rs` those comments **are** the published output:
+//! `gwm --help` printed 46 em dashes with this file's scanner green, on
+//! precisely the surface the issue is about.
+//!
+//! The fix is not to teach the scanner which doc comments clap consumes.
+//! That is a proxy for the question, and it would still miss `long_about`,
+//! `after_help`, a `value_enum` name and whatever clap renders next. The
+//! second test asks the binary instead: walk the help tree, subcommands and
+//! their subcommands, and read what a user reads. Slower, and it cannot drift
+//! from the surface it checks, because it *is* the surface.
+//!
+//! `gwm completions <shell>` is not walked separately. `clap_complete` embeds
+//! the same short help, so it carried 23 dashes on zsh before the sweep and
+//! zero after it, without a line of its own here. Measured, not assumed.
+//!
 //! # Scope, stated
 //!
 //! `src/` only. The fixtures below are in `tests/`, so the sweep cannot
@@ -33,7 +52,13 @@
 //! A dash assembled at runtime: `format!("{a} {} {b}", '\u{2014}')` reads as
 //! an escape here and nothing links it to the character. Nothing in the tree
 //! does that, and covering it means evaluating const expressions.
+//!
+//! An ordinary doc comment, deliberately: `///` on a helper function is read
+//! in the source by whoever maintains it, and several quote a spec or a
+//! command's real output verbatim. The help walk covers the ones that reach a
+//! user, which is the whole distinction.
 
+use assert_cmd::Command;
 use std::path::{Path, PathBuf};
 
 const EM_DASH: char = '\u{2014}';
@@ -230,6 +255,40 @@ fn closes(src: &[char], at: usize, hashes: usize) -> bool {
   (1..=hashes).all(|n| src.get(at + n) == Some(&'#'))
 }
 
+/// `gwm <path...> --help`, as the user would read it.
+fn help(path: &[&str]) -> String {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(path).arg("--help");
+  let out = cmd.output().unwrap_or_else(|e| panic!("gwm {path:?} --help: {e}"));
+  String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// The subcommand names clap lists in `text`.
+///
+/// Read off the listing column, which clap indents by two and follows with at
+/// least two spaces: `  create  Create a worktree`. Matching the name alone
+/// would also collect every option and every word of prose. An alias is
+/// rendered on its parent's row (`path ... [alias: cd]`), so it is not a row
+/// here and does not need visiting: it runs the same command.
+fn subcommands(text: &str) -> Vec<String> {
+  text
+    .lines()
+    .filter_map(|l| {
+      let rest = l.strip_prefix("  ")?;
+      if rest.starts_with(' ') {
+        return None;
+      }
+      let name = rest.split_whitespace().next()?;
+      let ok = name.starts_with(|c: char| c.is_ascii_lowercase())
+        && name
+          .chars()
+          .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && rest[name.len()..].starts_with("  ");
+      ok.then(|| name.to_string())
+    })
+    .collect()
+}
+
 #[test]
 fn no_string_literal_under_src_carries_an_em_dash() {
   let root = repo_root();
@@ -261,6 +320,59 @@ fn no_string_literal_under_src_carries_an_em_dash() {
     "a string printed by gwm must not carry an em dash (issue #567): use a colon where it \
      introduces an explanation, a comma for an apposition, a full stop where the clause \
      already carries a colon. {} offender(s):\n  {}",
+    offenders.len(),
+    offenders.join("\n  ")
+  );
+}
+
+#[test]
+fn no_help_page_carries_an_em_dash() {
+  // The scanner above cannot see this surface, and was green while it was
+  // broken: clap builds `--help` from the `///` on each struct, field and
+  // variant, and `gwm --help` alone printed three. Asking the binary is not a
+  // convenience here, it is the only oracle that stays true when clap changes
+  // what it renders.
+  let mut offenders = Vec::new();
+  let mut visited = 0usize;
+
+  let root = help(&[]);
+  let mut queue: Vec<Vec<String>> = subcommands(&root).into_iter().map(|s| vec![s]).collect();
+  let mut pages = vec![(String::from("gwm"), root)];
+
+  while let Some(path) = queue.pop() {
+    let args: Vec<&str> = path.iter().map(String::as_str).collect();
+    let text = help(&args);
+    // A subcommand group lists its own children; a leaf lists none, so this
+    // terminates on the tree's real shape rather than on a fixed depth.
+    for child in subcommands(&text) {
+      let mut next = path.clone();
+      next.push(child);
+      queue.push(next);
+    }
+    pages.push((format!("gwm {}", path.join(" ")), text));
+  }
+
+  for (name, text) in &pages {
+    visited += 1;
+    for (n, line) in text.lines().enumerate() {
+      if line.contains(EM_DASH) {
+        offenders.push(format!("{name} --help:{} {}", n + 1, line.trim()));
+      }
+    }
+  }
+
+  // The walk parses clap's own layout, so a formatter change upstream could
+  // silently stop finding subcommands and leave this reading one page. There
+  // are 39 top-level subcommands today, plus their children.
+  assert!(
+    visited >= 30,
+    "expected the help walk to reach the subcommands, visited {visited} page(s)"
+  );
+  assert!(
+    offenders.is_empty(),
+    "a help page must not carry an em dash (issue #567); clap prints the `///` on a struct, \
+     field or variant verbatim, so those doc comments are output, not commentary. \
+     {} line(s):\n  {}",
     offenders.len(),
     offenders.join("\n  ")
   );

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4109,7 +4109,7 @@ fn a_simultaneous_refresh_keeps_its_status_over_the_github_report() {
   // Behaviour-preserving guard (issue #255): pre-spine the event loop drained
   // the GitHub channel before the task channel, so when a worktree refresh and
   // a GitHub fetch completed on the same tick, `apply_refreshed_worktrees`'
-  // "refreshed — N" message ran last and stood. Now both drain in one pass; the
+  // "refreshed: N" message ran last and stood. Now both drain in one pass; the
   // post-loop GitHub report is gated on `!refresh_applied` to preserve that.
   use gwm::tui::{TaskKind, TaskMsg};
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
@@ -4128,7 +4128,7 @@ fn a_simultaneous_refresh_keeps_its_status_over_the_github_report() {
   app.drain_task_results();
 
   assert!(
-    app.status.starts_with("refreshed —"),
+    app.status.starts_with("refreshed:"),
     "the refresh message must win a simultaneous completion (pre-#255 order), got {:?}",
     app.status
   );

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1234,7 +1234,7 @@ fn an_all_literal_pattern_set_names_no_field_at_all() {
   app.enter_create();
   assert!(app.create_form.fields().is_empty());
 
-  assert_eq!(app.status, "enter: submit — esc: cancel");
+  assert_eq!(app.status, "enter: submit · esc: cancel");
   let buf = render(&mut app);
   for absent in ["Type", "Issue", "Desc"] {
     assert!(


### PR DESCRIPTION
## Description

The rule this project writes under is that published prose does not use the em
dash, and the binary's own output is as published as the README. #516 swept
`docs/` and #543 finished the skills; neither reached `src/`. Two surfaces, not
one: 165 dashes across 161 string literals, and 49 more in `gwm --help`, which
`clap` builds out of the doc comments on the CLI types. Plus a test on each so
the habit does not come back.

Closes #567

## Type of change

- [x] ♻️ Refactor (no behaviour change)

## Changes

- **The literal guard, committed first and red on its own** (`5385fd9`). It
  listed 161 offenders as an assertion failure, which is the contract the next
  commit satisfies. A grep cannot state it: `grep -rn '"[^"]*—[^"]*"'` finds
  138 lines where the real figure is 161 literals, it cannot see one that spans
  lines, and it reads the quotes inside a doc comment as a literal's delimiters.
  That last one decides the design, since the ~1900 em dashes in comments are
  deliberately out of scope.
- **The literal sweep**, one connector chosen per call site rather than
  substituted. A colon where the dash introduced the remedy, a semicolon where
  the clause already carried a colon, a full stop where a second colon would
  have made the sentence unreadable, a comma for an apposition. #516 is why this
  is not a `sed`: an automated pass there produced `Source: …: MSRV 1.95` and
  four lines had to be reworked by hand.
- **The TUI separators**, where the dash was not punctuation but a value.
  `/ filter`, the create form hints and the loader detail take `·`, which the
  segments beside them already used. Where the tail was already `·`-joined a
  colon separates the title from the list, so the two roles stay distinct. Two
  labels became parenthetical, which is what they always were: `(conflict)` and
  `New Worktree (free-form)`.
- **The help guard** (`bbe5561`, also red on its own, 174 lines). Excluding doc
  comments is only sound while a doc comment stays a comment, and clap's derive
  makes those in `src/cli.rs` the published output. Rather than teach the
  scanner which ones clap consumes, which is a proxy that would still miss
  `long_about`, `after_help` and whatever clap renders next, this walks the help
  tree and reads what a user reads.
- **The help sweep**, with two shapes the messages did not have. A dash used in
  **pairs** to bracket an aside became a parenthesis, since commas would collide
  with the ones already inside it (`gwm review`, `gwm statusline`). In the
  `gwm pr` placeholder table the dash was a **column separator**, the case #516
  found in the `docs/` tables, so the row now reads `=`. `gwm completions zsh`
  is fixed by the same edit, 23 dashes to none.
- **Two assertions** pinned a rewritten string and travel with it, so the suite
  is green at every point of the history.

## Tests

- [x] `cargo test` passes locally (2966 tests, 100 binaries, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (`tests/em_dash_guard_tests.rs`)

Four tests, because a scanner that desynchronises reports an empty offender list
exactly like a clean tree does: the literal sweep with a floor under the 4867
literals `src/` holds today, the help walk with a floor on pages visited, a
fixture pass exercising each construct in both directions (raw strings, escaped
quotes, nested block comments, the lifetime tick), and a pass reading the two
hardest constructs off the real tree rather than off a fixture.

## Screenshots / TUI captures

Deliberately not regenerated here. Several captures show a rewritten string
(`filter`, `keybindings`, `palette`, `countdown`, `shell-init`, and `demo.gif`
walks two of those states), and each one needs an eyeball that cannot be
automated. `docs-sync.yml` fires on a push to `main` and never on `dev`, so the
published site keeps the current captures until the next release cut. Tracked in
#575 rather than stacked here, per the house rule on scope.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no surface change: same commands,
      same flags, same exit codes; only the wording of the help text)
- [ ] `examples/gwm.toml.example` updated if config schema changed (unchanged)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #567
- Follow-up: #575 (doc captures)
- Prior sweeps: #516 (`docs/`), #543 (skills)

## Notes for reviewers

Three points where I read the issue against the tree rather than following it:

1. **The issue undercounts twice, in the same direction.** Its `grep` reports
   135 string literals; a scanner finds 161, and the help surface it does not
   look at carries 49 more. Both numbers are in the commits that fix them.
2. The issue says a string a test pins must not be rewritten. CLAUDE.md's own
   exception list says the opposite, that a pinned string has its assertion
   updated, and that is what happened here. It was two assertions, not the churn
   the issue anticipated: most of the 101 em-dash literals under `tests/` are
   assert *messages*, which are read by whoever runs the suite and are not
   published.
3. Nothing here touches a frozen contract. `json_api.rs` and `contract.rs` carry
   em dashes only in doc comments, and the one JSON-adjacent literal
   (`daemon.rs`, a Windows pipe-bind failure) is an error message, not a pinned
   field. Checked before the sweep, not after.

Also measured and left alone: the en dash appears three times in `src/`, all in
comments, all of them the range in `3–5×`. It is a numeral, not a connector, so
both guards cover U+2014 only.
