### PR TITLE
🐛 fix(tui): a linked row with nothing fetched paints no status at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A linked row with nothing fetched yet is white, not green and purple**
+  ([#596](https://github.com/kbrdn1/gwm-cli/issues/596)). The table's `I/P`
+  marker painted its two placeholder slots with a different status role each:
+  `clean` green for the issue, `locked` purple for the PR. So one row said two
+  different things about the same missing data, and both colours were on loan
+  from a loaded state (`clean` is an open issue and an open PR, `locked` is a
+  merged PR, a closed issue, and the locked-worktree badge). That is the state
+  every linked row launches in, since nothing is fetched until `F`. Both slots
+  now take `name`, the one role in the marker that neither badge map can
+  produce and the colour the empty slot beside them already uses. The glyph
+  still tells the two apart: `-` is "no link", `●` is "linked, not fetched
+  yet".
+
 - **The note column captions itself**
   ([#595](https://github.com/kbrdn1/gwm-cli/issues/595)). The column shipped
   with an empty header on the grounds that its marker is binary, which left

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -7594,10 +7594,27 @@ pub fn issue_badge_color(state: IssueState, theme: &Theme) -> Color {
 /// pre-#73 convention). Every other row renders two Issue/PR slots:
 ///
 /// - left = **Issue** — `●` with the loaded issue-state colour when known,
-///   `●` in `clean` green when only a link is known, else `-` in white.
+///   `●` in `name` white when only a link is known, else `-` in white.
 /// - right = **PR** — `●` with the loaded PR-state colour when known, `●`
-///   in `locked` violet when only a link is known, else `-` in white.
+///   in `name` white when only a link is known, else `-` in white.
 /// - a `muted` `/` separates them.
+///
+/// Both "linked, not fetched yet" slots take `name` (#596). They used to take
+/// a status role each, `clean` for the issue and `locked` for the PR, so the
+/// row said two different things about one absence of data and each borrowed a
+/// colour a loaded state owns: `clean` is [`issue_badge_color`]'s and
+/// [`pr_badge_color`]'s Open, `locked` is Merged, Closed, and the
+/// locked-worktree badge.
+///
+/// `name` is the one role here that neither badge map can produce, and it is
+/// already the other half of this same cell (the empty-slot dash), so the two
+/// slots agree without claiming anything. `muted` is not the neutral it looks
+/// like: it is the Draft colour and the separator's. `sidebar_status_dot`
+/// reaches for the same idea on its own surface, though not the same value:
+/// it hard-codes `Color::White` because it has no glyph to vary and needs a
+/// colour outside the theme's roles entirely, where the marker can lean on
+/// `●` vs `-` instead. So `name` and that white coincide in the default theme
+/// and differ in every preset, by design on both sides.
 ///
 /// The table is normally the no-fetch read path. Once GitHub status has been
 /// fetched for linked rows, their snapshots carry loaded states so
@@ -7609,17 +7626,19 @@ pub fn table_marker(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
   if w.is_main {
     return Line::from(Span::styled("★", Style::default().fg(theme.main)));
   }
-  // An empty slot stays `name`-white so "no link" reads as a neutral
-  // placeholder rather than borrowing a status colour that would claim the
-  // row. A linked slot takes its accent unless a live loaded state exists.
+  // A slot stays `name`-white until a live state is loaded, so neither "no
+  // link" nor "not fetched yet" borrows a status colour that would claim the
+  // row. The two cases stay apart on the glyph (`●` vs `-`), not the colour.
+  // The arms are kept split rather than collapsed to `_`: the day one of the
+  // two stops being white, the site to change is already there.
   let issue_color = match (w.link.issue, w.issue_state) {
     (Some(_), Some(state)) => issue_badge_color(state, theme),
-    (Some(_), None) => theme.clean,
+    (Some(_), None) => theme.name,
     (None, _) => theme.name,
   };
   let pr_color = match (w.link.pr, w.pr_state) {
     (Some(_), Some(state)) => pr_badge_color(state, theme),
-    (Some(_), None) => theme.locked,
+    (Some(_), None) => theme.name,
     (None, _) => theme.name,
   };
   Line::from(vec![

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -5369,7 +5369,7 @@ fn table_marker_for_main_worktree_is_a_yellow_star() {
 }
 
 #[test]
-fn table_marker_paints_green_issue_and_violet_pr_pastilles() {
+fn table_marker_paints_both_unfetched_pastilles_white() {
   use gwm::github::{BranchLink, LinkSource};
   let mut w = worktree_fixture("feat-1");
   w.is_main = false;
@@ -5387,9 +5387,9 @@ fn table_marker_paints_green_issue_and_violet_pr_pastilles() {
   assert_eq!(
     marker_cells(&line),
     vec![
-      ("●".to_string(), Some(Color::Green)),    // issue linked → clean role
+      ("●".to_string(), Some(Color::White)),    // issue linked, unfetched → name role
       ("/".to_string(), Some(Color::DarkGray)), // muted separator
-      ("●".to_string(), Some(Color::Magenta)),  // pr linked → locked role
+      ("●".to_string(), Some(Color::White)),    // pr linked, unfetched → name role too (#596)
     ]
   );
 }
@@ -5411,7 +5411,7 @@ fn table_marker_issue_only_leaves_the_pr_slot_as_dash() {
   };
   let line = gwm::tui::table_marker(&w, &Theme::default());
   let cells = marker_cells(&line);
-  assert_eq!(cells[0].1, Some(Color::Green), "issue dot green");
+  assert_eq!(cells[0].1, Some(Color::White), "unfetched issue dot white (#596)");
   assert_eq!(cells[2].0, "-", "empty pr slot uses a dash");
   assert_eq!(cells[2].1, Some(Color::White), "empty pr dash white");
 }
@@ -5542,7 +5542,7 @@ fn table_marker_pr_only_leaves_the_issue_slot_as_dash() {
   let cells = marker_cells(&line);
   assert_eq!(cells[0].0, "-", "empty issue slot uses a dash");
   assert_eq!(cells[0].1, Some(Color::White), "empty issue dash white");
-  assert_eq!(cells[2].1, Some(Color::Magenta), "pr dot violet");
+  assert_eq!(cells[2].1, Some(Color::White), "unfetched pr dot white (#596)");
 }
 
 #[test]

--- a/tests/tui_theme_audit_tests.rs
+++ b/tests/tui_theme_audit_tests.rs
@@ -237,8 +237,9 @@ fn table_marker_resolves_through_theme_roles() {
     "main marker → main role"
   );
 
-  // Issue linked, PR empty: issue dot → `clean`, separator → `muted`, the
-  // empty PR dash → `name` (the neutral white slot).
+  // Issue linked but unfetched, PR empty: issue dot → `name`, separator →
+  // `muted`, the empty PR dash → `name` too. Colour alone cannot tell the two
+  // slots apart here (#596) — the glyph does, and both are asserted.
   let mut issue_only = base_worktree("issue");
   issue_only.link = BranchLink {
     issue: Some(7),
@@ -246,7 +247,8 @@ fn table_marker_resolves_through_theme_roles() {
   };
   let line = table_marker(&issue_only, &t);
   assert_eq!(line.spans[2].content.as_ref(), "-", "empty pr slot → dash");
-  assert_eq!(line.spans[0].style.fg, Some(t.clean), "issue dot → clean role");
+  assert_eq!(line.spans[0].content.as_ref(), "●", "linked issue slot → dot");
+  assert_eq!(line.spans[0].style.fg, Some(t.name), "unfetched issue dot → name role");
   assert_eq!(line.spans[1].style.fg, Some(t.muted), "separator → muted role");
   assert_eq!(line.spans[2].style.fg, Some(t.name), "empty pr dash → name role");
 
@@ -261,7 +263,12 @@ fn table_marker_resolves_through_theme_roles() {
     "closed issue dot → issue_badge_color closed role"
   );
 
-  // PR linked, issue empty: mirror — empty issue dash → `name`, PR → `locked`.
+  // PR linked, issue empty: mirror — empty issue dash → `name`, PR → `name`.
+  // #596: an unfetched slot takes `name`, the one role in the marker that is
+  // not a status. It used to take `locked` (= `pr_badge_color(Merged)`, the
+  // Closed-issue role, and the locked-worktree badge) while the unfetched
+  // issue slot took `clean` (= both badge maps' Open), so each half of one
+  // marker claimed a different loaded state for the same missing data.
   let mut pr_only = base_worktree("pr");
   pr_only.link = BranchLink {
     pr: Some(8),
@@ -270,7 +277,9 @@ fn table_marker_resolves_through_theme_roles() {
   let line = table_marker(&pr_only, &t);
   assert_eq!(line.spans[0].content.as_ref(), "-", "empty issue slot → dash");
   assert_eq!(line.spans[0].style.fg, Some(t.name), "empty issue dash → name role");
-  assert_eq!(line.spans[2].style.fg, Some(t.locked), "pr dot → locked role");
+  assert_eq!(line.spans[2].style.fg, Some(t.name), "unfetched pr dot → name role");
+  assert_ne!(t.name, t.clean, "audit theme must keep name and clean distinct");
+  assert_ne!(t.name, t.locked, "audit theme must keep name and locked distinct");
 
   let mut closed_pr = pr_only.clone();
   closed_pr.pr_state = Some(PrState::Closed);


### PR DESCRIPTION
## Description

The table's `I/P` marker gave its two placeholder slots a different status role
each: `clean` green for the issue, `locked` purple for the PR. Every linked row
launches in that state, since nothing is fetched until `F`
(`Action::FetchGithub`), so the first thing the table says about a row is two
different things about the same absence of data.

Neither colour was free to borrow. `clean` is what `issue_badge_color` and
`pr_badge_color` both give an **open** item; `locked` is a **merged** PR, a
**closed** issue, and the locked-worktree badge.

Both slots now take `name` white.

Closes #596

## Type of change

- [ ] Feature (new functionality)
- [x] Fix (bug fix)
- [ ] Hotfix (critical production fix)
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Tests
- [ ] Perf
- [ ] Chore / CI / build

## Changes

- `src/tui/ui.rs` - both `(Some(_), None)` arms in `table_marker` return
  `theme.name`. The arms are kept split rather than collapsed to `_` so the
  site to change is already there if one of the two stops being white.
- `tests/tui_app_tests.rs` - `table_marker_paints_both_unfetched_pastilles_white`
  (renamed) plus the two sibling `..._leaves_the_*_slot_as_dash` cases, which
  each asserted one of the old placeholder colours.
- `tests/tui_theme_audit_tests.rs` - the role-resolution case pins both
  unfetched dots to `name`, asserts the `●` glyph next to the colour, and adds
  `assert_ne!(t.name, t.clean)` / `assert_ne!(t.name, t.locked)`.
- `CHANGELOG.md` - entry under `[Unreleased] / Fixed`.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

Red was proved on the value, not on a compile error. Two guards keep the new
assertions from passing vacuously: `name` is now also the empty slot's colour,
so the audit case asserts the `●` glyph alongside the role, and the two
`assert_ne!`s stop the assertion succeeding by roles collapsing onto one value
in the audit theme.

## Screenshots / TUI captures

No capture regenerated. `docs/_capture/setup-demo.sh` writes no `gwm-pr` branch
config, and the only `(Some(_), None)` arms in the tree are the two this PR
touches, so no committed capture contains a slot whose colour changes.

Worth a look before merge all the same: a colour role is not settled by a green
test.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #596

## Notes for reviewers

**This does not implement the fix the issue proposed, and the reason is worth a
minute.** #596 proposed pointing the PR slot at `clean` to match the issue slot.
That settles the disagreement between the two slots but keeps both of them
borrowing the colour of a loaded open item.

The issue also left the real question open: *"whether 'linked but unknown'
should be `clean` at all, or a neutral role"*. It turns out the codebase had
already answered it. `sidebar_status_dot` (`src/tui/ui.rs:1517`) hits the same
case and resolves it to a neutral white, with the rationale in a comment:

> Link exists but not fetched yet - neutral white so the user sees there's
> *something* to refresh with `F`. White carries no theme role (it is "not yet
> known", not a status), so it stays white.

The table now applies the same idea, but not the same value, and the difference
is worth stating plainly: the sidebar hard-codes `Color::White` because it has
one dot and no glyph to vary, so it needs a colour outside the theme's roles to
separate "unfetched" from "no link". The marker separates those two on `●` vs
`-`, so it can stay inside the roles and take `name` -- which no badge map
produces (`issue_badge_color` yields clean/locked, `pr_badge_color` yields
clean/muted/locked/prunable) and which the empty slot in the same cell already
uses. The two values coincide only in the default theme; `name` is off-white in
all four presets. Same reasoning, different surface, not literal parity.

Cost: the issue slot changes too (green to white), one line beyond what #596
asked for. That is the reason this wants a look rather than a rubber stamp.

`muted` was the third option, named in the issue. It is the `PrState::Draft`
colour and the marker's own `/` separator, so all three characters of the cell
would have gone one colour.
