### PR TITLE
📝 docs(multiplexer): unduplicate the detect_split_command summary line

### DIFF
--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -156,7 +156,7 @@ pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode, workspace: 
   }
 }
 
-/// Resolve which multiplexer the process is inside/// Resolve which multiplexer the process is inside and build its `Split`
+/// Resolve which multiplexer the process is inside and build its `Split`
 /// argv, in the order tmux, zellij, herdr.
 ///
 /// Both TUI call sites (`t`, and a `[tui.macro*]` with


### PR DESCRIPTION
## Description

`src/multiplexer.rs:159` carried the first sentence of `detect_split_command`'s doc comment twice on one line, landed by a patch script in #588.

Closes #602

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [ ] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- Drop the duplicated half of the summary line. One line, one word deleted twice over.

## Tests

- [ ] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] New tests added under `tests/`

Comment-only change, which is one of the three exceptions CONTRIBUTING and the house rules name for the TDD gate: nothing asserts on this text, and rustdoc is why nothing caught it in the first place. `cargo fmt --check` was run; CI covers the rest.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [ ] CHANGELOG.md updated under `## [Unreleased]`. A comment that never reached a user is not a changelog entry.
- [ ] README updated if CLI surface changed. No surface change.
- [ ] `examples/gwm.toml.example` updated if config schema changed. No schema change.
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #602
- Introduced by: #598

## Notes for reviewers

Worth knowing rather than reviewing: fmt, clippy, 3079 tests and thirteen CI checks all passed over this. A malformed doc comment is invisible to every gate this repo has, `cargo doc` being the only place it shows.