### PR TITLE
✨ feat(config,multiplexer,tui): a setting for whether a mux spawn is a pane, a tab, or a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **A setting for which direction a mux pane opens in**
-  ([#589](https://github.com/kbrdn1/gwm-cli/issues/589)). `[tui]
-  mux_pane_direction` decides where the TUI's `t` key puts the worktree it
-  opens: `"right"` (default) or `"down"` to split the current pane, `"window"`
-  for a whole tmux window or zellij / herdr tab. It is also the direction a
-  bare `gwm tmux|zellij|herdr <pattern> --split` takes, and the new
-  `--direction right|down` overrides it for one invocation. The knob cycles
+- **Two settings for what a mux spawn opens, and where**
+  ([#589](https://github.com/kbrdn1/gwm-cli/issues/589),
+  [#608](https://github.com/kbrdn1/gwm-cli/issues/608)). The TUI's `t` key
+  took whatever each backend felt like giving it. Two `[tui]` keys now say:
+
+  ```toml
+  [tui]
+  mux_open_in        = "pane"    # "pane" | "tab" | "workspace"
+  mux_pane_direction = "right"   # "right" | "down", pane only
+  ```
+
+  `"tab"` is a whole screen of its own: a tmux window, a zellij or herdr tab,
+  one thing under three names. `"workspace"` is herdr's level above a tab and
+  runs `herdr workspace create --label <name> --cwd <path> --focus`.
+  `mux_pane_direction` is also the direction a bare
+  `gwm tmux|zellij|herdr <pattern> --split` takes, and the new
+  `--direction right|down` overrides it for one invocation. Both keys cycle
   live in the Settings panel under the **TUI** tab.
 
   Two directions rather than four: `left` and `up` reach tmux only through
@@ -26,10 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   values: right, down]`, so a fuller compass would be values one backend could
   not honour.
 
-  One caveat, and it is the same shape as the herdr one below: under
-  `"window"` a `[tui.macro*]` with `open_in = "mux_pane"` falls back to the
-  PTY overlay on zellij, because `zellij action new-tab` takes no trailing
-  command to run. The status bar names the backend that refused.
+  **`"workspace"` is refused on tmux and zellij, not downgraded to a tab.**
+  Neither has a level there, and quietly opening something else would leave
+  the setting describing what did not happen. The status bar names the backend
+  that cannot and the one that can. (Both have *sessions*, the structural
+  analogue, but gwm runs inside one: tmux would need two commands to create
+  and switch to a sibling, and zellij refuses to nest sessions.)
+
+  One caveat, the same shape as the herdr one below: a `[tui.macro*]` with
+  `open_in = "mux_pane"` falls back to the PTY overlay under `"tab"` on
+  zellij and under `"workspace"` on every backend, because those verbs take
+  no trailing command to run. The status bar names which one refused.
 
 - **herdr is a third multiplexer backend**
   ([#588](https://github.com/kbrdn1/gwm-cli/issues/588)). `gwm herdr <pattern>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Two settings for what a mux spawn opens, and where**
   ([#589](https://github.com/kbrdn1/gwm-cli/issues/589),
-  [#608](https://github.com/kbrdn1/gwm-cli/issues/608)). The TUI's `t` key
+  [#608](https://github.com/kbrdn1/gwm-cli/issues/608),
+  [#611](https://github.com/kbrdn1/gwm-cli/issues/611)). The TUI's `t` key
   took whatever each backend felt like giving it. Two `[tui]` keys now say:
 
   ```toml
   [tui]
   mux_open_in        = "pane"    # "pane" | "tab" | "workspace"
-  mux_pane_direction = "right"   # "right" | "down", pane only
+  mux_pane_direction = "right"   # "right" | "down" | "left" | "up", pane only
   ```
 
   `"tab"` is a whole screen of its own: a tmux window, a zellij or herdr tab,
@@ -28,13 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs `herdr workspace create --label <name> --cwd <path> --focus`.
   `mux_pane_direction` is also the direction a bare
   `gwm tmux|zellij|herdr <pattern> --split` takes, and the new
-  `--direction right|down` overrides it for one invocation. Both keys cycle
+  `--direction <dir>` overrides it for one invocation. Both keys cycle
   live in the Settings panel under the **TUI** tab.
 
-  Two directions rather than four: `left` and `up` reach tmux only through
-  `split-window -b`, and herdr declares its `--direction` as `[possible
-  values: right, down]`, so a fuller compass would be values one backend could
-  not honour.
+  `mux_pane_direction` takes all four compass points
+  ([#611](https://github.com/kbrdn1/gwm-cli/issues/611)). `left` and `up` are
+  tmux's `-h -b` / `-v -b` (`-b` flips the side on the axis `-h` / `-v`
+  picked, measured on 3.7c through `split-window -P -F`) and zellij's own
+  words. **herdr takes only `right` and `down`**, declaring `[possible values:
+  right, down]`, so the other two are refused there rather than substituted:
+
+  ```
+  herdr splits only right or down: left and up are tmux and zellij directions
+  ```
 
   **`"workspace"` is refused on tmux and zellij, not downgraded to a tab.**
   Neither has a level there, and quietly opening something else would leave

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -62,7 +62,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `L`         | launch the configured [`[git_tui]`](/tui/launchers) command fullscreen (`lazygit_fullscreen`)     |
 | `r`         | launch the configured [`[review]`](/tui/launchers) command in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) (`review_pty`): AI / web reviewer over `git diff base..head` |
 | `R`         | launch the configured [`[review]`](/tui/launchers) command fullscreen (`review_fullscreen`)       |
-| `t`         | open the selected worktree in a new tmux / zellij / herdr pane (`mux_pane`), where [`[tui] mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction) picks the half it takes (or a whole window / tab); falls back to a status-bar hint when no multiplexer is detected |
+| `t`         | open the selected worktree in a new tmux / zellij / herdr pane (`mux_pane`), where [`[tui] mux_open_in`](/configuration/gwm-toml#mux_open_in) picks the level (pane, tab, or a herdr workspace) and [`mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction) the half a pane takes; falls back to a status-bar hint when no multiplexer is detected |
 | `h`         | run the user-configured [`[tui.macro1]`](/configuration/gwm-toml#tuimacro1-and-tuimacro2) command (`macro_one`) |
 | `H`         | run the user-configured [`[tui.macro2]`](/configuration/gwm-toml#tuimacro1-and-tuimacro2) command (`macro_two`) |
 | `y`         | yank the selected worktree's **branch name** to the clipboard (`yank_branch_name`)                |

--- a/docs/3.cli/1.reference.md
+++ b/docs/3.cli/1.reference.md
@@ -491,7 +491,7 @@ Print a static completion script. Supported shells: `zsh`, `bash`, `fish`, `powe
 
 Print the `gcd` shell wrapper. Supported shells: `zsh`, `bash`, `fish`, `powershell`. See [Getting started → Shell init](/getting-started/shell-init).
 
-## `gwm tmux <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm tmux <pattern> [-p|--split] [--direction <dir>]`
 
 Open the matched worktree in a new tmux window of the **current** session. `--split` substitutes `split-window` for `new-window`. Requires `$TMUX` to be set.
 
@@ -501,21 +501,21 @@ gwm tmux auth -p                  # split the current pane instead
 gwm tmux auth --direction down    # ...stacked rather than side by side
 ```
 
-`--split` takes its direction from [`[tui] mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction), which defaults to `right` (`split-window -h`). `--direction right|down` overrides it for one invocation and implies `--split`. Before #589 a split carried no flag at all and tmux stacked it.
+`--split` takes its direction from [`[tui] mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction), which defaults to `right` (`split-window -h`). `--direction <dir>` (`right`, `down`, `left`, `up`) overrides it for one invocation and implies `--split`. Before #589 a split carried no flag at all and tmux stacked it.
 
 Outside a tmux session, exits non-zero with a clear error (does not spawn a stray server).
 
-## `gwm zellij <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm zellij <pattern> [-p|--split] [--direction <dir>]`
 
 Same as `gwm tmux` but for zellij. Uses `zellij action new-tab --cwd <path>` (requires zellij ≥ 0.40 for the `--cwd` flag) or `new-pane --direction <dir> --cwd <path>` with `-p`. Requires `$ZELLIJ`.
 
 The direction is passed rather than left out: without it zellij places the pane in "the biggest available space", which is a layout-dependent answer to a keystroke that should have a fixed one.
 
-## `gwm herdr <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm herdr <pattern> [-p|--split] [--direction <dir>]`
 
 Same as `gwm tmux` but for [herdr](https://herdr.dev). Uses `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`, or `herdr pane split --current --direction <dir> --cwd <path> --focus` with `-p`. Requires `$HERDR_ENV`, which herdr sets in every pane it manages.
 
-herdr's parser has no default for `--direction`, so the flag is not optional here: the value comes from `--direction` or from `[tui] mux_pane_direction`. `--focus` and `--workspace` are passed because neither is herdr's default: without them the tab opens unfocused, in whichever workspace the server had focused rather than yours. The workspace id comes from `$HERDR_WORKSPACE_ID`.
+herdr's parser has no default for `--direction`, so the flag is not optional here: the value comes from `--direction` or from `[tui] mux_pane_direction`. herdr takes only `right` and `down`: `left` and `up` are refused there, with a message that says so. `--focus` and `--workspace` are passed because neither is herdr's default: without them the tab opens unfocused, in whichever workspace the server had focused rather than yours. The workspace id comes from `$HERDR_WORKSPACE_ID`.
 
 See [CLI → Multiplexer integration](/cli/multiplexer) for the full surface and edge cases.
 

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -19,11 +19,11 @@ gwm tmux auth --direction down   # ...stacked rather than side by side
 Under the hood:
 
 - **new window** (default): `tmux new-window -n <name> -c <path>`
-- **split** (`-p` / `--split`): `tmux split-window -h -c <path>`, or `-v` under `down`
+- **split** (`-p` / `--split`): `tmux split-window -h -c <path>`, or `-v` under `down`, plus `-b` under `left` / `up`
 
 The `-n <name>` arg names the new window after the worktree slug so it stands out in the status bar.
 
-`-h` is tmux's *horizontal split*, and it puts the new pane to the **right**; `-v` stacks it below. tmux names the axis the divider runs along, not where the pane goes, which is worth knowing before reading the two flags as the words suggest.
+`-h` is tmux's *horizontal split*, and it puts the new pane to the **right**; `-v` stacks it below. tmux names the axis the divider runs along, not where the pane goes, which is worth knowing before reading the two flags as the words suggest. `-b` ("before") flips the side on whichever axis was picked, so `left` is `-h -b` and `up` is `-v -b`. Measured on tmux 3.7c by reading the new pane's geometry back through `split-window -P -F`.
 
 ## zellij
 
@@ -36,7 +36,7 @@ gwm zellij auth --direction down # ...stacked rather than side by side
 Under the hood:
 
 - **new tab** (default): `zellij action new-tab --name <name> --cwd <path>`
-- **new pane** (`-p` / `--split`): `zellij action new-pane --direction <right|down> --cwd <path>`
+- **new pane** (`-p` / `--split`): `zellij action new-pane --direction <dir> --cwd <path>`
 
 `--direction` is optional in zellij's own parser: without it, zellij "will try to use the biggest available space", which makes the pane's position a property of the current layout rather than of the command. gwm passes it so the answer is the same every time.
 
@@ -53,11 +53,11 @@ gwm herdr auth --direction down  # ...stacked rather than side by side
 Under the hood:
 
 - **new tab** (default): `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`
-- **split** (`-p` / `--split`): `herdr pane split --current --direction <right|down> --cwd <path> --focus`
+- **split** (`-p` / `--split`): `herdr pane split --current --direction <right|down> --cwd <path> --focus`, and only those two
 
 [herdr](https://herdr.dev) drives its own server over a socket, so both verbs are control commands rather than a `new-window` equivalent. Four details differ from tmux and zellij:
 
-- **the split direction is not optional.** herdr's parser has no default for `--direction`, so gwm always passes one. Since #589 the value comes from `--direction` or from `[tui] mux_pane_direction` rather than from a hardcoded `right`, and herdr declares `[possible values: right, down]`, which is why gwm offers exactly those two on all three backends.
+- **the split direction is not optional.** herdr's parser has no default for `--direction`, so gwm always passes one. Since #589 the value comes from `--direction` or from `[tui] mux_pane_direction` rather than from a hardcoded `right`. herdr declares `[possible values: right, down]`, so the `left` and `up` that #611 added for tmux and zellij are **refused** here rather than translated into something else.
 - **the split takes no label.** A herdr pane is named after the fact with `herdr pane rename`, and `pane split` reads a bare argument as the pane to split, so gwm passes the worktree name only on `tab create`.
 - **`--focus` is not the default.** Both verbs come back `"focused": false` without it, where `tmux new-window` and `zellij action new-tab` move you to what they create. gwm passes it so herdr is not the one backend that opens the worktree out of sight.
 - **the new tab is pinned to your workspace.** Without `--workspace`, herdr targets the workspace the *server* has focused, which is another project's window as often as not. gwm passes `$HERDR_WORKSPACE_ID`, which every managed pane carries; outside one, the flag is dropped and herdr picks. A split needs none of this, `--current` already resolves the workspace.
@@ -90,6 +90,6 @@ The `<pattern>` arg uses the same fuzzy matcher as `gwm path / remove / bootstra
 ## see also
 
 - [TUI → Fuzzy filter](/tui/filter): the matcher's case-sensitivity and scoring rules
-- [CLI → Subcommand reference](/cli/reference#gwm-tmux-pattern--p--split---direction-rightdown): flags and exit codes
+- [CLI → Subcommand reference](/cli/reference#gwm-tmux-pattern--p--split---direction-dir): flags and exit codes
 - [Configuration → `mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction): the setting a bare `--split` reads, shared with the TUI's `t`
 - [Configuration → `mux_open_in`](/configuration/gwm-toml#mux_open_in): the level the TUI's `t` opens, herdr workspace included

--- a/docs/3.cli/3.multiplexer.md
+++ b/docs/3.cli/3.multiplexer.md
@@ -62,6 +62,8 @@ Under the hood:
 - **`--focus` is not the default.** Both verbs come back `"focused": false` without it, where `tmux new-window` and `zellij action new-tab` move you to what they create. gwm passes it so herdr is not the one backend that opens the worktree out of sight.
 - **the new tab is pinned to your workspace.** Without `--workspace`, herdr targets the workspace the *server* has focused, which is another project's window as often as not. gwm passes `$HERDR_WORKSPACE_ID`, which every managed pane carries; outside one, the flag is dropped and herdr picks. A split needs none of this, `--current` already resolves the workspace.
 
+A third level exists on herdr with no CLI equivalent: `herdr workspace create --label <name> --cwd <path> --focus`, reachable from the TUI's `t` through [`[tui] mux_open_in = "workspace"`](/configuration/gwm-toml#mux_open_in). tmux and zellij have no level above the tab, so they refuse that setting rather than open something else.
+
 Verified against **herdr 0.8.2**, against a live server rather than the help text: the focus and workspace behaviours above were both measured, and both are the opposite of what the flag names suggest.
 
 ## required session
@@ -90,3 +92,4 @@ The `<pattern>` arg uses the same fuzzy matcher as `gwm path / remove / bootstra
 - [TUI → Fuzzy filter](/tui/filter): the matcher's case-sensitivity and scoring rules
 - [CLI → Subcommand reference](/cli/reference#gwm-tmux-pattern--p--split---direction-rightdown): flags and exit codes
 - [Configuration → `mux_pane_direction`](/configuration/gwm-toml#mux_pane_direction): the setting a bare `--split` reads, shared with the TUI's `t`
+- [Configuration → `mux_open_in`](/configuration/gwm-toml#mux_open_in): the level the TUI's `t` opens, herdr workspace included

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -432,8 +432,9 @@ note_vim = true
 # tmux window / zellij tab / herdr tab), or "workspace" (herdr only).
 mux_open_in = "pane"
 
-# Which half a mux pane takes: "right" (default) or "down". Only meaningful
-# under mux_open_in = "pane". Also the direction a CLI `--split` takes.
+# Which half a mux pane takes: "right" (default), "down", "left" or "up".
+# herdr takes only the first two. Only meaningful under mux_open_in = "pane".
+# Also the direction a CLI `--split` takes.
 mux_pane_direction = "right"
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
@@ -552,13 +553,23 @@ This key does not reach the CLI. `gwm tmux|zellij|herdr <pattern>` spells its ow
 | Value | Behaviour |
 |:------|:----------|
 | `"right"` | **Default.** Side by side: `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
-| `"down"` | Stacked: `tmux split-window -v`, `--direction down` on the other two. |
+| `"down"` | Stacked below: `tmux split-window -v`, `--direction down` on the other two. |
+| `"left"` | Side by side, other side: `tmux split-window -h -b`, `--direction left` on zellij. **Refused by herdr.** |
+| `"up"` | Stacked above: `tmux split-window -v -b`, `--direction up` on zellij. **Refused by herdr.** |
 
 **`right` is a behaviour change for tmux and zellij users**, and a deliberate one. Up to 1.9 a split carried no direction, so each backend answered for itself: tmux fell back to `-v` and stacked the pane, zellij took "the biggest available space", and herdr went right because gwm hardcoded it there. `right` is what the `--split` help has promised since it shipped ("a horizontal split of the current pane"), and the half that is actually free on a wide screen. Set `mux_pane_direction = "down"` to get the old tmux behaviour back.
 
-Two directions, not four: `left` and `up` reach tmux only through `split-window -b`, and herdr 0.8.2 declares its `--direction` as `[possible values: right, down]`, so a fuller compass would be values one backend could not honour. An unknown value is a **hard config error at load time**, and so is `"window"`, which moved to `mux_open_in = "tab"`.
+`-b` is where the second pair comes from, and it is worth knowing before reading tmux's flags as the words suggest: `-h` is the *horizontal split* and puts the pane to the **right**, `-v` stacks it **below**, and `-b` ("before") flips the side on whichever axis was picked. Measured on tmux 3.7c by reading the new pane's geometry back through `split-window -P -F` rather than inferring it from pane order.
 
-On the CLI, `gwm tmux|zellij|herdr <pattern> --split` takes its direction from here unless `--direction right|down` overrides it for that one invocation.
+**`left` and `up` are refused on herdr**, which declares its `--direction` as `[possible values: right, down]` (0.8.2). The status bar says so rather than substituting a direction herdr does have:
+
+```
+herdr splits only right or down: left and up are tmux and zellij directions
+```
+
+This is [`mux_open_in = "workspace"`](#mux_open_in) inverted: there one backend can do what the other two cannot, here two can do what the third cannot. An unknown value is a **hard config error at load time**, and so is `"window"`, which moved to `mux_open_in = "tab"`.
+
+On the CLI, `gwm tmux|zellij|herdr <pattern> --split` takes its direction from here unless `--direction <dir>` overrides it for that one invocation.
 
 `clipboard` (issue #367) selects how yanked text (path, branch, worktree name, command logs) reaches the clipboard:
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -428,9 +428,12 @@ status_one_line = true
 # false for the modeless editor, where one `Esc` writes and closes.
 note_vim = true
 
-# Where the TUI opens a worktree in the multiplexer: "right" (default) or
-# "down" to split the current pane, "window" for a whole tmux window /
-# zellij tab / herdr tab. Also the direction a CLI `--split` takes.
+# What the TUI opens in the multiplexer: "pane" (default), "tab" (a whole
+# tmux window / zellij tab / herdr tab), or "workspace" (herdr only).
+mux_open_in = "pane"
+
+# Which half a mux pane takes: "right" (default) or "down". Only meaningful
+# under mux_open_in = "pane". Also the direction a CLI `--split` takes.
 mux_pane_direction = "right"
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
@@ -476,7 +479,7 @@ The header fill is the `section_bg` [theme role](/tui/themes), an indexed colour
 
 Overlays and modals keep their border under either value — a panel floating over content is where a rule earns its keep.
 
-An unknown value is a **hard config error at load time**. `layout`, `dim_unfocused`, `status_one_line`, `note_vim` and `mux_pane_direction` are also exposed in the Settings panel under the **TUI** tab (`4`), where cycling the choice applies live.
+An unknown value is a **hard config error at load time**. `layout`, `dim_unfocused`, `status_one_line`, `note_vim`, `mux_open_in` and `mux_pane_direction` are also exposed in the Settings panel under the **TUI** tab (`4`), where cycling the choice applies live.
 
 ### dim_unfocused
 
@@ -518,25 +521,44 @@ It changes no binding: `[tui.keys.modal.note]` holds the same four verbs either 
 
 No counts, no registers, no undo. `Ctrl+e` still hands the file to the real vim, and that handoff is the answer for anything this mode does not cover.
 
-### mux_pane_direction
+### mux_open_in
 
-`mux_pane_direction` (issue [#589](https://github.com/kbrdn1/gwm-cli/issues/589)) decides where the TUI's `t` key puts the worktree it opens, and which half a `--split` takes on the CLI.
+`mux_open_in` (issue [#608](https://github.com/kbrdn1/gwm-cli/issues/608)) decides *what* the TUI's `t` key opens in the multiplexer. A multiplexer nests panes inside tabs, and herdr nests tabs inside workspaces; this picks the level.
 
 | Value | Behaviour |
 |:------|:----------|
-| `"right"` | **Default.** Split side by side: `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
-| `"down"` | Split stacked: `tmux split-window -v`, `--direction down` on the other two. |
-| `"window"` | No split at all: a new tmux window, or a new zellij / herdr tab. |
+| `"pane"` | **Default.** Split the current pane. Which half it takes is [`mux_pane_direction`](#mux_pane_direction) below. |
+| `"tab"` | A whole screen of its own: a `tmux` **window**, a zellij or herdr **tab**. One thing under three names; the status bar uses your backend's word. |
+| `"workspace"` | herdr's level above a tab. **herdr only.** |
+
+**`"workspace"` is refused on tmux and zellij, not downgraded.** Neither has a level there, so `t` says so on the status bar and opens nothing:
+
+```
+tmux has no workspace level: herdr is the only backend with one
+```
+
+Quietly opening a tab instead would leave the setting describing something that did not happen, which is worse than a key that refuses and explains itself. The two backends do have *sessions*, which is the structural analogue, but gwm runs inside one: tmux would need two commands to create and switch to a sibling, and zellij refuses to nest sessions at all.
+
+Under `"workspace"`, herdr runs `herdr workspace create --label <name> --cwd <path> --focus`. It is `tab create` minus the `--workspace` it would be creating.
+
+A `[tui.macro*]` with `open_in = "mux_pane"` reads this key too, and under `"workspace"` it falls back to the PTY overlay on **every** backend: tmux and zellij have no workspace, and herdr's `workspace create` takes no trailing command any more than its `tab create` does. The status bar names which one refused.
+
+This key does not reach the CLI. `gwm tmux|zellij|herdr <pattern>` spells its own target: bare is a tab, `--split` is a pane. There is no workspace flag, and `--workspace` is taken by the repo-set flag (issue #36).
+
+### mux_pane_direction
+
+`mux_pane_direction` (issue [#589](https://github.com/kbrdn1/gwm-cli/issues/589)) decides which half a pane takes, under `mux_open_in = "pane"` and on the CLI's `--split`.
+
+| Value | Behaviour |
+|:------|:----------|
+| `"right"` | **Default.** Side by side: `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
+| `"down"` | Stacked: `tmux split-window -v`, `--direction down` on the other two. |
 
 **`right` is a behaviour change for tmux and zellij users**, and a deliberate one. Up to 1.9 a split carried no direction, so each backend answered for itself: tmux fell back to `-v` and stacked the pane, zellij took "the biggest available space", and herdr went right because gwm hardcoded it there. `right` is what the `--split` help has promised since it shipped ("a horizontal split of the current pane"), and the half that is actually free on a wide screen. Set `mux_pane_direction = "down"` to get the old tmux behaviour back.
 
-Two directions, not four: `left` and `up` reach tmux only through `split-window -b`, and herdr 0.8.2 declares its `--direction` as `[possible values: right, down]`, so a fuller compass would be values one backend could not honour. An unknown value is a **hard config error at load time**.
+Two directions, not four: `left` and `up` reach tmux only through `split-window -b`, and herdr 0.8.2 declares its `--direction` as `[possible values: right, down]`, so a fuller compass would be values one backend could not honour. An unknown value is a **hard config error at load time**, and so is `"window"`, which moved to `mux_open_in = "tab"`.
 
-Three surfaces read it:
-
-- the TUI's `t` key, which opens a pane or, under `"window"`, a whole window / tab. The status bar names what it opened.
-- a `[tui.macro*]` with `open_in = "mux_pane"`, with one caveat: `"window"` leaves zellij nothing to run the command in, since `zellij action new-tab` takes no trailing command. Such a macro falls back to the PTY overlay and the status bar says which backend refused. herdr already did that in both modes.
-- `gwm tmux|zellij|herdr <pattern> --split`, unless `--direction right|down` overrides it for that one invocation. Under `"window"` a bare `--split` splits right: the flag has already said it wants a pane, and the config has no direction left to give it.
+On the CLI, `gwm tmux|zellij|herdr <pattern> --split` takes its direction from here unless `--direction right|down` overrides it for that one invocation.
 
 `clipboard` (issue #367) selects how yanked text (path, branch, worktree name, command logs) reaches the clipboard:
 
@@ -1040,6 +1062,7 @@ Single-pass expansion: `wip = "ll"` followed by `ll = "list --format names"` exp
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
 | `[tui].note_vim`                     | `true`                           |
+| `[tui].mux_open_in`                  | `pane`                           |
 | `[tui].mux_pane_direction`           | `right`                          |
 | `[tui].clipboard`                    | `auto`                           |
 | `[tui].auto_refresh_secs`            | `60` (`0` disables)              |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -66,7 +66,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `L`         | lancer la commande [`[git_tui]`](/fr/tui/launchers) configurée en plein écran (`lazygit_fullscreen`) |
 | `r`         | lancer la commande [`[review]`](/fr/tui/launchers) configurée dans une surcouche PTY (`review_pty`) : relecteur IA / web sur `git diff base..head` |
 | `R`         | lancer la commande [`[review]`](/fr/tui/launchers) configurée en plein écran (`review_fullscreen`) |
-| `t`         | ouvrir le worktree sélectionné dans un nouveau panneau tmux / zellij / herdr (`mux_pane`), où [`[tui] mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction) choisit la moitié qu'il prend (ou une fenêtre / un onglet entier) ; repli sur une indication dans la barre de statut si aucun multiplexeur n'est détecté |
+| `t`         | ouvrir le worktree sélectionné dans un nouveau panneau tmux / zellij / herdr (`mux_pane`), où [`[tui] mux_open_in`](/fr/configuration/gwm-toml#mux_open_in) choisit le niveau (panneau, onglet, ou workspace herdr) et [`mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction) la moitié que prend un panneau ; repli sur une indication dans la barre de statut si aucun multiplexeur n'est détecté |
 | `h`         | lancer la commande [`[tui.macro1]`](/fr/configuration/gwm-toml#tuimacro1-et-tuimacro2) configurée par l'utilisateur (`macro_one`) |
 | `H`         | lancer la commande [`[tui.macro2]`](/fr/configuration/gwm-toml#tuimacro1-et-tuimacro2) configurée par l'utilisateur (`macro_two`) |
 | `y`         | copier le **nom de branche** du worktree sélectionné dans le presse-papiers (`yank_branch_name`)  |

--- a/docs/fr/3.cli/1.reference.md
+++ b/docs/fr/3.cli/1.reference.md
@@ -494,7 +494,7 @@ Affiche un script de complétion statique. Shells pris en charge : `zsh`, `bash`
 
 Affiche le wrapper de shell `gcd`. Shells pris en charge : `zsh`, `bash`, `fish`, `powershell`. Voir [Premiers pas → Shell init](/fr/getting-started/shell-init).
 
-## `gwm tmux <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm tmux <pattern> [-p|--split] [--direction <dir>]`
 
 Ouvre le worktree correspondant dans une nouvelle fenêtre tmux de la session **courante**. `--split` substitue `split-window` à `new-window`. Nécessite que `$TMUX` soit défini.
 
@@ -504,21 +504,21 @@ gwm tmux auth -p                  # split the current pane instead
 gwm tmux auth --direction down    # ...empilé plutôt que côte à côte
 ```
 
-`--split` prend sa direction dans [`[tui] mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction), dont le défaut est `right` (`split-window -h`). `--direction right|down` la remplace pour une invocation et implique `--split`. Avant #589, un split ne portait aucun flag et tmux l'empilait.
+`--split` prend sa direction dans [`[tui] mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction), dont le défaut est `right` (`split-window -h`). `--direction <dir>` (`right`, `down`, `left`, `up`) la remplace pour une invocation et implique `--split`. Avant #589, un split ne portait aucun flag et tmux l'empilait.
 
 En dehors d'une session tmux, sort avec un code non nul et une erreur claire (ne lance pas de serveur orphelin).
 
-## `gwm zellij <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm zellij <pattern> [-p|--split] [--direction <dir>]`
 
 Comme `gwm tmux` mais pour zellij. Utilise `zellij action new-tab --cwd <path>` (nécessite zellij ≥ 0.40 pour le flag `--cwd`) ou `new-pane --direction <dir> --cwd <path>` avec `-p`. Nécessite `$ZELLIJ`.
 
 La direction est passée plutôt qu'omise : sans elle, zellij place le panneau dans « le plus grand espace disponible », une réponse dépendante du layout à une touche qui devrait en avoir une fixe.
 
-## `gwm herdr <pattern> [-p|--split] [--direction <right|down>]`
+## `gwm herdr <pattern> [-p|--split] [--direction <dir>]`
 
 Comme `gwm tmux` mais pour [herdr](https://herdr.dev). Utilise `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`, ou `herdr pane split --current --direction <dir> --cwd <path> --focus` avec `-p`. Nécessite `$HERDR_ENV`, que herdr fixe dans chaque panneau qu'il gère.
 
-Le parseur de herdr n'a pas de défaut pour `--direction`, donc le flag n'y est pas optionnel : la valeur vient de `--direction` ou de `[tui] mux_pane_direction`. `--focus` et `--workspace` sont passés car aucun des deux n'est le défaut de herdr : sans eux, l'onglet s'ouvre sans focus, dans le workspace que le serveur avait en focus plutôt que le vôtre. L'id du workspace vient de `$HERDR_WORKSPACE_ID`.
+Le parseur de herdr n'a pas de défaut pour `--direction`, donc le flag n'y est pas optionnel : la valeur vient de `--direction` ou de `[tui] mux_pane_direction`. herdr ne prend que `right` et `down` : `left` et `up` y sont refusés, avec le message qui le dit. `--focus` et `--workspace` sont passés car aucun des deux n'est le défaut de herdr : sans eux, l'onglet s'ouvre sans focus, dans le workspace que le serveur avait en focus plutôt que le vôtre. L'id du workspace vient de `$HERDR_WORKSPACE_ID`.
 
 Voir [CLI → Intégration multiplexeur](/fr/cli/multiplexer) pour la surface complète et les cas limites.
 

--- a/docs/fr/3.cli/3.multiplexer.md
+++ b/docs/fr/3.cli/3.multiplexer.md
@@ -62,6 +62,8 @@ Sous le capot :
 - **`--focus` n'est pas le défaut.** Les deux verbes reviennent `"focused": false` sans lui, là où `tmux new-window` et `zellij action new-tab` vous amènent sur ce qu'ils créent. gwm le passe pour que herdr ne soit pas le seul backend à ouvrir le worktree hors de votre vue.
 - **le nouvel onglet est épinglé sur votre workspace.** Sans `--workspace`, herdr vise le workspace que le *serveur* a en focus, soit la fenêtre d'un autre projet une fois sur deux. gwm passe `$HERDR_WORKSPACE_ID`, que chaque panneau géré transporte ; en dehors d'un panneau géré, le flag est omis et herdr choisit. Un split n'en a pas besoin, `--current` résout déjà le workspace.
 
+Un troisième niveau existe côté herdr et n'a pas d'équivalent CLI : `herdr workspace create --label <name> --cwd <path> --focus`, atteignable depuis la touche `t` du TUI via [`[tui] mux_open_in = "workspace"`](/fr/configuration/gwm-toml#mux_open_in). tmux et zellij n'ont pas de niveau au-dessus de l'onglet, donc ils refusent ce réglage au lieu d'ouvrir autre chose.
+
 Vérifié contre **herdr 0.8.2**, contre un serveur en fonctionnement et non contre l'aide en ligne : les comportements de focus et de workspace ci-dessus ont tous deux été mesurés, et sont tous deux l'inverse de ce que le nom des flags suggère.
 
 ## session requise
@@ -90,3 +92,4 @@ L'argument `<pattern>` utilise le même matcher fuzzy que `gwm path / remove / b
 - [TUI → Filtre fuzzy](/fr/tui/filter) : les règles de sensibilité à la casse et de scoring du matcher
 - [CLI → Référence des sous-commandes](/fr/cli/reference#gwm-tmux-pattern--p--split---direction-rightdown) : flags et codes de sortie
 - [Configuration → `mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction) : le réglage que lit un `--split` seul, partagé avec la touche `t` du TUI
+- [Configuration → `mux_open_in`](/fr/configuration/gwm-toml#mux_open_in) : le niveau que la touche `t` ouvre, workspace herdr compris

--- a/docs/fr/3.cli/3.multiplexer.md
+++ b/docs/fr/3.cli/3.multiplexer.md
@@ -19,11 +19,11 @@ gwm tmux auth --direction down   # ...empilé plutôt que côte à côte
 Sous le capot :
 
 - **nouvelle fenêtre** (défaut) : `tmux new-window -n <name> -c <path>`
-- **split** (`-p` / `--split`) : `tmux split-window -h -c <path>`, ou `-v` sous `down`
+- **split** (`-p` / `--split`) : `tmux split-window -h -c <path>`, ou `-v` sous `down`, plus `-b` sous `left` / `up`
 
 L'argument `-n <name>` nomme la nouvelle fenêtre d'après le slug du worktree pour qu'elle ressorte dans la barre de statut.
 
-`-h` est le *split horizontal* de tmux, et il place le nouveau panneau à **droite** ; `-v` l'empile en dessous. tmux nomme l'axe que suit la séparation, pas la direction que prend le panneau, ce qu'il vaut mieux savoir avant de lire les deux flags comme les mots le suggèrent.
+`-h` est le *split horizontal* de tmux, et il place le nouveau panneau à **droite** ; `-v` l'empile en dessous. tmux nomme l'axe que suit la séparation, pas la direction que prend le panneau, ce qu'il vaut mieux savoir avant de lire les deux flags comme les mots le suggèrent. `-b` (« before ») inverse le côté sur l'axe choisi, donc `left` est `-h -b` et `up` est `-v -b`. Mesuré sur tmux 3.7c en relisant la géométrie du nouveau panneau via `split-window -P -F`.
 
 ## zellij
 
@@ -36,7 +36,7 @@ gwm zellij auth --direction down # ...empilé plutôt que côte à côte
 Sous le capot :
 
 - **nouvel onglet** (défaut) : `zellij action new-tab --name <name> --cwd <path>`
-- **nouveau panneau** (`-p` / `--split`) : `zellij action new-pane --direction <right|down> --cwd <path>`
+- **nouveau panneau** (`-p` / `--split`) : `zellij action new-pane --direction <dir> --cwd <path>`
 
 `--direction` est optionnel dans le parseur de zellij : sans lui, zellij « essaie d'utiliser le plus grand espace disponible », ce qui fait de la position du panneau une propriété du layout courant plutôt que de la commande. gwm le passe pour que la réponse soit la même à chaque fois.
 
@@ -53,11 +53,11 @@ gwm herdr auth --direction down  # ...empilé plutôt que côte à côte
 Sous le capot :
 
 - **nouvel onglet** (défaut) : `herdr tab create --workspace <id> --label <name> --cwd <path> --focus`
-- **split** (`-p` / `--split`) : `herdr pane split --current --direction <right|down> --cwd <path> --focus`
+- **split** (`-p` / `--split`) : `herdr pane split --current --direction <right|down> --cwd <path> --focus`, et rien d'autre
 
 [herdr](https://herdr.dev) pilote son propre serveur via une socket, donc les deux verbes sont des commandes de contrôle plutôt qu'un équivalent de `new-window`. Quatre détails diffèrent de tmux et zellij :
 
-- **la direction du split n'est pas optionnelle.** Le parseur de herdr n'a pas de valeur par défaut pour `--direction`, donc gwm en passe toujours une. Depuis #589, la valeur vient de `--direction` ou de `[tui] mux_pane_direction` au lieu d'un `right` codé en dur, et herdr déclare `[possible values: right, down]`, ce qui explique que gwm n'offre que ces deux valeurs, sur les trois backends.
+- **la direction du split n'est pas optionnelle.** Le parseur de herdr n'a pas de valeur par défaut pour `--direction`, donc gwm en passe toujours une. Depuis #589, la valeur vient de `--direction` ou de `[tui] mux_pane_direction` au lieu d'un `right` codé en dur. herdr déclare `[possible values: right, down]`, donc les `left` et `up` que #611 a ajoutés pour tmux et zellij y sont **refusés** plutôt que traduits en autre chose.
 - **le split ne prend pas de label.** Un panneau herdr se nomme après coup avec `herdr pane rename`, et `pane split` lit un argument nu comme le panneau à découper, donc gwm ne passe le nom du worktree que sur `tab create`.
 - **`--focus` n'est pas le défaut.** Les deux verbes reviennent `"focused": false` sans lui, là où `tmux new-window` et `zellij action new-tab` vous amènent sur ce qu'ils créent. gwm le passe pour que herdr ne soit pas le seul backend à ouvrir le worktree hors de votre vue.
 - **le nouvel onglet est épinglé sur votre workspace.** Sans `--workspace`, herdr vise le workspace que le *serveur* a en focus, soit la fenêtre d'un autre projet une fois sur deux. gwm passe `$HERDR_WORKSPACE_ID`, que chaque panneau géré transporte ; en dehors d'un panneau géré, le flag est omis et herdr choisit. Un split n'en a pas besoin, `--current` résout déjà le workspace.
@@ -90,6 +90,6 @@ L'argument `<pattern>` utilise le même matcher fuzzy que `gwm path / remove / b
 ## voir aussi
 
 - [TUI → Filtre fuzzy](/fr/tui/filter) : les règles de sensibilité à la casse et de scoring du matcher
-- [CLI → Référence des sous-commandes](/fr/cli/reference#gwm-tmux-pattern--p--split---direction-rightdown) : flags et codes de sortie
+- [CLI → Référence des sous-commandes](/fr/cli/reference#gwm-tmux-pattern--p--split---direction-dir) : flags et codes de sortie
 - [Configuration → `mux_pane_direction`](/fr/configuration/gwm-toml#mux_pane_direction) : le réglage que lit un `--split` seul, partagé avec la touche `t` du TUI
 - [Configuration → `mux_open_in`](/fr/configuration/gwm-toml#mux_open_in) : le niveau que la touche `t` ouvre, workspace herdr compris

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -430,9 +430,12 @@ status_one_line = true
 # false rend l'éditeur sans mode, où une seule `Échap` enregistre et ferme.
 note_vim = true
 
-# Where the TUI opens a worktree in the multiplexer: "right" (default) or
-# "down" to split the current pane, "window" for a whole tmux window /
-# zellij tab / herdr tab. Also the direction a CLI `--split` takes.
+# What the TUI opens in the multiplexer: "pane" (default), "tab" (a whole
+# tmux window / zellij tab / herdr tab), or "workspace" (herdr only).
+mux_open_in = "pane"
+
+# Which half a mux pane takes: "right" (default) or "down". Only meaningful
+# under mux_open_in = "pane". Also the direction a CLI `--split` takes.
 mux_pane_direction = "right"
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
@@ -478,7 +481,7 @@ L'aplat de l'en-tête est le [rôle de thème](/fr/tui/themes) `section_bg`, une
 
 Les surcouches et les modales gardent leur bordure dans les deux cas — un panneau qui flotte au-dessus du contenu est précisément là où un filet se justifie.
 
-Une valeur inconnue est une **erreur de config au chargement**. `layout`, `dim_unfocused`, `status_one_line`, `note_vim` et `mux_pane_direction` sont aussi exposés dans le panneau Settings sous l'onglet **TUI** (`4`), où faire défiler le choix s'applique à chaud.
+Une valeur inconnue est une **erreur de config au chargement**. `layout`, `dim_unfocused`, `status_one_line`, `note_vim`, `mux_open_in` et `mux_pane_direction` sont aussi exposés dans le panneau Settings sous l'onglet **TUI** (`4`), où faire défiler le choix s'applique à chaud.
 
 ### dim_unfocused
 
@@ -520,25 +523,44 @@ L'option ne change aucun binding : `[tui.keys.modal.note]` porte les mêmes quat
 
 Pas de compteurs, pas de registres, pas d'annulation. `Ctrl+e` confie toujours le fichier au vrai vim, et ce relais est la réponse pour tout ce que ce mode ne couvre pas.
 
-### mux_pane_direction
+### mux_open_in
 
-`mux_pane_direction` (issue [#589](https://github.com/kbrdn1/gwm-cli/issues/589)) décide où la touche `t` du TUI ouvre le worktree, et quelle moitié prend un `--split` en CLI.
+`mux_open_in` (issue [#608](https://github.com/kbrdn1/gwm-cli/issues/608)) décide *ce que* la touche `t` du TUI ouvre dans le multiplexeur. Un multiplexeur imbrique des panneaux dans des onglets, et herdr imbrique des onglets dans des workspaces ; cette clé choisit le niveau.
 
 | Valeur | Comportement |
 |:-------|:-------------|
-| `"right"` | **Défaut.** Split côte à côte : `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
-| `"down"` | Split empilé : `tmux split-window -v`, `--direction down` pour les deux autres. |
-| `"window"` | Pas de split du tout : une nouvelle fenêtre tmux, ou un nouvel onglet zellij / herdr. |
+| `"pane"` | **Défaut.** Découpe le panneau courant. Quelle moitié il prend, c'est [`mux_pane_direction`](#mux_pane_direction) ci-dessous. |
+| `"tab"` | Un écran entier : une **fenêtre** tmux, un **onglet** zellij ou herdr. Une seule chose sous trois noms ; la barre de statut emploie le mot de votre backend. |
+| `"workspace"` | Le niveau de herdr au-dessus de l'onglet. **herdr uniquement.** |
+
+**`"workspace"` est refusé sur tmux et zellij, pas dégradé.** Aucun des deux n'a de niveau équivalent, donc `t` le dit dans la barre de statut et n'ouvre rien :
+
+```
+tmux has no workspace level: herdr is the only backend with one
+```
+
+Ouvrir un onglet à la place, en silence, laisserait le réglage décrire quelque chose qui n'a pas eu lieu : pire qu'une touche qui refuse et s'explique. Les deux backends ont bien des *sessions*, l'analogue structurel, mais gwm tourne à l'intérieur de l'une d'elles : tmux demanderait deux commandes pour créer une session sœur et y basculer, et zellij refuse purement l'imbrication de sessions.
+
+Sous `"workspace"`, herdr lance `herdr workspace create --label <name> --cwd <path> --focus`. C'est `tab create` moins le `--workspace` qu'il serait en train de créer.
+
+Une `[tui.macro*]` avec `open_in = "mux_pane"` lit cette clé aussi, et sous `"workspace"` elle se rabat sur l'overlay PTY sur **tous** les backends : tmux et zellij n'ont pas de workspace, et le `workspace create` de herdr ne prend pas plus de commande finale que son `tab create`. La barre de statut nomme celui qui a refusé.
+
+Cette clé n'atteint pas le CLI. `gwm tmux|zellij|herdr <pattern>` énonce sa propre cible : sans flag c'est un onglet, avec `--split` c'est un panneau. Il n'y a pas de flag workspace, et `--workspace` est déjà pris par le flag de jeu de dépôts (issue #36).
+
+### mux_pane_direction
+
+`mux_pane_direction` (issue [#589](https://github.com/kbrdn1/gwm-cli/issues/589)) décide quelle moitié prend un panneau, sous `mux_open_in = "pane"` et sur le `--split` du CLI.
+
+| Valeur | Comportement |
+|:-------|:-------------|
+| `"right"` | **Défaut.** Côte à côte : `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
+| `"down"` | Empilé : `tmux split-window -v`, `--direction down` pour les deux autres. |
 
 **`right` est un changement de comportement pour les utilisateurs tmux et zellij**, et il est délibéré. Jusqu'à la 1.9, un split ne portait aucune direction, donc chaque backend répondait pour lui-même : tmux retombait sur `-v` et empilait le panneau, zellij prenait « le plus grand espace disponible », et herdr allait à droite parce que gwm le codait en dur. `right` est ce que l'aide de `--split` promet depuis sa sortie (« a horizontal split of the current pane »), et la moitié réellement libre sur un écran large. Mettez `mux_pane_direction = "down"` pour retrouver l'ancien comportement tmux.
 
-Deux directions, pas quatre : `left` et `up` ne s'atteignent sur tmux qu'à travers `split-window -b`, et herdr 0.8.2 déclare son `--direction` en `[possible values: right, down]`. Une rose des vents complète serait donc des valeurs qu'un backend ne pourrait pas honorer. Une valeur inconnue est une **erreur de config au chargement**.
+Deux directions, pas quatre : `left` et `up` ne s'atteignent sur tmux qu'à travers `split-window -b`, et herdr 0.8.2 déclare son `--direction` en `[possible values: right, down]`. Une rose des vents complète serait donc des valeurs qu'un backend ne pourrait pas honorer. Une valeur inconnue est une **erreur de config au chargement**, et `"window"` aussi : elle a déménagé vers `mux_open_in = "tab"`.
 
-Trois surfaces la lisent :
-
-- la touche `t` du TUI, qui ouvre un panneau ou, sous `"window"`, une fenêtre / un onglet entier. La barre de statut nomme ce qui a été ouvert.
-- une `[tui.macro*]` avec `open_in = "mux_pane"`, avec une réserve : `"window"` ne laisse à zellij aucun endroit où lancer la commande, puisque `zellij action new-tab` ne prend pas de commande finale. Une telle macro se rabat sur l'overlay PTY et la barre de statut dit quel backend a refusé. herdr le faisait déjà, dans les deux modes.
-- `gwm tmux|zellij|herdr <pattern> --split`, sauf si `--direction right|down` la remplace pour cette invocation. Sous `"window"`, un `--split` seul ouvre à droite : le flag a déjà dit qu'il voulait un panneau, et la config n'a plus de direction à lui donner.
+Côté CLI, `gwm tmux|zellij|herdr <pattern> --split` prend sa direction ici, sauf si `--direction right|down` la remplace pour cette invocation.
 
 `clipboard` (issue #367) choisit comment le texte yanké (chemin, branche, nom de worktree, logs de commandes) atteint le presse-papier :
 
@@ -1041,6 +1063,7 @@ Expansion en une seule passe : `wip = "ll"` suivi de `ll = "list --format names"
 | `[tui].dim_unfocused`                | `false`                          |
 | `[tui].status_one_line`              | `true`                           |
 | `[tui].note_vim`                     | `true`                           |
+| `[tui].mux_open_in`                  | `pane`                           |
 | `[tui].mux_pane_direction`           | `right`                          |
 | `[tui].auto_refresh_secs`            | `60` (`0` désactive)             |
 | `[tui.macro1]` / `[tui.macro2]`      | absent, `h` / `H` sont des no-ops |

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -434,8 +434,9 @@ note_vim = true
 # tmux window / zellij tab / herdr tab), or "workspace" (herdr only).
 mux_open_in = "pane"
 
-# Which half a mux pane takes: "right" (default) or "down". Only meaningful
-# under mux_open_in = "pane". Also the direction a CLI `--split` takes.
+# Which half a mux pane takes: "right" (default), "down", "left" or "up".
+# herdr takes only the first two. Only meaningful under mux_open_in = "pane".
+# Also the direction a CLI `--split` takes.
 mux_pane_direction = "right"
 
 # How yanked text reaches the clipboard: "auto" (OSC52 over SSH, host tools
@@ -554,13 +555,23 @@ Cette clé n'atteint pas le CLI. `gwm tmux|zellij|herdr <pattern>` énonce sa pr
 | Valeur | Comportement |
 |:-------|:-------------|
 | `"right"` | **Défaut.** Côte à côte : `tmux split-window -h`, `zellij action new-pane --direction right`, `herdr pane split --direction right`. |
-| `"down"` | Empilé : `tmux split-window -v`, `--direction down` pour les deux autres. |
+| `"down"` | Empilé en dessous : `tmux split-window -v`, `--direction down` pour les deux autres. |
+| `"left"` | Côte à côte, de l'autre côté : `tmux split-window -h -b`, `--direction left` sur zellij. **Refusé par herdr.** |
+| `"up"` | Empilé au-dessus : `tmux split-window -v -b`, `--direction up` sur zellij. **Refusé par herdr.** |
 
 **`right` est un changement de comportement pour les utilisateurs tmux et zellij**, et il est délibéré. Jusqu'à la 1.9, un split ne portait aucune direction, donc chaque backend répondait pour lui-même : tmux retombait sur `-v` et empilait le panneau, zellij prenait « le plus grand espace disponible », et herdr allait à droite parce que gwm le codait en dur. `right` est ce que l'aide de `--split` promet depuis sa sortie (« a horizontal split of the current pane »), et la moitié réellement libre sur un écran large. Mettez `mux_pane_direction = "down"` pour retrouver l'ancien comportement tmux.
 
-Deux directions, pas quatre : `left` et `up` ne s'atteignent sur tmux qu'à travers `split-window -b`, et herdr 0.8.2 déclare son `--direction` en `[possible values: right, down]`. Une rose des vents complète serait donc des valeurs qu'un backend ne pourrait pas honorer. Une valeur inconnue est une **erreur de config au chargement**, et `"window"` aussi : elle a déménagé vers `mux_open_in = "tab"`.
+`-b` est d'où vient la seconde paire, et il vaut mieux le savoir avant de lire les flags tmux comme les mots le suggèrent : `-h` est le *split horizontal* et place le panneau à **droite**, `-v` l'empile **en dessous**, et `-b` (« before ») inverse le côté sur l'axe choisi. Mesuré sur tmux 3.7c en relisant la géométrie du nouveau panneau via `split-window -P -F`, plutôt qu'en la déduisant de l'ordre des panneaux.
 
-Côté CLI, `gwm tmux|zellij|herdr <pattern> --split` prend sa direction ici, sauf si `--direction right|down` la remplace pour cette invocation.
+**`left` et `up` sont refusés sur herdr**, qui déclare son `--direction` en `[possible values: right, down]` (0.8.2). La barre de statut le dit au lieu de substituer une direction que herdr sait faire :
+
+```
+herdr splits only right or down: left and up are tmux and zellij directions
+```
+
+C'est [`mux_open_in = "workspace"`](#mux_open_in) à l'envers : là un backend sait ce que les deux autres ne savent pas, ici deux savent ce que le troisième ne sait pas. Une valeur inconnue est une **erreur de config au chargement**, et `"window"` aussi : elle a déménagé vers `mux_open_in = "tab"`.
+
+Côté CLI, `gwm tmux|zellij|herdr <pattern> --split` prend sa direction ici, sauf si `--direction <dir>` la remplace pour cette invocation.
 
 `clipboard` (issue #367) choisit comment le texte yanké (chemin, branche, nom de worktree, logs de commandes) atteint le presse-papier :
 

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -362,7 +362,9 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 #
 # `mux_pane_direction` — which half a pane takes, under "pane" only:
 #   "right"  side by side (DEFAULT since #589)
-#   "down"   stacked
+#   "down"   stacked below
+#   "left"   side by side, other side  (tmux `-h -b`, zellij; REFUSED by herdr)
+#   "up"     stacked above             (tmux `-v -b`, zellij; REFUSED by herdr)
 #
 # `right` is a behaviour change for tmux and zellij users, and a deliberate
 # one. Before #589 a split carried no direction at all, so each backend
@@ -371,10 +373,11 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # is what the `--split` help has promised since it shipped, and the half that
 # is free on a wide screen. Set "down" for the old tmux behaviour.
 #
-# Two directions, not four: `left` / `up` reach tmux only through
-# `split-window -b`, and herdr declares `[possible values: right, down]`.
+# `-b` ("before") flips the side on the axis `-h` / `-v` picked, which is where
+# left and up come from on tmux. herdr declares `[possible values: right, down]`
+# and REFUSES the other two rather than substituting one it does have.
 #
-# `gwm tmux|zellij|herdr <pattern> --direction right|down` overrides the
+# `gwm tmux|zellij|herdr <pattern> --direction <dir>` overrides the
 # direction for one invocation. The CLI spells its own target instead (bare is
 # a tab, `-p` is a pane), so `mux_open_in` does not reach it.
 #

--- a/examples/gwm.toml.example
+++ b/examples/gwm.toml.example
@@ -347,12 +347,22 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # [tui]
 # note_vim = false
 
-# --- Where a mux pane opens (issue #589) -------------------------------------
-# Where the TUI's `t` key puts the worktree it opens, and which half a CLI
-# `--split` takes:
-#   "right"   split side by side (DEFAULT since #589)
-#   "down"    split stacked
-#   "window"  no split: a new tmux window, or a new zellij / herdr tab
+# --- What a mux spawn opens (issues #589 / #608) -----------------------------
+# `mux_open_in` — what the TUI's `t` key opens in the multiplexer:
+#   "pane"       split the current pane (DEFAULT)
+#   "tab"        a whole screen: a tmux window, a zellij or herdr tab
+#   "workspace"  herdr's level above a tab. HERDR ONLY.
+#
+# "workspace" is REFUSED on tmux and zellij, not downgraded: neither has a
+# level there, so `t` says so on the status bar and opens nothing. A silent
+# tab would leave this setting describing something that did not happen.
+# (Both have sessions, the structural analogue, but gwm runs inside one:
+# tmux would need two commands to create and switch to a sibling, and zellij
+# refuses to nest sessions.)
+#
+# `mux_pane_direction` — which half a pane takes, under "pane" only:
+#   "right"  side by side (DEFAULT since #589)
+#   "down"   stacked
 #
 # `right` is a behaviour change for tmux and zellij users, and a deliberate
 # one. Before #589 a split carried no direction at all, so each backend
@@ -364,12 +374,16 @@ when = "glob_exists:src/**/*.rs && !env_set:CI"
 # Two directions, not four: `left` / `up` reach tmux only through
 # `split-window -b`, and herdr declares `[possible values: right, down]`.
 #
-# `gwm tmux|zellij|herdr <pattern> --direction right|down` overrides this for
-# one invocation. A `[tui.macro*]` with `open_in = "mux_pane"` reads it too,
-# with one caveat: under "window" a zellij macro falls back to the PTY overlay,
-# since `zellij action new-tab` takes no trailing command to run.
+# `gwm tmux|zellij|herdr <pattern> --direction right|down` overrides the
+# direction for one invocation. The CLI spells its own target instead (bare is
+# a tab, `-p` is a pane), so `mux_open_in` does not reach it.
+#
+# A `[tui.macro*]` with `open_in = "mux_pane"` reads both, with one caveat:
+# under "tab" a zellij macro and under "workspace" every macro falls back to
+# the PTY overlay, because those verbs take no trailing command to run.
 #
 # [tui]
+# mux_open_in        = "workspace"
 # mux_pane_direction = "down"
 
 # --- TUI clipboard (issue #367) ----------------------------------------------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4028,12 +4028,7 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool, direction: Op
     // cannot break the two forms that never needed a direction.
     (true, None) => {
       let workdir = repo.workdir().unwrap_or_else(|| repo.path()).to_path_buf();
-      SpawnMode::Split(
-        Config::load_for_repo(&workdir)?
-          .tui
-          .mux_pane_direction
-          .split_direction(),
-      )
+      SpawnMode::Split(Config::load_for_repo(&workdir)?.tui.mux_pane_direction)
     }
     (false, None) => SpawnMode::Window,
   };
@@ -4041,13 +4036,19 @@ fn cmd_multiplexer(mux: Multiplexer, pattern: String, split: bool, direction: Op
   // workspace; without it herdr uses whichever workspace the server has
   // focused, which is a different project's window as often as not. The
   // other two backends ignore it, and so does a herdr split.
+  // The refusal is unreachable from here today — this handler never builds a
+  // `Workspace`, because the CLI spells its own target (bare is a tab, `-p`
+  // is a pane) and `--workspace` is taken by the repo-set flag (#36). It is
+  // still surfaced rather than unwrapped: the day a flag does reach it, the
+  // user gets the builder's own sentence instead of a panic.
   let argv = build_command(
     mux,
     &found.name,
     &found.path,
     mode,
     std::env::var("HERDR_WORKSPACE_ID").ok().as_deref(),
-  );
+  )
+  .map_err(|why| GwmError::Other(why.to_string()))?;
   spawn_multiplexer(mux, &argv)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -887,21 +887,32 @@ pub struct TuiConfig {
   #[serde(default = "default_status_one_line")]
   pub status_one_line: bool,
 
-  /// Where the TUI opens a worktree in the multiplexer (issue #589).
+  /// What the TUI opens in the multiplexer: a pane, a whole tab, or a
+  /// workspace (issue #608).
   ///
-  /// Read by the two call sites that ask for a pane — the `t` key and a
-  /// `[tui.macro*]` with `open_in = "mux_pane"` — and by `gwm tmux|zellij|
-  /// herdr --split`, which takes its direction from here unless
-  /// `--direction` overrides it.
+  /// Read by the two call sites that open one — the `t` key and a
+  /// `[tui.macro*]` with `open_in = "mux_pane"`. The CLI spells its own
+  /// target instead (bare is a tab, `--split` is a pane), so this key does
+  /// not reach it.
+  ///
+  /// Default `pane`, which is what `t` has always done.
+  #[serde(default)]
+  pub mux_open_in: MuxTarget,
+
+  /// Which half a mux pane takes (issue #589).
+  ///
+  /// Only meaningful under `mux_open_in = "pane"`. Also the direction
+  /// `gwm tmux|zellij|herdr --split` takes, unless `--direction` overrides
+  /// it for that invocation.
   ///
   /// Default `right`, which is a visible change for tmux and zellij users:
-  /// up to 1.9 `Split` carried no direction, so tmux fell back to `-v` and
+  /// up to 1.9 a split carried no direction, so tmux fell back to `-v` and
   /// stacked the pane. `right` is what the `--split` help has promised
   /// since it shipped ("a horizontal split of the current pane"), what
   /// herdr already hardcoded, and the half that is actually free on a wide
   /// screen. Set `down` for the pre-#589 tmux behaviour.
   #[serde(default)]
-  pub mux_pane_direction: MuxPaneDirection,
+  pub mux_pane_direction: SplitDirection,
 
   /// Give the in-TUI note editor a vim normal mode (issue #557).
   ///
@@ -916,63 +927,52 @@ pub struct TuiConfig {
   pub note_vim: bool,
 }
 
-/// Where a mux pane opens, for the TUI call sites that open one (issue
-/// #589).
+/// What a mux spawn opens (issue #608): the level of the multiplexer's own
+/// hierarchy the worktree lands in.
 ///
-/// Two directions plus an escape hatch: `window` asks for a whole tmux
-/// window / zellij tab / herdr tab instead of a split, which is what the
-/// `t` key gives someone who wants the full screen rather than half of it.
-/// The two directions are [`SplitDirection`]'s, and serialise identically,
-/// so `right` in the config is the `right` in the argv.
+/// Split off `mux_pane_direction`, which carried a `window` value that was
+/// not a direction at all. The two questions are orthogonal: this one says
+/// *what*, [`SplitDirection`] says *which half* when the answer is a pane.
 ///
 /// `kebab-case` for the same reason as [`TuiLayout`]: it keeps the
 /// serialised form equal to [`Self::label`], so a Settings-panel write-back
 /// produces a file that still loads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum MuxPaneDirection {
-  /// Split side by side. The default since #589.
+pub enum MuxTarget {
+  /// Split the current pane. The default, and what `t` has always done.
   #[default]
-  Right,
-  /// Split stacked — what tmux did on its own before #589.
-  Down,
-  /// No split at all: a new window (tmux) or tab (zellij, herdr).
-  Window,
+  Pane,
+  /// A whole screen of its own: a tmux window, a zellij or herdr tab. One
+  /// thing under three names, so the value takes the majority spelling and
+  /// [`crate::multiplexer::Multiplexer::window_noun`] renders the local one.
+  Tab,
+  /// herdr's level above a tab. **herdr only**: tmux and zellij have
+  /// nothing at that level, and the builders refuse rather than quietly
+  /// open a tab, which would make this setting lie about what it did.
+  Workspace,
 }
 
-impl MuxPaneDirection {
+impl MuxTarget {
   /// Every variant, default first.
-  pub const ALL: [MuxPaneDirection; 3] = [
-    MuxPaneDirection::Right,
-    MuxPaneDirection::Down,
-    MuxPaneDirection::Window,
-  ];
+  pub const ALL: [MuxTarget; 3] = [MuxTarget::Pane, MuxTarget::Tab, MuxTarget::Workspace];
 
   /// Settings-panel label, equal to the serialised TOML spelling.
   pub const fn label(self) -> &'static str {
     match self {
-      MuxPaneDirection::Right => SplitDirection::Right.label(),
-      MuxPaneDirection::Down => SplitDirection::Down.label(),
-      MuxPaneDirection::Window => "window",
+      MuxTarget::Pane => "pane",
+      MuxTarget::Tab => "tab",
+      MuxTarget::Workspace => "workspace",
     }
   }
 
-  /// What the TUI call sites build from this.
-  pub const fn spawn_mode(self) -> SpawnMode {
+  /// What the TUI call sites build from this. `direction` is consumed only
+  /// by `Pane`; the other two targets have no half to take.
+  pub const fn spawn_mode(self, direction: SplitDirection) -> SpawnMode {
     match self {
-      MuxPaneDirection::Right => SpawnMode::Split(SplitDirection::Right),
-      MuxPaneDirection::Down => SpawnMode::Split(SplitDirection::Down),
-      MuxPaneDirection::Window => SpawnMode::Window,
-    }
-  }
-
-  /// The direction an explicit `--split` takes. `window` has none to give
-  /// and the flag has already said it wants a pane, so it falls back to the
-  /// default rather than overriding the flag the user just typed.
-  pub const fn split_direction(self) -> SplitDirection {
-    match self {
-      MuxPaneDirection::Down => SplitDirection::Down,
-      MuxPaneDirection::Right | MuxPaneDirection::Window => SplitDirection::Right,
+      MuxTarget::Pane => SpawnMode::Split(direction),
+      MuxTarget::Tab => SpawnMode::Window,
+      MuxTarget::Workspace => SpawnMode::Workspace,
     }
   }
 }
@@ -1033,7 +1033,8 @@ impl Default for TuiConfig {
       layout: TuiLayout::Compact,
       dim_unfocused: false,
       status_one_line: default_status_one_line(),
-      mux_pane_direction: MuxPaneDirection::default(),
+      mux_open_in: MuxTarget::default(),
+      mux_pane_direction: SplitDirection::default(),
       note_vim: default_note_vim(),
     }
   }

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -11,6 +11,7 @@
 //! `tui/mod.rs::run_lazygit`.
 
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// Multiplexer the user opted into via `gwm tmux …` / `gwm zellij …` /
@@ -53,9 +54,11 @@ impl Multiplexer {
 /// through `split-window -b`, and herdr 0.8.2 declares its `--direction`
 /// as `[possible values: right, down]` outright, so a fuller compass
 /// would be variants one backend could not honour.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum SplitDirection {
   /// Side by side. tmux `-h`, `--direction right` on zellij and herdr.
+  #[default]
   Right,
   /// Stacked. tmux `-v`, `--direction down` on zellij and herdr.
   Down,
@@ -88,13 +91,29 @@ impl SplitDirection {
 }
 
 /// How to open the worktree inside the multiplexer.
-/// `Window`   = new tmux window / zellij tab / herdr tab (full screen real estate).
-/// `Split(d)` = split the current pane towards `d` (the `-p` flag — keeps both views visible).
+///
+/// * `Split(d)`  = split the current pane towards `d` (the `-p` flag — keeps
+///   both views visible).
+/// * `Window`    = a whole screen of its own: a tmux **window**, a zellij or
+///   herdr **tab**. One thing under three names, which is why the variant
+///   keeps tmux's word (it is also the verb, `new-window`) while
+///   [`Multiplexer::window_noun`] renders the user's.
+/// * `Workspace` = herdr's level above a tab (issue #608). tmux and zellij
+///   have nothing at that level, so their builders refuse rather than open
+///   something else.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpawnMode {
   Window,
   Split(SplitDirection),
+  Workspace,
 }
+
+/// The two refusals a target can produce (issue #608). They are the text
+/// the TUI's status bar shows and the CLI's error carries, so they name the
+/// backend rather than the enum: a user who set `mux_open_in = "workspace"`
+/// needs to know which of their three multiplexers cannot honour it.
+const TMUX_HAS_NO_WORKSPACE: &str = "tmux has no workspace level: herdr is the only backend with one";
+const ZELLIJ_HAS_NO_WORKSPACE: &str = "zellij has no workspace level: herdr is the only backend with one";
 
 /// Build `tmux new-window -n <name> -c <path>` (Window) or
 /// `tmux split-window -h|-v -c <path>` (Split). `<name>` is the worktree's
@@ -105,9 +124,10 @@ pub enum SpawnMode {
 /// without one it falls back to `-v` and stacks the pane, and that is what
 /// `--split` did up to 1.9 while its own `--help` promised "a horizontal
 /// split of the current pane" (issue #589).
-pub fn build_tmux_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<String> {
+pub fn build_tmux_command(name: &str, path: &Path, mode: SpawnMode) -> Result<Vec<String>, &'static str> {
   let path_str = path.display().to_string();
-  match mode {
+  Ok(match mode {
+    SpawnMode::Workspace => return Err(TMUX_HAS_NO_WORKSPACE),
     SpawnMode::Window => vec![
       "tmux".into(),
       "new-window".into(),
@@ -123,7 +143,7 @@ pub fn build_tmux_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Strin
       "-c".into(),
       path_str,
     ],
-  }
+  })
 }
 
 /// Build `zellij action new-tab --name <name> --cwd <path>` (Window) or
@@ -136,9 +156,10 @@ pub fn build_tmux_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Strin
 /// space"), so passing it is what makes the choice gwm's rather than the
 /// layout's. It conflicts with `--floating` / `--in-place`, neither of
 /// which gwm passes.
-pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<String> {
+pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Result<Vec<String>, &'static str> {
   let path_str = path.display().to_string();
-  match mode {
+  Ok(match mode {
+    SpawnMode::Workspace => return Err(ZELLIJ_HAS_NO_WORKSPACE),
     SpawnMode::Window => vec![
       "zellij".into(),
       "action".into(),
@@ -157,7 +178,7 @@ pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Str
       "--cwd".into(),
       path_str,
     ],
-  }
+  })
 }
 
 /// Build `herdr tab create --label <name> --cwd <path>` (Window) or
@@ -194,9 +215,29 @@ pub fn build_zellij_command(name: &str, path: &Path, mode: SpawnMode) -> Vec<Str
 /// `Split` mode: passing it bare would be read as the optional `[PANE_ID]`
 /// positional and split someone else's pane. `workspace` is likewise
 /// ignored there.
-pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode, workspace: Option<&str>) -> Vec<String> {
+pub fn build_herdr_command(
+  name: &str,
+  path: &Path,
+  mode: SpawnMode,
+  workspace: Option<&str>,
+) -> Result<Vec<String>, &'static str> {
   let path_str = path.display().to_string();
-  match mode {
+  Ok(match mode {
+    // `herdr workspace create` is `tab create` minus the `--workspace` it
+    // would be creating, and it is the one target the other two backends
+    // cannot match (issue #608). Measured on 0.8.2: `--cwd`, `--label`,
+    // `--env`, `--focus` / `--no-focus`. `--focus` is passed for the same
+    // reason as on a tab: without it the workspace comes back unfocused.
+    SpawnMode::Workspace => vec![
+      "herdr".into(),
+      "workspace".into(),
+      "create".into(),
+      "--label".into(),
+      name.into(),
+      "--cwd".into(),
+      path_str,
+      "--focus".into(),
+    ],
     SpawnMode::Window => {
       let mut argv = vec!["herdr".into(), "tab".into(), "create".into()];
       if let Some(ws) = workspace.filter(|ws| !ws.is_empty()) {
@@ -223,7 +264,7 @@ pub fn build_herdr_command(name: &str, path: &Path, mode: SpawnMode, workspace: 
       path_str,
       "--focus".into(),
     ],
-  }
+  })
 }
 
 /// Resolve which multiplexer the process is inside, in the order tmux,
@@ -268,7 +309,7 @@ pub fn build_command(
   path: &Path,
   mode: SpawnMode,
   workspace: Option<&str>,
-) -> Vec<String> {
+) -> Result<Vec<String>, &'static str> {
   match mux {
     Multiplexer::Tmux => build_tmux_command(name, path, mode),
     Multiplexer::Zellij => build_zellij_command(name, path, mode),
@@ -284,6 +325,7 @@ pub fn spawn_noun(mux: Multiplexer, mode: SpawnMode) -> &'static str {
   match mode {
     SpawnMode::Split(_) => "pane",
     SpawnMode::Window => mux.window_noun(),
+    SpawnMode::Workspace => "workspace",
   }
 }
 
@@ -297,16 +339,23 @@ pub fn spawn_noun(mux: Multiplexer, mode: SpawnMode) -> &'static str {
 /// * `zellij action new-pane -- <cmd>` takes one; `zellij action new-tab`
 ///   does not, so `mux_pane_direction = "window"` has nothing to hand a
 ///   zellij macro (#589).
-/// * neither herdr verb takes one. Running a command in a herdr pane is
+/// * neither herdr verb takes one, `workspace create` included (#608).
+///   Running a command in a herdr pane is
 ///   `herdr pane run <pane-id> <cmd>`, and the id only comes back in the
 ///   JSON `pane split` prints, so it is two processes and a parse, not an
 ///   argv (#599).
+///
+/// This answers "can this backend RUN a command", not "can it open this
+/// target at all" — the builders answer the second, with an `Err`. A macro
+/// asks both, and the caller checks this one first so its status names the
+/// macro's problem rather than the target's.
 ///
 /// Splitting anyway would open an empty pane and silently drop the macro,
 /// so the caller falls back to the PTY overlay and puts the reason in the
 /// status bar.
 pub const fn macro_refusal(mux: Multiplexer, mode: SpawnMode) -> Option<&'static str> {
   match (mux, mode) {
+    (Multiplexer::Herdr, SpawnMode::Workspace) => Some("herdr workspaces take no command"),
     (Multiplexer::Herdr, _) => Some("herdr panes take no command"),
     (Multiplexer::Zellij, SpawnMode::Window) => Some("zellij tabs take no command"),
     _ => None,

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -47,26 +47,47 @@ impl Multiplexer {
   }
 }
 
-/// Which half of the split a new pane takes (issue #589).
+/// Which half of the split a new pane takes (issues #589 / #611).
 ///
-/// Two variants rather than four: `right` and `down` are the intersection
-/// of what the three backends accept. tmux reaches `left` / `up` only
-/// through `split-window -b`, and herdr 0.8.2 declares its `--direction`
-/// as `[possible values: right, down]` outright, so a fuller compass
-/// would be variants one backend could not honour.
+/// All four compass points, which two of the three backends honour
+/// directly. Measured on tmux 3.7c by reading the *new* pane's geometry
+/// back through `split-window -P -F`, rather than inferring it from pane
+/// order: `-h` puts it at `left=101`, `-h -b` at `left=0`, `-v` at
+/// `top=26`, `-v -b` at `top=1`. zellij takes the four words on
+/// `new-pane --direction`.
+///
+/// **herdr 0.8.2 takes only two**: `herdr pane split --help` declares
+/// `--direction [possible values: right, down]`, so [`Left`] and [`Up`]
+/// are refused there the way `Workspace` is refused on tmux and zellij
+/// (#608). Same mechanism, opposite backend.
+///
+/// [`Left`]: SplitDirection::Left
+/// [`Up`]: SplitDirection::Up
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SplitDirection {
-  /// Side by side. tmux `-h`, `--direction right` on zellij and herdr.
+  /// Side by side, to the right. tmux `-h`, `--direction right` on zellij
+  /// and herdr.
   #[default]
   Right,
-  /// Stacked. tmux `-v`, `--direction down` on zellij and herdr.
+  /// Stacked, below. tmux `-v`, `--direction down` on zellij and herdr.
   Down,
+  /// Side by side, to the left. tmux `-h -b`, `--direction left` on
+  /// zellij. Refused by herdr.
+  Left,
+  /// Stacked, above. tmux `-v -b`, `--direction up` on zellij. Refused by
+  /// herdr.
+  Up,
 }
 
 impl SplitDirection {
-  /// Every variant, default first.
-  pub const ALL: [SplitDirection; 2] = [SplitDirection::Right, SplitDirection::Down];
+  /// Every variant, default first, then the two herdr cannot honour.
+  pub const ALL: [SplitDirection; 4] = [
+    SplitDirection::Right,
+    SplitDirection::Down,
+    SplitDirection::Left,
+    SplitDirection::Up,
+  ];
 
   /// The serialised spelling — equal to the `[tui] mux_pane_direction`
   /// value, to the `--direction` flag's value, and to the argument zellij
@@ -75,17 +96,29 @@ impl SplitDirection {
     match self {
       SplitDirection::Right => "right",
       SplitDirection::Down => "down",
+      SplitDirection::Left => "left",
+      SplitDirection::Up => "up",
     }
   }
 
-  /// tmux's own spelling. `-h` is a *horizontal split*, which puts the new
-  /// pane to the RIGHT, and `-v` stacks it BELOW: tmux names the axis the
-  /// divider runs along, not the direction the pane goes. The two
-  /// vocabularies meet here and nowhere else.
-  pub const fn tmux_flag(self) -> &'static str {
+  /// `true` for the two directions herdr's parser has no value for.
+  pub const fn is_herdr_capable(self) -> bool {
+    matches!(self, SplitDirection::Right | SplitDirection::Down)
+  }
+
+  /// tmux's own spelling, which needs two words for half the compass.
+  ///
+  /// `-h` is a *horizontal split* and puts the new pane to the RIGHT; `-v`
+  /// stacks it BELOW. tmux names the axis the divider runs along, not the
+  /// direction the pane goes, and `-b` ("before") flips the side on
+  /// whichever axis was picked. The two vocabularies meet here and nowhere
+  /// else.
+  pub const fn tmux_flags(self) -> &'static [&'static str] {
     match self {
-      SplitDirection::Right => "-h",
-      SplitDirection::Down => "-v",
+      SplitDirection::Right => &["-h"],
+      SplitDirection::Down => &["-v"],
+      SplitDirection::Left => &["-h", "-b"],
+      SplitDirection::Up => &["-v", "-b"],
     }
   }
 }
@@ -114,6 +147,9 @@ pub enum SpawnMode {
 /// needs to know which of their three multiplexers cannot honour it.
 const TMUX_HAS_NO_WORKSPACE: &str = "tmux has no workspace level: herdr is the only backend with one";
 const ZELLIJ_HAS_NO_WORKSPACE: &str = "zellij has no workspace level: herdr is the only backend with one";
+/// herdr 0.8.2 declares `--direction [possible values: right, down]`, so the
+/// other half of the compass is a tmux and zellij capability (issue #611).
+const HERDR_SPLITS_RIGHT_OR_DOWN: &str = "herdr splits only right or down: left and up are tmux and zellij directions";
 
 /// Build `tmux new-window -n <name> -c <path>` (Window) or
 /// `tmux split-window -h|-v -c <path>` (Split). `<name>` is the worktree's
@@ -136,13 +172,12 @@ pub fn build_tmux_command(name: &str, path: &Path, mode: SpawnMode) -> Result<Ve
       "-c".into(),
       path_str,
     ],
-    SpawnMode::Split(dir) => vec![
-      "tmux".into(),
-      "split-window".into(),
-      dir.tmux_flag().into(),
-      "-c".into(),
-      path_str,
-    ],
+    SpawnMode::Split(dir) => {
+      let mut argv: Vec<String> = vec!["tmux".into(), "split-window".into()];
+      argv.extend(dir.tmux_flags().iter().map(|f| (*f).to_string()));
+      argv.extend(["-c".into(), path_str]);
+      argv
+    }
   })
 }
 
@@ -253,6 +288,7 @@ pub fn build_herdr_command(
       ]);
       argv
     }
+    SpawnMode::Split(dir) if !dir.is_herdr_capable() => return Err(HERDR_SPLITS_RIGHT_OR_DOWN),
     SpawnMode::Split(dir) => vec![
       "herdr".into(),
       "pane".into(),

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -317,6 +317,47 @@ pub fn build_command(
   }
 }
 
+/// What a `[tui.macro*]` with `open_in = "mux_pane"` should spawn, or the
+/// reason it has to fall back to the PTY overlay.
+///
+/// The three steps a macro runs on (detect, refuse, build) were an inline
+/// chain in `run_macro`, which is the one place they could not be tested:
+/// the function takes a `Terminal` and drives the event loop. Extracting
+/// them makes the decision a value, and the fallback is the branch worth
+/// pinning, since getting it wrong drops the user's command into a pane
+/// nobody looks at (Codex review on PR #609).
+///
+/// Two refusals in one, asked in the order that produces the more useful
+/// sentence: [`macro_refusal`] answers "can this backend run a command at
+/// all", [`build_command`] answers "can it open this target". A macro's own
+/// problem is what the status bar should name when both apply.
+///
+/// The env values are parameters for the same reason as in
+/// [`detect_multiplexer`]: `$TMUX` is read by the clipboard path too, so a
+/// test that unset it would pull every yank test in the same binary under
+/// the env lock.
+pub fn macro_mux_command(
+  label: &str,
+  path: &Path,
+  mode: SpawnMode,
+  tmux: Option<String>,
+  zellij: Option<String>,
+  herdr: Option<String>,
+  workspace: Option<&str>,
+) -> Result<(Multiplexer, Vec<String>), &'static str> {
+  let Some(mux) = detect_multiplexer(tmux, zellij, herdr) else {
+    return Err(NO_MULTIPLEXER);
+  };
+  if let Some(why) = macro_refusal(mux, mode) {
+    return Err(why);
+  }
+  build_command(mux, label, path, mode, workspace).map(|argv| (mux, argv))
+}
+
+/// The one refusal that is not a backend's fault. Kept next to the others so
+/// the status bar's four sentences read as one set.
+const NO_MULTIPLEXER: &str = "no multiplexer";
+
 /// What `mode` just opened, for a status line that names the thing the
 /// user is looking at rather than the thing the key is called: `t` can now
 /// open a whole window or tab (#589), and "opened <name> in new pane" was

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5542,19 +5542,32 @@ impl App {
     };
     let path = w.path.clone();
     let name = w.name.clone();
-    // `[tui] mux_pane_direction` says which half the pane takes, or asks
-    // for a whole window/tab instead (#589). It used to be a Split with no
+    // `[tui] mux_open_in` says what to open and `mux_pane_direction` which
+    // half a pane takes (#608 / #589). Before them this was a Split with no
     // direction at all, which left the answer to each backend: tmux stacked,
     // zellij took the biggest free space, herdr went right.
     //
     // Herdr comes last in the cascade, so a user running gwm inside both it
     // and tmux keeps what they had before #588.
-    let mode = self.config.tui.mux_pane_direction.spawn_mode();
+    let mode = self
+      .config
+      .tui
+      .mux_open_in
+      .spawn_mode(self.config.tui.mux_pane_direction);
     let Some(mux) = crate::multiplexer::detect_multiplexer(tmux, zellij, herdr) else {
       self.status = "no multiplexer detected ($TMUX / $ZELLIJ / $HERDR_ENV not set)".into();
       return;
     };
-    let cmd = crate::multiplexer::build_command(mux, &name, &path, mode, workspace.as_deref());
+    // A target the backend has no level for (`workspace` outside herdr) is
+    // refused here rather than downgraded to a tab: the setting saying one
+    // thing while the screen shows another is the failure worth avoiding.
+    let cmd = match crate::multiplexer::build_command(mux, &name, &path, mode, workspace.as_deref()) {
+      Ok(cmd) => cmd,
+      Err(why) => {
+        self.status = why.into();
+        return;
+      }
+    };
     let bin = cmd[0].as_str();
     // `output()` rather than `spawn()`: both pipes have to be captured
     // because this runs while ratatui owns the screen, and a child that

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1432,7 +1432,7 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
     app.status = format!("macro{} not configured: add [tui.macro{}] to .gwm.toml", n, n);
     return Ok(());
   };
-  use crate::multiplexer::{build_command, detect_multiplexer, macro_refusal, Multiplexer};
+  use crate::multiplexer::{macro_mux_command, Multiplexer};
   // Macros run in the selected worktree. With nothing selected (e.g. a filter
   // with no matches), refuse rather than silently running in the main repo —
   // a destructive command must not hit the wrong tree (Codex review on #292).
@@ -1453,37 +1453,24 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
   let mux_cmd = if matches!(macro_cfg.open_in, MacroOpenMode::MuxPane) {
     let label = format!("macro{}", n);
     let mode = app.config.tui.mux_open_in.spawn_mode(app.config.tui.mux_pane_direction);
-    match detect_multiplexer(
+    let ws = std::env::var("HERDR_WORKSPACE_ID").ok();
+    // A multiplexer can be detected and still be unable to carry the macro's
+    // command: herdr in every mode, zellij under a tab, and every backend
+    // under a workspace (#588 / #589 / #608). Opening anyway would run
+    // nothing in it and drop the macro silently, so the PTY overlay is the
+    // honest fallback and the status bar says which backend said no.
+    match macro_mux_command(
+      &label,
+      &path,
+      mode,
       std::env::var("TMUX").ok(),
       std::env::var("ZELLIJ").ok(),
       std::env::var("HERDR_ENV").ok(),
+      ws.as_deref(),
     ) {
-      // A multiplexer can be detected and still be unable to carry the
-      // macro's command: herdr in either mode, and zellij once
-      // `mux_pane_direction = "window"` asks for a tab (#588 / #589).
-      // Opening the pane anyway would run nothing in it and drop the macro
-      // silently, so the PTY overlay stays the honest fallback and the
-      // status bar says which backend said no.
-      // Two different refusals, asked in this order: `macro_refusal` is
-      // about running a command at all, the builder about opening the
-      // target. A macro's own problem is the more useful thing to name when
-      // both apply.
-      Some(mux) => {
-        let ws = std::env::var("HERDR_WORKSPACE_ID").ok();
-        let built = match macro_refusal(mux, mode) {
-          Some(why) => Err(why),
-          None => build_command(mux, &label, &path, mode, ws.as_deref()).map(|argv| (mux, argv)),
-        };
-        match built {
-          Ok(spawn) => Some(spawn),
-          Err(why) => {
-            app.status = format!("macro{}: {}; falling back to PTY overlay", n, why);
-            None
-          }
-        }
-      }
-      None => {
-        app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
+      Ok(spawn) => Some(spawn),
+      Err(why) => {
+        app.status = format!("macro{}: {}; falling back to PTY overlay", n, why);
         None
       }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1452,7 +1452,7 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
   // review on PR #292), rather than no-oping.
   let mux_cmd = if matches!(macro_cfg.open_in, MacroOpenMode::MuxPane) {
     let label = format!("macro{}", n);
-    let mode = app.config.tui.mux_pane_direction.spawn_mode();
+    let mode = app.config.tui.mux_open_in.spawn_mode(app.config.tui.mux_pane_direction);
     match detect_multiplexer(
       std::env::var("TMUX").ok(),
       std::env::var("ZELLIJ").ok(),
@@ -1464,22 +1464,24 @@ fn run_macro(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut Ap
       // Opening the pane anyway would run nothing in it and drop the macro
       // silently, so the PTY overlay stays the honest fallback and the
       // status bar says which backend said no.
-      Some(mux) => match macro_refusal(mux, mode) {
-        Some(why) => {
-          app.status = format!("macro{}: {}; falling back to PTY overlay", n, why);
-          None
+      // Two different refusals, asked in this order: `macro_refusal` is
+      // about running a command at all, the builder about opening the
+      // target. A macro's own problem is the more useful thing to name when
+      // both apply.
+      Some(mux) => {
+        let ws = std::env::var("HERDR_WORKSPACE_ID").ok();
+        let built = match macro_refusal(mux, mode) {
+          Some(why) => Err(why),
+          None => build_command(mux, &label, &path, mode, ws.as_deref()).map(|argv| (mux, argv)),
+        };
+        match built {
+          Ok(spawn) => Some(spawn),
+          Err(why) => {
+            app.status = format!("macro{}: {}; falling back to PTY overlay", n, why);
+            None
+          }
         }
-        None => Some((
-          mux,
-          build_command(
-            mux,
-            &label,
-            &path,
-            mode,
-            std::env::var("HERDR_WORKSPACE_ID").ok().as_deref(),
-          ),
-        )),
-      },
+      }
       None => {
         app.status = format!("macro{}: no multiplexer; falling back to PTY overlay", n);
         None

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -20,8 +20,9 @@
 //! the renderer each frame against the live viewport.
 
 use crate::config::{
-  ClipboardMode, Config, ConfigRow, ConfigSource, MuxPaneDirection, SidebarOrientation, SidebarPosition, TuiLayout,
+  ClipboardMode, Config, ConfigRow, ConfigSource, MuxTarget, SidebarOrientation, SidebarPosition, TuiLayout,
 };
+use crate::multiplexer::SplitDirection;
 use crate::tui::keymap::{Action, KeyStroke, Keymap};
 use crate::tui::modal_keymap::{ModalAction, ModalKeymap};
 
@@ -82,6 +83,7 @@ impl SettingsTab {
         SettingField::DimUnfocused,
         SettingField::StatusOneLine,
         SettingField::NoteVim,
+        SettingField::MuxOpenIn,
         SettingField::MuxPaneDirection,
         SettingField::SidebarPosition,
         SettingField::SidebarOrientation,
@@ -290,11 +292,12 @@ const SIDEBAR_ORIENTATION_CHOICES: &[&str] = &[
 // `TuiOpenMode` has no `label()` to derive from; the round-trip test
 // (`every_choice_is_a_value_the_config_can_load_back`) guards it instead.
 const OPEN_MODE_CHOICES: &[&str] = &["shell", "editor", "finder"];
-const MUX_PANE_DIRECTION_CHOICES: &[&str] = &[
-  MuxPaneDirection::Right.label(),
-  MuxPaneDirection::Down.label(),
-  MuxPaneDirection::Window.label(),
+const MUX_OPEN_IN_CHOICES: &[&str] = &[
+  MuxTarget::Pane.label(),
+  MuxTarget::Tab.label(),
+  MuxTarget::Workspace.label(),
 ];
+const MUX_PANE_DIRECTION_CHOICES: &[&str] = &[SplitDirection::Right.label(), SplitDirection::Down.label()];
 const CLIPBOARD_CHOICES: &[&str] = &[
   ClipboardMode::Auto.label(),
   ClipboardMode::Osc52.label(),
@@ -320,7 +323,9 @@ pub enum SettingField {
   StatusOneLine,
   /// `tui.note_vim` — the note editor's vim normal mode (issue #557).
   NoteVim,
-  /// `tui.mux_pane_direction` — right / down / window (issue #589).
+  /// `tui.mux_open_in` — pane / tab / workspace (issue #608).
+  MuxOpenIn,
+  /// `tui.mux_pane_direction` — right / down (issue #589).
   MuxPaneDirection,
   /// `tui.sidebar_position` — left / right.
   SidebarPosition,
@@ -353,7 +358,8 @@ impl SettingField {
       SettingField::DimUnfocused => "dim unfocused pane",
       SettingField::StatusOneLine => "status on one line",
       SettingField::NoteVim => "note vim mode",
-      SettingField::MuxPaneDirection => "mux pane opens",
+      SettingField::MuxOpenIn => "mux opens in",
+      SettingField::MuxPaneDirection => "mux pane side",
       SettingField::SidebarOrientation => "sidebar layout",
       SettingField::Clipboard => "clipboard",
       SettingField::OpenMode => "open mode",
@@ -376,6 +382,7 @@ impl SettingField {
       SettingField::DimUnfocused => "tui.dim_unfocused",
       SettingField::StatusOneLine => "tui.status_one_line",
       SettingField::NoteVim => "tui.note_vim",
+      SettingField::MuxOpenIn => "tui.mux_open_in",
       SettingField::MuxPaneDirection => "tui.mux_pane_direction",
       SettingField::SidebarOrientation => "tui.sidebar_orientation",
       SettingField::Clipboard => "tui.clipboard",
@@ -395,6 +402,7 @@ impl SettingField {
       | SettingField::SidebarPosition
       | SettingField::SidebarOrientation
       | SettingField::Clipboard
+      | SettingField::MuxOpenIn
       | SettingField::MuxPaneDirection
       | SettingField::OpenMode => FieldKind::Choice,
       SettingField::DimUnfocused | SettingField::StatusOneLine | SettingField::NoteVim => FieldKind::Bool,
@@ -424,6 +432,7 @@ impl SettingField {
       SettingField::Layout => LAYOUT_CHOICES,
       SettingField::DimUnfocused | SettingField::StatusOneLine | SettingField::NoteVim => BOOL_CHOICES,
       SettingField::SidebarOrientation => SIDEBAR_ORIENTATION_CHOICES,
+      SettingField::MuxOpenIn => MUX_OPEN_IN_CHOICES,
       SettingField::MuxPaneDirection => MUX_PANE_DIRECTION_CHOICES,
       SettingField::Clipboard => CLIPBOARD_CHOICES,
       SettingField::OpenMode => OPEN_MODE_CHOICES,
@@ -443,6 +452,7 @@ impl SettingField {
       SettingField::DimUnfocused => cfg.tui.dim_unfocused.to_string(),
       SettingField::StatusOneLine => cfg.tui.status_one_line.to_string(),
       SettingField::NoteVim => cfg.tui.note_vim.to_string(),
+      SettingField::MuxOpenIn => cfg.tui.mux_open_in.label().into(),
       SettingField::MuxPaneDirection => cfg.tui.mux_pane_direction.label().into(),
       SettingField::SidebarOrientation => cfg.tui.sidebar_orientation.label().into(),
       SettingField::Clipboard => cfg.tui.clipboard.label().into(),

--- a/src/tui/state/config_panel.rs
+++ b/src/tui/state/config_panel.rs
@@ -297,7 +297,12 @@ const MUX_OPEN_IN_CHOICES: &[&str] = &[
   MuxTarget::Tab.label(),
   MuxTarget::Workspace.label(),
 ];
-const MUX_PANE_DIRECTION_CHOICES: &[&str] = &[SplitDirection::Right.label(), SplitDirection::Down.label()];
+const MUX_PANE_DIRECTION_CHOICES: &[&str] = &[
+  SplitDirection::Right.label(),
+  SplitDirection::Down.label(),
+  SplitDirection::Left.label(),
+  SplitDirection::Up.label(),
+];
 const CLIPBOARD_CHOICES: &[&str] = &[
   ClipboardMode::Auto.label(),
   ClipboardMode::Osc52.label(),
@@ -325,7 +330,7 @@ pub enum SettingField {
   NoteVim,
   /// `tui.mux_open_in` — pane / tab / workspace (issue #608).
   MuxOpenIn,
-  /// `tui.mux_pane_direction` — right / down (issue #589).
+  /// `tui.mux_pane_direction` — right / down / left / up (issues #589 / #611).
   MuxPaneDirection,
   /// `tui.sidebar_position` — left / right.
   SidebarPosition,

--- a/tests/cli_binary.rs
+++ b/tests/cli_binary.rs
@@ -1588,21 +1588,22 @@ fn herdr_outside_herdr_session_fails_with_clear_error() {
 /// echoed back), which has no shell in it.
 #[test]
 fn tmux_direction_rejects_a_value_no_backend_can_honour() {
-  // `left` is the tempting one: tmux reaches it through `split-window -b`,
-  // zellij accepts the word, and herdr declares `[possible values: right,
-  // down]`. A value one backend cannot honour must fail at the parse, not
-  // reach a builder that would have to guess.
+  // `left` and `up` joined the set in #611 (tmux `-h -b` / `-v -b`, zellij
+  // takes the words), so the rejected value has to be one no backend
+  // spells. It must fail at the parse rather than reach a builder that
+  // would have to guess.
   let (dir, _repo) = init_repo();
   Command::cargo_bin("gwm")
     .unwrap()
     .current_dir(dir.path())
     .env("TMUX", "/fake-socket,1,0")
-    .args(["tmux", "anything", "--direction", "left"])
+    .args(["tmux", "anything", "--direction", "sideways"])
     .assert()
     .failure()
     .code(2)
-    .stderr(predicate::str::contains("left"))
-    .stderr(predicate::str::contains("right").and(predicate::str::contains("down")));
+    .stderr(predicate::str::contains("sideways"))
+    .stderr(predicate::str::contains("right").and(predicate::str::contains("down")))
+    .stderr(predicate::str::contains("left").and(predicate::str::contains("up")));
 }
 
 /// Issue #589. The whole chain the builder tests cannot reach: clap parses
@@ -1676,6 +1677,22 @@ mux_pane_direction = "down"
   assert!(
     argv.contains("split-window -h"),
     "`--direction right` must beat the config and imply a split, got: {argv}"
+  );
+
+  // The two directions #611 added cost tmux a second flag (`-b` flips the
+  // side on the axis `-h` / `-v` picked), so this is where a builder that
+  // dropped one of the two would show up.
+  let out = run(&["tmux", "mux-dir", "--direction", "left"]);
+  let argv = String::from_utf8_lossy(&out.stdout).into_owned();
+  assert!(
+    argv.contains("split-window -h -b"),
+    "`--direction left` must reach tmux as `-h -b`, got: {argv}"
+  );
+  let out = run(&["tmux", "mux-dir", "--direction", "up"]);
+  let argv = String::from_utf8_lossy(&out.stdout).into_owned();
+  assert!(
+    argv.contains("split-window -v -b"),
+    "`--direction up` must reach tmux as `-v -b`, got: {argv}"
   );
 
   // No flag at all is still a window, whatever the direction says.

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -3070,7 +3070,12 @@ fn tui_mux_pane_direction_defaults_to_right() {
 fn tui_mux_pane_direction_round_trips_every_documented_value() {
   // Both values are what the Settings panel writes back, so each one has to
   // load from the file it produces.
-  for (value, expected) in [("right", SplitDirection::Right), ("down", SplitDirection::Down)] {
+  for (value, expected) in [
+    ("right", SplitDirection::Right),
+    ("down", SplitDirection::Down),
+    ("left", SplitDirection::Left),
+    ("up", SplitDirection::Up),
+  ] {
     let dir = TempDir::new().unwrap();
     std::fs::write(
       dir.path().join(CONFIG_FILE),
@@ -3085,13 +3090,16 @@ fn tui_mux_pane_direction_round_trips_every_documented_value() {
 
 #[test]
 fn tui_mux_pane_direction_rejects_a_value_no_backend_can_honour() {
-  // tmux reaches `left` only through `split-window -b` and herdr 0.8.2
-  // declares `[possible values: right, down]`, so `left` is not a direction
-  // gwm can pass on. A typo has to fail at load rather than silently fall
-  // back to the default.
+  // `left` and `up` joined the set in #611, so the rejected value has to be
+  // one no backend spells. A typo must fail at load rather than silently
+  // fall back to the default.
   let dir = TempDir::new().unwrap();
-  std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nmux_pane_direction = \"left\"\n").unwrap();
-  let err = Config::load_layered(dir.path(), None).expect_err("`left` is not a value gwm can honour");
+  std::fs::write(
+    dir.path().join(CONFIG_FILE),
+    "[tui]\nmux_pane_direction = \"sideways\"\n",
+  )
+  .unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("`sideways` is not a value gwm can honour");
   assert!(
     format!("{err}").contains("mux_pane_direction"),
     "the error must name the key, got: {err}"

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,8 +1,9 @@
 use gwm::config::{
   expand_placeholders, resolved_rows, review_tool_preset, BranchTypesSource, ClipboardMode, Config, ConfigRow,
-  ConfigSource, MacroOpenMode, MuxPaneDirection, SidebarOrientation, SidebarPosition, TuiLayout, TuiOpenMode,
-  WorktreeConfig, CONFIG_FILE,
+  ConfigSource, MacroOpenMode, MuxTarget, SidebarOrientation, SidebarPosition, TuiLayout, TuiOpenMode, WorktreeConfig,
+  CONFIG_FILE,
 };
+use gwm::multiplexer::SplitDirection;
 use tempfile::TempDir;
 
 /// Process-global lock guarding every test in this binary that can **observe**
@@ -2985,6 +2986,69 @@ fn handed_repo_bytes_go_through_the_same_validators() {
 }
 
 #[test]
+fn tui_mux_open_in_defaults_to_a_pane() {
+  // #608. `t` has always opened a pane, so the split of `mux_pane_direction`
+  // into two keys must not move what the key does by default.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[worktree]\nbase = \"~/wt\"\n").unwrap();
+  let cfg = Config::load_layered(dir.path(), None).unwrap();
+  assert_eq!(cfg.tui.mux_open_in, MuxTarget::Pane);
+  assert_eq!(
+    Config::default().tui.mux_open_in,
+    MuxTarget::Pane,
+    "`Config::default()` must agree with the serde default"
+  );
+}
+
+#[test]
+fn tui_mux_open_in_round_trips_every_documented_value() {
+  for (value, expected) in [
+    ("pane", MuxTarget::Pane),
+    ("tab", MuxTarget::Tab),
+    ("workspace", MuxTarget::Workspace),
+  ] {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+      dir.path().join(CONFIG_FILE),
+      format!("[tui]\nmux_open_in = \"{value}\"\n"),
+    )
+    .unwrap();
+    let cfg = Config::load_layered(dir.path(), None).unwrap();
+    assert_eq!(cfg.tui.mux_open_in, expected, "`{value}` must load back");
+    assert_eq!(expected.label(), value, "the label is the TOML spelling");
+  }
+}
+
+#[test]
+fn tui_mux_open_in_rejects_a_level_no_multiplexer_has() {
+  // `session` is the tempting one: tmux and zellij both have sessions, but
+  // gwm runs *inside* one and none of the three can spawn a sibling from
+  // there. A value the loader accepted would reach a builder with no arm.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nmux_open_in = \"session\"\n").unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("`session` is not a target gwm can open");
+  assert!(
+    format!("{err}").contains("mux_open_in"),
+    "the error must name the key, got: {err}"
+  );
+}
+
+#[test]
+fn tui_mux_pane_direction_is_a_direction_and_nothing_else() {
+  // #608 took `window` out of this key: it said *what* to open, not *which
+  // half*, and it now lives in `mux_open_in = "tab"`. The old spelling must
+  // fail at load rather than parse as something else, so a config written
+  // against the unreleased #589 shape is told where the value went.
+  let dir = TempDir::new().unwrap();
+  std::fs::write(dir.path().join(CONFIG_FILE), "[tui]\nmux_pane_direction = \"window\"\n").unwrap();
+  let err = Config::load_layered(dir.path(), None).expect_err("`window` is not a direction");
+  assert!(
+    format!("{err}").contains("mux_pane_direction"),
+    "the error must name the key, got: {err}"
+  );
+}
+
+#[test]
 fn tui_mux_pane_direction_defaults_to_right() {
   // #589. Up to 1.9 a split carried no direction and each backend answered
   // for itself: tmux stacked, zellij took the biggest free space, herdr went
@@ -2994,25 +3058,19 @@ fn tui_mux_pane_direction_defaults_to_right() {
   let dir = TempDir::new().unwrap();
   std::fs::write(dir.path().join(CONFIG_FILE), "[worktree]\nbase = \"~/wt\"\n").unwrap();
   let cfg = Config::load_layered(dir.path(), None).unwrap();
-  assert_eq!(cfg.tui.mux_pane_direction, MuxPaneDirection::Right);
+  assert_eq!(cfg.tui.mux_pane_direction, SplitDirection::Right);
   assert_eq!(
     Config::default().tui.mux_pane_direction,
-    MuxPaneDirection::Right,
+    SplitDirection::Right,
     "`Config::default()` must agree with the serde default"
   );
 }
 
 #[test]
 fn tui_mux_pane_direction_round_trips_every_documented_value() {
-  // The three values are what the Settings panel writes back, so each one
-  // has to load from the file it produces. `window` is the odd one: it is
-  // not a direction at all, it asks for a whole window/tab instead of half
-  // a screen.
-  for (value, expected) in [
-    ("right", MuxPaneDirection::Right),
-    ("down", MuxPaneDirection::Down),
-    ("window", MuxPaneDirection::Window),
-  ] {
+  // Both values are what the Settings panel writes back, so each one has to
+  // load from the file it produces.
+  for (value, expected) in [("right", SplitDirection::Right), ("down", SplitDirection::Down)] {
     let dir = TempDir::new().unwrap();
     std::fs::write(
       dir.path().join(CONFIG_FILE),

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -20,7 +20,7 @@ fn tmux_new_window_uses_new_window_subverb() {
   // labels the window (so it's discoverable in tmux's status bar) and
   // `-c` sets the new window's cwd, which is what the user expects when
   // running `gwm tmux <pattern>`.
-  let argv = build_tmux_command("feat-99-auth", Path::new("/tmp/wt/feat-99-auth"), SpawnMode::Window);
+  let argv = build_tmux_command("feat-99-auth", Path::new("/tmp/wt/feat-99-auth"), SpawnMode::Window).unwrap();
   assert_eq!(argv[0], "tmux");
   assert_eq!(argv[1], "new-window");
   // `-n <name>` and `-c <path>` are both required.
@@ -39,7 +39,8 @@ fn tmux_split_pane_uses_split_window_subverb() {
     "feat-12-x",
     Path::new("/tmp/wt/feat-12-x"),
     SpawnMode::Split(SplitDirection::Right),
-  );
+  )
+  .unwrap();
   assert_eq!(argv[0], "tmux");
   assert_eq!(argv[1], "split-window");
   let has_c = argv.windows(2).any(|w| w[0] == "-c" && w[1] == "/tmp/wt/feat-12-x");
@@ -67,7 +68,7 @@ fn zellij_new_tab_uses_action_new_tab() {
   // Zellij is driven by `zellij action <verb>`. The new-tab verb supports
   // both `--name` and `--cwd` since 0.40 — the latter is what makes the
   // tab open inside the worktree.
-  let argv = build_zellij_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window);
+  let argv = build_zellij_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window).unwrap();
   assert_eq!(argv[0], "zellij");
   assert_eq!(argv[1], "action");
   assert_eq!(argv[2], "new-tab");
@@ -85,7 +86,8 @@ fn zellij_split_pane_uses_action_new_pane() {
     "feat-7-foo",
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Split(SplitDirection::Right),
-  );
+  )
+  .unwrap();
   assert_eq!(argv[0], "zellij");
   assert_eq!(argv[1], "action");
   assert_eq!(argv[2], "new-pane");
@@ -113,7 +115,8 @@ fn herdr_new_tab_uses_tab_create() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Window,
     Some("w2K"),
-  );
+  )
+  .unwrap();
   assert_eq!(argv[0], "herdr");
   assert_eq!(argv[1], "tab");
   assert_eq!(argv[2], "create");
@@ -136,7 +139,8 @@ fn herdr_new_tab_asks_for_the_focus_tmux_and_zellij_give_for_free() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Window,
     Some("w2K"),
-  );
+  )
+  .unwrap();
   assert!(
     argv.iter().any(|a| a == "--focus"),
     "tab create must focus, got: {:?}",
@@ -147,7 +151,8 @@ fn herdr_new_tab_asks_for_the_focus_tmux_and_zellij_give_for_free() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Split(SplitDirection::Right),
     None,
-  );
+  )
+  .unwrap();
   assert!(
     argv.iter().any(|a| a == "--focus"),
     "pane split must focus, got: {:?}",
@@ -168,7 +173,8 @@ fn herdr_new_tab_targets_the_callers_workspace() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Window,
     Some("w2K"),
-  );
+  )
+  .unwrap();
   let has_ws = argv.windows(2).any(|w| w[0] == "--workspace" && w[1] == "w2K");
   assert!(has_ws, "expected `--workspace w2K` in argv, got: {:?}", argv);
 }
@@ -178,7 +184,7 @@ fn herdr_new_tab_omits_the_workspace_flag_when_the_id_is_unknown() {
   // Outside a managed pane there is no `$HERDR_WORKSPACE_ID` to pass, and
   // `--workspace ""` is an argument herdr would have to reject. Falling back
   // to herdr's own choice of workspace beats failing the whole command.
-  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window, None);
+  let argv = build_herdr_command("feat-7-foo", Path::new("/tmp/wt/feat-7-foo"), SpawnMode::Window, None).unwrap();
   assert!(
     !argv.iter().any(|a| a == "--workspace"),
     "no workspace id means no flag, got: {:?}",
@@ -189,7 +195,8 @@ fn herdr_new_tab_omits_the_workspace_flag_when_the_id_is_unknown() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Window,
     Some(""),
-  );
+  )
+  .unwrap();
   assert!(
     !argv.iter().any(|a| a == "--workspace"),
     "an empty workspace id is not an id, got: {:?}",
@@ -209,7 +216,8 @@ fn herdr_split_pane_uses_pane_split_with_direction() {
     Path::new("/tmp/wt/feat-7-foo"),
     SpawnMode::Split(SplitDirection::Right),
     None,
-  );
+  )
+  .unwrap();
   assert_eq!(argv[0], "herdr");
   assert_eq!(argv[1], "pane");
   assert_eq!(argv[2], "split");
@@ -317,12 +325,12 @@ fn tmux_translates_the_direction_into_h_or_v() {
   // `-h` is the HORIZONTAL split, and it puts the new pane to the RIGHT.
   // Getting this pair backwards is silent — both flags are valid, so the
   // only symptom is a pane in the wrong half.
-  let right = build_tmux_command("feat-7-foo", path(), SpawnMode::Split(SplitDirection::Right));
+  let right = build_tmux_command("feat-7-foo", path(), SpawnMode::Split(SplitDirection::Right)).unwrap();
   assert_eq!(right[2], "-h", "right is tmux's horizontal split, got: {:?}", right);
-  let down = build_tmux_command("feat-7-foo", path(), SpawnMode::Split(SplitDirection::Down));
+  let down = build_tmux_command("feat-7-foo", path(), SpawnMode::Split(SplitDirection::Down)).unwrap();
   assert_eq!(down[2], "-v", "down is tmux's vertical split, got: {:?}", down);
   // A window takes neither: `tmux new-window -h` is an error, not a hint.
-  let window = build_tmux_command("feat-7-foo", path(), SpawnMode::Window);
+  let window = build_tmux_command("feat-7-foo", path(), SpawnMode::Window).unwrap();
   assert!(
     !window.iter().any(|a| a == "-h" || a == "-v"),
     "new-window must carry no split flag, got: {:?}",
@@ -336,12 +344,12 @@ fn zellij_passes_the_direction_it_would_otherwise_guess() {
   // will try to use the biggest available space" — a layout-dependent
   // answer, which is exactly what #589 takes away from it.
   for dir in SplitDirection::ALL {
-    let argv = build_zellij_command("feat-7-foo", path(), SpawnMode::Split(dir));
+    let argv = build_zellij_command("feat-7-foo", path(), SpawnMode::Split(dir)).unwrap();
     let has_dir = argv.windows(2).any(|w| w[0] == "--direction" && w[1] == dir.label());
     assert!(has_dir, "expected `--direction {}`, got: {:?}", dir.label(), argv);
   }
   // `new-tab` has no direction to take.
-  let argv = build_zellij_command("feat-7-foo", path(), SpawnMode::Window);
+  let argv = build_zellij_command("feat-7-foo", path(), SpawnMode::Window).unwrap();
   assert!(
     !argv.iter().any(|a| a == "--direction"),
     "new-tab must carry no direction, got: {:?}",
@@ -352,7 +360,7 @@ fn zellij_passes_the_direction_it_would_otherwise_guess() {
 #[test]
 fn herdr_passes_the_direction_it_used_to_hardcode() {
   for dir in SplitDirection::ALL {
-    let argv = build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None);
+    let argv = build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None).unwrap();
     let has_dir = argv.windows(2).any(|w| w[0] == "--direction" && w[1] == dir.label());
     assert!(has_dir, "expected `--direction {}`, got: {:?}", dir.label(), argv);
   }
@@ -382,6 +390,86 @@ fn a_herdr_split_ignores_the_workspace_id_in_either_direction() {
       dir.label()
     );
   }
+}
+
+// --------------------------------------------------------------------------
+// the workspace target (#608)
+// --------------------------------------------------------------------------
+//
+// herdr's hierarchy is workspace > tab > pane and gwm could only reach the
+// bottom two. tmux and zellij stop at the tab (window), so the third target
+// is the one place the three backends are not interchangeable.
+
+#[test]
+fn herdr_opens_a_workspace_of_its_own() {
+  // `workspace create` is `tab create` minus the `--workspace` it would be
+  // creating. Measured on herdr 0.8.2: `--cwd`, `--label`, `--env`,
+  // `--focus` / `--no-focus`.
+  let argv = build_herdr_command("feat-7-foo", path(), SpawnMode::Workspace, None).unwrap();
+  assert_eq!(argv[0], "herdr");
+  assert_eq!(argv[1], "workspace");
+  assert_eq!(argv[2], "create");
+  let has_label = argv.windows(2).any(|w| w[0] == "--label" && w[1] == "feat-7-foo");
+  let has_cwd = argv.windows(2).any(|w| w[0] == "--cwd" && w[1] == "/tmp/wt/feat-7-foo");
+  assert!(has_label, "expected `--label feat-7-foo`, got: {:?}", argv);
+  assert!(has_cwd, "expected `--cwd /tmp/wt/feat-7-foo`, got: {:?}", argv);
+  // Same reason as `tab create`: without it the workspace comes back
+  // `"focused": false` and the worktree opens where the user cannot see it.
+  assert!(
+    argv.iter().any(|a| a == "--focus"),
+    "workspace create must focus, got: {:?}",
+    argv
+  );
+  // The workspace IS the thing being created, so there is no parent id to
+  // pass. A `--workspace` here would be an argument herdr has no arm for.
+  assert!(
+    !argv.iter().any(|a| a == "--workspace"),
+    "a workspace has no parent workspace, got: {:?}",
+    argv
+  );
+  // A workspace id is meaningless on this verb, and passing one must not
+  // change what gets built.
+  assert_eq!(
+    build_herdr_command("feat-7-foo", path(), SpawnMode::Workspace, Some("w2K")).unwrap(),
+    argv,
+    "a workspace id must make no difference to `workspace create`"
+  );
+  assert!(
+    !argv.iter().any(|a| a == "--direction"),
+    "a workspace is not a split, got: {:?}",
+    argv
+  );
+}
+
+#[test]
+fn only_herdr_has_a_workspace_level_and_the_others_say_so() {
+  // The refusal is the point of #608: a tmux or zellij that quietly opened
+  // a window instead would leave `mux_open_in = "workspace"` describing
+  // something that did not happen. The message names the backend that
+  // cannot, and the one that can, because the setting is global while the
+  // capability is not.
+  for (mux, build) in [
+    ("tmux", build_tmux_command("feat-7-foo", path(), SpawnMode::Workspace)),
+    (
+      "zellij",
+      build_zellij_command("feat-7-foo", path(), SpawnMode::Workspace),
+    ),
+  ] {
+    let why = build.expect_err("neither backend has a workspace level");
+    assert!(why.contains(mux), "the refusal must name {mux}, got: {why}");
+    assert!(
+      why.contains("herdr"),
+      "the refusal must name the backend that can: {why}"
+    );
+  }
+  assert!(
+    build_herdr_command("feat-7-foo", path(), SpawnMode::Workspace, None).is_ok(),
+    "herdr is the backend the target exists for"
+  );
+  // And the refusal is per target, not per backend: tmux still opens the
+  // other two.
+  assert!(build_tmux_command("feat-7-foo", path(), SpawnMode::Window).is_ok());
+  assert!(build_tmux_command("feat-7-foo", path(), SpawnMode::Split(SplitDirection::Right)).is_ok());
 }
 
 // --------------------------------------------------------------------------
@@ -458,6 +546,13 @@ fn build_command_dispatches_to_the_matching_backend() {
     build_herdr_command("feat-7-foo", path(), SpawnMode::Window, Some("w2K")),
     "the workspace id must reach `tab create`"
   );
+  // The dispatcher forwards the refusal rather than turning it into a
+  // different argv (#608).
+  assert!(
+    build_command(Multiplexer::Zellij, "feat-7-foo", path(), SpawnMode::Workspace, None).is_err(),
+    "a target zellij has no level for must come back as a refusal"
+  );
+  assert!(build_command(Multiplexer::Herdr, "feat-7-foo", path(), SpawnMode::Workspace, None).is_ok());
 }
 
 // --------------------------------------------------------------------------
@@ -477,10 +572,17 @@ fn a_macro_is_refused_by_the_backends_with_no_trailing_command_form() {
     );
   }
   // `zellij action new-tab` takes no command either, which only became
-  // reachable when `mux_pane_direction = "window"` shipped (#589).
+  // reachable when the tab target shipped (#589 / #608).
   assert!(
     macro_refusal(Multiplexer::Zellij, SpawnMode::Window).is_some(),
     "a zellij tab carries no macro command"
+  );
+  // A workspace is refused for its own reason, and the message says which
+  // level it is talking about rather than reusing the pane sentence (#608).
+  let why = macro_refusal(Multiplexer::Herdr, SpawnMode::Workspace).expect("no trailing command there either");
+  assert!(
+    why.contains("workspace"),
+    "the refusal must name the level it refused, got: {why}"
   );
 }
 

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -320,6 +320,60 @@ fn detect_herdr_false_when_herdr_env_missing_or_empty() {
 // rather than one shared loop.
 
 #[test]
+fn tmux_spends_two_flags_on_half_the_compass() {
+  // Measured on tmux 3.7c through `split-window -P -F`, which prints the
+  // NEW pane's geometry: `-h` -> left=101, `-h -b` -> left=0, `-v` ->
+  // top=26, `-v -b` -> top=1. `-b` is "before": it flips the side on
+  // whichever axis `-h` / `-v` picked, which is why left and up cost a
+  // second word (#611).
+  for (dir, expected) in [
+    (SplitDirection::Right, vec!["-h"]),
+    (SplitDirection::Down, vec!["-v"]),
+    (SplitDirection::Left, vec!["-h", "-b"]),
+    (SplitDirection::Up, vec!["-v", "-b"]),
+  ] {
+    let argv = build_tmux_command("feat-7-foo", path(), SpawnMode::Split(dir)).unwrap();
+    let flags: Vec<&str> = argv[2..argv.len() - 2].iter().map(String::as_str).collect();
+    assert_eq!(
+      flags,
+      expected,
+      "{} must reach tmux as {expected:?}, got: {argv:?}",
+      dir.label()
+    );
+    // The path still lands after the flags, however many there were.
+    assert_eq!(argv[argv.len() - 2], "-c");
+    assert_eq!(argv[argv.len() - 1], "/tmp/wt/feat-7-foo");
+  }
+}
+
+#[test]
+fn herdr_refuses_the_two_directions_its_parser_has_no_value_for() {
+  // #611, the mirror of #608: there one backend could do something the
+  // other two could not, here two can do something the third cannot. herdr
+  // 0.8.2 declares `--direction [possible values: right, down]`, so passing
+  // `left` would be a call it rejects at the socket rather than a pane in
+  // the wrong half.
+  for dir in [SplitDirection::Left, SplitDirection::Up] {
+    let why = build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None)
+      .expect_err("herdr has no value for this direction");
+    assert!(why.contains("herdr"), "the refusal must name the backend, got: {why}");
+    assert!(
+      why.contains("left") && why.contains("up"),
+      "and the two values it cannot take, got: {why}"
+    );
+  }
+  // The refusal is per direction, not per backend: the other two still work.
+  for dir in [SplitDirection::Right, SplitDirection::Down] {
+    assert!(build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None).is_ok());
+  }
+  // tmux and zellij take all four.
+  for dir in SplitDirection::ALL {
+    assert!(build_tmux_command("feat-7-foo", path(), SpawnMode::Split(dir)).is_ok());
+    assert!(build_zellij_command("feat-7-foo", path(), SpawnMode::Split(dir)).is_ok());
+  }
+}
+
+#[test]
 fn tmux_translates_the_direction_into_h_or_v() {
   // tmux names the axis the divider runs along, not where the pane goes:
   // `-h` is the HORIZONTAL split, and it puts the new pane to the RIGHT.
@@ -359,7 +413,9 @@ fn zellij_passes_the_direction_it_would_otherwise_guess() {
 
 #[test]
 fn herdr_passes_the_direction_it_used_to_hardcode() {
-  for dir in SplitDirection::ALL {
+  // Only the two herdr has a value for; the other two are refused, which
+  // `herdr_refuses_the_two_directions_its_parser_has_no_value_for` pins.
+  for dir in SplitDirection::ALL.into_iter().filter(|d| d.is_herdr_capable()) {
     let argv = build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None).unwrap();
     let has_dir = argv.windows(2).any(|w| w[0] == "--direction" && w[1] == dir.label());
     assert!(has_dir, "expected `--direction {}`, got: {:?}", dir.label(), argv);
@@ -373,6 +429,8 @@ fn the_direction_label_is_the_spelling_every_surface_uses() {
   // here silently desyncs the config from the argv.
   assert_eq!(SplitDirection::Right.label(), "right");
   assert_eq!(SplitDirection::Down.label(), "down");
+  assert_eq!(SplitDirection::Left.label(), "left");
+  assert_eq!(SplitDirection::Up.label(), "up");
 }
 
 #[test]

--- a/tests/multiplexer_tests.rs
+++ b/tests/multiplexer_tests.rs
@@ -5,7 +5,7 @@
 
 use gwm::multiplexer::{
   build_command, build_herdr_command, build_tmux_command, build_zellij_command, detect_herdr, detect_multiplexer,
-  detect_tmux, detect_zellij, macro_refusal, Multiplexer, SpawnMode, SplitDirection,
+  detect_tmux, detect_zellij, macro_mux_command, macro_refusal, Multiplexer, SpawnMode, SplitDirection,
 };
 use std::path::Path;
 
@@ -388,6 +388,87 @@ fn a_herdr_split_ignores_the_workspace_id_in_either_direction() {
       build_herdr_command("feat-7-foo", path(), SpawnMode::Split(dir), None),
       "a workspace id must make no difference to a split ({})",
       dir.label()
+    );
+  }
+}
+
+// --------------------------------------------------------------------------
+// what a macro actually spawns, or why it does not (#609 review)
+// --------------------------------------------------------------------------
+//
+// `run_macro` takes a `Terminal` and drives the event loop, so the three
+// steps it ran on (detect, refuse, build) were the one decision in the mux
+// path with no test. Getting the fallback wrong does not crash: it opens a
+// pane and drops the user's command into it, which nobody sees.
+
+#[test]
+fn a_macro_spawns_where_the_backend_can_carry_its_command() {
+  let (mux, argv) = macro_mux_command(
+    "macro1",
+    path(),
+    SpawnMode::Split(SplitDirection::Right),
+    Some("/tmp/tmux-501/default,1,0".into()),
+    None,
+    None,
+    None,
+  )
+  .expect("tmux takes a trailing command on split-window");
+  assert_eq!(mux, Multiplexer::Tmux);
+  assert_eq!(argv[1], "split-window");
+  // The label reaches the argv only where the backend has somewhere to put
+  // it; a split has none, which is what `run_macro` relies on.
+  assert!(argv.iter().any(|a| a == "/tmp/wt/feat-7-foo"), "got: {argv:?}");
+
+  let (mux, argv) = macro_mux_command(
+    "macro1",
+    path(),
+    SpawnMode::Split(SplitDirection::Down),
+    None,
+    Some("0".into()),
+    None,
+    None,
+  )
+  .expect("`zellij action new-pane -- <cmd>` takes one");
+  assert_eq!(mux, Multiplexer::Zellij);
+  assert_eq!(argv[2], "new-pane");
+}
+
+#[test]
+fn a_macro_falls_back_with_the_reason_the_status_bar_shows() {
+  // Four sentences, one per way this can refuse. Each is what
+  // `run_macro` interpolates into `macro<n>: {}; falling back to PTY
+  // overlay`, so an empty or wrong one leaves the user with a key that
+  // did nothing and said nothing useful.
+  let split = SpawnMode::Split(SplitDirection::Right);
+
+  // No multiplexer at all: not a backend's fault, but still a fallback.
+  let why = macro_mux_command("macro1", path(), split, None, None, None, None)
+    .expect_err("nothing is running, so nothing can carry the command");
+  assert!(why.contains("multiplexer"), "got: {why}");
+
+  // herdr: `pane split` has no trailing-command form (#599).
+  let why = macro_mux_command("macro1", path(), split, None, None, Some("1".into()), None)
+    .expect_err("herdr panes take no command");
+  assert!(why.contains("herdr"), "the sentence must name the backend, got: {why}");
+
+  // zellij under a tab: `new-tab` takes no command either (#589).
+  let why = macro_mux_command("macro1", path(), SpawnMode::Window, None, Some("0".into()), None, None)
+    .expect_err("a zellij tab takes no command");
+  assert!(why.contains("zellij"), "got: {why}");
+
+  // Every backend under a workspace (#608), for two different reasons:
+  // tmux and zellij have no such level, herdr has one but it takes no
+  // command. Both must still come back as a refusal, not as a spawn.
+  for (name, tmux, zellij, herdr) in [
+    ("tmux", Some("/tmp/x,1,0".to_string()), None, None),
+    ("zellij", None, Some("0".to_string()), None),
+    ("herdr", None, None, Some("1".to_string())),
+  ] {
+    let why = macro_mux_command("macro1", path(), SpawnMode::Workspace, tmux, zellij, herdr, None)
+      .expect_err("no backend runs a macro in a workspace");
+    assert!(
+      why.contains(name) || why.contains("workspace"),
+      "the {name} refusal must name the backend or the level, got: {why}"
     );
   }
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -1902,45 +1902,86 @@ fn mux_pane_with_no_multiplexer_names_all_three_variables() {
 }
 
 #[test]
-fn the_mux_pane_knob_picks_the_mode_the_t_key_builds() {
-  // `t` reads `[tui] mux_pane_direction` (#589). The spawn itself is not
-  // reachable from a test (it shells out to a multiplexer that is not on the
-  // runner), so this pins the two pure steps the key runs on: the config
-  // value it resolves, and the argv that value produces for the backend the
-  // cascade would have picked.
-  use gwm::config::MuxPaneDirection;
+fn the_mux_knobs_pick_the_mode_the_t_key_builds() {
+  // `t` reads `[tui] mux_open_in` and `mux_pane_direction` (#608 / #589).
+  // The spawn itself is not reachable from a test (it shells out to a
+  // multiplexer that is not on the runner), so this pins the pure steps the
+  // key runs on: the two config values it resolves, and the argv they
+  // produce for the backend the cascade would have picked.
+  use gwm::config::MuxTarget;
   use gwm::multiplexer::{build_command, spawn_noun, Multiplexer, SpawnMode, SplitDirection};
 
   let (_dir, mut app) = make_app();
   app.worktrees = vec![worktree_fixture("feat-7-foo")];
   app.list_state.select(Some(0));
   let path = app.worktrees[0].path.clone();
+  let mode_of = |app: &gwm::tui::App| app.config.tui.mux_open_in.spawn_mode(app.config.tui.mux_pane_direction);
 
   // Default: a pane on the right, where 1.9 and earlier left the choice to
   // the backend and tmux answered "below".
-  assert_eq!(app.config.tui.mux_pane_direction, MuxPaneDirection::Right);
-  let mode = app.config.tui.mux_pane_direction.spawn_mode();
+  assert_eq!(app.config.tui.mux_open_in, MuxTarget::Pane);
+  assert_eq!(app.config.tui.mux_pane_direction, SplitDirection::Right);
+  let mode = mode_of(&app);
   assert_eq!(mode, SpawnMode::Split(SplitDirection::Right));
-  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode, None);
+  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode, None).unwrap();
   assert_eq!(argv[1], "split-window");
   assert_eq!(argv[2], "-h", "the default must reach tmux as `-h`, got: {:?}", argv);
   assert_eq!(spawn_noun(Multiplexer::Tmux, mode), "pane");
 
-  app.config.tui.mux_pane_direction = MuxPaneDirection::Down;
-  let mode = app.config.tui.mux_pane_direction.spawn_mode();
-  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode, None);
+  app.config.tui.mux_pane_direction = SplitDirection::Down;
+  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode_of(&app), None).unwrap();
   assert_eq!(argv[2], "-v", "`down` must reach tmux as `-v`, got: {:?}", argv);
 
-  // `window` is the escape hatch: `t` opens a whole window/tab instead of
-  // half a screen, and the status bar has to say so.
-  app.config.tui.mux_pane_direction = MuxPaneDirection::Window;
-  let mode = app.config.tui.mux_pane_direction.spawn_mode();
+  // `tab` is the whole-screen target: a tmux window, a zellij or herdr tab.
+  // The direction is still set and must be ignored rather than leak.
+  app.config.tui.mux_open_in = MuxTarget::Tab;
+  let mode = mode_of(&app);
   assert_eq!(mode, SpawnMode::Window);
-  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode, None);
-  assert_eq!(argv[1], "new-window", "`window` must not split, got: {:?}", argv);
+  let argv = build_command(Multiplexer::Tmux, "feat-7-foo", &path, mode, None).unwrap();
+  assert_eq!(argv[1], "new-window", "`tab` must not split, got: {:?}", argv);
+  assert!(
+    !argv.iter().any(|a| a == "-v" || a == "-h"),
+    "a leftover direction must not reach a window, got: {:?}",
+    argv
+  );
   assert_eq!(spawn_noun(Multiplexer::Tmux, mode), "window");
   assert_eq!(spawn_noun(Multiplexer::Zellij, mode), "tab");
   assert_eq!(spawn_noun(Multiplexer::Herdr, mode), "tab");
+
+  // `workspace` is herdr's level and nobody else's: the other two refuse
+  // instead of opening a tab, so the setting cannot describe something that
+  // did not happen (#608).
+  app.config.tui.mux_open_in = MuxTarget::Workspace;
+  let mode = mode_of(&app);
+  assert_eq!(mode, SpawnMode::Workspace);
+  let argv = build_command(Multiplexer::Herdr, "feat-7-foo", &path, mode, None).unwrap();
+  assert_eq!(argv[1], "workspace");
+  assert_eq!(argv[2], "create");
+  assert_eq!(spawn_noun(Multiplexer::Herdr, mode), "workspace");
+  for mux in [Multiplexer::Tmux, Multiplexer::Zellij] {
+    assert!(
+      build_command(mux, "feat-7-foo", &path, mode, None).is_err(),
+      "{mux:?} has no workspace level to open"
+    );
+  }
+}
+
+#[test]
+fn the_t_key_puts_a_refused_target_on_the_status_bar() {
+  // The refusal has to reach the user: `t` under `mux_open_in = "workspace"`
+  // inside tmux opens nothing, and a silent no-op reads as a broken key.
+  use gwm::config::MuxTarget;
+
+  let (_dir, mut app) = make_app();
+  app.worktrees = vec![worktree_fixture("feat-7-foo")];
+  app.list_state.select(Some(0));
+  app.config.tui.mux_open_in = MuxTarget::Workspace;
+  app.open_in_mux_pane_from(Some("/tmp/tmux-501/default,1,0".into()), None, None, None);
+  assert!(
+    app.status.contains("tmux") && app.status.contains("workspace"),
+    "the status must name the backend and the level it cannot open, got: {}",
+    app.status
+  );
 }
 
 #[test]

--- a/tests/tui_state_config_panel_tests.rs
+++ b/tests/tui_state_config_panel_tests.rs
@@ -156,8 +156,8 @@ fn selected_field_follows_the_tab() {
   let mut panel = ConfigPanel::new();
   // Theme tab → theme preset.
   assert_eq!(panel.selected_field(), Some(SettingField::ThemePreset));
-  // Tui tab → layout / dim unfocused / status one line / note vim / mux pane
-  // opens / sidebar position / sidebar layout / clipboard / open / countdown
+  // Tui tab → layout / dim unfocused / status one line / note vim / mux
+  // opens in / mux pane side / sidebar position / sidebar layout / clipboard / open / countdown
   // / auto refresh in order. `layout` leads since #545: it is the structural
   // choice the rest of the tab refines, and the boolean knobs (#545, #547,
   // #557) sit right under it.
@@ -169,6 +169,8 @@ fn selected_field_follows_the_tab() {
   assert_eq!(panel.selected_field(), Some(SettingField::StatusOneLine));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::NoteVim));
+  panel.select_next();
+  assert_eq!(panel.selected_field(), Some(SettingField::MuxOpenIn));
   panel.select_next();
   assert_eq!(panel.selected_field(), Some(SettingField::MuxPaneDirection));
   panel.select_next();
@@ -535,6 +537,7 @@ fn every_choice_is_a_value_the_config_can_load_back() {
     SettingField::SidebarPosition,
     SettingField::SidebarOrientation,
     SettingField::Clipboard,
+    SettingField::MuxOpenIn,
     SettingField::MuxPaneDirection,
     SettingField::OpenMode,
   ] {
@@ -569,7 +572,8 @@ fn sidebar_choice_lists_cover_every_variant() {
   // that is the exhaustive `match` in `label()`, which fails to compile on a new
   // variant and forces a visit to the `ALL` right above it. Closing the gap
   // properly would need a derive (strum); not worth a dependency for two enums.
-  use gwm::config::{ClipboardMode, MuxPaneDirection, SidebarOrientation, SidebarPosition};
+  use gwm::config::{ClipboardMode, MuxTarget, SidebarOrientation, SidebarPosition};
+  use gwm::multiplexer::SplitDirection;
 
   for o in SidebarOrientation::ALL {
     assert!(
@@ -597,7 +601,20 @@ fn sidebar_choice_lists_cover_every_variant() {
     "no stale choice left behind"
   );
 
-  for d in MuxPaneDirection::ALL {
+  for t in MuxTarget::ALL {
+    assert!(
+      SettingField::MuxOpenIn.choices().contains(&t.label()),
+      "{t:?} ({}) is missing from the mux target choices",
+      t.label()
+    );
+  }
+  assert_eq!(
+    SettingField::MuxOpenIn.choices().len(),
+    MuxTarget::ALL.len(),
+    "no stale choice left behind"
+  );
+
+  for d in SplitDirection::ALL {
     assert!(
       SettingField::MuxPaneDirection.choices().contains(&d.label()),
       "{d:?} ({}) is missing from the mux pane direction choices",
@@ -606,7 +623,7 @@ fn sidebar_choice_lists_cover_every_variant() {
   }
   assert_eq!(
     SettingField::MuxPaneDirection.choices().len(),
-    MuxPaneDirection::ALL.len(),
+    SplitDirection::ALL.len(),
     "no stale choice left behind"
   );
 


### PR DESCRIPTION
## Description

**Stacked on #606** (base is `feat/#589-mux-pane-direction`, not `dev`). GitHub retargets it to `dev` when #606 merges; review the two commits here, not the combined diff.

#589 shipped one key carrying two questions. `right` and `down` say which half a pane takes; `window` said *what to open*, which is not a direction. Splitting them makes room for the level gwm could not reach at all: herdr's workspace, above a tab.

```toml
[tui]
mux_open_in        = "pane"    # "pane" | "tab" | "workspace"
mux_pane_direction = "right"   # "right" | "down", pane only
```

Closes #608

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- **`mux_open_in`** (`pane` / `tab` / `workspace`, default `pane`) picks the level the TUI's `t` key opens. `tab` is the old `window` value under the spelling two of three backends use; `Multiplexer::window_noun` already renders the local word, so a tmux user still reads "window" in the status bar.
- **`workspace` is herdr only, and refused elsewhere.** `herdr workspace create --label <name> --cwd <path> --focus` is `tab create` minus the `--workspace` it would be creating (measured on 0.8.2). tmux and zellij get `tmux has no workspace level: herdr is the only backend with one` on the status bar and open nothing.
- **The refusal lives in the type**: the three builders return `Result<Vec<String>, &'static str>`, so a caller cannot forget a gate, and the sentence names both the backend that cannot and the one that can.
- **`macro_refusal` gains a workspace arm** worded for the level it refuses. A `mux_pane` macro under `workspace` falls back to the PTY overlay on all three backends; the macro path asks `macro_refusal` first so its status names the macro's problem rather than the target's.
- **`SplitDirection` doubles as the config type**, which deletes the parallel `MuxPaneDirection` enum and the `split_direction()` shim that existed only to answer for `window`.
- Docs EN + FR (config reference, multiplexer page, keybindings table), `examples/gwm.toml.example`, and the changelog entry folded with #589's.

## Tests

- [x] `cargo test` passes locally (exit 0, 104 `test result: ok`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

New coverage: the `workspace create` argv (label, cwd, focus, **no** `--workspace` and no `--direction`, and a workspace id making no difference), both refusals naming their backend and herdr, the refusal being per-target rather than per-backend (tmux still opens the other two), `build_command` forwarding the refusal instead of substituting an argv, the macro refusal naming the level, `mux_open_in` defaulting to `pane` and round-tripping its three values, `session` rejected at load, **`mux_pane_direction = "window"` now rejected** so a config written against the unreleased #589 shape fails loudly, the Settings-panel choice lists against both `ALL`s and the new field order, and `t` resolving the two keys to a mode, an argv and a status noun across all three targets.

Checked red: making tmux's `Workspace` arm fall through to the window argv (the silent downgrade this PR exists to avoid) fails `only_herdr_has_a_workspace_level_and_the_others_say_so` with the argv it actually got.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (the CLI surface is unchanged; `docs/3.cli/` still updated for the herdr verb)
- [x] `examples/gwm.toml.example` updated
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #608
- Related PR: #606 (base; this renames the key it introduces)

## Notes for reviewers

**This must land in the same unreleased cycle as #606, or it stops being free.** `mux_pane_direction = "window"` exists only on `dev`. Renaming it now costs nothing because nobody has written it; renaming it after a release is a config-schema break under the 1.0 promise. If #606 ships without this, the follow-up needs a deprecation path instead.

**Why refuse rather than fall back.** The `mux_pane` macro degrades to the PTY overlay because the macro still has to run *somewhere*. Here there is nothing to preserve: a tab is not a smaller workspace, it is a different thing, and a setting that quietly did something else is the failure mode worth designing against. Both alternatives (silent fallback, and giving tmux a real session) are argued in the issue.

**No CLI flag on purpose.** `--workspace` is taken by the global `--workspace <DIR>` (#36), and the CLI already spells its target: bare is a tab, `--split` is a pane. `mux_open_in` is a `[tui]` key that does not reach the CLI, which is stated in its doc comment and in the reference. A per-invocation workspace flag is a separate ask if it turns out to be wanted.

**herdr is measured, the other two are not, for this target.** `herdr workspace create --help` on 0.8.2 gives `--cwd <PATH>`, `--label <TEXT>`, `--env <KEY=VALUE>`, `--focus` / `--no-focus`. tmux and zellij need no measurement here: the assertion about them is that they have *no* such verb.