### PR TITLE
✨ feat(tui): the Working Tree listing full size, and the toggle key that closes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`5` opens the Working Tree listing at full size**
+  ([#592](https://github.com/kbrdn1/gwm-cli/issues/592)). The sidebar's
+  Working Tree pane is one block among five in a column that is a fraction of
+  the screen, so a worktree with more than a handful of changed files could
+  only be read two rows at a time through `J` / `K`. `5` now opens the same
+  file-explorer tree as a full-size overlay: same icons, same per-category
+  colours, the same change counts on the bottom rule, scrolled with
+  `j` / `k`, `g` / `G`, closed with `Esc` / `q` (or `5` again), and
+  rebindable under `[tui.keys.modal.working_tree]`.
+
+  The listing is read when the overlay opens rather than taken from the
+  sidebar's cache, so it does not go blank in the two states where that cache
+  is never built: sidebar hidden, or the Details panel showing stashes.
 - **`o` on the agents overlay resumes the session in the multiplexer**
   ([#591](https://github.com/kbrdn1/gwm-cli/issues/591)). The overlay told you
   which agent was working where and then left you to get there by hand. `a`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`5` opens the Working Tree listing at full size**
+- **`W` opens the Working Tree listing at full size**
   ([#592](https://github.com/kbrdn1/gwm-cli/issues/592)). The sidebar's
   Working Tree pane is one block among five in a column that is a fraction of
   the screen, so a worktree with more than a handful of changed files could
-  only be read two rows at a time through `J` / `K`. `5` now opens the same
+  only be read two rows at a time through `J` / `K`. `W` now opens the same
   file-explorer tree as a full-size overlay: same icons, same per-category
   colours, the same change counts on the bottom rule, scrolled with
-  `j` / `k`, `g` / `G`, closed with `Esc` / `q` (or `5` again, whatever `5`
+  `j` / `k`, `g` / `G`, closed with `Esc` / `q` (or `W` again, whatever `W`
   gets rebound to, see #613 below), and rebindable under
   `[tui.keys.modal.working_tree]`.
 
@@ -310,7 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **An overlay's toggle key closes it whatever it is bound to**
-  ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). `3`, `4` and `5`
+  ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). `3`, `4` and `W`
   each close the overlay they open, but the guard doing it asked
   `key_matches_action`, which reads a single stroke and only ran after the
   modal verbs had their turn. Two silent holes: a multi-stroke binding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then scrolled it. The toggle now resolves first, against that one action
   rather than the whole keymap, and it accumulates its chord, so a prefix
   stroke is consumed instead of firing a scroll verb on the way through.
+
+  Each of the three overlays routes its keys through an `App` method now
+  (the shape the create overlay has had since #217), because the ordering
+  is the fix and a `match` in the run loop cannot be tested. `d` still
+  cannot reach the delete confirm from behind an overlay: the toggle
+  resolves against its one action, not the whole keymap.
 - **A compact pane's header says where you are, and its name no longer
   dims when it is not**
   ([#605](https://github.com/kbrdn1/gwm-cli/issues/605)). In the default
@@ -297,12 +303,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Bordered mode is otherwise untouched: there the accent still paints the
   four rules and the title inside the top one.
-
-  Each of the three overlays routes its keys through an `App` method now
-  (the shape the create overlay has had since #217), because the ordering
-  is the fix and a `match` in the run loop cannot be tested. `d` still
-  cannot reach the delete confirm from behind an overlay: the toggle
-  resolves against its one action, not the whole keymap.
 
 - **A linked row with nothing fetched yet is white, not green and purple**
   ([#596](https://github.com/kbrdn1/gwm-cli/issues/596)). The table's `I/P`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only be read two rows at a time through `J` / `K`. `5` now opens the same
   file-explorer tree as a full-size overlay: same icons, same per-category
   colours, the same change counts on the bottom rule, scrolled with
-  `j` / `k`, `g` / `G`, closed with `Esc` / `q` (or `5` again), and
-  rebindable under `[tui.keys.modal.working_tree]`.
+  `j` / `k`, `g` / `G`, closed with `Esc` / `q` (or `5` again, whatever `5`
+  gets rebound to, see #613 below), and rebindable under
+  `[tui.keys.modal.working_tree]`.
 
   The listing is read when the overlay opens rather than taken from the
   sidebar's cache, so it does not go blank in the two states where that cache
@@ -240,6 +241,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An overlay's toggle key closes it whatever it is bound to**
+  ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). `3`, `4` and `5`
+  each close the overlay they open, but the guard doing it asked
+  `key_matches_action`, which reads a single stroke and only ran after the
+  modal verbs had their turn. Two silent holes: a multi-stroke binding
+  (`working_tree = ["g w"]`) could open the overlay and never shut it, and a
+  binding the overlay's own context already claimed (`= ["j"]`) opened it and
+  then scrolled it. The toggle now resolves first, against that one action
+  rather than the whole keymap, and it accumulates its chord, so a prefix
+  stroke is consumed instead of firing a scroll verb on the way through.
 - **A compact pane's header says where you are, and its name no longer
   dims when it is not**
   ([#605](https://github.com/kbrdn1/gwm-cli/issues/605)). In the default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Bordered mode is otherwise untouched: there the accent still paints the
   four rules and the title inside the top one.
 
+  Each of the three overlays routes its keys through an `App` method now
+  (the shape the create overlay has had since #217), because the ordering
+  is the fix and a `match` in the run loop cannot be tested. `d` still
+  cannot reach the delete confirm from behind an overlay: the toggle
+  resolves against its one action, not the whole keymap.
+
 - **A linked row with nothing fetched yet is white, not green and purple**
   ([#596](https://github.com/kbrdn1/gwm-cli/issues/596)). The table's `I/P`
   marker painted its two placeholder slots with a different status role each:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The listing is read when the overlay opens rather than taken from the
   sidebar's cache, so it does not go blank in the two states where that cache
-  is never built: sidebar hidden, or the Details panel showing stashes.
+  is never built: sidebar hidden, or the Details panel showing stashes. The
+  read runs on a worker and the overlay opens on a loader, so a repository
+  whose untracked walk is slow does not freeze the event loop on the
+  keypress.
 - **`o` on the agents overlay resumes the session in the multiplexer**
   ([#591](https://github.com/kbrdn1/gwm-cli/issues/591)). The overlay told you
   which agent was working where and then left you to get there by hand. `a`

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -308,6 +308,12 @@ pick up changes made while it was closed.
 | `G` / `End`    | jump to the bottom (`scroll_bottom`)   |
 | `Esc` / `q`    | close (`close`); `5` closes it too     |
 
+Whatever `working_tree` is rebound to closes the overlay as well as opens
+it, including a multi-stroke chord and a key the overlay's own context
+otherwise uses for scrolling ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)).
+The toggle wins over the modal verb in that case, which is what binding it
+there asked for.
+
 ## issue / PR link prompt (`i`)
 
 The first stage (`[tui.keys.modal.link.choose_target]`) is a navigable

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -80,7 +80,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `2`         | open (if hidden) and focus the status pane (`focus_status`)                                       |
 | `3`         | open the Command Logs overlay (`command_logs`): scrollable transcript of the commands gwm ran    |
 | `4`         | open the [Settings panel](#settings-panel-4) (`config_panel`): edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column |
-| `5`         | open the [Working Tree overlay](#working-tree-overlay-5) (`working_tree`): the sidebar's file-explorer listing at full size |
+| `W`         | open the [Working Tree overlay](#working-tree-overlay-w) (`working_tree`): the sidebar's file-explorer listing at full size |
 | `c`         | open the [commit listing](#commit-listing-c) (`commits`): the sidebar's Commits pane at full size, with a load-more key |
 | `x`         | open the [exec picker overlay](#exec-picker-overlay-x) (`exec_overlay`): pick a [`[exec.profiles]`](/configuration/gwm-toml#exec) profile and run it in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) on the selected worktree |
 | `X`         | open the [clean overlay](#clean-overlay-x) (`clean_overlay`): preview and reclaim build artifacts in the selected worktree (safety countdown before deleting) |
@@ -288,7 +288,7 @@ unbinds the action. `Esc`, `Enter`, `Backspace` and `Ctrl+C` can't themselves
 be assigned via capture: hand-edit `.gwm.toml` for those (see
 [`[tui.keys]`](/configuration/gwm-toml#tuikeys)).
 
-## working tree overlay (`5`)
+## working tree overlay (`W`)
 
 The sidebar's Working Tree pane, given the whole screen. Same tree, same
 nerd-font icons, same per-category colours and the same `<glyph> <n>` change
@@ -298,7 +298,7 @@ a handful of files reads in one go instead of two rows at a time through
 
 The listing is read when the overlay opens, so it does not depend on the
 sidebar being visible or on which Details mode (`commits` / `stashes`) is
-selected: `5` shows the change set even with the sidebar hidden. Re-open to
+selected: `W` shows the change set even with the sidebar hidden. Re-open to
 pick up changes made while it was closed. The read runs in the background,
 so the overlay opens on `loading…` on a repository large enough for `git
 status` to take a moment; the keys work while it waits.
@@ -325,7 +325,7 @@ readable file name. The name is never what goes.
 | `D` / `U`      | scroll half a screen (`half_down` / `half_up`) |
 | `g` / `Home`   | jump to the top (`scroll_top`)           |
 | `G` / `End`    | jump to the bottom (`scroll_bottom`)     |
-| `Esc` / `q`    | close (`close`); `5` closes it too       |
+| `Esc` / `q`    | close (`close`); `W` closes it too       |
 
 Whatever `working_tree` is rebound to closes the overlay as well as opens
 it, including a multi-stroke chord and a key the overlay's own context

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -298,7 +298,9 @@ a handful of files reads in one go instead of two rows at a time through
 The listing is read when the overlay opens, so it does not depend on the
 sidebar being visible or on which Details mode (`commits` / `stashes`) is
 selected: `5` shows the change set even with the sidebar hidden. Re-open to
-pick up changes made while it was closed.
+pick up changes made while it was closed. The read runs in the background,
+so the overlay opens on `loading…` on a repository large enough for `git
+status` to take a moment; the keys work while it waits.
 
 | Key            | Verb (`[tui.keys.modal.working_tree]`) |
 |:---------------|:---------------------------------------|

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -80,6 +80,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `2`         | open (if hidden) and focus the status pane (`focus_status`)                                       |
 | `3`         | open the Command Logs overlay (`command_logs`): scrollable transcript of the commands gwm ran    |
 | `4`         | open the [Settings panel](#settings-panel-4) (`config_panel`): edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column |
+| `5`         | open the [Working Tree overlay](#working-tree-overlay-5) (`working_tree`): the sidebar's file-explorer listing at full size |
 | `x`         | open the [exec picker overlay](#exec-picker-overlay-x) (`exec_overlay`): pick a [`[exec.profiles]`](/configuration/gwm-toml#exec) profile and run it in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) on the selected worktree |
 | `X`         | open the [clean overlay](#clean-overlay-x) (`clean_overlay`): preview and reclaim build artifacts in the selected worktree (safety countdown before deleting) |
 | `a`         | open the [agent sessions overlay](#agent-sessions-overlay-a) (`agent_sessions`): list the AI-agent sessions (Claude Code, Codex, opencode, Mistral Vibe) attached to the selected worktree |
@@ -285,6 +286,27 @@ immediately. An empty capture (`Enter` with nothing recorded, global only)
 unbinds the action. `Esc`, `Enter`, `Backspace` and `Ctrl+C` can't themselves
 be assigned via capture: hand-edit `.gwm.toml` for those (see
 [`[tui.keys]`](/configuration/gwm-toml#tuikeys)).
+
+## working tree overlay (`5`)
+
+The sidebar's Working Tree pane, given the whole screen. Same tree, same
+nerd-font icons, same per-category colours and the same `<glyph> <n>` change
+counts on the bottom rule. The difference is that a change set of more than
+a handful of files reads in one go instead of two rows at a time through
+`J` / `K`.
+
+The listing is read when the overlay opens, so it does not depend on the
+sidebar being visible or on which Details mode (`commits` / `stashes`) is
+selected: `5` shows the change set even with the sidebar hidden. Re-open to
+pick up changes made while it was closed.
+
+| Key            | Verb (`[tui.keys.modal.working_tree]`) |
+|:---------------|:---------------------------------------|
+| `j` / `↓`      | scroll down (`scroll_down`)            |
+| `k` / `↑`      | scroll up (`scroll_up`)                |
+| `g` / `Home`   | jump to the top (`scroll_top`)         |
+| `G` / `End`    | jump to the bottom (`scroll_bottom`)   |
+| `Esc` / `q`    | close (`close`); `5` closes it too     |
 
 ## issue / PR link prompt (`i`)
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -650,7 +650,7 @@ Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal con
 
 ```toml
 [tui.keys]
-working_tree = ["5"]          # global: opens the overlay
+working_tree = ["W"]          # global: opens the overlay
 
 [tui.keys.modal.working_tree]  # modal: its verbs, same name, no conflict
 close = ["Esc", "q"]
@@ -700,7 +700,7 @@ authoritative if a future build shifts a default.
 | `focus_status`            | `2`              | focus the status pane                                 |
 | `command_logs`            | `3`              | open the Command Logs overlay                         |
 | `config_panel`            | `4`              | open the Settings panel                               |
-| `working_tree`            | `5`              | open the Working Tree listing at full size            |
+| `working_tree`            | `W`              | open the Working Tree listing at full size            |
 | `commits`                 | `c`              | open the commit listing full size, with load-more     |
 | `toggle_sidebar`          | `V`              | show / hide the details sidebar                       |
 | `toggle_sidebar_mode`     | `S`              | cycle the Details panel (`commits` ↔ `stashes`)       |

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -646,7 +646,19 @@ Binding either of those to a printable, `Enter`, `Backspace` or `Delete` is refu
 
 The set of contexts and verbs is what the TUI actually exposes. Run `gwm tui keys` to print every modal context (`confirm`, `create`, `help`, `command_logs`, `working_tree`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) with its verbs and resolved keys. Binding under a context **group** rather than a leaf stage (e.g. `[tui.keys.modal.link]` instead of `[tui.keys.modal.link.choose_target]`) is a load-time error that names the stage to use.
 
-Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `working_tree`, `link`) exist as both a global action and a modal context; TOML forbids defining the same key twice, so pick the array form (global) or the `[tui.keys.modal.<name>]` table form (modal) in a given file.
+Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `working_tree`, `link`) exist as both a global action and a modal context. They do **not** collide: the global binding is the array at `tui.keys.<name>`, the modal one is the table at `tui.keys.modal.<name>`, two different paths, and both can live in the same file. What is rejected is putting the modal table at the global path, which names the fix:
+
+```toml
+[tui.keys]
+working_tree = ["5"]          # global: opens the overlay
+
+[tui.keys.modal.working_tree]  # modal: its verbs, same name, no conflict
+close = ["Esc", "q"]
+```
+
+```
+tui.keys.working_tree: expected an array of chords; modal contexts go under [tui.keys.modal.<context>], got table
+```
 
 See [TUI → Keymap and palette](/tui/keymap-and-palette).
 

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -644,9 +644,9 @@ open_editor = ["Ctrl+e"]  # hands the same file to $EDITOR
 
 Binding either of those to a printable, `Enter`, `Backspace` or `Delete` is refused at load time: the key would type instead of firing, leaving the editor with no way out.
 
-The set of contexts and verbs is what the TUI actually exposes. Run `gwm tui keys` to print every modal context (`confirm`, `create`, `help`, `command_logs`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) with its verbs and resolved keys. Binding under a context **group** rather than a leaf stage (e.g. `[tui.keys.modal.link]` instead of `[tui.keys.modal.link.choose_target]`) is a load-time error that names the stage to use.
+The set of contexts and verbs is what the TUI actually exposes. Run `gwm tui keys` to print every modal context (`confirm`, `create`, `help`, `command_logs`, `working_tree`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) with its verbs and resolved keys. Binding under a context **group** rather than a leaf stage (e.g. `[tui.keys.modal.link]` instead of `[tui.keys.modal.link.choose_target]`) is a load-time error that names the stage to use.
 
-Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `link`) exist as both a global action and a modal context; TOML forbids defining the same key twice, so pick the array form (global) or the `[tui.keys.modal.<name>]` table form (modal) in a given file.
+Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `working_tree`, `link`) exist as both a global action and a modal context; TOML forbids defining the same key twice, so pick the array form (global) or the `[tui.keys.modal.<name>]` table form (modal) in a given file.
 
 See [TUI → Keymap and palette](/tui/keymap-and-palette).
 
@@ -688,6 +688,7 @@ authoritative if a future build shifts a default.
 | `focus_status`            | `2`              | focus the status pane                                 |
 | `command_logs`            | `3`              | open the Command Logs overlay                         |
 | `config_panel`            | `4`              | open the Settings panel                               |
+| `working_tree`            | `5`              | open the Working Tree listing at full size            |
 | `toggle_sidebar`          | `V`              | show / hide the details sidebar                       |
 | `toggle_sidebar_mode`     | `S`              | cycle the Details panel (`commits` ↔ `stashes`)       |
 | `cycle_sidebar_layout`    | `z`              | cycle layout (`auto` → side-by-side → stacked → auto) |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -84,7 +84,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (`focus_status`)                       |
 | `3`         | ouvrir l'overlay Command Logs (`command_logs`) : transcription scrollable des commandes lancées par gwm |
 | `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) (`config_panel`) : éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne |
-| `5`         | ouvrir la [surcouche Working Tree](#surcouche-working-tree-5) (`working_tree`) : l'explorateur de fichiers de la sidebar en pleine taille |
+| `W`         | ouvrir la [surcouche Working Tree](#surcouche-working-tree-w) (`working_tree`) : l'explorateur de fichiers de la sidebar en pleine taille |
 | `c`         | ouvrir la [liste des commits](#liste-des-commits-c) (`commits`) : le panneau Commits de la barre latérale en plein écran, avec une touche pour charger plus |
 | `x`         | ouvrir la [surcouche de sélection exec](#surcouche-de-sélection-exec-x) (`exec_overlay`) : choisir un profil [`[exec.profiles]`](/fr/configuration/gwm-toml#exec) et le lancer dans une [surcouche PTY](/fr/tui/launchers#la-surcouche-pty-embarquée-l--r) sur le worktree sélectionné |
 | `X`         | ouvrir la [surcouche de nettoyage](#surcouche-de-nettoyage-x) (`clean_overlay`) : prévisualiser et récupérer l'espace des artefacts de build du worktree sélectionné (compte à rebours de sécurité avant suppression) |
@@ -299,7 +299,7 @@ enregistrer, global uniquement) délie l'action. `Esc`, `Enter`, `Backspace` et
 `Ctrl+C` ne peuvent pas être assignés par capture : éditez `.gwm.toml` à la main
 pour ces cas (voir [`[tui.keys]`](/fr/configuration/gwm-toml#tuikeys)).
 
-## surcouche Working Tree (`5`)
+## surcouche Working Tree (`W`)
 
 Le panneau Working Tree de la sidebar, sur tout l'écran. Même arbre, mêmes
 icônes nerd font, mêmes couleurs par catégorie et les mêmes compteurs de
@@ -309,7 +309,7 @@ lignes à la fois via `J` / `K`.
 
 La liste est lue à l'ouverture de la surcouche, elle ne dépend donc ni de la
 visibilité de la sidebar ni du mode Details (`commits` / `stashes`)
-sélectionné : `5` montre le jeu de changements même sidebar masquée.
+sélectionné : `W` montre le jeu de changements même sidebar masquée.
 Rouvrez-la pour prendre en compte les changements survenus entre-temps. La
 lecture se fait en tâche de fond : sur un dépôt assez gros pour que `git
 status` prenne un instant, la surcouche s'ouvre sur `loading…` et les
@@ -338,7 +338,7 @@ la fois elle et un nom de fichier lisible. Le nom n'est jamais ce qui saute.
 | `D` / `U`      | défiler d'une demi-page (`half_down` / `half_up`) |
 | `g` / `Home`   | sauter en haut (`scroll_top`)             |
 | `G` / `End`    | sauter en bas (`scroll_bottom`)           |
-| `Esc` / `q`    | fermer (`close`) ; `5` ferme aussi        |
+| `Esc` / `q`    | fermer (`close`) ; `W` ferme aussi        |
 
 Ce sur quoi `working_tree` est remappé ferme la surcouche autant que ça
 l'ouvre, y compris une frappe multiple et une touche que le contexte de la

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -319,6 +319,13 @@ Rouvrez-la pour prendre en compte les changements survenus entre-temps.
 | `G` / `End`    | sauter en bas (`scroll_bottom`)         |
 | `Esc` / `q`    | fermer (`close`) ; `5` ferme aussi      |
 
+Ce sur quoi `working_tree` est remappé ferme la surcouche autant que ça
+l'ouvre, y compris une frappe multiple et une touche que le contexte de la
+surcouche utilise par ailleurs pour défiler
+([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). Le toggle l'emporte
+sur le verbe modal dans ce cas, ce qui est exactement ce que la remappe
+demandait.
+
 ## invite de liaison issue / PR (`i`)
 
 La première étape (`[tui.keys.modal.link.choose_target]`) est un sélecteur

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -84,6 +84,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (`focus_status`)                       |
 | `3`         | ouvrir l'overlay Command Logs (`command_logs`) : transcription scrollable des commandes lancées par gwm |
 | `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) (`config_panel`) : éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne |
+| `5`         | ouvrir la [surcouche Working Tree](#surcouche-working-tree-5) (`working_tree`) : l'explorateur de fichiers de la sidebar en pleine taille |
 | `x`         | ouvrir la [surcouche de sélection exec](#surcouche-de-sélection-exec-x) (`exec_overlay`) : choisir un profil [`[exec.profiles]`](/fr/configuration/gwm-toml#exec) et le lancer dans une [surcouche PTY](/fr/tui/launchers#la-surcouche-pty-embarquée-l--r) sur le worktree sélectionné |
 | `X`         | ouvrir la [surcouche de nettoyage](#surcouche-de-nettoyage-x) (`clean_overlay`) : prévisualiser et récupérer l'espace des artefacts de build du worktree sélectionné (compte à rebours de sécurité avant suppression) |
 | `a`         | ouvrir la [surcouche des sessions d'agents](#surcouche-des-sessions-dagents-a) (`agent_sessions`) : lister les sessions d'agents IA (Claude Code, Codex, opencode, Mistral Vibe) attachées au worktree sélectionné |
@@ -296,6 +297,27 @@ la nouvelle touche fonctionne immédiatement. Une capture vide (`Enter` sans rie
 enregistrer, global uniquement) délie l'action. `Esc`, `Enter`, `Backspace` et
 `Ctrl+C` ne peuvent pas être assignés par capture : éditez `.gwm.toml` à la main
 pour ces cas (voir [`[tui.keys]`](/fr/configuration/gwm-toml#tuikeys)).
+
+## surcouche Working Tree (`5`)
+
+Le panneau Working Tree de la sidebar, sur tout l'écran. Même arbre, mêmes
+icônes nerd font, mêmes couleurs par catégorie et les mêmes compteurs de
+changements `<glyphe> <n>` sur le filet du bas : la différence est qu'un jeu
+de changements de plus de quelques fichiers se lit d'un coup au lieu de deux
+lignes à la fois via `J` / `K`.
+
+La liste est lue à l'ouverture de la surcouche, elle ne dépend donc ni de la
+visibilité de la sidebar ni du mode Details (`commits` / `stashes`)
+sélectionné : `5` montre le jeu de changements même sidebar masquée.
+Rouvrez-la pour prendre en compte les changements survenus entre-temps.
+
+| Touche         | Verbe (`[tui.keys.modal.working_tree]`) |
+|:---------------|:----------------------------------------|
+| `j` / `↓`      | défiler vers le bas (`scroll_down`)     |
+| `k` / `↑`      | défiler vers le haut (`scroll_up`)      |
+| `g` / `Home`   | sauter en haut (`scroll_top`)           |
+| `G` / `End`    | sauter en bas (`scroll_bottom`)         |
+| `Esc` / `q`    | fermer (`close`) ; `5` ferme aussi      |
 
 ## invite de liaison issue / PR (`i`)
 

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -309,7 +309,10 @@ lignes à la fois via `J` / `K`.
 La liste est lue à l'ouverture de la surcouche, elle ne dépend donc ni de la
 visibilité de la sidebar ni du mode Details (`commits` / `stashes`)
 sélectionné : `5` montre le jeu de changements même sidebar masquée.
-Rouvrez-la pour prendre en compte les changements survenus entre-temps.
+Rouvrez-la pour prendre en compte les changements survenus entre-temps. La
+lecture se fait en tâche de fond : sur un dépôt assez gros pour que `git
+status` prenne un instant, la surcouche s'ouvre sur `loading…` et les
+touches répondent pendant l'attente.
 
 | Touche         | Verbe (`[tui.keys.modal.working_tree]`) |
 |:---------------|:----------------------------------------|

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -646,7 +646,19 @@ Lier l'une des deux à un caractère imprimable, à `Entrée`, `Retour arrière`
 
 L'ensemble des contextes et des verbes est exactement ce que la TUI expose. Exécutez `gwm tui keys` pour afficher chaque contexte de modal (`confirm`, `create`, `help`, `command_logs`, `working_tree`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) avec ses verbes et ses touches résolues. Binder sous un **groupe** de contexte plutôt que sous une étape feuille (par ex. `[tui.keys.modal.link]` au lieu de `[tui.keys.modal.link.choose_target]`) est une erreur au chargement qui nomme l'étape à utiliser.
 
-La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `working_tree`, `link`) existent à la fois comme action globale et comme contexte de modal ; TOML interdit de définir deux fois la même clé, donc choisissez la forme tableau (globale) ou la forme table `[tui.keys.modal.<name>]` (modal) dans un fichier donné.
+La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `working_tree`, `link`) existent à la fois comme action globale et comme contexte de modal. Ils n'entrent **pas** en collision : la liaison globale est le tableau à `tui.keys.<name>`, la modale est la table à `tui.keys.modal.<name>`, deux chemins différents, et les deux peuvent coexister dans le même fichier. Ce qui est refusé, c'est de mettre la table modale au chemin global, et le message nomme le correctif :
+
+```toml
+[tui.keys]
+working_tree = ["5"]          # global : ouvre la surcouche
+
+[tui.keys.modal.working_tree]  # modal : ses verbes, même nom, aucun conflit
+close = ["Esc", "q"]
+```
+
+```
+tui.keys.working_tree: expected an array of chords; modal contexts go under [tui.keys.modal.<context>], got table
+```
 
 Voir [TUI → Keymap et palette](/fr/tui/keymap-and-palette).
 

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -644,9 +644,9 @@ open_editor = ["Ctrl+e"]  # confie le même fichier à $EDITOR
 
 Lier l'une des deux à un caractère imprimable, à `Entrée`, `Retour arrière` ou `Suppr` est refusé au chargement : la touche taperait au lieu de déclencher, et l'éditeur n'aurait plus de sortie.
 
-L'ensemble des contextes et des verbes est exactement ce que la TUI expose. Exécutez `gwm tui keys` pour afficher chaque contexte de modal (`confirm`, `create`, `help`, `command_logs`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) avec ses verbes et ses touches résolues. Binder sous un **groupe** de contexte plutôt que sous une étape feuille (par ex. `[tui.keys.modal.link]` au lieu de `[tui.keys.modal.link.choose_target]`) est une erreur au chargement qui nomme l'étape à utiliser.
+L'ensemble des contextes et des verbes est exactement ce que la TUI expose. Exécutez `gwm tui keys` pour afficher chaque contexte de modal (`confirm`, `create`, `help`, `command_logs`, `working_tree`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) avec ses verbes et ses touches résolues. Binder sous un **groupe** de contexte plutôt que sous une étape feuille (par ex. `[tui.keys.modal.link]` au lieu de `[tui.keys.modal.link.choose_target]`) est une erreur au chargement qui nomme l'étape à utiliser.
 
-La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `link`) existent à la fois comme action globale et comme contexte de modal ; TOML interdit de définir deux fois la même clé, donc choisissez la forme tableau (globale) ou la forme table `[tui.keys.modal.<name>]` (modal) dans un fichier donné.
+La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `working_tree`, `link`) existent à la fois comme action globale et comme contexte de modal ; TOML interdit de définir deux fois la même clé, donc choisissez la forme tableau (globale) ou la forme table `[tui.keys.modal.<name>]` (modal) dans un fichier donné.
 
 Voir [TUI → Keymap et palette](/fr/tui/keymap-and-palette).
 
@@ -688,6 +688,7 @@ et fait foi si un futur build décale une valeur par défaut.
 | `focus_status`            | `2`                 | focus sur le panneau de statut                        |
 | `command_logs`            | `3`                 | ouvrir l'overlay Command Logs                         |
 | `config_panel`            | `4`                 | ouvrir le panneau Settings                            |
+| `working_tree`            | `5`                 | ouvrir la liste Working Tree en pleine taille         |
 | `toggle_sidebar`          | `V`                 | afficher / masquer la sidebar de détails              |
 | `toggle_sidebar_mode`     | `S`                 | faire cycler le panneau Details (`commits` ↔ `stashes`) |
 | `cycle_sidebar_layout`    | `z`                 | faire cycler le layout (`auto` → côte-à-côte → empilé → auto) |

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -650,7 +650,7 @@ La validation au chargement rejette, comme un `GwmError::Config` dur : un contex
 
 ```toml
 [tui.keys]
-working_tree = ["5"]          # global : ouvre la surcouche
+working_tree = ["W"]          # global : ouvre la surcouche
 
 [tui.keys.modal.working_tree]  # modal : ses verbes, même nom, aucun conflit
 close = ["Esc", "q"]
@@ -700,7 +700,7 @@ et fait foi si un futur build décale une valeur par défaut.
 | `focus_status`            | `2`                 | focus sur le panneau de statut                        |
 | `command_logs`            | `3`                 | ouvrir l'overlay Command Logs                         |
 | `config_panel`            | `4`                 | ouvrir le panneau Settings                            |
-| `working_tree`            | `5`                 | ouvrir la liste Working Tree en pleine taille         |
+| `working_tree`            | `W`                 | ouvrir la liste Working Tree en pleine taille         |
 | `commits`                 | `c`                 | ouvrir la liste des commits en plein écran, avec load-more |
 | `toggle_sidebar`          | `V`                 | afficher / masquer la sidebar de détails              |
 | `toggle_sidebar_mode`     | `S`                 | faire cycler le panneau Details (`commits` ↔ `stashes`) |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2226,6 +2226,19 @@ impl App {
           applied = true;
           refresh_applied = true;
         }
+        TaskMsg::WorkingTree(generation, path, lines, counts) => {
+          if !self.tasks.complete(TaskKind::WorkingTree, generation) {
+            continue;
+          }
+          // The selection moved while the read ran (or the overlay was
+          // closed and reopened elsewhere): this payload describes a
+          // worktree the overlay is no longer showing.
+          if self.working_tree.path.as_deref() != Some(path.as_path()) {
+            continue;
+          }
+          self.working_tree.load(lines, counts);
+          applied = true;
+        }
         TaskMsg::Sidebar(generation, path, mode, sections) => {
           // Late result — the selection moved and `refresh` bumped the slot's
           // generation (a mutation invalidated a pre-mutation rebuild), so this
@@ -2509,26 +2522,41 @@ impl App {
   pub fn modal_toggle_stroke(&mut self, key: KeyEvent, action: Action) -> ToggleStroke {
     let stroke = KeyStroke::from_event(&key);
     let mut tentative = self.pending_chord.clone();
-    tentative.push(stroke);
+    tentative.push(stroke.clone());
 
+    let outcome = match self.resolve_toggle_buffer(action, &tentative) {
+      ToggleStroke::Unclaimed if !self.pending_chord.is_empty() => {
+        // Mismatched continuation. Drop the in-flight prefix and retry the
+        // stroke on its own, the vim-style fallback `dispatch_key` does:
+        // one action can hold several chords, so with
+        // `working_tree = ["g w", "j k"]` a `g` followed by `j` has to start
+        // the second chord rather than fall through to a scroll verb.
+        self.pending_chord.clear();
+        self.resolve_toggle_buffer(action, &[stroke])
+      }
+      other => other,
+    };
+    match &outcome {
+      ToggleStroke::Pending => {}
+      // Fired or Unclaimed: nothing is in flight either way.
+      _ => self.pending_chord.clear(),
+    }
+    self.sync_legacy_pending_flag();
+    outcome
+  }
+
+  /// Resolve one buffer against the chords bound to `action` alone, arming
+  /// [`Self::pending_chord`] on a strict prefix. The inner step of
+  /// [`Self::modal_toggle_stroke`], which owns the retry and the clears.
+  fn resolve_toggle_buffer(&mut self, action: Action, buffer: &[KeyStroke]) -> ToggleStroke {
     let chords = self.keymap.chords_for(action);
-    if chords.iter().any(|c| c == &tentative) {
-      self.pending_chord.clear();
-      self.sync_legacy_pending_flag();
+    if chords.iter().any(|c| c.as_slice() == buffer) {
       return ToggleStroke::Fired;
     }
-    if chords
-      .iter()
-      .any(|c| c.len() > tentative.len() && c.starts_with(&tentative))
-    {
-      self.pending_chord = tentative;
-      self.sync_legacy_pending_flag();
+    if chords.iter().any(|c| c.len() > buffer.len() && c.starts_with(buffer)) {
+      self.pending_chord = buffer.to_vec();
       return ToggleStroke::Pending;
     }
-    // Not this action's key. Drop any half-typed toggle prefix so a stray
-    // `g` does not turn the next stroke into a phantom match.
-    self.pending_chord.clear();
-    self.sync_legacy_pending_flag();
     ToggleStroke::Unclaimed
   }
 
@@ -2928,32 +2956,46 @@ impl App {
     self.view = View::CommandLogs;
   }
 
-  /// Open the full-size Working Tree listing (issue #592). Reads the
-  /// selected worktree's `git status` and builds the same file-explorer
-  /// rows the sidebar pane paints, then rewinds the scroll so a re-open
-  /// starts at the top. The renderer republishes `max_scroll` against the
-  /// live viewport.
+  /// Open the full-size Working Tree listing (issues #592, #613).
   ///
-  /// The read is synchronous, unlike the sidebar's (issue #343): that rule
-  /// bans shelling out from `terminal.draw`, and this runs once per
-  /// keypress, not once per frame. It is bounded — `git_status_short` kills
-  /// git at [`crate::worktree::STATUS_SCAN_CAP`] records rather than letting
-  /// a pathological untracked tree walk forever.
-  /// ponytail: sync `git status` on open; move to a `TaskKind` worker if the
-  /// keypress ever feels slow on a huge repo.
+  /// The overlay opens immediately on a loader and the `git status` read
+  /// runs on a [`TaskKind::WorkingTree`] worker. It is deliberately NOT
+  /// inline: `STATUS_SCAN_CAP` bounds how many records git yields, not how
+  /// long it takes to produce the first one, so an untracked tree on a cold
+  /// or network filesystem would freeze the event loop for the length of the
+  /// walk (Copilot review, PR #612). Same boundary as the sidebar's own
+  /// preview (#343), reached from a keypress rather than from navigation.
+  ///
+  /// The rows are read fresh rather than taken from `SidebarState::cache`:
+  /// that cache is keyed by `(path, mode)` and only rebuilt while the
+  /// sidebar is open and in commits mode, so it is empty in the two states
+  /// where the overlay is most useful.
   ///
   /// With nothing selected the overlay still opens, empty — the
   /// [`Self::enter_config_panel`] precedent: a modal that refuses to open
   /// reads as a dead key.
   pub fn enter_working_tree(&mut self) {
-    match self.selected() {
-      Some(w) => {
-        let (lines, counts) = super::ui::working_tree_lines(w, &self.theme);
-        self.working_tree.load(lines, counts);
-      }
-      None => self.working_tree.load(Vec::new(), Default::default()),
-    }
+    let selected = self.selected().cloned();
+    self.working_tree.begin(selected.as_ref().map(|w| w.path.as_path()));
     self.view = View::WorkingTree;
+    let Some(w) = selected else {
+      return;
+    };
+    let Some(generation) = self.tasks.request(TaskKind::WorkingTree) else {
+      // A read is already in flight for this open; coalesce onto it.
+      return;
+    };
+    let theme = self.theme;
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let (lines, counts) = crate::tui::ui::working_tree_lines(&w, &theme);
+      let _ = tx.send(TaskMsg::WorkingTree(generation, w.path, lines, counts));
+    });
+  }
+
+  /// `true` while the Working Tree overlay is waiting on its worker.
+  pub fn is_working_tree_loading(&self) -> bool {
+    self.working_tree.loading
   }
 
   /// Route one keystroke through the Command Logs overlay (issues #226,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -150,7 +150,7 @@ pub enum View {
   /// Full-size Working Tree listing (issue #592). A ~90% fullscreen modal
   /// showing the same file-explorer tree the sidebar pane paints, given the
   /// whole screen so a large change set reads in one go instead of two rows
-  /// at a time through `J` / `K`. Opened on `5`, scrolled like the help
+  /// at a time through `J` / `K`. Opened on `W`, scrolled like the help
   /// overlay; state lives on [`App::working_tree`].
   WorkingTree,
   /// Full-size commit listing (issue #593). A ~90% fullscreen modal
@@ -3048,7 +3048,7 @@ impl App {
     };
     let Some(generation) = self.tasks.request(TaskKind::WorkingTree) else {
       // A read for this same worktree is already out; ride on it, which is
-      // what keeps a held `5` from spawning a `git status` per repeat.
+      // what keeps a held `W` from spawning a `git status` per repeat.
       return;
     };
     let theme = self.theme;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,6 +17,7 @@ use super::state::link_prompt::LinkPrompt;
 use super::state::pty_overlay::PtyOverlay;
 use super::state::sidebar::SidebarState;
 use super::state::spinner::Spinner;
+use super::state::working_tree::WorkingTreeModal;
 use super::theme::Theme;
 use crate::bootstrap::{self, BootstrapCtx, BootstrapReport, StepStatus};
 use crate::config::BranchType;
@@ -118,6 +119,12 @@ pub enum View {
   /// commands gwm ran. Opened on `3`, scrolled like the help overlay;
   /// state lives on [`App::command_logs`].
   CommandLogs,
+  /// Full-size Working Tree listing (issue #592). A ~90% fullscreen modal
+  /// showing the same file-explorer tree the sidebar pane paints, given the
+  /// whole screen so a large change set reads in one go instead of two rows
+  /// at a time through `J` / `K`. Opened on `5`, scrolled like the help
+  /// overlay; state lives on [`App::working_tree`].
+  WorkingTree,
   /// Configuration panel (issue #232). A ~90% fullscreen modal over a
   /// dimmed list showing the resolved `.gwm.toml` (user-level global
   /// deep-merged under the repo file) with a per-row source column
@@ -596,6 +603,10 @@ pub struct App {
   /// plus the resolved-row snapshot, filled by [`Self::enter_config_panel`].
   pub config_panel: ConfigPanel,
 
+  /// Full-size Working Tree overlay state (issue #592): the scroll cursor
+  /// plus the snapshotted tree rows, filled by [`Self::enter_working_tree`].
+  pub working_tree: WorkingTreeModal,
+
   /// The user-level global config path this `App` was constructed with
   /// (issue #232). Stored so [`Self::enter_config_panel`] resolves the
   /// panel's source attribution against the *same* layers the running
@@ -878,6 +889,7 @@ impl App {
       task_rx,
       command_logs: CommandLogs::new(),
       config_panel: ConfigPanel::new(),
+      working_tree: WorkingTreeModal::new(),
       global_path: global_path.map(Path::to_path_buf),
       pty_overlay: None,
       exec_picker: ExecPicker::new(),
@@ -2719,6 +2731,8 @@ impl App {
       // The Configuration panel (issue #232) is likewise a ~90% fullscreen
       // modal; the statusbar behind it keeps the underlying pane context.
       View::Config => self.pane_hint_context(),
+      // Same for the full-size Working Tree listing (issue #592).
+      View::WorkingTree => self.pane_hint_context(),
       View::Pty => super::ui::HintContext::Pty,
       View::ExecPicker => HintContext::ExecPicker,
       // #557: the note bar follows the mode. With the knob off there is no
@@ -2838,6 +2852,34 @@ impl App {
     self.command_logs.sync();
     self.command_logs.reset();
     self.view = View::CommandLogs;
+  }
+
+  /// Open the full-size Working Tree listing (issue #592). Reads the
+  /// selected worktree's `git status` and builds the same file-explorer
+  /// rows the sidebar pane paints, then rewinds the scroll so a re-open
+  /// starts at the top. The renderer republishes `max_scroll` against the
+  /// live viewport.
+  ///
+  /// The read is synchronous, unlike the sidebar's (issue #343): that rule
+  /// bans shelling out from `terminal.draw`, and this runs once per
+  /// keypress, not once per frame. It is bounded — `git_status_short` kills
+  /// git at [`crate::worktree::STATUS_SCAN_CAP`] records rather than letting
+  /// a pathological untracked tree walk forever.
+  /// ponytail: sync `git status` on open; move to a `TaskKind` worker if the
+  /// keypress ever feels slow on a huge repo.
+  ///
+  /// With nothing selected the overlay still opens, empty — the
+  /// [`Self::enter_config_panel`] precedent: a modal that refuses to open
+  /// reads as a dead key.
+  pub fn enter_working_tree(&mut self) {
+    match self.selected() {
+      Some(w) => {
+        let (lines, counts) = super::ui::working_tree_lines(w, &self.theme);
+        self.working_tree.load(lines, counts);
+      }
+      None => self.working_tree.load(Vec::new(), Default::default()),
+    }
+    self.view = View::WorkingTree;
   }
 
   /// Open the Configuration panel (issue #232). Resolves the effective

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -96,6 +96,20 @@ pub struct PendingMerge {
   pub noun: String,
 }
 
+/// Outcome of [`App::modal_toggle_stroke`] (issue #613): what a modal
+/// should do with a keystroke offered to its toggle key before the modal
+/// verbs get a look at it.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ToggleStroke {
+  /// The buffer completed the toggle chord. Close the overlay.
+  Fired,
+  /// The buffer is a strict prefix of the toggle chord. The stroke is
+  /// consumed; wait for the next one and do not run the modal verbs.
+  Pending,
+  /// Nothing to do with the toggle. Fall through to the modal verbs.
+  Unclaimed,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum View {
   List,
@@ -2458,6 +2472,53 @@ impl App {
     outcome
   }
 
+  /// What one keystroke means for a modal's own toggle key (issue #613).
+  ///
+  /// [`Self::key_matches_action`] answers the same question for a single
+  /// stroke, which left two silent holes in every overlay that closes on
+  /// its opener:
+  ///
+  /// - a **multi-stroke** binding (`working_tree = ["g w"]`) could open the
+  ///   overlay through the chord-aware list dispatch but never match here,
+  ///   because the lookup only ever saw the last stroke;
+  /// - a binding the overlay's own context already claims (`= ["j"]`) was
+  ///   resolved as a modal verb first, so the key opened the overlay and
+  ///   then scrolled it instead of closing.
+  ///
+  /// This resolves against `action` **alone** rather than the whole keymap:
+  /// inside a modal the toggle is the one global binding allowed to fire,
+  /// and letting [`Self::dispatch_key`] run there would make `d` open the
+  /// delete confirm from behind an overlay.
+  ///
+  /// [`ToggleStroke::Pending`] means the stroke was consumed as the prefix
+  /// of the toggle chord: the caller must NOT hand it to the modal verbs,
+  /// or `g` would scroll to the top on its way to `g w`.
+  pub fn modal_toggle_stroke(&mut self, key: KeyEvent, action: Action) -> ToggleStroke {
+    let stroke = KeyStroke::from_event(&key);
+    let mut tentative = self.pending_chord.clone();
+    tentative.push(stroke);
+
+    let chords = self.keymap.chords_for(action);
+    if chords.iter().any(|c| c == &tentative) {
+      self.pending_chord.clear();
+      self.sync_legacy_pending_flag();
+      return ToggleStroke::Fired;
+    }
+    if chords
+      .iter()
+      .any(|c| c.len() > tentative.len() && c.starts_with(&tentative))
+    {
+      self.pending_chord = tentative;
+      self.sync_legacy_pending_flag();
+      return ToggleStroke::Pending;
+    }
+    // Not this action's key. Drop any half-typed toggle prefix so a stray
+    // `g` does not turn the next stroke into a phantom match.
+    self.pending_chord.clear();
+    self.sync_legacy_pending_flag();
+    ToggleStroke::Unclaimed
+  }
+
   pub fn key_matches_action(&self, key: KeyEvent, action: Action) -> bool {
     matches!(
       self.keymap.lookup(&[KeyStroke::from_event(&key)]),
@@ -2880,6 +2941,32 @@ impl App {
       None => self.working_tree.load(Vec::new(), Default::default()),
     }
     self.view = View::WorkingTree;
+  }
+
+  /// Route one keystroke through the full-size Working Tree overlay
+  /// (issues #592, #613). Returns `true` when the overlay should close.
+  ///
+  /// The routing lives here rather than in the event loop, the way
+  /// [`Self::handle_create_key`] does (issue #217), so the ONE thing a
+  /// `match` in the run loop cannot express in a test is pinned: the
+  /// toggle resolves **before** the modal verbs. Move the two blocks and
+  /// `a_rebound_toggle_beats_the_scroll_verb_it_shadows` goes red.
+  pub fn handle_working_tree_key(&mut self, key: KeyEvent) -> bool {
+    match self.modal_toggle_stroke(key, Action::WorkingTree) {
+      ToggleStroke::Fired => return true,
+      // Consumed as a chord prefix: the modal verbs must not see it.
+      ToggleStroke::Pending => return false,
+      ToggleStroke::Unclaimed => {}
+    }
+    match self.resolve_modal(KeyContext::WorkingTree, key) {
+      Some(ModalAction::WorkingTreeClose) => return true,
+      Some(ModalAction::WorkingTreeScrollDown) => self.working_tree.scroll_down(),
+      Some(ModalAction::WorkingTreeScrollUp) => self.working_tree.scroll_up(),
+      Some(ModalAction::WorkingTreeScrollTop) => self.working_tree.scroll_to_top(),
+      Some(ModalAction::WorkingTreeScrollBottom) => self.working_tree.scroll_to_bottom(),
+      _ => {}
+    }
+    false
   }
 
   /// Open the Configuration panel (issue #232). Resolves the effective

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2976,13 +2976,25 @@ impl App {
   /// reads as a dead key.
   pub fn enter_working_tree(&mut self) {
     let selected = self.selected().cloned();
-    self.working_tree.begin(selected.as_ref().map(|w| w.path.as_path()));
+    let target = selected.as_ref().map(|w| w.path.as_path());
+    // Coalescing is only sound while the in-flight read is for the SAME
+    // worktree (Copilot review, PR #612). Close a slow snapshot for A,
+    // select B, reopen: the request would come back `None` because the slot
+    // is still A's, no worker would exist for B, and A's payload is dropped
+    // on the path check below — leaving the loader up with nothing left to
+    // clear it. `invalidate` bumps the generation and frees the slot, so A's
+    // late result is discarded and B gets its own read.
+    if self.working_tree.loading && self.working_tree.path.as_deref() != target {
+      self.tasks.invalidate(TaskKind::WorkingTree);
+    }
+    self.working_tree.begin(target);
     self.view = View::WorkingTree;
     let Some(w) = selected else {
       return;
     };
     let Some(generation) = self.tasks.request(TaskKind::WorkingTree) else {
-      // A read is already in flight for this open; coalesce onto it.
+      // A read for this same worktree is already out; ride on it, which is
+      // what keeps a held `5` from spawning a `git status` per repeat.
       return;
     };
     let theme = self.theme;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,6 +7,7 @@ use super::state::async_task::{
 };
 use super::state::clean_overlay::CleanOverlay;
 use super::state::command_logs::CommandLogs;
+use super::state::config_panel::SettingsTab;
 use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field, Mode};
@@ -94,6 +95,18 @@ pub struct PendingMerge {
   pub checks_total: u32,
   /// `PR` / `MR`, resolved by the caller.
   pub noun: String,
+}
+
+/// Outcome of [`App::handle_command_logs_key`] (issue #613): the two side
+/// effects the run loop owns, since neither belongs in a state transition.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum CommandLogsKey {
+  /// Close the overlay.
+  Close,
+  /// Write the transcript to the clipboard (the run loop owns the I/O).
+  Copy,
+  /// Consumed; nothing for the caller to do.
+  Handled,
 }
 
 /// Outcome of [`App::modal_toggle_stroke`] (issue #613): what a modal
@@ -2941,6 +2954,86 @@ impl App {
       None => self.working_tree.load(Vec::new(), Default::default()),
     }
     self.view = View::WorkingTree;
+  }
+
+  /// Route one keystroke through the Command Logs overlay (issues #226,
+  /// #613). The two side effects the run loop owns (close, clipboard write)
+  /// come back as [`CommandLogsKey`] rather than firing here, so the routing
+  /// stays a pure state transition, the way [`Self::handle_create_key`] does
+  /// (issue #217).
+  ///
+  /// Same precedence as [`Self::handle_working_tree_key`]: the toggle first,
+  /// then the modal verbs.
+  pub fn handle_command_logs_key(&mut self, key: KeyEvent) -> CommandLogsKey {
+    match self.modal_toggle_stroke(key, Action::CommandLogs) {
+      ToggleStroke::Fired => return CommandLogsKey::Close,
+      ToggleStroke::Pending => return CommandLogsKey::Handled,
+      ToggleStroke::Unclaimed => {}
+    }
+    match self.resolve_modal(KeyContext::CommandLogs, key) {
+      Some(ModalAction::CommandLogsClose) => return CommandLogsKey::Close,
+      Some(ModalAction::CommandLogsCopy) => return CommandLogsKey::Copy,
+      Some(ModalAction::CommandLogsScrollDown) => self.command_logs.scroll_down(),
+      Some(ModalAction::CommandLogsScrollUp) => self.command_logs.scroll_up(),
+      Some(ModalAction::CommandLogsScrollRight) => self.command_logs.scroll_right(),
+      Some(ModalAction::CommandLogsScrollLeft) => self.command_logs.scroll_left(),
+      Some(ModalAction::CommandLogsScrollTop) => self.command_logs.scroll_to_top(),
+      Some(ModalAction::CommandLogsScrollBottom) => self.command_logs.scroll_to_bottom(),
+      _ => {}
+    }
+    CommandLogsKey::Handled
+  }
+
+  /// Route one keystroke through the Settings panel's navigation mode
+  /// (issues #232, #613). Returns `true` when the panel should close.
+  ///
+  /// Navigation ONLY: the capture and edit sub-modes own every stroke while
+  /// they are live and stay routed ahead of this in the run loop, so a
+  /// `config_panel` key rebound to a digit still types into a numeric field
+  /// instead of closing the panel out from under the edit.
+  pub fn handle_config_nav_key(&mut self, key: KeyEvent) -> bool {
+    match self.modal_toggle_stroke(key, Action::ConfigPanel) {
+      ToggleStroke::Fired => return true,
+      ToggleStroke::Pending => return false,
+      ToggleStroke::Unclaimed => {}
+    }
+    let on_all = self.config_panel.tab == SettingsTab::All;
+    match self.resolve_modal(KeyContext::Config, key) {
+      Some(ModalAction::ConfigClose) => return true,
+      Some(ModalAction::ConfigNextTab) => self.config_panel.next_tab(),
+      Some(ModalAction::ConfigPrevTab) => self.config_panel.prev_tab(),
+      Some(ModalAction::ConfigToggleLayer) => self.config_panel.toggle_layer(),
+      // On the Keys tab `activate` arms a live keystroke capture for the
+      // selected binding (issue #294); elsewhere it cycles a choice or
+      // opens the numeric/text edit buffer.
+      Some(ModalAction::ConfigActivate) => {
+        if self.config_panel.tab == SettingsTab::Keys {
+          self.config_panel.begin_capture();
+        } else {
+          self.activate_selected_setting();
+        }
+      }
+      Some(ModalAction::ConfigSelectNext) => {
+        if on_all {
+          self.config_panel.scroll_down();
+        } else {
+          self.config_panel.select_next();
+        }
+      }
+      Some(ModalAction::ConfigSelectPrev) => {
+        if on_all {
+          self.config_panel.scroll_up();
+        } else {
+          self.config_panel.select_prev();
+        }
+      }
+      Some(ModalAction::ConfigScrollRight) if on_all => self.config_panel.scroll_right(),
+      Some(ModalAction::ConfigScrollLeft) if on_all => self.config_panel.scroll_left(),
+      Some(ModalAction::ConfigScrollTop) if on_all => self.config_panel.scroll_to_top(),
+      Some(ModalAction::ConfigScrollBottom) if on_all => self.config_panel.scroll_to_bottom(),
+      _ => {}
+    }
+    false
   }
 
   /// Route one keystroke through the full-size Working Tree overlay

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -524,9 +524,12 @@ impl Keymap {
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
       def(Action::ConfigPanel, &["4"]),
-      // #592: `5` keeps the "numbers open panels" family going — the
-      // Working Tree listing at full size.
-      def(Action::WorkingTree, &["5"]),
+      // #592: `W` for the Working Tree listing at full size. A letter and
+      // not the next number in the `3` / `4` family: those two open gwm's
+      // own panels (the command transcript, the settings), while this one
+      // and `c` / `C` open a pane's content, which is the register the
+      // letters name.
+      def(Action::WorkingTree, &["W"]),
       // #593: `c` for commits, `C` for the checks — the same pair in both
       // panes, so the key does not change meaning under the focus. It cost
       // `c` its rename, which moved to `E`, and the #436 contextual

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -752,6 +752,24 @@ impl Keymap {
       .map(|chord| format_chord(chord))
   }
 
+  /// Every chord bound to `action`, as the parsed stroke sequences, or an
+  /// empty slice when the action is unbound.
+  ///
+  /// [`Self::lookup`] answers "what does this buffer resolve to", which is
+  /// the wrong question inside a modal: there, the only binding that may
+  /// fire is the overlay's own toggle, and every other global action has to
+  /// stay unreachable. Issue #613 needs the inverse lookup, so a caller can
+  /// ask whether a buffer matches (or is a prefix of) one specific action
+  /// without letting the rest of the keymap through.
+  pub fn chords_for(&self, action: Action) -> &[Vec<KeyStroke>] {
+    self
+      .entries
+      .iter()
+      .find(|b| b.action == action)
+      .map(|b| b.chords.as_slice())
+      .unwrap_or(&[])
+  }
+
   /// Every chord bound to `action`, comma-joined (`"j, Down"`) or empty when
   /// unbound — the help-overlay / Keys-tab row form. Mirrors
   /// [`crate::tui::modal_keymap::ModalKeymap::keys_display`].

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -150,6 +150,8 @@ define_actions! {
   // Overlays
   CommandLogs       => "command_logs",
   ConfigPanel       => "config_panel",
+  // #592: the sidebar's Working Tree pane, given the whole terminal.
+  WorkingTree       => "working_tree",
   // #436: CI checks overlay — also reachable via `c` in the status context.
   CiChecks          => "ci_checks",
   // #420: rich PR / issue view — description, checks, reviews, comments.
@@ -519,6 +521,9 @@ impl Keymap {
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
       def(Action::ConfigPanel, &["4"]),
+      // #592: `5` keeps the "numbers open panels" family going — the
+      // Working Tree listing at full size.
+      def(Action::WorkingTree, &["5"]),
       // #436: `C` opens the CI checks overlay from anywhere in the list
       // view; `c` does the same while the status pane holds the focus
       // (contextual routing, same mechanism as j/k sidebar scroll).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,8 +28,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 pub use app::{
-  agent_pane_status, mux_pane_status, plan_agent_pane, read_pins_from_sources, AgentPanePlan, App, ConfirmKind,
-  CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, NoteKey, OpenTarget,
+  agent_pane_status, mux_pane_status, plan_agent_pane, read_pins_from_sources, AgentPanePlan, App, CommandLogsKey,
+  ConfirmKind, CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, NoteKey, OpenTarget,
   PendingMerge, RepoMeta, ToggleStroke, View, WorkspaceState,
 };
 pub use state::async_task::{
@@ -514,21 +514,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // so the open key toggles it shut even when rebound.
       // #219: keys resolved through the `command_logs` modal context. The
       // bound global `command_logs` key still toggles the overlay shut.
-      View::CommandLogs => match app.modal_toggle_stroke(key, Action::CommandLogs) {
-        ToggleStroke::Fired => app.view = View::List,
-        ToggleStroke::Pending => {}
-        ToggleStroke::Unclaimed => match app.resolve_modal(KeyContext::CommandLogs, key) {
-          Some(ModalAction::CommandLogsClose) => app.view = View::List,
-          // `y` copies the whole transcript to the clipboard (issue #279).
-          Some(ModalAction::CommandLogsCopy) => copy_command_logs_to_clipboard(&mut app),
-          Some(ModalAction::CommandLogsScrollDown) => app.command_logs.scroll_down(),
-          Some(ModalAction::CommandLogsScrollUp) => app.command_logs.scroll_up(),
-          Some(ModalAction::CommandLogsScrollRight) => app.command_logs.scroll_right(),
-          Some(ModalAction::CommandLogsScrollLeft) => app.command_logs.scroll_left(),
-          Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
-          Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
-          _ => {}
-        },
+      View::CommandLogs => match app.handle_command_logs_key(key) {
+        CommandLogsKey::Close => app.view = View::List,
+        // `y` copies the whole transcript to the clipboard (issue #279).
+        CommandLogsKey::Copy => copy_command_logs_to_clipboard(&mut app),
+        CommandLogsKey::Handled => {}
       },
       // Full-size Working Tree listing (issue #592). A read-only overlay
       // over an already-taken snapshot: it scrolls like the command logs,
@@ -576,47 +566,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         // this arm: the capture and edit sub-modes above own every stroke
         // while they are live, so a `config_panel` key rebound to a digit
         // must still type into a numeric field.
-        match app.modal_toggle_stroke(key, Action::ConfigPanel) {
-          ToggleStroke::Fired => app.view = View::List,
-          ToggleStroke::Pending => {}
-          ToggleStroke::Unclaimed => {
-            let on_all = app.config_panel.tab == SettingsTab::All;
-            match app.resolve_modal(KeyContext::Config, key) {
-              Some(ModalAction::ConfigClose) => app.view = View::List,
-              Some(ModalAction::ConfigNextTab) => app.config_panel.next_tab(),
-              Some(ModalAction::ConfigPrevTab) => app.config_panel.prev_tab(),
-              Some(ModalAction::ConfigToggleLayer) => app.config_panel.toggle_layer(),
-              // On the Keys tab `activate` arms a live keystroke capture for the
-              // selected binding (issue #294); elsewhere it cycles a choice or
-              // opens the numeric/text edit buffer.
-              Some(ModalAction::ConfigActivate) => {
-                if app.config_panel.tab == SettingsTab::Keys {
-                  app.config_panel.begin_capture();
-                } else {
-                  app.activate_selected_setting();
-                }
-              }
-              Some(ModalAction::ConfigSelectNext) => {
-                if on_all {
-                  app.config_panel.scroll_down();
-                } else {
-                  app.config_panel.select_next();
-                }
-              }
-              Some(ModalAction::ConfigSelectPrev) => {
-                if on_all {
-                  app.config_panel.scroll_up();
-                } else {
-                  app.config_panel.select_prev();
-                }
-              }
-              Some(ModalAction::ConfigScrollRight) if on_all => app.config_panel.scroll_right(),
-              Some(ModalAction::ConfigScrollLeft) if on_all => app.config_panel.scroll_left(),
-              Some(ModalAction::ConfigScrollTop) if on_all => app.config_panel.scroll_to_top(),
-              Some(ModalAction::ConfigScrollBottom) if on_all => app.config_panel.scroll_to_bottom(),
-              _ => {}
-            }
-          }
+        if app.handle_config_nav_key(key) {
+          app.view = View::List;
         }
       }
       // Create-overlay keys live in a testable `App` method (issue #217);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -524,7 +524,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       },
       // Full-size Working Tree listing (issue #592). A read-only overlay
       // over an already-taken snapshot: it scrolls like the command logs,
-      // and the bound global `working_tree` key (default `5`) toggles it
+      // and the bound global `working_tree` key (default `W`) toggles it
       // shut even when rebound.
       // Routing lives in a testable `App` method (the #217 shape), because
       // the precedence it encodes is the whole point of #613.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 pub use app::{
   agent_pane_status, mux_pane_status, plan_agent_pane, read_pins_from_sources, AgentPanePlan, App, ConfirmKind,
   CreateKey, ExecPickerKey, LauncherPlan, LinkPromptKey, LinkPromptStage, LinkTarget, NoteKey, OpenTarget,
-  PendingMerge, RepoMeta, View, WorkspaceState,
+  PendingMerge, RepoMeta, ToggleStroke, View, WorkspaceState,
 };
 pub use state::async_task::{
   CreateWorktreeResult, DeleteBatchOutcome, DeleteFailure, DeleteTarget, TaskKind, TaskMsg, TaskRunner,
@@ -514,32 +514,33 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // so the open key toggles it shut even when rebound.
       // #219: keys resolved through the `command_logs` modal context. The
       // bound global `command_logs` key still toggles the overlay shut.
-      View::CommandLogs => match app.resolve_modal(KeyContext::CommandLogs, key) {
-        Some(ModalAction::CommandLogsClose) => app.view = View::List,
-        // `y` copies the whole transcript to the clipboard (issue #279).
-        Some(ModalAction::CommandLogsCopy) => copy_command_logs_to_clipboard(&mut app),
-        Some(ModalAction::CommandLogsScrollDown) => app.command_logs.scroll_down(),
-        Some(ModalAction::CommandLogsScrollUp) => app.command_logs.scroll_up(),
-        Some(ModalAction::CommandLogsScrollRight) => app.command_logs.scroll_right(),
-        Some(ModalAction::CommandLogsScrollLeft) => app.command_logs.scroll_left(),
-        Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
-        Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
-        _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
-        _ => {}
+      View::CommandLogs => match app.modal_toggle_stroke(key, Action::CommandLogs) {
+        ToggleStroke::Fired => app.view = View::List,
+        ToggleStroke::Pending => {}
+        ToggleStroke::Unclaimed => match app.resolve_modal(KeyContext::CommandLogs, key) {
+          Some(ModalAction::CommandLogsClose) => app.view = View::List,
+          // `y` copies the whole transcript to the clipboard (issue #279).
+          Some(ModalAction::CommandLogsCopy) => copy_command_logs_to_clipboard(&mut app),
+          Some(ModalAction::CommandLogsScrollDown) => app.command_logs.scroll_down(),
+          Some(ModalAction::CommandLogsScrollUp) => app.command_logs.scroll_up(),
+          Some(ModalAction::CommandLogsScrollRight) => app.command_logs.scroll_right(),
+          Some(ModalAction::CommandLogsScrollLeft) => app.command_logs.scroll_left(),
+          Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
+          Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
+          _ => {}
+        },
       },
       // Full-size Working Tree listing (issue #592). A read-only overlay
       // over an already-taken snapshot: it scrolls like the command logs,
       // and the bound global `working_tree` key (default `5`) toggles it
       // shut even when rebound.
-      View::WorkingTree => match app.resolve_modal(KeyContext::WorkingTree, key) {
-        Some(ModalAction::WorkingTreeClose) => app.view = View::List,
-        Some(ModalAction::WorkingTreeScrollDown) => app.working_tree.scroll_down(),
-        Some(ModalAction::WorkingTreeScrollUp) => app.working_tree.scroll_up(),
-        Some(ModalAction::WorkingTreeScrollTop) => app.working_tree.scroll_to_top(),
-        Some(ModalAction::WorkingTreeScrollBottom) => app.working_tree.scroll_to_bottom(),
-        _ if app.key_matches_action(key, Action::WorkingTree) => app.view = View::List,
-        _ => {}
-      },
+      // Routing lives in a testable `App` method (the #217 shape), because
+      // the precedence it encodes is the whole point of #613.
+      View::WorkingTree => {
+        if app.handle_working_tree_key(key) {
+          app.view = View::List;
+        }
+      }
       // Settings panel (issue #232; editable in #279). While a numeric input
       // is armed, keystrokes route to the edit buffer and only Enter / Esc
       // escape — so `q` / `j` / Tab while typing a countdown never quit or
@@ -571,42 +572,51 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
       // tab exactly as before; the bound global `config_panel` key still
       // toggles the overlay shut.
       View::Config => {
-        let on_all = app.config_panel.tab == SettingsTab::All;
-        match app.resolve_modal(KeyContext::Config, key) {
-          Some(ModalAction::ConfigClose) => app.view = View::List,
-          Some(ModalAction::ConfigNextTab) => app.config_panel.next_tab(),
-          Some(ModalAction::ConfigPrevTab) => app.config_panel.prev_tab(),
-          Some(ModalAction::ConfigToggleLayer) => app.config_panel.toggle_layer(),
-          // On the Keys tab `activate` arms a live keystroke capture for the
-          // selected binding (issue #294); elsewhere it cycles a choice or
-          // opens the numeric/text edit buffer.
-          Some(ModalAction::ConfigActivate) => {
-            if app.config_panel.tab == SettingsTab::Keys {
-              app.config_panel.begin_capture();
-            } else {
-              app.activate_selected_setting();
+        // The toggle resolves BEFORE the nav verbs (issue #613), and only on
+        // this arm: the capture and edit sub-modes above own every stroke
+        // while they are live, so a `config_panel` key rebound to a digit
+        // must still type into a numeric field.
+        match app.modal_toggle_stroke(key, Action::ConfigPanel) {
+          ToggleStroke::Fired => app.view = View::List,
+          ToggleStroke::Pending => {}
+          ToggleStroke::Unclaimed => {
+            let on_all = app.config_panel.tab == SettingsTab::All;
+            match app.resolve_modal(KeyContext::Config, key) {
+              Some(ModalAction::ConfigClose) => app.view = View::List,
+              Some(ModalAction::ConfigNextTab) => app.config_panel.next_tab(),
+              Some(ModalAction::ConfigPrevTab) => app.config_panel.prev_tab(),
+              Some(ModalAction::ConfigToggleLayer) => app.config_panel.toggle_layer(),
+              // On the Keys tab `activate` arms a live keystroke capture for the
+              // selected binding (issue #294); elsewhere it cycles a choice or
+              // opens the numeric/text edit buffer.
+              Some(ModalAction::ConfigActivate) => {
+                if app.config_panel.tab == SettingsTab::Keys {
+                  app.config_panel.begin_capture();
+                } else {
+                  app.activate_selected_setting();
+                }
+              }
+              Some(ModalAction::ConfigSelectNext) => {
+                if on_all {
+                  app.config_panel.scroll_down();
+                } else {
+                  app.config_panel.select_next();
+                }
+              }
+              Some(ModalAction::ConfigSelectPrev) => {
+                if on_all {
+                  app.config_panel.scroll_up();
+                } else {
+                  app.config_panel.select_prev();
+                }
+              }
+              Some(ModalAction::ConfigScrollRight) if on_all => app.config_panel.scroll_right(),
+              Some(ModalAction::ConfigScrollLeft) if on_all => app.config_panel.scroll_left(),
+              Some(ModalAction::ConfigScrollTop) if on_all => app.config_panel.scroll_to_top(),
+              Some(ModalAction::ConfigScrollBottom) if on_all => app.config_panel.scroll_to_bottom(),
+              _ => {}
             }
           }
-          Some(ModalAction::ConfigSelectNext) => {
-            if on_all {
-              app.config_panel.scroll_down();
-            } else {
-              app.config_panel.select_next();
-            }
-          }
-          Some(ModalAction::ConfigSelectPrev) => {
-            if on_all {
-              app.config_panel.scroll_up();
-            } else {
-              app.config_panel.select_prev();
-            }
-          }
-          Some(ModalAction::ConfigScrollRight) if on_all => app.config_panel.scroll_right(),
-          Some(ModalAction::ConfigScrollLeft) if on_all => app.config_panel.scroll_left(),
-          Some(ModalAction::ConfigScrollTop) if on_all => app.config_panel.scroll_to_top(),
-          Some(ModalAction::ConfigScrollBottom) if on_all => app.config_panel.scroll_to_bottom(),
-          _ if app.key_matches_action(key, Action::ConfigPanel) => app.view = View::List,
-          _ => {}
         }
       }
       // Create-overlay keys live in a testable `App` method (issue #217);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -49,6 +49,7 @@ pub use state::link_prompt::LinkPrompt;
 pub use state::note_editor::NoteEditor;
 pub use state::pty_overlay::{key_to_bytes, PtyKind, PtyOverlay};
 pub use state::sidebar::SidebarState;
+pub use state::working_tree::WorkingTreeModal;
 
 /// Ordered list of clipboard tools to try for the host OS (issue #73).
 /// First entry that resolves on `$PATH` wins. Returned in the
@@ -524,6 +525,19 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
         Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
         _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
+        _ => {}
+      },
+      // Full-size Working Tree listing (issue #592). A read-only overlay
+      // over an already-taken snapshot: it scrolls like the command logs,
+      // and the bound global `working_tree` key (default `5`) toggles it
+      // shut even when rebound.
+      View::WorkingTree => match app.resolve_modal(KeyContext::WorkingTree, key) {
+        Some(ModalAction::WorkingTreeClose) => app.view = View::List,
+        Some(ModalAction::WorkingTreeScrollDown) => app.working_tree.scroll_down(),
+        Some(ModalAction::WorkingTreeScrollUp) => app.working_tree.scroll_up(),
+        Some(ModalAction::WorkingTreeScrollTop) => app.working_tree.scroll_to_top(),
+        Some(ModalAction::WorkingTreeScrollBottom) => app.working_tree.scroll_to_bottom(),
+        _ if app.key_matches_action(key, Action::WorkingTree) => app.view = View::List,
         _ => {}
       },
       // Settings panel (issue #232; editable in #279). While a numeric input
@@ -1165,6 +1179,9 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     // overlay it is read-only and not picker-gated — harmless inside
     // `gwm switch`, opening from any List state.
     Action::ConfigPanel => app.enter_config_panel(),
+    // Issue #592: `5` opens the Working Tree listing at full size. Read-only
+    // like the two overlays above, so it is not picker-gated either.
+    Action::WorkingTree => app.enter_working_tree(),
     // Issue #325: `x` opens the exec profile picker. Picker-gated —
     // running a profile in a PTY is a focus-mode action, meaningless in
     // the stripped-down `gwm switch` picker.

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -89,6 +89,10 @@ pub enum KeyContext {
   Detail,
   /// Command-logs overlay (issue #226, scroll-only + copy).
   CommandLogs,
+  /// Full-size Working Tree listing (issue #592, scroll-only). Its own
+  /// context rather than a share of [`Self::CommandLogs`]: the two look
+  /// alike but rebinding one must not silently rebind the other.
+  WorkingTree,
   /// Settings panel navigation (issue #232).
   Config,
   /// Settings panel while a numeric field is being edited (sub-mode of
@@ -170,6 +174,7 @@ impl KeyContext {
       KeyContext::Help => "help",
       KeyContext::Detail => "detail",
       KeyContext::CommandLogs => "command_logs",
+      KeyContext::WorkingTree => "working_tree",
       KeyContext::Config => "config",
       KeyContext::ConfigEdit => "config.edit",
       KeyContext::Report => "report",
@@ -200,6 +205,7 @@ impl KeyContext {
       Help,
       Detail,
       CommandLogs,
+      WorkingTree,
       Config,
       ConfigEdit,
       Report,
@@ -312,6 +318,13 @@ define_modal_actions! {
     CommandLogsScrollLeft   => "scroll_left"   [ "Left", "h" ],
     CommandLogsScrollTop    => "scroll_top"    [ "Home", "g" ],
     CommandLogsScrollBottom => "scroll_bottom" [ "End", "G" ],
+  }
+  WorkingTree {
+    WorkingTreeClose        => "close"         [ "Esc", "q" ],
+    WorkingTreeScrollDown   => "scroll_down"   [ "Down", "j" ],
+    WorkingTreeScrollUp     => "scroll_up"     [ "Up", "k" ],
+    WorkingTreeScrollTop    => "scroll_top"    [ "Home", "g" ],
+    WorkingTreeScrollBottom => "scroll_bottom" [ "End", "G" ],
   }
   Config {
     ConfigClose        => "close"         [ "Esc", "q" ],

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -262,6 +262,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "show the resolved configuration panel",
     },
     PaletteEntry {
+      action: Action::WorkingTree,
+      name: "working-tree",
+      description: "show the working tree listing at full size",
+    },
+    PaletteEntry {
       action: Action::ExecOverlay,
       name: "exec",
       description: "pick an [exec.profiles] profile and run it in a PTY",

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -38,8 +38,9 @@ use crate::bootstrap::BootstrapReport;
 use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
 use crate::tui::state::sidebar::SidebarMode;
-use crate::tui::ui::SidebarSections;
+use crate::tui::ui::{SidebarSections, WorkingTreeCounts};
 use crate::worktree::WorktreeInfo;
+use ratatui::text::Line;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -126,6 +127,15 @@ pub enum TaskKind {
   /// per row; the render key-check discards a result for a since-moved
   /// selection and the next tick requests the settled one.
   Sidebar,
+  /// Off-thread snapshot for the full-size Working Tree overlay (issues
+  /// #592, #613). The same `git status --porcelain -z` the sidebar pane
+  /// runs, but requested by a keypress rather than by navigation, and it
+  /// cannot run inline: `STATUS_SCAN_CAP` bounds how many records are read,
+  /// not how long git takes to produce the first one, so an untracked tree
+  /// on a cold or network filesystem would freeze the event loop for as
+  /// long as the walk takes. A single global slot; a second `5` while one
+  /// is in flight coalesces onto it.
+  WorkingTree,
   /// Off-thread agent-session detection (issue #408): the four artefact
   /// scans under the user's home (`agent_sessions::detect_all`) touch the
   /// filesystem and must never run inside `terminal.draw()`. A single global
@@ -162,6 +172,7 @@ impl TaskKind {
       TaskKind::EditWorktree => "renaming worktree…",
       TaskKind::RefreshWorkspace => "refreshing worktrees…",
       TaskKind::Sidebar => "loading preview…",
+      TaskKind::WorkingTree => "reading the working tree…",
       TaskKind::AgentSessions => "detecting agent sessions…",
       TaskKind::AgentPane => "opening agent pane…",
     }
@@ -392,6 +403,11 @@ pub enum TaskMsg {
   /// `SidebarState::cache`; a result whose selection has since moved is dropped
   /// by [`TaskRunner::complete`] (generation) and ignored by the render (key).
   Sidebar(u64, PathBuf, SidebarMode, SidebarSections),
+  /// Working Tree overlay snapshot (issues #592, #613): the generation, the
+  /// worktree `path` it was read for, the file-explorer rows and their
+  /// per-category counts. The drain hands it to `WorkingTreeModal::load`;
+  /// a result for a path the user has since navigated away from is dropped.
+  WorkingTree(u64, PathBuf, Vec<Line<'static>>, WorkingTreeCounts),
   /// An agent-session detection result (issue #408): the worker's generation
   /// and the per-worktree-path summary. The drain replaces the app snapshot
   /// atomically; a superseded late result is dropped by

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -134,7 +134,7 @@ pub enum TaskKind {
   /// cannot run inline: `STATUS_SCAN_CAP` bounds how many records are read,
   /// not how long git takes to produce the first one, so an untracked tree
   /// on a cold or network filesystem would freeze the event loop for as
-  /// long as the walk takes. A single global slot; a second `5` while one
+  /// long as the walk takes. A single global slot; a second `W` while one
   /// is in flight coalesces onto it.
   WorkingTree,
   /// Off-thread snapshot for the full-size commit listing (issue #593).

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -32,3 +32,4 @@ pub mod pty_overlay;
 pub mod rich_view;
 pub mod sidebar;
 pub mod spinner;
+pub mod working_tree;

--- a/src/tui/state/working_tree.rs
+++ b/src/tui/state/working_tree.rs
@@ -1,0 +1,76 @@
+//! Full-size Working Tree overlay state (issue #592).
+//!
+//! The sidebar's Working Tree pane is a fraction of the screen shared with
+//! four other blocks, so a worktree with more than a handful of changed
+//! files can only be read two rows at a time through `J` / `K`. This is the
+//! same listing given the whole terminal.
+//!
+//! The rows are an owned snapshot taken when the overlay opens
+//! ([`crate::tui::App::enter_working_tree`]) rather than a read of
+//! `SidebarState::cache`: that cache is keyed by `(path, mode)` and is only
+//! rebuilt while the sidebar is *open* and in `Commits` mode, so reading it
+//! would leave the overlay blank in exactly the two states — sidebar hidden,
+//! or `Stashes` selected — where seeing the change set is most useful.
+//!
+//! Scroll follows the help / command-logs contract: the cursor lives here,
+//! but `max_scroll` is republished by the renderer each frame against the
+//! real viewport, since only the renderer knows both the row count and the
+//! inner modal height.
+
+use super::super::ui::WorkingTreeCounts;
+use ratatui::text::Line;
+
+/// Owned state for the full-size Working Tree overlay: the snapshotted
+/// file-explorer rows, their per-category counts, and the scroll cursor
+/// with its renderer-published bound.
+#[derive(Debug, Default)]
+pub struct WorkingTreeModal {
+  /// The tree rows, exactly as the sidebar pane paints them (nerd-font
+  /// icons, connector prefixes, per-category colour) — or the `✓ clean`
+  /// row, or a load error.
+  pub lines: Vec<Line<'static>>,
+  /// Created / modified / deleted counts for the footer (issue #287),
+  /// captured with the same `git status` read as [`Self::lines`].
+  pub counts: WorkingTreeCounts,
+  /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
+  pub scroll: u16,
+  /// Maximum vertical scroll offset, republished by the renderer each
+  /// frame as `content_rows.saturating_sub(viewport_rows)`.
+  pub max_scroll: u16,
+}
+
+impl WorkingTreeModal {
+  /// An empty overlay at the origin.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Replace the listing and rewind to the top. Called on every open so a
+  /// previously-scrolled visit starts fresh and the rows track a change set
+  /// that moved while the overlay was closed.
+  pub fn load(&mut self, lines: Vec<Line<'static>>, counts: WorkingTreeCounts) {
+    self.lines = lines;
+    self.counts = counts;
+    self.scroll = 0;
+  }
+
+  /// Scroll down one row, never past the last line.
+  pub fn scroll_down(&mut self) {
+    self.scroll = (self.scroll + 1).min(self.max_scroll);
+  }
+
+  /// Scroll up one row, never above the top.
+  pub fn scroll_up(&mut self) {
+    self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Jump to the first row (`g`).
+  pub fn scroll_to_top(&mut self) {
+    self.scroll = 0;
+  }
+
+  /// Jump to the last row (`G`).
+  pub fn scroll_to_bottom(&mut self) {
+    self.scroll = self.max_scroll;
+  }
+}

--- a/src/tui/state/working_tree.rs
+++ b/src/tui/state/working_tree.rs
@@ -5,12 +5,19 @@
 //! files can only be read two rows at a time through `J` / `K`. This is the
 //! same listing given the whole terminal.
 //!
-//! The rows are an owned snapshot taken when the overlay opens
+//! The rows are an owned snapshot requested when the overlay opens
 //! ([`crate::tui::App::enter_working_tree`]) rather than a read of
 //! `SidebarState::cache`: that cache is keyed by `(path, mode)` and is only
 //! rebuilt while the sidebar is *open* and in `Commits` mode, so reading it
 //! would leave the overlay blank in exactly the two states — sidebar hidden,
 //! or `Stashes` selected — where seeing the change set is most useful.
+//!
+//! The read itself runs on a worker (`TaskKind::WorkingTree`), not inline on
+//! the keypress. `STATUS_SCAN_CAP` bounds how many records `git status`
+//! yields, not how long git takes to reach the first one, so on a cold or
+//! network filesystem an inline call would freeze the event loop for the
+//! length of the walk. The overlay opens on `loading` and fills in when the
+//! worker lands (Copilot review, PR #612).
 //!
 //! Scroll follows the help / command-logs contract: the cursor lives here,
 //! but `max_scroll` is republished by the renderer each frame against the
@@ -19,6 +26,7 @@
 
 use super::super::ui::WorkingTreeCounts;
 use ratatui::text::Line;
+use std::path::{Path, PathBuf};
 
 /// Owned state for the full-size Working Tree overlay: the snapshotted
 /// file-explorer rows, their per-category counts, and the scroll cursor
@@ -37,6 +45,12 @@ pub struct WorkingTreeModal {
   /// Maximum vertical scroll offset, republished by the renderer each
   /// frame as `content_rows.saturating_sub(viewport_rows)`.
   pub max_scroll: u16,
+  /// `true` between the open and the worker's payload. The renderer paints
+  /// a loader rather than an empty canvas, which would read as "no changes".
+  pub loading: bool,
+  /// The worktree [`Self::lines`] describe, so a payload for a selection the
+  /// user has navigated away from can be dropped instead of shown.
+  pub path: Option<PathBuf>,
 }
 
 impl WorkingTreeModal {
@@ -45,13 +59,26 @@ impl WorkingTreeModal {
     Self::default()
   }
 
-  /// Replace the listing and rewind to the top. Called on every open so a
-  /// previously-scrolled visit starts fresh and the rows track a change set
-  /// that moved while the overlay was closed.
+  /// Arm the overlay for `path`: drop the previous listing, rewind the
+  /// scroll, and show the loader until [`Self::load`] lands. Called on every
+  /// open, so a previously-scrolled visit starts fresh and a stale change
+  /// set is never mistaken for the current one.
+  pub fn begin(&mut self, path: Option<&Path>) {
+    self.lines.clear();
+    self.counts = WorkingTreeCounts::default();
+    self.scroll = 0;
+    self.max_scroll = 0;
+    self.path = path.map(Path::to_path_buf);
+    // With nothing selected there is nothing to wait for.
+    self.loading = path.is_some();
+  }
+
+  /// Install the worker's payload and clear the loader.
   pub fn load(&mut self, lines: Vec<Line<'static>>, counts: WorkingTreeCounts) {
     self.lines = lines;
     self.counts = counts;
     self.scroll = 0;
+    self.loading = false;
   }
 
   /// Scroll down one row, never past the last line.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3214,6 +3214,9 @@ impl HintContext {
         // ahead of the verbs that are reached less often.
         Hint::Key(Commits, "commits"),
         Hint::Key(CiChecks, "ci checks"),
+        // #592: the change set at full size belongs to the same register,
+        // and `W` means it in either pane.
+        Hint::Key(WorkingTree, "tree"),
         Hint::Key(ExecOverlay, "exec"),
         Hint::Key(AgentSessions, "agents"),
         // #515: the note is written far more often than a review is
@@ -3235,6 +3238,9 @@ impl HintContext {
         // Read the status pane.
         Hint::Key(Down, "scroll"),
         Hint::Key(WtScrollDown, "wt scroll"),
+        // #592: this pane holds the Working Tree block, so the key that opens
+        // it full size sits with the pair that scrolls it in place.
+        Hint::Key(WorkingTree, "tree"),
         Hint::Key(FetchGithub, "fetch"),
         // #593: `c` / `C` mean the same thing in both panes — this one's
         // own content at full size, and the linked PR's checks.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4451,13 +4451,6 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   );
 }
 
-/// Render the Command Logs overlay (issue #226): a ~90% fullscreen modal
-/// over the dimmed list showing the lazygit-style transcript of the
-/// external commands gwm ran, newest-first. Scrolls like the help overlay —
-/// the renderer republishes `command_logs.max_scroll` / `max_x_scroll`
-/// against the live viewport so `App`'s scroll cursor can never run past
-/// the content. Colours track `[theme]` roles (`clean` ok / `prunable`
-/// fail / `muted` output) so a theme override applies here too.
 /// Full-size Working Tree listing (issue #592) — the sidebar pane's tree
 /// given the whole modal area.
 ///
@@ -4482,6 +4475,24 @@ fn draw_working_tree(f: &mut Frame, app: &mut App) {
   f.render_widget(block, area);
 
   let [body_area, footer_area] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+  // While the worker is out, a muted loader rather than an empty canvas:
+  // blank reads as "nothing changed", which is the one answer this overlay
+  // must not give by accident (Copilot review, PR #612). Same word the
+  // sidebar's cold cache uses.
+  if app.working_tree.loading {
+    f.render_widget(
+      Paragraph::new(Line::from(Span::styled(
+        " loading…".to_string(),
+        Style::default().fg(theme.muted),
+      ))),
+      body_area,
+    );
+    let footer_owned = working_tree_footer_hints(&app.modal_keymap);
+    let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+    f.render_widget(modal_hint_line(&footer_hints, &theme), footer_area);
+    return;
+  }
 
   // Publish the scroll bound against the BODY viewport only, then clamp the
   // cursor the key handler moved (the help / command-logs contract).
@@ -4511,6 +4522,13 @@ fn draw_working_tree(f: &mut Frame, app: &mut App) {
   f.render_widget(modal_hint_line(&footer_hints, &theme), footer_area);
 }
 
+/// Render the Command Logs overlay (issue #226): a ~90% fullscreen modal
+/// over the dimmed list showing the lazygit-style transcript of the
+/// external commands gwm ran, newest-first. Scrolls like the help overlay —
+/// the renderer republishes `command_logs.max_scroll` / `max_x_scroll`
+/// against the live viewport so `App`'s scroll cursor can never run past
+/// the content. Colours track `[theme]` roles (`clean` ok / `prunable`
+/// fail / `muted` output) so a theme override applies here too.
 fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let area = centered(90, 85, f.area());
   let accent = app.theme.accent;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -171,6 +171,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::LinkPrompt => draw_link_prompt(f, app),
     View::CommandPalette => draw_command_palette(f, app),
     View::CommandLogs => draw_command_logs(f, app),
+    View::WorkingTree => draw_working_tree(f, app),
     View::Config => draw_config_panel(f, app),
     View::Pty => draw_pty_overlay(f, app),
     View::Note => draw_note_editor(f, app),
@@ -1921,7 +1922,14 @@ fn badges_line(w: &WorktreeInfo, theme: &Theme) -> Line<'static> {
   Line::from(spans)
 }
 
-fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, WorkingTreeCounts) {
+/// Build the Working Tree file-explorer rows for one worktree plus their
+/// per-category counts, from one `git status --porcelain -z` read.
+///
+/// `pub(super)` since #592: the full-size overlay snapshots the same rows
+/// the sidebar pane paints, and it is deliberately NOT routed through
+/// [`build_sidebar_sections`], which would also run `git log` / `git stash
+/// list` / the diff-vs-base stat for panes the overlay does not show.
+pub(super) fn working_tree_lines(w: &WorktreeInfo, theme: &Theme) -> (Vec<Line<'static>>, WorkingTreeCounts) {
   match worktree::git_status_short(&w.path) {
     Ok((s, _)) if s.trim().is_empty() => (
       vec![Line::from(Span::styled(
@@ -3385,6 +3393,21 @@ pub fn command_logs_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
   hints
 }
 
+/// Full-size Working Tree overlay footer hints (issue #592). Same shape as
+/// [`command_logs_footer_hints`] minus the copy verb: `close` resolves from
+/// `[tui.keys.modal.working_tree]` so a rebind shows through, the movement
+/// pairs stay literal.
+pub fn working_tree_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
+  let mut hints: Vec<(String, String)> = vec![
+    ("j/k".to_string(), "scroll".to_string()),
+    ("g/G".to_string(), "top/bottom".to_string()),
+  ];
+  if let Some(k) = modal.primary_key(ModalAction::WorkingTreeClose) {
+    hints.push((k, "close".to_string()));
+  }
+  hints
+}
+
 pub fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKeymap, theme: &Theme) -> Line<'static> {
   modal_hint_for_context_with_fields(ctx, keymap, modal, theme, &CANONICAL_TRIPLE)
 }
@@ -3894,6 +3917,7 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
   rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
   rows.push(entry(Action::ConfigPanel, "show the resolved configuration panel"));
+  rows.push(entry(Action::WorkingTree, "show the working tree listing at full size"));
   // #334 review: the exec / clean overlays are picker-gated (`run_action`
   // no-ops them in `gwm switch`), so only advertise them outside picker mode.
   if !picker_mode {
@@ -4202,6 +4226,14 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       ),
       modal_entry(ModalAction::CommandLogsClose, "close"),
       HelpRow::Blank,
+      HelpRow::Section("Working Tree".to_string()),
+      HelpRow::Blank,
+      modal_entry(ModalAction::WorkingTreeScrollDown, "scroll down"),
+      modal_entry(ModalAction::WorkingTreeScrollUp, "scroll up"),
+      modal_entry(ModalAction::WorkingTreeScrollTop, "jump to the top"),
+      modal_entry(ModalAction::WorkingTreeScrollBottom, "jump to the bottom"),
+      modal_entry(ModalAction::WorkingTreeClose, "close"),
+      HelpRow::Blank,
       HelpRow::Section("Settings".to_string()),
       HelpRow::Blank,
       modal_entry(ModalAction::ConfigNextTab, "next tab"),
@@ -4426,6 +4458,59 @@ fn draw_help(f: &mut Frame, app: &mut App) {
 /// against the live viewport so `App`'s scroll cursor can never run past
 /// the content. Colours track `[theme]` roles (`clean` ok / `prunable`
 /// fail / `muted` output) so a theme override applies here too.
+/// Full-size Working Tree listing (issue #592) — the sidebar pane's tree
+/// given the whole modal area.
+///
+/// Same shell as the Command Logs overlay: a fixed title on the top rule,
+/// a scrollable body with a scrollbar when it overflows, and a fixed footer
+/// hint line. The pane's change-count line (issue #287) rides the bottom
+/// rule right-aligned, exactly where the bordered sidebar pane puts it, so
+/// the two surfaces read as the same block at two sizes.
+///
+/// The rows are NOT rebuilt here — they are the snapshot
+/// [`App::enter_working_tree`] took, so this frame shells out to nothing
+/// (the #343 rule).
+fn draw_working_tree(f: &mut Frame, app: &mut App) {
+  let area = centered(90, 85, f.area());
+  let theme = app.theme;
+  let block = match working_tree_counts_footer(&app.working_tree.counts, &theme) {
+    Some(counts) => overlay_block_titled("Working Tree", theme.accent).title_bottom(counts.right_aligned()),
+    None => overlay_block_titled("Working Tree", theme.accent),
+  };
+  let inner = block.inner(area);
+  f.render_widget(Clear, area);
+  f.render_widget(block, area);
+
+  let [body_area, footer_area] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+  // Publish the scroll bound against the BODY viewport only, then clamp the
+  // cursor the key handler moved (the help / command-logs contract).
+  let rows = app.working_tree.lines.len();
+  app.working_tree.max_scroll = (rows.saturating_sub(body_area.height as usize)) as u16;
+  app.working_tree.scroll = app.working_tree.scroll.min(app.working_tree.max_scroll);
+  let scroll = app.working_tree.scroll;
+
+  let text_area = scrollable_body_area(f, body_area, scroll, rows, &theme);
+  // One leading space per row, as the sidebar pane pads its own body, so the
+  // tree does not touch the left border. Spans borrow from the snapshot.
+  let padded: Vec<Line<'_>> = app
+    .working_tree
+    .lines
+    .iter()
+    .map(|l| {
+      let mut spans = Vec::with_capacity(l.spans.len() + 1);
+      spans.push(Span::raw(" "));
+      spans.extend(l.spans.iter().map(|s| Span::styled(s.content.as_ref(), s.style)));
+      Line::from(spans)
+    })
+    .collect();
+  f.render_widget(Paragraph::new(padded).scroll((scroll, 0)), text_area);
+
+  let footer_owned = working_tree_footer_hints(&app.modal_keymap);
+  let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+  f.render_widget(modal_hint_line(&footer_hints, &theme), footer_area);
+}
+
 fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let area = centered(90, 85, f.area());
   let accent = app.theme.accent;

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -377,13 +377,13 @@ fn the_working_tree_overlay_binds_its_own_scroll_and_exit() {
   // The copy verb belongs to the command logs, not here.
   assert_eq!(km.resolve(KeyContext::WorkingTree, &ch('y')), None);
   // The open key closes the overlay too. Since #613 the toggle resolves
-  // BEFORE the modal verbs, so a verb bound to `5` no longer shadows the
+  // BEFORE the modal verbs, so a verb bound to `W` no longer shadows the
   // close: it is the verb that becomes unreachable. Still worth pinning
-  // that the default context leaves `5` alone, because a context claiming
+  // that the default context leaves `W` alone, because a context claiming
   // its own overlay's opener would silently cost the user that verb.
   assert_eq!(
-    km.resolve(KeyContext::WorkingTree, &ch('5')),
+    km.resolve(KeyContext::WorkingTree, &ch('W')),
     None,
-    "the context must leave `5` to the global keymap, which is what closes the overlay"
+    "the context must leave `W` to the global keymap, which is what closes the overlay"
   );
 }

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -376,10 +376,11 @@ fn the_working_tree_overlay_binds_its_own_scroll_and_exit() {
   );
   // The copy verb belongs to the command logs, not here.
   assert_eq!(km.resolve(KeyContext::WorkingTree, &ch('y')), None);
-  // The open key closes the overlay too, and the dispatch arm that does it
-  // sits AFTER the modal resolution: it is only reachable while the context
-  // leaves `5` unclaimed. Binding a verb to `5` here would shadow the arm
-  // with nothing going red, so the gap is the assertion.
+  // The open key closes the overlay too. Since #613 the toggle resolves
+  // BEFORE the modal verbs, so a verb bound to `5` no longer shadows the
+  // close: it is the verb that becomes unreachable. Still worth pinning
+  // that the default context leaves `5` alone, because a context claiming
+  // its own overlay's opener would silently cost the user that verb.
   assert_eq!(
     km.resolve(KeyContext::WorkingTree, &ch('5')),
     None,

--- a/tests/modal_keymap_tests.rs
+++ b/tests/modal_keymap_tests.rs
@@ -345,3 +345,44 @@ fn detail_context_binds_o_to_the_resume_pane_verb() {
     Some(ModalAction::DetailAttach)
   );
 }
+
+#[test]
+fn the_working_tree_overlay_binds_its_own_scroll_and_exit() {
+  // Issue #592: the full-size Working Tree listing is a scroll-only overlay,
+  // so it ships the same verb set as the other read-only modals — and under
+  // its own context, so rebinding `[tui.keys.modal.working_tree]` does not
+  // reach into `command_logs`.
+  let km = ModalKeymap::defaults();
+  assert_eq!(KeyContext::WorkingTree.config_path(), "working_tree");
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &stroke(KeyCode::Esc)),
+    Some(ModalAction::WorkingTreeClose)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &ch('q')),
+    Some(ModalAction::WorkingTreeClose)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &ch('j')),
+    Some(ModalAction::WorkingTreeScrollDown)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &ch('k')),
+    Some(ModalAction::WorkingTreeScrollUp)
+  );
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &ch('G')),
+    Some(ModalAction::WorkingTreeScrollBottom)
+  );
+  // The copy verb belongs to the command logs, not here.
+  assert_eq!(km.resolve(KeyContext::WorkingTree, &ch('y')), None);
+  // The open key closes the overlay too, and the dispatch arm that does it
+  // sits AFTER the modal resolution: it is only reachable while the context
+  // leaves `5` unclaimed. Binding a verb to `5` here would shadow the arm
+  // with nothing going red, so the gap is the assertion.
+  assert_eq!(
+    km.resolve(KeyContext::WorkingTree, &ch('5')),
+    None,
+    "the context must leave `5` to the global keymap, which is what closes the overlay"
+  );
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15137,3 +15137,107 @@ fn emptying_the_buffer_with_dd_removes_the_note_too() {
 
   assert!(!path.exists(), "an emptied note is removed, not blanked");
 }
+
+/// Flatten a rendered sidebar/modal line into its plain text.
+fn line_text(l: &ratatui::text::Line<'_>) -> String {
+  l.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+#[test]
+fn working_tree_modal_snapshots_the_dirty_tree_on_open() {
+  // Issue #592: `5` opens the Working Tree listing full size. The snapshot
+  // is taken AT OPEN, not read from the sidebar cache — the sidebar is a
+  // hidden pane here (`open = false`), the state in which that cache is
+  // never rebuilt, and the overlay must still show the change set.
+  let (dir, mut app) = make_app();
+  std::fs::write(dir.path().join("scratch.rs"), "fn main() {}\n").unwrap();
+  app.sidebar.open = false;
+
+  app.enter_working_tree();
+
+  assert_eq!(app.view, View::WorkingTree);
+  let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
+  assert!(
+    text.iter().any(|l| l.contains("scratch.rs")),
+    "the untracked file is listed — got {text:?}"
+  );
+  assert_eq!(app.working_tree.scroll, 0, "a fresh open starts at the top");
+  assert_eq!(
+    app.working_tree.counts.created, 1,
+    "the footer counts come with the snapshot — got {:?}",
+    app.working_tree.counts
+  );
+}
+
+#[test]
+fn the_working_tree_open_key_is_also_what_closes_it() {
+  // `5` toggles: the dispatch arm closing the overlay resolves the key
+  // through the global keymap, so a rebind of `working_tree` moves both the
+  // open and the close with it. Pinned here rather than through the run
+  // loop, which owns the dispatch.
+  let (_dir, mut app) = make_app();
+  app.enter_working_tree();
+
+  assert!(app.key_matches_action(
+    KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+    gwm::tui::keymap::Action::WorkingTree
+  ));
+}
+
+#[test]
+fn working_tree_modal_reports_a_clean_tree() {
+  // The empty-state: `init_repo` leaves no dirty file, so the overlay says
+  // so rather than rendering a blank canvas.
+  let (_dir, mut app) = make_app();
+
+  app.enter_working_tree();
+
+  let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
+  assert!(
+    text.iter().any(|l| l.contains("clean")),
+    "a clean worktree gets the clean row — got {text:?}"
+  );
+}
+
+#[test]
+fn reopening_the_working_tree_modal_rewinds_the_scroll_and_resnapshots() {
+  // Two invariants in one gesture: a stale scroll offset from the previous
+  // visit does not survive the re-open (the `enter_help` / `enter_command_logs`
+  // contract), and the listing is re-read, so a file created while the
+  // overlay was closed shows up on the next open.
+  let (dir, mut app) = make_app();
+  app.enter_working_tree();
+  app.working_tree.max_scroll = 40;
+  app.working_tree.scroll = 12;
+
+  std::fs::write(dir.path().join("late.rs"), "// added after the first open\n").unwrap();
+  app.enter_working_tree();
+
+  assert_eq!(app.working_tree.scroll, 0);
+  let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
+  assert!(
+    text.iter().any(|l| l.contains("late.rs")),
+    "the re-open re-reads the tree — got {text:?}"
+  );
+}
+
+#[test]
+fn the_working_tree_modal_scroll_clamps_to_the_published_bound() {
+  // Same scroll contract as the help overlay: the renderer publishes
+  // `max_scroll` against the live viewport and the cursor never passes it.
+  let (_dir, mut app) = make_app();
+  app.enter_working_tree();
+  app.working_tree.max_scroll = 2;
+
+  for _ in 0..5 {
+    app.working_tree.scroll_down();
+  }
+  assert_eq!(app.working_tree.scroll, 2);
+
+  app.working_tree.scroll_to_top();
+  assert_eq!(app.working_tree.scroll, 0);
+  app.working_tree.scroll_up();
+  assert_eq!(app.working_tree.scroll, 0, "the top is a floor, not a wrap");
+  app.working_tree.scroll_to_bottom();
+  assert_eq!(app.working_tree.scroll, 2);
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15139,6 +15139,21 @@ fn emptying_the_buffer_with_dd_removes_the_note_too() {
   assert!(!path.exists(), "an emptied note is removed, not blanked");
 }
 
+/// Drain until the Working Tree overlay's worker lands (issues #592, #613).
+/// The snapshot runs off-thread, so a test that reads the rows has to wait
+/// for the payload the same way the event loop does.
+fn settle_working_tree(app: &mut App) {
+  let deadline = Instant::now() + Duration::from_secs(10);
+  while app.is_working_tree_loading() && Instant::now() < deadline {
+    app.drain_task_results();
+    std::thread::sleep(Duration::from_millis(5));
+  }
+  assert!(
+    !app.is_working_tree_loading(),
+    "the working-tree worker never landed within 10s"
+  );
+}
+
 /// Rebind `action` to `chords` on a live `App`, the way a `[tui.keys]`
 /// override would. Used by the #613 toggle tests, which are exactly about
 /// what a rebind does to the dispatch.
@@ -15164,6 +15179,11 @@ fn working_tree_modal_snapshots_the_dirty_tree_on_open() {
   app.sidebar.open = false;
 
   app.enter_working_tree();
+  assert!(
+    app.is_working_tree_loading(),
+    "the overlay opens on a loader; the git read is on a worker, not the keypress"
+  );
+  settle_working_tree(&mut app);
 
   assert_eq!(app.view, View::WorkingTree);
   let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
@@ -15294,6 +15314,7 @@ fn a_rebound_toggle_beats_the_scroll_verb_it_shadows() {
   let (_dir, mut app) = make_app();
   rebind(&mut app, Action::WorkingTree, &["j"]);
   app.enter_working_tree();
+  settle_working_tree(&mut app);
   app.working_tree.max_scroll = 10;
 
   let close = app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
@@ -15308,6 +15329,7 @@ fn an_unclaimed_key_still_reaches_the_modal_verbs() {
   // swallow the rest of the context.
   let (_dir, mut app) = make_app();
   app.enter_working_tree();
+  settle_working_tree(&mut app);
   app.working_tree.max_scroll = 10;
 
   assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
@@ -15323,6 +15345,7 @@ fn a_chord_prefix_does_not_reach_the_scroll_verbs() {
   let (_dir, mut app) = make_app();
   rebind(&mut app, Action::WorkingTree, &["g w"]);
   app.enter_working_tree();
+  settle_working_tree(&mut app);
   app.working_tree.max_scroll = 10;
   app.working_tree.scroll = 7;
 
@@ -15451,12 +15474,91 @@ fn every_overlay_that_advertises_a_toggle_resolves_one() {
 }
 
 #[test]
+fn a_second_chord_bound_to_the_same_action_can_start_after_a_failed_one() {
+  // Copilot review, PR #612: one action may hold several chords. With two of
+  // them, a first stroke that is not followed by its own continuation must
+  // not just drop the buffer, it has to retry that stroke as the start of
+  // the other chord. `dispatch_key` does this for the list view; the toggle
+  // now does too.
+  //
+  // `6` / `7` because the keymap refuses a chord whose prefix is another
+  // action's key, so `j k` cannot be used here: `j` is `down`.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["6 w", "7 k"]);
+  app.enter_working_tree();
+  settle_working_tree(&mut app);
+  app.working_tree.max_scroll = 10;
+  app.working_tree.scroll = 5;
+
+  assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('6'), KeyModifiers::NONE)));
+  // `7` is not `6`'s continuation, but it IS the start of the second chord,
+  // so it must arm rather than fall through to the modal verbs.
+  assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('7'), KeyModifiers::NONE)));
+  assert!(app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)));
+  assert_eq!(
+    app.working_tree.scroll, 5,
+    "neither the retried stroke nor the continuation reached `scroll_up`"
+  );
+}
+
+#[test]
+fn a_working_tree_payload_for_a_worktree_left_behind_is_dropped() {
+  // The read is off-thread, so the user can navigate (or reopen elsewhere)
+  // while it runs. A payload that describes a worktree the overlay is no
+  // longer showing must not be painted as if it were the current one.
+  let (_dir, mut app) = make_app();
+  app.enter_working_tree();
+  settle_working_tree(&mut app);
+  let real = app.working_tree.lines.clone();
+
+  use gwm::tui::state::async_task::{TaskKind, TaskMsg};
+  let generation = app.tasks.request(TaskKind::WorkingTree).expect("a free slot");
+  app
+    .task_result_sender()
+    .send(TaskMsg::WorkingTree(
+      generation,
+      PathBuf::from("/tmp/gwm-test/some-other-worktree"),
+      vec![ratatui::text::Line::from("rows from the wrong worktree")],
+      Default::default(),
+    ))
+    .unwrap();
+  app.drain_task_results();
+
+  let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
+  assert!(
+    !text.iter().any(|l| l.contains("wrong worktree")),
+    "a payload for another path is dropped, not shown — got {text:?}"
+  );
+  assert_eq!(
+    app.working_tree.lines.len(),
+    real.len(),
+    "and the listing that was already there survives"
+  );
+}
+
+#[test]
+fn opening_the_overlay_with_nothing_selected_does_not_wait_on_a_worker() {
+  // The empty-selection path spawns nothing, so the loader would never
+  // clear: `begin` must leave `loading` false when there is no worktree.
+  let (_dir, mut app) = make_app();
+  app.worktrees.clear();
+  app.list_state.select(None);
+
+  app.enter_working_tree();
+
+  assert_eq!(app.view, View::WorkingTree);
+  assert!(!app.is_working_tree_loading(), "nothing to wait for, so no loader");
+  assert!(app.working_tree.lines.is_empty());
+}
+
+#[test]
 fn working_tree_modal_reports_a_clean_tree() {
   // The empty-state: `init_repo` leaves no dirty file, so the overlay says
   // so rather than rendering a blank canvas.
   let (_dir, mut app) = make_app();
 
   app.enter_working_tree();
+  settle_working_tree(&mut app);
 
   let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
   assert!(
@@ -15473,11 +15575,13 @@ fn reopening_the_working_tree_modal_rewinds_the_scroll_and_resnapshots() {
   // overlay was closed shows up on the next open.
   let (dir, mut app) = make_app();
   app.enter_working_tree();
+  settle_working_tree(&mut app);
   app.working_tree.max_scroll = 40;
   app.working_tree.scroll = 12;
 
   std::fs::write(dir.path().join("late.rs"), "// added after the first open\n").unwrap();
   app.enter_working_tree();
+  settle_working_tree(&mut app);
 
   assert_eq!(app.working_tree.scroll, 0);
   let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
@@ -15493,6 +15597,7 @@ fn the_working_tree_modal_scroll_clamps_to_the_published_bound() {
   // `max_scroll` against the live viewport and the cursor never passes it.
   let (_dir, mut app) = make_app();
   app.enter_working_tree();
+  settle_working_tree(&mut app);
   app.working_tree.max_scroll = 2;
 
   for _ in 0..5 {

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2,10 +2,11 @@ mod common;
 
 use common::init_repo;
 use gwm::naming::BRANCH_TYPES;
+use gwm::tui::keymap::Action;
 use gwm::tui::theme::Theme;
 use gwm::tui::{
   branch_name_color, filled_cells_for_progress, freshness_color, panel_border_color, pr_badge_color, App,
-  ConfirmKeyAction, CountdownTickOutcome, Field, NoteKey, View,
+  ConfirmKeyAction, CountdownTickOutcome, Field, NoteKey, ToggleStroke, View,
 };
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::style::Color;
@@ -15138,6 +15139,15 @@ fn emptying_the_buffer_with_dd_removes_the_note_too() {
   assert!(!path.exists(), "an emptied note is removed, not blanked");
 }
 
+/// Rebind `action` to `chords` on a live `App`, the way a `[tui.keys]`
+/// override would. Used by the #613 toggle tests, which are exactly about
+/// what a rebind does to the dispatch.
+fn rebind(app: &mut App, action: Action, chords: &[&str]) {
+  use gwm::tui::keymap::KeyStroke;
+  let parsed: Vec<Vec<KeyStroke>> = chords.iter().map(|c| KeyStroke::parse_chord(c).unwrap()).collect();
+  app.keymap.apply_override(action, parsed).unwrap();
+}
+
 /// Flatten a rendered sidebar/modal line into its plain text.
 fn line_text(l: &ratatui::text::Line<'_>) -> String {
   l.spans.iter().map(|s| s.content.as_ref()).collect()
@@ -15171,17 +15181,194 @@ fn working_tree_modal_snapshots_the_dirty_tree_on_open() {
 
 #[test]
 fn the_working_tree_open_key_is_also_what_closes_it() {
-  // `5` toggles: the dispatch arm closing the overlay resolves the key
-  // through the global keymap, so a rebind of `working_tree` moves both the
-  // open and the close with it. Pinned here rather than through the run
-  // loop, which owns the dispatch.
+  // `5` toggles. The dispatch resolves the toggle before the modal verbs
+  // and against the action alone, so this is the pin for the default: one
+  // stroke, `Fired`.
   let (_dir, mut app) = make_app();
   app.enter_working_tree();
 
-  assert!(app.key_matches_action(
-    KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
-    gwm::tui::keymap::Action::WorkingTree
-  ));
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+      gwm::tui::keymap::Action::WorkingTree
+    ),
+    ToggleStroke::Fired
+  );
+}
+
+#[test]
+fn a_multi_stroke_toggle_closes_the_overlay_it_opened() {
+  // Issue #613, first hole: the old guard asked `key_matches_action`, which
+  // looks up ONE stroke, so `working_tree = ["g w"]` opened the overlay
+  // through the chord-aware list dispatch and then had no way to shut it.
+  // The prefix must be consumed (`Pending`), not handed to the modal verbs,
+  // or `g` jumps the listing to the top on its way through.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["g w"]);
+  app.enter_working_tree();
+
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Pending
+  );
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Fired
+  );
+}
+
+#[test]
+fn a_stray_prefix_stroke_does_not_arm_a_phantom_toggle() {
+  // The other half of the chord contract: a `g` that is not followed by the
+  // toggle's own continuation must drop the buffer, or the next unrelated
+  // stroke would complete a chord the user never typed.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["g w"]);
+  app.enter_working_tree();
+
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Pending
+  );
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Unclaimed,
+    "`j` is not the continuation, so it falls through to the modal verbs"
+  );
+  assert!(app.pending_chord_is_empty(), "the half-typed prefix is dropped");
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Unclaimed,
+    "a bare `w` must not complete the chord the dropped `g` started"
+  );
+}
+
+#[test]
+fn a_toggle_rebound_onto_a_modal_verbs_key_still_closes() {
+  // Issue #613, second hole: the guard used to run AFTER the modal
+  // resolution, so `working_tree = ["j"]` opened the overlay and then
+  // scrolled it. The toggle wins now, which is what the user asked for by
+  // binding it there.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["j"]);
+  app.enter_working_tree();
+
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Fired
+  );
+  // `k` is untouched: only the rebound key is taken from the context.
+  assert_eq!(
+    app.modal_toggle_stroke(
+      KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+      Action::WorkingTree
+    ),
+    ToggleStroke::Unclaimed
+  );
+}
+
+#[test]
+fn a_rebound_toggle_beats_the_scroll_verb_it_shadows() {
+  // The precedence itself, not just the resolver: `handle_working_tree_key`
+  // asks the toggle first. With `working_tree = ["j"]`, `j` closes and the
+  // listing does NOT scroll. Put the modal resolution back in front and the
+  // scroll assertion below goes red.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["j"]);
+  app.enter_working_tree();
+  app.working_tree.max_scroll = 10;
+
+  let close = app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+
+  assert!(close, "the rebound toggle closes the overlay");
+  assert_eq!(app.working_tree.scroll, 0, "and the shadowed scroll verb never ran");
+}
+
+#[test]
+fn an_unclaimed_key_still_reaches_the_modal_verbs() {
+  // The other side of that precedence: taking the toggle first must not
+  // swallow the rest of the context.
+  let (_dir, mut app) = make_app();
+  app.enter_working_tree();
+  app.working_tree.max_scroll = 10;
+
+  assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
+  assert_eq!(app.working_tree.scroll, 1);
+  assert!(app.handle_working_tree_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+}
+
+#[test]
+fn a_chord_prefix_does_not_reach_the_scroll_verbs() {
+  // `working_tree = ["g w"]`: the `g` is consumed as a prefix. Were it
+  // handed to the modal verbs it would fire `scroll_top`, so the listing
+  // would jump to the top on the way to closing.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::WorkingTree, &["g w"]);
+  app.enter_working_tree();
+  app.working_tree.max_scroll = 10;
+  app.working_tree.scroll = 7;
+
+  assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)));
+  assert_eq!(app.working_tree.scroll, 7, "the prefix did not fire `scroll_top`");
+  assert!(app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE)));
+}
+
+#[test]
+fn the_modal_toggle_never_fires_another_global_action() {
+  // The reason this is not `dispatch_key`: inside an overlay the toggle is
+  // the ONE global binding allowed through. `d` would otherwise open the
+  // delete confirm from behind the modal.
+  let (_dir, mut app) = make_app();
+  app.enter_working_tree();
+
+  for c in ['d', 'n', 'q', 'x', '3', '4'] {
+    assert_eq!(
+      app.modal_toggle_stroke(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE), Action::WorkingTree),
+      ToggleStroke::Unclaimed,
+      "`{c}` is not the working_tree toggle and must not resolve here"
+    );
+  }
+}
+
+#[test]
+fn every_overlay_that_advertises_a_toggle_resolves_one() {
+  // The three overlays whose docs promise "the open key closes it too"
+  // (issue #613 fixed all of them at once, not just #592's). Enumerated so
+  // a fourth overlay copying the shape has a place to declare itself.
+  let (_dir, mut app) = make_app();
+  for (action, chord, ch) in [
+    (Action::CommandLogs, "3", '3'),
+    (Action::ConfigPanel, "4", '4'),
+    (Action::WorkingTree, "5", '5'),
+  ] {
+    assert_eq!(
+      app.keymap.primary_chord(action).as_deref(),
+      Some(chord),
+      "{action:?} default chord moved; update this table"
+    );
+    assert_eq!(
+      app.modal_toggle_stroke(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE), action),
+      ToggleStroke::Fired
+    );
+  }
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -6,7 +6,7 @@ use gwm::tui::keymap::Action;
 use gwm::tui::theme::Theme;
 use gwm::tui::{
   branch_name_color, filled_cells_for_progress, freshness_color, panel_border_color, pr_badge_color, App,
-  ConfirmKeyAction, CountdownTickOutcome, Field, NoteKey, ToggleStroke, View,
+  CommandLogsKey, ConfirmKeyAction, CountdownTickOutcome, Field, NoteKey, SettingsTab, ToggleStroke, View,
 };
 use gwm::worktree::{BranchStatus, WorktreeInfo};
 use ratatui::style::Color;
@@ -15346,6 +15346,85 @@ fn the_modal_toggle_never_fires_another_global_action() {
       "`{c}` is not the working_tree toggle and must not resolve here"
     );
   }
+}
+
+#[test]
+fn the_command_logs_toggle_beats_the_verb_it_shadows() {
+  // #613's precedence, pinned on the second of the three overlays rather
+  // than assumed from the first. `command_logs = ["j"]`: `j` closes, and
+  // the transcript does not scroll on the way out.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::CommandLogs, &["j"]);
+  app.enter_command_logs();
+  app.command_logs.max_scroll = 10;
+
+  assert_eq!(
+    app.handle_command_logs_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+    CommandLogsKey::Close
+  );
+  assert_eq!(app.command_logs.scroll, 0, "the shadowed scroll verb never ran");
+
+  // And the rest of the context is untouched.
+  rebind(&mut app, Action::CommandLogs, &["3"]);
+  assert_eq!(
+    app.handle_command_logs_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)),
+    CommandLogsKey::Handled
+  );
+  assert_eq!(app.command_logs.scroll, 1);
+  assert_eq!(
+    app.handle_command_logs_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE)),
+    CommandLogsKey::Copy,
+    "the clipboard side effect still comes back for the run loop to perform"
+  );
+}
+
+#[test]
+fn the_settings_toggle_beats_the_verb_it_shadows() {
+  // Third of the three. `config_panel = ["j"]`: `j` closes instead of
+  // moving the selection.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::ConfigPanel, &["j"]);
+  app.enter_config_panel();
+  // The read-only `All` tab routes select onto scroll, so pick an editable
+  // tab and watch the field cursor, which is what `j` moves there.
+  app.config_panel.tab = SettingsTab::Tui;
+  app.config_panel.selected = 0;
+
+  assert!(app.handle_config_nav_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
+  assert_eq!(app.config_panel.selected, 0, "the shadowed select verb never ran");
+
+  rebind(&mut app, Action::ConfigPanel, &["4"]);
+  assert!(!app.handle_config_nav_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)));
+  assert_eq!(app.config_panel.selected, 1, "and `j` navigates again once unbound");
+}
+
+#[test]
+fn a_multi_stroke_toggle_closes_every_overlay_that_has_one() {
+  // The chord half, across all three. Each takes the prefix without firing
+  // a verb, then closes on the continuation.
+  // Distinct chords per action: the keymap refuses one chord bound twice,
+  // which is itself the guarantee that makes a per-action lookup sound.
+  let (_dir, mut app) = make_app();
+  rebind(&mut app, Action::CommandLogs, &["g l"]);
+  rebind(&mut app, Action::ConfigPanel, &["g c"]);
+  rebind(&mut app, Action::WorkingTree, &["g w"]);
+  app.enter_command_logs();
+  assert_eq!(
+    app.handle_command_logs_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+    CommandLogsKey::Handled
+  );
+  assert_eq!(
+    app.handle_command_logs_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)),
+    CommandLogsKey::Close
+  );
+
+  app.enter_config_panel();
+  assert!(!app.handle_config_nav_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)));
+  assert!(app.handle_config_nav_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)));
+
+  app.enter_working_tree();
+  assert!(!app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)));
+  assert!(app.handle_working_tree_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE)));
 }
 
 #[test]

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15537,6 +15537,77 @@ fn a_working_tree_payload_for_a_worktree_left_behind_is_dropped() {
 }
 
 #[test]
+fn the_overlay_never_waits_on_a_worker_that_is_not_there() {
+  // The invariant behind three rounds of review on PR #612, each of which
+  // found a different unenumerated state of this slot: the loader is up if
+  // and only if a read is actually in flight. Every way in is walked here,
+  // rather than waiting for a fourth state to be reported.
+  //
+  // | selection | slot            | what must happen                     |
+  // |-----------|-----------------|--------------------------------------|
+  // | none      | free            | no worker, no loader                 |
+  // | some      | free            | worker spawned, loader up            |
+  // | some      | busy same path  | coalesce onto it, loader stays up    |
+  // | some      | busy other path | invalidate, own worker, loader up    |
+  //
+  // The two drop paths (stale generation, path mismatch) are covered by
+  // `a_working_tree_payload_for_a_worktree_left_behind_is_dropped` and by
+  // `TaskRunner::complete`'s own tests; neither can leave the loader up,
+  // because both only run once the slot has already been settled.
+  //
+  // A worker that dies without sending would break this after the fact
+  // (`let _ = tx.send(..)` swallows the failure and the slot stays claimed),
+  // but `working_tree_lines` is total: every arm of its `git_status_short`
+  // match returns rows, an `Err` included. No defensive machinery for a
+  // state that cannot be reached.
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  let a = app.selected().expect("a worktree is selected").path.clone();
+  let inflight = |app: &App| app.tasks.is_loading(TaskKind::WorkingTree);
+
+  // none / free
+  app.worktrees.clear();
+  app.list_state.select(None);
+  app.enter_working_tree();
+  assert!(!app.is_working_tree_loading(), "nothing selected, nothing to wait on");
+  assert_eq!(app.is_working_tree_loading(), inflight(&app));
+
+  // some / free
+  let (_dir2, mut app) = make_app();
+  app.enter_working_tree();
+  assert_eq!(
+    app.is_working_tree_loading(),
+    inflight(&app),
+    "the loader tracks the worker, both up"
+  );
+  settle_working_tree(&mut app);
+  assert_eq!(app.is_working_tree_loading(), inflight(&app), "and both down");
+
+  // some / busy, same path
+  app.working_tree.begin(Some(&a));
+  let _held = app.tasks.request(TaskKind::WorkingTree).expect("slot free");
+  app.enter_working_tree();
+  assert_eq!(
+    app.is_working_tree_loading(),
+    inflight(&app),
+    "coalesced onto the read already out"
+  );
+
+  // some / busy, other path
+  app.worktrees.push(worktree_fixture("elsewhere"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.enter_working_tree();
+  assert_eq!(
+    app.is_working_tree_loading(),
+    inflight(&app),
+    "the stale slot was invalidated and a fresh worker claimed it"
+  );
+  settle_working_tree(&mut app);
+  assert_eq!(app.is_working_tree_loading(), inflight(&app));
+}
+
+#[test]
 fn reopening_on_another_worktree_does_not_wait_on_the_previous_read() {
   // Copilot review, PR #612: the coalescing that makes a held `5` cheap is
   // only sound while the in-flight read is for the SAME worktree. Close a

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15325,7 +15325,7 @@ fn the_working_tree_column_is_dropped_before_the_file_name_is() {
 
 #[test]
 fn the_working_tree_open_key_is_also_what_closes_it() {
-  // `5` toggles. The dispatch resolves the toggle before the modal verbs
+  // `W` toggles. The dispatch resolves the toggle before the modal verbs
   // and against the action alone, so this is the pin for the default: one
   // stroke, `Fired`.
   let (_dir, mut app) = make_app();
@@ -15333,7 +15333,7 @@ fn the_working_tree_open_key_is_also_what_closes_it() {
 
   assert_eq!(
     app.modal_toggle_stroke(
-      KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+      KeyEvent::new(KeyCode::Char('W'), KeyModifiers::NONE),
       gwm::tui::keymap::Action::WorkingTree
     ),
     ToggleStroke::Fired
@@ -15583,7 +15583,7 @@ fn every_overlay_that_advertises_a_toggle_resolves_one() {
   for (action, chord, ch) in [
     (Action::CommandLogs, "3", '3'),
     (Action::ConfigPanel, "4", '4'),
-    (Action::WorkingTree, "5", '5'),
+    (Action::WorkingTree, "W", 'W'),
   ] {
     assert_eq!(
       app.keymap.primary_chord(action).as_deref(),
@@ -15735,7 +15735,7 @@ fn the_overlay_never_waits_on_a_worker_that_is_not_there() {
 
 #[test]
 fn reopening_on_another_worktree_does_not_wait_on_the_previous_read() {
-  // Copilot review, PR #612: the coalescing that makes a held `5` cheap is
+  // Copilot review, PR #612: the coalescing that makes a held `W` cheap is
   // only sound while the in-flight read is for the SAME worktree. Close a
   // slow snapshot for A, select B, reopen: `request` would hand back `None`
   // (slot busy with A), no worker would exist for B, and A's payload gets
@@ -15764,7 +15764,7 @@ fn reopening_on_another_worktree_does_not_wait_on_the_previous_read() {
 
 #[test]
 fn reopening_on_the_same_worktree_still_coalesces() {
-  // The other half: same path must NOT invalidate, or a held `5` spawns a
+  // The other half: same path must NOT invalidate, or a held `W` spawns a
   // `git status` per repeat.
   use gwm::tui::state::async_task::TaskKind;
 

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15537,6 +15537,70 @@ fn a_working_tree_payload_for_a_worktree_left_behind_is_dropped() {
 }
 
 #[test]
+fn reopening_on_another_worktree_does_not_wait_on_the_previous_read() {
+  // Copilot review, PR #612: the coalescing that makes a held `5` cheap is
+  // only sound while the in-flight read is for the SAME worktree. Close a
+  // slow snapshot for A, select B, reopen: `request` would hand back `None`
+  // (slot busy with A), no worker would exist for B, and A's payload gets
+  // dropped by the path check, so the loader stays up forever.
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  let a = app.selected().expect("a worktree is selected").path.clone();
+  // A read for A is out: the slot is claimed and the overlay is waiting.
+  app.working_tree.begin(Some(&a));
+  let _inflight = app.tasks.request(TaskKind::WorkingTree).expect("slot free");
+  assert!(app.is_working_tree_loading());
+
+  // The user moves to another worktree and reopens before A lands.
+  app.worktrees.push(worktree_fixture("some-other-worktree"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+  app.enter_working_tree();
+
+  settle_working_tree(&mut app);
+  assert_eq!(
+    app.working_tree.path.as_deref(),
+    Some(app.selected().unwrap().path.as_path()),
+    "the listing that landed is the one the overlay is showing"
+  );
+}
+
+#[test]
+fn reopening_on_the_same_worktree_still_coalesces() {
+  // The other half: same path must NOT invalidate, or a held `5` spawns a
+  // `git status` per repeat.
+  use gwm::tui::state::async_task::TaskKind;
+
+  let (_dir, mut app) = make_app();
+  let a = app.selected().expect("a worktree is selected").path.clone();
+  app.working_tree.begin(Some(&a));
+  let inflight = app.tasks.request(TaskKind::WorkingTree).expect("slot free");
+
+  app.enter_working_tree();
+
+  assert!(
+    app.tasks.request(TaskKind::WorkingTree).is_none(),
+    "the slot is still held by the first read, so the reopen coalesced"
+  );
+  // And the generation was not bumped, which is what `invalidate` would do.
+  app
+    .task_result_sender()
+    .send(gwm::tui::state::async_task::TaskMsg::WorkingTree(
+      inflight,
+      a.clone(),
+      vec![ratatui::text::Line::from("from the coalesced read")],
+      Default::default(),
+    ))
+    .unwrap();
+  app.drain_task_results();
+  let text: Vec<String> = app.working_tree.lines.iter().map(line_text).collect();
+  assert!(
+    text.iter().any(|l| l.contains("coalesced")),
+    "the original worker's payload is still the authoritative one — got {text:?}"
+  );
+}
+
+#[test]
 fn opening_the_overlay_with_nothing_selected_does_not_wait_on_a_worker() {
   // The empty-selection path spawns nothing, so the loader would never
   // clear: `begin` must leave `loading` false when there is no worktree.

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -545,6 +545,7 @@ fn help_overlay_documents_every_modal_action_in_its_section() {
       KeyContext::Help => "Help Overlay",
       KeyContext::Detail => "Agent Sessions",
       KeyContext::CommandLogs => "Command Logs",
+      KeyContext::WorkingTree => "Working Tree",
       KeyContext::Config | KeyContext::ConfigEdit => "Settings",
       KeyContext::Report => "Bootstrap Report",
       KeyContext::OpenMenu => "Browse Links",

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -368,6 +368,8 @@ fn worktrees_hints_are_grouped_lifecycle_then_act_then_navigate_then_global() {
       "git",
       "commits",
       "ci checks",
+      // #592: the same pane content at full size, in the same register.
+      "tree",
       "exec",
       "agents",
       "note",
@@ -399,7 +401,10 @@ fn status_hints_are_grouped_read_then_sidebar_then_navigate_then_global() {
     vec![
       "scroll",
       "wt scroll", // #437: Working Tree pane scroll
-      "fetch",     // read the status pane
+      // #592: this pane's own block at full size, next to the pair that
+      // scrolls it in place.
+      "tree",
+      "fetch", // read the status pane
       // #593: this pane's own content at full size, then the linked PR's
       // checks. The pair reads the same in the worktrees footer.
       "commits",

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -2600,6 +2600,25 @@ fn working_tree_modal_renders_its_title_body_and_footer() {
 }
 
 #[test]
+fn working_tree_modal_renders_a_loader_while_the_worker_is_out() {
+  // The read moved to a worker (Copilot review, PR #612), so there is a
+  // frame with no rows yet. It must say so: an empty canvas reads as "no
+  // changes", which is the one answer this overlay must not give by
+  // accident.
+  let (_dir, mut app) = make_app();
+  app
+    .working_tree
+    .begin(Some(std::path::Path::new("/tmp/gwm-test/pending")));
+  app.view = View::WorkingTree;
+
+  let buf = render(&mut app);
+  assert_present(&buf, "Working Tree", "working tree overlay title");
+  assert_present(&buf, "loading", "the loader, not a blank canvas");
+  // The exit is still advertised while it waits.
+  assert_present(&buf, "close", "the modal footer advertises the exit");
+}
+
+#[test]
 fn working_tree_modal_renders_an_empty_listing_without_panicking() {
   // The empty snapshot is what `enter_working_tree` loads when nothing is
   // selected. It is NOT the errored-`git status` case: that one still

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1379,6 +1379,12 @@ fn modal_rows(buf: &Buffer) -> Vec<String> {
     .collect()
 }
 
+/// Byte offset of `needle` in `row`, for slicing what precedes it. Panics
+/// when absent, which the caller has already asserted against.
+fn tail_of(row: &str, needle: &str) -> usize {
+  row.find(needle).expect("needle present in row")
+}
+
 fn modal_width_at(setup: &dyn Fn() -> (tempfile::TempDir, App), w: u16, h: u16) -> u16 {
   let (_dir, mut app) = setup();
   let buf = render_at(&mut app, w, h);
@@ -2558,27 +2564,47 @@ fn working_tree_modal_renders_its_title_body_and_footer() {
   assert_present(&buf, "Working Tree", "working tree overlay title");
   assert_present(&buf, "ui.rs", "a tree row from the injected listing");
   assert_present(&buf, "README.md", "a second tree row");
-  // The pane's change-count footer travels with the listing (issue #287) —
+  // The pane's change-count footer travels with the listing (issue #287):
   // the same `<glyph> <n>` segments the bordered sidebar pane puts on its
   // bottom rule, asserted through the constants so a glyph change here is a
   // deliberate edit rather than a silently-passing literal.
-  assert_present(
-    &buf,
-    &format!("{WT_CREATED_ICON} 1"),
-    "the created count follows the tree",
+  //
+  // Scanned on the modal's LAST row and pinned to the right (Copilot review,
+  // PR #612): a whole-buffer `assert_present` catches the counts vanishing,
+  // but not `title_bottom(...)` losing its `.right_aligned()` or the segments
+  // migrating into the body. Placement is the observable part here. The
+  // per-category COLOURS are not re-pinned: `working_tree_counts_footer` owns
+  // them and `tui_ui_helpers_tests::working_tree_counts_footer_shows_only_nonzero_colored_segments`
+  // is where they are asserted, at the shared source both surfaces call.
+  let rows = modal_rows(&buf);
+  let bottom = rows.last().expect("the modal renders at least one row").clone();
+  let created = format!("{WT_CREATED_ICON} 1");
+  let modified = format!("{WT_MODIFIED_ICON} 2");
+  assert!(
+    bottom.contains(&created) && bottom.contains(&modified),
+    "the change counts ride the modal's bottom rule — bottom row was {bottom:?}, modal rows:\n{}",
+    rows.join("\n")
   );
-  assert_present(
-    &buf,
-    &format!("{WT_MODIFIED_ICON} 2"),
-    "the modified count follows the tree",
+  // Right-aligned means nothing but padding and the corner follows the last
+  // segment. Left or centred would leave `─` rule on its right.
+  let last = bottom.find(&modified).expect("modified segment on the bottom rule") + modified.len();
+  assert!(
+    bottom[last..].chars().all(|c| c == ' ' || c == '╯'),
+    "the counts ride the RIGHT of the bottom rule; found rule after them in {bottom:?}"
+  );
+  assert!(
+    bottom[..tail_of(&bottom, &created)].contains('─'),
+    "and the rule runs up to them from the left in {bottom:?}"
   );
   assert_present(&buf, "close", "the modal footer advertises the exit");
 }
 
 #[test]
 fn working_tree_modal_renders_an_empty_listing_without_panicking() {
-  // A worktree whose snapshot came back with nothing at all (an errored
-  // `git status` leaves no rows): the overlay still opens on its frame.
+  // The empty snapshot is what `enter_working_tree` loads when nothing is
+  // selected. It is NOT the errored-`git status` case: that one still
+  // produces a row (`! <error>`, `working_tree_lines`), which is the point
+  // of rendering it. The overlay still opens on its frame either way.
   let (_dir, mut app) = make_app();
   app.working_tree.lines.clear();
   app.view = View::WorkingTree;

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -2712,9 +2712,13 @@ fn the_working_tree_counts_ride_the_right_edge_and_yield_to_a_narrow_name() {
     "and they are pinned right: only padding and the border follow, got {row:?}"
   );
 
-  // Narrow: the name survives whole, the column is what goes. `WT_NAME_FLOOR`
-  // plus the gap plus the column is more than this body has.
-  let narrow = render_at(&mut app, 40, 40);
+  // Narrow: the name survives whole, the column is what goes. The modal takes
+  // 90% of the terminal and spends two more cells on its border, so 30
+  // columns leave a 25-cell body — less than the 34 the column needs beside
+  // `WT_NAME_FLOOR`. 40 would NOT do: it leaves exactly 34, which fits, and
+  // the assertion would fail on the boundary rather than past it. The exact
+  // boundary is pinned on `meta_pick` itself, in `tui_app_tests`.
+  let narrow = render_at(&mut app, 30, 40);
   let rows = modal_rows(&narrow);
   let row = rows
     .iter()

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -1538,6 +1538,16 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
       180,
     ),
     (
+      "working-tree",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.view = View::WorkingTree;
+        (d, a)
+      }),
+      72,
+      180,
+    ),
+    (
       "note-editor",
       Box::new(|| {
         let (d, mut a) = make_app();
@@ -2524,4 +2534,55 @@ fn the_mode_badge_is_absent_with_the_mode_off() {
     "no badge without the mode, row:\n{}",
     (x..x + w).map(|col| buf[(col, row)].symbol()).collect::<String>()
   );
+}
+
+#[test]
+fn working_tree_modal_renders_its_title_body_and_footer() {
+  use gwm::tui::{WorkingTreeCounts, WT_CREATED_ICON, WT_MODIFIED_ICON};
+  use ratatui::text::Line;
+
+  // Issue #592: the sidebar pane's tree, given the whole screen. The rows
+  // are injected as owned state (the same boundary the command-logs render
+  // test pins) so this stays offline and deterministic — `enter_working_tree`
+  // is what shells out, and `tui_app_tests` covers that half.
+  let (_dir, mut app) = make_app();
+  app.working_tree.lines = vec![Line::from("src/tui/"), Line::from("└─ ui.rs"), Line::from("README.md")];
+  app.working_tree.counts = WorkingTreeCounts {
+    created: 1,
+    modified: 2,
+    deleted: 0,
+  };
+  app.view = View::WorkingTree;
+
+  let buf = render(&mut app);
+  assert_present(&buf, "Working Tree", "working tree overlay title");
+  assert_present(&buf, "ui.rs", "a tree row from the injected listing");
+  assert_present(&buf, "README.md", "a second tree row");
+  // The pane's change-count footer travels with the listing (issue #287) —
+  // the same `<glyph> <n>` segments the bordered sidebar pane puts on its
+  // bottom rule, asserted through the constants so a glyph change here is a
+  // deliberate edit rather than a silently-passing literal.
+  assert_present(
+    &buf,
+    &format!("{WT_CREATED_ICON} 1"),
+    "the created count follows the tree",
+  );
+  assert_present(
+    &buf,
+    &format!("{WT_MODIFIED_ICON} 2"),
+    "the modified count follows the tree",
+  );
+  assert_present(&buf, "close", "the modal footer advertises the exit");
+}
+
+#[test]
+fn working_tree_modal_renders_an_empty_listing_without_panicking() {
+  // A worktree whose snapshot came back with nothing at all (an errored
+  // `git status` leaves no rows): the overlay still opens on its frame.
+  let (_dir, mut app) = make_app();
+  app.working_tree.lines.clear();
+  app.view = View::WorkingTree;
+
+  let buf = render(&mut app);
+  assert_present(&buf, "Working Tree", "working tree overlay title");
 }

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -2643,6 +2643,9 @@ fn working_tree_stats_counts_staged_and_unstaged_together() {
     idx.write().unwrap();
   }
   std::fs::write(dir.path().join("dirty.rs"), "a\n").unwrap();
+  // libgit2 mmaps the index, so the handle goes before git is asked to read
+  // the same file (this repo has taken that red on windows-latest before).
+  drop(repo);
 
   let stats = worktree::working_tree_stats(dir.path()).unwrap();
   assert_eq!(stats["staged.rs"].insertions, 2, "the staged half counts — {stats:?}");


### PR DESCRIPTION
## Description

`5` opens the sidebar's Working Tree pane as a full-size overlay. Same
file-explorer tree, same nerd-font icons, same per-category colours, the
same `<glyph> <n>` change counts on the bottom rule. The difference is
that a change set of more than a handful of files reads in one go instead
of two rows at a time through `J` / `K`.

Review then turned up a bug underneath it, filed as #613 and fixed here
at the user's request: the guard that lets an overlay close on its own
opener never worked for a rebound key. That half touches the command logs
and the settings panel too.

Closes #592
Closes #613

## Type of change

- [x] ✨ Feature (new functionality) — the overlay, #592
- [x] 🐛 Fix (bug fix) — the toggle key, #613
- [x] ♻️ Refactor (no behaviour change) — routing lifted into `App` methods

## Changes

### The overlay (#592)

- `Action::WorkingTree` (`working_tree`, default `5`), in the numeric
  family with `1` `2` `3` `4`, plus its command-palette entry and its
  help-overlay row.
- `View::WorkingTree` + `KeyContext::WorkingTree`, five verbs under
  `[tui.keys.modal.working_tree]`: `close`, `scroll_down`, `scroll_up`,
  `scroll_top`, `scroll_bottom`. Its own context rather than a share of
  `command_logs`, so rebinding one does not silently rebind the other.
- `WorkingTreeModal` state (`src/tui/state/working_tree.rs`): the
  snapshotted rows, their counts, and the scroll cursor with its
  renderer-published bound.
- `draw_working_tree`: the command-logs shell (fixed title, scrollable
  body with scrollbar, fixed footer hints) with the change counts
  right-aligned on the bottom rule, where the bordered sidebar pane puts
  them.

**The one design call worth reviewing.** The rows are snapshotted in
`enter_working_tree` rather than read from `SidebarState::cache`. That
cache is keyed by `(path, mode)` and is only rebuilt while the sidebar is
**open** and in **commits** mode, so reading it would leave the overlay
blank in exactly the two states where seeing the change set is most
useful: sidebar hidden, or the Details panel showing stashes.
`tui_app_tests` closes the sidebar before opening, so a cache-reading
version goes red there.

**The read runs on a worker**, not on the keypress. It shipped inline at
first, argued as bounded because `git_status_short` kills git at
`STATUS_SCAN_CAP` records. That was the wrong reassurance: the cap bounds
how many records git yields, not how long it takes to produce the first
one, so an untracked walk on a cold or network filesystem froze the event
loop for its whole duration. `TaskKind::WorkingTree` +
`TaskMsg::WorkingTree` now carry it, the shape the sidebar preview has
had since #343; the overlay opens on a loader and fills in when the
worker lands.

Coalescing on that slot is per-path: a repeated `5` on the same worktree
rides the read already out, while a reopen on a different one invalidates
it, because its payload would be dropped on the path check and the loader
would have nothing left to clear it.

It is not routed through `build_sidebar_sections`, which would also run
`git log`, `git stash list` and the diff-vs-base stat for panes the
overlay does not show.

### The toggle key (#613)

`3`, `4` and `5` each close the overlay they open, but the guard doing it
asked `key_matches_action` (a single-stroke lookup) and only ran after
the modal verbs. Two silent holes:

- `working_tree = ["g w"]` opened the overlay through the chord-aware
  list dispatch and could never shut it;
- `working_tree = ["j"]` opened it and then scrolled it, because the
  modal verb resolved first.

- `Keymap::chords_for` is the inverse lookup `lookup` cannot do: what is
  bound to *this* action.
- `App::modal_toggle_stroke` walks it against the pending buffer and
  answers `Fired` / `Pending` / `Unclaimed`, so a chord accumulates and
  its prefix is **consumed** rather than handed to a scroll verb (`g`
  would otherwise jump the listing to the top on its way to `g w`).
- Deliberately **not** `dispatch_key`: that resolves the whole keymap,
  and `d` opening the delete confirm from behind an overlay would be
  worse than the bug being fixed.

Applies to all three overlays. The settings panel keeps its capture and
edit sub-modes ahead of the toggle, since those own every stroke while
live. `ToggleDeleteBranch` / `FetchGithub` keep the old guard: they are
global actions reused inside a modal, not toggles, and nothing promises
they close anything.

### Routing

`handle_working_tree_key`, `handle_command_logs_key` (returning
`CommandLogsKey`, since one outcome is a clipboard write the run loop
owns) and `handle_config_nav_key` lift each overlay's dispatch into a
testable `App` method, the shape the create overlay has had since #217.
That is what makes the precedence assertable at all: a `match` in the run
loop cannot go red.

### Docs

Keybindings table + a section per language, the config reference's modal
context list and rebindable-actions table, and a CHANGELOG entry under
`[Unreleased]` in both Added and Fixed.

## Tests

- [x] `cargo test` passes locally (104 test binaries ok, run under a
  CI-like minimal `PATH`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Twenty-four new pins. The ones worth naming:

- **The cache trap** — the snapshot with the sidebar closed, which is the
  state that would have shipped an empty overlay.
- **Precedence, once per overlay** — with the toggle rebound onto a
  scroll key, the overlay closes *and* the listing does not move. Each of
  the three was verified red by swapping the two blocks back.
- **Chords** — the prefix is consumed without firing `scroll_top`, and a
  stray prefix is dropped rather than left armed to complete a chord the
  user never typed.
- **Blast radius** — `d` / `n` / `x` / `3` / `4` all come back
  `Unclaimed` from the working-tree toggle, which is the invariant that
  rules out `dispatch_key`.
- **Placement, not just presence** — the change counts are scanned on the
  modal's last row with rule to their left and nothing but padding to
  their right. Verified red by dropping `.right_aligned()`.
- **The sizing matrix** entry (a text canvas like the transcript: 90%, no
  ceiling), verified red on a wrong pin rather than left to sit unread.
- **The async slot, enumerated** — `the_overlay_never_waits_on_a_worker_that_is_not_there`
  walks all four ways into the overlay (nothing selected / slot free /
  slot busy same path / slot busy other path) and asserts the loader is up
  exactly when a read is in flight. Written because three review rounds
  each found a different unenumerated state of this machinery; the fourth
  is enumerated rather than waited for.
- **The loader frame** — an empty canvas reads as "no changes", the one
  answer this overlay must not give by accident.

## Screenshots / TUI captures

No terminal capture: the session that produced this is non-interactive,
so the overlay was driven through `TestBackend` rather than a real TTY.
The layout is pinned by the render tests above (title on the top rule,
padded tree body, counts right-aligned on the bottom rule, centred `j/k
scroll  g/G top/bottom  Esc close` hint line). **A visual pass on a real
terminal is still worth doing before merge.**

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a: TUI-only)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a:
  no new config key; the new `[tui.keys.modal.working_tree]` context is
  documented in the config reference like the other modal contexts)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issues: #592, #613
- Twin still open: #593 (the commit listing full size). Deliberately not
  factored into a shared shell here: one implementation, no abstraction
  invented for a second caller that does not exist yet. It will hit the
  same sidebar-cache trap.

## Notes for reviewers

Three things that are pre-existing scope rather than regressions:

- The overlay is **bordered** rather than following `[tui] layout`. True
  of every modal today; #594's scope.
- The listing keeps the pane's `WT_TREE_MAX_FILES = 500` cap and its
  `… N more` row. Same tree the pane builds, at a bigger size; the cap is
  not raised.
- The **config-reference correction** reaches past this feature. The
  paragraph told users to pick the array form *or* the table form for
  `create` / `help` / `command_logs` / `link`, on the grounds that TOML
  forbids the same key twice. That describes the world before #219: the
  two live at different paths (`tui.keys.<name>` vs
  `tui.keys.modal.<name>`) and `config.rs` skips the `modal` namespace
  precisely so both survive the merge. Caught by Copilot when this PR
  extended the stale list with `working_tree`; corrected in both
  languages rather than extended.

**Review sources.** Copilot went three rounds:

- `2004813`, five findings: the #613 dispatch bug, the stale config
  paragraph EN + FR, the placement-blind count assertion, a test comment
  that described the opposite of the code.
- `7551808`, four: the inline `git status`, the missing multi-chord
  fallback, a rustdoc adopted by the function inserted above it, a test
  comment describing the ordering #613 had just replaced.
- `49cf7ae`, one: coalescing across worktrees leaving the loader up.

All addressed. Each round found a different unenumerated state of the new
async / dispatch machinery, so the last commit writes that state table
down as a test instead of inviting a fourth round.

Codex cloud and Codex CLI were both quota-blocked. CodeRabbit CLI ran
clean on the branch diff (0 findings across 17 files) before rate-limiting
on the re-run.

**CI note.** `pull_request: synchronize` has not fired on this PR since it
was opened: the only event-driven `ci` run is on `2004813`. Later heads
were validated by `workflow_dispatch` (`49cf7ae` green across all ten
jobs, `1f4b38e` running). Worth forcing a real synchronize before merge
if the branch protection wants the check on the head commit.
