### PR TITLE
✨ feat(cli,tui): add herdr as a third multiplexer backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **herdr is a third multiplexer backend**
+  ([#588](https://github.com/kbrdn1/gwm-cli/issues/588)). `gwm herdr <pattern>`
+  opens the matched worktree in a new [herdr](https://herdr.dev) tab, `-p`
+  splits the current pane instead, and the TUI's `t` key finds herdr the way
+  it finds tmux and zellij. Detection reads `$HERDR_ENV`, which herdr sets in
+  every pane it manages, and it comes last in the cascade so nothing changes
+  for a tmux or zellij user.
+
+  Under the hood: `herdr tab create --label <name> --cwd <path>` and
+  `herdr pane split --current --direction right --cwd <path>`, verified
+  against herdr 0.8.2. The split needs a direction because herdr's parser has
+  no default for one, and `right` is the analogue of tmux's `-h`.
+
+  One surface stays on its old path: a `[tui.macro*]` with
+  `open_in = "mux_pane"` still falls back to the PTY overlay under herdr, and
+  now says so. A macro needs the new pane to run a command, and
+  `herdr pane split` has no trailing-command form, so running one takes a
+  second call with the pane id that `pane split` prints back.
+
 - **A worktree note can be a checklist**
   ([#557](https://github.com/kbrdn1/gwm-cli/issues/557)). `Ctrl+t` in the note
   editor ticks the box on the line and spawns one when the line has none, from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every pane it manages, and it comes last in the cascade so nothing changes
   for a tmux or zellij user.
 
-  Under the hood: `herdr tab create --label <name> --cwd <path>` and
-  `herdr pane split --current --direction right --cwd <path>`, verified
-  against herdr 0.8.2. The split needs a direction because herdr's parser has
-  no default for one, and `right` is the analogue of tmux's `-h`.
+  Under the hood: `herdr tab create --workspace <id> --label <name> --cwd
+  <path> --focus` and `herdr pane split --current --direction right --cwd
+  <path> --focus`, verified against a live herdr 0.8.2 rather than its help
+  text. The split needs a direction because herdr's parser has no default for
+  one, and `right` is the analogue of tmux's `-h`. The other two flags are
+  there because herdr's defaults are the opposite of what the names suggest:
+  without `--focus` the tab opens where you cannot see it, and without
+  `--workspace` it opens in whichever workspace the server had focused, which
+  is another project's window as often as not.
 
   One surface stays on its old path: a `[tui.macro*]` with
   `open_in = "mux_pane"` still falls back to the PTY overlay under herdr, and

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -62,7 +62,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `L`         | launch the configured [`[git_tui]`](/tui/launchers) command fullscreen (`lazygit_fullscreen`)     |
 | `r`         | launch the configured [`[review]`](/tui/launchers) command in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) (`review_pty`): AI / web reviewer over `git diff base..head` |
 | `R`         | launch the configured [`[review]`](/tui/launchers) command fullscreen (`review_fullscreen`)       |
-| `t`         | open the selected worktree in a new tmux / zellij pane (`mux_pane`), falls back to a status-bar hint when no multiplexer is detected |
+| `t`         | open the selected worktree in a new tmux / zellij / herdr pane (`mux_pane`), falls back to a status-bar hint when no multiplexer is detected |
 | `h`         | run the user-configured [`[tui.macro1]`](/configuration/gwm-toml#tuimacro1-and-tuimacro2) command (`macro_one`) |
 | `H`         | run the user-configured [`[tui.macro2]`](/configuration/gwm-toml#tuimacro1-and-tuimacro2) command (`macro_two`) |
 | `y`         | yank the selected worktree's **branch name** to the clipboard (`yank_branch_name`)                |
@@ -490,7 +490,7 @@ several keys to make room for the new verbs. The biggest changes to relearn:
 | `R` (review) | `r` / `R` | `r` runs the review in a PTY overlay, `R` runs it fullscreen        |
 | _(none)_  | `c`    | rename the selected worktree (`edit_worktree`)                          |
 | _(none)_  | `e`    | exit the TUI to the selected path (`exit_to_worktree`)                  |
-| _(none)_  | `t`    | open the worktree in a new tmux / zellij pane (`mux_pane`)              |
+| _(none)_  | `t`    | open the worktree in a new tmux / zellij / herdr pane (`mux_pane`)      |
 | _(none)_  | `h` / `H` | run `[tui.macro1]` / `[tui.macro2]`                                  |
 
 Existing `[tui.keys]` overrides written with the old slugs (`git_tui`,

--- a/docs/2.tui/8.keymap-and-palette.md
+++ b/docs/2.tui/8.keymap-and-palette.md
@@ -98,7 +98,7 @@ command = "cargo install --path ."
 open_in = "pty"          # "pty" (default, embedded overlay) or "mux_pane"
 ```
 
-`open_in` defaults to `"pty"` (an embedded [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r), TUI suspends until exit); set it to `"mux_pane"` to launch the command in a new tmux / zellij pane instead. The `h` / `H` bindings are themselves rebindable as the `macro_one` / `macro_two` actions in `[tui.keys]`.
+`open_in` defaults to `"pty"` (an embedded [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r), TUI suspends until exit); set it to `"mux_pane"` to launch the command in a new tmux / zellij pane instead (herdr panes take no command, so a herdr session keeps the PTY overlay). The `h` / `H` bindings are themselves rebindable as the `macro_one` / `macro_two` actions in `[tui.keys]`.
 
 ## command palette
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -508,9 +508,9 @@ Same as `gwm tmux` but for zellij. Uses `zellij action new-tab --cwd <path>` (re
 
 ## `gwm herdr <pattern> [-p|--split]`
 
-Same as `gwm tmux` but for [herdr](https://herdr.dev). Uses `herdr tab create --label <name> --cwd <path>`, or `herdr pane split --current --direction right --cwd <path>` with `-p`. Requires `$HERDR_ENV`, which herdr sets in every pane it manages.
+Same as `gwm tmux` but for [herdr](https://herdr.dev). Uses `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`, or `herdr pane split --current --direction right --cwd <path> --focus` with `-p`. Requires `$HERDR_ENV`, which herdr sets in every pane it manages.
 
-The split opens to the right: herdr has no implicit direction, so gwm picks the analogue of tmux's horizontal split.
+The split opens to the right: herdr has no implicit direction, so gwm picks the analogue of tmux's horizontal split. `--focus` and `--workspace` are passed because neither is herdr's default: without them the tab opens unfocused, in whichever workspace the server had focused rather than yours. The workspace id comes from `$HERDR_WORKSPACE_ID`.
 
 See [CLI → Multiplexer integration](/cli/multiplexer) for the full surface and edge cases.
 

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -506,6 +506,12 @@ Outside a tmux session, exits non-zero with a clear error (does not spawn a stra
 
 Same as `gwm tmux` but for zellij. Uses `zellij action new-tab --cwd <path>` (requires zellij ≥ 0.40 for the `--cwd` flag) or `new-pane --cwd` with `-p`. Requires `$ZELLIJ`.
 
+## `gwm herdr <pattern> [-p|--split]`
+
+Same as `gwm tmux` but for [herdr](https://herdr.dev). Uses `herdr tab create --label <name> --cwd <path>`, or `herdr pane split --current --direction right --cwd <path>` with `-p`. Requires `$HERDR_ENV`, which herdr sets in every pane it manages.
+
+The split opens to the right: herdr has no implicit direction, so gwm picks the analogue of tmux's horizontal split.
+
 See [CLI → Multiplexer integration](/cli/multiplexer) for the full surface and edge cases.
 
 ## `gwm link {issue|pr} <N> [--worktree <pattern>]`

--- a/docs/3.cli/2.completions.md
+++ b/docs/3.cli/2.completions.md
@@ -34,13 +34,13 @@ Open a fresh shell (or `source` your rc file) and tab completion is live for eve
 
 ## dynamic worktree-name completion
 
-The static script knows about subcommands and flags but **not** about the worktrees in your repo, which change every time you run `gwm create / remove`. Wire a custom completer to `gwm list --format=names` for live completion of the worktree-name arg on `path` / `cd` / `remove` / `bootstrap` / `sync` / `tmux` / `zellij` / `exec` / `clean` (all of which resolve their positional through the same fuzzy matcher).
+The static script knows about subcommands and flags but **not** about the worktrees in your repo, which change every time you run `gwm create / remove`. Wire a custom completer to `gwm list --format=names` for live completion of the worktree-name arg on `path` / `cd` / `remove` / `bootstrap` / `sync` / `tmux` / `zellij` / `herdr` / `exec` / `clean` (all of which resolve their positional through the same fuzzy matcher).
 
 ### zsh
 
 ```zsh
 _gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
-compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-sync gwm-tmux gwm-zellij gwm-exec gwm-clean
+compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-sync gwm-tmux gwm-zellij gwm-herdr gwm-exec gwm-clean
 ```
 
 (`gwm-path`, `gwm-cd`, etc. are the auto-generated function names the static `_gwm` completer registers per-subcommand.)
@@ -58,7 +58,7 @@ complete -F _gwm_worktrees -o default gwm
 ### fish
 
 ```fish
-complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap sync tmux zellij exec clean" \
+complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap sync tmux zellij herdr exec clean" \
   -f -a "(gwm list --format=names 2>/dev/null)"
 ```
 

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -65,6 +65,8 @@ All three commands require the corresponding multiplexer to actually be running:
 - `gwm zellij` checks for `$ZELLIJ`.
 - `gwm herdr` checks for `$HERDR_ENV`, which herdr sets to `1` in every pane it manages.
 
+One caveat on that last one, upstream rather than gwm's: a tmux server started from inside a herdr pane copies the whole `HERDR_*` set into its server-global environment ([herdrdev/herdr#2134](https://github.com/herdrdev/herdr/issues/2134)), so unrelated sessions on that server also claim to be herdr panes. The TUI's `t` is unaffected, since those sessions have `$TMUX` set and tmux comes first in the cascade. `gwm herdr <pattern>` typed in such a session will reach a stale pane id and herdr will refuse it, which surfaces as a failed command rather than a wrong tab.
+
 Outside a session, the command **refuses** with a clear error rather than spawning a stray server: the alternative (spawning detached) leads to orphaned sessions that the user never sees.
 
 ```bash

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -45,15 +45,17 @@ gwm herdr auth -p              # split the current pane instead
 
 Under the hood:
 
-- **new tab** (default): `herdr tab create --label <name> --cwd <path>`
-- **split** (`-p` / `--split`): `herdr pane split --current --direction right --cwd <path>`
+- **new tab** (default): `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`
+- **split** (`-p` / `--split`): `herdr pane split --current --direction right --cwd <path> --focus`
 
-[herdr](https://herdr.dev) drives its own server over a socket, so both verbs are control commands rather than a `new-window` equivalent. Two details differ from tmux and zellij:
+[herdr](https://herdr.dev) drives its own server over a socket, so both verbs are control commands rather than a `new-window` equivalent. Four details differ from tmux and zellij:
 
 - **the split has a direction.** herdr's parser has no default for `--direction`, so gwm passes `right`, the analogue of tmux's `-h`. Making it a preference is a separate issue.
 - **the split takes no label.** A herdr pane is named after the fact with `herdr pane rename`, and `pane split` reads a bare argument as the pane to split, so gwm passes the worktree name only on `tab create`.
+- **`--focus` is not the default.** Both verbs come back `"focused": false` without it, where `tmux new-window` and `zellij action new-tab` move you to what they create. gwm passes it so herdr is not the one backend that opens the worktree out of sight.
+- **the new tab is pinned to your workspace.** Without `--workspace`, herdr targets the workspace the *server* has focused, which is another project's window as often as not. gwm passes `$HERDR_WORKSPACE_ID`, which every managed pane carries; outside one, the flag is dropped and herdr picks. A split needs none of this, `--current` already resolves the workspace.
 
-Verified against **herdr 0.8.2**.
+Verified against **herdr 0.8.2**, against a live server rather than the help text: the focus and workspace behaviours above were both measured, and both are the opposite of what the flag names suggest.
 
 ## required session
 

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -1,11 +1,11 @@
 ---
-title: tmux / zellij integration
-description: "`gwm tmux` / `gwm zellij` to open a worktree in a new window, pane, or tab."
+title: tmux / zellij / herdr integration
+description: "`gwm tmux` / `gwm zellij` / `gwm herdr` to open a worktree in a new window, pane, or tab."
 ---
 
-# tmux / zellij integration
+# tmux / zellij / herdr integration
 
-Inside an already-running multiplexer session, `gwm tmux` and `gwm zellij` spawn a new window / pane / tab whose shell starts inside the matched worktree, with no manual `cd` round-trip needed.
+Inside an already-running multiplexer session, `gwm tmux`, `gwm zellij` and `gwm herdr` spawn a new window / pane / tab whose shell starts inside the matched worktree, with no manual `cd` round-trip needed.
 
 ## tmux
 
@@ -36,12 +36,32 @@ Under the hood:
 
 The `--cwd` flag on `new-tab` requires **zellij ≥ 0.40**; older versions error out. `new-pane --cwd` has been stable longer, so use `-p` if you're stuck on an older zellij.
 
+## herdr
+
+```bash
+gwm herdr auth                 # new herdr tab inside the matched worktree
+gwm herdr auth -p              # split the current pane instead
+```
+
+Under the hood:
+
+- **new tab** (default): `herdr tab create --label <name> --cwd <path>`
+- **split** (`-p` / `--split`): `herdr pane split --current --direction right --cwd <path>`
+
+[herdr](https://herdr.dev) drives its own server over a socket, so both verbs are control commands rather than a `new-window` equivalent. Two details differ from tmux and zellij:
+
+- **the split has a direction.** herdr's parser has no default for `--direction`, so gwm passes `right`, the analogue of tmux's `-h`. Making it a preference is a separate issue.
+- **the split takes no label.** A herdr pane is named after the fact with `herdr pane rename`, and `pane split` reads a bare argument as the pane to split, so gwm passes the worktree name only on `tab create`.
+
+Verified against **herdr 0.8.2**.
+
 ## required session
 
-Both commands require the corresponding multiplexer to actually be running:
+All three commands require the corresponding multiplexer to actually be running:
 
 - `gwm tmux` checks for `$TMUX` in the environment.
 - `gwm zellij` checks for `$ZELLIJ`.
+- `gwm herdr` checks for `$HERDR_ENV`, which herdr sets to `1` in every pane it manages.
 
 Outside a session, the command **refuses** with a clear error rather than spawning a stray server: the alternative (spawning detached) leads to orphaned sessions that the user never sees.
 

--- a/docs/3.cli/index.md
+++ b/docs/3.cli/index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: The scriptable side of gwm, from the subcommand reference to the shell completions and the tmux / zellij integration.
+description: The scriptable side of gwm, from the subcommand reference to the shell completions and the tmux / zellij / herdr integration.
 navigation:
   title: CLI
 ---
@@ -9,8 +9,8 @@ navigation:
 
 `gwm <subcommand>` is the scriptable side of gwm, designed to be safe in pipelines, shell completions, and pre-commit hooks. Every subcommand exits with a meaningful code (`0` ok, `1` warning, `2` failure) so you can wire `gwm doctor` into CI without parsing stdout.
 
-- **[Reference](/cli/reference)**: every subcommand, exhaustive (`init`, `config`, `create`, `new`, `pr`, `review`, `list`, `path`, `cd`, `switch`, `bootstrap`, `sync`, `remove`, `prune`, `exec`, `clean`, `undo`, `history`, `link`, `unlink`, `open`, `status`, `labels`, `milestones`, `doctor`, `daemon`, `statusline`, `trust`, `types`, `commit-prefix`, `hooks`, `theme`, `tui keys`, `aliases`, `tmux`, `zellij`, `completions`, `shell-init`).
+- **[Reference](/cli/reference)**: every subcommand, exhaustive (`init`, `config`, `create`, `new`, `pr`, `review`, `list`, `path`, `cd`, `switch`, `bootstrap`, `sync`, `remove`, `prune`, `exec`, `clean`, `undo`, `history`, `link`, `unlink`, `open`, `status`, `labels`, `milestones`, `doctor`, `daemon`, `statusline`, `trust`, `types`, `commit-prefix`, `hooks`, `theme`, `tui keys`, `aliases`, `tmux`, `zellij`, `herdr`, `completions`, `shell-init`).
 - **[Shell completions](/cli/completions)**: generate completion scripts for zsh / bash / fish / PowerShell / elvish, plus dynamic worktree-name completion via `gwm list --format=names`.
-- **[Multiplexer integration](/cli/multiplexer)**: `gwm tmux` / `gwm zellij` to open a worktree in a new tab or pane of the current session.
+- **[Multiplexer integration](/cli/multiplexer)**: `gwm tmux` / `gwm zellij` / `gwm herdr` to open a worktree in a new tab or pane of the current session.
 
 The CLI never spawns a TUI of its own: every subcommand is non-interactive and prints to stdout/stderr. The only TUI surface is bare `gwm` (or `gwm switch` in picker mode), covered in the [TUI section](/tui).

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -654,7 +654,7 @@ authoritative if a future build shifts a default.
 | `yank_path`               | `Y`              | copy the worktree path                                |
 | `yank_branch_name`        | `y`              | copy the branch name                                  |
 | `yank_worktree_name`      | `w`              | copy the worktree name                                |
-| `mux_pane`                | `t`              | open the worktree in a new tmux / zellij pane         |
+| `mux_pane`                | `t`              | open the worktree in a new tmux / zellij / herdr pane |
 | `macro_one`               | `h`              | run `[tui.macro1]`                                    |
 | `macro_two`               | `H`              | run `[tui.macro2]`                                    |
 | `browse_links`            | `B`              | browse the issue / PR links                           |

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -86,7 +86,7 @@ tests/
 ├── aliases_tests.rs             # [aliases] resolution + shadowing + shell-pipeline refusal
 ├── doctor_tests.rs              # gwm doctor checks + severity arithmetic
 ├── hooks_tests.rs               # gwm hooks install commit-msg (force, linked worktree, hooksPath)
-├── multiplexer_tests.rs         # gwm tmux / gwm zellij argv construction + $TMUX guard
+├── multiplexer_tests.rs         # gwm tmux / zellij / herdr argv construction + env guard
 ├── launcher_tests.rs            # [git_tui] / [review] placeholder expansion + base resolution
 ├── error_tests.rs               # GwmError variants + Display + From impls
 ├── error_variants_tests.rs      # newer GwmError variants (unborn HEAD, gh JSON parse, …)

--- a/docs/8.comparison.md
+++ b/docs/8.comparison.md
@@ -133,7 +133,7 @@ for a tool that is finished, and a real risk if you need a bug fixed.
 
 Roughly at parity, with differences of shape rather than presence:
 
-- tmux and zellij integration
+- tmux, zellij and herdr integration
 - a command palette
 - shell helpers and completions (bash, zsh, fish)
 - custom commands bound to keys

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -66,7 +66,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `L`         | lancer la commande [`[git_tui]`](/fr/tui/launchers) configurée en plein écran (`lazygit_fullscreen`) |
 | `r`         | lancer la commande [`[review]`](/fr/tui/launchers) configurée dans une surcouche PTY (`review_pty`) : relecteur IA / web sur `git diff base..head` |
 | `R`         | lancer la commande [`[review]`](/fr/tui/launchers) configurée en plein écran (`review_fullscreen`) |
-| `t`         | ouvrir le worktree sélectionné dans un nouveau panneau tmux / zellij (`mux_pane`), repli sur une indication dans la barre de statut si aucun multiplexeur n'est détecté |
+| `t`         | ouvrir le worktree sélectionné dans un nouveau panneau tmux / zellij / herdr (`mux_pane`), repli sur une indication dans la barre de statut si aucun multiplexeur n'est détecté |
 | `h`         | lancer la commande [`[tui.macro1]`](/fr/configuration/gwm-toml#tuimacro1-et-tuimacro2) configurée par l'utilisateur (`macro_one`) |
 | `H`         | lancer la commande [`[tui.macro2]`](/fr/configuration/gwm-toml#tuimacro1-et-tuimacro2) configurée par l'utilisateur (`macro_two`) |
 | `y`         | copier le **nom de branche** du worktree sélectionné dans le presse-papiers (`yank_branch_name`)  |
@@ -510,7 +510,7 @@ changements les plus importants à réapprendre :
 | `R` (review) | `r` / `R` | `r` lance la review dans une surcouche PTY, `R` la lance en plein écran |
 | _(aucune)_  | `c`    | renommer le worktree sélectionné (`edit_worktree`)                   |
 | _(aucune)_  | `e`    | quitter la TUI vers le chemin sélectionné (`exit_to_worktree`)       |
-| _(aucune)_  | `t`    | ouvrir le worktree dans un nouveau panneau tmux / zellij (`mux_pane`)|
+| _(aucune)_  | `t`    | ouvrir le worktree dans un nouveau panneau tmux / zellij / herdr (`mux_pane`)|
 | _(aucune)_  | `h` / `H` | lancer `[tui.macro1]` / `[tui.macro2]`                            |
 
 Les overrides `[tui.keys]` existants écrits avec les anciens slugs (`git_tui`,

--- a/docs/fr/2.tui/8.keymap-and-palette.md
+++ b/docs/fr/2.tui/8.keymap-and-palette.md
@@ -98,7 +98,7 @@ command = "cargo install --path ."
 open_in = "pty"          # "pty" (défaut, surcouche embarquée) ou "mux_pane"
 ```
 
-`open_in` vaut `"pty"` par défaut (une [surcouche PTY](/fr/tui/launchers#loverlay-pty-embarqué-l--r) embarquée, la TUI se suspend jusqu'à la sortie) ; mettez `"mux_pane"` pour lancer la commande dans un nouveau panneau tmux / zellij à la place. Les bindings `h` / `H` sont eux-mêmes remappables comme les actions `macro_one` / `macro_two` dans `[tui.keys]`.
+`open_in` vaut `"pty"` par défaut (une [surcouche PTY](/fr/tui/launchers#loverlay-pty-embarqué-l--r) embarquée, la TUI se suspend jusqu'à la sortie) ; mettez `"mux_pane"` pour lancer la commande dans un nouveau panneau tmux / zellij à la place (les panneaux herdr ne prennent pas de commande, donc une session herdr garde la surcouche PTY). Les bindings `h` / `H` sont eux-mêmes remappables comme les actions `macro_one` / `macro_two` dans `[tui.keys]`.
 
 ## palette de commandes
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -511,9 +511,9 @@ Comme `gwm tmux` mais pour zellij. Utilise `zellij action new-tab --cwd <path>` 
 
 ## `gwm herdr <pattern> [-p|--split]`
 
-Comme `gwm tmux` mais pour [herdr](https://herdr.dev). Utilise `herdr tab create --label <name> --cwd <path>`, ou `herdr pane split --current --direction right --cwd <path>` avec `-p`. Nécessite `$HERDR_ENV`, que herdr fixe dans chaque panneau qu'il gère.
+Comme `gwm tmux` mais pour [herdr](https://herdr.dev). Utilise `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`, ou `herdr pane split --current --direction right --cwd <path> --focus` avec `-p`. Nécessite `$HERDR_ENV`, que herdr fixe dans chaque panneau qu'il gère.
 
-Le split s'ouvre à droite : herdr n'a pas de direction implicite, donc gwm choisit l'analogue du split horizontal de tmux.
+Le split s'ouvre à droite : herdr n'a pas de direction implicite, donc gwm choisit l'analogue du split horizontal de tmux. `--focus` et `--workspace` sont passés car aucun des deux n'est le défaut de herdr : sans eux, l'onglet s'ouvre sans focus, dans le workspace que le serveur avait en focus plutôt que le vôtre. L'id du workspace vient de `$HERDR_WORKSPACE_ID`.
 
 Voir [CLI → Intégration multiplexeur](/fr/cli/multiplexer) pour la surface complète et les cas limites.
 

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -509,6 +509,12 @@ En dehors d'une session tmux, sort avec un code non nul et une erreur claire (ne
 
 Comme `gwm tmux` mais pour zellij. Utilise `zellij action new-tab --cwd <path>` (nécessite zellij ≥ 0.40 pour le flag `--cwd`) ou `new-pane --cwd` avec `-p`. Nécessite `$ZELLIJ`.
 
+## `gwm herdr <pattern> [-p|--split]`
+
+Comme `gwm tmux` mais pour [herdr](https://herdr.dev). Utilise `herdr tab create --label <name> --cwd <path>`, ou `herdr pane split --current --direction right --cwd <path>` avec `-p`. Nécessite `$HERDR_ENV`, que herdr fixe dans chaque panneau qu'il gère.
+
+Le split s'ouvre à droite : herdr n'a pas de direction implicite, donc gwm choisit l'analogue du split horizontal de tmux.
+
 Voir [CLI → Intégration multiplexeur](/fr/cli/multiplexer) pour la surface complète et les cas limites.
 
 ## `gwm link {issue|pr} <N> [--worktree <pattern>]`

--- a/docs/fr/3.cli/2.completions.md
+++ b/docs/fr/3.cli/2.completions.md
@@ -34,13 +34,13 @@ Ouvrez un nouveau shell (ou faites `source` de votre fichier rc) et la compléti
 
 ## complétion dynamique des noms de worktree
 
-Le script statique connaît les sous-commandes et les flags mais **pas** les worktrees de votre dépôt, qui changent à chaque fois que vous lancez `gwm create / remove`. Branchez un completer personnalisé à `gwm list --format=names` pour une complétion en direct de l'argument nom-de-worktree sur `path` / `cd` / `remove` / `bootstrap` / `sync` / `tmux` / `zellij` / `exec` / `clean` (qui résolvent tous leur positionnel via le même matcher flou).
+Le script statique connaît les sous-commandes et les flags mais **pas** les worktrees de votre dépôt, qui changent à chaque fois que vous lancez `gwm create / remove`. Branchez un completer personnalisé à `gwm list --format=names` pour une complétion en direct de l'argument nom-de-worktree sur `path` / `cd` / `remove` / `bootstrap` / `sync` / `tmux` / `zellij` / `herdr` / `exec` / `clean` (qui résolvent tous leur positionnel via le même matcher flou).
 
 ### zsh
 
 ```zsh
 _gwm_worktrees() { compadd $(gwm list --format=names 2>/dev/null) }
-compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-sync gwm-tmux gwm-zellij gwm-exec gwm-clean
+compdef _gwm_worktrees gwm-path gwm-cd gwm-remove gwm-bootstrap gwm-sync gwm-tmux gwm-zellij gwm-herdr gwm-exec gwm-clean
 ```
 
 (`gwm-path`, `gwm-cd`, etc. sont les noms de fonction auto-générés que le completer statique `_gwm` enregistre par sous-commande.)
@@ -58,7 +58,7 @@ complete -F _gwm_worktrees -o default gwm
 ### fish
 
 ```fish
-complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap sync tmux zellij exec clean" \
+complete -c gwm -n "__fish_seen_subcommand_from path cd remove bootstrap sync tmux zellij herdr exec clean" \
   -f -a "(gwm list --format=names 2>/dev/null)"
 ```
 

--- a/docs/fr/3.cli/3.multiplexer.md
+++ b/docs/fr/3.cli/3.multiplexer.md
@@ -45,15 +45,17 @@ gwm herdr auth -p              # split the current pane instead
 
 Sous le capot :
 
-- **nouvel onglet** (défaut) : `herdr tab create --label <name> --cwd <path>`
-- **split** (`-p` / `--split`) : `herdr pane split --current --direction right --cwd <path>`
+- **nouvel onglet** (défaut) : `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`
+- **split** (`-p` / `--split`) : `herdr pane split --current --direction right --cwd <path> --focus`
 
-[herdr](https://herdr.dev) pilote son propre serveur via une socket, donc les deux verbes sont des commandes de contrôle plutôt qu'un équivalent de `new-window`. Deux détails diffèrent de tmux et zellij :
+[herdr](https://herdr.dev) pilote son propre serveur via une socket, donc les deux verbes sont des commandes de contrôle plutôt qu'un équivalent de `new-window`. Quatre détails diffèrent de tmux et zellij :
 
 - **le split a une direction.** Le parseur de herdr n'a pas de valeur par défaut pour `--direction`, donc gwm passe `right`, l'analogue du `-h` de tmux. En faire une préférence fait l'objet d'une issue séparée.
 - **le split ne prend pas de label.** Un panneau herdr se nomme après coup avec `herdr pane rename`, et `pane split` lit un argument nu comme le panneau à découper, donc gwm ne passe le nom du worktree que sur `tab create`.
+- **`--focus` n'est pas le défaut.** Les deux verbes reviennent `"focused": false` sans lui, là où `tmux new-window` et `zellij action new-tab` vous amènent sur ce qu'ils créent. gwm le passe pour que herdr ne soit pas le seul backend à ouvrir le worktree hors de votre vue.
+- **le nouvel onglet est épinglé sur votre workspace.** Sans `--workspace`, herdr vise le workspace que le *serveur* a en focus, soit la fenêtre d'un autre projet une fois sur deux. gwm passe `$HERDR_WORKSPACE_ID`, que chaque panneau géré transporte ; en dehors d'un panneau géré, le flag est omis et herdr choisit. Un split n'en a pas besoin, `--current` résout déjà le workspace.
 
-Vérifié contre **herdr 0.8.2**.
+Vérifié contre **herdr 0.8.2**, contre un serveur en fonctionnement et non contre l'aide en ligne : les comportements de focus et de workspace ci-dessus ont tous deux été mesurés, et sont tous deux l'inverse de ce que le nom des flags suggère.
 
 ## session requise
 

--- a/docs/fr/3.cli/3.multiplexer.md
+++ b/docs/fr/3.cli/3.multiplexer.md
@@ -65,6 +65,8 @@ Les trois commandes nécessitent que le multiplexeur correspondant soit effectiv
 - `gwm zellij` vérifie celle de `$ZELLIJ`.
 - `gwm herdr` vérifie celle de `$HERDR_ENV`, que herdr fixe à `1` dans chaque panneau qu'il gère.
 
+Une réserve sur ce dernier point, qui vient de herdr et non de gwm : un serveur tmux démarré depuis un panneau herdr recopie tout le jeu `HERDR_*` dans son environnement global ([herdrdev/herdr#2134](https://github.com/herdrdev/herdr/issues/2134)), si bien que des sessions sans rapport sur ce serveur se déclarent elles aussi panneaux herdr. La touche `t` de la TUI n'est pas concernée : ces sessions ont `$TMUX` défini et tmux passe en premier dans la cascade. `gwm herdr <pattern>` tapé dans une telle session visera un id de panneau périmé, que herdr refusera, ce qui se voit comme une commande en échec plutôt que comme un mauvais onglet.
+
 En dehors d'une session, la commande **refuse** avec une erreur claire plutôt que de lancer un serveur orphelin : l'alternative (lancer en détaché) mène à des sessions orphelines que l'utilisateur ne voit jamais.
 
 ```bash

--- a/docs/fr/3.cli/3.multiplexer.md
+++ b/docs/fr/3.cli/3.multiplexer.md
@@ -1,11 +1,11 @@
 ---
-title: Intégration tmux / zellij
-description: "`gwm tmux` / `gwm zellij` pour ouvrir un worktree dans une nouvelle fenêtre, un panneau ou un onglet."
+title: Intégration tmux / zellij / herdr
+description: "`gwm tmux` / `gwm zellij` / `gwm herdr` pour ouvrir un worktree dans une nouvelle fenêtre, un panneau ou un onglet."
 ---
 
-# Intégration tmux / zellij
+# Intégration tmux / zellij / herdr
 
-À l'intérieur d'une session de multiplexeur déjà en cours, `gwm tmux` et `gwm zellij` lancent une nouvelle fenêtre / un nouveau panneau / un nouvel onglet dont le shell démarre à l'intérieur du worktree correspondant, sans aller-retour manuel de `cd`.
+À l'intérieur d'une session de multiplexeur déjà en cours, `gwm tmux`, `gwm zellij` et `gwm herdr` lancent une nouvelle fenêtre / un nouveau panneau / un nouvel onglet dont le shell démarre à l'intérieur du worktree correspondant, sans aller-retour manuel de `cd`.
 
 ## tmux
 
@@ -36,12 +36,32 @@ Sous le capot :
 
 Le flag `--cwd` sur `new-tab` nécessite **zellij ≥ 0.40** ; les versions plus anciennes échouent. `new-pane --cwd` est stable depuis plus longtemps, donc utilisez `-p` si vous êtes coincé sur un zellij plus ancien.
 
+## herdr
+
+```bash
+gwm herdr auth                 # new herdr tab inside the matched worktree
+gwm herdr auth -p              # split the current pane instead
+```
+
+Sous le capot :
+
+- **nouvel onglet** (défaut) : `herdr tab create --label <name> --cwd <path>`
+- **split** (`-p` / `--split`) : `herdr pane split --current --direction right --cwd <path>`
+
+[herdr](https://herdr.dev) pilote son propre serveur via une socket, donc les deux verbes sont des commandes de contrôle plutôt qu'un équivalent de `new-window`. Deux détails diffèrent de tmux et zellij :
+
+- **le split a une direction.** Le parseur de herdr n'a pas de valeur par défaut pour `--direction`, donc gwm passe `right`, l'analogue du `-h` de tmux. En faire une préférence fait l'objet d'une issue séparée.
+- **le split ne prend pas de label.** Un panneau herdr se nomme après coup avec `herdr pane rename`, et `pane split` lit un argument nu comme le panneau à découper, donc gwm ne passe le nom du worktree que sur `tab create`.
+
+Vérifié contre **herdr 0.8.2**.
+
 ## session requise
 
-Les deux commandes nécessitent que le multiplexeur correspondant soit effectivement en cours d'exécution :
+Les trois commandes nécessitent que le multiplexeur correspondant soit effectivement en cours d'exécution :
 
 - `gwm tmux` vérifie la présence de `$TMUX` dans l'environnement.
 - `gwm zellij` vérifie celle de `$ZELLIJ`.
+- `gwm herdr` vérifie celle de `$HERDR_ENV`, que herdr fixe à `1` dans chaque panneau qu'il gère.
 
 En dehors d'une session, la commande **refuse** avec une erreur claire plutôt que de lancer un serveur orphelin : l'alternative (lancer en détaché) mène à des sessions orphelines que l'utilisateur ne voit jamais.
 

--- a/docs/fr/3.cli/index.md
+++ b/docs/fr/3.cli/index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: La face scriptable de gwm, de la référence des sous-commandes aux complétions de shell et à l'intégration tmux / zellij.
+description: La face scriptable de gwm, de la référence des sous-commandes aux complétions de shell et à l'intégration tmux / zellij / herdr.
 navigation:
   title: CLI
 ---
@@ -9,8 +9,8 @@ navigation:
 
 `gwm <subcommand>` est la face scriptable de gwm, conçue pour être sûre dans les pipelines, les complétions de shell et les hooks de pre-commit. Chaque sous-commande se termine avec un code significatif (`0` ok, `1` avertissement, `2` échec), de sorte que vous pouvez brancher `gwm doctor` dans la CI sans parser la sortie standard.
 
-- **[Référence](/fr/cli/reference)** : chaque sous-commande, exhaustive (`init`, `config`, `create`, `new`, `pr`, `review`, `list`, `path`, `cd`, `switch`, `bootstrap`, `sync`, `remove`, `prune`, `exec`, `clean`, `undo`, `history`, `link`, `unlink`, `open`, `status`, `labels`, `milestones`, `doctor`, `daemon`, `statusline`, `trust`, `types`, `commit-prefix`, `hooks`, `theme`, `tui keys`, `aliases`, `tmux`, `zellij`, `completions`, `shell-init`).
+- **[Référence](/fr/cli/reference)** : chaque sous-commande, exhaustive (`init`, `config`, `create`, `new`, `pr`, `review`, `list`, `path`, `cd`, `switch`, `bootstrap`, `sync`, `remove`, `prune`, `exec`, `clean`, `undo`, `history`, `link`, `unlink`, `open`, `status`, `labels`, `milestones`, `doctor`, `daemon`, `statusline`, `trust`, `types`, `commit-prefix`, `hooks`, `theme`, `tui keys`, `aliases`, `tmux`, `zellij`, `herdr`, `completions`, `shell-init`).
 - **[Complétions de shell](/fr/cli/completions)** : générer des scripts de complétion pour zsh / bash / fish / PowerShell / elvish, plus la complétion dynamique des noms de worktree via `gwm list --format=names`.
-- **[Intégration multiplexeur](/fr/cli/multiplexer)** : `gwm tmux` / `gwm zellij` pour ouvrir un worktree dans un nouvel onglet ou panneau de la session courante.
+- **[Intégration multiplexeur](/fr/cli/multiplexer)** : `gwm tmux` / `gwm zellij` / `gwm herdr` pour ouvrir un worktree dans un nouvel onglet ou panneau de la session courante.
 
 La CLI ne lance jamais de TUI de son côté : chaque sous-commande est non interactive et écrit sur stdout/stderr. La seule surface TUI est `gwm` seul (ou `gwm switch` en mode sélecteur), couverte dans la [section TUI](/fr/tui).

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -656,7 +656,7 @@ et fait foi si un futur build décale une valeur par défaut.
 | `yank_path`               | `Y`                 | copier le chemin du worktree                          |
 | `yank_branch_name`        | `y`                 | copier le nom de la branche                           |
 | `yank_worktree_name`      | `w`                 | copier le nom du worktree                             |
-| `mux_pane`                | `t`                 | ouvrir le worktree dans un nouveau pane tmux / zellij |
+| `mux_pane`                | `t`                 | ouvrir le worktree dans un nouveau pane tmux / zellij / herdr |
 | `macro_one`               | `h`                 | exécuter `[tui.macro1]`                               |
 | `macro_two`               | `H`                 | exécuter `[tui.macro2]`                               |
 | `browse_links`            | `B`                 | parcourir les liens issue / PR                        |

--- a/docs/fr/6.development/1.testing.md
+++ b/docs/fr/6.development/1.testing.md
@@ -86,7 +86,7 @@ tests/
 ├── aliases_tests.rs             # [aliases] resolution + shadowing + shell-pipeline refusal
 ├── doctor_tests.rs              # gwm doctor checks + severity arithmetic
 ├── hooks_tests.rs               # gwm hooks install commit-msg (force, linked worktree, hooksPath)
-├── multiplexer_tests.rs         # gwm tmux / gwm zellij argv construction + $TMUX guard
+├── multiplexer_tests.rs         # gwm tmux / zellij / herdr argv construction + env guard
 ├── launcher_tests.rs            # [git_tui] / [review] placeholder expansion + base resolution
 ├── error_tests.rs               # GwmError variants + Display + From impls
 ├── error_variants_tests.rs      # newer GwmError variants (unborn HEAD, gh JSON parse, …)

--- a/docs/fr/8.comparison.md
+++ b/docs/fr/8.comparison.md
@@ -140,7 +140,7 @@ bug corrigé.
 
 À peu près à parité, avec des différences de forme plutôt que de présence :
 
-- l'intégration tmux et zellij
+- l'intégration tmux, zellij et herdr
 - une palette de commandes
 - des helpers shell et des complétions (bash, zsh, fish)
 - des commandes personnalisées liées à des touches

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -384,6 +384,7 @@ const BUILT_IN_SUBCOMMANDS: &[&str] = &[
   "switch",
   "tmux",
   "zellij",
+  "herdr",
   "link",
   "unlink",
   "open",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,8 @@ use crate::labels::{self, LabelDiff};
 use crate::lifecycle::{self, HookContext, HookPhase, HookSkips};
 use crate::milestones::{self, MilestoneDiff};
 use crate::multiplexer::{
-  build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode,
+  build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij, Multiplexer,
+  SpawnMode,
 };
 use crate::naming::{BranchSpec, WorktreeName};
 use crate::pr_templates::{self, PrTemplateContext};
@@ -546,6 +547,20 @@ pub enum Command {
     /// Fuzzy worktree name pattern (same matcher as `gwm path / remove`).
     pattern: String,
     /// Split the current tab into a new pane instead of opening a new tab.
+    #[arg(short = 'p', long = "split")]
+    split: bool,
+  },
+  /// Open the matched worktree in a new herdr tab (current session).
+  ///
+  /// Requires `$HERDR_ENV` to be set, i.e. gwm must be invoked from a
+  /// pane herdr manages. Uses `herdr tab create`, or `herdr pane split`
+  /// with `--split` to open in a pane of the current tab instead. The
+  /// split opens to the right; herdr has no implicit direction, so gwm
+  /// picks the analogue of tmux's horizontal split.
+  Herdr {
+    /// Fuzzy worktree name pattern (same matcher as `gwm path / remove`).
+    pattern: String,
+    /// Split the current pane instead of opening a new tab.
     #[arg(short = 'p', long = "split")]
     split: bool,
   },
@@ -1141,6 +1156,7 @@ pub fn run(cli: Cli) -> Result<()> {
     Command::Switch => cmd_switch(),
     Command::Tmux { pattern, split } => cmd_multiplexer(Multiplexer::Tmux, pattern, split),
     Command::Zellij { pattern, split } => cmd_multiplexer(Multiplexer::Zellij, pattern, split),
+    Command::Herdr { pattern, split } => cmd_multiplexer(Multiplexer::Herdr, pattern, split),
     Command::Link {
       target,
       number,
@@ -3931,10 +3947,11 @@ fn cmd_switch() -> Result<()> {
   }
 }
 
-/// `gwm tmux <pattern>` / `gwm zellij <pattern>` — open the matched
-/// worktree in a new window/tab (or split with `--split`). The handler
-/// is shared between the two multiplexers because the only difference
-/// is the argv shape, already encoded in `multiplexer::build_*_command`.
+/// `gwm tmux <pattern>` / `gwm zellij <pattern>` / `gwm herdr <pattern>`
+/// — open the matched worktree in a new window/tab (or split with
+/// `--split`). The handler is shared between the three multiplexers
+/// because the only difference is the argv shape, already encoded in
+/// `multiplexer::build_*_command`.
 ///
 /// Error contract (ordered, first match wins):
 ///   1. Not inside a git repo → `NotInGitRepo`.
@@ -3950,11 +3967,15 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool) -> Result<()>
   let env_name = match mux {
     Multiplexer::Tmux => "TMUX",
     Multiplexer::Zellij => "ZELLIJ",
+    // Herdr sets HERDR_ENV=1 in every pane it manages; the other
+    // HERDR_* variables (pane id, tab id, socket) ride along with it.
+    Multiplexer::Herdr => "HERDR_ENV",
   };
   let env_value = std::env::var(env_name).ok();
   let running = match mux {
     Multiplexer::Tmux => detect_tmux(env_value),
     Multiplexer::Zellij => detect_zellij(env_value),
+    Multiplexer::Herdr => detect_herdr(env_value),
   };
   if !running {
     // `${env_name}` renders bare in stderr (not shell source, so no
@@ -3972,6 +3993,7 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool) -> Result<()>
   let argv = match mux {
     Multiplexer::Tmux => build_tmux_command(&found.name, &found.path, mode),
     Multiplexer::Zellij => build_zellij_command(&found.name, &found.path, mode),
+    Multiplexer::Herdr => build_herdr_command(&found.name, &found.path, mode),
   };
   spawn_multiplexer(mux, &argv)
 }
@@ -3987,7 +4009,8 @@ fn spawn_multiplexer(mux: Multiplexer, argv: &[String]) -> Result<()> {
       mux.binary()
     ))
   })?;
-  // The data string already names the binary (`tmux` / `zellij`), so
+  // The data string already names the binary (`tmux` / `zellij` /
+  // `herdr`), so
   // the rendered message reads `command failed: tmux exited with
   // status Some(1)` — attributable to the verb the user typed.
   let status = std::process::Command::new(bin)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3993,7 +3993,15 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool) -> Result<()>
   let argv = match mux {
     Multiplexer::Tmux => build_tmux_command(&found.name, &found.path, mode),
     Multiplexer::Zellij => build_zellij_command(&found.name, &found.path, mode),
-    Multiplexer::Herdr => build_herdr_command(&found.name, &found.path, mode),
+    // `$HERDR_WORKSPACE_ID` pins the new tab to the calling pane's
+    // workspace; without it herdr uses whichever workspace the server has
+    // focused, which is a different project's window as often as not.
+    Multiplexer::Herdr => build_herdr_command(
+      &found.name,
+      &found.path,
+      mode,
+      std::env::var("HERDR_WORKSPACE_ID").ok().as_deref(),
+    ),
   };
   spawn_multiplexer(mux, &argv)
 }

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -95,7 +95,8 @@ pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Str
 /// commands rather than a `new-window` equivalent; measured against
 /// herdr 0.8.2 (`herdr tab create --help`, `herdr pane split --help`).
 ///
-/// Two shapes differ from the tmux / zellij builders:
+/// Four shapes differ from the tmux / zellij builders, three of them
+/// measured against a live server rather than read off the help text:
 ///
 /// * `pane split` needs `--current` to target the caller's pane. Without
 ///   it herdr has no pane to split from.
@@ -104,27 +105,43 @@ pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Str
 ///   herdr's own agent guidance reaches for on a wide pane. Making it a
 ///   preference is filed separately; this is the hardcoded default until
 ///   that lands.
+/// * **`--focus` is not the default.** `tab create` and `pane split` both
+///   come back `"focused": false` when the flag is omitted, where
+///   `tmux new-window` and `zellij action new-tab` move the user to what
+///   they create. Omitting it would make herdr the one backend that opens
+///   the worktree somewhere the user cannot see.
+/// * **`tab create` needs `--workspace`.** Without it herdr uses the
+///   server's *focused* workspace, not the caller's: run from a pane in
+///   `w2K` with `w2P` focused, the tab landed in `w2P`. `workspace` is
+///   `$HERDR_WORKSPACE_ID`, which every managed pane carries. An absent or
+///   empty id drops the flag rather than passing one herdr would reject,
+///   so a caller outside a managed pane degrades to herdr's own choice.
+///   A split needs none of this: `--current` names the pane, which already
+///   resolves the workspace (measured, the pane came back in `w2K`).
 ///
 /// `pane split` takes no `--label` (a pane is renamed after the fact with
 /// `herdr pane rename`), so the worktree name is deliberately dropped in
 /// `Split` mode: passing it bare would be read as the optional `[PANE_ID]`
-/// positional and split someone else's pane.
-///
-/// Neither verb pins `--focus` / `--no-focus`: herdr focuses what it
-/// creates by default, which is what `tmux new-window` and
-/// `zellij action new-tab` do, and gwm has no reason to override it.
-pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<String> {
+/// positional and split someone else's pane. `workspace` is likewise
+/// ignored there.
+pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode, workspace: Option<&str>) -> Vec<String> {
   let path_str = path.display().to_string();
   match mode {
-    SpawnMode::Window => vec![
-      "herdr".into(),
-      "tab".into(),
-      "create".into(),
-      "--label".into(),
-      name.into(),
-      "--cwd".into(),
-      path_str,
-    ],
+    SpawnMode::Window => {
+      let mut argv = vec!["herdr".into(), "tab".into(), "create".into()];
+      if let Some(ws) = workspace.filter(|ws| !ws.is_empty()) {
+        argv.push("--workspace".into());
+        argv.push(ws.into());
+      }
+      argv.extend([
+        "--label".into(),
+        name.into(),
+        "--cwd".into(),
+        path_str,
+        "--focus".into(),
+      ]);
+      argv
+    }
     SpawnMode::Split => vec![
       "herdr".into(),
       "pane".into(),
@@ -134,11 +151,12 @@ pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Stri
       "right".into(),
       "--cwd".into(),
       path_str,
+      "--focus".into(),
     ],
   }
 }
 
-/// Resolve which multiplexer the process is inside and build its `Split`
+/// Resolve which multiplexer the process is inside/// Resolve which multiplexer the process is inside and build its `Split`
 /// argv, in the order tmux, zellij, herdr.
 ///
 /// Both TUI call sites (`t`, and a `[tui.macro*]` with
@@ -165,7 +183,11 @@ pub fn detect_split_command(
   } else if detect_zellij(zellij) {
     Some((Multiplexer::Zellij, build_zellij_command(name, path, SpawnMode::Split)))
   } else if detect_herdr(herdr) {
-    Some((Multiplexer::Herdr, build_herdr_command(name, path, SpawnMode::Split)))
+    // A split needs no workspace id: `--current` resolves it.
+    Some((
+      Multiplexer::Herdr,
+      build_herdr_command(name, path, SpawnMode::Split, None),
+    ))
   } else {
     None
   }

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -1,23 +1,26 @@
 //! Terminal-multiplexer integration. Builds the argv vectors for
-//! `tmux new-window/split-window` and `zellij action new-tab/new-pane` so
-//! `gwm tmux <pattern>` / `gwm zellij <pattern>` can open a worktree in
+//! `tmux new-window/split-window`, `zellij action new-tab/new-pane` and
+//! `herdr tab create / pane split` so `gwm tmux <pattern>` /
+//! `gwm zellij <pattern>` / `gwm herdr <pattern>` can open a worktree in
 //! one keystroke from inside an already-running multiplexer session.
 //!
 //! The command builders are pure functions returning `Vec<String>` so the
-//! integration tests can pin the exact incantation without spawning tmux
-//! or zellij on every test runner. The actual `std::process::Command`
+//! integration tests can pin the exact incantation without spawning tmux,
+//! zellij or herdr on every test runner. The actual `std::process::Command`
 //! spawn lives in `cli.rs`, matching the lazygit-launch pattern in
 //! `tui/mod.rs::run_lazygit`.
 
 use std::path::Path;
 
-/// Multiplexer the user opted into via `gwm tmux …` / `gwm zellij …`.
+/// Multiplexer the user opted into via `gwm tmux …` / `gwm zellij …` /
+/// `gwm herdr …`.
 /// Carried through the CLI dispatch so the not-running error and the
 /// argv builder share one source of truth for the binary name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Multiplexer {
   Tmux,
   Zellij,
+  Herdr,
 }
 
 impl Multiplexer {
@@ -27,12 +30,13 @@ impl Multiplexer {
     match self {
       Multiplexer::Tmux => "tmux",
       Multiplexer::Zellij => "zellij",
+      Multiplexer::Herdr => "herdr",
     }
   }
 }
 
 /// How to open the worktree inside the multiplexer.
-/// `Window` = new tmux window / zellij tab (the default — full screen real estate).
+/// `Window` = new tmux window / zellij tab / herdr tab (the default — full screen real estate).
 /// `Split`  = split the current pane (the `-p` flag — keeps both views visible).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpawnMode {
@@ -85,6 +89,55 @@ pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Str
   }
 }
 
+/// Build `herdr tab create --label <name> --cwd <path>` (Window) or
+/// `herdr pane split --current --direction right --cwd <path>` (Split).
+/// Herdr drives its own server over a socket, so both verbs are control
+/// commands rather than a `new-window` equivalent; measured against
+/// herdr 0.8.2 (`herdr tab create --help`, `herdr pane split --help`).
+///
+/// Two shapes differ from the tmux / zellij builders:
+///
+/// * `pane split` needs `--current` to target the caller's pane. Without
+///   it herdr has no pane to split from.
+/// * `--direction` has no default in herdr's parser, so it must be
+///   passed. `right` is the analogue of tmux's `-h` and of the direction
+///   herdr's own agent guidance reaches for on a wide pane. Making it a
+///   preference is filed separately; this is the hardcoded default until
+///   that lands.
+///
+/// `pane split` takes no `--label` (a pane is renamed after the fact with
+/// `herdr pane rename`), so the worktree name is deliberately dropped in
+/// `Split` mode: passing it bare would be read as the optional `[PANE_ID]`
+/// positional and split someone else's pane.
+///
+/// Neither verb pins `--focus` / `--no-focus`: herdr focuses what it
+/// creates by default, which is what `tmux new-window` and
+/// `zellij action new-tab` do, and gwm has no reason to override it.
+pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<String> {
+  let path_str = path.display().to_string();
+  match mode {
+    SpawnMode::Window => vec![
+      "herdr".into(),
+      "tab".into(),
+      "create".into(),
+      "--label".into(),
+      name.into(),
+      "--cwd".into(),
+      path_str,
+    ],
+    SpawnMode::Split => vec![
+      "herdr".into(),
+      "pane".into(),
+      "split".into(),
+      "--current".into(),
+      "--direction".into(),
+      "right".into(),
+      "--cwd".into(),
+      path_str,
+    ],
+  }
+}
+
 /// `true` when `$TMUX` is set to a non-empty value — tmux exports the
 /// socket path to every process spawned inside a session, so its
 /// presence is the canonical "am I inside tmux?" probe.
@@ -103,6 +156,19 @@ pub fn detect_tmux(env: Option<String>) -> bool {
 /// `true` when `$ZELLIJ` is set to a non-empty value. Zellij exports the
 /// variable to every command spawned inside a session, similar to tmux.
 pub fn detect_zellij(env: Option<String>) -> bool {
+  match env {
+    Some(s) => !s.is_empty(),
+    None => false,
+  }
+}
+
+/// `true` when `$HERDR_ENV` is set to a non-empty value. Herdr exports it
+/// as `1` to every process it starts in a managed pane, alongside
+/// `HERDR_PANE_ID` / `HERDR_TAB_ID` / `HERDR_SOCKET_PATH`. The value is
+/// not parsed, only its presence: `$HERDR_ENV` is the direct analogue of
+/// `$TMUX`, and a herdr that one day exports something richer than `1`
+/// keeps working.
+pub fn detect_herdr(env: Option<String>) -> bool {
   match env {
     Some(s) => !s.is_empty(),
     None => false,

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -138,6 +138,39 @@ pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Stri
   }
 }
 
+/// Resolve which multiplexer the process is inside and build its `Split`
+/// argv, in the order tmux, zellij, herdr.
+///
+/// Both TUI call sites (`t`, and a `[tui.macro*]` with
+/// `open_in = "mux_pane"`) need that same answer, and until #588 each wrote
+/// its own if-chain: adding a third backend was two edits that could
+/// disagree about the order. The `Multiplexer` comes back with the argv
+/// because the macro path has to tell herdr apart, whose panes take no
+/// command.
+///
+/// The three env values are parameters rather than reads, the shape
+/// [`detect_tmux`] already uses, so the state tests can drive every branch
+/// without rewriting a process-global variable. That is not theoretical
+/// here: `$TMUX` is also read by the clipboard path, so a test that unset it
+/// would pull every yank test in the same binary under the env lock.
+pub fn detect_split_command(
+  name: &str,
+  path: &Path,
+  tmux: Option<String>,
+  zellij: Option<String>,
+  herdr: Option<String>,
+) -> Option<(Multiplexer, Vec<String>)> {
+  if detect_tmux(tmux) {
+    Some((Multiplexer::Tmux, build_tmux_command(name, path, SpawnMode::Split)))
+  } else if detect_zellij(zellij) {
+    Some((Multiplexer::Zellij, build_zellij_command(name, path, SpawnMode::Split)))
+  } else if detect_herdr(herdr) {
+    Some((Multiplexer::Herdr, build_herdr_command(name, path, SpawnMode::Split)))
+  } else {
+    None
+  }
+}
+
 /// `true` when `$TMUX` is set to a non-empty value — tmux exports the
 /// socket path to every process spawned inside a session, so its
 /// presence is the canonical "am I inside tmux?" probe.

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -223,6 +223,24 @@ pub fn detect_zellij(env: Option<String>) -> bool {
 /// not parsed, only its presence: `$HERDR_ENV` is the direct analogue of
 /// `$TMUX`, and a herdr that one day exports something richer than `1`
 /// keeps working.
+///
+/// # The one case this probe gets wrong
+///
+/// A tmux server started from inside a herdr pane promotes the whole
+/// `HERDR_*` set to its server-global environment, so every later session
+/// on that server carries `HERDR_ENV=1` and a pane id it does not own
+/// (herdrdev/herdr#2134, filed against 0.7.5 and closed unfixed for
+/// template non-compliance, so still live in 0.8.2).
+///
+/// [`detect_split_command`] is immune by construction: that leak only
+/// happens inside a tmux session, where `$TMUX` is set and tmux wins the
+/// cascade first. `gwm herdr <pattern>` is not, and cannot be made so
+/// here. The upstream issue reports every marker variable leaking
+/// together, pane id and socket path included, so no local check can tell
+/// a real pane from a leaked one: only asking the running server whether
+/// it owns `$HERDR_PANE_ID` separates them, which is the socket round trip
+/// #599 tracks. Until then the failure is loud rather than silent, since
+/// herdr answers a stale pane id with a non-zero exit.
 pub fn detect_herdr(env: Option<String>) -> bool {
   match env {
     Some(s) => !s.is_empty(),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5151,30 +5151,30 @@ impl App {
   /// Detects tmux / zellij / herdr at runtime via environment variables;
   /// prints a status message when no supported multiplexer is active.
   pub fn open_in_mux_pane(&mut self) {
-    use crate::multiplexer::{
-      build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij,
-      SpawnMode,
-    };
+    self.open_in_mux_pane_from(
+      std::env::var("TMUX").ok(),
+      std::env::var("ZELLIJ").ok(),
+      std::env::var("HERDR_ENV").ok(),
+    );
+  }
+
+  /// [`Self::open_in_mux_pane`] with the three env probes passed in, so a
+  /// state test can drive the refusals without rewriting a process-global
+  /// variable (#588). `$TMUX` is read by the clipboard path too, so unsetting
+  /// it in a test would put every yank test in the same binary under the env
+  /// lock.
+  pub fn open_in_mux_pane_from(&mut self, tmux: Option<String>, zellij: Option<String>, herdr: Option<String>) {
     let Some(w) = self.selected() else {
       self.status = "no worktree selected".into();
       return;
     };
     let path = w.path.clone();
     let name = w.name.clone();
-    // `mux_pane` promises a pane, so split the current pane (tmux
-    // `split-window` / zellij `new-pane` / herdr `pane split`) rather
-    // than opening a new window/tab (Codex review on PR #292).
-    //
-    // Herdr goes last in the cascade so a user running gwm inside both
-    // (herdr hosting a tmux session, say) keeps the behaviour they had
-    // before #588: the innermost multiplexer is the one that splits.
-    let cmd = if detect_tmux(std::env::var("TMUX").ok()) {
-      build_tmux_command(&name, &path, SpawnMode::Split)
-    } else if detect_zellij(std::env::var("ZELLIJ").ok()) {
-      build_zellij_command(&name, &path, SpawnMode::Split)
-    } else if detect_herdr(std::env::var("HERDR_ENV").ok()) {
-      build_herdr_command(&name, &path, SpawnMode::Split)
-    } else {
+    // `mux_pane` promises a pane, so the shared cascade builds a Split (tmux
+    // `split-window` / zellij `new-pane` / herdr `pane split`) rather than a
+    // new window/tab (Codex review on PR #292). Herdr comes last in it, so a
+    // user running gwm inside both keeps what they had before #588.
+    let Some((_, cmd)) = crate::multiplexer::detect_split_command(&name, &path, tmux, zellij, herdr) else {
       self.status = "no multiplexer detected ($TMUX / $ZELLIJ / $HERDR_ENV not set)".into();
       return;
     };

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5179,19 +5179,28 @@ impl App {
       return;
     };
     let bin = cmd[0].as_str();
-    // Both pipes go to `/dev/null` because this runs while ratatui owns the
-    // screen: a child that inherits them draws over the frame, and the status
-    // bar is the only channel gwm has for runtime feedback. tmux and zellij
-    // say nothing on success so it never came up; `herdr pane split` prints
-    // its `pane_info` JSON on every call (#588), which would land in the
-    // middle of the worktree table.
-    match std::process::Command::new(bin)
-      .args(&cmd[1..])
-      .stdout(std::process::Stdio::null())
-      .stderr(std::process::Stdio::null())
-      .spawn()
-    {
-      Ok(_) => self.status = format!("opened {} in new pane", name),
+    // `output()` rather than `spawn()`: both pipes have to be captured
+    // because this runs while ratatui owns the screen, and a child that
+    // inherits them draws over the frame (`herdr pane split` prints its
+    // `pane_info` JSON on every call, which would land in the middle of the
+    // worktree table). Capturing without reading would then deadlock on a
+    // full pipe, and dropping the streams on the floor would leave the status
+    // bar saying "opened" over a refusal.
+    //
+    // Waiting is affordable because all three verbs are control commands that
+    // return as soon as the pane exists: `herdr tab create` measured 40ms,
+    // and `tmux split-window` / `zellij action new-pane` do not wait on the
+    // shell they start either. A multiplexer that hangs here hangs the TUI,
+    // which is the trade for a status bar that does not lie.
+    match std::process::Command::new(bin).args(&cmd[1..]).output() {
+      Ok(out) => {
+        self.status = mux_pane_status(
+          &name,
+          out.status.success(),
+          &String::from_utf8_lossy(&out.stdout),
+          &String::from_utf8_lossy(&out.stderr),
+        )
+      }
       Err(e) => self.status = format!("mux-pane failed: {}", e),
     }
   }
@@ -7079,4 +7088,26 @@ fn resolve_editor_command(cfg: &TuiOpenConfig) -> String {
     .clone()
     .or_else(|| std::env::var("EDITOR").ok())
     .unwrap_or_else(|| "vi".into())
+}
+
+/// Status-bar line for a finished `mux_pane` spawn (#588).
+///
+/// Split out of [`App::open_in_mux_pane_from`] because it is the observable
+/// half: the spawn cannot be exercised from a test without opening a real
+/// pane, but what the status bar says about its outcome can.
+///
+/// A refusal reads out of the multiplexer's own words. stderr wins when both
+/// streams spoke (tmux and zellij put diagnostics there), but stdout is not
+/// ignored: herdr answers over its socket API, so its error arrives as a JSON
+/// body on stdout with a non-zero exit. The line is trimmed to its first
+/// non-empty line because the status bar is one row.
+pub fn mux_pane_status(name: &str, ok: bool, stdout: &str, stderr: &str) -> String {
+  if ok {
+    return format!("opened {} in new pane", name);
+  }
+  let detail = [stderr, stdout]
+    .iter()
+    .find_map(|stream| stream.lines().map(str::trim).find(|line| !line.is_empty()))
+    .unwrap_or("no output");
+  format!("mux-pane refused: {}", detail)
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5179,7 +5179,18 @@ impl App {
       return;
     };
     let bin = cmd[0].as_str();
-    match std::process::Command::new(bin).args(&cmd[1..]).spawn() {
+    // Both pipes go to `/dev/null` because this runs while ratatui owns the
+    // screen: a child that inherits them draws over the frame, and the status
+    // bar is the only channel gwm has for runtime feedback. tmux and zellij
+    // say nothing on success so it never came up; `herdr pane split` prints
+    // its `pane_info` JSON on every call (#588), which would land in the
+    // middle of the worktree table.
+    match std::process::Command::new(bin)
+      .args(&cmd[1..])
+      .stdout(std::process::Stdio::null())
+      .stderr(std::process::Stdio::null())
+      .spawn()
+    {
       Ok(_) => self.status = format!("opened {} in new pane", name),
       Err(e) => self.status = format!("mux-pane failed: {}", e),
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5148,10 +5148,13 @@ impl App {
   }
 
   /// Open the selected worktree in a new multiplexer pane/tab (`t`, #290).
-  /// Detects tmux / zellij at runtime via environment variables; prints a
-  /// status message when no supported multiplexer is active.
+  /// Detects tmux / zellij / herdr at runtime via environment variables;
+  /// prints a status message when no supported multiplexer is active.
   pub fn open_in_mux_pane(&mut self) {
-    use crate::multiplexer::{build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, SpawnMode};
+    use crate::multiplexer::{
+      build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij,
+      SpawnMode,
+    };
     let Some(w) = self.selected() else {
       self.status = "no worktree selected".into();
       return;
@@ -5159,14 +5162,20 @@ impl App {
     let path = w.path.clone();
     let name = w.name.clone();
     // `mux_pane` promises a pane, so split the current pane (tmux
-    // `split-window` / zellij `new-pane`) rather than opening a new
-    // window/tab (Codex review on PR #292).
+    // `split-window` / zellij `new-pane` / herdr `pane split`) rather
+    // than opening a new window/tab (Codex review on PR #292).
+    //
+    // Herdr goes last in the cascade so a user running gwm inside both
+    // (herdr hosting a tmux session, say) keeps the behaviour they had
+    // before #588: the innermost multiplexer is the one that splits.
     let cmd = if detect_tmux(std::env::var("TMUX").ok()) {
       build_tmux_command(&name, &path, SpawnMode::Split)
     } else if detect_zellij(std::env::var("ZELLIJ").ok()) {
       build_zellij_command(&name, &path, SpawnMode::Split)
+    } else if detect_herdr(std::env::var("HERDR_ENV").ok()) {
+      build_herdr_command(&name, &path, SpawnMode::Split)
     } else {
-      self.status = "no multiplexer detected ($TMUX / $ZELLIJ not set)".into();
+      self.status = "no multiplexer detected ($TMUX / $ZELLIJ / $HERDR_ENV not set)".into();
       return;
     };
     let bin = cmd[0].as_str();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1394,7 +1394,9 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
     app.status = format!("macro{} not configured: add [tui.macro{}] to .gwm.toml", n, n);
     return Ok(());
   };
-  use crate::multiplexer::{build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, SpawnMode};
+  use crate::multiplexer::{
+    build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij, SpawnMode,
+  };
   // Macros run in the selected worktree. With nothing selected (e.g. a filter
   // with no matches), refuse rather than silently running in the main repo —
   // a destructive command must not hit the wrong tree (Codex review on #292).
@@ -1418,6 +1420,18 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
       Some(build_tmux_command(&label, &path, SpawnMode::Split))
     } else if detect_zellij(std::env::var("ZELLIJ").ok()) {
       Some(build_zellij_command(&label, &path, SpawnMode::Split))
+    } else if detect_herdr(std::env::var("HERDR_ENV").ok()) {
+      // Herdr is detected but deliberately not built here (#588): a macro
+      // needs the pane to run a command, and `herdr pane split` has no
+      // trailing-command form the way `tmux split-window <cmd>` and
+      // `zellij action new-pane -- <cmd>` do. Running one takes
+      // `herdr pane run <pane-id> <cmd>`, and the id only comes back in the
+      // JSON `pane split` prints, so it is two processes and a parse, not an
+      // argv. Splitting anyway would open an empty pane and silently drop
+      // the macro, so the PTY overlay stays the honest fallback and the
+      // status says why.
+      app.status = format!("macro{}: herdr panes take no command; falling back to PTY overlay", n);
+      None
     } else {
       app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
       None

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1394,9 +1394,7 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
     app.status = format!("macro{} not configured: add [tui.macro{}] to .gwm.toml", n, n);
     return Ok(());
   };
-  use crate::multiplexer::{
-    build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij, SpawnMode,
-  };
+  use crate::multiplexer::{detect_split_command, Multiplexer};
   // Macros run in the selected worktree. With nothing selected (e.g. a filter
   // with no matches), refuse rather than silently running in the main repo —
   // a destructive command must not hit the wrong tree (Codex review on #292).
@@ -1416,25 +1414,31 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
   // review on PR #292), rather than no-oping.
   let mux_cmd = if matches!(macro_cfg.open_in, MacroOpenMode::MuxPane) {
     let label = format!("macro{}", n);
-    if detect_tmux(std::env::var("TMUX").ok()) {
-      Some(build_tmux_command(&label, &path, SpawnMode::Split))
-    } else if detect_zellij(std::env::var("ZELLIJ").ok()) {
-      Some(build_zellij_command(&label, &path, SpawnMode::Split))
-    } else if detect_herdr(std::env::var("HERDR_ENV").ok()) {
-      // Herdr is detected but deliberately not built here (#588): a macro
-      // needs the pane to run a command, and `herdr pane split` has no
+    match detect_split_command(
+      &label,
+      &path,
+      std::env::var("TMUX").ok(),
+      std::env::var("ZELLIJ").ok(),
+      std::env::var("HERDR_ENV").ok(),
+    ) {
+      // Herdr is detected but its argv is deliberately dropped (#588): a
+      // macro needs the pane to run a command, and `herdr pane split` has no
       // trailing-command form the way `tmux split-window <cmd>` and
       // `zellij action new-pane -- <cmd>` do. Running one takes
       // `herdr pane run <pane-id> <cmd>`, and the id only comes back in the
       // JSON `pane split` prints, so it is two processes and a parse, not an
-      // argv. Splitting anyway would open an empty pane and silently drop
-      // the macro, so the PTY overlay stays the honest fallback and the
+      // argv (#599). Splitting anyway would open an empty pane and silently
+      // drop the macro, so the PTY overlay stays the honest fallback and the
       // status says why.
-      app.status = format!("macro{}: herdr panes take no command; falling back to PTY overlay", n);
-      None
-    } else {
-      app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
-      None
+      Some((Multiplexer::Herdr, _)) => {
+        app.status = format!("macro{}: herdr panes take no command; falling back to PTY overlay", n);
+        None
+      }
+      Some((_, cmd)) => Some(cmd),
+      None => {
+        app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
+        None
+      }
     }
   } else {
     None

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,8 +28,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 pub use app::{
-  read_pins_from_sources, App, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget,
-  NoteKey, OpenTarget, RepoMeta, View, WorkspaceState,
+  mux_pane_status, read_pins_from_sources, App, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage,
+  LinkTarget, NoteKey, OpenTarget, RepoMeta, View, WorkspaceState,
 };
 pub use state::async_task::{
   CreateWorktreeResult, DeleteBatchOutcome, DeleteFailure, DeleteTarget, TaskKind, TaskMsg, TaskRunner,

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -51,6 +51,8 @@ fn help_prints_subcommands() {
     .stdout(predicate::str::contains("  switch "))
     .stdout(predicate::str::contains("  tmux "))
     .stdout(predicate::str::contains("  zellij "))
+    // Issue #588: herdr is the third multiplexer backend.
+    .stdout(predicate::str::contains("  herdr "))
     .stdout(predicate::str::contains("  doctor "))
     .stdout(predicate::str::contains("  link "))
     .stdout(predicate::str::contains("  unlink "))
@@ -1512,6 +1514,7 @@ fn list_format_table_is_default() {
 
 // --------------------------------------------------------------------------
 // Issue #23 — `gwm tmux <pattern>` / `gwm zellij <pattern>`
+// Issue #588 — `gwm herdr <pattern>`
 // --------------------------------------------------------------------------
 //
 // The actual spawn (`std::process::Command::new("tmux").args(...)`) is out
@@ -1519,9 +1522,9 @@ fn list_format_table_is_default() {
 // every CI runner. We instead pin the user-visible contract:
 //
 //   1. The subcommands exist and are listed in `gwm --help`.
-//   2. Outside the corresponding multiplexer (no `$TMUX` / `$ZELLIJ`),
-//      the command exits non-zero with a clear stderr that names the
-//      missing multiplexer — no silent no-op.
+//   2. Outside the corresponding multiplexer (no `$TMUX` / `$ZELLIJ` /
+//      `$HERDR_ENV`), the command exits non-zero with a clear stderr that
+//      names the missing multiplexer — no silent no-op.
 //   3. Outside a git repo, the standard `NotInGitRepo` error wins.
 //   4. The argv-builder unit tests in `tests/multiplexer_tests.rs`
 //      cover what gets handed to the spawn.
@@ -1556,6 +1559,22 @@ fn zellij_outside_zellij_session_fails_with_clear_error() {
 }
 
 #[test]
+fn herdr_outside_herdr_session_fails_with_clear_error() {
+  // Herdr sets `$HERDR_ENV` in the panes it manages; outside one the
+  // command must refuse rather than shell out to a herdr that would go
+  // looking for a socket that isn't there.
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env_remove("HERDR_ENV")
+    .args(["herdr", "anything"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("herdr").and(predicate::str::contains("not")));
+}
+
+#[test]
 fn tmux_outside_git_repo_fails() {
   // `NotInGitRepo` wins over the multiplexer-not-running gate when both
   // apply — the user is told to fix the more fundamental problem first.
@@ -1578,6 +1597,19 @@ fn zellij_outside_git_repo_fails() {
     .current_dir(dir.path())
     .env_remove("ZELLIJ")
     .args(["zellij", "anything"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn herdr_outside_git_repo_fails() {
+  let dir = tempfile::TempDir::new().unwrap();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env_remove("HERDR_ENV")
+    .args(["herdr", "anything"])
     .assert()
     .failure()
     .stderr(predicate::str::contains("not inside a git repository"));
@@ -1617,6 +1649,20 @@ fn zellij_outside_zellij_error_does_not_escape_dollar() {
 }
 
 #[test]
+fn herdr_outside_herdr_error_does_not_escape_dollar() {
+  let (dir, _repo) = init_repo();
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd
+    .current_dir(dir.path())
+    .env_remove("HERDR_ENV")
+    .args(["herdr", "anything"])
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("\\$").not())
+    .stderr(predicate::str::contains("$HERDR_ENV"));
+}
+
+#[test]
 fn tmux_help_mentions_split_flag() {
   // The `-p` flag (split-pane instead of new-window) is the one knob users
   // care about; it must show up in `--help` so it's discoverable without
@@ -1630,6 +1676,13 @@ fn tmux_help_mentions_split_flag() {
 fn zellij_help_mentions_split_flag() {
   let mut cmd = Command::cargo_bin("gwm").unwrap();
   cmd.args(["zellij", "--help"]);
+  cmd.assert().success().stdout(predicate::str::contains("--split"));
+}
+
+#[test]
+fn herdr_help_mentions_split_flag() {
+  let mut cmd = Command::cargo_bin("gwm").unwrap();
+  cmd.args(["herdr", "--help"]);
   cmd.assert().success().stdout(predicate::str::contains("--split"));
 }
 

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -1,9 +1,12 @@
 //! Pure-logic tests for `gwm::multiplexer`. The module's command builders
 //! and env-var probes are deliberately decoupled from any process spawn, so
-//! these tests do not require `tmux` or `zellij` to be installed on the
-//! runner — they assert against the produced argv vectors.
+//! these tests do not require `tmux`, `zellij` or `herdr` to be installed on
+//! the runner — they assert against the produced argv vectors.
 
-use gwm::multiplexer::{build_tmux_command, build_zellij_command, detect_tmux, detect_zellij, Multiplexer, SpawnMode};
+use gwm::multiplexer::{
+  build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij, Multiplexer,
+  SpawnMode,
+};
 use std::path::Path;
 
 // --------------------------------------------------------------------------
@@ -88,6 +91,69 @@ fn zellij_split_pane_uses_action_new_pane() {
 }
 
 // --------------------------------------------------------------------------
+// herdr command builder (#588)
+// --------------------------------------------------------------------------
+
+#[test]
+fn herdr_new_tab_uses_tab_create() {
+  // Herdr drives its server over a socket API: `herdr tab create` is the
+  // new-tab verb, with `--cwd` for the working directory and `--label` for
+  // the name shown on the tab. Measured against herdr 0.8.2
+  // (`herdr tab create --help`).
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window);
+  assert_eq!(argv[0], "herdr");
+  assert_eq!(argv[1], "tab");
+  assert_eq!(argv[2], "create");
+  let has_label = argv.windows(2).any(|w| w[0] == "--label" && w[1] == "feat-7-foo");
+  let has_cwd = argv.windows(2).any(|w| w[0] == "--cwd" && w[1] == "/tmp/wt/feat-7-foo");
+  assert!(has_label, "expected `--label feat-7-foo` in argv, got: {:?}", argv);
+  assert!(has_cwd, "expected `--cwd /tmp/wt/feat-7-foo` in argv, got: {:?}", argv);
+  // No `--focus` / `--no-focus`: herdr focuses a created tab by default,
+  // which is what `tmux new-window` and `zellij action new-tab` do too.
+  // Passing the flag explicitly would pin a default gwm has no opinion on.
+  assert!(
+    !argv.iter().any(|a| a == "--focus" || a == "--no-focus"),
+    "tab create must not pin the focus flag, got: {:?}",
+    argv
+  );
+}
+
+#[test]
+fn herdr_split_pane_uses_pane_split_with_direction() {
+  // `-p` → split the current pane. `herdr pane split` needs `--current` to
+  // target the caller's pane, and `--direction` is not optional (its clap
+  // arg has no default): omitting it makes herdr reject the call. `right`
+  // is the analogue of tmux's `-h`. The pane-direction preference is filed
+  // separately; until it lands, `right` is hardcoded.
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Split);
+  assert_eq!(argv[0], "herdr");
+  assert_eq!(argv[1], "pane");
+  assert_eq!(argv[2], "split");
+  assert!(
+    argv.iter().any(|a| a == "--current"),
+    "split must target the current pane, got: {:?}",
+    argv
+  );
+  let has_direction = argv.windows(2).any(|w| w[0] == "--direction" && w[1] == "right");
+  assert!(has_direction, "expected `--direction right` in argv, got: {:?}", argv);
+  let has_cwd = argv.windows(2).any(|w| w[0] == "--cwd" && w[1] == "/tmp/wt/feat-7-foo");
+  assert!(has_cwd, "pane split must set `--cwd`, got: {:?}", argv);
+  // `herdr pane split` takes no `--label` (panes are renamed after the fact
+  // via `herdr pane rename`), so forwarding the worktree name here would be
+  // parsed as the optional `[PANE_ID]` positional and split the wrong pane.
+  assert!(
+    !argv.iter().any(|a| a == "--label"),
+    "pane split must NOT carry `--label` (herdr rejects it on panes), got: {:?}",
+    argv
+  );
+  assert!(
+    !argv.iter().any(|a| a == "feat-7-foo"),
+    "the worktree name must not leak into argv as a bare positional (herdr would read it as PANE_ID), got: {:?}",
+    argv
+  );
+}
+
+// --------------------------------------------------------------------------
 // multiplexer detection
 // --------------------------------------------------------------------------
 
@@ -126,6 +192,22 @@ fn detect_zellij_false_when_zellij_env_missing_or_empty() {
   assert!(!detect_zellij(Some(String::new())));
 }
 
+#[test]
+fn detect_herdr_true_when_herdr_env_set() {
+  // Inside a herdr-managed pane, `$HERDR_ENV` is `1` (alongside
+  // HERDR_PANE_ID / HERDR_TAB_ID / HERDR_SOCKET_PATH). Presence is the
+  // gate; the value is deliberately not parsed, so a future herdr that
+  // exports something richer than `1` keeps working.
+  assert!(detect_herdr(Some("1".to_string())));
+  assert!(detect_herdr(Some("any-nonempty-string".to_string())));
+}
+
+#[test]
+fn detect_herdr_false_when_herdr_env_missing_or_empty() {
+  assert!(!detect_herdr(None));
+  assert!(!detect_herdr(Some(String::new())));
+}
+
 // --------------------------------------------------------------------------
 // Multiplexer enum: name + binary
 // --------------------------------------------------------------------------
@@ -137,4 +219,5 @@ fn multiplexer_binary_matches_verb() {
   // can name the right multiplexer in one line.
   assert_eq!(Multiplexer::Tmux.binary(), "tmux");
   assert_eq!(Multiplexer::Zellij.binary(), "zellij");
+  assert_eq!(Multiplexer::Herdr.binary(), "herdr");
 }

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -304,6 +304,12 @@ fn detect_split_command_prefers_tmux_over_the_other_two() {
   // Order matters, and it is the reason herdr goes last: someone running gwm
   // inside a tmux session nested in a herdr pane has both variables set, and
   // #588 must not move them onto the newer backend.
+  //
+  // It is also what makes the TUI immune to herdrdev/herdr#2134: a tmux
+  // server started from a herdr pane promotes the whole `HERDR_*` set to its
+  // server-global environment, so unrelated sessions on that server claim a
+  // pane they do not own. Every one of them has `$TMUX` set, so this
+  // assertion is the guard, not a preference.
   let (mux, argv) = detect_split_command(
     "feat-7-foo",
     path(),

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -4,8 +4,8 @@
 //! the runner — they assert against the produced argv vectors.
 
 use gwm::multiplexer::{
-  build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_tmux, detect_zellij, Multiplexer,
-  SpawnMode,
+  build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_split_command, detect_tmux,
+  detect_zellij, Multiplexer, SpawnMode,
 };
 use std::path::Path;
 
@@ -206,6 +206,74 @@ fn detect_herdr_true_when_herdr_env_set() {
 fn detect_herdr_false_when_herdr_env_missing_or_empty() {
   assert!(!detect_herdr(None));
   assert!(!detect_herdr(Some(String::new())));
+}
+
+// --------------------------------------------------------------------------
+// the cascade the TUI runs on (#588)
+// --------------------------------------------------------------------------
+//
+// `t` and the `mux_pane` macro both have to answer "which multiplexer am I
+// inside, and what is its split argv". That answer used to be an if-chain
+// written out twice, once per call site, which is why adding a third backend
+// was two edits that could disagree. `detect_split_command` is the one
+// answer, and it takes the three env values as parameters (the shape
+// `detect_tmux` already uses) so these tests never touch the process
+// environment: `tui_app_tests` rewrites variables under a lock precisely
+// because `$TMUX` is read by the clipboard path too.
+
+fn path() -> &'static Path {
+  Path::new("/tmp/wt/feat-7-foo")
+}
+
+#[test]
+fn detect_split_command_prefers_tmux_over_the_other_two() {
+  // Order matters, and it is the reason herdr goes last: someone running gwm
+  // inside a tmux session nested in a herdr pane has both variables set, and
+  // #588 must not move them onto the newer backend.
+  let (mux, argv) = detect_split_command(
+    "feat-7-foo",
+    path(),
+    Some("/tmp/tmux-501/default,1,0".into()),
+    Some("0".into()),
+    Some("1".into()),
+  )
+  .expect("tmux is active, so a command must come back");
+  assert_eq!(mux, Multiplexer::Tmux);
+  assert_eq!(argv[1], "split-window", "tmux wins the cascade, got: {:?}", argv);
+}
+
+#[test]
+fn detect_split_command_falls_through_to_zellij_then_herdr() {
+  let (mux, argv) = detect_split_command("feat-7-foo", path(), None, Some("0".into()), Some("1".into()))
+    .expect("zellij is active, so a command must come back");
+  assert_eq!(mux, Multiplexer::Zellij);
+  assert_eq!(argv[2], "new-pane", "zellij beats herdr, got: {:?}", argv);
+
+  let (mux, argv) = detect_split_command("feat-7-foo", path(), None, None, Some("1".into()))
+    .expect("herdr is active, so a command must come back");
+  assert_eq!(mux, Multiplexer::Herdr);
+  assert_eq!(argv[1], "pane", "herdr must be reached last, got: {:?}", argv);
+  assert_eq!(
+    argv[2], "split",
+    "the cascade builds a Split, never a Window, got: {:?}",
+    argv
+  );
+}
+
+#[test]
+fn detect_split_command_is_none_when_nothing_is_active() {
+  // The three empty strings are not padding: a shell that ran `unset TMUX`
+  // and a shell that never had it both surface as an empty value through
+  // some wrappers, and neither means "inside a multiplexer".
+  assert!(detect_split_command("feat-7-foo", path(), None, None, None).is_none());
+  assert!(detect_split_command(
+    "feat-7-foo",
+    path(),
+    Some(String::new()),
+    Some(String::new()),
+    Some(String::new())
+  )
+  .is_none());
 }
 
 // --------------------------------------------------------------------------

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -100,7 +100,12 @@ fn herdr_new_tab_uses_tab_create() {
   // new-tab verb, with `--cwd` for the working directory and `--label` for
   // the name shown on the tab. Measured against herdr 0.8.2
   // (`herdr tab create --help`).
-  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window);
+  let argv = build_herdr_command(
+    "feat-7-foo",
+    Path::new("/tmp/wt/feat-7-foo"),
+    SpawnMode::Window,
+    Some("w2K"),
+  );
   assert_eq!(argv[0], "herdr");
   assert_eq!(argv[1], "tab");
   assert_eq!(argv[2], "create");
@@ -108,12 +113,73 @@ fn herdr_new_tab_uses_tab_create() {
   let has_cwd = argv.windows(2).any(|w| w[0] == "--cwd" && w[1] == "/tmp/wt/feat-7-foo");
   assert!(has_label, "expected `--label feat-7-foo` in argv, got: {:?}", argv);
   assert!(has_cwd, "expected `--cwd /tmp/wt/feat-7-foo` in argv, got: {:?}", argv);
-  // No `--focus` / `--no-focus`: herdr focuses a created tab by default,
-  // which is what `tmux new-window` and `zellij action new-tab` do too.
-  // Passing the flag explicitly would pin a default gwm has no opinion on.
+}
+
+#[test]
+fn herdr_new_tab_asks_for_the_focus_tmux_and_zellij_give_for_free() {
+  // Measured on herdr 0.8.2, and the opposite of what this test asserted
+  // when the builder was first written: `herdr tab create --cwd <path>` with
+  // no focus flag comes back `"focused": false`. `tmux new-window` and
+  // `zellij action new-tab` both move the user to what they create, so
+  // omitting the flag would make `gwm herdr` the one backend that opens the
+  // worktree somewhere the user cannot see.
+  let argv = build_herdr_command(
+    "feat-7-foo",
+    Path::new("/tmp/wt/feat-7-foo"),
+    SpawnMode::Window,
+    Some("w2K"),
+  );
   assert!(
-    !argv.iter().any(|a| a == "--focus" || a == "--no-focus"),
-    "tab create must not pin the focus flag, got: {:?}",
+    argv.iter().any(|a| a == "--focus"),
+    "tab create must focus, got: {:?}",
+    argv
+  );
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Split, None);
+  assert!(
+    argv.iter().any(|a| a == "--focus"),
+    "pane split must focus, got: {:?}",
+    argv
+  );
+}
+
+#[test]
+fn herdr_new_tab_targets_the_callers_workspace() {
+  // Measured on herdr 0.8.2 with two workspaces open: `herdr tab create`
+  // without `--workspace` lands in the server's *focused* workspace, not the
+  // caller's. Running it from a pane in `w2K` put the tab in `w2P`, i.e.
+  // `gwm herdr <pattern>` would open the worktree in a different project's
+  // window. `$HERDR_WORKSPACE_ID` is what the calling pane carries, so it is
+  // what pins the target.
+  let argv = build_herdr_command(
+    "feat-7-foo",
+    Path::new("/tmp/wt/feat-7-foo"),
+    SpawnMode::Window,
+    Some("w2K"),
+  );
+  let has_ws = argv.windows(2).any(|w| w[0] == "--workspace" && w[1] == "w2K");
+  assert!(has_ws, "expected `--workspace w2K` in argv, got: {:?}", argv);
+}
+
+#[test]
+fn herdr_new_tab_omits_the_workspace_flag_when_the_id_is_unknown() {
+  // Outside a managed pane there is no `$HERDR_WORKSPACE_ID` to pass, and
+  // `--workspace ""` is an argument herdr would have to reject. Falling back
+  // to herdr's own choice of workspace beats failing the whole command.
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window, None);
+  assert!(
+    !argv.iter().any(|a| a == "--workspace"),
+    "no workspace id means no flag, got: {:?}",
+    argv
+  );
+  let argv = build_herdr_command(
+    "feat-7-foo",
+    Path::new("/tmp/wt/feat-7-foo"),
+    SpawnMode::Window,
+    Some(""),
+  );
+  assert!(
+    !argv.iter().any(|a| a == "--workspace"),
+    "an empty workspace id is not an id, got: {:?}",
     argv
   );
 }
@@ -125,10 +191,18 @@ fn herdr_split_pane_uses_pane_split_with_direction() {
   // arg has no default): omitting it makes herdr reject the call. `right`
   // is the analogue of tmux's `-h`. The pane-direction preference is filed
   // separately; until it lands, `right` is hardcoded.
-  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Split);
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Split, None);
   assert_eq!(argv[0], "herdr");
   assert_eq!(argv[1], "pane");
   assert_eq!(argv[2], "split");
+  // No `--workspace` on a split: `--current` names the caller's pane, which
+  // already resolves the workspace. Measured on 0.8.2, the new pane came
+  // back in `w2K` while the server's focused workspace was `w2P`.
+  assert!(
+    !argv.iter().any(|a| a == "--workspace"),
+    "`--current` already pins the workspace on a split, got: {:?}",
+    argv
+  );
   assert!(
     argv.iter().any(|a| a == "--current"),
     "split must target the current pane, got: {:?}",

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1816,6 +1816,49 @@ fn exit_filter_cancel_clears_query() {
 }
 
 #[test]
+fn mux_pane_status_reports_the_multiplexers_own_refusal() {
+  // Issue #588, second Codex pass. The spawn used to inherit both pipes,
+  // which let a failing multiplexer draw its error over the ratatui frame;
+  // sending them to `/dev/null` fixed that and traded it for a status bar
+  // that said "opened" whatever happened. herdr answers a refusal with a
+  // non-zero exit and a JSON body on stdout, so the message is built from
+  // whichever stream spoke.
+  let ok = gwm::tui::mux_pane_status("feat-7-foo", true, "{\"result\":{}}", "");
+  assert_eq!(ok, "opened feat-7-foo in new pane");
+
+  let err = gwm::tui::mux_pane_status(
+    "feat-7-foo",
+    false,
+    "{\"error\":{\"message\":\"unknown workspace w9Z\"}}\n",
+    "",
+  );
+  assert!(
+    err.contains("unknown workspace w9Z"),
+    "the multiplexer's own words must reach the status bar, got: {}",
+    err
+  );
+  assert!(!err.contains('\n'), "the status bar is one line, got: {}", err);
+
+  // stderr wins when both spoke: tmux and zellij put their diagnostics
+  // there, and it is the more specific of the two.
+  let err = gwm::tui::mux_pane_status("feat-7-foo", false, "some stdout", "no server running");
+  assert!(
+    err.contains("no server running"),
+    "expected the stderr text, got: {}",
+    err
+  );
+
+  // A refusal with nothing on either stream still has to read as a failure,
+  // not as a success with an empty reason.
+  let quiet = gwm::tui::mux_pane_status("feat-7-foo", false, "", "");
+  assert!(
+    !quiet.starts_with("opened"),
+    "a silent non-zero exit is still a failure, got: {}",
+    quiet
+  );
+}
+
+#[test]
 fn mux_pane_without_a_selection_says_so_and_spawns_nothing() {
   // Issue #588. `t` on an empty list (or a filter that matches nothing) must
   // refuse on the status bar rather than reach the multiplexer with no path.

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1816,6 +1816,41 @@ fn exit_filter_cancel_clears_query() {
 }
 
 #[test]
+fn mux_pane_without_a_selection_says_so_and_spawns_nothing() {
+  // Issue #588. `t` on an empty list (or a filter that matches nothing) must
+  // refuse on the status bar rather than reach the multiplexer with no path.
+  let (_dir, mut app) = make_app();
+  app.worktrees.clear();
+  app.list_state.select(None);
+  app.open_in_mux_pane_from(None, None, Some("1".into()));
+  assert_eq!(
+    app.status, "no worktree selected",
+    "the selection gate comes before the multiplexer probe"
+  );
+}
+
+#[test]
+fn mux_pane_with_no_multiplexer_names_all_three_variables() {
+  // The hint is the only thing a user gets when `t` does nothing, so it has
+  // to name what gwm actually looked for. Before #588 it said `$TMUX /
+  // $ZELLIJ`, which reads as "gwm has no idea what you are running" to
+  // someone sitting in a herdr pane.
+  //
+  // The three values are passed in rather than removed from the environment:
+  // `$TMUX` is also read by the clipboard path, so rewriting it here would
+  // pull every yank test in this binary under the env lock.
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![worktree_fixture("feat-7-foo")];
+  app.list_state.select(Some(0));
+  app.open_in_mux_pane_from(None, None, None);
+  assert!(
+    app.status.contains("$TMUX") && app.status.contains("$ZELLIJ") && app.status.contains("$HERDR_ENV"),
+    "the hint must name all three probes, got: {}",
+    app.status
+  );
+}
+
+#[test]
 fn filtered_indices_returns_all_when_query_empty() {
   let (_dir, mut app) = make_app();
   app.worktrees = vec![


### PR DESCRIPTION
## Description

Adds `Multiplexer::Herdr` next to `Tmux` and `Zellij`, so [herdr](https://herdr.dev) gets the same three pieces the other two have: a detector, an argv builder, and the arms in the three call sites, plus a `gwm herdr <pattern>` subcommand for parity.

Closes #588

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `src/multiplexer.rs`: `Multiplexer::Herdr`, `build_herdr_command`, `detect_herdr`, and `detect_split_command`, the cascade both TUI call sites now share.
- `src/cli.rs`: `gwm herdr <pattern> [-p|--split]`, dispatched through the existing shared `cmd_multiplexer` handler (`HERDR_ENV` as the env gate).
- `src/tui/app.rs`: the `t` key splits a herdr pane; the no-multiplexer status names all three variables; the spawn captures both pipes and reports what the multiplexer answered.
- `src/tui/mod.rs`: an explicit herdr arm on the `open_in = "mux_pane"` macro path that falls back to the PTY overlay and says why (see below).
- `src/aliases.rs`: `herdr` added to the built-in subcommand list so an alias cannot shadow it.
- Docs EN + FR, `CHANGELOG.md` under `[Unreleased] > Added`.

## Two decisions the issue left open

**`herdr worktree open` was evaluated and rejected.** The issue flagged it as possibly the better builder. It is not, for two reasons that are visible from `herdr worktree open --help`: it has no window/split axis at all, so it could at best serve the `Window` mode and leave `pane split` doing the other half, and it is a workspace-topology primitive (`--workspace`, `--branch`) where the `t` key promises a pane. herdr's own agent guidance says not to create a worktree or workspace unless that topology was asked for. `tab create` / `pane split` keeps the module's shape (one pure builder per multiplexer, both modes) and mirrors tmux and zellij exactly.

**The `mux_pane` macro path deliberately keeps the PTY overlay under herdr.** A macro needs the new pane to *run a command*, and `herdr pane split` has no trailing-command form the way `tmux split-window <cmd>` and `zellij action new-pane -- <cmd>` do: running one takes `herdr pane run <pane-id> <cmd>`, and the id only comes back in the JSON that `pane split` prints. That is two processes and a parse of a third-party JSON shape, which the single-argv contract of `multiplexer::build_*_command` cannot carry.

The arm is explicit rather than a silent fall-through, because falling through to the existing `else` branch would append the macro command where herdr reads its optional `[PANE_ID]` positional, i.e. split a pane picked by whatever the command string happened to resolve to. Follow-up filed as #599 for the two-step split-then-run.

## What the review changed

Four Codex passes ran on this branch. Three produced real defects, all confirmed against a running herdr rather than its help text, and two of them would have shipped as bug reports:

1. **The cascade had no test, and it was written out twice.** `t` and the macro each had their own if-chain, so a third backend was two edits that could disagree. `detect_split_command` is now the single answer and is tested for precedence; two TUI refusals are pinned as state tests.
2. **`--focus` is not herdr's default.** Both verbs come back `"focused": false` without it, where tmux and zellij move you to what they create. The builder's own doc comment claimed the opposite, written from the flag names.
3. **`tab create` without `--workspace` opens in the wrong project.** Run from a pane in `w2K` with `w2P` focused, the tab landed in `w2P`. gwm now passes `$HERDR_WORKSPACE_ID`. A split needs none of it, `--current` resolves the workspace (measured).
4. **The status bar could not lie or pollute.** Capturing both pipes keeps herdr's JSON off the ratatui frame; `mux_pane_status` reports the refusal instead of saying "opened" over it.

Two findings were refuted with a measurement rather than applied:

- *"fail when `$HERDR_ENV` is set without `$HERDR_WORKSPACE_ID`"*: both variables are injected together, a pane created by `pane split` carries `WS=[w2K] ENV=[1]`. Refusing where `herdr tab create` itself succeeds would only break gwm the day herdr renames a variable.
- *"validate the pane identity against the socket"* ([herdrdev/herdr#2134](https://github.com/herdrdev/herdr/issues/2134), a real leak of `HERDR_*` into a tmux server's global env): ruled out by its own source, which reports every marker variable leaking together, pane id and socket path included. Only asking the server separates them, which is #599. The TUI is immune by construction since the leak lives inside tmux, where tmux wins the cascade first, and the precedence test is now written as that guard. Documented in the code and in both locales.

Two were left as an explicit trade, stated rather than hidden:

- **`output()` waits on the child.** The third pass asked for the status bar to stop lying, the fourth asked for the wait to go away; both cannot hold. All three verbs are control commands that return as soon as the pane exists (`herdr tab create` measured at 40ms), so waiting buys a truthful status for a hang that only a broken multiplexer produces. Routing it through the existing `TaskRunner` is the clean answer and is a change of its own.
- **`$HERDR_WORKSPACE_ID` is read once.** A pane moved between workspaces keeps its original value, so a `Window` open after a `herdr pane move` targets the old workspace. Strictly better than before (which always used the server's focused one) and its fix is the same socket round trip as #599.

## Measured, not assumed

Everything was measured against the installed **herdr 0.8.2** rather than taken from the issue body (which quotes a `herdr 2026-08` that does not name a version the CLI reports):

- `$HERDR_ENV=1` in a managed pane, alongside `HERDR_PANE_ID` / `HERDR_TAB_ID` / `HERDR_SOCKET_PATH` / `HERDR_WORKSPACE_ID`.
- `herdr tab create --label <name> --cwd <path>` returns `tab_created` with the right label and cwd (run live, tab closed after).
- `herdr pane split --current --direction right --cwd <path>` returns `pane_info` with the right cwd (run live, pane closed after).
- `--direction` is not optional: omitting it prints the usage line and refuses. That is why the builder hardcodes `right`, the analogue of tmux's `-h`; making it a preference is the separate pane-direction issue.
- `herdr pane split` takes no `--label`, and its only positional is `[PANE_ID]`. The `Split` builder therefore drops the worktree name, and a test asserts it never leaks into the argv.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Red first: the argv and detection tests were committed alone and failed on the missing symbols before `src/multiplexer.rs` existed.

- `tests/multiplexer_tests.rs`: both modes' argv, plus two negative assertions that cover the real failure mode (no `--label` on a split, no bare positional), and the `detect_herdr` branches.
- `tests/cli_binary.rs`: the four zellij tests mirrored (not-running, not-in-a-repo, unescaped `$` in the hint, `--split` in `--help`), and `help_prints_subcommands` extended, which the house rules make the canary for every new subcommand.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed. The README's feature list does not enumerate the multiplexer subcommands (it never mentioned `gwm tmux` / `gwm zellij` either), so adding herdr there would be new copy, not a sync. `docs/3.cli/3.multiplexer.md` and the reference are updated in both locales.
- [ ] `examples/gwm.toml.example` updated if config schema changed. No config schema change: the pane direction is hardcoded pending its own issue.
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #588
- Follow-up: #599
- Docs: `docs/3.cli/3.multiplexer.md`, `docs/fr/3.cli/3.multiplexer.md`

## Notes for reviewers

The detection cascade puts herdr last in all three call sites, so nothing changes for an existing tmux or zellij user, including someone running one inside the other.
