### PR TITLE
📝 docs: frontmatter metadata that reaches the published site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gwm path --format=json` is unaffected and stays absolute: this is a rendering
   change in the TUI only.
 
+### Docs
+
+- **The frontmatter says what the published page should say**
+  ([#579](https://github.com/kbrdn1/gwm-cli/issues/579)). The frontmatter of
+  `docs/` is the source of the `<title>` and the `<meta name="description">` on
+  [gwm.kbrdn.dev](https://gwm.kbrdn.dev): the bridge carries it through
+  verbatim, so a defect there is only fixable here, and it ships green because
+  nothing in the build reads a description.
+
+  Three of them are closed. `3.cli/index.md` and `3.cli/1.reference.md` said
+  the same sentence to a word, in both locales, so two separately crawled URLs
+  competed for one snippet; the section landing now describes the section it
+  routes to rather than the reference it links. Both roadmap descriptions ran
+  to 297 and 307 characters by enumerating every version line since v1.0.0,
+  which put what is shipping now behind the truncation; they stop at the
+  current line. `Getting Started` was the only title-cased page in a
+  sentence-case tree and disagreed with the sidebar label and the OG card table
+  the site builds, both of which say `Getting started`; the title, the
+  `navigation.title`, the H1 and the ten cross-references that spell the page
+  name follow. The French `.gwm.toml` page also started on a lowercase
+  `schéma`, which the bridge was quietly capitalising on publish.
+
+  Two of the three are now pinned by `tests/docs_frontmatter_tests.rs`: a
+  description over 250 characters, and two pages of the same locale describing
+  themselves the same way. Title casing is left to the author, since separating
+  `Getting Started` from `GitHub issue / PR linking` needs a hand-written list
+  of proper nouns that goes stale on the first page named after something not
+  on it.
+
 ### Fixed
 
 - **Tilde compression fires on Windows, and with a trailing separator on

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The full tree lives under [`docs/`](docs/): 39 pages in English, every one of th
 
 | Section                                                         | Read this when …                                                              |
 |:----------------------------------------------------------------|:------------------------------------------------------------------------------|
-| [Getting Started](docs/1.getting-started/index.md)              | you want to install gwm and create your first worktree                        |
+| [Getting started](docs/1.getting-started/index.md)              | you want to install gwm and create your first worktree                        |
 | [TUI](docs/2.tui/index.md)                                      | you live in the ratatui interface: keymap, sidebar, launchers, filter        |
 | [CLI](docs/3.cli/index.md)                                      | you script gwm from shells, CI jobs, or `gh` aliases                          |
 | [Configuration](docs/4.configuration/index.md)                  | you're writing or extending `.gwm.toml`: bootstrap, guards, predicates       |

--- a/docs/1.getting-started/index.md
+++ b/docs/1.getting-started/index.md
@@ -1,11 +1,11 @@
 ---
-title: Getting Started
+title: Getting started
 description: Install gwm, create your first worktree, and wire up the one-line cd helper.
 navigation:
-  title: Getting Started
+  title: Getting started
 ---
 
-# Getting Started
+# Getting started
 
 Three steps to a working gwm setup:
 

--- a/docs/2.tui/3.filter.md
+++ b/docs/2.tui/3.filter.md
@@ -45,4 +45,4 @@ When you launch `gwm switch` (or hit bare `gcd` with the [shell-init helper](/ge
 ## related
 
 - [Keybindings → list view](/tui/keybindings#list-view-default): every key the filter view listens to
-- [Getting Started → Shell init](/getting-started/shell-init): wire up `gcd` for one-keystroke worktree jumping
+- [Getting started → Shell init](/getting-started/shell-init): wire up `gcd` for one-keystroke worktree jumping

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -197,7 +197,7 @@ The rules are not gated to Windows because a branch travels to a teammate's mach
 
 In the TUI, `Ctrl-T` toggles the create form (and only that form) between the structured triple and a single free-form `Name` field.
 
-End-to-end walkthrough lives in [Getting Started → First worktree](/getting-started/first-worktree).
+End-to-end walkthrough lives in [Getting started → First worktree](/getting-started/first-worktree).
 
 ## `gwm new <type> <desc>`
 
@@ -341,7 +341,7 @@ gwm path auth --format=json    # { "name": ..., "path": ..., "branch": ... }
 
 The default `text` form prints the bare path for `$(...)` consumption. `--format=json` (issue #38) emits the `{ name, path, branch }` triple, with the schema at [`docs/schema/path.schema.json`](https://github.com/kbrdn1/gwm-cli/blob/main/docs/schema/path.schema.json).
 
-Both forms share semantics: fuzzy resolve, exit `0` on a unique hit, `1` on miss / ambiguous / not in a repo. Pair with `gwm shell-init` for the `gcd` one-liner. See [Getting Started → Shell init](/getting-started/shell-init).
+Both forms share semantics: fuzzy resolve, exit `0` on a unique hit, `1` on miss / ambiguous / not in a repo. Pair with `gwm shell-init` for the `gcd` one-liner. See [Getting started → Shell init](/getting-started/shell-init).
 
 ## `gwm note show [<slug>]` (issue #515)
 
@@ -489,7 +489,7 @@ Print a static completion script. Supported shells: `zsh`, `bash`, `fish`, `powe
 
 ## `gwm shell-init <shell>`
 
-Print the `gcd` shell wrapper. Supported shells: `zsh`, `bash`, `fish`, `powershell`. See [Getting Started → Shell init](/getting-started/shell-init).
+Print the `gcd` shell wrapper. Supported shells: `zsh`, `bash`, `fish`, `powershell`. See [Getting started → Shell init](/getting-started/shell-init).
 
 ## `gwm tmux <pattern> [-p|--split]`
 

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -64,5 +64,5 @@ complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap sync tm
 
 ## see also
 
-- [Getting Started → Shell init](/getting-started/shell-init): the `gcd` wrapper that ships alongside `completions`
+- [Getting started → Shell init](/getting-started/shell-init): the `gcd` wrapper that ships alongside `completions`
 - [CLI → Subcommand reference](/cli/reference#gwm-list---formattablenames---detect-pr): the `--format=names` output used by the completers

--- a/docs/3.cli/index.md
+++ b/docs/3.cli/index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Every gwm subcommand, with synopsis, flags, and shell-friendly examples.
+description: The scriptable side of gwm, from the subcommand reference to the shell completions and the tmux / zellij integration.
 navigation:
   title: CLI
 ---

--- a/docs/5.integrations/3.homebrew-nix.md
+++ b/docs/5.integrations/3.homebrew-nix.md
@@ -5,7 +5,7 @@ description: Packaging surface, covering the Homebrew tap, the Nix flake and the
 
 # Homebrew and Nix
 
-gwm ships through several managed channels in addition to `cargo install`: Homebrew, Nix, `cargo binstall`, and the raw prebuilt archives. Pick whichever fits your environment. End-user install instructions live in [Getting Started → Install](/getting-started/install); this page covers the **packaging surface** for contributors, maintainers, and downstream packagers.
+gwm ships through several managed channels in addition to `cargo install`: Homebrew, Nix, `cargo binstall`, and the raw prebuilt archives. Pick whichever fits your environment. End-user install instructions live in [Getting started → Install](/getting-started/install); this page covers the **packaging surface** for contributors, maintainers, and downstream packagers.
 
 ## Homebrew tap
 
@@ -75,7 +75,7 @@ cargo binstall gwm-cli
 
 The metadata pins the archive naming to the `release.yml` matrix output; `tests/binstall_metadata_tests.rs` guards against artefact-naming drift so a renamed asset can't silently break `cargo binstall`.
 
-See [Getting Started → Install](/getting-started/install) for the end-user comparison of `cargo binstall` vs `cargo install` vs the prebuilt archives.
+See [Getting started → Install](/getting-started/install) for the end-user comparison of `cargo binstall` vs `cargo install` vs the prebuilt archives.
 
 ## prebuilt binaries
 
@@ -103,5 +103,5 @@ github.com/kbrdn1/homebrew-tap        ← formula bump PR
 
 ## related
 
-- [Getting Started → Install](/getting-started/install): end-user install for the four channels
+- [Getting started → Install](/getting-started/install): end-user install for the four channels
 - [Development → Contributing](/development/contributing): branch / commit / PR conventions and the CHANGELOG split rules

--- a/docs/7.roadmap.md
+++ b/docs/7.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: What's shipped, the v1.8.0 density line (compact TUI by default, one modal width policy, truncation measured in terminal cells) on top of the v1.7.x feature line, the v1.6.x security and bidi work, the v1.5.0 multi-forge support and the frozen v1.0.0 contracts, plus the link to the issue tracker.
+description: What ships today in the v1.8.0 density line, with a compact TUI by default, one modal width policy, and truncation measured in terminal cells. Earlier lines follow.
 ---
 
 # Roadmap

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,23 @@ description: <one-sentence teaser, used for SEO and search>
 ---
 ```
 
+Both fields reach the published site verbatim, as the `<title>` and the
+`<meta name="description">` of the page. Nothing in the build reads them, so a
+defect there ships green and is only visible in a search result. Two rules on
+`description`, pinned by `tests/docs_frontmatter_tests.rs`:
+
+- **250 characters at most.** Past that, no variant of the sentence comes out
+  of a search result cut intact, so lead with the current state and drop the
+  history.
+- **Distinct from every other page of the same locale.** Two URLs saying the
+  same sentence compete for one snippet, and an engine drops or rewrites one of
+  them. Section `index.md` files are where this happens: describe the section,
+  not the page it links to.
+
+Titles read in **sentence case** (`First worktree`, `Shell completions`), with
+proper nouns kept as they are spelled (`GitHub issue / PR linking`, `gwm
+doctor`). This one is on the author, not on a test.
+
 Optional fields:
 
 - `navigation.title`: short label for the sidebar when the full title is too long.

--- a/docs/fr/3.cli/index.md
+++ b/docs/fr/3.cli/index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: Chaque sous-commande gwm, avec sa synopsis, ses flags et des exemples prêts pour le shell.
+description: La face scriptable de gwm, de la référence des sous-commandes aux complétions de shell et à l'intégration tmux / zellij.
 navigation:
   title: CLI
 ---

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -1,9 +1,9 @@
 ---
-title: schéma .gwm.toml
+title: Schéma .gwm.toml
 description: Chaque section (worktree, bootstrap.*, hooks.*, theme, tui, tui.keys, tui.open, git_tui, review, doctor) avec valeurs par défaut et règles de validation.
 ---
 
-# schéma `.gwm.toml`
+# Schéma `.gwm.toml`
 
 `.gwm.toml` vit à la racine du dépôt. Sans lui, gwm utilise des valeurs par défaut raisonnables (path = `~/cc-worktree/<repo>/<type>-<issue>-<desc>`, pas de bootstrap, `lazygit -p {path}` comme `l`). Avec lui, vous pouvez configurer chaque facette : nommage de branche, copies de fichiers, guards de sécurité, commandes de launcher, comportement de la TUI, et checks de doctor.
 

--- a/docs/fr/7.roadmap.md
+++ b/docs/fr/7.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: Ce qui est livré, la ligne v1.8.0 (TUI compacte par défaut, une seule politique de largeur des modales, troncature mesurée en cellules de terminal) au-dessus de la ligne v1.7.x, des lignes de sécurité et bidi v1.6.x, du multi-forge v1.5.0 et des contrats v1.0.0 gelés, plus le lien vers le tracker d'issues.
+description: Ce qui est livré aujourd'hui dans la ligne densité v1.8.0, avec une TUI compacte par défaut, une politique unique de largeur des modales et la troncature mesurée en cellules de terminal.
 ---
 
 # Roadmap

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Rust CLI + ratatui TUI to manage git worktrees across projects.
 
 | Section                                            | Read this when …                                                              |
 |:---------------------------------------------------|:------------------------------------------------------------------------------|
-| [Getting Started](/getting-started)                | you want to install gwm and create your first worktree                        |
+| [Getting started](/getting-started)                | you want to install gwm and create your first worktree                        |
 | [TUI](/tui)                                        | you live in the ratatui interface: keymap, sidebar, launchers, filter        |
 | [CLI](/cli)                                        | you script gwm from shells, CI jobs, or `gh` aliases                          |
 | [Configuration](/configuration)                    | you're writing or extending `.gwm.toml`: bootstrap, guards, predicates       |

--- a/tests/docs_frontmatter_tests.rs
+++ b/tests/docs_frontmatter_tests.rs
@@ -72,6 +72,8 @@ fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
 ///
 /// `docs/schema/README.md` and `docs/_capture/README.md` are working notes
 /// with no frontmatter at all; they are skipped rather than excluded by name.
+/// `docs/README.md` does carry frontmatter, so it is held to the same rules as
+/// a page: it is hidden from the sidebar, not from a crawler.
 ///
 /// Line endings are normalised because Windows runners check out with
 /// `core.autocrlf=true`, and a trailing `\r` would otherwise count as a

--- a/tests/docs_frontmatter_tests.rs
+++ b/tests/docs_frontmatter_tests.rs
@@ -1,0 +1,185 @@
+//! Guards on the `description` frontmatter of `docs/**` (issue #579).
+//!
+//! The frontmatter of this tree is the source of the published `<title>` and
+//! `<meta name="description">`: the `kbrdn-docs` bridge carries it through
+//! verbatim, it does not rewrite the copy. So a metadata defect here is only
+//! fixable here, and it ships green — nothing in the build looks at a
+//! description, and the page renders identically either way.
+//!
+//! Two failure modes are mechanical enough to pin, and both were live when
+//! this file was written:
+//!
+//! 1. **A description too long to survive truncation.** Engines cut and
+//!    rewrite anyway, so length alone is not a fault; past a point though no
+//!    variant of the sentence comes out intact and the useful half sits
+//!    behind the cut. Both roadmap pages read 297 (EN) / 307 (FR).
+//! 2. **Two pages sharing a description.** `3.cli/index.md` and
+//!    `3.cli/1.reference.md` said the same sentence to a word, in both
+//!    locales: two separately crawled URLs, one of which gets dropped or
+//!    rewritten, when the two pages have distinct jobs (the section landing
+//!    against the exhaustive index).
+//!
+//! Title casing is *not* guarded. Separating `Getting Started` from
+//! `GitHub issue / PR linking` or `Open dispatch (o and O)` needs a
+//! hand-written allow-list of proper nouns, which is a census that goes stale
+//! the first time a page is named after something not on it.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Past this many characters, no variant of the sentence survives the cut.
+///
+/// A ceiling on egregiousness, not a style rule: the longest page that is
+/// *not* a defect (`fr/4.configuration/index.md`) already sits at 242, so
+/// there is little room under this line — a description that trips it is
+/// long enough that the fix is to say less, not to raise the cap.
+const MAX_DESCRIPTION_CHARS: usize = 250;
+
+/// Word-overlap past which two descriptions read as the same sentence.
+///
+/// Measured on the tree, same locale, every pair: the two defective pairs
+/// scored 0.667 (EN) and 0.632 (FR), the next pair 0.312, and once #579 is
+/// applied the highest score anywhere is 0.312. The threshold sits in that
+/// gap rather than on either edge of it.
+const MAX_DESCRIPTION_OVERLAP: f64 = 0.5;
+
+fn docs_root() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs")
+}
+
+/// Every `.md` under `docs/`, repo-relative, sorted for stable failures.
+fn markdown_pages() -> Vec<PathBuf> {
+  let mut out = Vec::new();
+  collect_markdown(&docs_root(), &mut out);
+  out.sort();
+  out
+}
+
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
+  let entries = fs::read_dir(dir).unwrap_or_else(|err| panic!("{} must be readable: {err}", dir.display()));
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_dir() {
+      collect_markdown(&path, out);
+    } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+      out.push(path);
+    }
+  }
+}
+
+/// The `description` of a page, or `None` when it carries no frontmatter.
+///
+/// `docs/schema/README.md` and `docs/_capture/README.md` are working notes
+/// with no frontmatter at all; they are skipped rather than excluded by name.
+///
+/// Line endings are normalised because Windows runners check out with
+/// `core.autocrlf=true`, and a trailing `\r` would otherwise count as a
+/// character and as a word.
+fn description(page: &Path) -> Option<String> {
+  let text = fs::read_to_string(page)
+    .unwrap_or_else(|err| panic!("{} must be readable: {err}", page.display()))
+    .replace("\r\n", "\n");
+  let body = text.strip_prefix("---\n")?;
+  let front = body.split("\n---").next()?;
+  let value = front.lines().find_map(|line| line.strip_prefix("description:"))?;
+  Some(unquote(value.trim()).to_string())
+}
+
+/// Strip the one layer of YAML quoting a description may carry, which the
+/// pages starting on an inline code span need (`` `gwm tmux` / … ``).
+fn unquote(value: &str) -> &str {
+  for quote in ['"', '\''] {
+    if let Some(inner) = value.strip_prefix(quote).and_then(|v| v.strip_suffix(quote)) {
+      return inner;
+    }
+  }
+  value
+}
+
+/// Locale of a page: the two are crawled as separate sites, so a shared
+/// description across locales is a translation, not a duplicate.
+fn locale(page: &Path) -> &'static str {
+  if page.starts_with(docs_root().join("fr")) {
+    "fr"
+  } else {
+    "en"
+  }
+}
+
+/// The words of a description, lowercased, punctuation and backticks dropped.
+fn words(description: &str) -> BTreeSet<String> {
+  description
+    .to_lowercase()
+    .replace('`', "")
+    .split(|c: char| !c.is_alphanumeric())
+    .filter(|w| !w.is_empty())
+    .map(str::to_string)
+    .collect()
+}
+
+/// Jaccard index of two word sets: shared words over words used at all.
+fn overlap(left: &BTreeSet<String>, right: &BTreeSet<String>) -> f64 {
+  let union = left.union(right).count();
+  if union == 0 {
+    return 0.0;
+  }
+  left.intersection(right).count() as f64 / union as f64
+}
+
+/// Every page description stays short enough to be served whole.
+#[test]
+fn descriptions_survive_search_result_truncation() {
+  let root = docs_root();
+  let mut long = Vec::new();
+  for page in markdown_pages() {
+    let Some(description) = description(&page) else {
+      continue;
+    };
+    let len = description.chars().count();
+    if len > MAX_DESCRIPTION_CHARS {
+      let rel = page.strip_prefix(&root).unwrap_or(&page);
+      long.push(format!("{} ({len} chars)", rel.display()));
+    }
+  }
+  assert!(
+    long.is_empty(),
+    "these descriptions run past {MAX_DESCRIPTION_CHARS} characters, so what a search engine \
+     shows of them is whatever fits before the cut; say the current state first and drop the \
+     history (the longest page that is not a defect already sits at 242, so this is a wide \
+     line to cross):\n  {}",
+    long.join("\n  ")
+  );
+}
+
+/// No two pages of the same locale describe themselves the same way.
+#[test]
+fn descriptions_are_distinct_within_a_locale() {
+  let root = docs_root();
+  let pages: Vec<(PathBuf, BTreeSet<String>)> = markdown_pages()
+    .into_iter()
+    .filter_map(|page| description(&page).map(|d| (page, words(&d))))
+    .collect();
+  let mut clashes = Vec::new();
+  for (i, (left, left_words)) in pages.iter().enumerate() {
+    for (right, right_words) in pages.iter().skip(i + 1) {
+      if locale(left) != locale(right) {
+        continue;
+      }
+      let score = overlap(left_words, right_words);
+      if score >= MAX_DESCRIPTION_OVERLAP {
+        clashes.push(format!(
+          "{} ↔ {} ({score:.3} word overlap)",
+          left.strip_prefix(&root).unwrap_or(left).display(),
+          right.strip_prefix(&root).unwrap_or(right).display()
+        ));
+      }
+    }
+  }
+  assert!(
+    clashes.is_empty(),
+    "these pages are crawled as separate URLs and say the same sentence, so an engine drops \
+     or rewrites one of the two; give each the description of its own job:\n  {}",
+    clashes.join("\n  ")
+  );
+}


### PR DESCRIPTION
## Description

The frontmatter of `docs/` is the source of the `<title>` and the
`<meta name="description">` on [gwm.kbrdn.dev](https://gwm.kbrdn.dev): the
`kbrdn-docs` bridge carries it through verbatim. So the four metadata defects
in #579 are only fixable here, and they ship green because nothing in the build
reads a description.

Two of the four are mechanical enough to pin, and `tests/docs_frontmatter_tests.rs`
now does, red first on this tree:

```
descriptions_survive_search_result_truncation
  7.roadmap.md (297 chars)
  fr/7.roadmap.md (307 chars)

descriptions_are_distinct_within_a_locale
  3.cli/1.reference.md ↔ 3.cli/index.md (0.667 word overlap)
  fr/3.cli/1.reference.md ↔ fr/3.cli/index.md (0.632 word overlap)
```

Closes #579

## Type of change

- [x] 📝 Docs

## Changes

- `3.cli/index.md` describes the section it routes to instead of repeating the
  reference page's sentence, EN and FR. Same-locale word overlap drops from
  0.667 to 0.15 (EN) and 0.632 to 0.19 (FR); the closest unrelated pair in the
  tree is 0.312, before and after.
- Both roadmap descriptions stop at the current version line instead of
  enumerating every line since v1.0.0: 297 → 159 (EN), 307 → 186 (FR).
- `Getting Started` reads `Getting started`, along with its `navigation.title`,
  its H1 and the ten cross-references that spell the page name. It was the only
  title-cased page in the tree and disagreed with both places the site names it
  (the sidebar label and the OG card table, both `Getting started`).
- `fr/4.configuration/1.gwm-toml.md` is capitalised at the source. The bridge
  was capitalising it on publish, so the site already showed `Schéma .gwm.toml`.
- `docs/README.md` records the two rules under the frontmatter contract, and the
  sentence-case habit that no test checks.

## Tests

- [x] `cargo test` passes locally (2989 tests, 103 binaries, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/` (`docs_frontmatter_tests.rs`, committed red
      before the fixes; the output above is that run)

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface change; the README's
      docs table follows the page rename)
- [ ] `examples/gwm.toml.example` updated if config schema changed (no schema change)

## Notes for reviewers

**The issue's measurements were stale.** It reported the roadmap descriptions at
271 (EN) and 258 (FR); the tree reads 297 and 307, because the v1.8.0 cut
rewrote both. Re-measured, the defect is worse, not absent.

**Why the length cap sits at 250.** It is a ceiling on egregiousness, not a
style rule, exactly as the issue frames it. Worth knowing that the longest
description that is *not* a defect (`fr/4.configuration/index.md`) already sits
at 242, so there is little room under the line.

**Why the overlap threshold is 0.5.** Measured over every same-locale pair: the
two defective pairs scored 0.667 and 0.632, the next pair 0.312, and post-fix
the highest score anywhere is still 0.312. The threshold sits in that gap rather
than on either edge of it.

**No guard on title casing.** Separating `Getting Started` from `GitHub issue /
PR linking`, `Open dispatch (o and O)` or `gwm doctor` needs a hand-written list
of proper nouns, which is a census that goes stale the first time a page is
named after something not on it. It is stated in `docs/README.md` instead.

**The French `schéma` cross-references stay lowercase.** Thirteen of them read
as running French prose (`Voir [schéma \`.gwm.toml\`](…)`), not as the page
name, unlike the English `Getting Started →` breadcrumbs which do.

**Observation, no action taken.** Four pre-existing descriptions carry an
unquoted `: ` and so are not valid YAML by a strict parser
(`8.comparison.md`, `fr/8.comparison.md`, `fr/5.integrations/5.gitlab.md`,
`fr/5.integrations/6.herdr.md`). The bridge copes: the live pages publish those
descriptions whole, checked against the deployed HTML. Nothing to fix, but the
four new descriptions here avoid the construct rather than add to the pile.

## Linked issues / docs

- Issue: #579
- Bridge-side counterpart: [kbrdn-docs#70](https://github.com/kbrdn1/kbrdn-docs/issues/70)