### PR TITLE
✨ feat(tui): richer note editing, lists first and a vim mode behind a knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,31 +15,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A worktree note can be a checklist**
   ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `Ctrl+t` in the note
   editor ticks the box on the line and spawns one when the line has none, from
-  anywhere on the line; `Ctrl+l` makes the line a list item or takes the marker
+  anywhere on the line; `Ctrl+u` makes the line a list item or takes the marker
   back off it; `Enter` continues the list and ends it on an empty item, the way
   every Markdown editor does. Both chords are Ctrl-modified because an
-  unmodified printable is text in that modal, and neither is `Ctrl+b`, which is
-  the tmux prefix and would never reach a note written inside tmux.
+  unmodified printable is text in that modal, and which chord is left over is
+  tmux's call: `Ctrl+b` is its prefix, and `Ctrl+h` / `Ctrl+j` / `Ctrl+k` /
+  `Ctrl+l` are the vim-tmux-navigator pane set that tmux forwards only to a
+  pane running vim.
 
   Ticking used to mean arrowing onto the right column and retyping a character
   by hand, which is what a note becomes after a day: "what to check before
   opening the PR" is a list you tick off.
 
-- **An opt-in vim normal mode for the note editor**
-  ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `[tui] note_vim =
-  true` opens `N` in normal mode: `hjkl`, `w` / `b` / `e` and their `W` / `B` /
-  `E`, `0` / `^` / `$`, `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` /
-  `O` to enter insert. `o` and `O` carry the list marker the way `Enter` does,
-  and the modal title carries a `NORMAL` / `INSERT` chip.
+- **A vim normal mode for the note editor**
+  ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `N` opens in normal
+  mode: `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`,
+  `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` / `O` to enter
+  insert. `o` and `O` carry the list marker the way `Enter` does, the modal
+  title carries a `NORMAL` / `INSERT` chip, and the statusbar under the modal
+  names the mode and lists the keys that mode takes.
 
-  **Off by default, and that is the feature.** With a mode, the first `Esc`
-  leaves insert rather than writing and closing, and `Esc` writing and closing
-  on the first press is a shipped default fingers already know. Nobody gets a
-  mode without asking for one. No counts, no registers, no undo: this is a
-  scratch buffer, and `Ctrl+e` still hands the file to the real vim. The verbs
-  are hard-coded rather than bindable, so `[tui.keys.modal.note]` holds the
-  same four verbs either way and an unmodified printable bound to one of them
-  is still refused at load time.
+  **The cost is `Esc`, so it gets its own line: it no longer writes and closes
+  on the first press.** It leaves insert, and the second press saves.
+  `[tui] note_vim = false` buys the single-press gesture back and returns the
+  editor to the modeless one, where every printable is text. No counts, no
+  registers, no undo: this is a scratch buffer, and `Ctrl+e` still hands the
+  file to the real vim. The verbs are hard-coded rather than bindable, so
+  `[tui.keys.modal.note]` holds the same four verbs either way and an
+  unmodified printable bound to one of them is still refused at load time.
 
 ## Past releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A worktree note can be a checklist**
+  ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `Ctrl+t` in the note
+  editor ticks the box on the line and spawns one when the line has none, from
+  anywhere on the line; `Ctrl+l` makes the line a list item or takes the marker
+  back off it; `Enter` continues the list and ends it on an empty item, the way
+  every Markdown editor does. Both chords are Ctrl-modified because an
+  unmodified printable is text in that modal, and neither is `Ctrl+b`, which is
+  the tmux prefix and would never reach a note written inside tmux.
+
+  Ticking used to mean arrowing onto the right column and retyping a character
+  by hand, which is what a note becomes after a day: "what to check before
+  opening the PR" is a list you tick off.
+
+- **An opt-in vim normal mode for the note editor**
+  ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `[tui] note_vim =
+  true` opens `N` in normal mode: `hjkl`, `w` / `b` / `e` and their `W` / `B` /
+  `E`, `0` / `^` / `$`, `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` /
+  `O` to enter insert. `o` and `O` carry the list marker the way `Enter` does,
+  and the modal title carries a `NORMAL` / `INSERT` chip.
+
+  **Off by default, and that is the feature.** With a mode, the first `Esc`
+  leaves insert rather than writing and closing, and `Esc` writing and closing
+  on the first press is a shipped default fingers already know. Nobody gets a
+  mode without asking for one. No counts, no registers, no undo: this is a
+  scratch buffer, and `Ctrl+e` still hands the file to the real vim. The verbs
+  are hard-coded rather than bindable, so `[tui.keys.modal.note]` holds the
+  same four verbs either way and an unmodified printable bound to one of them
+  is still refused at load time.
+
 ## Past releases
 
 In reverse chronological order:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **The cost is `Esc`, so it gets its own line: it no longer writes and closes
   on the first press.** It leaves insert, and the second press saves.
   `[tui] note_vim = false` buys the single-press gesture back and returns the
-  editor to the modeless one, where every printable is text. No counts, no
+  editor to the modeless one, where every printable is text, and it is a
+  toggle in the Settings panel's TUI tab like the other two TUI booleans. No counts, no
   registers, no undo: this is a scratch buffer, and `Ctrl+e` still hands the
   file to the real vim. The verbs are hard-coded rather than bindable, so
   `[tui.keys.modal.note]` holds the same four verbs either way and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mode: `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`,
   `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` / `O` to enter
   insert. `o` and `O` carry the list marker the way `Enter` does, the modal
-  title carries a `NORMAL` / `INSERT` chip, and the statusbar under the modal
-  names the mode and lists the keys that mode takes.
+  title carries a `NORMAL` / `INSERT` chip, and the modal's own last row
+  names the mode and lists the keys that mode takes, as does the statusbar
+  behind it. A list too long for the row is cut with a `…` rather than
+  clipped at the frame, which reads as a list that ends there.
 
   **The cost is `Esc`, so it gets its own line: it no longer writes and closes
   on the first press.** It leaves insert, and the second press saves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` / `O` to enter
   insert. `o` and `O` carry the list marker the way `Enter` does, the modal
   title carries a `NORMAL` / `INSERT` chip, and the modal's own last row
-  names the mode and lists the keys that mode takes, as does the statusbar
-  behind it. A list too long for the row is cut with a `…` rather than
+  leads with the mode as a reverse-video badge (the treatment the statusbar
+  context anchor already wears) before listing the keys that mode takes,
+  as does the statusbar behind it. A list too long for the row is cut with a `…` rather than
   clipped at the frame, which reads as a list that ends there.
 
   **The cost is `Esc`, so it gets its own line: it no longer writes and closes

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -136,9 +136,9 @@ The non-interactive counterpart is [`gwm remove a b c`](/cli/reference#gwm-remov
 
 `N` opens the selected worktree's note in a modal you type straight into. A note is usually three lines written in the ten seconds between two thoughts, and suspending the whole TUI to spawn an editor is a heavier gesture than that. `Ctrl+e` inside the modal hands the same file to `$EDITOR` when the note needs more, through the handoff `o` uses in [`mode = "editor"`](/tui/open-dispatch): `editor_cmd` in `.gwm.toml`, then `$EDITOR`, then `vi`. What that editor writes is reloaded into the modal when it exits.
 
-**`Esc` writes and closes.** There is no "quit without saving" — the reflex on leaving a note is to keep it, and the alternative makes `Esc` destroy prose nothing can regenerate. To delete a note, empty it: a blank buffer removes the file rather than leaving one that reads as absent everywhere. A buffer nothing touched is not written at all, so opening a note to read it does not move its mtime.
+**`Esc` writes and closes**, and with the vim mode below (on by default) it takes two presses: the first leaves insert, the second writes. There is no "quit without saving" either way. The reflex on leaving a note is to keep it, and the alternative makes `Esc` destroy prose nothing can regenerate. To delete a note, empty it: a blank buffer removes the file rather than leaving one that reads as absent everywhere. A buffer nothing touched is not written at all, so opening a note to read it does not move its mtime.
 
-The editor takes text, `Enter`, `Backspace`, `Delete`, the four arrows, `Home` / `End` and `PageUp` / `PageDown`. None of those are rebindable, because in a text buffer they are text: the four verbs under `[tui.keys.modal.note]` are `close` (`Esc`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+l`) and `toggle_checkbox` (`Ctrl+t`). Long lines scroll rather than wrap, so the caret always sits on the character it will push; `Ctrl+e` is the answer for prose that needs the width.
+The editor takes text, `Enter`, `Backspace`, `Delete`, the four arrows, `Home` / `End` and `PageUp` / `PageDown`. None of those are rebindable, because in a text buffer they are text: the four verbs under `[tui.keys.modal.note]` are `close` (`Esc`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+u`) and `toggle_checkbox` (`Ctrl+t`). Long lines scroll rather than wrap, so the caret always sits on the character it will push; `Ctrl+e` is the answer for prose that needs the width.
 
 ### lists and checkboxes ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
@@ -146,21 +146,21 @@ A note becomes a checklist after a day, because "what to check before opening th
 
 | Key | Effect |
 |:----|:-------|
-| `Ctrl+l` | make the line a list item (`- `), or take the marker back off it |
+| `Ctrl+u` | make the line a list item (`- `), or take the marker back off it |
 | `Ctrl+t` | tick the box on the line, spawning one (`- [ ] `) if it has none |
 | `Enter` | continue the list, or end it when the item is empty |
 
-Both are Ctrl-modified for the reason the whole modal exists: an unmodified printable is text here, and binding one to a note verb is refused at load time. Neither is `Ctrl+b`, which is the tmux prefix and would never reach a note written inside tmux.
+Both are Ctrl-modified for the reason the whole modal exists: an unmodified printable is text here, and binding one to a note verb is refused at load time. Which chord is left over is decided by tmux: `Ctrl+b` is its prefix, and `Ctrl+h` / `Ctrl+j` / `Ctrl+k` / `Ctrl+l` are the vim-tmux-navigator pane set that ships in tmux.nvim and in most dotfiles that copied it. tmux forwards those only to a pane running vim, so inside tmux they never reach gwm at all.
 
-`Ctrl+t` ticks from anywhere on the line, so the gesture is one key and no navigation. A bullet gains an empty box rather than a ticked one: the first press writes the item, the second ticks it. `Ctrl+l` on a checkbox line removes the whole marker, since `- [ ] ` is a bullet too and leaving a widowed `[ ]` behind is not what "no longer a list item" means.
+`Ctrl+t` ticks from anywhere on the line, so the gesture is one key and no navigation. A bullet gains an empty box rather than a ticked one: the first press writes the item, the second ticks it. `Ctrl+u` on a checkbox line removes the whole marker, since `- [ ] ` is a bullet too and leaving a widowed `[ ]` behind is not what "no longer a list item" means.
 
 `Enter` on a list item carries the marker onto the next line, indentation included, and a box is never continued ticked. `Enter` on an item whose text is empty ends the list instead, which is the second `Enter` every Markdown editor breaks out on. A line has to *look* like an item to be treated as one: `-foo` is prose and `--flag` is a flag, and both keep their text.
 
-### vim normal mode (opt-in, [#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+### vim normal mode ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
-`[tui] note_vim = true` gives the editor a normal mode. **It is off by default**, and the default is the point: with a mode, the first `Esc` leaves insert rather than writing and closing, and that is a shipped default fingers already know. Nobody gets a mode without asking for one.
+The editor has a normal mode, and **it is on by default**. `N` opens in normal mode, the title carries a `NORMAL` / `INSERT` chip, and the statusbar under the modal names the mode it is in and lists the keys that mode takes.
 
-With it on, `N` opens in normal mode and the title carries a `NORMAL` / `INSERT` chip:
+**The cost is `Esc`:** it leaves insert rather than writing and closing, so saving takes two presses. `[tui] note_vim = false` buys the single-press gesture back and returns the editor to the one #515 shipped, where every printable is text and there are no modes at all.
 
 | Key | Effect |
 |:----|:-------|

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -138,7 +138,44 @@ The non-interactive counterpart is [`gwm remove a b c`](/cli/reference#gwm-remov
 
 **`Esc` writes and closes.** There is no "quit without saving" — the reflex on leaving a note is to keep it, and the alternative makes `Esc` destroy prose nothing can regenerate. To delete a note, empty it: a blank buffer removes the file rather than leaving one that reads as absent everywhere. A buffer nothing touched is not written at all, so opening a note to read it does not move its mtime.
 
-The editor takes text, `Enter`, `Backspace`, `Delete`, the four arrows, `Home` / `End` and `PageUp` / `PageDown`. None of those are rebindable, because in a text buffer they are text: only `close` (`Esc`) and `open_editor` (`Ctrl+e`) live under `[tui.keys.modal.note]`. Long lines scroll rather than wrap, so the caret always sits on the character it will push; `Ctrl+e` is the answer for prose that needs the width.
+The editor takes text, `Enter`, `Backspace`, `Delete`, the four arrows, `Home` / `End` and `PageUp` / `PageDown`. None of those are rebindable, because in a text buffer they are text: the four verbs under `[tui.keys.modal.note]` are `close` (`Esc`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+l`) and `toggle_checkbox` (`Ctrl+t`). Long lines scroll rather than wrap, so the caret always sits on the character it will push; `Ctrl+e` is the answer for prose that needs the width.
+
+### lists and checkboxes ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+
+A note becomes a checklist after a day, because "what to check before opening the PR" is a list you tick off. Two chords write one:
+
+| Key | Effect |
+|:----|:-------|
+| `Ctrl+l` | make the line a list item (`- `), or take the marker back off it |
+| `Ctrl+t` | tick the box on the line, spawning one (`- [ ] `) if it has none |
+| `Enter` | continue the list, or end it when the item is empty |
+
+Both are Ctrl-modified for the reason the whole modal exists: an unmodified printable is text here, and binding one to a note verb is refused at load time. Neither is `Ctrl+b`, which is the tmux prefix and would never reach a note written inside tmux.
+
+`Ctrl+t` ticks from anywhere on the line, so the gesture is one key and no navigation. A bullet gains an empty box rather than a ticked one: the first press writes the item, the second ticks it. `Ctrl+l` on a checkbox line removes the whole marker, since `- [ ] ` is a bullet too and leaving a widowed `[ ]` behind is not what "no longer a list item" means.
+
+`Enter` on a list item carries the marker onto the next line, indentation included, and a box is never continued ticked. `Enter` on an item whose text is empty ends the list instead, which is the second `Enter` every Markdown editor breaks out on. A line has to *look* like an item to be treated as one: `-foo` is prose and `--flag` is a flag, and both keep their text.
+
+### vim normal mode (opt-in, [#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+
+`[tui] note_vim = true` gives the editor a normal mode. **It is off by default**, and the default is the point: with a mode, the first `Esc` leaves insert rather than writing and closing, and that is a shipped default fingers already know. Nobody gets a mode without asking for one.
+
+With it on, `N` opens in normal mode and the title carries a `NORMAL` / `INSERT` chip:
+
+| Key | Effect |
+|:----|:-------|
+| `h` `j` `k` `l` | move. `h` / `l` stop at the line ends; the arrows still wrap onto the neighbouring line |
+| `w` `b` `e` | word forward / back / end. `W` `B` `E` for blank-separated words |
+| `0` `^` `$` | first column, first non-blank, last char |
+| `gg` `G` | first / last line |
+| `x` `dd` | delete the char under the caret / the line |
+| `i` `I` `a` `A` | insert before the caret, at the first non-blank, after the caret, at the end of the line |
+| `o` `O` | open a line below / above and start typing, carrying the list marker |
+| `Esc` | insert to normal, then normal writes and closes |
+
+No counts (`3j`), no registers, and therefore no `p` and no undo. This is a scratch buffer three lines long; `Ctrl+e` hands the file to the real vim for anything that wants the rest. The caret sits **on** a character in normal mode rather than one past the last one, or `x` at the end of a line would delete nothing.
+
+The verbs stay hard-coded rather than rebindable, exactly as the arrows are: `[tui.keys.modal.note]` holds the same four verbs with or without the knob, and an unmodified printable bound to one of them is still refused at load time. `Backspace`, `Enter` and `Delete` are text in insert mode, so in normal mode they mean `h`, `j` and `x` instead of editing.
 
 A note is what only you can write down: what you had just figured out, what is blocking, what to check before opening the PR. gwm already knows the branch, the linked issue, the diff against base and the agent session, and none of that says where you were.
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -158,7 +158,7 @@ Both are Ctrl-modified for the reason the whole modal exists: an unmodified prin
 
 ### vim normal mode ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
-The editor has a normal mode, and **it is on by default**. `N` opens in normal mode, the title carries a `NORMAL` / `INSERT` chip, and the statusbar under the modal names the mode it is in and lists the keys that mode takes.
+The editor has a normal mode, and **it is on by default**. `N` opens in normal mode, the title carries a `NORMAL` / `INSERT` chip, and the modal's own last row leads with the mode as a colour badge before listing the keys that mode takes.
 
 **The cost is `Esc`:** it leaves insert rather than writing and closing, so saving takes two presses. `[tui] note_vim = false` buys the single-press gesture back and returns the editor to the one #515 shipped, where every printable is text and there are no modes at all.
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -471,7 +471,7 @@ The header fill is the `section_bg` [theme role](/tui/themes), an indexed colour
 
 Overlays and modals keep their border under either value — a panel floating over content is where a rule earns its keep.
 
-An unknown value is a **hard config error at load time**. `layout`, `dim_unfocused` and `status_one_line` are also exposed in the Settings panel under the **TUI** tab (`4`), where cycling the choice applies live.
+An unknown value is a **hard config error at load time**. `layout`, `dim_unfocused`, `status_one_line` and `note_vim` are also exposed in the Settings panel under the **TUI** tab (`4`), where cycling the choice applies live.
 
 ### dim_unfocused
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -423,9 +423,10 @@ dim_unfocused = false
 # diff · age). On by default; set to false for the labelled four-row block.
 status_one_line = true
 
-# Give the in-TUI note editor (`N`) a vim normal mode. Off by default: with
-# it on, the first `Esc` leaves insert instead of writing and closing.
-note_vim = false
+# Give the in-TUI note editor (`N`) a vim normal mode. On by default: the
+# first `Esc` leaves insert, and the second one writes and closes. Set it to
+# false for the modeless editor, where one `Esc` writes and closes.
+note_vim = true
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
 # otherwise), "osc52", or "tools".
@@ -502,11 +503,11 @@ It is a knob rather than a compact-mode behaviour, so it applies under **both** 
 
 ### note_vim
 
-`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) gives the in-TUI note editor (`N`) a vim normal mode. **Off by default.**
+`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) gives the in-TUI note editor (`N`) a vim normal mode. **On by default.**
 
-On, `N` opens in normal mode, `i` / `I` / `a` / `A` / `o` / `O` enter insert, `Esc` goes back to normal, and the second `Esc` writes and closes. The motions are `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` and `dd`. The full table is in [TUI → keybindings](/tui/keybindings#vim-normal-mode-opt-in-557).
+`N` opens in normal mode, `i` / `I` / `a` / `A` / `o` / `O` enter insert, `Esc` goes back to normal, and the second `Esc` writes and closes. The motions are `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` and `dd`. The full table is in [TUI → keybindings](/tui/keybindings#vim-normal-mode-557).
 
-That second sentence is the whole reason this is a knob rather than the new behaviour: **with a mode, the first `Esc` no longer writes and closes**, and that is a shipped default fingers already know. Off, the editor is exactly the one #515 shipped, where every printable is text and `Esc` leaves straight away.
+That second sentence is the cost, so it is worth stating on its own: **the first `Esc` no longer writes and closes**. Set `note_vim = false` and the editor is exactly the one #515 shipped, where every printable is text and one `Esc` writes and closes.
 
 It changes no binding: `[tui.keys.modal.note]` holds the same four verbs either way, and an unmodified printable bound to one of them is refused at load time with or without the mode. What it does change is what unbound printables mean, which is why the modal title carries a `NORMAL` / `INSERT` chip while it is on.
 
@@ -1013,7 +1014,7 @@ Single-pass expansion: `wip = "ll"` followed by `ll = "list --format names"` exp
 | `[tui].layout`                       | `compact`                        |
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
-| `[tui].note_vim`                     | `false`                          |
+| `[tui].note_vim`                     | `true`                           |
 | `[tui].clipboard`                    | `auto`                           |
 | `[tui].auto_refresh_secs`            | `60` (`0` disables)              |
 | `[tui.macro1]` / `[tui.macro2]`      | absent, `h` / `H` are no-ops     |

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -423,6 +423,10 @@ dim_unfocused = false
 # diff · age). On by default; set to false for the labelled four-row block.
 status_one_line = true
 
+# Give the in-TUI note editor (`N`) a vim normal mode. Off by default: with
+# it on, the first `Esc` leaves insert instead of writing and closing.
+note_vim = false
+
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
 # otherwise), "osc52", or "tools".
 clipboard = "auto"
@@ -495,6 +499,18 @@ Four labelled rows for four values of a handful of characters each was the sideb
 It is a knob rather than a compact-mode behaviour, so it applies under **both** layouts — `bordered` folds too unless you turn this off. The `Path` row is never folded in: a path is the one value long enough that sharing a row would clip the path and whatever joined it.
 
 **Segment order is the width policy.** The sidebar does not wrap, so a row wider than the pane is clipped on the right: identity (branch, head) leads because it is what the row is for, and `Created` trails because it is the value the pane can most afford to lose. Every segment keeps the [theme role](/tui/themes) it wears in the labelled block.
+
+### note_vim
+
+`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) gives the in-TUI note editor (`N`) a vim normal mode. **Off by default.**
+
+On, `N` opens in normal mode, `i` / `I` / `a` / `A` / `o` / `O` enter insert, `Esc` goes back to normal, and the second `Esc` writes and closes. The motions are `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` and `dd`. The full table is in [TUI → keybindings](/tui/keybindings#vim-normal-mode-opt-in-557).
+
+That second sentence is the whole reason this is a knob rather than the new behaviour: **with a mode, the first `Esc` no longer writes and closes**, and that is a shipped default fingers already know. Off, the editor is exactly the one #515 shipped, where every printable is text and `Esc` leaves straight away.
+
+It changes no binding: `[tui.keys.modal.note]` holds the same four verbs either way, and an unmodified printable bound to one of them is refused at load time with or without the mode. What it does change is what unbound printables mean, which is why the modal title carries a `NORMAL` / `INSERT` chip while it is on.
+
+No counts, no registers, no undo. `Ctrl+e` still hands the file to the real vim, and that handoff is the answer for anything this mode does not cover.
 
 `clipboard` (issue #367) selects how yanked text (path, branch, worktree name, command logs) reaches the clipboard:
 
@@ -997,6 +1013,7 @@ Single-pass expansion: `wip = "ll"` followed by `ll = "list --format names"` exp
 | `[tui].layout`                       | `compact`                        |
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
+| `[tui].note_vim`                     | `false`                          |
 | `[tui].clipboard`                    | `auto`                           |
 | `[tui].auto_refresh_secs`            | `60` (`0` disables)              |
 | `[tui.macro1]` / `[tui.macro2]`      | absent, `h` / `H` are no-ops     |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -147,7 +147,44 @@ Le pendant non interactif est [`gwm remove a b c`](/fr/cli/reference#gwm-remove-
 
 **`Échap` enregistre et ferme.** Il n'y a pas de « quitter sans enregistrer » : le réflexe en quittant une note est de la garder, et l'inverse ferait détruire par `Échap` une prose que rien ne régénère. Pour supprimer une note, videz-la : un tampon vide efface le fichier au lieu d'en laisser un que tout le reste lit comme absent. Un tampon auquel on n'a pas touché n'est pas écrit du tout, donc ouvrir une note pour la lire ne déplace pas sa date de modification.
 
-L'éditeur accepte le texte, `Entrée`, `Retour arrière`, `Suppr`, les quatre flèches, `Début` / `Fin` et `Page préc.` / `Page suiv.`. Rien de tout ça n'est reconfigurable, parce que dans un tampon de texte ce sont des caractères : seuls `close` (`Échap`) et `open_editor` (`Ctrl+e`) vivent sous `[tui.keys.modal.note]`. Les lignes longues défilent au lieu de se replier, pour que le curseur reste toujours sur le caractère qu'il va pousser ; `Ctrl+e` est la réponse quand la prose demande la largeur.
+L'éditeur accepte le texte, `Entrée`, `Retour arrière`, `Suppr`, les quatre flèches, `Début` / `Fin` et `Page préc.` / `Page suiv.`. Rien de tout ça n'est reconfigurable, parce que dans un tampon de texte ce sont des caractères : les quatre verbes qui vivent sous `[tui.keys.modal.note]` sont `close` (`Échap`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+l`) et `toggle_checkbox` (`Ctrl+t`). Les lignes longues défilent au lieu de se replier, pour que le curseur reste toujours sur le caractère qu'il va pousser ; `Ctrl+e` est la réponse quand la prose demande la largeur.
+
+### listes et cases à cocher ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+
+Une note devient une checklist au bout d'un jour, parce que « ce qu'il faut vérifier avant d'ouvrir la PR » est une liste qu'on coche. Deux accords en écrivent une :
+
+| Touche | Effet |
+|:-------|:------|
+| `Ctrl+l` | fait de la ligne un item de liste (`- `), ou lui retire son marqueur |
+| `Ctrl+t` | coche la case de la ligne, en la créant (`- [ ] `) s'il n'y en a pas |
+| `Entrée` | continue la liste, ou la termine quand l'item est vide |
+
+Les deux portent `Ctrl` pour la raison même qui fait exister cette modale : un imprimable non modifié est du texte ici, et le lier à un verbe de note est refusé au chargement. Ni l'un ni l'autre n'est `Ctrl+b`, qui est le préfixe tmux et n'atteindrait jamais une note écrite dans tmux.
+
+`Ctrl+t` coche depuis n'importe où sur la ligne : le geste tient en une touche, sans navigation préalable. Une puce reçoit une case vide plutôt qu'une case cochée : la première pression écrit l'item, la seconde le coche. `Ctrl+l` sur une ligne à case retire le marqueur entier, puisque `- [ ] ` est aussi une puce et laisser un `[ ]` orphelin n'est pas ce que « ce n'est plus un item » veut dire.
+
+`Entrée` sur un item de liste reporte le marqueur sur la ligne suivante, indentation comprise, et une case n'est jamais continuée cochée. `Entrée` sur un item dont le texte est vide termine la liste : c'est la deuxième `Entrée` sur laquelle tous les éditeurs Markdown sortent d'une liste. Encore faut-il que la ligne *ressemble* à un item : `-foo` est de la prose et `--flag` est une option, et les deux gardent leur texte.
+
+### mode normal vim (optionnel, [#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+
+`[tui] note_vim = true` donne un mode normal à l'éditeur. **C'est désactivé par défaut**, et ce défaut est le sujet : avec un mode, la première `Échap` quitte l'insertion au lieu d'enregistrer et fermer, or c'est un comportement livré que les doigts connaissent déjà. Personne n'hérite d'un mode sans l'avoir demandé.
+
+Avec l'option, `N` ouvre en mode normal et le titre porte une pastille `NORMAL` / `INSERT` :
+
+| Touche | Effet |
+|:-------|:------|
+| `h` `j` `k` `l` | déplacement. `h` / `l` s'arrêtent aux bouts de ligne ; les flèches, elles, passent toujours sur la ligne voisine |
+| `w` `b` `e` | mot suivant / précédent / fin de mot. `W` `B` `E` pour les mots séparés par des blancs |
+| `0` `^` `$` | première colonne, premier non-blanc, dernier caractère |
+| `gg` `G` | première / dernière ligne |
+| `x` `dd` | supprime le caractère sous le curseur / la ligne |
+| `i` `I` `a` `A` | insertion avant le curseur, au premier non-blanc, après le curseur, en fin de ligne |
+| `o` `O` | ouvre une ligne dessous / dessus et passe en insertion, marqueur de liste reporté |
+| `Échap` | insertion vers normal, puis normal enregistre et ferme |
+
+Pas de compteurs (`3j`), pas de registres, donc pas de `p` ni d'annulation. C'est un tampon de brouillon de trois lignes ; `Ctrl+e` confie le fichier au vrai vim pour tout ce qui demande le reste. En mode normal le curseur se pose **sur** un caractère plutôt qu'un cran après le dernier, sinon `x` en fin de ligne ne supprimerait rien.
+
+Les verbes restent codés en dur plutôt que reconfigurables, exactement comme les flèches : `[tui.keys.modal.note]` porte les mêmes quatre verbes avec ou sans l'option, et un imprimable non modifié lié à l'un d'eux reste refusé au chargement. `Retour arrière`, `Entrée` et `Suppr` sont du texte en insertion, donc en mode normal ils valent `h`, `j` et `x` au lieu de modifier le tampon.
 
 Une note, c'est ce que vous seul pouvez écrire : ce que vous veniez de comprendre, ce qui bloque, ce qu'il faut vérifier avant d'ouvrir la PR. gwm connaît déjà la branche, l'issue liée, le diff contre la base et la session d'agent, et rien de tout ça ne dit où vous en étiez.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -167,7 +167,7 @@ Les deux portent `Ctrl` pour la raison même qui fait exister cette modale : un 
 
 ### mode normal vim ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
-L'éditeur a un mode normal, et **il est actif par défaut**. `N` ouvre en mode normal, le titre porte une pastille `NORMAL` / `INSERT`, et la barre d'état sous la modale nomme le mode courant et liste les touches que ce mode accepte.
+L'éditeur a un mode normal, et **il est actif par défaut**. `N` ouvre en mode normal, le titre porte une pastille `NORMAL` / `INSERT`, et la dernière ligne de la modale ouvre sur le mode en pastille colorée avant de lister les touches que ce mode accepte.
 
 **Le coût, c'est `Échap`** : il quitte l'insertion au lieu d'enregistrer et fermer, donc enregistrer demande deux pressions. `[tui] note_vim = false` rachète le geste en une pression et rend l'éditeur exactement tel que #515 l'a livré, où tout imprimable est du texte et où il n'y a aucun mode.
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -145,9 +145,9 @@ Le pendant non interactif est [`gwm remove a b c`](/fr/cli/reference#gwm-remove-
 
 `N` ouvre la note du worktree sélectionné dans une modale où vous tapez directement. Une note tient en général en trois lignes écrites dans les dix secondes qui séparent deux pensées, et suspendre tout le TUI pour lancer un éditeur est un geste plus lourd que ça. Depuis la modale, `Ctrl+e` confie le même fichier à `$EDITOR` quand la note demande plus, par le relais que `o` utilise en [`mode = "editor"`](/fr/tui/open-dispatch) : `editor_cmd` dans `.gwm.toml`, puis `$EDITOR`, puis `vi`. Ce que cet éditeur écrit est rechargé dans la modale à sa sortie.
 
-**`Échap` enregistre et ferme.** Il n'y a pas de « quitter sans enregistrer » : le réflexe en quittant une note est de la garder, et l'inverse ferait détruire par `Échap` une prose que rien ne régénère. Pour supprimer une note, videz-la : un tampon vide efface le fichier au lieu d'en laisser un que tout le reste lit comme absent. Un tampon auquel on n'a pas touché n'est pas écrit du tout, donc ouvrir une note pour la lire ne déplace pas sa date de modification.
+**`Échap` enregistre et ferme**, et avec le mode vim ci-dessous (actif par défaut) il faut deux pressions : la première quitte l'insertion, la seconde enregistre. Dans les deux cas il n'y a pas de « quitter sans enregistrer » : le réflexe en quittant une note est de la garder, et l'inverse ferait détruire par `Échap` une prose que rien ne régénère. Pour supprimer une note, videz-la : un tampon vide efface le fichier au lieu d'en laisser un que tout le reste lit comme absent. Un tampon auquel on n'a pas touché n'est pas écrit du tout, donc ouvrir une note pour la lire ne déplace pas sa date de modification.
 
-L'éditeur accepte le texte, `Entrée`, `Retour arrière`, `Suppr`, les quatre flèches, `Début` / `Fin` et `Page préc.` / `Page suiv.`. Rien de tout ça n'est reconfigurable, parce que dans un tampon de texte ce sont des caractères : les quatre verbes qui vivent sous `[tui.keys.modal.note]` sont `close` (`Échap`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+l`) et `toggle_checkbox` (`Ctrl+t`). Les lignes longues défilent au lieu de se replier, pour que le curseur reste toujours sur le caractère qu'il va pousser ; `Ctrl+e` est la réponse quand la prose demande la largeur.
+L'éditeur accepte le texte, `Entrée`, `Retour arrière`, `Suppr`, les quatre flèches, `Début` / `Fin` et `Page préc.` / `Page suiv.`. Rien de tout ça n'est reconfigurable, parce que dans un tampon de texte ce sont des caractères : les quatre verbes qui vivent sous `[tui.keys.modal.note]` sont `close` (`Échap`), `open_editor` (`Ctrl+e`), `toggle_bullet` (`Ctrl+u`) et `toggle_checkbox` (`Ctrl+t`). Les lignes longues défilent au lieu de se replier, pour que le curseur reste toujours sur le caractère qu'il va pousser ; `Ctrl+e` est la réponse quand la prose demande la largeur.
 
 ### listes et cases à cocher ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
@@ -155,21 +155,21 @@ Une note devient une checklist au bout d'un jour, parce que « ce qu'il faut vé
 
 | Touche | Effet |
 |:-------|:------|
-| `Ctrl+l` | fait de la ligne un item de liste (`- `), ou lui retire son marqueur |
+| `Ctrl+u` | fait de la ligne un item de liste (`- `), ou lui retire son marqueur |
 | `Ctrl+t` | coche la case de la ligne, en la créant (`- [ ] `) s'il n'y en a pas |
 | `Entrée` | continue la liste, ou la termine quand l'item est vide |
 
-Les deux portent `Ctrl` pour la raison même qui fait exister cette modale : un imprimable non modifié est du texte ici, et le lier à un verbe de note est refusé au chargement. Ni l'un ni l'autre n'est `Ctrl+b`, qui est le préfixe tmux et n'atteindrait jamais une note écrite dans tmux.
+Les deux portent `Ctrl` pour la raison même qui fait exister cette modale : un imprimable non modifié est du texte ici, et le lier à un verbe de note est refusé au chargement. Quels accords restent disponibles, c'est tmux qui le décide : `Ctrl+b` est son préfixe, et `Ctrl+h` / `Ctrl+j` / `Ctrl+k` / `Ctrl+l` sont le jeu de navigation entre panes de vim-tmux-navigator, livré par tmux.nvim et par la plupart des dotfiles qui l'ont copié. tmux ne les transmet qu'à un pane qui exécute vim, donc dans tmux ils n'atteignent jamais gwm.
 
-`Ctrl+t` coche depuis n'importe où sur la ligne : le geste tient en une touche, sans navigation préalable. Une puce reçoit une case vide plutôt qu'une case cochée : la première pression écrit l'item, la seconde le coche. `Ctrl+l` sur une ligne à case retire le marqueur entier, puisque `- [ ] ` est aussi une puce et laisser un `[ ]` orphelin n'est pas ce que « ce n'est plus un item » veut dire.
+`Ctrl+t` coche depuis n'importe où sur la ligne : le geste tient en une touche, sans navigation préalable. Une puce reçoit une case vide plutôt qu'une case cochée : la première pression écrit l'item, la seconde le coche. `Ctrl+u` sur une ligne à case retire le marqueur entier, puisque `- [ ] ` est aussi une puce et laisser un `[ ]` orphelin n'est pas ce que « ce n'est plus un item » veut dire.
 
 `Entrée` sur un item de liste reporte le marqueur sur la ligne suivante, indentation comprise, et une case n'est jamais continuée cochée. `Entrée` sur un item dont le texte est vide termine la liste : c'est la deuxième `Entrée` sur laquelle tous les éditeurs Markdown sortent d'une liste. Encore faut-il que la ligne *ressemble* à un item : `-foo` est de la prose et `--flag` est une option, et les deux gardent leur texte.
 
-### mode normal vim (optionnel, [#557](https://github.com/kbrdn1/gwm-cli/issues/557))
+### mode normal vim ([#557](https://github.com/kbrdn1/gwm-cli/issues/557))
 
-`[tui] note_vim = true` donne un mode normal à l'éditeur. **C'est désactivé par défaut**, et ce défaut est le sujet : avec un mode, la première `Échap` quitte l'insertion au lieu d'enregistrer et fermer, or c'est un comportement livré que les doigts connaissent déjà. Personne n'hérite d'un mode sans l'avoir demandé.
+L'éditeur a un mode normal, et **il est actif par défaut**. `N` ouvre en mode normal, le titre porte une pastille `NORMAL` / `INSERT`, et la barre d'état sous la modale nomme le mode courant et liste les touches que ce mode accepte.
 
-Avec l'option, `N` ouvre en mode normal et le titre porte une pastille `NORMAL` / `INSERT` :
+**Le coût, c'est `Échap`** : il quitte l'insertion au lieu d'enregistrer et fermer, donc enregistrer demande deux pressions. `[tui] note_vim = false` rachète le geste en une pression et rend l'éditeur exactement tel que #515 l'a livré, où tout imprimable est du texte et où il n'y a aucun mode.
 
 | Touche | Effet |
 |:-------|:------|

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -425,6 +425,10 @@ dim_unfocused = false
 # diff · âge). On par défaut ; false rend le bloc labellisé de quatre lignes.
 status_one_line = true
 
+# Donne un mode normal vim à l'éditeur de notes du TUI (`N`). Off par défaut :
+# avec l'option, la première `Échap` quitte l'insertion au lieu d'enregistrer.
+note_vim = false
+
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
 # otherwise), "osc52", or "tools".
 clipboard = "auto"
@@ -497,6 +501,18 @@ Quatre lignes labellisées pour quatre valeurs de quelques caractères chacune :
 C'est un réglage et non un comportement propre au mode compact : il vaut donc pour les **deux** dispositions — `bordered` se replie aussi, sauf si on met ce réglage à off. La ligne `Path` n'est jamais repliée : un chemin est la seule valeur assez longue pour que partager une ligne tronque à la fois le chemin et ce qui l'y aurait rejoint.
 
 **L'ordre des segments est la politique de largeur.** La sidebar ne fait pas de retour à la ligne : une ligne plus large que le panneau est coupée à droite. L'identité (branche, head) ouvre la ligne parce que c'est ce pour quoi elle existe, et `Created` la ferme parce que c'est la valeur que le panneau peut le mieux se permettre de perdre. Chaque segment garde le [rôle de thème](/fr/tui/themes) qu'il porte dans le bloc labellisé.
+
+### note_vim
+
+`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) donne un mode normal vim à l'éditeur de notes du TUI (`N`). **Off par défaut.**
+
+Activé, `N` ouvre en mode normal, `i` / `I` / `a` / `A` / `o` / `O` passent en insertion, `Échap` revient au normal, et la deuxième `Échap` enregistre et ferme. Les déplacements sont `hjkl`, `w` / `b` / `e` et leurs `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` et `dd`. La table complète est dans [TUI → raccourcis](/fr/tui/keybindings#mode-normal-vim-optionnel-557).
+
+Cette deuxième phrase est toute la raison pour laquelle c'est une option et non le nouveau comportement : **avec un mode, la première `Échap` n'enregistre plus et ne ferme plus**, or c'est un défaut livré que les doigts connaissent déjà. Désactivé, l'éditeur est exactement celui de #515, où chaque imprimable est du texte et `Échap` sort tout de suite.
+
+L'option ne change aucun binding : `[tui.keys.modal.note]` porte les mêmes quatre verbes dans les deux cas, et un imprimable non modifié lié à l'un d'eux est refusé au chargement avec ou sans le mode. Ce qu'elle change, c'est le sens des imprimables non liés, d'où la pastille `NORMAL` / `INSERT` dans le titre de la modale tant qu'elle est active.
+
+Pas de compteurs, pas de registres, pas d'annulation. `Ctrl+e` confie toujours le fichier au vrai vim, et ce relais est la réponse pour tout ce que ce mode ne couvre pas.
 
 `clipboard` (issue #367) choisit comment le texte yanké (chemin, branche, nom de worktree, logs de commandes) atteint le presse-papier :
 
@@ -998,6 +1014,7 @@ Expansion en une seule passe : `wip = "ll"` suivi de `ll = "list --format names"
 | `[tui].layout`                       | `compact`                        |
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
+| `[tui].note_vim`                     | `false`                          |
 | `[tui].auto_refresh_secs`            | `60` (`0` désactive)             |
 | `[tui.macro1]` / `[tui.macro2]`      | absent, `h` / `H` sont des no-ops |
 | `[tui.keys]`                         | keymap intégré (voir la table ci-dessus) |

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -473,7 +473,7 @@ L'aplat de l'en-tête est le [rôle de thème](/fr/tui/themes) `section_bg`, une
 
 Les surcouches et les modales gardent leur bordure dans les deux cas — un panneau qui flotte au-dessus du contenu est précisément là où un filet se justifie.
 
-Une valeur inconnue est une **erreur de config au chargement**. `layout`, `dim_unfocused` et `status_one_line` sont aussi exposés dans le panneau Settings sous l'onglet **TUI** (`4`), où faire défiler le choix s'applique à chaud.
+Une valeur inconnue est une **erreur de config au chargement**. `layout`, `dim_unfocused`, `status_one_line` et `note_vim` sont aussi exposés dans le panneau Settings sous l'onglet **TUI** (`4`), où faire défiler le choix s'applique à chaud.
 
 ### dim_unfocused
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -425,9 +425,10 @@ dim_unfocused = false
 # diff · âge). On par défaut ; false rend le bloc labellisé de quatre lignes.
 status_one_line = true
 
-# Donne un mode normal vim à l'éditeur de notes du TUI (`N`). Off par défaut :
-# avec l'option, la première `Échap` quitte l'insertion au lieu d'enregistrer.
-note_vim = false
+# Donne un mode normal vim à l'éditeur de notes du TUI (`N`). On par défaut :
+# la première `Échap` quitte l'insertion, la seconde enregistre et ferme.
+# false rend l'éditeur sans mode, où une seule `Échap` enregistre et ferme.
+note_vim = true
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
 # otherwise), "osc52", or "tools".
@@ -504,11 +505,11 @@ C'est un réglage et non un comportement propre au mode compact : il vaut donc p
 
 ### note_vim
 
-`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) donne un mode normal vim à l'éditeur de notes du TUI (`N`). **Off par défaut.**
+`note_vim` (issue [#557](https://github.com/kbrdn1/gwm-cli/issues/557)) donne un mode normal vim à l'éditeur de notes du TUI (`N`). **On par défaut.**
 
-Activé, `N` ouvre en mode normal, `i` / `I` / `a` / `A` / `o` / `O` passent en insertion, `Échap` revient au normal, et la deuxième `Échap` enregistre et ferme. Les déplacements sont `hjkl`, `w` / `b` / `e` et leurs `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` et `dd`. La table complète est dans [TUI → raccourcis](/fr/tui/keybindings#mode-normal-vim-optionnel-557).
+`N` ouvre en mode normal, `i` / `I` / `a` / `A` / `o` / `O` passent en insertion, `Échap` revient au normal, et la deuxième `Échap` enregistre et ferme. Les déplacements sont `hjkl`, `w` / `b` / `e` et leurs `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, plus `x` et `dd`. La table complète est dans [TUI → raccourcis](/fr/tui/keybindings#mode-normal-vim-557).
 
-Cette deuxième phrase est toute la raison pour laquelle c'est une option et non le nouveau comportement : **avec un mode, la première `Échap` n'enregistre plus et ne ferme plus**, or c'est un défaut livré que les doigts connaissent déjà. Désactivé, l'éditeur est exactement celui de #515, où chaque imprimable est du texte et `Échap` sort tout de suite.
+Cette deuxième phrase est le coût, et il mérite d'être énoncé seul : **la première `Échap` n'enregistre plus et ne ferme plus**. Avec `note_vim = false`, l'éditeur est exactement celui de #515, où chaque imprimable est du texte et où une seule `Échap` enregistre et ferme.
 
 L'option ne change aucun binding : `[tui.keys.modal.note]` porte les mêmes quatre verbes dans les deux cas, et un imprimable non modifié lié à l'un d'eux est refusé au chargement avec ou sans le mode. Ce qu'elle change, c'est le sens des imprimables non liés, d'où la pastille `NORMAL` / `INSERT` dans le titre de la modale tant qu'elle est active.
 
@@ -1014,7 +1015,7 @@ Expansion en une seule passe : `wip = "ll"` suivi de `ll = "list --format names"
 | `[tui].layout`                       | `compact`                        |
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
-| `[tui].note_vim`                     | `false`                          |
+| `[tui].note_vim`                     | `true`                           |
 | `[tui].auto_refresh_secs`            | `60` (`0` désactive)             |
 | `[tui.macro1]` / `[tui.macro2]`      | absent, `h` / `H` sont des no-ops |
 | `[tui.keys]`                         | keymap intégré (voir la table ci-dessus) |

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -328,23 +328,24 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # layout = "bordered"
 
 # --- TUI note editor: vim normal mode (issue #557) ---------------------------
-# `note_vim` gives the in-TUI note editor (`N`) a vim normal mode. OFF by
-# default, and the default is the feature: with a mode, the first `Esc` leaves
-# insert instead of writing and closing, and `Esc` writing and closing on the
-# first press is what the editor has always done.
+# `note_vim` gives the in-TUI note editor (`N`) a vim normal mode. ON by
+# default, and the cost is `Esc`: it leaves insert instead of writing and
+# closing, so saving takes two presses. Turn it off for the modeless editor,
+# where one `Esc` writes and closes.
 #
-# On, `N` opens in normal mode and the modal title carries a NORMAL / INSERT
-# chip. `i` / `I` / `a` / `A` / `o` / `O` enter insert; `hjkl`, `w` / `b` / `e`
-# (and `W` / `B` / `E`), `0` / `^` / `$`, `gg` / `G`, `x` and `dd` are the
-# motions. No counts, no registers, no undo: `Ctrl+e` hands the file to the
-# real vim for anything past that.
+# On, `N` opens in normal mode, the modal title carries a NORMAL / INSERT chip
+# and the statusbar under it lists that mode's keys. `i` / `I` / `a` / `A` /
+# `o` / `O` enter insert; `hjkl`, `w` / `b` / `e` (and `W` / `B` / `E`),
+# `0` / `^` / `$`, `gg` / `G`, `x` and `dd` are the motions. No counts, no
+# registers, no undo: `Ctrl+e` hands the file to the real vim for anything
+# past that.
 #
 # It changes no binding. `[tui.keys.modal.note]` holds the same four verbs
 # either way (`close`, `open_editor`, `toggle_bullet`, `toggle_checkbox`), and
 # an unmodified printable bound to one of them is still refused at load time.
 #
 # [tui]
-# note_vim = true
+# note_vim = false
 
 # --- TUI clipboard (issue #367) ----------------------------------------------
 # How yanked text (path / branch / worktree name / command logs) reaches the

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -327,6 +327,25 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # [tui]
 # layout = "bordered"
 
+# --- TUI note editor: vim normal mode (issue #557) ---------------------------
+# `note_vim` gives the in-TUI note editor (`N`) a vim normal mode. OFF by
+# default, and the default is the feature: with a mode, the first `Esc` leaves
+# insert instead of writing and closing, and `Esc` writing and closing on the
+# first press is what the editor has always done.
+#
+# On, `N` opens in normal mode and the modal title carries a NORMAL / INSERT
+# chip. `i` / `I` / `a` / `A` / `o` / `O` enter insert; `hjkl`, `w` / `b` / `e`
+# (and `W` / `B` / `E`), `0` / `^` / `$`, `gg` / `G`, `x` and `dd` are the
+# motions. No counts, no registers, no undo: `Ctrl+e` hands the file to the
+# real vim for anything past that.
+#
+# It changes no binding. `[tui.keys.modal.note]` holds the same four verbs
+# either way (`close`, `open_editor`, `toggle_bullet`, `toggle_checkbox`), and
+# an unmodified printable bound to one of them is still refused at load time.
+#
+# [tui]
+# note_vim = true
+
 # --- TUI clipboard (issue #367) ----------------------------------------------
 # How yanked text (path / branch / worktree name / command logs) reaches the
 # clipboard:

--- a/src/config.rs
+++ b/src/config.rs
@@ -876,6 +876,21 @@ pub struct TuiConfig {
   /// long enough that sharing a row with anything else would clip both.
   #[serde(default = "default_status_one_line")]
   pub status_one_line: bool,
+
+  /// Give the in-TUI note editor a vim normal mode (issue #557).
+  ///
+  /// Default `false`, and deliberately opt-in rather than the new
+  /// behaviour: with it on, `N` opens in normal mode, `i` / `I` / `a` /
+  /// `A` / `o` / `O` enter insert, `Esc` goes back to normal, and the
+  /// second `Esc` writes and closes. That last sentence is the reason for
+  /// the knob. `Esc` writing and closing on the FIRST press is a shipped
+  /// default people's fingers already know, and a mode is not something to
+  /// hand someone who never asked for one.
+  ///
+  /// Off, the editor is exactly the one #515 shipped: every printable is
+  /// text, and `Esc` writes and closes straight away.
+  #[serde(default)]
+  pub note_vim: bool,
 }
 
 /// How the TUI frames its panes and sidebar sections (issue #545).
@@ -934,6 +949,7 @@ impl Default for TuiConfig {
       layout: TuiLayout::Compact,
       dim_unfocused: false,
       status_one_line: default_status_one_line(),
+      note_vim: false,
     }
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -879,17 +879,14 @@ pub struct TuiConfig {
 
   /// Give the in-TUI note editor a vim normal mode (issue #557).
   ///
-  /// Default `false`, and deliberately opt-in rather than the new
-  /// behaviour: with it on, `N` opens in normal mode, `i` / `I` / `a` /
-  /// `A` / `o` / `O` enter insert, `Esc` goes back to normal, and the
-  /// second `Esc` writes and closes. That last sentence is the reason for
-  /// the knob. `Esc` writing and closing on the FIRST press is a shipped
-  /// default people's fingers already know, and a mode is not something to
-  /// hand someone who never asked for one.
+  /// Default `true`: `N` opens in normal mode, `i` / `I` / `a` / `A` / `o`
+  /// / `O` enter insert, `Esc` goes back to normal, and the second `Esc`
+  /// writes and closes. The cost is that last sentence, so it is stated
+  /// twice: `Esc` no longer writes and closes on the FIRST press.
   ///
-  /// Off, the editor is exactly the one #515 shipped: every printable is
-  /// text, and `Esc` writes and closes straight away.
-  #[serde(default)]
+  /// Set it to `false` for exactly the editor #515 shipped: every
+  /// printable is text, no modes, and one `Esc` writes and closes.
+  #[serde(default = "default_note_vim")]
   pub note_vim: bool,
 }
 
@@ -949,7 +946,7 @@ impl Default for TuiConfig {
       layout: TuiLayout::Compact,
       dim_unfocused: false,
       status_one_line: default_status_one_line(),
-      note_vim: false,
+      note_vim: default_note_vim(),
     }
   }
 }
@@ -1299,6 +1296,13 @@ fn default_confirm_countdown_secs() -> u32 {
 /// (which yields `false` for a bool) would invert the contract for every
 /// config that does not spell the key out.
 fn default_status_one_line() -> bool {
+  true
+}
+
+/// `[tui] note_vim` defaults to `true` (issue #557), so a bare
+/// `#[serde(default)]` would hand every config that does not spell the key
+/// out the modeless editor instead of the mode.
+fn default_note_vim() -> bool {
   true
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4386,13 +4386,12 @@ impl App {
     match self.resolve_modal(KeyContext::Note, key) {
       Some(ModalAction::NoteClose) => {
         // #557: with a mode, the first `Esc` is the one that leaves insert
-        // and closing takes two. That is exactly why the mode is opt-in:
-        // `Esc` writing and closing on the first press is a shipped
-        // default, and it stays the default for everyone else.
+        // and closing takes two. That is the cost of shipping the mode on,
+        // and `note_vim = false` is what buys the single press back.
         //
         // This reads the knob where the block above reads the mode, and
         // they are the same fact from two sides: normal mode is only ever
-        // entered behind the knob, but insert mode is where both worlds
+        // entered with the knob on, but insert mode is where both worlds
         // meet, so `Esc` cannot tell them apart without asking.
         if self.config.tui.note_vim {
           if let Some(editor) = self.note_editor.as_mut() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4220,7 +4220,13 @@ impl App {
       return;
     };
     let text = crate::notes::read(&self.repo, &branch).unwrap_or_default();
-    self.note_editor = Some(crate::tui::state::note_editor::NoteEditor::open(branch, path, &text));
+    let mut editor = crate::tui::state::note_editor::NoteEditor::open(branch, path, &text);
+    // #557: `note_vim` opens in normal mode, the way vim itself does. The
+    // knob is what keeps that off everyone else's `N`.
+    if self.config.tui.note_vim {
+      editor.enter_normal();
+    }
+    self.note_editor = Some(editor);
     self.view = View::Note;
   }
 
@@ -4299,7 +4305,40 @@ impl App {
     use crate::tui::modal_keymap::{KeyContext, ModalAction};
     use crossterm::event::KeyCode as KC;
 
+    use crate::tui::state::note_editor::NoteMode;
+
     let stroke = crate::tui::keymap::KeyStroke::from_event(&key);
+
+    // #557: normal mode routes BEFORE the typing reservation, because that
+    // reservation is what makes `j` a letter. Only reachable behind
+    // `[tui] note_vim = true`, so with the knob off this block never sees
+    // a key and the #515 editor is untouched.
+    let normal = self.note_editor.as_ref().is_some_and(|e| e.mode == NoteMode::Normal);
+    if normal
+      && !stroke
+        .modifiers
+        .intersects(crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::ALT)
+    {
+      // Backspace, Enter and Delete are text in insert mode, so they must
+      // not edit here: a Backspace that ate a character would be prose
+      // lost to a key pressed to move. vim's own answers are `h`, `j`, `x`.
+      // Everything else (Esc, the arrows, the page keys) means the same in
+      // both modes and falls through to the blocks below.
+      let verb = match key.code {
+        KC::Char(c) => Some(c),
+        KC::Backspace => Some('h'),
+        KC::Enter => Some('j'),
+        KC::Delete => Some('x'),
+        _ => None,
+      };
+      if let Some(c) = verb {
+        if let Some(editor) = self.note_editor.as_mut() {
+          editor.normal_key(c);
+        }
+        return NoteKey::Handled;
+      }
+    }
+
     if KeyContext::Note.reserved_typing_stroke(&stroke) {
       if let Some(editor) = self.note_editor.as_mut() {
         match key.code {
@@ -4315,6 +4354,18 @@ impl App {
 
     match self.resolve_modal(KeyContext::Note, key) {
       Some(ModalAction::NoteClose) => {
+        // #557: with a mode, the first `Esc` is the one that leaves insert
+        // and closing takes two. That is exactly why the mode is opt-in:
+        // `Esc` writing and closing on the first press is a shipped
+        // default, and it stays the default for everyone else.
+        if self.config.tui.note_vim {
+          if let Some(editor) = self.note_editor.as_mut() {
+            if editor.mode == NoteMode::Insert {
+              editor.enter_normal();
+              return NoteKey::Handled;
+            }
+          }
+        }
         self.flush_note();
         self.note_editor = None;
         self.view = View::List;
@@ -4376,8 +4427,16 @@ impl App {
       return;
     };
     let (branch, path) = (editor.branch.clone(), editor.path.clone());
+    // #557: the buffer is rebuilt, so the mode has to be carried over by
+    // hand — coming back from `$EDITOR` into insert mode would leave a vim
+    // user typing verbs into their note.
+    let mode = editor.mode;
     let text = std::fs::read_to_string(&path).unwrap_or_default();
-    self.note_editor = Some(crate::tui::state::note_editor::NoteEditor::open(branch, path, &text));
+    let mut editor = crate::tui::state::note_editor::NoteEditor::open(branch, path, &text);
+    if mode == crate::tui::state::note_editor::NoteMode::Normal {
+      editor.enter_normal();
+    }
+    self.note_editor = Some(editor);
   }
 
   /// Re-read the selected row's note presence once the editor has exited

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4332,6 +4332,20 @@ impl App {
         }
         return NoteKey::Handled;
       }
+      // #557: the two list verbs. Ctrl-modified, so they reach this far
+      // rather than being consumed as text above.
+      Some(ModalAction::NoteToggleBullet) => {
+        if let Some(editor) = self.note_editor.as_mut() {
+          editor.toggle_bullet();
+        }
+        return NoteKey::Handled;
+      }
+      Some(ModalAction::NoteToggleCheckbox) => {
+        if let Some(editor) = self.note_editor.as_mut() {
+          editor.toggle_checkbox();
+        }
+        return NoteKey::Handled;
+      }
       _ => {}
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4358,6 +4358,11 @@ impl App {
         // and closing takes two. That is exactly why the mode is opt-in:
         // `Esc` writing and closing on the first press is a shipped
         // default, and it stays the default for everyone else.
+        //
+        // This reads the knob where the block above reads the mode, and
+        // they are the same fact from two sides: normal mode is only ever
+        // entered behind the knob, but insert mode is where both worlds
+        // meet, so `Esc` cannot tell them apart without asking.
         if self.config.tui.note_vim {
           if let Some(editor) = self.note_editor.as_mut() {
             if editor.mode == NoteMode::Insert {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4314,28 +4314,49 @@ impl App {
     // `[tui] note_vim = true`, so with the knob off this block never sees
     // a key and the #515 editor is untouched.
     let normal = self.note_editor.as_ref().is_some_and(|e| e.mode == NoteMode::Normal);
-    if normal
-      && !stroke
-        .modifiers
-        .intersects(crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::ALT)
-    {
+    if normal {
       // Backspace, Enter and Delete are text in insert mode, so they must
       // not edit here: a Backspace that ate a character would be prose
       // lost to a key pressed to move. vim's own answers are `h`, `j`, `x`.
-      // Everything else (Esc, the arrows, the page keys) means the same in
-      // both modes and falls through to the blocks below.
-      let verb = match key.code {
-        KC::Char(c) => Some(c),
-        KC::Backspace => Some('h'),
-        KC::Enter => Some('j'),
-        KC::Delete => Some('x'),
-        _ => None,
-      };
-      if let Some(c) = verb {
-        if let Some(editor) = self.note_editor.as_mut() {
-          editor.normal_key(c);
+      // Everything else (Esc, the arrows, the page keys, the Ctrl chords)
+      // means the same in both modes and falls through to the blocks below.
+      //
+      // The letter comes off `stroke`, not off `key`: terminals disagree on
+      // how they report a shifted letter (bare `Char('G')`, `Char('G')` +
+      // SHIFT, or the kitty protocol's `Char('g')` + SHIFT), and
+      // `KeyStroke::new` is what folds all three to `Char('G')` (PR #192).
+      // Routing the raw code would turn `G` into `g` and take every
+      // uppercase verb with it (Codex review #582, first pass).
+      let verb = if stroke
+        .modifiers
+        .intersects(crossterm::event::KeyModifiers::CONTROL | crossterm::event::KeyModifiers::ALT)
+      {
+        None
+      } else {
+        match stroke.code {
+          KC::Char(c) => Some(c),
+          KC::Backspace => Some('h'),
+          KC::Enter => Some('j'),
+          KC::Delete => Some('x'),
+          _ => None,
         }
-        return NoteKey::Handled;
+      };
+      match verb {
+        Some(c) => {
+          if let Some(editor) = self.note_editor.as_mut() {
+            editor.normal_key(c);
+          }
+          return NoteKey::Handled;
+        }
+        // Any other key abandons a half-typed sequence, which is what
+        // `pending` promises: `d`, `Down`, `d` must open a fresh `dd`
+        // rather than delete the line the arrow landed on. There is no
+        // undo here, so a `dd` nobody typed is prose gone for good.
+        None => {
+          if let Some(editor) = self.note_editor.as_mut() {
+            editor.pending = None;
+          }
+        }
       }
     }
 
@@ -4391,15 +4412,11 @@ impl App {
       // #557: the two list verbs. Ctrl-modified, so they reach this far
       // rather than being consumed as text above.
       Some(ModalAction::NoteToggleBullet) => {
-        if let Some(editor) = self.note_editor.as_mut() {
-          editor.toggle_bullet();
-        }
+        self.edit_note_buffer(|editor| editor.toggle_bullet());
         return NoteKey::Handled;
       }
       Some(ModalAction::NoteToggleCheckbox) => {
-        if let Some(editor) = self.note_editor.as_mut() {
-          editor.toggle_checkbox();
-        }
+        self.edit_note_buffer(|editor| editor.toggle_checkbox());
         return NoteKey::Handled;
       }
       _ => {}
@@ -4409,20 +4426,36 @@ impl App {
     // module note gives for `Esc` / `Enter`: an arrow key means one thing
     // in a text buffer and rebinding it would only take it away.
     let height = self.note_editor.as_ref().map_or(10, |e| e.viewport);
+    self.edit_note_buffer(|editor| match key.code {
+      KC::Left => editor.left(),
+      KC::Right => editor.right(),
+      KC::Up => editor.up(),
+      KC::Down => editor.down(),
+      KC::Home => editor.home(),
+      KC::End => editor.end(),
+      KC::PageUp => editor.page_up(height),
+      KC::PageDown => editor.page_down(height),
+      _ => {}
+    });
+    NoteKey::Handled
+  }
+
+  /// Run `f` on the open note buffer, then restore the normal-mode caret
+  /// invariant (issue #557, Codex review #582).
+  ///
+  /// Movement and the list toggles are written for insert mode, where the
+  /// caret may sit one past the last char. In normal mode it may not, or
+  /// `x` deletes nothing and `i` inserts past the end of the line. Whoever
+  /// moves the caret restores the invariant, rather than every reader of
+  /// `cursor_col` having to distrust it.
+  fn edit_note_buffer(&mut self, f: impl FnOnce(&mut crate::tui::state::note_editor::NoteEditor)) {
+    use crate::tui::state::note_editor::NoteMode;
     if let Some(editor) = self.note_editor.as_mut() {
-      match key.code {
-        KC::Left => editor.left(),
-        KC::Right => editor.right(),
-        KC::Up => editor.up(),
-        KC::Down => editor.down(),
-        KC::Home => editor.home(),
-        KC::End => editor.end(),
-        KC::PageUp => editor.page_up(height),
-        KC::PageDown => editor.page_down(height),
-        _ => {}
+      f(editor);
+      if editor.mode == NoteMode::Normal {
+        editor.clamp_normal();
       }
     }
-    NoteKey::Handled
   }
 
   /// Re-read the note after `$EDITOR` exited (issue #515), so the modal

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2591,7 +2591,17 @@ impl App {
       View::Config => self.pane_hint_context(),
       View::Pty => super::ui::HintContext::Pty,
       View::ExecPicker => HintContext::ExecPicker,
-      View::Note => HintContext::Note,
+      // #557: the note bar follows the mode. With the knob off there is no
+      // mode to follow, and the #515 bar is what stays — a `NORMAL` chip on
+      // an editor that has no normal mode would name a state nobody can be
+      // in.
+      View::Note => match self.note_editor.as_ref() {
+        Some(editor) if self.config.tui.note_vim => match editor.mode {
+          crate::tui::state::note_editor::NoteMode::Normal => HintContext::NoteNormal,
+          crate::tui::state::note_editor::NoteMode::Insert => HintContext::NoteInsert,
+        },
+        _ => HintContext::Note,
+      },
       View::CleanReport => HintContext::Clean,
       View::Edit => self.rename_hint_context(),
       // Issue #408: the detail overlay advertises its close/scroll keys.

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -381,7 +381,7 @@ define_modal_actions! {
     RichViewOpen    => "open"        [ "Enter" ],
     RichViewRefresh => "refresh"     [ "f" ],
   }
-  // #515: two verbs, because everything else is text. `Esc` writes and
+  // #515: the verbs, because everything else is text. `Esc` writes and
   // closes — there is no discard, the buffer is emptied instead (see
   // `state::note_editor`). `Ctrl+e` hands the same file to `$EDITOR`,
   // which is what `N` itself used to do.
@@ -389,9 +389,16 @@ define_modal_actions! {
   // `Ctrl+e` is now spoken for. If line motions ever land here, the
   // readline `Ctrl+a` / `Ctrl+e` pair cannot have it — pick another key
   // rather than shadowing the way out to a real editor.
+  //
+  // #557: the two list verbs are Ctrl-modified for the reason the whole
+  // context exists — an unmodified printable is text here, and binding one
+  // to a verb is refused at load time. Neither is `Ctrl+b`: that is the
+  // tmux prefix, and a note written inside tmux would never see it.
   Note {
-    NoteClose      => "close"       [ "Esc" ],
-    NoteOpenEditor => "open_editor" [ "Ctrl+e" ],
+    NoteClose          => "close"           [ "Esc" ],
+    NoteOpenEditor     => "open_editor"     [ "Ctrl+e" ],
+    NoteToggleBullet   => "toggle_bullet"   [ "Ctrl+l" ],
+    NoteToggleCheckbox => "toggle_checkbox" [ "Ctrl+t" ],
   }
 }
 

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -392,12 +392,17 @@ define_modal_actions! {
   //
   // #557: the two list verbs are Ctrl-modified for the reason the whole
   // context exists — an unmodified printable is text here, and binding one
-  // to a verb is refused at load time. Neither is `Ctrl+b`: that is the
-  // tmux prefix, and a note written inside tmux would never see it.
+  // to a verb is refused at load time. Which chord is left is decided by
+  // what tmux keeps for itself: `Ctrl+b` is the prefix, and `Ctrl+h` /
+  // `Ctrl+j` / `Ctrl+k` / `Ctrl+l` are the vim-tmux-navigator pane set that
+  // ships in tmux.nvim and every dotfiles repo that copied it. tmux only
+  // forwards those when the pane is running vim, so a note written inside
+  // tmux never sees them — measured on a real config, where `Ctrl+l` did
+  // nothing at all. `Ctrl+u` is free and reads as "unordered".
   Note {
     NoteClose          => "close"           [ "Esc" ],
     NoteOpenEditor     => "open_editor"     [ "Ctrl+e" ],
-    NoteToggleBullet   => "toggle_bullet"   [ "Ctrl+l" ],
+    NoteToggleBullet   => "toggle_bullet"   [ "Ctrl+u" ],
     NoteToggleCheckbox => "toggle_checkbox" [ "Ctrl+t" ],
   }
 }

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -79,6 +79,7 @@ impl SettingsTab {
         SettingField::Layout,
         SettingField::DimUnfocused,
         SettingField::StatusOneLine,
+        SettingField::NoteVim,
         SettingField::SidebarPosition,
         SettingField::SidebarOrientation,
         SettingField::Clipboard,
@@ -309,6 +310,8 @@ pub enum SettingField {
   DimUnfocused,
   /// `tui.status_one_line` — fold the sidebar Status block (issue #547).
   StatusOneLine,
+  /// `tui.note_vim` — the note editor's vim normal mode (issue #557).
+  NoteVim,
   /// `tui.sidebar_position` — left / right.
   SidebarPosition,
   /// `tui.sidebar_orientation` — stacked / side-by-side / auto.
@@ -339,6 +342,7 @@ impl SettingField {
       SettingField::Layout => "layout",
       SettingField::DimUnfocused => "dim unfocused pane",
       SettingField::StatusOneLine => "status on one line",
+      SettingField::NoteVim => "note vim mode",
       SettingField::SidebarOrientation => "sidebar layout",
       SettingField::Clipboard => "clipboard",
       SettingField::OpenMode => "open mode",
@@ -360,6 +364,7 @@ impl SettingField {
       SettingField::Layout => "tui.layout",
       SettingField::DimUnfocused => "tui.dim_unfocused",
       SettingField::StatusOneLine => "tui.status_one_line",
+      SettingField::NoteVim => "tui.note_vim",
       SettingField::SidebarOrientation => "tui.sidebar_orientation",
       SettingField::Clipboard => "tui.clipboard",
       SettingField::OpenMode => "tui.open.mode",
@@ -379,7 +384,7 @@ impl SettingField {
       | SettingField::SidebarOrientation
       | SettingField::Clipboard
       | SettingField::OpenMode => FieldKind::Choice,
-      SettingField::DimUnfocused | SettingField::StatusOneLine => FieldKind::Bool,
+      SettingField::DimUnfocused | SettingField::StatusOneLine | SettingField::NoteVim => FieldKind::Bool,
       SettingField::ConfirmCountdown | SettingField::AutoRefreshSecs => FieldKind::Uint,
       SettingField::WorktreeBase
       | SettingField::WorktreePathPattern
@@ -404,7 +409,7 @@ impl SettingField {
       SettingField::ThemePreset => crate::tui::theme::preset_names(),
       SettingField::SidebarPosition => SIDEBAR_CHOICES,
       SettingField::Layout => LAYOUT_CHOICES,
-      SettingField::DimUnfocused | SettingField::StatusOneLine => BOOL_CHOICES,
+      SettingField::DimUnfocused | SettingField::StatusOneLine | SettingField::NoteVim => BOOL_CHOICES,
       SettingField::SidebarOrientation => SIDEBAR_ORIENTATION_CHOICES,
       SettingField::Clipboard => CLIPBOARD_CHOICES,
       SettingField::OpenMode => OPEN_MODE_CHOICES,
@@ -423,6 +428,7 @@ impl SettingField {
       SettingField::Layout => cfg.tui.layout.label().into(),
       SettingField::DimUnfocused => cfg.tui.dim_unfocused.to_string(),
       SettingField::StatusOneLine => cfg.tui.status_one_line.to_string(),
+      SettingField::NoteVim => cfg.tui.note_vim.to_string(),
       SettingField::SidebarOrientation => cfg.tui.sidebar_orientation.label().into(),
       SettingField::Clipboard => cfg.tui.clipboard.label().into(),
       SettingField::OpenMode => match cfg.tui.open.mode {

--- a/src/tui/state/note_editor.rs
+++ b/src/tui/state/note_editor.rs
@@ -26,6 +26,87 @@
 
 use std::path::PathBuf;
 
+/// How a line opens, in Markdown terms (issue #557).
+///
+/// A note becomes a checklist after a day, and the three shapes below are
+/// the whole vocabulary of one: a bullet, a box, a ticked box. Anything
+/// else is prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListPrefix {
+  /// `- `
+  Bullet,
+  /// `- [ ] `
+  Unchecked,
+  /// `- [x] `, and `- [X] ` reads the same: notes are plain Markdown other
+  /// editors have written into.
+  Checked,
+}
+
+impl ListPrefix {
+  /// The marker a continued item is born with. A box is never born ticked:
+  /// ticking is an act.
+  fn continued(self) -> &'static str {
+    match self {
+      ListPrefix::Bullet => "- ",
+      ListPrefix::Unchecked | ListPrefix::Checked => "- [ ] ",
+    }
+  }
+}
+
+/// The list marker a line carries, measured in `char`s so the cursor (which
+/// counts `char`s) can be moved by the same amount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ListLine {
+  /// Leading whitespace, in `char`s. Hand-written nesting lives here, so
+  /// every rewrite goes *after* it and a continued item copies it.
+  indent: usize,
+  kind: ListPrefix,
+  /// Chars from the start of the line to the item text: `indent` plus the
+  /// marker. Measured rather than derived from `kind`, because a line can
+  /// end right after `]` with no trailing space.
+  width: usize,
+}
+
+impl ListLine {
+  /// Read the marker off `line`, or `None` when the line is prose.
+  ///
+  /// A marker needs its space: `-foo` is prose and `--flag` is a flag, and
+  /// silently treating either as an item would rewrite text the user meant
+  /// literally.
+  fn parse(line: &str) -> Option<Self> {
+    let body = line.trim_start();
+    let indent = line[..line.len() - body.len()].chars().count();
+    let rest = body.strip_prefix('-')?;
+    let (kind, marker) = if let Some(after) = rest.strip_prefix(" [") {
+      let mut chars = after.chars();
+      let kind = match chars.next()? {
+        ' ' => ListPrefix::Unchecked,
+        'x' | 'X' => ListPrefix::Checked,
+        _ => return None,
+      };
+      if chars.next() != Some(']') {
+        return None;
+      }
+      match chars.next() {
+        Some(' ') => (kind, 6),
+        None => (kind, 5),
+        _ => return None,
+      }
+    } else if rest.is_empty() {
+      (ListPrefix::Bullet, 1)
+    } else if rest.starts_with(' ') {
+      (ListPrefix::Bullet, 2)
+    } else {
+      return None;
+    };
+    Some(Self {
+      indent,
+      kind,
+      width: indent + marker,
+    })
+  }
+}
+
 /// Buffer, cursor and viewport for one note.
 ///
 /// `lines` is never empty: an empty note is `[""]`, one empty line, so the
@@ -116,13 +197,105 @@ impl NoteEditor {
     self.dirty = true;
   }
 
-  /// Split the current line at the cursor.
+  /// Split the current line at the cursor, continuing the list the line is
+  /// part of (issue #557).
+  ///
+  /// An item whose text is empty ends the list instead: that second `Enter`
+  /// after the last item is how every Markdown editor breaks out, and
+  /// without it the only way out of a list is to backspace the bullet the
+  /// editor just wrote.
   pub fn newline(&mut self) {
+    let list = ListLine::parse(&self.lines[self.cursor_line]);
+    if let Some(l) = list {
+      let line = &self.lines[self.cursor_line];
+      let text_at = Self::byte_at(line, l.width);
+      if line[text_at..].trim().is_empty() {
+        self.lines[self.cursor_line].clear();
+        self.cursor_col = 0;
+        self.dirty = true;
+        return;
+      }
+    }
+    let prefix = match list {
+      Some(l) => {
+        let indent: String = self.lines[self.cursor_line].chars().take(l.indent).collect();
+        format!("{indent}{}", l.kind.continued())
+      }
+      None => String::new(),
+    };
     let at = Self::byte_at(&self.lines[self.cursor_line], self.cursor_col);
     let tail = self.lines[self.cursor_line].split_off(at);
-    self.lines.insert(self.cursor_line + 1, tail);
+    self.cursor_col = prefix.chars().count();
+    self.lines.insert(self.cursor_line + 1, format!("{prefix}{tail}"));
     self.cursor_line += 1;
-    self.cursor_col = 0;
+    self.dirty = true;
+  }
+
+  // -------------------------------------------------------------------
+  // Lists (issue #557)
+  // -------------------------------------------------------------------
+
+  /// Make the current line a list item, or take the marker back off it.
+  ///
+  /// `- [ ] ` *is* a bullet, so turning a checkbox line off removes the
+  /// whole marker rather than leaving a widowed `[ ]`.
+  pub fn toggle_bullet(&mut self) {
+    match ListLine::parse(&self.lines[self.cursor_line]) {
+      Some(l) => self.rewrite_marker(l.indent, l.width, ""),
+      None => {
+        let indent = self.indent_of(self.cursor_line);
+        self.rewrite_marker(indent, indent, "- ");
+      }
+    }
+  }
+
+  /// Tick the box under the caret, from anywhere on the line, spawning one
+  /// first if the line does not have it yet. One chord covers writing the
+  /// item and ticking it, which is the gesture a checklist exists for.
+  pub fn toggle_checkbox(&mut self) {
+    match ListLine::parse(&self.lines[self.cursor_line]) {
+      Some(l) => {
+        // A bullet gains an empty box rather than a ticked one: the first
+        // press writes the item, the second one ticks it.
+        let marker = if l.kind == ListPrefix::Unchecked {
+          "- [x] "
+        } else {
+          "- [ ] "
+        };
+        self.rewrite_marker(l.indent, l.width, marker);
+      }
+      None => {
+        let indent = self.indent_of(self.cursor_line);
+        self.rewrite_marker(indent, indent, "- [ ] ");
+      }
+    }
+  }
+
+  /// Leading whitespace of `index`, in `char`s.
+  fn indent_of(&self, index: usize) -> usize {
+    let line = &self.lines[index];
+    line.chars().take_while(|c| c.is_whitespace()).count()
+  }
+
+  /// Replace the chars in `indent..old` on the cursor line with `marker`,
+  /// carrying the caret along so it stays on the character it was on.
+  ///
+  /// A same-width rewrite (ticking a box) leaves the caret exactly where it
+  /// is; a caret standing inside a marker that shrinks lands on the item
+  /// text, since the column it pointed at no longer exists.
+  fn rewrite_marker(&mut self, indent: usize, old: usize, marker: &str) {
+    let line = &mut self.lines[self.cursor_line];
+    let from = Self::byte_at(line, indent);
+    let to = Self::byte_at(line, old);
+    line.replace_range(from..to, marker);
+    let new = indent + marker.chars().count();
+    self.cursor_col = if new == old {
+      self.cursor_col
+    } else if self.cursor_col >= old {
+      self.cursor_col - old + new
+    } else {
+      new
+    };
     self.dirty = true;
   }
 

--- a/src/tui/state/note_editor.rs
+++ b/src/tui/state/note_editor.rs
@@ -107,6 +107,41 @@ impl ListLine {
   }
 }
 
+/// Which half of the vim split the buffer is in (issue #557).
+///
+/// Only reachable behind `[tui] note_vim = true`: with the knob off the
+/// editor is always [`Insert`](Self::Insert) and every printable is text,
+/// exactly as it shipped in #515.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NoteMode {
+  /// Keys are text. The caret may sit one past the last char, which is
+  /// where the next character goes.
+  #[default]
+  Insert,
+  /// Keys are verbs. The caret sits ON a character, which is what makes
+  /// `x` at the end of a line delete something.
+  Normal,
+}
+
+/// Character class for the word motions, in vim's terms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharClass {
+  Blank,
+  /// A keyword char, or any non-blank when the motion is a `W` / `B` / `E`.
+  Word,
+  Punct,
+}
+
+fn class_of(c: char, big: bool) -> CharClass {
+  if c.is_whitespace() {
+    CharClass::Blank
+  } else if big || c.is_alphanumeric() || c == '_' {
+    CharClass::Word
+  } else {
+    CharClass::Punct
+  }
+}
+
 /// Buffer, cursor and viewport for one note.
 ///
 /// `lines` is never empty: an empty note is `[""]`, one empty line, so the
@@ -136,6 +171,13 @@ pub struct NoteEditor {
   /// close is skipped when it does not, so opening a note to read it does
   /// not touch its mtime.
   pub dirty: bool,
+  /// Insert or normal (issue #557). Stays [`NoteMode::Insert`] for the
+  /// whole life of the editor unless `[tui] note_vim = true`.
+  pub mode: NoteMode,
+  /// First half of a two-key normal-mode sequence (`gg`, `dd`), waiting for
+  /// its second. Dropped whole when the next key is not the pair, the way
+  /// vim drops an unfinished command.
+  pub pending: Option<char>,
 }
 
 impl NoteEditor {
@@ -157,6 +199,8 @@ impl NoteEditor {
       scroll: 0,
       viewport: 10,
       dirty: false,
+      mode: NoteMode::Insert,
+      pending: None,
     }
   }
 
@@ -216,13 +260,7 @@ impl NoteEditor {
         return;
       }
     }
-    let prefix = match list {
-      Some(l) => {
-        let indent: String = self.lines[self.cursor_line].chars().take(l.indent).collect();
-        format!("{indent}{}", l.kind.continued())
-      }
-      None => String::new(),
-    };
+    let prefix = self.continuation_prefix(self.cursor_line);
     let at = Self::byte_at(&self.lines[self.cursor_line], self.cursor_col);
     let tail = self.lines[self.cursor_line].split_off(at);
     self.cursor_col = prefix.chars().count();
@@ -268,6 +306,20 @@ impl NoteEditor {
         let indent = self.indent_of(self.cursor_line);
         self.rewrite_marker(indent, indent, "- [ ] ");
       }
+    }
+  }
+
+  /// The marker a line opened under `index` is born with: its indentation
+  /// plus the continued list marker, or nothing when `index` is prose.
+  /// Shared by `Enter` and by `o` / `O`, so one rule answers "what goes on
+  /// a new line under this one" whichever key asked.
+  fn continuation_prefix(&self, index: usize) -> String {
+    match ListLine::parse(&self.lines[index]) {
+      Some(l) => {
+        let indent: String = self.lines[index].chars().take(l.indent).collect();
+        format!("{indent}{}", l.kind.continued())
+      }
+      None => String::new(),
     }
   }
 
@@ -389,6 +441,237 @@ impl NoteEditor {
     let last = self.lines.len().saturating_sub(1);
     self.cursor_line = (self.cursor_line + height.max(1)).min(last);
     self.cursor_col = self.cursor_col.min(self.line_len(self.cursor_line));
+  }
+
+  // -------------------------------------------------------------------
+  // Normal mode (issue #557)
+  // -------------------------------------------------------------------
+
+  /// Leave insert mode. Pulls the caret back onto a character, because
+  /// normal mode sits on one rather than after it.
+  pub fn enter_normal(&mut self) {
+    self.mode = NoteMode::Normal;
+    self.pending = None;
+    self.clamp_normal();
+  }
+
+  /// Keep the caret on a character. Insert mode is allowed one past the
+  /// last one (that is where typing goes); normal mode is not, or `x` at
+  /// the end of a line would have nothing under it.
+  fn clamp_normal(&mut self) {
+    let last = self.line_len(self.cursor_line).saturating_sub(1);
+    self.cursor_col = self.cursor_col.min(last);
+  }
+
+  /// Route one printable while the buffer is in normal mode.
+  ///
+  /// The verbs are hard-coded rather than bindable, for the reason the
+  /// arrows are: a printable bound to a note verb is refused at load time
+  /// precisely so typing that letter keeps working, and normal mode does
+  /// not change what `[tui.keys.modal.note]` may hold.
+  ///
+  /// No counts (`3j`), no registers, and therefore no `p` or undo: this is
+  /// a scratch buffer three lines long, and `Ctrl+e` hands the file to the
+  /// real vim for anything that wants the rest.
+  pub fn normal_key(&mut self, c: char) {
+    if let Some(first) = self.pending.take() {
+      match (first, c) {
+        ('g', 'g') => {
+          self.cursor_line = 0;
+          self.clamp_normal();
+        }
+        ('d', 'd') => self.delete_line(),
+        // Anything else drops the whole sequence, the way vim drops an
+        // unfinished command rather than running its second half.
+        _ => {}
+      }
+      return;
+    }
+
+    match c {
+      'h' => self.cursor_col = self.cursor_col.saturating_sub(1),
+      'l' => {
+        let last = self.line_len(self.cursor_line).saturating_sub(1);
+        self.cursor_col = (self.cursor_col + 1).min(last);
+      }
+      'j' => self.down(),
+      'k' => self.up(),
+      '0' => self.cursor_col = 0,
+      '^' => self.cursor_col = self.indent_of(self.cursor_line),
+      '$' => self.end(),
+      'w' => self.word_forward(false),
+      'W' => self.word_forward(true),
+      'b' => self.word_backward(false),
+      'B' => self.word_backward(true),
+      'e' => self.word_end(false),
+      'E' => self.word_end(true),
+      'G' => self.cursor_line = self.lines.len() - 1,
+      'g' | 'd' => self.pending = Some(c),
+      'x' => self.delete_under(),
+      'i' => self.mode = NoteMode::Insert,
+      'I' => {
+        self.cursor_col = self.indent_of(self.cursor_line);
+        self.mode = NoteMode::Insert;
+      }
+      'a' => {
+        self.cursor_col = (self.cursor_col + 1).min(self.line_len(self.cursor_line));
+        self.mode = NoteMode::Insert;
+      }
+      'A' => {
+        self.end();
+        self.mode = NoteMode::Insert;
+      }
+      'o' => self.open_line(self.cursor_line + 1),
+      'O' => self.open_line(self.cursor_line),
+      _ => {}
+    }
+
+    // Insert mode is allowed past the end of the line, so `a` and `A` must
+    // not be clamped back onto the last char they just moved past.
+    if self.mode == NoteMode::Normal {
+      self.clamp_normal();
+    }
+  }
+
+  /// Delete the char under the caret. Unlike `Delete`, it never pulls the
+  /// next line up: at the end of a line there is nothing under the caret.
+  fn delete_under(&mut self) {
+    if self.cursor_col < self.line_len(self.cursor_line) {
+      let at = Self::byte_at(&self.lines[self.cursor_line], self.cursor_col);
+      self.lines[self.cursor_line].remove(at);
+      self.dirty = true;
+    }
+  }
+
+  /// `dd`. The buffer bottoms out at one empty line, the invariant every
+  /// other method indexes on.
+  fn delete_line(&mut self) {
+    if self.lines.len() == 1 {
+      if !self.lines[0].is_empty() {
+        self.lines[0].clear();
+        self.dirty = true;
+      }
+    } else {
+      self.lines.remove(self.cursor_line);
+      self.cursor_line = self.cursor_line.min(self.lines.len() - 1);
+      self.dirty = true;
+    }
+    self.cursor_col = 0;
+  }
+
+  /// `o` / `O`: insert a line at `index` and start typing on it, carrying
+  /// the list marker the way `Enter` does.
+  fn open_line(&mut self, index: usize) {
+    let prefix = self.continuation_prefix(self.cursor_line);
+    self.cursor_col = prefix.chars().count();
+    self.lines.insert(index, prefix);
+    self.cursor_line = index;
+    self.mode = NoteMode::Insert;
+    self.dirty = true;
+  }
+
+  /// `w` / `W`: the start of the next word, crossing lines. On the last
+  /// word of the buffer it parks on its last char rather than running off
+  /// the end.
+  fn word_forward(&mut self, big: bool) {
+    let mut line = self.cursor_line;
+    let mut col = self.cursor_col;
+    let mut chars: Vec<char> = self.lines[line].chars().collect();
+    if col < chars.len() {
+      let from = class_of(chars[col], big);
+      while from != CharClass::Blank && col < chars.len() && class_of(chars[col], big) == from {
+        col += 1;
+      }
+    }
+    loop {
+      if col >= chars.len() {
+        if line + 1 >= self.lines.len() {
+          self.cursor_line = line;
+          self.cursor_col = chars.len().saturating_sub(1);
+          return;
+        }
+        line += 1;
+        chars = self.lines[line].chars().collect();
+        col = 0;
+        // An empty line is a word of its own, which is how `w` walks
+        // through the blank lines between two paragraphs.
+        if chars.is_empty() {
+          break;
+        }
+        continue;
+      }
+      if class_of(chars[col], big) == CharClass::Blank {
+        col += 1;
+      } else {
+        break;
+      }
+    }
+    self.cursor_line = line;
+    self.cursor_col = col;
+  }
+
+  /// `b` / `B`: the start of the word before the caret, crossing lines.
+  fn word_backward(&mut self, big: bool) {
+    let mut line = self.cursor_line;
+    let mut col = self.cursor_col;
+    let mut chars: Vec<char> = self.lines[line].chars().collect();
+    loop {
+      if col == 0 {
+        if line == 0 {
+          self.cursor_line = 0;
+          self.cursor_col = 0;
+          return;
+        }
+        line -= 1;
+        chars = self.lines[line].chars().collect();
+        col = chars.len();
+        if chars.is_empty() {
+          self.cursor_line = line;
+          self.cursor_col = 0;
+          return;
+        }
+        continue;
+      }
+      col -= 1;
+      if class_of(chars[col], big) != CharClass::Blank {
+        break;
+      }
+    }
+    let from = class_of(chars[col], big);
+    while col > 0 && class_of(chars[col - 1], big) == from {
+      col -= 1;
+    }
+    self.cursor_line = line;
+    self.cursor_col = col;
+  }
+
+  /// `e` / `E`: the last char of the word the caret is heading into.
+  fn word_end(&mut self, big: bool) {
+    let mut line = self.cursor_line;
+    let mut col = self.cursor_col;
+    let mut chars: Vec<char> = self.lines[line].chars().collect();
+    loop {
+      col += 1;
+      if col >= chars.len() {
+        if line + 1 >= self.lines.len() {
+          self.cursor_line = line;
+          self.cursor_col = chars.len().saturating_sub(1);
+          return;
+        }
+        line += 1;
+        chars = self.lines[line].chars().collect();
+        col = 0;
+      }
+      if col < chars.len() && class_of(chars[col], big) != CharClass::Blank {
+        break;
+      }
+    }
+    let from = class_of(chars[col], big);
+    while col + 1 < chars.len() && class_of(chars[col + 1], big) == from {
+      col += 1;
+    }
+    self.cursor_line = line;
+    self.cursor_col = col;
   }
 
   /// Pull `scroll` just far enough that the cursor is inside a `height`-row

--- a/src/tui/state/note_editor.rs
+++ b/src/tui/state/note_editor.rs
@@ -458,7 +458,13 @@ impl NoteEditor {
   /// Keep the caret on a character. Insert mode is allowed one past the
   /// last one (that is where typing goes); normal mode is not, or `x` at
   /// the end of a line would have nothing under it.
-  fn clamp_normal(&mut self) {
+  ///
+  /// Public because the invariant is broken from outside as well: the
+  /// arrows, `Home` / `End` and the page keys are insert-mode movement
+  /// shared with normal mode, and a list toggle parks the caret where the
+  /// item text goes. Whoever moves the caret restores it (Codex review
+  /// #582, first pass).
+  pub fn clamp_normal(&mut self) {
     let last = self.line_len(self.cursor_line).saturating_sub(1);
     self.cursor_col = self.cursor_col.min(last);
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3938,7 +3938,21 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
         "tick the box on the line, spawning one first",
       ),
       modal_entry(ModalAction::NoteOpenEditor, "open the same file in $EDITOR"),
-      modal_entry(ModalAction::NoteClose, "save and close (empty the note to delete it)"),
+      modal_entry(
+        ModalAction::NoteClose,
+        "leave insert, then save and close (empty it to delete)",
+      ),
+      // #557: the normal-mode verbs are hard-coded, so they are `fixed`
+      // rows. They belong here rather than only in the modal's own bar
+      // because `?` is a printable inside the editor: this overlay is the
+      // one place they can be read at leisure. `[tui] note_vim = false`
+      // turns the mode off, and then these six rows do not apply.
+      fixed("h j k l", "normal mode: move"),
+      fixed("w b e", "word forward / back / end (W B E: blank-separated)"),
+      fixed("0 ^ $", "first column / first non-blank / last char"),
+      fixed("gg G", "first / last line"),
+      fixed("x dd", "delete the char under the caret / the line"),
+      fixed("i I a A o O", "enter insert (o / O open a line, carrying the marker)"),
       HelpRow::Blank,
       HelpRow::Section("Bootstrap Report".to_string()),
       HelpRow::Blank,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3273,6 +3273,54 @@ pub fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKe
   modal_hint_for_context_with_fields(ctx, keymap, modal, theme, &CANONICAL_TRIPLE)
 }
 
+/// As [`modal_hint_for_context`], bounded to `width` cells: whole hint
+/// groups are dropped from the end and a `…` marks that they were (issue
+/// #557).
+///
+/// `modal_hint_line` renders the list whatever it measures, and a
+/// `Paragraph` clips the overflow at the rect edge — which reads as a
+/// complete list that happens to end at `Ctrl+u bullet`. The statusbar has
+/// always truncated visibly; the note editor's mode line is the first modal
+/// footer long enough to need the same, because it spells out a whole
+/// keymap rather than two or three verbs.
+pub fn modal_hint_for_context_within(
+  ctx: HintContext,
+  keymap: &Keymap,
+  modal: &ModalKeymap,
+  theme: &Theme,
+  width: usize,
+) -> Line<'static> {
+  let resolved = ctx.resolve(keymap, modal);
+  let group_w = |key: &str, label: &str| cells(key) + 1 + cells(label);
+  let full: usize = resolved
+    .iter()
+    .enumerate()
+    .map(|(i, (k, l))| if i > 0 { 2 } else { 0 } + group_w(k, l))
+    .sum();
+  // Measured whole first: a list that fits must not lose its last group to
+  // the space held for a marker nothing needs. `Esc normal mode` is exactly
+  // that group at 100 columns, and it is the one telling the user how to
+  // leave the mode.
+  if full <= width {
+    let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+    return modal_hint_line(&hints, theme);
+  }
+  let mut kept: Vec<(&str, &str)> = Vec::new();
+  let mut used = 0usize;
+  for (key, label) in &resolved {
+    let sep = if kept.is_empty() { 0 } else { 2 };
+    // The ` …` costs two cells, and past this branch it is certain.
+    if used + sep + group_w(key, label) > width.saturating_sub(2) {
+      break;
+    }
+    used += sep + group_w(key, label);
+    kept.push((key.as_str(), label.as_str()));
+  }
+  let mut line = modal_hint_line(&kept, theme);
+  line.spans.push(Span::styled(" …", hint_label_style(theme)));
+  line
+}
+
 /// As [`modal_hint_for_context`], for the two footers whose form knows which
 /// fields it presents (issue #418). Every other modal keeps the plain call.
 pub fn modal_hint_for_context_with_fields(
@@ -5677,6 +5725,31 @@ fn draw_note_editor(f: &mut Frame, app: &mut App) {
   let block = overlay_block_titled(&title, app.theme.accent);
   let inner = block.inner(area);
   f.render_widget(block, area);
+
+  // #557: the modal carries its own mode line on its last row. The
+  // statusbar already says the same thing through the same
+  // `HintContext` (#418, so the two cannot disagree), but it sits at the
+  // bottom of the terminal — on a tall screen that is thirty rows away
+  // from the box the keys are being pressed in.
+  //
+  // Resolved before the buffer is borrowed mutably, the way the title is.
+  let hint = modal_hint_for_context_within(
+    app.hint_context(),
+    &app.keymap,
+    &app.modal_keymap,
+    &app.theme,
+    inner.width as usize,
+  );
+  let rows = Layout::default()
+    .direction(Direction::Vertical)
+    // `Min(1)`, not `Min(0)`: the text pane is what the modal is for, and
+    // at the two-row inner height where they compete the buffer wins the
+    // row. The mode line then renders into a zero-height rect, which
+    // ratatui draws as nothing rather than as a panic.
+    .constraints([Constraint::Min(1), Constraint::Length(1)])
+    .split(inner);
+  let (inner, hint_row) = (rows[0], rows[1]);
+  f.render_widget(Paragraph::new(hint), hint_row);
 
   let Some(editor) = app.note_editor.as_mut() else {
     return;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5594,7 +5594,21 @@ fn draw_note_editor(f: &mut Frame, app: &mut App) {
   f.render_widget(Clear, area);
 
   let title = match app.note_editor.as_ref() {
-    Some(editor) => format!("note · {}", crate::naming::sanitise_for_terminal(&editor.branch)),
+    Some(editor) => {
+      let branch = crate::naming::sanitise_for_terminal(&editor.branch);
+      // #557: the mode chip only exists behind `note_vim`. A mode the user
+      // cannot see is a mode they type verbs into by accident, and a chip
+      // for a mode that can never change is chrome nobody asked for.
+      if app.config.tui.note_vim {
+        let mode = match editor.mode {
+          crate::tui::state::note_editor::NoteMode::Normal => "NORMAL",
+          crate::tui::state::note_editor::NoteMode::Insert => "INSERT",
+        };
+        format!("note · {branch} · {mode}")
+      } else {
+        format!("note · {branch}")
+      }
+    }
     None => "note".to_string(),
   };
   // Already rode the top rule before #549; routed through the shared

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4007,21 +4007,28 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
         "tick the box on the line, spawning one first",
       ),
       modal_entry(ModalAction::NoteOpenEditor, "open the same file in $EDITOR"),
-      modal_entry(
-        ModalAction::NoteClose,
-        "leave insert, then save and close (empty it to delete)",
-      ),
+      modal_entry(ModalAction::NoteClose, "save and close (empty it to delete)"),
+      HelpRow::Blank,
       // #557: the normal-mode verbs are hard-coded, so they are `fixed`
       // rows. They belong here rather than only in the modal's own bar
       // because `?` is a printable inside the editor: this overlay is the
-      // one place they can be read at leisure. `[tui] note_vim = false`
-      // turns the mode off, and then these six rows do not apply.
-      fixed("h j k l", "normal mode: move"),
+      // one place they can be read at leisure.
+      //
+      // Their own section, and the heading names the knob: `help_rows` has
+      // no config to read, and `note_vim = false` is a supported config
+      // where none of these letters is a verb — under a heading that says
+      // so, the rows stay true for both. Same reason the close row above
+      // stops at "save and close": with the mode on, the press that leaves
+      // insert is documented here instead (Codex review #582, second pass).
+      HelpRow::Section("Note Editor · normal mode ([tui] note_vim, on by default)".to_string()),
+      HelpRow::Blank,
+      fixed("h j k l", "move"),
       fixed("w b e", "word forward / back / end (W B E: blank-separated)"),
       fixed("0 ^ $", "first column / first non-blank / last char"),
       fixed("gg G", "first / last line"),
       fixed("x dd", "delete the char under the caret / the line"),
       fixed("i I a A o O", "enter insert (o / O open a line, carrying the marker)"),
+      fixed("Esc", "insert to normal; from normal, save and close"),
       HelpRow::Blank,
       HelpRow::Section("Bootstrap Report".to_string()),
       HelpRow::Blank,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3289,9 +3289,15 @@ pub fn modal_hint_for_context_within(
   modal: &ModalKeymap,
   theme: &Theme,
   width: usize,
+  lead: Option<(&str, Color)>,
 ) -> Line<'static> {
   let resolved = ctx.resolve(keymap, modal);
   let group_w = |key: &str, label: &str| cells(key) + 1 + cells(label);
+  // The leading badge is state, not a verb: it takes the reverse-video
+  // treatment the statusbar's context anchor has always had, so the mode
+  // reads as a block of colour from across the screen rather than as one
+  // more word in a list of keys.
+  let lead_w = lead.map_or(0, |(text, _)| cells(text) + 2);
   let full: usize = resolved
     .iter()
     .enumerate()
@@ -3301,16 +3307,17 @@ pub fn modal_hint_for_context_within(
   // the space held for a marker nothing needs. `Esc normal mode` is exactly
   // that group at 100 columns, and it is the one telling the user how to
   // leave the mode.
-  if full <= width {
+  if full + lead_w <= width {
     let hints: Vec<(&str, &str)> = resolved.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
-    return modal_hint_line(&hints, theme);
+    return with_lead(modal_hint_line(&hints, theme), lead);
   }
+  let budget = width.saturating_sub(lead_w);
   let mut kept: Vec<(&str, &str)> = Vec::new();
   let mut used = 0usize;
   for (key, label) in &resolved {
     let sep = if kept.is_empty() { 0 } else { 2 };
     // The ` …` costs two cells, and past this branch it is certain.
-    if used + sep + group_w(key, label) > width.saturating_sub(2) {
+    if used + sep + group_w(key, label) > budget.saturating_sub(2) {
       break;
     }
     used += sep + group_w(key, label);
@@ -3318,6 +3325,20 @@ pub fn modal_hint_for_context_within(
   }
   let mut line = modal_hint_line(&kept, theme);
   line.spans.push(Span::styled(" …", hint_label_style(theme)));
+  with_lead(line, lead)
+}
+
+/// Put `lead` at the head of a hint line as a reverse-video chip. The line
+/// stays centred as a whole, badge included: splitting the row into a
+/// left-pinned badge and centred hints would need two rects, and a modal
+/// footer that is one `Paragraph` is what every other modal already draws.
+fn with_lead(mut line: Line<'static>, lead: Option<(&str, Color)>) -> Line<'static> {
+  let Some((text, color)) = lead else {
+    return line;
+  };
+  let mut spans = vec![Span::styled(text.to_string(), chip_style(color)), Span::raw("  ")];
+  spans.append(&mut line.spans);
+  line.spans = spans;
   line
 }
 
@@ -5733,12 +5754,26 @@ fn draw_note_editor(f: &mut Frame, app: &mut App) {
   // from the box the keys are being pressed in.
   //
   // Resolved before the buffer is borrowed mutably, the way the title is.
+  // #557: the mode reads as a badge, the way vim's own statusline does.
+  // `focus` is the anchor colour the statusbar context chip wears, and
+  // `clean` is the theme's green, so insert stands apart at a glance
+  // without inventing a role. With the mode off there is no badge, because
+  // there is no state to be in.
+  let mode_chip = app
+    .note_editor
+    .as_ref()
+    .filter(|_| app.config.tui.note_vim)
+    .map(|editor| match editor.mode {
+      crate::tui::state::note_editor::NoteMode::Normal => (" NORMAL ", app.theme.focus),
+      crate::tui::state::note_editor::NoteMode::Insert => (" INSERT ", app.theme.clean),
+    });
   let hint = modal_hint_for_context_within(
     app.hint_context(),
     &app.keymap,
     &app.modal_keymap,
     &app.theme,
     inner.width as usize,
+    mode_chip,
   );
   let rows = Layout::default()
     .direction(Direction::Vertical)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2922,10 +2922,15 @@ impl HintContext {
         Hint::Modal(ModalAction::RichViewRefresh, "refresh"),
         Hint::Modal(ModalAction::RichViewClose, "close"),
       ],
-      // #515: no verbs beyond the exits — j/k are letters here, and the
-      // arrows are hard-coded for the same reason `Esc` is elsewhere.
+      // #515: no verbs beyond the exits and the #557 list chords — j/k are
+      // letters here, and the arrows are hard-coded for the same reason
+      // `Esc` is elsewhere. This bar is the only discovery surface the
+      // editor has: `?` is a printable, so the help overlay cannot be
+      // opened from inside it.
       HintContext::Note => &[
         Hint::Lit("↑/↓/←/→", "move"),
+        Hint::Modal(ModalAction::NoteToggleBullet, "bullet"),
+        Hint::Modal(ModalAction::NoteToggleCheckbox, "tick"),
         Hint::Modal(ModalAction::NoteOpenEditor, "$EDITOR"),
         Hint::Modal(ModalAction::NoteClose, "save & close"),
       ],
@@ -3883,6 +3888,14 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       fixed("Left/Right/Up/Down", "move the cursor"),
       fixed("Home/End", "start / end of line"),
       fixed("PgUp/PgDn", "page through the note"),
+      modal_entry(
+        ModalAction::NoteToggleBullet,
+        "make the line a list item, or plain again",
+      ),
+      modal_entry(
+        ModalAction::NoteToggleCheckbox,
+        "tick the box on the line, spawning one first",
+      ),
       modal_entry(ModalAction::NoteOpenEditor, "open the same file in $EDITOR"),
       modal_entry(ModalAction::NoteClose, "save and close (empty the note to delete it)"),
       HelpRow::Blank,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -5599,6 +5599,12 @@ fn draw_note_editor(f: &mut Frame, app: &mut App) {
       // #557: the mode chip only exists behind `note_vim`. A mode the user
       // cannot see is a mode they type verbs into by accident, and a chip
       // for a mode that can never change is chrome nobody asked for.
+      //
+      // It sits AFTER the branch because a centred title that overflows is
+      // clipped from the LEFT (measured, not assumed: the guard in
+      // `tui_modal_render_tests` fails with the two halves the other way
+      // round). The chip is the half worth keeping, so it goes where the
+      // clip does not reach.
       if app.config.tui.note_vim {
         let mode = match editor.mode {
           crate::tui::state::note_editor::NoteMode::Normal => "NORMAL",

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2734,9 +2734,19 @@ pub enum HintContext {
   /// PR's or issue's description, reviews and conversation — j/k select,
   /// Enter opens the row's URL, f re-fetches, Esc closes.
   RichView,
-  /// The in-TUI note editor (issue #515): every printable is text, so the
-  /// only verbs advertised are the two ways out.
+  /// The in-TUI note editor with `[tui] note_vim = false` (issue #515):
+  /// every printable is text, so the only verbs advertised are the two
+  /// ways out and the two list chords.
   Note,
+  /// The note editor in normal mode (issue #557). A separate context
+  /// because the two modes take different keys entirely: the letters are
+  /// verbs here and text next door, so one static hint list would lie in
+  /// whichever mode it was not written for.
+  NoteNormal,
+  /// The note editor in insert mode, with the mode enabled (issue #557).
+  /// Same keys as [`HintContext::Note`] except the one that matters:
+  /// `Esc` leaves the mode rather than writing and closing.
+  NoteInsert,
 }
 
 impl HintContext {
@@ -2763,6 +2773,11 @@ impl HintContext {
       HintContext::CiChecks => "checks",
       HintContext::RichView => "pr/issue",
       HintContext::Note => "note",
+      // #557: the mode belongs in the context slot, not in a hint — it is
+      // state, not a key. The title carries the same chip; this is the
+      // half the eye is already on when it reads the verbs.
+      HintContext::NoteNormal => "note · NORMAL",
+      HintContext::NoteInsert => "note · INSERT",
     }
   }
 
@@ -2934,6 +2949,32 @@ impl HintContext {
         Hint::Modal(ModalAction::NoteOpenEditor, "$EDITOR"),
         Hint::Modal(ModalAction::NoteClose, "save & close"),
       ],
+      // #557: the motions are literals because they are hard-coded verbs,
+      // not modal bindings — the same reason the arrows are literals above.
+      // They lead: in normal mode the letters are the surface, and the bar
+      // is the only place the editor can say so (`?` is a printable here,
+      // so the help overlay cannot be opened from inside the modal).
+      HintContext::NoteNormal => &[
+        Hint::Lit("hjkl", "move"),
+        Hint::Lit("w/b/e", "word"),
+        Hint::Lit("gg/G", "doc"),
+        Hint::Lit("i/a/o", "insert"),
+        Hint::Lit("x/dd", "delete"),
+        Hint::Modal(ModalAction::NoteToggleBullet, "bullet"),
+        Hint::Modal(ModalAction::NoteToggleCheckbox, "tick"),
+        Hint::Modal(ModalAction::NoteOpenEditor, "$EDITOR"),
+        Hint::Modal(ModalAction::NoteClose, "save & close"),
+      ],
+      // The one verb whose meaning the mode changes: `Esc` leaves insert
+      // instead of writing and closing, so the bar must not promise the
+      // gesture it promises everywhere else.
+      HintContext::NoteInsert => &[
+        Hint::Lit("↑/↓/←/→", "move"),
+        Hint::Modal(ModalAction::NoteToggleBullet, "bullet"),
+        Hint::Modal(ModalAction::NoteToggleCheckbox, "tick"),
+        Hint::Modal(ModalAction::NoteOpenEditor, "$EDITOR"),
+        Hint::Modal(ModalAction::NoteClose, "normal mode"),
+      ],
       HintContext::Help => &[
         Hint::Lit("j/k", "scroll"),
         Hint::Lit("h/l", "pan"),
@@ -3056,7 +3097,7 @@ impl HintContext {
       HintContext::Detail => KeyContext::Detail,
       HintContext::CiChecks => KeyContext::CiChecks,
       HintContext::RichView => KeyContext::RichView,
-      HintContext::Note => KeyContext::Note,
+      HintContext::Note | HintContext::NoteNormal | HintContext::NoteInsert => KeyContext::Note,
       HintContext::ExecPicker => KeyContext::ExecPicker,
       HintContext::Clean => KeyContext::Clean,
       HintContext::Worktrees | HintContext::Status | HintContext::Picker | HintContext::Pty => return None,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2985,17 +2985,17 @@ fn handed_repo_bytes_go_through_the_same_validators() {
 }
 
 #[test]
-fn tui_note_vim_is_off_unless_asked_for() {
-  // #557: the knob turns the note editor's normal mode on. Off is the
-  // shipped #515 editor, where `Esc` writes and closes on the first press
-  // and every printable is text — a default that flipped would change a
-  // surface under the fingers of everyone already writing notes.
+fn tui_note_vim_is_on_unless_turned_off() {
+  // #557: the mode ships on. A `#[serde(default)]` on a bool yields
+  // `false`, so the serde default has to be spelled out — miss it and
+  // every config that does not name the key silently gets the modeless
+  // editor while `Config::default()` says otherwise.
   let dir = TempDir::new().unwrap();
   std::fs::write(dir.path().join(CONFIG_FILE), "[worktree]\nbase = \"~/wt\"\n").unwrap();
   let cfg = Config::load_layered(dir.path(), None).unwrap();
-  assert!(!cfg.tui.note_vim, "note_vim must default to false");
+  assert!(cfg.tui.note_vim, "note_vim must default to true");
   assert!(
-    !Config::default().tui.note_vim,
+    Config::default().tui.note_vim,
     "`Config::default()` must agree with the serde default"
   );
 }
@@ -3007,10 +3007,10 @@ fn tui_note_vim_round_trips_through_toml() {
     dir.path().join(CONFIG_FILE),
     r#"
 [tui]
-note_vim = true
+note_vim = false
 "#,
   )
   .unwrap();
   let cfg = Config::load_layered(dir.path(), None).unwrap();
-  assert!(cfg.tui.note_vim);
+  assert!(!cfg.tui.note_vim, "the opt-out is the value worth round-tripping now");
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2983,3 +2983,34 @@ fn handed_repo_bytes_go_through_the_same_validators() {
     "the semantic validator has to run on handed bytes too, got: {err}"
   );
 }
+
+#[test]
+fn tui_note_vim_is_off_unless_asked_for() {
+  // #557: the knob turns the note editor's normal mode on. Off is the
+  // shipped #515 editor, where `Esc` writes and closes on the first press
+  // and every printable is text — a default that flipped would change a
+  // surface under the fingers of everyone already writing notes.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[worktree]\nbase = \"~/wt\"\n").unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert!(!cfg.tui.note_vim, "note_vim must default to false");
+  assert!(
+    !Config::default().tui.note_vim,
+    "`Config::default()` must agree with the serde default"
+  );
+}
+
+#[test]
+fn tui_note_vim_round_trips_through_toml() {
+  let dir = TempDir::new().unwrap();
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    r#"
+[tui]
+note_vim = true
+"#,
+  )
+  .unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert!(cfg.tui.note_vim);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -13517,3 +13517,57 @@ fn every_panel_choice_survives_the_write_it_triggers() {
     }
   }
 }
+
+// ---- lists in the note editor (#557) -------------------------------------
+
+#[test]
+fn the_checkbox_chord_spawns_a_box_then_ticks_it() {
+  // Ctrl-modified on purpose: the note editor reserves every unmodified
+  // printable for the buffer, so a bare letter here would be swallowed
+  // mid-sentence.
+  let (_dir, mut app) = app_with_note_open();
+  for c in "ship it".chars() {
+    app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+  }
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- [ ] ship it"]);
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- [x] ship it"]);
+}
+
+#[test]
+fn the_bullet_chord_marks_the_line_as_an_item() {
+  let (_dir, mut app) = app_with_note_open();
+  for c in "one".chars() {
+    app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+  }
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL));
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- one"]);
+
+  // And Enter continues what the chord started, without a second chord.
+  app.handle_note_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+  for c in "two".chars() {
+    app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+  }
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- one", "- two"]);
+}
+
+#[test]
+fn a_ticked_box_survives_the_round_trip_to_disk() {
+  // The end of the gesture: tick, leave, and the file reads as a checklist
+  // in an editor that never saw gwm.
+  let (_dir, mut app) = app_with_note_open();
+  for c in "check the CI".chars() {
+    app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+  }
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+  let path = app.note_editor.as_ref().unwrap().path.clone();
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+  assert_eq!(std::fs::read_to_string(&path).unwrap(), "- [x] check the CI\n");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -13697,3 +13697,97 @@ fn the_mode_survives_a_trip_through_the_real_editor() {
   assert_eq!(editor.lines, vec!["written outside", ""]);
   assert_eq!(editor.mode, NoteMode::Normal, "still in normal mode");
 }
+
+#[test]
+fn a_shifted_letter_reaches_normal_mode_as_its_uppercase_verb() {
+  // Terminals disagree on how they report a shifted letter: legacy sends
+  // `Char('G')` bare, many modern ones `Char('G')` + SHIFT, the kitty
+  // protocol the base key `Char('g')` + SHIFT. `KeyStroke::new` folds all
+  // three to `Char('G')` (PR #192) — routing `key.code` instead would turn
+  // `G` into `g` and take every uppercase verb (`G W B E I A O`) with it.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["one".into(), "two".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::SHIFT));
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.cursor_line, 1, "`Shift+g` is `G`, the last-line verb");
+  assert!(editor.pending.is_none(), "and not a half-typed `gg`");
+}
+
+#[test]
+fn the_arrows_keep_the_caret_on_a_character_in_normal_mode() {
+  // The arrows are insert-mode movement: `End` parks one past the last
+  // char, which is where typing goes. In normal mode that position has no
+  // character under it, so `x` would delete nothing and `i` would insert
+  // past the end of the line.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["abc".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  app.handle_note_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+  assert_eq!(app.note_editor.as_ref().unwrap().cursor_col, 2, "on `c`, not past it");
+
+  note_key(&mut app, 'x');
+  assert_eq!(
+    app.note_editor.as_ref().unwrap().lines,
+    vec!["ab"],
+    "so `x` has something to delete"
+  );
+}
+
+#[test]
+fn a_list_chord_leaves_the_caret_on_a_character_in_normal_mode() {
+  // `Ctrl+t` on an empty line writes `- [ ] ` and parks the caret where the
+  // item text goes, which is past the end. Same invariant, same fix.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec![String::new()];
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.lines, vec!["- [ ] "]);
+  assert_eq!(editor.cursor_col, 5, "the caret sits on the last char, not after it");
+}
+
+#[test]
+fn a_key_that_is_not_the_pair_abandons_a_half_typed_sequence() {
+  // `d` then an arrow then `d`: the second `d` must open a fresh sequence,
+  // not complete the first one on the line the arrow landed on. There is no
+  // undo here, so a `dd` the user did not type is prose gone for good.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["one".into(), "two".into(), "three".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  note_key(&mut app, 'd');
+  app.handle_note_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+  note_key(&mut app, 'd');
+
+  assert_eq!(
+    app.note_editor.as_ref().unwrap().lines,
+    vec!["one", "two", "three"],
+    "the arrow dropped the pending `d`"
+  );
+}
+
+#[test]
+fn a_chord_also_abandons_a_half_typed_sequence() {
+  // Same contract for the Ctrl-modified verbs, which route past
+  // `normal_key` entirely.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["one".into(), "two".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  note_key(&mut app, 'd');
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL));
+  note_key(&mut app, 'd');
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.lines, vec!["- one", "two"], "the bullet landed, the line stayed");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -13571,3 +13571,129 @@ fn a_ticked_box_survives_the_round_trip_to_disk() {
 
   assert_eq!(std::fs::read_to_string(&path).unwrap(), "- [x] check the CI\n");
 }
+
+// ---- the note editor's normal mode (#557) --------------------------------
+
+use gwm::tui::state::note_editor::NoteMode;
+
+/// Open the note editor with `[tui] note_vim = true`, which is the only way
+/// normal mode is reachable at all.
+fn app_with_vim_note_open() -> (tempfile::TempDir, App) {
+  let (dir, mut app) = make_app();
+  app.config.tui.note_vim = true;
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+  (dir, app)
+}
+
+fn note_key(app: &mut App, c: char) {
+  app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+}
+
+#[test]
+fn the_knob_opens_the_note_in_normal_mode() {
+  let (_dir, app) = app_with_vim_note_open();
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Normal);
+}
+
+#[test]
+fn with_the_knob_on_the_motion_keys_are_verbs_not_letters() {
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["one".into(), "two".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  note_key(&mut app, 'j');
+  note_key(&mut app, 'l');
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.lines, vec!["one", "two"], "nothing was typed");
+  assert_eq!((editor.cursor_line, editor.cursor_col), (1, 1));
+}
+
+#[test]
+fn with_the_knob_off_the_same_keys_are_still_letters() {
+  // The #515 editor, untouched: this is what the knob defends.
+  let (_dir, mut app) = app_with_note_open();
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Insert);
+  for c in "jkl".chars() {
+    note_key(&mut app, c);
+  }
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["jkl"]);
+}
+
+#[test]
+fn i_opens_insert_mode_and_the_next_keys_are_text_again() {
+  let (_dir, mut app) = app_with_vim_note_open();
+  note_key(&mut app, 'i');
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Insert);
+  for c in "done".chars() {
+    note_key(&mut app, c);
+  }
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["done"]);
+  assert_eq!(app.view, View::Note, "and no global verb fired on the `d`");
+}
+
+#[test]
+fn esc_leaves_insert_mode_before_it_leaves_the_note() {
+  // The whole reason the knob exists: with a mode, the first `Esc` is the
+  // one that leaves insert, so closing takes two.
+  let (_dir, mut app) = app_with_vim_note_open();
+  note_key(&mut app, 'i');
+  for c in "kept".chars() {
+    note_key(&mut app, c);
+  }
+  let path = app.note_editor.as_ref().unwrap().path.clone();
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+  assert_eq!(app.view, View::Note, "the first Esc only left insert mode");
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Normal);
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+  assert_eq!(app.view, View::List, "the second one closed it");
+  assert_eq!(std::fs::read_to_string(&path).unwrap(), "kept\n");
+}
+
+#[test]
+fn enter_and_backspace_are_motions_in_normal_mode() {
+  // They are text keys in insert mode, so in normal mode they must not
+  // edit: a Backspace that eats a character there is prose lost to a key
+  // the user pressed to move.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["one".into(), "two".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 2;
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+  app.handle_note_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.lines, vec!["one", "two"], "the buffer is untouched");
+  assert_eq!((editor.cursor_line, editor.cursor_col), (1, 1));
+}
+
+#[test]
+fn the_list_chords_still_work_from_normal_mode() {
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["ship it".into()];
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL));
+
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- [ ] ship it"]);
+}
+
+#[test]
+fn the_mode_survives_a_trip_through_the_real_editor() {
+  // `Ctrl+e` re-reads the file into a fresh buffer; landing back in insert
+  // mode would leave the user typing verbs into their note.
+  let (_dir, mut app) = app_with_vim_note_open();
+  let path = app.note_editor.as_ref().unwrap().path.clone();
+  std::fs::write(&path, "written outside\n").unwrap();
+
+  app.reload_note_after_editor();
+
+  let editor = app.note_editor.as_ref().unwrap();
+  assert_eq!(editor.lines, vec!["written outside", ""]);
+  assert_eq!(editor.mode, NoteMode::Normal, "still in normal mode");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -12983,6 +12983,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 /// Open the note editor on the main row, which always carries a branch.
 fn app_with_note_open() -> (tempfile::TempDir, App) {
   let (dir, mut app) = make_app();
+  // #557: the mode ships on, so the #515 editor is now the opt-out. These
+  // tests are the contract for `note_vim = false`, which is a supported
+  // config and not a leftover — every printable is text and one `Esc`
+  // writes and closes.
+  app.config.tui.note_vim = false;
   app.list_state.select(Some(0));
   app.open_note_editor();
   assert_eq!(app.view, View::Note, "the editor must be the active view");
@@ -13059,7 +13064,11 @@ fn clearing_the_buffer_removes_the_note_instead_of_writing_a_blank_file() {
   // The only way to discard, so it has to actually delete: a one-byte file
   // reads as "no note" everywhere but would still sit on disk and be found
   // by `gwm doctor` once the branch is gone.
+  //
+  // Backspace is the gesture with the mode off (#557); `dd` is its twin in
+  // the default mode, pinned by the test below.
   let (dir, mut app) = make_app();
+  app.config.tui.note_vim = false;
   app.list_state.select(Some(0));
   let branch = app.selected().unwrap().branch.clone().unwrap();
   let path = gwm::notes::prepare(&git2::Repository::open(dir.path()).unwrap(), &branch)
@@ -13544,7 +13553,7 @@ fn the_bullet_chord_marks_the_line_as_an_item() {
     app.handle_note_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
   }
 
-  app.handle_note_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL));
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
   assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- one"]);
 
   // And Enter continues what the chord started, without a second chord.
@@ -13785,9 +13794,122 @@ fn a_chord_also_abandons_a_half_typed_sequence() {
   app.note_editor.as_mut().unwrap().cursor_col = 0;
 
   note_key(&mut app, 'd');
-  app.handle_note_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL));
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
   note_key(&mut app, 'd');
 
   let editor = app.note_editor.as_ref().unwrap();
   assert_eq!(editor.lines, vec!["- one", "two"], "the bullet landed, the line stayed");
+}
+
+// ---- the mode ships on, and the bullet chord moved (#557, install pass) ---
+
+#[test]
+fn the_note_editor_opens_in_normal_mode_out_of_the_box() {
+  // The knob flipped after the first install pass: `note_vim = false` is
+  // the opt-out now, not the default. An editor whose vim keys type
+  // themselves into the prose is the surface a vim user actually meets,
+  // and a knob nobody knows to set is a mode nobody gets.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Normal);
+}
+
+#[test]
+fn esc_leaves_insert_before_it_closes_out_of_the_box() {
+  // The cost of the flip, pinned: `Esc` no longer writes and closes on the
+  // first press. It leaves insert, and the second press is the one that
+  // saves. `note_vim = false` buys the old gesture back.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+  note_key(&mut app, 'i');
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+  assert_eq!(app.view, View::Note, "the first Esc only leaves insert");
+  assert_eq!(app.note_editor.as_ref().unwrap().mode, NoteMode::Normal);
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+  assert!(app.note_editor.is_none(), "the second one writes and closes");
+}
+
+#[test]
+fn the_bullet_chord_is_ctrl_u_because_tmux_eats_ctrl_l() {
+  // `Ctrl+h` / `j` / `k` / `l` are the tmux.nvim pane-navigation set: tmux
+  // consumes them unless the pane runs vim, so gwm never sees the key.
+  // Measured on a real config, same class as `Ctrl+b` being the prefix.
+  let (_dir, mut app) = app_with_note_open();
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["- "]);
+
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL));
+  assert_eq!(
+    app.note_editor.as_ref().unwrap().lines,
+    vec!["- "],
+    "and the chord tmux steals no longer toggles anything"
+  );
+}
+
+#[test]
+fn appending_at_the_end_of_the_line_types_past_the_last_char() {
+  // `A` is the one verb that legally leaves the caret one past the end of
+  // the line: it enters insert before the normal-mode clamp runs, so the
+  // clamp does not pull it back onto the last character.
+  let (_dir, mut app) = app_with_vim_note_open();
+  app.note_editor.as_mut().unwrap().lines = vec!["abc".into()];
+  app.note_editor.as_mut().unwrap().cursor_line = 0;
+  app.note_editor.as_mut().unwrap().cursor_col = 0;
+
+  note_key(&mut app, 'A');
+  app.handle_note_key(KeyEvent::new(KeyCode::Char('X'), KeyModifiers::NONE));
+
+  assert_eq!(app.note_editor.as_ref().unwrap().lines, vec!["abcX"]);
+}
+
+#[test]
+fn the_note_hint_context_follows_the_mode() {
+  // The bar is redrawn every frame from `hint_context()`, so the mode line
+  // is only ever as truthful as this mapping.
+  use gwm::tui::HintContext;
+
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+  assert_eq!(app.hint_context(), HintContext::NoteNormal);
+
+  note_key(&mut app, 'i');
+  assert_eq!(app.hint_context(), HintContext::NoteInsert);
+
+  let (_dir, app) = app_with_note_open();
+  assert_eq!(
+    app.hint_context(),
+    HintContext::Note,
+    "with the mode off the #515 bar is what stays"
+  );
+}
+
+#[test]
+fn emptying_the_buffer_with_dd_removes_the_note_too() {
+  // The discard gesture in the mode that now ships by default: `dd` on the
+  // last line leaves an empty buffer, and an empty buffer is a deleted
+  // note rather than a one-byte file `gwm doctor` will report later.
+  let (dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  let branch = app.selected().unwrap().branch.clone().unwrap();
+  let path = gwm::notes::prepare(&git2::Repository::open(dir.path()).unwrap(), &branch)
+    .unwrap()
+    .unwrap();
+  std::fs::write(&path, "old prose\n").unwrap();
+
+  app.open_note_editor();
+  // Twice: the file's trailing newline is a blank last line, and that is
+  // the line the caret opens on. Both go before the buffer reads empty.
+  for _ in 0..2 {
+    note_key(&mut app, 'd');
+    note_key(&mut app, 'd');
+  }
+  app.handle_note_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+  assert!(!path.exists(), "an emptied note is removed, not blanked");
 }

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -611,3 +611,72 @@ fn a_bidi_control_in_the_action_log_never_reaches_the_row() {
     }
   }
 }
+
+// ── the note editor's mode line (#557, install pass) ───────────────────────
+
+#[test]
+fn the_note_footer_names_the_mode_it_is_in() {
+  // The bar under the modal is the context line: it already carries the
+  // pane name, so the mode belongs in the same slot rather than in a hint.
+  // With the mode turned off there is no state to name.
+  assert_eq!(HintContext::NoteNormal.label(), "note · NORMAL");
+  assert_eq!(HintContext::NoteInsert.label(), "note · INSERT");
+  assert_eq!(HintContext::Note.label(), "note");
+}
+
+#[test]
+fn the_normal_mode_footer_lists_the_motions() {
+  // `?` is a printable inside the editor, so the help overlay cannot be
+  // reached from it: this bar is the only place the vim verbs are ever
+  // spelled out.
+  use gwm::tui::keymap::Keymap;
+  let resolved = HintContext::NoteNormal.resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults());
+  for (key, label) in [
+    ("hjkl", "move"),
+    ("w/b/e", "word"),
+    ("i/a/o", "insert"),
+    ("x/dd", "delete"),
+  ] {
+    assert!(
+      resolved.iter().any(|(k, l)| k == key && l == label),
+      "normal mode must advertise `{key} {label}`: {resolved:?}"
+    );
+  }
+  assert!(
+    resolved.iter().any(|(k, l)| k == "Esc" && l == "save & close"),
+    "and the way out, which is what `Esc` does from normal mode: {resolved:?}"
+  );
+}
+
+#[test]
+fn the_insert_mode_footer_does_not_promise_esc_saves() {
+  // The one verb whose meaning the mode changes. A bar that still said
+  // "save & close" here would send the user's first `Esc` somewhere it
+  // does not go.
+  use gwm::tui::keymap::Keymap;
+  let resolved = HintContext::NoteInsert.resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults());
+  assert!(
+    resolved.iter().any(|(k, l)| k == "Esc" && l == "normal mode"),
+    "insert mode must say where `Esc` goes: {resolved:?}"
+  );
+  assert!(
+    !resolved.iter().any(|(_, l)| l == "save & close"),
+    "and must not promise the gesture it no longer performs: {resolved:?}"
+  );
+}
+
+#[test]
+fn the_note_bullet_hint_follows_the_chord_that_reaches_the_app() {
+  // `Ctrl+l` never arrives inside tmux (tmux.nvim binds the whole
+  // `Ctrl+h/j/k/l` pane set), so the advertised chord is the one gwm can
+  // actually receive.
+  use gwm::tui::keymap::Keymap;
+  for ctx in [HintContext::Note, HintContext::NoteNormal, HintContext::NoteInsert] {
+    let resolved = ctx.resolve(&Keymap::defaults(), &gwm::tui::modal_keymap::ModalKeymap::defaults());
+    assert!(
+      resolved.iter().any(|(k, l)| k == "Ctrl+u" && l == "bullet"),
+      "{:?} must advertise `Ctrl+u bullet`: {resolved:?}",
+      ctx.label()
+    );
+  }
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -680,3 +680,33 @@ fn the_note_bullet_hint_follows_the_chord_that_reaches_the_app() {
     );
   }
 }
+
+#[test]
+fn the_help_overlay_teaches_the_normal_mode_verbs() {
+  // `?` is a printable inside the note editor, so the overlay cannot be
+  // opened from it: whoever wants to read the vim verbs at leisure reads
+  // them here, on the surface reachable from the list.
+  use gwm::tui::{help_rows, keymap::Keymap, HelpRow};
+  let rows = help_rows(
+    &Keymap::defaults(),
+    &gwm::tui::modal_keymap::ModalKeymap::defaults(),
+    HintContext::Help,
+  );
+  let keys: Vec<String> = rows
+    .iter()
+    .filter_map(|r| match r {
+      HelpRow::Entry { keys, .. } => Some(keys.clone()),
+      _ => None,
+    })
+    .collect();
+  for verb in ["h j k l", "w b e", "gg G", "x dd", "i I a A o O"] {
+    assert!(
+      keys.iter().any(|k| k == verb),
+      "the help overlay must document the normal-mode `{verb}` row: {keys:?}"
+    );
+  }
+  assert!(
+    keys.iter().any(|k| k == "Ctrl+u"),
+    "and the bullet chord as bound, not as it once was: {keys:?}"
+  );
+}

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -710,3 +710,53 @@ fn the_help_overlay_teaches_the_normal_mode_verbs() {
     "and the bullet chord as bound, not as it once was: {keys:?}"
   );
 }
+
+#[test]
+fn the_help_overlay_scopes_the_mode_rows_to_the_mode() {
+  // `note_vim = false` is a supported config, and in it the editor has no
+  // modes at all: every printable is text and one `Esc` writes and closes.
+  // `help_rows` takes no config, so the rows have to be true either way —
+  // which means the motions live under a heading that names the knob, and
+  // the close verb stops claiming it leaves insert first.
+  use gwm::tui::{help_rows, keymap::Keymap, HelpRow};
+  let rows = help_rows(
+    &Keymap::defaults(),
+    &gwm::tui::modal_keymap::ModalKeymap::defaults(),
+    HintContext::Help,
+  );
+
+  let close = rows
+    .iter()
+    .find_map(|r| match r {
+      HelpRow::Entry { keys, label } if keys == "Esc" && label.contains("save and close") => Some(label.clone()),
+      _ => None,
+    })
+    .expect("the note editor's close row");
+  assert!(
+    !close.contains("leave insert"),
+    "the close row must hold for `note_vim = false` too, got: {close}"
+  );
+
+  let section = rows
+    .iter()
+    .position(|r| matches!(r, HelpRow::Section(s) if s.contains("note_vim")))
+    .expect("a heading that names the knob the mode rows depend on");
+  let motions = rows
+    .iter()
+    .position(|r| matches!(r, HelpRow::Entry { keys, .. } if keys == "h j k l"))
+    .expect("the motion row");
+  assert!(
+    section < motions,
+    "the motion rows must sit under that heading (heading at {section}, motions at {motions})"
+  );
+  let next_section = rows
+    .iter()
+    .skip(section + 1)
+    .position(|r| matches!(r, HelpRow::Section(_)))
+    .map(|i| i + section + 1)
+    .unwrap_or(rows.len());
+  assert!(
+    motions < next_section,
+    "and before the next heading (motions at {motions}, next heading at {next_section})"
+  );
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1940,8 +1940,9 @@ fn the_note_title_names_the_mode_when_the_knob_is_on() {
 
 #[test]
 fn the_note_title_says_nothing_about_modes_with_the_knob_off() {
-  // The #515 title, unchanged, for everyone who never asked for a mode.
+  // The #515 title, unchanged, for everyone who turns the mode back off.
   let (_dir, mut app) = make_app();
+  app.config.tui.note_vim = false;
   app.list_state.select(Some(0));
   app.open_note_editor();
 

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1973,3 +1973,58 @@ fn a_long_branch_name_does_not_push_the_mode_chip_off_the_title() {
     row_strings(&buf).join("\n")
   );
 }
+
+#[test]
+fn the_note_modal_carries_the_mode_line_on_its_own_last_row() {
+  // The app footer says the same thing, but it sits at the bottom of the
+  // terminal: on a tall screen that is thirty rows away from the box the
+  // eye is in, which is where the keys are being pressed. Asserted on the
+  // modal's own last inner row, so the footer behind it cannot satisfy it.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  // Frame anatomy from the bottom: the border, the block's one row of
+  // bottom padding, then the mode line.
+  let rows = closed_modal_rows(&buf, "note at 100x40");
+  let last_inner = rows[rows.len() - 3].clone();
+  assert!(
+    last_inner.contains("hjkl"),
+    "the modal's last row must carry the normal-mode keys, got:\n{}",
+    rows.join("\n")
+  );
+
+  app.handle_note_key(crossterm::event::KeyEvent::new(
+    crossterm::event::KeyCode::Char('i'),
+    crossterm::event::KeyModifiers::NONE,
+  ));
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  let rows = closed_modal_rows(&buf, "note in insert at 100x40");
+  let last_inner = rows[rows.len() - 3].clone();
+  assert!(
+    last_inner.contains("normal mode") && !last_inner.contains("save & close"),
+    "and it must follow the mode into insert, got:\n{last_inner}"
+  );
+}
+
+#[test]
+fn the_note_modal_still_renders_when_there_is_no_room_for_both() {
+  // The mode line takes a row off the buffer, so the smallest modal has to
+  // stay drawable: a layout whose text pane collapses to zero must not
+  // panic or lose the frame.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+  for c in "note".chars() {
+    app.handle_note_key(crossterm::event::KeyEvent::new(
+      crossterm::event::KeyCode::Char(c),
+      crossterm::event::KeyModifiers::NONE,
+    ));
+  }
+
+  for (w, h) in [(40u16, 6u16), (30, 5), (20, 4)] {
+    let buf = render_at(&mut app, w, h);
+    assert!(!row_strings(&buf).is_empty(), "the note modal must survive {w}x{h}");
+  }
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1949,3 +1949,26 @@ fn the_note_title_says_nothing_about_modes_with_the_knob_off() {
   assert!(!buffer_contains(&buf, "INSERT"), "no mode chip without the knob");
   assert!(!buffer_contains(&buf, "NORMAL"));
 }
+
+#[test]
+fn a_long_branch_name_does_not_push_the_mode_chip_off_the_title() {
+  // The title is clipped from the right, so whichever half sits last is the
+  // half a long branch name costs. Whether the keys are text is worth more
+  // than the name of the branch the modal was opened from.
+  let (_dir, mut app) = make_app();
+  app.config.tui.note_vim = true;
+  app.note_editor = Some(gwm::tui::state::note_editor::NoteEditor::open(
+    "feat/#557-a-branch-name-long-enough-to-run-past-the-right-hand-edge-of-the-modal".into(),
+    PathBuf::from("/tmp/n.md"),
+    "",
+  ));
+  app.note_editor.as_mut().unwrap().enter_normal();
+  app.view = View::Note;
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  assert!(
+    buffer_contains(&buf, "NORMAL"),
+    "the mode chip was clipped off by the branch name:\n{}",
+    row_strings(&buf).join("\n")
+  );
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1907,3 +1907,45 @@ fn a_form_that_had_to_scroll_says_so() {
     rows.join("\n")
   );
 }
+
+// ── the note editor's mode indicator (#557) ────────────────────────────────
+
+#[test]
+fn the_note_title_names_the_mode_when_the_knob_is_on() {
+  // A mode the user cannot see is a mode they type verbs into by accident.
+  // The title is the one piece of chrome the editor already has.
+  let (_dir, mut app) = make_app();
+  app.config.tui.note_vim = true;
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  assert!(
+    buffer_contains(&buf, "NORMAL"),
+    "the modal must say which mode it is in:\n{}",
+    row_strings(&buf).join("\n")
+  );
+
+  app.handle_note_key(crossterm::event::KeyEvent::new(
+    crossterm::event::KeyCode::Char('i'),
+    crossterm::event::KeyModifiers::NONE,
+  ));
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  assert!(
+    buffer_contains(&buf, "INSERT"),
+    "and it must follow the mode:\n{}",
+    row_strings(&buf).join("\n")
+  );
+}
+
+#[test]
+fn the_note_title_says_nothing_about_modes_with_the_knob_off() {
+  // The #515 title, unchanged, for everyone who never asked for a mode.
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  assert!(!buffer_contains(&buf, "INSERT"), "no mode chip without the knob");
+  assert!(!buffer_contains(&buf, "NORMAL"));
+}

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -2003,8 +2003,20 @@ fn the_note_modal_carries_the_mode_line_on_its_own_last_row() {
   let rows = closed_modal_rows(&buf, "note in insert at 100x40");
   let last_inner = rows[rows.len() - 3].clone();
   assert!(
-    last_inner.contains("normal mode") && !last_inner.contains("save & close"),
+    last_inner.contains("INSERT") && !last_inner.contains("hjkl"),
     "and it must follow the mode into insert, got:\n{last_inner}"
+  );
+
+  // Where the row has the width for the whole list, `Esc` names what it
+  // does in this mode rather than the gesture it performs in the other.
+  // At 100 columns the tail is what the truncation eats, which is the
+  // documented order and why the help overlay carries the same keys.
+  let buf = render_at(&mut app, 160, TERM_H);
+  let rows = closed_modal_rows(&buf, "note in insert at 160x40");
+  let last_inner = rows[rows.len() - 3].clone();
+  assert!(
+    last_inner.contains("Esc normal mode") && !last_inner.contains("save & close"),
+    "the full insert line must say where `Esc` goes, got:\n{last_inner}"
   );
 }
 
@@ -2027,4 +2039,64 @@ fn the_note_modal_still_renders_when_there_is_no_room_for_both() {
     let buf = render_at(&mut app, w, h);
     assert!(!row_strings(&buf).is_empty(), "the note modal must survive {w}x{h}");
   }
+}
+
+#[test]
+fn the_mode_badge_is_painted_not_just_spelled() {
+  // A word in a row of words is a word; the mode is state, and it reads as
+  // state when it is a block of colour. Same reverse-video treatment the
+  // statusbar's context anchor has always had.
+  use ratatui::style::Modifier;
+
+  let (_dir, mut app) = make_app();
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  let (x, y, w, h) = modal_rect(&buf).expect("the note modal");
+  // The frame from the bottom: border, one row of block padding, the mode
+  // line.
+  let row = y + h - 3;
+  let painted: String = (x..x + w)
+    .filter(|col| buf[(*col, row)].modifier.contains(Modifier::REVERSED))
+    .map(|col| buf[(col, row)].symbol())
+    .collect();
+  assert_eq!(
+    painted.trim(),
+    "NORMAL",
+    "the mode badge must be the reverse-video run on the mode line, row:\n{}",
+    (x..x + w).map(|col| buf[(col, row)].symbol()).collect::<String>()
+  );
+
+  app.handle_note_key(crossterm::event::KeyEvent::new(
+    crossterm::event::KeyCode::Char('i'),
+    crossterm::event::KeyModifiers::NONE,
+  ));
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  let painted: String = (x..x + w)
+    .filter(|col| buf[(*col, row)].modifier.contains(Modifier::REVERSED))
+    .map(|col| buf[(col, row)].symbol())
+    .collect();
+  assert_eq!(painted.trim(), "INSERT", "and it follows the mode");
+}
+
+#[test]
+fn the_mode_badge_is_absent_with_the_mode_off() {
+  // No badge for a state nobody can be in: with `note_vim = false` the
+  // editor has one mode and naming it would be chrome.
+  use ratatui::style::Modifier;
+
+  let (_dir, mut app) = make_app();
+  app.config.tui.note_vim = false;
+  app.list_state.select(Some(0));
+  app.open_note_editor();
+
+  let buf = render_at(&mut app, TERM_W, TERM_H);
+  let (x, y, w, h) = modal_rect(&buf).expect("the note modal");
+  let row = y + h - 3;
+  assert!(
+    (x..x + w).all(|col| !buf[(col, row)].modifier.contains(Modifier::REVERSED)),
+    "no badge without the mode, row:\n{}",
+    (x..x + w).map(|col| buf[(col, row)].symbol()).collect::<String>()
+  );
 }

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -156,16 +156,19 @@ fn selected_field_follows_the_tab() {
   let mut panel = ConfigPanel::new();
   // Theme tab → theme preset.
   assert_eq!(panel.selected_field(), Some(SettingField::ThemePreset));
-  // Tui tab → layout / dim unfocused / status one line / sidebar position /
-  // sidebar layout / clipboard / open / countdown / auto refresh in order.
-  // `layout` leads since #545: it is the structural choice the rest of the
-  // tab refines, and the two density knobs (#545, #547) sit right under it.
+  // Tui tab → layout / dim unfocused / status one line / note vim / sidebar
+  // position / sidebar layout / clipboard / open / countdown / auto refresh
+  // in order. `layout` leads since #545: it is the structural choice the
+  // rest of the tab refines, and the boolean knobs (#545, #547, #557) sit
+  // right under it.
   panel.tab = SettingsTab::Tui;
   assert_eq!(panel.selected_field(), Some(SettingField::Layout));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::DimUnfocused));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::StatusOneLine));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::NoteVim));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::SidebarPosition));
   panel.select_next();
@@ -682,6 +685,30 @@ fn the_tui_tab_reaches_the_status_fold_setting() {
     assert!(
       choice.parse::<bool>().is_ok(),
       "status_one_line choice {choice:?} must parse as a bool"
+    );
+  }
+}
+
+#[test]
+fn the_tui_tab_reaches_the_note_mode_setting() {
+  // #557: the vim mode ships on, so `note_vim = false` is the opt-out —
+  // and an opt-out only a TOML editor can reach is one most users will
+  // never find. Same `Bool` reasoning as the two fields above.
+  let fields = SettingsTab::Tui.fields();
+  assert!(
+    fields.contains(&SettingField::NoteVim),
+    "note_vim must be reachable from the TUI tab, got {fields:?}"
+  );
+  assert_eq!(SettingField::NoteVim.kind(), FieldKind::Bool);
+  assert_eq!(SettingField::NoteVim.key_path(), "tui.note_vim");
+
+  let cfg = gwm::config::Config::default();
+  assert_eq!(SettingField::NoteVim.current(&cfg), "true");
+  assert_eq!(SettingField::NoteVim.next_choice(&cfg).as_deref(), Some("false"));
+  for choice in SettingField::NoteVim.choices() {
+    assert!(
+      choice.parse::<bool>().is_ok(),
+      "note_vim choice {choice:?} must parse as a bool"
     );
   }
 }

--- a/tests/tui_state_note_editor_tests.rs
+++ b/tests/tui_state_note_editor_tests.rs
@@ -543,3 +543,274 @@ fn a_line_that_only_looks_like_a_bullet_is_not_one() {
     assert_eq!(e.lines[1], "", "`{text}` is prose, not a list item");
   }
 }
+
+// ---------------------------------------------------------------------------
+// Normal mode (issue #557)
+// ---------------------------------------------------------------------------
+//
+// Off unless `[tui] note_vim = true`, which is why nothing above knows the
+// mode exists. `j` is a letter in a text buffer, so the motions only become
+// keys once the buffer is told it is not taking text.
+
+use gwm::tui::state::note_editor::NoteMode;
+
+/// An editor parked in normal mode with the caret at the top of the buffer.
+fn normal(text: &str) -> NoteEditor {
+  let mut e = editor(text);
+  e.cursor_line = 0;
+  e.cursor_col = 0;
+  e.mode = NoteMode::Normal;
+  e
+}
+
+/// Feed a run of normal-mode keys, the way a user types them.
+fn keys(e: &mut NoteEditor, run: &str) {
+  for c in run.chars() {
+    e.normal_key(c);
+  }
+}
+
+#[test]
+fn hjkl_walks_the_buffer() {
+  let mut e = normal("abc\ndef");
+  keys(&mut e, "ll");
+  assert_eq!(at(&e), (0, 2));
+  keys(&mut e, "j");
+  assert_eq!(at(&e), (1, 2));
+  keys(&mut e, "h");
+  assert_eq!(at(&e), (1, 1));
+  keys(&mut e, "k");
+  assert_eq!(at(&e), (0, 1));
+}
+
+#[test]
+fn h_and_l_stop_at_the_line_ends_rather_than_wrapping() {
+  // The arrows wrap onto the neighbouring line; `h` and `l` are vim's, and
+  // vim's stay on the line.
+  let mut e = normal("ab\ncd");
+  keys(&mut e, "h");
+  assert_eq!(at(&e), (0, 0), "`h` at column 0 stays put");
+  keys(&mut e, "lll");
+  assert_eq!(at(&e), (0, 1), "`l` stops on the last char, not past it");
+}
+
+#[test]
+fn the_caret_never_sits_past_the_last_char_in_normal_mode() {
+  // Insert mode parks the caret after the text (that is where the next
+  // character goes); normal mode sits ON a character, or `x` at the end of
+  // a line would delete nothing.
+  let mut e = editor("abc");
+  e.end();
+  assert_eq!(at(&e), (0, 3), "insert mode sits past the end");
+  e.enter_normal();
+  assert_eq!(at(&e), (0, 2), "entering normal mode pulls it back onto `c`");
+}
+
+#[test]
+fn zero_caret_and_dollar_are_the_line_ends() {
+  let mut e = normal("  indented line");
+  keys(&mut e, "$");
+  assert_eq!(at(&e), (0, 14));
+  keys(&mut e, "0");
+  assert_eq!(at(&e), (0, 0));
+  keys(&mut e, "^");
+  assert_eq!(at(&e), (0, 2), "`^` is the first non-blank, not the first column");
+}
+
+#[test]
+fn w_stops_at_the_start_of_each_word() {
+  let mut e = normal("one two three");
+  keys(&mut e, "w");
+  assert_eq!(at(&e), (0, 4));
+  keys(&mut e, "w");
+  assert_eq!(at(&e), (0, 8));
+}
+
+#[test]
+fn w_treats_punctuation_as_a_word_and_big_w_does_not() {
+  let mut e = normal("git.rs file");
+  keys(&mut e, "w");
+  assert_eq!(at(&e), (0, 3), "`w` stops on the dot");
+
+  let mut e = normal("git.rs file");
+  keys(&mut e, "W");
+  assert_eq!(at(&e), (0, 7), "`W` runs to the next blank-separated word");
+}
+
+#[test]
+fn b_walks_back_to_the_start_of_the_word() {
+  let mut e = normal("one two three");
+  keys(&mut e, "$");
+  keys(&mut e, "b");
+  assert_eq!(at(&e), (0, 8));
+  keys(&mut e, "b");
+  assert_eq!(at(&e), (0, 4));
+}
+
+#[test]
+fn e_lands_on_the_last_char_of_the_word() {
+  let mut e = normal("one two");
+  keys(&mut e, "e");
+  assert_eq!(at(&e), (0, 2), "on the `e` of `one`");
+  keys(&mut e, "e");
+  assert_eq!(at(&e), (0, 6), "on the `o` of `two`");
+}
+
+#[test]
+fn big_e_runs_to_the_end_of_the_blank_separated_word() {
+  let mut e = normal("git.rs file");
+  keys(&mut e, "E");
+  assert_eq!(at(&e), (0, 5), "the whole `git.rs`");
+}
+
+#[test]
+fn word_motions_cross_lines() {
+  let mut e = normal("one\ntwo");
+  keys(&mut e, "w");
+  assert_eq!(at(&e), (1, 0), "`w` walks onto the next line");
+  keys(&mut e, "b");
+  assert_eq!(at(&e), (0, 0), "and `b` walks back onto the previous one");
+}
+
+#[test]
+fn w_on_the_last_word_parks_on_its_last_char() {
+  // Rather than running off the buffer, which would be a key that puts the
+  // caret nowhere.
+  let mut e = normal("only");
+  keys(&mut e, "w");
+  assert_eq!(at(&e), (0, 3));
+}
+
+#[test]
+fn gg_and_g_walk_to_the_ends_of_the_buffer() {
+  let mut e = normal("1\n2\n3\n4");
+  keys(&mut e, "G");
+  assert_eq!(at(&e), (3, 0));
+  keys(&mut e, "gg");
+  assert_eq!(at(&e), (0, 0));
+}
+
+#[test]
+fn a_half_typed_pair_does_not_leak_into_the_next_key() {
+  // `g` alone is pending; `x` is not the pair it waits for, so the whole
+  // thing is dropped rather than deleting a character.
+  let mut e = normal("abc");
+  keys(&mut e, "gx");
+  assert_eq!(e.lines, vec!["abc"], "no edit, and no pending key left over");
+  keys(&mut e, "x");
+  assert_eq!(e.lines, vec!["bc"], "the next `x` is a plain `x` again");
+}
+
+#[test]
+fn x_removes_the_char_under_the_caret_without_pulling_the_next_line_up() {
+  // `Delete` joins lines at end of line; `x` is vim's and does not.
+  let mut e = normal("ab\ncd");
+  keys(&mut e, "$x");
+  assert_eq!(e.lines, vec!["a", "cd"]);
+  keys(&mut e, "x");
+  assert_eq!(e.lines, vec!["", "cd"], "the line empties");
+  keys(&mut e, "x");
+  assert_eq!(e.lines, vec!["", "cd"], "and an empty line has nothing to delete");
+}
+
+#[test]
+fn dd_removes_the_line_and_always_leaves_one_standing() {
+  let mut e = normal("one\ntwo\nthree");
+  keys(&mut e, "jdd");
+  assert_eq!(e.lines, vec!["one", "three"]);
+  assert_eq!(at(&e), (1, 0));
+  keys(&mut e, "dddd");
+  assert_eq!(e.lines, vec![""], "the buffer bottoms out at one empty line");
+  assert_eq!(at(&e), (0, 0));
+}
+
+#[test]
+fn dd_on_the_last_line_steps_the_caret_up() {
+  let mut e = normal("one\ntwo");
+  keys(&mut e, "Gdd");
+  assert_eq!(e.lines, vec!["one"]);
+  assert_eq!(at(&e), (0, 0), "the caret cannot stay on a line that is gone");
+}
+
+#[test]
+fn i_and_a_open_insert_mode_on_either_side_of_the_caret() {
+  let mut e = normal("ab");
+  keys(&mut e, "i");
+  assert_eq!(e.mode, NoteMode::Insert);
+  assert_eq!(at(&e), (0, 0), "`i` inserts before the caret");
+
+  let mut e = normal("ab");
+  keys(&mut e, "a");
+  assert_eq!(e.mode, NoteMode::Insert);
+  assert_eq!(at(&e), (0, 1), "`a` appends after it");
+}
+
+#[test]
+fn big_i_and_big_a_open_insert_at_the_line_ends() {
+  let mut e = normal("  indented");
+  keys(&mut e, "$I");
+  assert_eq!(e.mode, NoteMode::Insert);
+  assert_eq!(at(&e), (0, 2), "`I` is the first non-blank");
+
+  let mut e = normal("  indented");
+  keys(&mut e, "A");
+  assert_eq!(e.mode, NoteMode::Insert);
+  assert_eq!(at(&e), (0, 10), "`A` is past the last char, where typing goes");
+}
+
+#[test]
+fn a_at_the_end_of_a_line_appends_past_the_last_char() {
+  let mut e = normal("ab");
+  keys(&mut e, "$a");
+  assert_eq!(at(&e), (0, 2), "insert mode is allowed past the end; normal is not");
+}
+
+#[test]
+fn o_and_big_o_open_a_line_and_start_typing() {
+  let mut e = normal("one\ntwo");
+  keys(&mut e, "o");
+  assert_eq!(e.lines, vec!["one", "", "two"]);
+  assert_eq!(at(&e), (1, 0));
+  assert_eq!(e.mode, NoteMode::Insert);
+  assert!(e.dirty);
+
+  let mut e = normal("one\ntwo");
+  keys(&mut e, "jO");
+  assert_eq!(e.lines, vec!["one", "", "two"]);
+  assert_eq!(at(&e), (1, 0));
+  assert_eq!(e.mode, NoteMode::Insert);
+}
+
+#[test]
+fn o_continues_the_list_the_way_enter_does() {
+  // One rule for "a new line under a list item", whichever key asked for
+  // it, so a checklist written in normal mode reads like one written in
+  // insert mode.
+  let mut e = normal("- [ ] first");
+  keys(&mut e, "o");
+  assert_eq!(e.lines, vec!["- [ ] first", "- [ ] "]);
+  assert_eq!(at(&e), (1, 6));
+
+  let mut e = normal("  - first");
+  keys(&mut e, "O");
+  assert_eq!(e.lines, vec!["  - ", "  - first"]);
+  assert_eq!(at(&e), (0, 4));
+}
+
+#[test]
+fn enter_normal_is_idempotent_and_clamps_every_time() {
+  let mut e = editor("abc");
+  e.enter_normal();
+  e.enter_normal();
+  assert_eq!(e.mode, NoteMode::Normal);
+  assert_eq!(at(&e), (0, 2));
+}
+
+#[test]
+fn a_key_normal_mode_does_not_know_changes_nothing() {
+  let mut e = normal("abc");
+  keys(&mut e, "z");
+  assert_eq!(e.lines, vec!["abc"]);
+  assert_eq!(at(&e), (0, 0));
+  assert!(!e.dirty, "an unknown key is not an edit");
+}

--- a/tests/tui_state_note_editor_tests.rs
+++ b/tests/tui_state_note_editor_tests.rs
@@ -337,3 +337,209 @@ fn a_zero_height_viewport_does_not_divide_the_scroll_by_zero() {
   e.clamp_scroll(0);
   assert_eq!(e.scroll, 2, "a 0-row viewport is treated as 1 row, not as a panic");
 }
+
+// ---------------------------------------------------------------------------
+// Lists: bullets and checkboxes (issue #557)
+// ---------------------------------------------------------------------------
+//
+// A note becomes a checklist after a day ("what to check before opening the
+// PR"), and ticking an item used to mean arrowing onto the right column and
+// retyping a character by hand. Two verbs replace that, and both are
+// idempotent round trips: what a toggle writes, the same toggle takes back.
+
+#[test]
+fn a_plain_line_takes_a_bullet_and_gives_it_back() {
+  let mut e = editor("check the CI");
+  e.toggle_bullet();
+  assert_eq!(e.lines[0], "- check the CI");
+  e.toggle_bullet();
+  assert_eq!(e.lines[0], "check the CI", "the same key takes the bullet back");
+}
+
+#[test]
+fn the_bullet_lands_after_the_indentation() {
+  // Nested lists are written by hand with leading spaces; a prefix inserted
+  // at column 0 would break the nesting it was asked to mark.
+  let mut e = editor("  nested item");
+  e.toggle_bullet();
+  assert_eq!(e.lines[0], "  - nested item");
+}
+
+#[test]
+fn toggling_a_bullet_off_takes_the_checkbox_with_it() {
+  // `- [ ] ` IS a bullet, so "this line is no longer a list item" removes
+  // the whole prefix rather than leaving a widowed `[ ]`.
+  let mut e = editor("- [ ] ship it");
+  e.toggle_bullet();
+  assert_eq!(e.lines[0], "ship it");
+}
+
+#[test]
+fn a_plain_line_becomes_an_unchecked_box() {
+  let mut e = editor("run cargo test");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [ ] run cargo test");
+}
+
+#[test]
+fn an_empty_line_becomes_an_empty_box() {
+  let mut e = editor("");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [ ] ");
+  assert_eq!(at(&e), (0, 6), "the caret sits where the item text goes");
+}
+
+#[test]
+fn a_bullet_becomes_a_box_without_doubling_the_dash() {
+  let mut e = editor("- ship it");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [ ] ship it");
+}
+
+#[test]
+fn toggling_a_box_flips_the_mark_and_back() {
+  let mut e = editor("- [ ] ship it");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [x] ship it");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [ ] ship it");
+}
+
+#[test]
+fn an_uppercase_mark_reads_as_ticked() {
+  // `- [X]` is what several editors write, and a note is plain Markdown
+  // other tools have written into.
+  let mut e = editor("- [X] ship it");
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [ ] ship it");
+}
+
+#[test]
+fn the_box_toggles_from_anywhere_on_the_line() {
+  // The gesture a checklist exists for: no navigation first.
+  for col in [0, 3, 6, 12] {
+    let mut e = editor("- [ ] ship it");
+    e.cursor_col = col;
+    e.toggle_checkbox();
+    assert_eq!(e.lines[0], "- [x] ship it", "toggling from column {col}");
+    assert_eq!(e.cursor_col, col, "flipping the mark does not move the caret");
+  }
+}
+
+#[test]
+fn the_caret_keeps_its_place_in_the_text_when_a_prefix_appears() {
+  let mut e = editor("ship it");
+  e.home();
+  e.toggle_checkbox();
+  assert_eq!(at(&e), (0, 6), "still on the `s`, which moved right by the prefix");
+  e.toggle_bullet();
+  assert_eq!(at(&e), (0, 0), "and back onto it when the prefix goes away");
+}
+
+#[test]
+fn a_caret_inside_a_removed_prefix_lands_at_the_start_of_the_text() {
+  let mut e = editor("- [ ] ship it");
+  e.cursor_col = 3;
+  e.toggle_bullet();
+  assert_eq!(at(&e), (0, 0), "the column it pointed at is gone, so it clamps");
+}
+
+#[test]
+fn a_toggle_on_an_accented_line_never_slices_a_codepoint() {
+  let mut e = editor("- [ ] vérifier la CI");
+  e.end();
+  e.toggle_checkbox();
+  assert_eq!(e.lines[0], "- [x] vérifier la CI");
+  e.toggle_bullet();
+  assert_eq!(e.lines[0], "vérifier la CI");
+}
+
+#[test]
+fn every_list_toggle_marks_the_buffer_dirty() {
+  // `flush_note` skips the write on a clean buffer, so a toggle that leaves
+  // `dirty` false is a tick the user watched happen and then lost on `Esc`.
+  for toggle in [NoteEditor::toggle_bullet, NoteEditor::toggle_checkbox] {
+    let mut e = editor("- [ ] ship it");
+    assert!(!e.dirty);
+    toggle(&mut e);
+    assert!(e.dirty, "a list toggle changed the buffer");
+  }
+}
+
+// ── Enter continues the list ───────────────────────────────────────────────
+
+#[test]
+fn enter_continues_a_bullet() {
+  let mut e = editor("- first");
+  e.newline();
+  assert_eq!(e.lines, vec!["- first", "- "]);
+  assert_eq!(at(&e), (1, 2), "the caret sits after the new bullet");
+}
+
+#[test]
+fn enter_continues_a_box_unchecked_whatever_the_current_mark() {
+  // Ticking is an act; a continued item is never born done.
+  let mut e = editor("- [x] first");
+  e.newline();
+  assert_eq!(e.lines, vec!["- [x] first", "- [ ] "]);
+  assert_eq!(at(&e), (1, 6));
+}
+
+#[test]
+fn enter_carries_the_indentation_of_the_item_it_continues() {
+  let mut e = editor("  - first");
+  e.newline();
+  assert_eq!(e.lines, vec!["  - first", "  - "]);
+}
+
+#[test]
+fn enter_on_an_empty_item_breaks_out_of_the_list() {
+  // What every Markdown editor does: the second Enter after the last item
+  // ends the list rather than nesting another empty one.
+  let mut e = editor("- first\n- ");
+  e.cursor_line = 1;
+  e.end();
+  e.newline();
+  assert_eq!(e.lines, vec!["- first", ""], "the empty item lost its bullet");
+  assert_eq!(at(&e), (1, 0), "and no line was added");
+  assert!(e.dirty);
+}
+
+#[test]
+fn enter_on_an_empty_box_breaks_out_too() {
+  let mut e = editor("- [ ] ");
+  e.end();
+  e.newline();
+  assert_eq!(e.lines, vec![""]);
+  assert_eq!(at(&e), (0, 0));
+}
+
+#[test]
+fn enter_mid_item_carries_the_prefix_onto_the_tail() {
+  let mut e = editor("- one two");
+  e.cursor_line = 0;
+  e.cursor_col = 6;
+  e.newline();
+  assert_eq!(e.lines, vec!["- one ", "- two"]);
+  assert_eq!(at(&e), (1, 2));
+}
+
+#[test]
+fn enter_on_a_plain_line_still_just_splits_it() {
+  let mut e = editor("plain");
+  e.end();
+  e.newline();
+  assert_eq!(e.lines, vec!["plain", ""]);
+  assert_eq!(at(&e), (1, 0));
+}
+
+#[test]
+fn a_line_that_only_looks_like_a_bullet_is_not_one() {
+  // `-foo` has no space, and `--` is a separator, not an item.
+  for text in ["-foo", "--flag"] {
+    let mut e = editor(text);
+    e.end();
+    e.newline();
+    assert_eq!(e.lines[1], "", "`{text}` is prose, not a list item");
+  }
+}


### PR DESCRIPTION
## Description

Two halves, in the order the issue put them.

**Lists, for everyone.** `Ctrl+t` ticks the box on the line and spawns one when the line has none, from anywhere on the line. `Ctrl+l` makes the line a list item or takes the marker back off it. `Enter` continues the list, and ends it on an empty item the way every Markdown editor does. Ticking used to mean arrowing onto the right column and retyping a character by hand.

**A vim normal mode, for whoever asks.** `[tui] note_vim = true` opens `N` in normal mode: `hjkl`, `w` / `b` / `e` and their `W` / `B` / `E`, `0` / `^` / `$`, `gg` / `G`, `x`, `dd`, and `i` / `I` / `a` / `A` / `o` / `O` to enter insert. `Esc` goes back to normal, and the second `Esc` writes and closes.

**Off by default, and that is the design.** With a mode, the first `Esc` no longer writes and closes, and that is a shipped default fingers already know. The issue framed the choice as a product call between a real mode, modified chords, and an opt-in mode; the third is what this is. Nobody gets a mode without asking for one, and the shipped editor is untouched for everyone else.

Closes #557

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `NoteEditor` learns what a list is: `toggle_bullet`, `toggle_checkbox` and a `newline` that continues the list or breaks out of it. A marker is read off the line rather than assumed, so `-foo` stays prose and `--flag` stays a flag, and the indentation of a hand-nested item survives every rewrite.
- Two new verbs under `[tui.keys.modal.note]`, `toggle_bullet` (`Ctrl+l`) and `toggle_checkbox` (`Ctrl+t`), both advertised in the modal's hint bar. Ctrl-modified because an unmodified printable is text in that context; neither is `Ctrl+b`, which is the tmux prefix and would never reach a note written inside tmux.
- `NoteMode` plus the motions, the operators and the insert-entry keys on `NoteEditor`, routed from `handle_note_key` **before** the typing reservation, since that reservation is exactly what makes `j` a letter.
- `[tui] note_vim`, defaulting to `false`, and a `NORMAL` / `INSERT` chip in the modal title that only exists when it is on.
- Docs: the notes section of the keybindings page in English and French (its old "the editor takes text, `Enter`, `Backspace`…" sentence was false as written), `note_vim` on the config page in both languages, `examples/gwm.toml.example`, and the `[Unreleased]` changelog.

## Tests

- [x] `cargo test` passes locally (103 suites, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

46 new tests. The list verbs and the whole normal mode are pinned at the `NoteEditor` level in `tests/tui_state_note_editor_tests.rs` (69 tests in that file now); the wiring, the mode gate and the two-step `Esc` in `tests/tui_app_tests.rs`; the knob in `tests/config_tests.rs`; the mode chip in `tests/tui_modal_render_tests.rs`.

Also run with a CI-like minimal PATH (`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin"`), same 103 suites green.

## Screenshots / TUI captures

None yet, and that is the open item below.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (no CLI surface changed)
- [x] `examples/gwm.toml.example` updated
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #557
- Follows: #515 (the editor this extends)

## Notes for reviewers

Four things worth your attention, three of them limits I chose rather than missed.

1. **The issue's part A asked for a bullet "on the current line, or on a new line below"**. Only the current line has its own verb. A new line below is `Enter` then `Ctrl+l` with the knob off, and `o` with it on, so the gesture exists both ways without a third chord. Say the word if it should have one.

2. **The hint bar under the modal still reads `Esc save & close` in insert mode with `note_vim` on**, where the first `Esc` actually leaves insert. The hints are a static per-context list, so making them mode-aware means a second `HintContext` and a match arm in every table that enumerates them. The `INSERT` chip in the title carries the same fact for the audience that turned the mode on, and that bar is the editor's only discovery surface, since `?` is a printable and the help overlay cannot be opened from a text buffer. Happy to spend the variant if you would rather have it exact.

3. **No counts, no registers, no undo**, therefore no `p` and no `u`. `dd` is destructive with nothing to bring the line back, which is the same deal `Backspace` has always had here. `Ctrl+e` still hands the file to the real vim, and that handoff is the argument for stopping where this stops.

4. **The mode chip sits after the branch name on purpose.** A centred overlay title that overflows is clipped from the LEFT, which is the opposite of what it looks like, so the end of the title is the half that survives. `tests/tui_modal_render_tests.rs::a_long_branch_name_does_not_push_the_mode_chip_off_the_title` goes red with the two halves the other way round; that is how the direction was established rather than assumed.

**This is a TUI feature, so it wants your hands on it before merge**: `cargo install --path .`, `N` on a worktree, then the same with `note_vim = true` in `.gwm.toml`.