### PR TITLE
✨ feat(tui): the commit listing, given the whole screen and paged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,11 +72,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the overlay works with the sidebar hidden or showing stashes. Scroll is
   `j`/`k`, `g`/`G`, all rebindable under `[tui.keys.modal.commits]`.
 
-  Each row carries the author and the commit age on its right, coloured by
-  freshness, which is what the hash / initials / subject columns do not say.
-  The column is dropped when the subject cannot spare the room: it narrows
-  to the age alone first, then disappears, so a narrow terminal keeps a
-  readable subject instead of buying a column with it.
+  Each row carries, on its right, what the hash / initials / subject columns
+  do not say: the author, what the commit changed (`3~ 1+ 2- +120 -34`, in
+  the Working Tree pane's colours, empty categories omitted) and how long
+  ago it landed. Three tiers, picked on what the **subject** can spare
+  rather than on the terminal width, since the graph is as wide as the
+  branch topology makes it: `author · counts · age`, `counts · age`, the age
+  alone, nothing.
+
+  The counts arrive from a second, chained read, so the log is on screen
+  immediately and the column grows about a second later (up to three on the
+  deepest page). One `git log --raw --numstat` over the rows already shown
+  costs about a second where a `diff_tree_to_tree` per commit costs
+  thirty-three, measured. `--diff-merges=first-parent` is load-bearing:
+  without it `git log` says nothing at all about a merge, and this project
+  merges rather than squashes.
+
+  `D` / `U` scroll half a screen, matching the rich PR view.
 
 - **Two settings for what a mux spawn opens, and where**
   ([#589](https://github.com/kbrdn1/gwm-cli/issues/589),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the status bar, since resuming it in a second pane while it runs elsewhere
   may fork or refuse depending on the tool.
 
-- **`6` opens the commit listing full size, with load-more**
+- **`c` opens the commit listing full size, with load-more**
   ([#593](https://github.com/kbrdn1/gwm-cli/issues/593)). The sidebar's
   Commits pane is a fraction of a sidebar shared with four other blocks, and
-  it stops at 300 commits: seeing further meant leaving gwm for lazygit. `6`
+  it stops at 300 commits: seeing further meant leaving gwm for lazygit. `c`
   now paints the same graph on the whole canvas, and `m` re-reads one page
   deeper, up to 1500 commits, so history is paged rather than capped. The
   title carries the row count and a trailing `+` while a deeper page exists;
@@ -71,6 +71,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which is only rebuilt while the sidebar is open and in `commits` mode, so
   the overlay works with the sidebar hidden or showing stashes. Scroll is
   `j`/`k`, `g`/`G`, all rebindable under `[tui.keys.modal.commits]`.
+
+  Each row carries the author and the commit age on its right, coloured by
+  freshness, which is what the hash / initials / subject columns do not say.
+  The column is dropped when the subject cannot spare the room: it narrows
+  to the age alone first, then disappears, so a narrow terminal keeps a
+  readable subject instead of buying a column with it.
 
 - **Two settings for what a mux spawn opens, and where**
   ([#589](https://github.com/kbrdn1/gwm-cli/issues/589),
@@ -196,6 +202,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
 ### Changed
+
+- **`c` and `C` now mean the same thing in both panes, which moved three
+  bindings** ([#593](https://github.com/kbrdn1/gwm-cli/issues/593)).
+  `c` opens the commit listing and `C` the CI checks, in the worktrees pane
+  and in the status pane alike. A key that changes meaning under the focus
+  is a key you have to think about, so:
+
+  | Action | Was | Now |
+  |:---|:---|:---|
+  | `commits` | (new) | `c` |
+  | `ci_checks` | `C`, plus a contextual `c` on the status pane | `C` everywhere |
+  | `edit_worktree` (rename) | `c` | `e` |
+  | `exit_to_worktree` | `e` | `E` |
+
+  The contextual routing from
+  [#436](https://github.com/kbrdn1/gwm-cli/issues/436), which existed to give
+  the status pane its own `c` for the checks, is gone with it, and the PR
+  line's CI badge no longer changes between `[c]` and `[C]` under the focus.
+  Existing `[tui.keys]` overrides are untouched; only the defaults moved.
 
 - **The rich PR / issue view (`I`) had its design pass** ([#551](https://github.com/kbrdn1/gwm-cli/issues/551)). It was
   built to get the data on screen and had never been laid out; the compact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the status bar, since resuming it in a second pane while it runs elsewhere
   may fork or refuse depending on the tool.
 
+- **`6` opens the commit listing full size, with load-more**
+  ([#593](https://github.com/kbrdn1/gwm-cli/issues/593)). The sidebar's
+  Commits pane is a fraction of a sidebar shared with four other blocks, and
+  it stops at 300 commits: seeing further meant leaving gwm for lazygit. `6`
+  now paints the same graph on the whole canvas, and `m` re-reads one page
+  deeper, up to 1500 commits, so history is paged rather than capped. The
+  title carries the row count and a trailing `+` while a deeper page exists;
+  the `load more` hint disappears once the revwalk runs out of history or the
+  cap is reached, so the key is never advertised where it would do nothing.
+  The walk runs on a worker, never on the keypress: it sorts
+  `TIME | TOPOLOGICAL`, so it traverses the whole reachable graph before it
+  yields a row and the limit bounds the output, not the latency. The overlay
+  opens on a loader and fills in when the read lands.
+  The rows are snapshotted at open rather than read from the sidebar cache,
+  which is only rebuilt while the sidebar is open and in `commits` mode, so
+  the overlay works with the sidebar hidden or showing stashes. Scroll is
+  `j`/`k`, `g`/`G`, all rebindable under `[tui.keys.modal.commits]`.
+
 - **Two settings for what a mux spawn opens, and where**
   ([#589](https://github.com/kbrdn1/gwm-cli/issues/589),
   [#608](https://github.com/kbrdn1/gwm-cli/issues/608),
@@ -293,7 +311,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `≡` to the `nf-oct-markdown` glyph the Working Tree pane already paints
   on a `.md` file, since a note is one. The column stays conditional, so a
   user who never writes a note keeps the exact table they had before.
-
 
 ## Past releases
 

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -80,6 +80,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `2`         | open (if hidden) and focus the status pane (`focus_status`)                                       |
 | `3`         | open the Command Logs overlay (`command_logs`): scrollable transcript of the commands gwm ran    |
 | `4`         | open the [Settings panel](#settings-panel-4) (`config_panel`): edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column |
+| `6`         | open the [commit listing](#commit-listing-6) (`commits`): the sidebar's Commits pane at full size, with a load-more key |
 | `x`         | open the [exec picker overlay](#exec-picker-overlay-x) (`exec_overlay`): pick a [`[exec.profiles]`](/configuration/gwm-toml#exec) profile and run it in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) on the selected worktree |
 | `X`         | open the [clean overlay](#clean-overlay-x) (`clean_overlay`): preview and reclaim build artifacts in the selected worktree (safety countdown before deleting) |
 | `a`         | open the [agent sessions overlay](#agent-sessions-overlay-a) (`agent_sessions`): list the AI-agent sessions (Claude Code, Codex, opencode, Mistral Vibe) attached to the selected worktree |
@@ -285,6 +286,29 @@ immediately. An empty capture (`Enter` with nothing recorded, global only)
 unbinds the action. `Esc`, `Enter`, `Backspace` and `Ctrl+C` can't themselves
 be assigned via capture: hand-edit `.gwm.toml` for those (see
 [`[tui.keys]`](/configuration/gwm-toml#tuikeys)).
+
+## commit listing (`6`)
+
+`6` opens the sidebar's Commits pane on the full canvas: the same graph, the
+same short hash / author initials / subject columns, given the whole terminal
+instead of a fraction of the sidebar shared with four other blocks. It reads
+the log at open, so it works with the sidebar hidden or in `stashes` mode,
+where the pane itself shows nothing. The walk runs on a worker: the overlay
+opens on a `loading` line and fills in when the read lands, so a deep history
+never freezes the event loop.
+
+The sidebar caps the listing at 300 commits. Here, `m` re-reads one page
+deeper, up to 1500, so history is paged rather than capped. The title carries
+the row count and a trailing `+` while a deeper page exists; the `load more`
+hint disappears when the revwalk ran out of history or the cap was reached,
+so the key is never advertised where it would do nothing.
+
+| Key                        | Action               |
+|:---------------------------|:---------------------|
+| `j` / `k` (`Down` / `Up`)  | scroll               |
+| `g` / `G` (`Home` / `End`) | jump to top / bottom |
+| `m`                        | read one page deeper |
+| `Esc` / `q` / `6`          | close                |
 
 ## issue / PR link prompt (`i`)
 
@@ -561,7 +585,7 @@ its description. All colours follow the resolved `[theme]`.
 The overlay documents **every** key context: the global and list-view
 actions, then one section per modal overlay (Create Form, Delete
 Worktree, Browse Links, Link Prompt, Command Palette, Exec Profiles,
-Clean Reclaim, Agent Sessions, CI Checks, PR / Issue View, Command Logs, Settings,
+Clean Reclaim, Agent Sessions, CI Checks, PR / Issue View, Command Logs, Commits, Settings,
 Bootstrap Report, the PTY escape hatch, and the overlay's own
 navigation). Every modal verb resolves live against
 `[tui.keys.modal.<context>]`, so a rebind shows through and an

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -44,7 +44,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `gg`        | jump to the first worktree (`top`)                                                                |
 | `G` / `End` | jump to the last worktree (`bottom`)                                                              |
 | `n`         | new worktree (`create`; form: type → issue → description) · gated by the [TOFU trust ledger](/configuration/trust-ledger), refuses with a status-bar hint on untrusted `.gwm.toml` |
-| `c`         | rename the selected worktree (`edit_worktree`; form pre-filled from the current branch), renames the local branch, the remote branch if it exists, and moves the worktree directory, all off-thread. With the **status pane focused**, `c` opens the [CI checks overlay](#ci-checks-overlay-c) instead (contextual routing, like `j`/`k`) |
+| `e`         | rename the selected worktree (`edit_worktree`; form pre-filled from the current branch), renames the local branch, the remote branch if it exists, and moves the worktree directory, all off-thread |
 | `N`         | edit the selected worktree's note in a modal (`edit_note`), see [notes](#notes-n)                 |
 | `Space`     | mark / unmark the highlighted worktree (`toggle_select`), see [bulk delete](#bulk-delete-space--d)  |
 | `d`         | delete the marked worktrees, or the highlighted one when nothing is marked (`delete`; confirm `y` · countdown when `D` is armed, see [confirm-overlay](/tui/confirm-countdown)) |
@@ -55,7 +55,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `P`         | git push the selected worktree's branch (`push`), off-thread                                      |
 | `f`         | refresh the worktree list (`refresh`)                                                             |
 | `F`         | refresh the GitHub issue / PR status (`fetch_github`): off-thread `gh` fetch, statusbar spinner  |
-| `e`         | quit the TUI and print the selected path to stdout (`exit_to_worktree`), enables `cd "$(gwm)"` shell patterns |
+| `E`         | quit the TUI and print the selected path to stdout (`exit_to_worktree`), enables `cd "$(gwm)"` shell patterns |
 | `o`         | open a native `$SHELL` in an embedded [PTY overlay](/tui/open-dispatch) at the worktree (`terminal_pty`) |
 | `O`         | open a native `$SHELL` fullscreen, suspending the TUI (`terminal_fullscreen`)                     |
 | `l`         | launch the configured [`[git_tui]`](/tui/launchers) command in an embedded [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) (`lazygit_pty`) |
@@ -80,11 +80,11 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `2`         | open (if hidden) and focus the status pane (`focus_status`)                                       |
 | `3`         | open the Command Logs overlay (`command_logs`): scrollable transcript of the commands gwm ran    |
 | `4`         | open the [Settings panel](#settings-panel-4) (`config_panel`): edit theme / worktree / TUI knobs and **all keymaps**, with a per-row source column |
-| `6`         | open the [commit listing](#commit-listing-6) (`commits`): the sidebar's Commits pane at full size, with a load-more key |
+| `c`         | open the [commit listing](#commit-listing-c) (`commits`): the sidebar's Commits pane at full size, with a load-more key |
 | `x`         | open the [exec picker overlay](#exec-picker-overlay-x) (`exec_overlay`): pick a [`[exec.profiles]`](/configuration/gwm-toml#exec) profile and run it in a [PTY overlay](/tui/launchers#the-embedded-pty-overlay-l--r) on the selected worktree |
 | `X`         | open the [clean overlay](#clean-overlay-x) (`clean_overlay`): preview and reclaim build artifacts in the selected worktree (safety countdown before deleting) |
 | `a`         | open the [agent sessions overlay](#agent-sessions-overlay-a) (`agent_sessions`): list the AI-agent sessions (Claude Code, Codex, opencode, Mistral Vibe) attached to the selected worktree |
-| `C`         | open the [CI checks overlay](#ci-checks-overlay-c) (`ci_checks`): one row per check of the linked PR's rollup; also `c` while the status pane has focus |
+| `C`         | open the [CI checks overlay](#ci-checks-overlay-c) (`ci_checks`): one row per check of the linked PR's rollup |
 | `I`         | open the [PR / issue view](#pr--issue-view-i) (`rich_view`): the linked PR's (or issue's) description, metadata, reviews and conversation |
 | `m`         | merge the linked PR (`merge_pr`), behind the same confirmation the delete flow uses. Says what it cannot do rather than opening an empty modal: nothing linked, or linked but not fetched |
 | `/`         | open the [fuzzy filter](/tui/filter) bar (`filter`; `Enter` confirms · `Esc` clears)              |
@@ -185,7 +185,7 @@ The table carries a markdown marker on the rows that have a note, the nerd-font 
 
 - **Storage**: a plain Markdown file at `<main-checkout>/.git/gwm/notes/<branch>.md`, mirroring the `refs/heads/` layout, so a branch `feat/#515-notes` is `feat/#515-notes.md`. Greppable and editable with gwm shut down, never committed, readable from the main checkout, and it survives `gwm remove`. That last point is why it lives in the main checkout rather than inside the worktree: the note is usually still worth having between the removal and the merge.
 - **Presence means non-blank.** A modal closed without typing leaves no file at all, and `$EDITOR` saved over an empty buffer leaves a single newline. Neither lights the marker.
-- **Keyed on the branch**, with five consequences worth stating. A row on a detached HEAD has no branch to key on and says so in the status bar rather than doing nothing. A [rename](/tui/keybindings) (`c`) moves the note with the branch. And a branch name git accepts but no filesystem can back (`< > " |`, a component ending in `.`, a reserved device name like `CON`) carries no note, refused out loud rather than written under a name that means a different branch on another platform. And a rename onto a name that already carries a note is refused before anything moves: `git branch -m` would have rejected an existing branch, so that note is an orphan from a previous branch of the same name, and prose nothing can regenerate is not something to lose to a name reuse. And two branch names a volume folds together (`feat/foo` and `feat/Foo` on macOS or Windows, or an accented name against its differently-cased twin) share one file, so `N` refuses the pair by name rather than opening one branch's editor on the other's prose.
+- **Keyed on the branch**, with five consequences worth stating. A row on a detached HEAD has no branch to key on and says so in the status bar rather than doing nothing. A [rename](/tui/keybindings) (`e`) moves the note with the branch. And a branch name git accepts but no filesystem can back (`< > " |`, a component ending in `.`, a reserved device name like `CON`) carries no note, refused out loud rather than written under a name that means a different branch on another platform. And a rename onto a name that already carries a note is refused before anything moves: `git branch -m` would have rejected an existing branch, so that note is an orphan from a previous branch of the same name, and prose nothing can regenerate is not something to lose to a name reuse. And two branch names a volume folds together (`feat/foo` and `feat/Foo` on macOS or Windows, or an accented name against its differently-cased twin) share one file, so `N` refuses the pair by name rather than opening one branch's editor on the other's prose.
 - **Lifecycle**: the note lives as long as the branch, and `gwm doctor` reports the ones whose branch is gone. Not `gwm clean`, whose stated safety property is that `--yes` only removes directories git already ignores; deleting prose under it would contradict that.
 
 Read one from the CLI with [`gwm note show`](/cli/reference#gwm-note-show-slug-issue-515), or off the `--format=json` list rows, which carry the text in an additive `note` field.
@@ -214,7 +214,7 @@ progress bar as a live loader.
 
 ## create / rename overlay
 
-Both the New Worktree form (`n`) and the rename form (`c`) share the same
+Both the New Worktree form (`n`) and the rename form (`e`) share the same
 `[tui.keys.modal.create]` verbs:
 
 | Key                       | Verb (`[tui.keys.modal.create]`)                        |
@@ -287,15 +287,26 @@ unbinds the action. `Esc`, `Enter`, `Backspace` and `Ctrl+C` can't themselves
 be assigned via capture: hand-edit `.gwm.toml` for those (see
 [`[tui.keys]`](/configuration/gwm-toml#tuikeys)).
 
-## commit listing (`6`)
+## commit listing (`c`)
 
-`6` opens the sidebar's Commits pane on the full canvas: the same graph, the
+`c` opens the sidebar's Commits pane on the full canvas: the same graph, the
 same short hash / author initials / subject columns, given the whole terminal
 instead of a fraction of the sidebar shared with four other blocks. It reads
 the log at open, so it works with the sidebar hidden or in `stashes` mode,
 where the pane itself shows nothing. The walk runs on a worker: the overlay
 opens on a `loading` line and fills in when the read lands, so a deep history
 never freezes the event loop.
+
+`c` means the same thing in both panes, as does `C` for the checks. That
+uniformity is why the contextual routing that used to give the status pane
+its own `c` is gone, and why the rename moved to `e` (with
+`exit_to_worktree` to `E`).
+
+The right of each row carries what the columns do not: the author and how
+long ago the commit landed, coloured by freshness. It is dropped when the
+subject cannot spare the room, narrowing to the age alone first and then
+disappearing entirely, so a narrow terminal keeps a readable subject rather
+than buying a column with it.
 
 The sidebar caps the listing at 300 commits. Here, `m` re-reads one page
 deeper, up to 1500, so history is paged rather than capped. The title carries
@@ -308,7 +319,7 @@ so the key is never advertised where it would do nothing.
 | `j` / `k` (`Down` / `Up`)  | scroll               |
 | `g` / `G` (`Home` / `End`) | jump to top / bottom |
 | `m`                        | read one page deeper |
-| `Esc` / `q` / `6`          | close                |
+| `Esc` / `q` / `c`          | close                |
 
 ## issue / PR link prompt (`i`)
 
@@ -432,11 +443,10 @@ rollup order, the state icon coloured with the same theme roles as the
 sidebar's CI indicator (passing / failing / running) and the check name,
 plus a right-aligned muted detail column with the owning workflow and the
 run duration (elapsed time with an ellipsis while the check is in flight).
-Opens from anywhere in the list view with `C`, or with `c` while the status
-pane holds the focus (the same contextual dispatch that turns `j` / `k`
-into sidebar scroll). The PR line's CI indicator advertises that key
-(`… CI passing 10/10 [c]`). With no linked PR or an empty rollup, nothing
-opens and the status bar explains why.
+Opens from anywhere in the list view with `C`, in either pane. The PR
+line's CI indicator advertises that key (`… CI passing 10/10 [C]`). With
+no linked PR or an empty rollup, nothing opens and the status bar explains
+why.
 
 | Key            | Verb (`[tui.keys.modal.ci_checks]`)                                    |
 |:---------------|:------------------------------------------------------------------------|

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -302,11 +302,23 @@ uniformity is why the contextual routing that used to give the status pane
 its own `c` is gone, and why the rename moved to `e` (with
 `exit_to_worktree` to `E`).
 
-The right of each row carries what the columns do not: the author and how
-long ago the commit landed, coloured by freshness. It is dropped when the
-subject cannot spare the room, narrowing to the age alone first and then
-disappearing entirely, so a narrow terminal keeps a readable subject rather
-than buying a column with it.
+The right of each row carries what the columns do not: the author, what the
+commit changed, and how long ago it landed. The counts read
+`3~ 1+ 2- +120 -34`: files changed, added and removed, then lines inserted
+and deleted, in the same colours the Working Tree pane uses. An empty
+category is left out rather than printed as a zero.
+
+Three tiers, picked on what the **subject** can spare rather than on the
+terminal width (the graph is as wide as the branch topology makes it):
+`author · counts · age`, then `counts · age`, then the age alone, then
+nothing. A narrow terminal keeps a readable subject instead of buying a
+column with it.
+
+The counts come from a second read. The log appears first, the column grows
+about a second later on the first page and up to three on the deepest:
+`git log` computes them for every row at once, which is far cheaper than
+diffing each commit, but not free. Merges are diffed against their first
+parent, so a merge shows what it brought in rather than nothing.
 
 The sidebar caps the listing at 300 commits. Here, `m` re-reads one page
 deeper, up to 1500, so history is paged rather than capped. The title carries
@@ -317,6 +329,7 @@ so the key is never advertised where it would do nothing.
 | Key                        | Action               |
 |:---------------------------|:---------------------|
 | `j` / `k` (`Down` / `Up`)  | scroll               |
+| `D` / `U`                  | scroll half a screen |
 | `g` / `G` (`Home` / `End`) | jump to top / bottom |
 | `m`                        | read one page deeper |
 | `Esc` / `q` / `c`          | close                |

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -644,9 +644,9 @@ open_editor = ["Ctrl+e"]  # hands the same file to $EDITOR
 
 Binding either of those to a printable, `Enter`, `Backspace` or `Delete` is refused at load time: the key would type instead of firing, leaving the editor with no way out.
 
-The set of contexts and verbs is what the TUI actually exposes. Run `gwm tui keys` to print every modal context (`confirm`, `create`, `help`, `command_logs`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) with its verbs and resolved keys. Binding under a context **group** rather than a leaf stage (e.g. `[tui.keys.modal.link]` instead of `[tui.keys.modal.link.choose_target]`) is a load-time error that names the stage to use.
+The set of contexts and verbs is what the TUI actually exposes. Run `gwm tui keys` to print every modal context (`confirm`, `create`, `help`, `command_logs`, `commits`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) with its verbs and resolved keys. Binding under a context **group** rather than a leaf stage (e.g. `[tui.keys.modal.link]` instead of `[tui.keys.modal.link.choose_target]`) is a load-time error that names the stage to use.
 
-Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `link`) exist as both a global action and a modal context; TOML forbids defining the same key twice, so pick the array form (global) or the `[tui.keys.modal.<name>]` table form (modal) in a given file.
+Load-time validation rejects, as a hard `GwmError::Config`: an unknown modal context, an unknown verb for a context, an unparsable or multi-stroke key, and a per-context conflict. Note that a handful of names (`create`, `help`, `command_logs`, `commits`, `link`) exist as both a global action and a modal context; TOML forbids defining the same key twice, so pick the array form (global) or the `[tui.keys.modal.<name>]` table form (modal) in a given file.
 
 See [TUI → Keymap and palette](/tui/keymap-and-palette).
 
@@ -688,6 +688,7 @@ authoritative if a future build shifts a default.
 | `focus_status`            | `2`              | focus the status pane                                 |
 | `command_logs`            | `3`              | open the Command Logs overlay                         |
 | `config_panel`            | `4`              | open the Settings panel                               |
+| `commits`                 | `6`              | open the commit listing full size, with load-more     |
 | `toggle_sidebar`          | `V`              | show / hide the details sidebar                       |
 | `toggle_sidebar_mode`     | `S`              | cycle the Details panel (`commits` ↔ `stashes`)       |
 | `cycle_sidebar_layout`    | `z`              | cycle layout (`auto` → side-by-side → stacked → auto) |

--- a/docs/4.configuration/1.gwm-toml.md
+++ b/docs/4.configuration/1.gwm-toml.md
@@ -688,7 +688,7 @@ authoritative if a future build shifts a default.
 | `focus_status`            | `2`              | focus the status pane                                 |
 | `command_logs`            | `3`              | open the Command Logs overlay                         |
 | `config_panel`            | `4`              | open the Settings panel                               |
-| `commits`                 | `6`              | open the commit listing full size, with load-more     |
+| `commits`                 | `c`              | open the commit listing full size, with load-more     |
 | `toggle_sidebar`          | `V`              | show / hide the details sidebar                       |
 | `toggle_sidebar_mode`     | `S`              | cycle the Details panel (`commits` ↔ `stashes`)       |
 | `cycle_sidebar_layout`    | `z`              | cycle layout (`auto` → side-by-side → stacked → auto) |
@@ -703,9 +703,9 @@ authoritative if a future build shifts a default.
 | `delete_branch`           | `D`              | arm delete-branch-on-remove                           |
 | `pull`                    | `p`              | `git pull` on the selected branch (async)             |
 | `push`                    | `P`              | `git push` on the selected branch (async)             |
-| `edit_worktree`           | `c`              | rename the worktree / branch                          |
+| `edit_worktree`           | `e`              | rename the worktree / branch                          |
 | `edit_note`               | `N`              | edit the worktree's note in a modal                   |
-| `exit_to_worktree`        | `e`              | quit and print the selected path to stdout            |
+| `exit_to_worktree`        | `E`              | quit and print the selected path to stdout            |
 | `lazygit_pty`             | `l`              | lazygit in the embedded PTY overlay (`[git_tui]`)     |
 | `lazygit_fullscreen`      | `L`              | lazygit fullscreen                                    |
 | `review_pty`              | `r`              | review tool in the PTY overlay (`[review]`)           |

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -48,7 +48,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `gg`        | sauter au premier worktree (`top`)                                                                |
 | `G` / `End` | sauter au dernier worktree (`bottom`)                                                             |
 | `n`         | nouveau worktree (`create` ; formulaire : type → issue → description) · protégé par le [registre de confiance TOFU](/fr/configuration/trust-ledger), refuse avec une indication dans la barre de statut sur un `.gwm.toml` non approuvé |
-| `c`         | renommer le worktree sélectionné (`edit_worktree` ; formulaire pré-rempli depuis la branche courante), renomme la branche locale, la branche distante si elle existe, et déplace le répertoire du worktree, le tout hors thread. Avec le **pane status focalisé**, `c` ouvre la [surcouche des checks CI](#surcouche-des-checks-ci-c) à la place (routage contextuel, comme `j`/`k`) |
+| `e`         | renommer le worktree sélectionné (`edit_worktree` ; formulaire pré-rempli depuis la branche courante), renomme la branche locale, la branche distante si elle existe, et déplace le répertoire du worktree, le tout hors thread |
 | `N`         | éditer la note du worktree sélectionné dans une modale (`edit_note`), voir [notes](#notes-n)     |
 | `Space`     | marquer / démarquer le worktree survolé (`toggle_select`), voir [suppression en lot](#suppression-en-lot-space--d) |
 | `d`         | supprimer les worktrees marqués, ou celui survolé quand rien n'est marqué (`delete` ; confirmer `y` · compte à rebours quand `D` est armé, voir [surcouche de confirmation](/fr/tui/confirm-countdown)) |
@@ -59,7 +59,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `P`         | git push la branche du worktree sélectionné (`push`), hors thread                                 |
 | `f`         | rafraîchir la liste des worktrees (`refresh`)                                                      |
 | `F`         | rafraîchir le statut de l'issue / PR GitHub (`fetch_github`) : fetch `gh` hors thread, spinner    |
-| `e`         | quitter la TUI et imprimer le chemin sélectionné sur stdout (`exit_to_worktree`), permet les patterns shell `cd "$(gwm)"` |
+| `E`         | quitter la TUI et imprimer le chemin sélectionné sur stdout (`exit_to_worktree`), permet les patterns shell `cd "$(gwm)"` |
 | `o`         | ouvrir un `$SHELL` natif dans une [surcouche PTY](/fr/tui/open-dispatch) embarquée sur le worktree (`terminal_pty`) |
 | `O`         | ouvrir un `$SHELL` natif en plein écran, en suspendant la TUI (`terminal_fullscreen`)             |
 | `l`         | lancer la commande [`[git_tui]`](/fr/tui/launchers) configurée dans une surcouche PTY embarquée (`lazygit_pty`) |
@@ -84,11 +84,11 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (`focus_status`)                       |
 | `3`         | ouvrir l'overlay Command Logs (`command_logs`) : transcription scrollable des commandes lancées par gwm |
 | `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) (`config_panel`) : éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne |
-| `6`         | ouvrir la [liste des commits](#liste-des-commits-6) (`commits`) : le panneau Commits de la barre latérale en plein écran, avec une touche pour charger plus |
+| `c`         | ouvrir la [liste des commits](#liste-des-commits-c) (`commits`) : le panneau Commits de la barre latérale en plein écran, avec une touche pour charger plus |
 | `x`         | ouvrir la [surcouche de sélection exec](#surcouche-de-sélection-exec-x) (`exec_overlay`) : choisir un profil [`[exec.profiles]`](/fr/configuration/gwm-toml#exec) et le lancer dans une [surcouche PTY](/fr/tui/launchers#la-surcouche-pty-embarquée-l--r) sur le worktree sélectionné |
 | `X`         | ouvrir la [surcouche de nettoyage](#surcouche-de-nettoyage-x) (`clean_overlay`) : prévisualiser et récupérer l'espace des artefacts de build du worktree sélectionné (compte à rebours de sécurité avant suppression) |
 | `a`         | ouvrir la [surcouche des sessions d'agents](#surcouche-des-sessions-dagents-a) (`agent_sessions`) : lister les sessions d'agents IA (Claude Code, Codex, opencode, Mistral Vibe) attachées au worktree sélectionné |
-| `C`         | ouvrir la [surcouche des checks CI](#surcouche-des-checks-ci-c) (`ci_checks`) : une ligne par check du rollup de la PR liée ; aussi `c` quand le pane status a le focus |
+| `C`         | ouvrir la [surcouche des checks CI](#surcouche-des-checks-ci-c) (`ci_checks`) : une ligne par check du rollup de la PR liée |
 | `I`         | ouvrir la [vue PR / issue](#vue-pr--issue-i) (`rich_view`) : la description, les métadonnées, les reviews et la conversation de la PR (ou de l'issue) liée |
 | `m`         | merger la PR liée (`merge_pr`), derrière la même confirmation que le flux de suppression. Dit ce qu'il ne peut pas faire plutôt que d'ouvrir une modale vide : rien de lié, ou lié mais pas récupéré |
 | `/`         | ouvrir la barre de [filtre flou](/fr/tui/filter) (`filter` ; `Enter` confirme · `Esc` efface)     |
@@ -298,9 +298,9 @@ enregistrer, global uniquement) délie l'action. `Esc`, `Enter`, `Backspace` et
 `Ctrl+C` ne peuvent pas être assignés par capture : éditez `.gwm.toml` à la main
 pour ces cas (voir [`[tui.keys]`](/fr/configuration/gwm-toml#tuikeys)).
 
-## liste des commits (`6`)
+## liste des commits (`c`)
 
-`6` ouvre le panneau Commits de la barre latérale sur toute la surface : le
+`c` ouvre le panneau Commits de la barre latérale sur toute la surface : le
 même graphe, les mêmes colonnes hash court / initiales d'auteur / sujet, mais
 avec tout le terminal au lieu d'une fraction de la barre partagée avec quatre
 autres blocs. Le log est lu à l'ouverture, donc la surcouche fonctionne barre
@@ -308,6 +308,17 @@ latérale masquée ou en mode `stashes`, là où le panneau lui-même n'affiche
 rien. Le parcours tourne sur un worker : la surcouche s'ouvre sur une ligne
 `loading` et se remplit quand la lecture atterrit, donc un historique profond
 ne gèle jamais la boucle d'événements.
+
+`c` signifie la même chose dans les deux panes, tout comme `C` pour les
+checks. C'est cette uniformité qui fait disparaître le routage contextuel
+qui donnait au pane status son propre `c`, et qui déplace le renommage sur
+`e` (et `exit_to_worktree` sur `E`).
+
+La droite de chaque ligne porte ce que les colonnes n'ont pas : l'auteur et
+l'ancienneté du commit, colorée par fraîcheur. Elle disparaît quand le sujet
+ne peut pas céder la place, en se réduisant d'abord à l'âge seul, de sorte
+qu'un terminal étroit garde un sujet lisible au lieu de l'échanger contre
+une colonne.
 
 La barre latérale plafonne la liste à 300 commits. Ici, `m` relit une page
 plus profond, jusqu'à 1500, donc l'historique est paginé au lieu d'être
@@ -321,7 +332,7 @@ jamais annoncée là où elle ne ferait rien.
 | `j` / `k` (`Down` / `Up`)  | défiler                       |
 | `g` / `G` (`Home` / `End`) | aller en haut / en bas        |
 | `m`                        | lire une page plus profond    |
-| `Esc` / `q` / `6`          | fermer                        |
+| `Esc` / `q` / `c`          | fermer                        |
 
 ## invite de liaison issue / PR (`i`)
 
@@ -449,11 +460,10 @@ de thème que l'indicateur CI de la barre latérale (passing / failing /
 running) et le nom du check, plus une colonne de détails alignée à droite
 en muted avec le workflow propriétaire et la durée du run (temps écoulé
 avec une ellipse quand le check est en cours). S'ouvre depuis n'importe où
-dans la vue liste avec `C`, ou avec `c` quand le pane status a le focus (le
-même dispatch contextuel qui transforme `j` / `k` en défilement de la barre
-latérale). L'indicateur CI de la ligne PR affiche cette touche
-(`… CI passing 10/10 [c]`). Sans PR liée ou avec un rollup vide, rien ne
-s'ouvre et la barre de statut explique pourquoi.
+dans la vue liste avec `C`, dans les deux panes. L'indicateur CI de la
+ligne PR affiche cette touche (`… CI passing 10/10 [C]`). Sans PR liée ou
+avec un rollup vide, rien ne s'ouvre et la barre de statut explique
+pourquoi.
 
 | Touche         | Verbe (`[tui.keys.modal.ci_checks]`)                                    |
 |:---------------|:-------------------------------------------------------------------------|

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -84,6 +84,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `2`         | ouvrir (si masqué) et donner le focus au panneau de statut (`focus_status`)                       |
 | `3`         | ouvrir l'overlay Command Logs (`command_logs`) : transcription scrollable des commandes lancées par gwm |
 | `4`         | ouvrir le [panneau Paramètres](#panneau-paramètres-4) (`config_panel`) : éditer le thème / les worktrees / la TUI et **tous les keymaps**, avec une colonne de source par ligne |
+| `6`         | ouvrir la [liste des commits](#liste-des-commits-6) (`commits`) : le panneau Commits de la barre latérale en plein écran, avec une touche pour charger plus |
 | `x`         | ouvrir la [surcouche de sélection exec](#surcouche-de-sélection-exec-x) (`exec_overlay`) : choisir un profil [`[exec.profiles]`](/fr/configuration/gwm-toml#exec) et le lancer dans une [surcouche PTY](/fr/tui/launchers#la-surcouche-pty-embarquée-l--r) sur le worktree sélectionné |
 | `X`         | ouvrir la [surcouche de nettoyage](#surcouche-de-nettoyage-x) (`clean_overlay`) : prévisualiser et récupérer l'espace des artefacts de build du worktree sélectionné (compte à rebours de sécurité avant suppression) |
 | `a`         | ouvrir la [surcouche des sessions d'agents](#surcouche-des-sessions-dagents-a) (`agent_sessions`) : lister les sessions d'agents IA (Claude Code, Codex, opencode, Mistral Vibe) attachées au worktree sélectionné |
@@ -296,6 +297,31 @@ la nouvelle touche fonctionne immédiatement. Une capture vide (`Enter` sans rie
 enregistrer, global uniquement) délie l'action. `Esc`, `Enter`, `Backspace` et
 `Ctrl+C` ne peuvent pas être assignés par capture : éditez `.gwm.toml` à la main
 pour ces cas (voir [`[tui.keys]`](/fr/configuration/gwm-toml#tuikeys)).
+
+## liste des commits (`6`)
+
+`6` ouvre le panneau Commits de la barre latérale sur toute la surface : le
+même graphe, les mêmes colonnes hash court / initiales d'auteur / sujet, mais
+avec tout le terminal au lieu d'une fraction de la barre partagée avec quatre
+autres blocs. Le log est lu à l'ouverture, donc la surcouche fonctionne barre
+latérale masquée ou en mode `stashes`, là où le panneau lui-même n'affiche
+rien. Le parcours tourne sur un worker : la surcouche s'ouvre sur une ligne
+`loading` et se remplit quand la lecture atterrit, donc un historique profond
+ne gèle jamais la boucle d'événements.
+
+La barre latérale plafonne la liste à 300 commits. Ici, `m` relit une page
+plus profond, jusqu'à 1500, donc l'historique est paginé au lieu d'être
+plafonné. Le titre porte le nombre de lignes et un `+` final tant qu'une page
+plus profonde existe ; l'indice `load more` disparaît quand le revwalk a
+épuisé l'historique ou que le plafond est atteint, donc la touche n'est
+jamais annoncée là où elle ne ferait rien.
+
+| Touche                     | Action                        |
+|:---------------------------|:------------------------------|
+| `j` / `k` (`Down` / `Up`)  | défiler                       |
+| `g` / `G` (`Home` / `End`) | aller en haut / en bas        |
+| `m`                        | lire une page plus profond    |
+| `Esc` / `q` / `6`          | fermer                        |
 
 ## invite de liaison issue / PR (`i`)
 
@@ -585,7 +611,7 @@ se distingue de sa description. Toutes les couleurs suivent le `[theme]` résolu
 La surcouche documente **tous** les contextes de touches : les actions globales
 et de la vue liste, puis une section par overlay modal (formulaire de création,
 suppression, menu de liens, prompt de liaison, palette de commandes, profils
-exec, nettoyage, sessions d'agent, checks CI, vue PR / issue, journal de commandes, panneau de
+exec, nettoyage, sessions d'agent, checks CI, vue PR / issue, journal de commandes, commits, panneau de
 réglages, rapport de bootstrap, l'échappatoire PTY et la navigation de la
 surcouche elle-même). Chaque verbe modal est résolu en direct contre
 `[tui.keys.modal.<contexte>]` : un remappage s'affiche tel quel et un verbe

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -314,11 +314,24 @@ checks. C'est cette uniformité qui fait disparaître le routage contextuel
 qui donnait au pane status son propre `c`, et qui déplace le renommage sur
 `e` (et `exit_to_worktree` sur `E`).
 
-La droite de chaque ligne porte ce que les colonnes n'ont pas : l'auteur et
-l'ancienneté du commit, colorée par fraîcheur. Elle disparaît quand le sujet
-ne peut pas céder la place, en se réduisant d'abord à l'âge seul, de sorte
-qu'un terminal étroit garde un sujet lisible au lieu de l'échanger contre
-une colonne.
+La droite de chaque ligne porte ce que les colonnes n'ont pas : l'auteur, ce
+que le commit a changé, et son ancienneté. Les compteurs se lisent
+`3~ 1+ 2- +120 -34` : fichiers modifiés, ajoutés et supprimés, puis lignes
+insérées et supprimées, dans les mêmes couleurs que le panneau Working Tree.
+Une catégorie vide est omise plutôt qu'affichée à zéro.
+
+Trois paliers, choisis sur ce que le **sujet** peut céder plutôt que sur la
+largeur du terminal (le graphe est aussi large que la topologie des branches
+le veut) : `auteur · compteurs · âge`, puis `compteurs · âge`, puis l'âge
+seul, puis rien. Un terminal étroit garde un sujet lisible au lieu de
+l'échanger contre une colonne.
+
+Les compteurs viennent d'une seconde lecture. Le log s'affiche d'abord, la
+colonne s'élargit environ une seconde plus tard sur la première page et
+jusqu'à trois sur la plus profonde : `git log` les calcule pour toutes les
+lignes d'un coup, ce qui est bien moins cher que de differ chaque commit,
+mais pas gratuit. Les merges sont diffés contre leur premier parent, donc un
+merge montre ce qu'il a apporté plutôt que rien.
 
 La barre latérale plafonne la liste à 300 commits. Ici, `m` relit une page
 plus profond, jusqu'à 1500, donc l'historique est paginé au lieu d'être
@@ -330,6 +343,7 @@ jamais annoncée là où elle ne ferait rien.
 | Touche                     | Action                        |
 |:---------------------------|:------------------------------|
 | `j` / `k` (`Down` / `Up`)  | défiler                       |
+| `D` / `U`                  | défiler d'une demi-page       |
 | `g` / `G` (`Home` / `End`) | aller en haut / en bas        |
 | `m`                        | lire une page plus profond    |
 | `Esc` / `q` / `c`          | fermer                        |

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -688,7 +688,7 @@ et fait foi si un futur build décale une valeur par défaut.
 | `focus_status`            | `2`                 | focus sur le panneau de statut                        |
 | `command_logs`            | `3`                 | ouvrir l'overlay Command Logs                         |
 | `config_panel`            | `4`                 | ouvrir le panneau Settings                            |
-| `commits`                 | `6`                 | ouvrir la liste des commits en plein écran, avec load-more |
+| `commits`                 | `c`                 | ouvrir la liste des commits en plein écran, avec load-more |
 | `toggle_sidebar`          | `V`                 | afficher / masquer la sidebar de détails              |
 | `toggle_sidebar_mode`     | `S`                 | faire cycler le panneau Details (`commits` ↔ `stashes`) |
 | `cycle_sidebar_layout`    | `z`                 | faire cycler le layout (`auto` → côte-à-côte → empilé → auto) |
@@ -703,9 +703,9 @@ et fait foi si un futur build décale une valeur par défaut.
 | `delete_branch`           | `D`                 | armer la suppression de branche au remove             |
 | `pull`                    | `p`                 | `git pull` sur la branche sélectionnée (async)        |
 | `push`                    | `P`                 | `git push` sur la branche sélectionnée (async)        |
-| `edit_worktree`           | `c`                 | renommer le worktree / la branche                     |
+| `edit_worktree`           | `e`                 | renommer le worktree / la branche                     |
 | `edit_note`               | `N`                 | éditer la note du worktree dans une modale            |
-| `exit_to_worktree`        | `e`                 | quitter et imprimer le chemin sélectionné sur stdout  |
+| `exit_to_worktree`        | `E`                 | quitter et imprimer le chemin sélectionné sur stdout  |
 | `lazygit_pty`             | `l`                 | lazygit dans l'overlay PTY embarqué (`[git_tui]`)     |
 | `lazygit_fullscreen`      | `L`                 | lazygit en plein écran                                |
 | `review_pty`              | `r`                 | outil de review dans l'overlay PTY (`[review]`)       |

--- a/docs/fr/4.configuration/1.gwm-toml.md
+++ b/docs/fr/4.configuration/1.gwm-toml.md
@@ -644,9 +644,9 @@ open_editor = ["Ctrl+e"]  # confie le même fichier à $EDITOR
 
 Lier l'une des deux à un caractère imprimable, à `Entrée`, `Retour arrière` ou `Suppr` est refusé au chargement : la touche taperait au lieu de déclencher, et l'éditeur n'aurait plus de sortie.
 
-L'ensemble des contextes et des verbes est exactement ce que la TUI expose. Exécutez `gwm tui keys` pour afficher chaque contexte de modal (`confirm`, `create`, `help`, `command_logs`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) avec ses verbes et ses touches résolues. Binder sous un **groupe** de contexte plutôt que sous une étape feuille (par ex. `[tui.keys.modal.link]` au lieu de `[tui.keys.modal.link.choose_target]`) est une erreur au chargement qui nomme l'étape à utiliser.
+L'ensemble des contextes et des verbes est exactement ce que la TUI expose. Exécutez `gwm tui keys` pour afficher chaque contexte de modal (`confirm`, `create`, `help`, `command_logs`, `commits`, `config`, `config.edit`, `report`, `open_menu`, `palette`, `link.choose_target`, `link.input_number`, …) avec ses verbes et ses touches résolues. Binder sous un **groupe** de contexte plutôt que sous une étape feuille (par ex. `[tui.keys.modal.link]` au lieu de `[tui.keys.modal.link.choose_target]`) est une erreur au chargement qui nomme l'étape à utiliser.
 
-La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `link`) existent à la fois comme action globale et comme contexte de modal ; TOML interdit de définir deux fois la même clé, donc choisissez la forme tableau (globale) ou la forme table `[tui.keys.modal.<name>]` (modal) dans un fichier donné.
+La validation au chargement rejette, comme un `GwmError::Config` dur : un contexte de modal inconnu, un verbe inconnu pour un contexte, une touche non parsable ou multi-frappes, et un conflit par contexte. À noter qu'une poignée de noms (`create`, `help`, `command_logs`, `commits`, `link`) existent à la fois comme action globale et comme contexte de modal ; TOML interdit de définir deux fois la même clé, donc choisissez la forme tableau (globale) ou la forme table `[tui.keys.modal.<name>]` (modal) dans un fichier donné.
 
 Voir [TUI → Keymap et palette](/fr/tui/keymap-and-palette).
 
@@ -688,6 +688,7 @@ et fait foi si un futur build décale une valeur par défaut.
 | `focus_status`            | `2`                 | focus sur le panneau de statut                        |
 | `command_logs`            | `3`                 | ouvrir l'overlay Command Logs                         |
 | `config_panel`            | `4`                 | ouvrir le panneau Settings                            |
+| `commits`                 | `6`                 | ouvrir la liste des commits en plein écran, avec load-more |
 | `toggle_sidebar`          | `V`                 | afficher / masquer la sidebar de détails              |
 | `toggle_sidebar_mode`     | `S`                 | faire cycler le panneau Details (`commits` ↔ `stashes`) |
 | `cycle_sidebar_layout`    | `z`                 | faire cycler le layout (`auto` → côte-à-côte → empilé → auto) |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2912,6 +2912,33 @@ impl App {
     }
   }
 
+  /// The worktree the commit overlay opened on, if it is still listed.
+  ///
+  /// Deliberately not [`Self::selected`]: the auto-refresh moves the
+  /// selection while the overlay is up, and the drain matches a payload
+  /// against `commits.path`, so a read fired for the newly-selected
+  /// worktree is dropped on the path check *after* `complete` freed the
+  /// slot, leaving nothing to clear the loader (Codex review, PR #614).
+  ///
+  /// `None` once another process removes the worktree and the refresh drops
+  /// it from the list: there is no longer anything to walk.
+  fn commits_target(&self) -> Option<&WorktreeInfo> {
+    let path = self.commits.path.as_deref()?;
+    self.worktrees.iter().find(|w| w.path == path)
+  }
+
+  /// Whether the commit overlay can page deeper: the listing says a page
+  /// exists AND the worktree it opened on is still there to read.
+  ///
+  /// [`CommitsModal::can_load_more`] owns the arithmetic and cannot see the
+  /// worktree list, so on its own it keeps saying yes for a worktree that
+  /// has been removed underneath the overlay. The renderer and
+  /// [`Self::load_more_commits`] both read *this*, so the advertised key
+  /// and the key that acts can never disagree.
+  pub fn commits_can_load_more(&self) -> bool {
+    self.commits.can_load_more() && self.commits_target().is_some()
+  }
+
   /// Re-read the commit listing one page deeper (issue #593).
   ///
   /// A re-read rather than an append: the graph renderer resolves a row's
@@ -2922,28 +2949,15 @@ impl App {
   /// sidebar's.
   ///
   /// The rows already on screen stay up while the worker runs, so paging
-  /// keeps its place instead of blanking. The deeper read targets the
-  /// worktree captured at open rather than the live selection, which the
-  /// auto-refresh can move out from under an open overlay. A no-op when
-  /// [`CommitsModal::can_load_more`] is false: a read is in flight, the
-  /// history ran out, or the paging cap was reached. The footer drops the
-  /// `load more` hint on the same predicate, so the key is never advertised
+  /// keeps its place instead of blanking. A no-op when
+  /// [`Self::commits_can_load_more`] is false; the footer drops the `load
+  /// more` hint on that same predicate, so the key is never advertised
   /// where it would do nothing.
   pub fn load_more_commits(&mut self) {
-    if !self.commits.can_load_more() {
+    if !self.commits_can_load_more() {
       return;
     }
-    // Page the worktree the overlay OPENED on, not the live selection: the
-    // auto-refresh moves the selection while the overlay is up, and a read
-    // fired for another worktree is dropped by the drain on the path check
-    // — after `complete` freed the slot — so nothing would be left to clear
-    // the loader (Codex review, PR #614). Gone from the list entirely
-    // (deleted while the overlay was open) is a no-op: `can_load_more`
-    // required `!loading`, so there is no loader to strand.
-    let Some(path) = self.commits.path.clone() else {
-      return;
-    };
-    let Some(w) = self.worktrees.iter().find(|w| w.path == path).cloned() else {
+    let Some(w) = self.commits_target().cloned() else {
       return;
     };
     let limit = self.commits.next_limit();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2213,6 +2213,30 @@ impl App {
             continue;
           }
           self.commits.load(snap);
+          // Chained here rather than from `enter_commits`: the oids to read
+          // are the ones that just landed, and the identity to read them
+          // for is whatever the overlay holds NOW — the user may have
+          // closed and reopened while the rows were in flight.
+          self.request_commit_stats();
+          applied = true;
+        }
+        TaskMsg::CommitStats(generation, path, limit, tip, tiers) => {
+          if !self.tasks.complete(TaskKind::CommitStats, generation) {
+            continue;
+          }
+          // Same three-part identity the rows are matched on. A payload
+          // that fails it describes a listing the overlay is no longer
+          // showing; dropping it is safe here because, unlike the rows,
+          // nothing is waiting on it — the columns already say author and
+          // age, and the next `request_commit_stats` covers the current
+          // listing.
+          if self.commits.path.as_deref() != Some(path.as_path())
+            || self.commits.limit != limit
+            || self.commits.head != tip
+          {
+            continue;
+          }
+          self.commits.load_stats(tiers);
           applied = true;
         }
         TaskMsg::Sidebar(generation, path, mode, sections) => {
@@ -3003,6 +3027,46 @@ impl App {
   /// `true` while the commit listing is waiting on its worker.
   pub fn is_commits_loading(&self) -> bool {
     self.commits.loading
+  }
+
+  /// Spawn the second, slower read: one `git log --raw --numstat` over the
+  /// oids already on screen, rebuilding the metadata columns with the diff
+  /// counts (issue #593).
+  ///
+  /// Chained after the rows rather than folded into them. The revwalk takes
+  /// about 0.4s and this takes one to three seconds depending on the page
+  /// depth, so folding the two would hold the whole listing behind the
+  /// slower half. The rows appear first and the column grows under them.
+  ///
+  /// A no-op with nothing to read, and when the stats for this listing are
+  /// already in place — the drain calls this on every landing, including
+  /// the ones that only re-installed the same rows.
+  pub fn request_commit_stats(&mut self) {
+    if self.commits.stats_loaded || self.commits.rows.is_empty() {
+      return;
+    }
+    let Some(path) = self.commits.path.clone() else {
+      return;
+    };
+    let (limit, tip) = (self.commits.limit, self.commits.head.clone());
+    let oids: Vec<git2::Oid> = self.commits.rows.iter().map(|r| r.hash).collect();
+    let rows = self.commits.rows.clone();
+    // A read for a different listing is still out: free the slot, or this
+    // one never starts and the columns never grow.
+    if self.tasks.is_loading(TaskKind::CommitStats) {
+      self.tasks.invalidate(TaskKind::CommitStats);
+    }
+    let Some(generation) = self.tasks.request(TaskKind::CommitStats) else {
+      return;
+    };
+    let theme = self.theme;
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let stats = crate::worktree::commit_stats(&path, &oids).unwrap_or_default();
+      let now = crate::worktree::unix_now();
+      let tiers = crate::tui::ui::commit_meta_columns(&rows, now, &stats, &theme);
+      let _ = tx.send(TaskMsg::CommitStats(generation, path, limit, tip, tiers));
+    });
   }
 
   /// Open the Configuration panel (issue #232). Resolves the effective

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2922,7 +2922,9 @@ impl App {
   /// sidebar's.
   ///
   /// The rows already on screen stay up while the worker runs, so paging
-  /// keeps its place instead of blanking. A no-op when
+  /// keeps its place instead of blanking. The deeper read targets the
+  /// worktree captured at open rather than the live selection, which the
+  /// auto-refresh can move out from under an open overlay. A no-op when
   /// [`CommitsModal::can_load_more`] is false: a read is in flight, the
   /// history ran out, or the paging cap was reached. The footer drops the
   /// `load more` hint on the same predicate, so the key is never advertised
@@ -2931,7 +2933,17 @@ impl App {
     if !self.commits.can_load_more() {
       return;
     }
-    let Some(w) = self.selected().cloned() else {
+    // Page the worktree the overlay OPENED on, not the live selection: the
+    // auto-refresh moves the selection while the overlay is up, and a read
+    // fired for another worktree is dropped by the drain on the path check
+    // — after `complete` freed the slot — so nothing would be left to clear
+    // the loader (Codex review, PR #614). Gone from the list entirely
+    // (deleted while the overlay was open) is a no-op: `can_load_more`
+    // required `!loading`, so there is no loader to strand.
+    let Some(path) = self.commits.path.clone() else {
+      return;
+    };
+    let Some(w) = self.worktrees.iter().find(|w| w.path == path).cloned() else {
       return;
     };
     let limit = self.commits.next_limit();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2890,6 +2890,17 @@ impl App {
   /// is the sidebar's own limit, so a sidebar that already walked this tip
   /// makes the worker a hash lookup.
   ///
+  /// The tip comes from `WorktreeInfo.head`, the snapshot `worktree::list`
+  /// took at the last refresh, NOT from resolving HEAD here. A commit
+  /// landing between two refreshes is therefore invisible to the overlay
+  /// until the next one — which is exactly what the sidebar's Commits pane
+  /// shows, since it hands the same `WorktreeInfo` to the same memo
+  /// (`ui.rs`, `SidebarMode::Commits`). Resolving HEAD at open would make
+  /// the overlay disagree with the pane it is a full-size view of, and the
+  /// staleness window is one auto-refresh interval. Raised twice by Codex
+  /// on PR #614 and declined both times: the snapshot is the contract of
+  /// `recent_commits_cached`, not an oversight here.
+  ///
   /// With nothing selected the overlay still opens, empty — the
   /// [`Self::enter_config_panel`] precedent: a modal that refuses to open
   /// reads as a dead key.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2201,7 +2201,7 @@ impl App {
           applied = true;
           refresh_applied = true;
         }
-        TaskMsg::Commits(generation, path, limit, lines) => {
+        TaskMsg::Commits(generation, path, limit, lines, loaded) => {
           if !self.tasks.complete(TaskKind::Commits, generation) {
             continue;
           }
@@ -2212,7 +2212,7 @@ impl App {
           if self.commits.path.as_deref() != Some(path.as_path()) || self.commits.limit != limit {
             continue;
           }
-          self.commits.load(lines);
+          self.commits.load(lines, loaded);
           applied = true;
         }
         TaskMsg::Sidebar(generation, path, mode, sections) => {
@@ -2897,15 +2897,21 @@ impl App {
     let selected = self.selected().cloned();
     let target = selected.as_ref().map(|w| w.path.as_path());
     // Coalescing is only sound while the in-flight read is for the SAME
-    // worktree at the SAME limit (the #592 lesson, PR #612). Otherwise the
+    // worktree, at the SAME limit, on the SAME tip (the #592 lesson, PR
+    // #612; the tip added by a Codex review on PR #614 — a commit landing
+    // while the overlay is closed mid-read would otherwise be swallowed by
+    // a worker holding the old `head`). Otherwise the
     // request would come back `None` because the slot is still the old
     // read's, no worker would exist for this one, and the old payload is
     // dropped by the checks in the drain — leaving the loader up with
     // nothing left to clear it.
-    if self.commits.loading && (self.commits.path.as_deref() != target || self.commits.limit != COMMITS_PAGE) {
+    let tip = selected.as_ref().and_then(|w| w.head.clone());
+    if self.commits.loading
+      && (self.commits.path.as_deref() != target || self.commits.limit != COMMITS_PAGE || self.commits.head != tip)
+    {
       self.tasks.invalidate(TaskKind::Commits);
     }
-    self.commits.begin(target, COMMITS_PAGE);
+    self.commits.begin(target, COMMITS_PAGE, tip);
     self.view = View::Commits;
     if let Some(w) = selected {
       self.request_commits_read(w, COMMITS_PAGE);
@@ -2978,8 +2984,8 @@ impl App {
     let theme = self.theme;
     let tx = self.task_tx.clone();
     std::thread::spawn(move || {
-      let lines = crate::tui::ui::recent_commits_lines(&w, limit, &theme);
-      let _ = tx.send(TaskMsg::Commits(generation, w.path, limit, lines));
+      let (lines, loaded) = crate::tui::ui::recent_commits_listing(&w, limit, &theme);
+      let _ = tx.send(TaskMsg::Commits(generation, w.path, limit, lines, loaded));
     });
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2201,7 +2201,7 @@ impl App {
           applied = true;
           refresh_applied = true;
         }
-        TaskMsg::Commits(generation, path, limit, lines, loaded) => {
+        TaskMsg::Commits(generation, path, limit, snap) => {
           if !self.tasks.complete(TaskKind::Commits, generation) {
             continue;
           }
@@ -2212,7 +2212,7 @@ impl App {
           if self.commits.path.as_deref() != Some(path.as_path()) || self.commits.limit != limit {
             continue;
           }
-          self.commits.load(lines, loaded);
+          self.commits.load(snap);
           applied = true;
         }
         TaskMsg::Sidebar(generation, path, mode, sections) => {
@@ -2995,8 +2995,8 @@ impl App {
     let theme = self.theme;
     let tx = self.task_tx.clone();
     std::thread::spawn(move || {
-      let (lines, loaded) = crate::tui::ui::recent_commits_listing(&w, limit, &theme);
-      let _ = tx.send(TaskMsg::Commits(generation, w.path, limit, lines, loaded));
+      let snap = crate::tui::ui::recent_commits_listing(&w, limit, crate::worktree::unix_now(), &theme);
+      let _ = tx.send(TaskMsg::Commits(generation, w.path, limit, snap));
     });
   }
 
@@ -3908,23 +3908,6 @@ impl App {
       if let Some(n) = self.github.link.pr {
         self.spawn_github_pr_threads(n);
       }
-    }
-  }
-
-  /// Contextual KEY routing (issue #436) — same mechanism that turns
-  /// `j` / `k` into sidebar scroll: while the status pane holds the
-  /// focus, the `c` keystroke (EditWorktree) opens the CI checks
-  /// overlay instead of the rename modal. Applied by the event loop on
-  /// the **key path only** (Codex review #455): the command palette
-  /// dispatches actions by their NAME, so its `edit-worktree` entry
-  /// must stay a rename in every context (a dedicated `ci-checks`
-  /// entry already exists there). Pure, so the contract is pinned
-  /// without an event loop.
-  pub fn resolve_contextual_action(&self, action: Action) -> Action {
-    if action == Action::EditWorktree && self.sidebar.open && self.sidebar.focused {
-      Action::CiChecks
-    } else {
-      action
     }
   }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7,6 +7,7 @@ use super::state::async_task::{
 };
 use super::state::clean_overlay::CleanOverlay;
 use super::state::command_logs::CommandLogs;
+use super::state::commits::{CommitsModal, COMMITS_PAGE};
 use super::state::config_panel::{ConfigPanel, FieldKind, KeyTarget, SettingField, SettingsLayer};
 use super::state::confirm::{ConfirmKeyAction, ConfirmModal, CountdownTickOutcome};
 use super::state::create_form::{CreateForm, Field, Mode};
@@ -118,6 +119,13 @@ pub enum View {
   /// commands gwm ran. Opened on `3`, scrolled like the help overlay;
   /// state lives on [`App::command_logs`].
   CommandLogs,
+  /// Full-size commit listing (issue #593). A ~90% fullscreen modal
+  /// showing the same graph the sidebar's Commits pane paints, given the
+  /// whole screen, plus a load-more key that re-reads at a deeper limit so
+  /// history is paged rather than capped at
+  /// [`super::ui::RECENT_COMMITS_LIMIT`]. Opened on `6`, scrolled like the
+  /// help overlay; state lives on [`App::commits`].
+  Commits,
   /// Configuration panel (issue #232). A ~90% fullscreen modal over a
   /// dimmed list showing the resolved `.gwm.toml` (user-level global
   /// deep-merged under the repo file) with a per-row source column
@@ -592,6 +600,11 @@ pub struct App {
   /// renders off `App` state rather than locking the global mid-frame.
   pub command_logs: CommandLogs,
 
+  /// Full-size commit listing overlay state (issue #593): the scroll
+  /// cursor plus the paged graph snapshot, filled by
+  /// [`Self::enter_commits`] and deepened by [`Self::load_more_commits`].
+  pub commits: CommitsModal,
+
   /// Configuration panel overlay state (issue #232): the scroll cursor
   /// plus the resolved-row snapshot, filled by [`Self::enter_config_panel`].
   pub config_panel: ConfigPanel,
@@ -878,6 +891,7 @@ impl App {
       task_rx,
       command_logs: CommandLogs::new(),
       config_panel: ConfigPanel::new(),
+      commits: CommitsModal::new(),
       global_path: global_path.map(Path::to_path_buf),
       pty_overlay: None,
       exec_picker: ExecPicker::new(),
@@ -2187,6 +2201,20 @@ impl App {
           applied = true;
           refresh_applied = true;
         }
+        TaskMsg::Commits(generation, path, limit, lines) => {
+          if !self.tasks.complete(TaskKind::Commits, generation) {
+            continue;
+          }
+          // Two ways this payload can be stale: the selection moved while
+          // the walk ran (or the overlay was closed and reopened elsewhere),
+          // and the overlay paged past the limit this result was read at.
+          // Both describe a listing the overlay is no longer showing.
+          if self.commits.path.as_deref() != Some(path.as_path()) || self.commits.limit != limit {
+            continue;
+          }
+          self.commits.load(lines);
+          applied = true;
+        }
         TaskMsg::Sidebar(generation, path, mode, sections) => {
           // Late result — the selection moved and `refresh` bumped the slot's
           // generation (a mutation invalidated a pre-mutation rebuild), so this
@@ -2719,6 +2747,8 @@ impl App {
       // The Configuration panel (issue #232) is likewise a ~90% fullscreen
       // modal; the statusbar behind it keeps the underlying pane context.
       View::Config => self.pane_hint_context(),
+      // Same for the full-size commit listing (issue #593).
+      View::Commits => self.pane_hint_context(),
       View::Pty => super::ui::HintContext::Pty,
       View::ExecPicker => HintContext::ExecPicker,
       // #557: the note bar follows the mode. With the knob off there is no
@@ -2838,6 +2868,98 @@ impl App {
     self.command_logs.sync();
     self.command_logs.reset();
     self.view = View::CommandLogs;
+  }
+
+  /// Open the full-size commit listing (issue #593).
+  ///
+  /// The overlay opens immediately on a loader and the revwalk runs on a
+  /// [`TaskKind::Commits`] worker. It is deliberately NOT inline: the walk
+  /// sorts `TIME | TOPOLOGICAL`, so it traverses the whole reachable graph
+  /// before yielding a row. Measured on this repo, asking for 300 commits
+  /// costs the same as asking for all 2058 — the limit truncates the
+  /// output, it bounds nothing about the latency, so an inline call would
+  /// freeze the event loop for as long as the history is deep. Same
+  /// boundary as the sidebar's own preview (#343), reached from a keypress
+  /// rather than from navigation.
+  ///
+  /// The rows are read fresh rather than taken from `SidebarState::cache`:
+  /// that cache is keyed by `(path, mode)` and only rebuilt while the
+  /// sidebar is open and in commits mode, so it is empty in the two states
+  /// where the overlay is most useful. The read still goes through
+  /// [`crate::worktree::recent_commits_cached`] at [`COMMITS_PAGE`], which
+  /// is the sidebar's own limit, so a sidebar that already walked this tip
+  /// makes the worker a hash lookup.
+  ///
+  /// With nothing selected the overlay still opens, empty — the
+  /// [`Self::enter_config_panel`] precedent: a modal that refuses to open
+  /// reads as a dead key.
+  pub fn enter_commits(&mut self) {
+    let selected = self.selected().cloned();
+    let target = selected.as_ref().map(|w| w.path.as_path());
+    // Coalescing is only sound while the in-flight read is for the SAME
+    // worktree at the SAME limit (the #592 lesson, PR #612). Otherwise the
+    // request would come back `None` because the slot is still the old
+    // read's, no worker would exist for this one, and the old payload is
+    // dropped by the checks in the drain — leaving the loader up with
+    // nothing left to clear it.
+    if self.commits.loading && (self.commits.path.as_deref() != target || self.commits.limit != COMMITS_PAGE) {
+      self.tasks.invalidate(TaskKind::Commits);
+    }
+    self.commits.begin(target, COMMITS_PAGE);
+    self.view = View::Commits;
+    if let Some(w) = selected {
+      self.request_commits_read(w, COMMITS_PAGE);
+    }
+  }
+
+  /// Re-read the commit listing one page deeper (issue #593).
+  ///
+  /// A re-read rather than an append: the graph renderer resolves a row's
+  /// connectors against the parents of the rows below it, so a page tacked
+  /// onto the end would draw its topology against nothing. The memo in
+  /// [`crate::worktree::recent_commits_cached`] is keyed on the limit, so
+  /// the deeper read is a fresh entry rather than an invalidation of the
+  /// sidebar's.
+  ///
+  /// The rows already on screen stay up while the worker runs, so paging
+  /// keeps its place instead of blanking. A no-op when
+  /// [`CommitsModal::can_load_more`] is false: a read is in flight, the
+  /// history ran out, or the paging cap was reached. The footer drops the
+  /// `load more` hint on the same predicate, so the key is never advertised
+  /// where it would do nothing.
+  pub fn load_more_commits(&mut self) {
+    if !self.commits.can_load_more() {
+      return;
+    }
+    let Some(w) = self.selected().cloned() else {
+      return;
+    };
+    let limit = self.commits.next_limit();
+    self.commits.begin_more(limit);
+    self.request_commits_read(w, limit);
+  }
+
+  /// Spawn the worker that walks `w`'s log to `limit` and renders it.
+  ///
+  /// A `None` from the slot means a read for this same worktree and limit
+  /// is already out: ride on it, which is what keeps a held `6` from
+  /// spawning a revwalk per repeat. Callers that need a *different* read
+  /// invalidate the slot first.
+  fn request_commits_read(&mut self, w: WorktreeInfo, limit: usize) {
+    let Some(generation) = self.tasks.request(TaskKind::Commits) else {
+      return;
+    };
+    let theme = self.theme;
+    let tx = self.task_tx.clone();
+    std::thread::spawn(move || {
+      let lines = crate::tui::ui::recent_commits_lines(&w, limit, &theme);
+      let _ = tx.send(TaskMsg::Commits(generation, w.path, limit, lines));
+    });
+  }
+
+  /// `true` while the commit listing is waiting on its worker.
+  pub fn is_commits_loading(&self) -> bool {
+    self.commits.loading
   }
 
   /// Open the Configuration panel (issue #232). Resolves the effective

--- a/src/tui/commit_graph.rs
+++ b/src/tui/commit_graph.rs
@@ -456,5 +456,6 @@ pub fn test_row(hash: &str, parents: &[&str]) -> CommitRow {
     author: String::new(),
     parents: parents.iter().map(|s| oid(s)).collect(),
     subject: String::new(),
+    time: 0,
   }
 }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -522,9 +522,11 @@ impl Keymap {
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
       def(Action::ConfigPanel, &["4"]),
-      // #593: `6` keeps the "numbers open panels" family going — the commit
-      // listing at full size. `5` is the Working Tree listing (#592).
-      def(Action::Commits, &["6"]),
+      // #593: `c` for commits, `C` for the checks — the same pair in both
+      // panes, so the key does not change meaning under the focus. It cost
+      // `c` its rename, which moved to `E`, and the #436 contextual
+      // routing, which existed to give the status pane its own `c`.
+      def(Action::Commits, &["c"]),
       // #436: `C` opens the CI checks overlay from anywhere in the list
       // view; `c` does the same while the status pane holds the focus
       // (contextual routing, same mechanism as j/k sidebar scroll).
@@ -553,12 +555,16 @@ impl Keymap {
       // #290: `P` is Push.
       def(Action::Push, &["P"]),
       // #290: `c` opens the edit-worktree modal (rename branch).
-      def(Action::EditWorktree, &["c"]),
+      // #593: `e` for edit. `c` went to the commit listing in both panes,
+      // and the rename took the letter that names it, which sent
+      // `exit_to_worktree` to `E`.
+      def(Action::EditWorktree, &["e"]),
       // #515: `N` opens the selected worktree's note in $EDITOR. `i`, which
       // the reference implementation uses, is taken here — it is LinkPrompt.
       def(Action::EditNote, &["N"]),
       // #290: `e` exits the TUI and prints the selected worktree path to stdout.
-      def(Action::ExitToWorktree, &["e"]),
+      // #593: `E`, having lent `e` to the rename it names.
+      def(Action::ExitToWorktree, &["E"]),
       // #35/#290: `l` opens lazygit in an embedded PTY overlay.
       def(Action::LazyGitPty, &["l"]),
       // #290: `L` opens lazygit fullscreen (was unbound before #290).

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -150,6 +150,9 @@ define_actions! {
   // Overlays
   CommandLogs       => "command_logs",
   ConfigPanel       => "config_panel",
+  // #593: the sidebar's Commits pane, given the whole terminal, with a
+  // load-more key so history is paged rather than capped.
+  Commits           => "commits",
   // #436: CI checks overlay — also reachable via `c` in the status context.
   CiChecks          => "ci_checks",
   // #420: rich PR / issue view — description, checks, reviews, comments.
@@ -519,6 +522,9 @@ impl Keymap {
       def(Action::FocusStatus, &["2"]),
       def(Action::CommandLogs, &["3"]),
       def(Action::ConfigPanel, &["4"]),
+      // #593: `6` keeps the "numbers open panels" family going — the commit
+      // listing at full size. `5` is the Working Tree listing (#592).
+      def(Action::Commits, &["6"]),
       // #436: `C` opens the CI checks overlay from anywhere in the list
       // view; `c` does the same while the status pane holds the focus
       // (contextual routing, same mechanism as j/k sidebar scroll).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -83,13 +83,13 @@ pub use ui::{
   issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_keys, link_target_line,
   list_pane_counter, markdown_style, modal_height, modal_hint_for_context, modal_hint_for_context_with_fields,
   modal_hint_line, modal_width, overlay_modal_width, pad_cells, palette_name_style, pane_counter, panel_border_color,
-  picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_items_pane_title, reclaim_size_color,
-  rename_buttons_line, rich_view_modal_width, skip_cells, status_line, status_pane_title, table_marker,
-  tilde_compress_with_home, type_selector_line, working_tree_counts_footer, working_tree_pane_title,
-  working_tree_status_counts, working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title,
-  HelpRow, HintContext, SidebarSections, WorkingTreeCounts, CI_FAILING_ICON, CI_PASSING_ICON, CI_RUNNING_ICON,
-  COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON, WT_DELETED_ICON,
-  WT_MODIFIED_ICON,
+  picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_commits_listing,
+  recent_items_pane_title, reclaim_size_color, rename_buttons_line, rich_view_modal_width, skip_cells, status_line,
+  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_counts_footer,
+  working_tree_pane_title, working_tree_status_counts, working_tree_status_line, worktree_name_style,
+  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, WorkingTreeCounts, CI_FAILING_ICON,
+  CI_PASSING_ICON, CI_RUNNING_ICON, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
+  WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -537,6 +537,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         Some(ModalAction::CommitsScrollUp) => app.commits.scroll_up(),
         Some(ModalAction::CommitsScrollTop) => app.commits.scroll_to_top(),
         Some(ModalAction::CommitsScrollBottom) => app.commits.scroll_to_bottom(),
+        Some(ModalAction::CommitsHalfDown) => app.commits.scroll_half_down(),
+        Some(ModalAction::CommitsHalfUp) => app.commits.scroll_half_up(),
         _ => {}
       },
       // Settings panel (issue #232; editable in #279). While a numeric input

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -37,6 +37,7 @@ pub use state::async_task::{
 };
 pub use state::clean_overlay::CleanOverlay;
 pub use state::command_logs::CommandLogs;
+pub use state::commits::{CommitsModal, COMMITS_MAX, COMMITS_PAGE};
 pub use state::config_panel::{
   build_key_rows, ConfigPanel, FieldKind, KeyCapture, KeyRow, KeyTarget, SettingField, SettingsLayer, SettingsTab,
 };
@@ -524,6 +525,20 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         Some(ModalAction::CommandLogsScrollTop) => app.command_logs.scroll_to_top(),
         Some(ModalAction::CommandLogsScrollBottom) => app.command_logs.scroll_to_bottom(),
         _ if app.key_matches_action(key, Action::CommandLogs) => app.view = View::List,
+        _ => {}
+      },
+      // Full-size commit listing (issue #593). Scrolls like the Command
+      // Logs overlay; `m` re-reads one page deeper. Closes on Esc / `q` or
+      // the bound `commits` key (default `6`) so the open key toggles it
+      // shut.
+      View::Commits => match app.resolve_modal(KeyContext::Commits, key) {
+        Some(ModalAction::CommitsClose) => app.view = View::List,
+        Some(ModalAction::CommitsLoadMore) => app.load_more_commits(),
+        Some(ModalAction::CommitsScrollDown) => app.commits.scroll_down(),
+        Some(ModalAction::CommitsScrollUp) => app.commits.scroll_up(),
+        Some(ModalAction::CommitsScrollTop) => app.commits.scroll_to_top(),
+        Some(ModalAction::CommitsScrollBottom) => app.commits.scroll_to_bottom(),
+        _ if app.key_matches_action(key, Action::Commits) => app.view = View::List,
         _ => {}
       },
       // Settings panel (issue #232; editable in #279). While a numeric input
@@ -1165,6 +1180,9 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     // overlay it is read-only and not picker-gated — harmless inside
     // `gwm switch`, opening from any List state.
     Action::ConfigPanel => app.enter_config_panel(),
+    // Issue #593: `6` opens the commit listing full size. Read-only like
+    // the two overlays above, so it is not picker-gated either.
+    Action::Commits => app.enter_commits(),
     // Issue #325: `x` opens the exec profile picker. Picker-gated —
     // running a profile in a PTY is a focus-mode action, meaningless in
     // the stripped-down `gwm switch` picker.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -37,7 +37,7 @@ pub use state::async_task::{
 };
 pub use state::clean_overlay::CleanOverlay;
 pub use state::command_logs::CommandLogs;
-pub use state::commits::{CommitsModal, COMMITS_MAX, COMMITS_PAGE};
+pub use state::commits::{CommitsModal, CommitsSnapshot, MetaColumn, COMMITS_MAX, COMMITS_PAGE};
 pub use state::config_panel::{
   build_key_rows, ConfigPanel, FieldKind, KeyCapture, KeyRow, KeyTarget, SettingField, SettingsLayer, SettingsTab,
 };
@@ -73,23 +73,24 @@ pub fn clipboard_candidates() -> Vec<(&'static str, Vec<&'static str>)> {
 pub use ui::{
   agent_cell_label, agent_pane_lines, agents_pane_title, author_initials, badge_group_width, bootstrap_report_lines,
   branch_name_color, branch_status_color, build_sidebar_payload, build_sidebar_sections, cells, centered_abs,
-  chip_style, ci_indicator, clean_dir_icon, command_logs_footer_hints, compact_header_fill, compact_header_line,
-  compact_header_style, config_capture_footer_hints, config_edit_footer_hints, config_nav_footer_hints,
-  confirm_buttons_line, confirm_delete_branch_line, confirm_detail_line, create_buttons_line, delete_batch_title,
-  delete_worktree_title, detail_overlay_width, detail_visible_rows, display_path_with_home, ellipsize_middle,
-  field_input_line, filled_cells_for_progress, folded_status_line, footer_line, form_field_scroll, format_status,
-  freshness_color, github_status_lines, header_line, help_body_section_color, help_entry_line, help_label_style,
-  help_lines, help_rows, help_section_style, hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title,
-  issue_summary_line, link_open_modal_lines, link_prompt_modal_width, link_target_keys, link_target_line,
-  list_pane_counter, markdown_style, modal_height, modal_hint_for_context, modal_hint_for_context_with_fields,
-  modal_hint_line, modal_width, overlay_modal_width, pad_cells, palette_name_style, pane_counter, panel_border_color,
-  picker_window, pr_badge_color, pr_summary_line, recent_commits_lines, recent_commits_listing,
-  recent_items_pane_title, reclaim_size_color, rename_buttons_line, rich_view_modal_width, skip_cells, status_line,
-  status_pane_title, table_marker, tilde_compress_with_home, type_selector_line, working_tree_counts_footer,
-  working_tree_pane_title, working_tree_status_counts, working_tree_status_line, worktree_name_style,
-  worktree_path_style, worktrees_pane_title, HelpRow, HintContext, SidebarSections, WorkingTreeCounts, CI_FAILING_ICON,
-  CI_PASSING_ICON, CI_RUNNING_ICON, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT,
-  WT_CREATED_ICON, WT_DELETED_ICON, WT_MODIFIED_ICON,
+  chip_style, ci_indicator, clean_dir_icon, command_logs_footer_hints, commit_meta_columns, commits_meta_pick,
+  compact_header_fill, compact_header_line, compact_header_style, config_capture_footer_hints,
+  config_edit_footer_hints, config_nav_footer_hints, confirm_buttons_line, confirm_delete_branch_line,
+  confirm_detail_line, create_buttons_line, delete_batch_title, delete_worktree_title, detail_overlay_width,
+  detail_visible_rows, display_path_with_home, ellipsize_middle, field_input_line, filled_cells_for_progress,
+  folded_status_line, footer_line, form_field_scroll, format_status, freshness_color, github_status_lines, header_line,
+  help_body_section_color, help_entry_line, help_label_style, help_lines, help_rows, help_section_style,
+  hint_key_style, hint_label_style, issue_badge_color, issue_pr_pane_title, issue_summary_line, link_open_modal_lines,
+  link_prompt_modal_width, link_target_keys, link_target_line, list_pane_counter, markdown_style, modal_height,
+  modal_hint_for_context, modal_hint_for_context_with_fields, modal_hint_line, modal_width, overlay_modal_width,
+  pad_cells, palette_name_style, pane_counter, panel_border_color, picker_window, pr_badge_color, pr_summary_line,
+  recent_commits_lines, recent_commits_listing, recent_items_pane_title, reclaim_size_color, rename_buttons_line,
+  rich_view_modal_width, skip_cells, status_line, status_pane_title, table_marker, tilde_compress_with_home,
+  type_selector_line, working_tree_counts_footer, working_tree_pane_title, working_tree_status_counts,
+  working_tree_status_line, worktree_name_style, worktree_path_style, worktrees_pane_title, HelpRow, HintContext,
+  SidebarSections, WorkingTreeCounts, CI_FAILING_ICON, CI_PASSING_ICON, CI_RUNNING_ICON, COMMITS_META_GAP,
+  COMMITS_SUBJECT_FLOOR, COMMIT_HASH_DISPLAY_LEN, ISSUE_ICON, PR_ICON, RECENT_COMMITS_LIMIT, WT_CREATED_ICON,
+  WT_DELETED_ICON, WT_MODIFIED_ICON,
 };
 
 /// The single TUI render entry point. **Not part of the public SemVer
@@ -492,7 +493,6 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
             // (c → CI checks while the status pane is focused); the
             // palette path deliberately does not — its entries dispatch
             // by name (Codex review #455).
-            let action = app.resolve_contextual_action(action);
             run_action(terminal, &mut app, action)?;
           }
         }
@@ -528,9 +528,8 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         _ => {}
       },
       // Full-size commit listing (issue #593). Scrolls like the Command
-      // Logs overlay; `m` re-reads one page deeper. Closes on Esc / `q` or
-      // the bound `commits` key (default `6`) so the open key toggles it
-      // shut.
+      // Logs overlay; `m` re-reads one page deeper. Closes on Esc, `q` or
+      // `c` — the key that opened it.
       View::Commits => match app.resolve_modal(KeyContext::Commits, key) {
         Some(ModalAction::CommitsClose) => app.view = View::List,
         Some(ModalAction::CommitsLoadMore) => app.load_more_commits(),
@@ -538,7 +537,6 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, mut app: App) 
         Some(ModalAction::CommitsScrollUp) => app.commits.scroll_up(),
         Some(ModalAction::CommitsScrollTop) => app.commits.scroll_to_top(),
         Some(ModalAction::CommitsScrollBottom) => app.commits.scroll_to_bottom(),
-        _ if app.key_matches_action(key, Action::Commits) => app.view = View::List,
         _ => {}
       },
       // Settings panel (issue #232; editable in #279). While a numeric input
@@ -1180,8 +1178,9 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
     // overlay it is read-only and not picker-gated — harmless inside
     // `gwm switch`, opening from any List state.
     Action::ConfigPanel => app.enter_config_panel(),
-    // Issue #593: `6` opens the commit listing full size. Read-only like
-    // the two overlays above, so it is not picker-gated either.
+    // Issue #593: `c` opens the commit listing full size, in both panes.
+    // Read-only like the two overlays above, so it is not picker-gated
+    // either.
     Action::Commits => app.enter_commits(),
     // Issue #325: `x` opens the exec profile picker. Picker-gated —
     // running a profile in a PTY is a focus-mode action, meaningless in

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -89,6 +89,10 @@ pub enum KeyContext {
   Detail,
   /// Command-logs overlay (issue #226, scroll-only + copy).
   CommandLogs,
+  /// Full-size commit listing (issue #593, scroll + load-more). Its own
+  /// context rather than a share of [`Self::CommandLogs`]: the two scroll
+  /// alike but rebinding one must not silently rebind the other.
+  Commits,
   /// Settings panel navigation (issue #232).
   Config,
   /// Settings panel while a numeric field is being edited (sub-mode of
@@ -170,6 +174,7 @@ impl KeyContext {
       KeyContext::Help => "help",
       KeyContext::Detail => "detail",
       KeyContext::CommandLogs => "command_logs",
+      KeyContext::Commits => "commits",
       KeyContext::Config => "config",
       KeyContext::ConfigEdit => "config.edit",
       KeyContext::Report => "report",
@@ -200,6 +205,7 @@ impl KeyContext {
       Help,
       Detail,
       CommandLogs,
+      Commits,
       Config,
       ConfigEdit,
       Report,
@@ -312,6 +318,14 @@ define_modal_actions! {
     CommandLogsScrollLeft   => "scroll_left"   [ "Left", "h" ],
     CommandLogsScrollTop    => "scroll_top"    [ "Home", "g" ],
     CommandLogsScrollBottom => "scroll_bottom" [ "End", "G" ],
+  }
+  Commits {
+    CommitsClose        => "close"         [ "Esc", "q" ],
+    CommitsLoadMore     => "load_more"     [ "m" ],
+    CommitsScrollDown   => "scroll_down"   [ "Down", "j" ],
+    CommitsScrollUp     => "scroll_up"     [ "Up", "k" ],
+    CommitsScrollTop    => "scroll_top"    [ "Home", "g" ],
+    CommitsScrollBottom => "scroll_bottom" [ "End", "G" ],
   }
   Config {
     ConfigClose        => "close"         [ "Esc", "q" ],

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -326,6 +326,8 @@ define_modal_actions! {
     CommitsScrollUp     => "scroll_up"     [ "Up", "k" ],
     CommitsScrollTop    => "scroll_top"    [ "Home", "g" ],
     CommitsScrollBottom => "scroll_bottom" [ "End", "G" ],
+    CommitsHalfDown     => "half_down"     [ "D" ],
+    CommitsHalfUp       => "half_up"       [ "U" ],
   }
   Config {
     ConfigClose        => "close"         [ "Esc", "q" ],

--- a/src/tui/modal_keymap.rs
+++ b/src/tui/modal_keymap.rs
@@ -320,7 +320,7 @@ define_modal_actions! {
     CommandLogsScrollBottom => "scroll_bottom" [ "End", "G" ],
   }
   Commits {
-    CommitsClose        => "close"         [ "Esc", "q" ],
+    CommitsClose        => "close"         [ "Esc", "q", "c" ],
     CommitsLoadMore     => "load_more"     [ "m" ],
     CommitsScrollDown   => "scroll_down"   [ "Down", "j" ],
     CommitsScrollUp     => "scroll_up"     [ "Up", "k" ],

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -262,6 +262,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "show the resolved configuration panel",
     },
     PaletteEntry {
+      action: Action::Commits,
+      name: "commits",
+      description: "show the commit listing full size, with load-more",
+    },
+    PaletteEntry {
       action: Action::ExecOverlay,
       name: "exec",
       description: "pick an [exec.profiles] profile and run it in a PTY",

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -40,6 +40,7 @@ use crate::sync::SyncReport;
 use crate::tui::state::sidebar::SidebarMode;
 use crate::tui::ui::SidebarSections;
 use crate::worktree::WorktreeInfo;
+use ratatui::text::Line;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -126,6 +127,14 @@ pub enum TaskKind {
   /// per row; the render key-check discards a result for a since-moved
   /// selection and the next tick requests the settled one.
   Sidebar,
+  /// Off-thread snapshot for the full-size commit listing (issue #593).
+  /// The same revwalk the sidebar's Commits pane runs, but requested by a
+  /// keypress rather than by navigation, and it cannot run inline: the walk
+  /// sorts `TIME | TOPOLOGICAL`, so it traverses the whole reachable graph
+  /// before yielding a row and the limit bounds the output, not the
+  /// latency. A single global slot; a repeated `6` on the same worktree at
+  /// the same limit coalesces onto the read already out.
+  Commits,
   /// Off-thread agent-session detection (issue #408): the four artefact
   /// scans under the user's home (`agent_sessions::detect_all`) touch the
   /// filesystem and must never run inside `terminal.draw()`. A single global
@@ -162,6 +171,7 @@ impl TaskKind {
       TaskKind::EditWorktree => "renaming worktree…",
       TaskKind::RefreshWorkspace => "refreshing worktrees…",
       TaskKind::Sidebar => "loading preview…",
+      TaskKind::Commits => "reading the log…",
       TaskKind::AgentSessions => "detecting agent sessions…",
       TaskKind::AgentPane => "opening agent pane…",
     }
@@ -392,6 +402,12 @@ pub enum TaskMsg {
   /// `SidebarState::cache`; a result whose selection has since moved is dropped
   /// by [`TaskRunner::complete`] (generation) and ignored by the render (key).
   Sidebar(u64, PathBuf, SidebarMode, SidebarSections),
+  /// Commit-listing snapshot (issue #593): the generation, the worktree
+  /// `path` and the `limit` it was read at, and the rendered graph rows.
+  /// The drain hands the rows to `CommitsModal::load`; a result for a path
+  /// the user has navigated away from, or for a limit the overlay has since
+  /// paged past, is dropped.
+  Commits(u64, PathBuf, usize, Vec<Line<'static>>),
   /// An agent-session detection result (issue #408): the worker's generation
   /// and the per-worktree-path summary. The drain replaces the app snapshot
   /// atomically; a superseded late result is dropped by

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -37,10 +37,10 @@
 use crate::bootstrap::BootstrapReport;
 use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
+use crate::tui::state::commits::CommitsSnapshot;
 use crate::tui::state::sidebar::SidebarMode;
 use crate::tui::ui::SidebarSections;
 use crate::worktree::WorktreeInfo;
-use ratatui::text::Line;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -403,13 +403,14 @@ pub enum TaskMsg {
   /// by [`TaskRunner::complete`] (generation) and ignored by the render (key).
   Sidebar(u64, PathBuf, SidebarMode, SidebarSections),
   /// Commit-listing snapshot (issue #593): the generation, the worktree
-  /// `path` and the `limit` it was read at, the rendered graph rows, and
-  /// the commit count they describe (which is NOT `lines.len()` — the
-  /// empty and error cases paint one sentinel row).
+  /// `path` and the `limit` it was read at, and everything that read
+  /// produced: the rendered graph rows, the commit count they describe
+  /// (NOT `lines.len()` — the empty and error cases paint one sentinel
+  /// row), and the two right-hand metadata columns.
   /// The drain hands the rows to `CommitsModal::load`; a result for a path
   /// the user has navigated away from, or for a limit the overlay has since
   /// paged past, is dropped.
-  Commits(u64, PathBuf, usize, Vec<Line<'static>>, usize),
+  Commits(u64, PathBuf, usize, CommitsSnapshot),
   /// An agent-session detection result (issue #408): the worker's generation
   /// and the per-worktree-path summary. The drain replaces the app snapshot
   /// atomically; a superseded late result is dropped by

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -37,7 +37,7 @@
 use crate::bootstrap::BootstrapReport;
 use crate::github::{IssueStatus, PrStatus};
 use crate::sync::SyncReport;
-use crate::tui::state::commits::CommitsSnapshot;
+use crate::tui::state::commits::{CommitsSnapshot, MetaColumn};
 use crate::tui::state::sidebar::SidebarMode;
 use crate::tui::ui::SidebarSections;
 use crate::worktree::WorktreeInfo;
@@ -135,6 +135,13 @@ pub enum TaskKind {
   /// latency. A single global slot; a repeated `6` on the same worktree at
   /// the same limit coalesces onto the read already out.
   Commits,
+  /// Off-thread diff stats for the commit listing (issue #593). A second,
+  /// slower read chained after [`Self::Commits`]: one `git log --raw
+  /// --numstat` over exactly the oids already on screen, about a second
+  /// for a page and under three for the deepest. It cannot ride the first
+  /// read — that would hold the rows back behind it — so the overlay shows
+  /// the log immediately and the column grows when this lands.
+  CommitStats,
   /// Off-thread agent-session detection (issue #408): the four artefact
   /// scans under the user's home (`agent_sessions::detect_all`) touch the
   /// filesystem and must never run inside `terminal.draw()`. A single global
@@ -172,6 +179,7 @@ impl TaskKind {
       TaskKind::RefreshWorkspace => "refreshing worktrees…",
       TaskKind::Sidebar => "loading preview…",
       TaskKind::Commits => "reading the log…",
+      TaskKind::CommitStats => "reading the diffs…",
       TaskKind::AgentSessions => "detecting agent sessions…",
       TaskKind::AgentPane => "opening agent pane…",
     }
@@ -411,6 +419,13 @@ pub enum TaskMsg {
   /// the user has navigated away from, or for a limit the overlay has since
   /// paged past, is dropped.
   Commits(u64, PathBuf, usize, CommitsSnapshot),
+  /// Commit-listing diff stats (issue #593): the generation, the worktree
+  /// `path`, the `limit` and the `tip` the listing was read at, and the
+  /// rebuilt metadata columns. All three identity fields travel because
+  /// the listing can be reopened, repaged or moved on while this slower
+  /// read is out, and a column describing another listing is worse than
+  /// no column.
+  CommitStats(u64, PathBuf, usize, Option<String>, [MetaColumn; 3]),
   /// An agent-session detection result (issue #408): the worker's generation
   /// and the per-worktree-path summary. The drain replaces the app snapshot
   /// atomically; a superseded late result is dropped by

--- a/src/tui/state/async_task.rs
+++ b/src/tui/state/async_task.rs
@@ -403,11 +403,13 @@ pub enum TaskMsg {
   /// by [`TaskRunner::complete`] (generation) and ignored by the render (key).
   Sidebar(u64, PathBuf, SidebarMode, SidebarSections),
   /// Commit-listing snapshot (issue #593): the generation, the worktree
-  /// `path` and the `limit` it was read at, and the rendered graph rows.
+  /// `path` and the `limit` it was read at, the rendered graph rows, and
+  /// the commit count they describe (which is NOT `lines.len()` — the
+  /// empty and error cases paint one sentinel row).
   /// The drain hands the rows to `CommitsModal::load`; a result for a path
   /// the user has navigated away from, or for a limit the overlay has since
   /// paged past, is dropped.
-  Commits(u64, PathBuf, usize, Vec<Line<'static>>),
+  Commits(u64, PathBuf, usize, Vec<Line<'static>>, usize),
   /// An agent-session detection result (issue #408): the worker's generation
   /// and the per-worktree-path summary. The drain replaces the app snapshot
   /// atomically; a superseded late result is dropped by

--- a/src/tui/state/commits.rs
+++ b/src/tui/state/commits.rs
@@ -53,6 +53,35 @@ pub const COMMITS_PAGE: usize = RECENT_COMMITS_LIMIT;
 /// worktree keeps that well inside the budget.
 pub const COMMITS_MAX: usize = COMMITS_PAGE * 5;
 
+/// One right-hand metadata column: its rows and the width they need.
+///
+/// The width is measured once, when the column is built, so it cannot jump
+/// while the user scrolls: every row is padded to the same column.
+#[derive(Debug, Default, Clone)]
+pub struct MetaColumn {
+  pub lines: Vec<Line<'static>>,
+  pub width: usize,
+}
+
+/// Everything one read of the log produces, as it travels from the worker
+/// to the overlay.
+///
+/// One struct rather than a four-field message: the rows, their count and
+/// the two metadata columns are read together and installed together, and
+/// a caller that could install three of the four would be a bug waiting to
+/// happen.
+#[derive(Debug, Default)]
+pub struct CommitsSnapshot {
+  /// The graph rows, or a single sentinel row (empty history, load error).
+  pub lines: Vec<Line<'static>>,
+  /// Commits the rows describe. Zero for either sentinel.
+  pub loaded: usize,
+  /// `author · age` per row, shown when the subject keeps its floor.
+  pub wide: MetaColumn,
+  /// `age` per row, the fallback when `wide` does not fit.
+  pub narrow: MetaColumn,
+}
+
 /// Owned state for the full-size commit listing: the snapshotted graph
 /// rows, the limit they were read at, and the scroll cursor with its
 /// renderer-published bound.
@@ -69,6 +98,10 @@ pub struct CommitsModal {
   /// would read as a repository with one commit (Codex review, PR #614).
   /// [`super::super::ui::recent_commits_listing`] carries the real number.
   pub loaded: usize,
+  /// `author · age` per row, shown when the subject keeps its floor.
+  pub wide: MetaColumn,
+  /// `age` per row, the fallback when `wide` does not fit.
+  pub narrow: MetaColumn,
   /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
   pub scroll: u16,
   /// Maximum vertical scroll offset, republished by the renderer each
@@ -103,6 +136,8 @@ impl CommitsModal {
   /// fresh and a stale listing is never mistaken for the current one.
   pub fn begin(&mut self, path: Option<&Path>, limit: usize, head: Option<String>) {
     self.lines.clear();
+    self.wide = MetaColumn::default();
+    self.narrow = MetaColumn::default();
     self.loaded = 0;
     self.limit = limit;
     self.scroll = 0;
@@ -126,9 +161,11 @@ impl CommitsModal {
   /// commit count the read reported, not `lines.len()`. The scroll cursor
   /// is whatever [`Self::begin`] (top) or [`Self::begin_more`] (unchanged)
   /// left; the renderer re-clamps it against the new content.
-  pub fn load(&mut self, lines: Vec<Line<'static>>, loaded: usize) {
-    self.loaded = loaded;
-    self.lines = lines;
+  pub fn load(&mut self, snap: CommitsSnapshot) {
+    self.loaded = snap.loaded;
+    self.lines = snap.lines;
+    self.wide = snap.wide;
+    self.narrow = snap.narrow;
     self.loading = false;
   }
 

--- a/src/tui/state/commits.rs
+++ b/src/tui/state/commits.rs
@@ -76,10 +76,13 @@ pub struct CommitsSnapshot {
   pub lines: Vec<Line<'static>>,
   /// Commits the rows describe. Zero for either sentinel.
   pub loaded: usize,
-  /// `author · age` per row, shown when the subject keeps its floor.
-  pub wide: MetaColumn,
-  /// `age` per row, the fallback when `wide` does not fit.
-  pub narrow: MetaColumn,
+  /// The commits themselves, kept so the metadata columns can be rebuilt
+  /// when the diff stats land from the second read.
+  pub rows: Vec<crate::worktree::CommitRow>,
+  /// The metadata columns, widest first: `author · stats · age`,
+  /// `stats · age`, `age`. The stats halves are absent until the second
+  /// read fills them in.
+  pub tiers: [MetaColumn; 3],
 }
 
 /// Owned state for the full-size commit listing: the snapshotted graph
@@ -98,15 +101,24 @@ pub struct CommitsModal {
   /// would read as a repository with one commit (Codex review, PR #614).
   /// [`super::super::ui::recent_commits_listing`] carries the real number.
   pub loaded: usize,
-  /// `author · age` per row, shown when the subject keeps its floor.
-  pub wide: MetaColumn,
-  /// `age` per row, the fallback when `wide` does not fit.
-  pub narrow: MetaColumn,
+  /// The commits themselves, kept so [`Self::tiers`] can be rebuilt when
+  /// the diff stats land without a second revwalk.
+  pub rows: Vec<crate::worktree::CommitRow>,
+  /// The metadata columns, widest first. See [`CommitsSnapshot::tiers`].
+  pub tiers: [MetaColumn; 3],
+  /// `true` once the diff-stat read has landed for the current listing.
+  /// The columns are rebuilt then; until it does they carry author and age
+  /// alone.
+  pub stats_loaded: bool,
   /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
   pub scroll: u16,
   /// Maximum vertical scroll offset, republished by the renderer each
   /// frame as `content_rows.saturating_sub(viewport_rows)`.
   pub max_scroll: u16,
+  /// Rows the body can show, republished by the renderer alongside
+  /// `max_scroll`. Only the renderer knows it, and the half-page verbs
+  /// need it to move by something the user can see.
+  pub viewport: u16,
   /// `true` between the request and the worker's payload. The renderer
   /// paints a loader rather than an empty canvas, which would read as "no
   /// commits".
@@ -136,8 +148,9 @@ impl CommitsModal {
   /// fresh and a stale listing is never mistaken for the current one.
   pub fn begin(&mut self, path: Option<&Path>, limit: usize, head: Option<String>) {
     self.lines.clear();
-    self.wide = MetaColumn::default();
-    self.narrow = MetaColumn::default();
+    self.rows.clear();
+    self.tiers = Default::default();
+    self.stats_loaded = false;
     self.loaded = 0;
     self.limit = limit;
     self.scroll = 0;
@@ -164,9 +177,20 @@ impl CommitsModal {
   pub fn load(&mut self, snap: CommitsSnapshot) {
     self.loaded = snap.loaded;
     self.lines = snap.lines;
-    self.wide = snap.wide;
-    self.narrow = snap.narrow;
+    self.rows = snap.rows;
+    self.tiers = snap.tiers;
+    self.stats_loaded = false;
     self.loading = false;
+  }
+
+  /// Replace the metadata columns with ones that carry the diff stats.
+  ///
+  /// Separate from [`Self::load`] because it lands from a second, slower
+  /// read: the rows are already on screen and only the right-hand column
+  /// grows. The scroll cursor is untouched — the row count did not change.
+  pub fn load_stats(&mut self, tiers: [MetaColumn; 3]) {
+    self.tiers = tiers;
+    self.stats_loaded = true;
   }
 
   /// Whether a deeper page exists and is allowed.
@@ -193,6 +217,24 @@ impl CommitsModal {
   /// Scroll up one row, never above the top.
   pub fn scroll_up(&mut self) {
     self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Scroll down half a screen (`D`), never past the last line.
+  ///
+  /// Half of what the body last showed, and never zero: a viewport the
+  /// renderer has not published yet (nothing drawn) would otherwise make
+  /// the key silently do nothing.
+  pub fn scroll_half_down(&mut self) {
+    self.scroll = self.scroll.saturating_add(self.half_page()).min(self.max_scroll);
+  }
+
+  /// Scroll up half a screen (`U`), never above the top.
+  pub fn scroll_half_up(&mut self) {
+    self.scroll = self.scroll.saturating_sub(self.half_page());
+  }
+
+  fn half_page(&self) -> u16 {
+    (self.viewport / 2).max(1)
   }
 
   /// Jump to the first row (`g`).

--- a/src/tui/state/commits.rs
+++ b/src/tui/state/commits.rs
@@ -1,0 +1,160 @@
+//! Full-size commit listing overlay state (issue #593).
+//!
+//! The sidebar's Commits pane shares the sidebar with the identity, status
+//! and working-tree blocks, and it is capped at
+//! [`crate::tui::RECENT_COMMITS_LIMIT`] rows. This is the same graph
+//! renderer given the whole terminal, plus a way to ask for more history
+//! instead of leaving gwm for lazygit.
+//!
+//! The rows are an owned snapshot taken when the overlay opens
+//! ([`crate::tui::App::enter_commits`]) rather than a read of
+//! `SidebarState::cache`: that cache is only rebuilt while the sidebar is
+//! *open* and in `Commits` mode, so reading it would leave the overlay
+//! blank in exactly the two states, sidebar hidden or `Stashes` selected,
+//! where the listing is most useful.
+//!
+//! The read itself runs on a worker (`TaskKind::Commits`), not inline on
+//! the keypress. The revwalk sorts `TIME | TOPOLOGICAL`, which walks the
+//! whole reachable graph before it yields the first row: measured on this
+//! repo (2058 commits), asking for 300 costs the same as asking for all of
+//! them, so the limit truncates the output and bounds nothing about the
+//! latency. On a large history an inline call would freeze the event loop
+//! for the length of the walk. The overlay opens on a loader and fills in
+//! when the worker lands, the shape #592 settled on for the same reason.
+//!
+//! Paging is a re-read at a larger limit rather than an append.
+//! [`crate::worktree::recent_commits_cached`] is keyed by
+//! `(repo, tip, limit)`, so each page is a fresh entry rather than an
+//! invalidation, and the graph renderer needs the whole list anyway: a
+//! connector on row N depends on the parents of rows below it.
+//!
+//! Scroll follows the help / command-logs contract: the cursor lives here,
+//! but `max_scroll` is republished by the renderer each frame against the
+//! real viewport, since only the renderer knows both the row count and the
+//! inner modal height.
+
+use super::super::ui::RECENT_COMMITS_LIMIT;
+use ratatui::text::Line;
+use std::path::{Path, PathBuf};
+
+/// One page of history. Matched to the sidebar's own limit so the first
+/// snapshot hits the cache entry a sidebar in Commits mode already warmed
+/// instead of paying a second revwalk.
+pub const COMMITS_PAGE: usize = RECENT_COMMITS_LIMIT;
+
+/// Ceiling on the paged limit, in commits.
+///
+/// Two reasons to have one at all. Each page is a whole graph walk, so a
+/// deeper page is not cheaper than the one before it. And the memo in
+/// [`crate::worktree::recent_commits_cached`] holds
+/// `RECENT_COMMITS_CACHE_MAX_ENTRIES` (64) entries keyed on the limit,
+/// evicting an arbitrary one when full: unbounded paging would push other
+/// worktrees' sidebar entries out and make them re-walk. Five pages per
+/// worktree keeps that well inside the budget.
+pub const COMMITS_MAX: usize = COMMITS_PAGE * 5;
+
+/// Owned state for the full-size commit listing: the snapshotted graph
+/// rows, the limit they were read at, and the scroll cursor with its
+/// renderer-published bound.
+#[derive(Debug, Default)]
+pub struct CommitsModal {
+  /// The commit rows, exactly as the sidebar pane paints them (short hash,
+  /// author initials, `○` / `◎` graph, subject) — or the `(no commits)`
+  /// row, or a load error.
+  pub lines: Vec<Line<'static>>,
+  /// The limit [`Self::lines`] was read at.
+  pub limit: usize,
+  /// Rows actually returned. `recent_commits_lines` paints exactly one row
+  /// per commit, so this IS the commit count; the `(no commits)` and error
+  /// sentinels are a single row, far under a page, which reads as an
+  /// exhausted history and correctly disables paging on them.
+  pub loaded: usize,
+  /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
+  pub scroll: u16,
+  /// Maximum vertical scroll offset, republished by the renderer each
+  /// frame as `content_rows.saturating_sub(viewport_rows)`.
+  pub max_scroll: u16,
+  /// `true` between the request and the worker's payload. The renderer
+  /// paints a loader rather than an empty canvas, which would read as "no
+  /// commits".
+  pub loading: bool,
+  /// The worktree [`Self::lines`] describe, so a payload for a selection the
+  /// user has navigated away from can be dropped instead of shown.
+  pub path: Option<PathBuf>,
+}
+
+impl CommitsModal {
+  /// An empty overlay at the origin.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Arm the overlay for `path` at the first page: drop the previous
+  /// listing, rewind the scroll, and show the loader until [`Self::load`]
+  /// lands. Called on every open, so a previously-scrolled visit starts
+  /// fresh and a stale listing is never mistaken for the current one.
+  pub fn begin(&mut self, path: Option<&Path>, limit: usize) {
+    self.lines.clear();
+    self.loaded = 0;
+    self.limit = limit;
+    self.scroll = 0;
+    self.max_scroll = 0;
+    self.path = path.map(Path::to_path_buf);
+    // With nothing selected there is nothing to wait for.
+    self.loading = path.is_some();
+  }
+
+  /// Arm a deeper page, **keeping** the rows and the scroll cursor on
+  /// screen while the worker runs. The user pressed load-more from the
+  /// bottom of the list: blanking the canvas there would throw away both
+  /// the page they were reading and the position they paged from.
+  pub fn begin_more(&mut self, limit: usize) {
+    self.limit = limit;
+    self.loading = true;
+  }
+
+  /// Install the worker's payload and clear the loader. The scroll cursor
+  /// is whatever [`Self::begin`] (top) or [`Self::begin_more`] (unchanged)
+  /// left; the renderer re-clamps it against the new content.
+  pub fn load(&mut self, lines: Vec<Line<'static>>) {
+    self.loaded = lines.len();
+    self.lines = lines;
+    self.loading = false;
+  }
+
+  /// Whether a deeper page exists and is allowed.
+  ///
+  /// `loaded < limit` means the revwalk ran out of history before the limit
+  /// did, so there is nothing deeper to fetch however high the limit goes.
+  /// A read already in flight also blocks: `loaded` still describes the
+  /// previous page, so a second load-more would otherwise queue a duplicate
+  /// walk on the same keypress-repeat.
+  pub fn can_load_more(&self) -> bool {
+    !self.loading && self.loaded >= self.limit && self.limit < COMMITS_MAX
+  }
+
+  /// The limit the next page reads at, clamped to [`COMMITS_MAX`].
+  pub fn next_limit(&self) -> usize {
+    (self.limit + COMMITS_PAGE).min(COMMITS_MAX)
+  }
+
+  /// Scroll down one row, never past the last line.
+  pub fn scroll_down(&mut self) {
+    self.scroll = (self.scroll + 1).min(self.max_scroll);
+  }
+
+  /// Scroll up one row, never above the top.
+  pub fn scroll_up(&mut self) {
+    self.scroll = self.scroll.saturating_sub(1);
+  }
+
+  /// Jump to the first row (`g`).
+  pub fn scroll_to_top(&mut self) {
+    self.scroll = 0;
+  }
+
+  /// Jump to the last row (`G`).
+  pub fn scroll_to_bottom(&mut self) {
+    self.scroll = self.max_scroll;
+  }
+}

--- a/src/tui/state/commits.rs
+++ b/src/tui/state/commits.rs
@@ -64,10 +64,10 @@ pub struct CommitsModal {
   pub lines: Vec<Line<'static>>,
   /// The limit [`Self::lines`] was read at.
   pub limit: usize,
-  /// Rows actually returned. `recent_commits_lines` paints exactly one row
-  /// per commit, so this IS the commit count; the `(no commits)` and error
-  /// sentinels are a single row, far under a page, which reads as an
-  /// exhausted history and correctly disables paging on them.
+  /// Commits the listing describes. NOT `lines.len()`: an unborn HEAD, an
+  /// empty history and a failed read each paint one sentinel row, which
+  /// would read as a repository with one commit (Codex review, PR #614).
+  /// [`super::super::ui::recent_commits_listing`] carries the real number.
   pub loaded: usize,
   /// Vertical scroll offset, in rows. Clamped to `max_scroll`.
   pub scroll: u16,
@@ -81,6 +81,14 @@ pub struct CommitsModal {
   /// The worktree [`Self::lines`] describe, so a payload for a selection the
   /// user has navigated away from can be dropped instead of shown.
   pub path: Option<PathBuf>,
+  /// The branch tip the in-flight (or loaded) read was taken at.
+  ///
+  /// Part of a read's identity alongside the path and the limit: close the
+  /// overlay mid-read, land a commit, reopen on the same worktree, and
+  /// path and limit both still match, so the reopen would ride on a worker
+  /// holding the OLD tip and quietly show a log missing the new commits
+  /// (Codex review, PR #614).
+  pub head: Option<String>,
 }
 
 impl CommitsModal {
@@ -93,13 +101,14 @@ impl CommitsModal {
   /// listing, rewind the scroll, and show the loader until [`Self::load`]
   /// lands. Called on every open, so a previously-scrolled visit starts
   /// fresh and a stale listing is never mistaken for the current one.
-  pub fn begin(&mut self, path: Option<&Path>, limit: usize) {
+  pub fn begin(&mut self, path: Option<&Path>, limit: usize, head: Option<String>) {
     self.lines.clear();
     self.loaded = 0;
     self.limit = limit;
     self.scroll = 0;
     self.max_scroll = 0;
     self.path = path.map(Path::to_path_buf);
+    self.head = head;
     // With nothing selected there is nothing to wait for.
     self.loading = path.is_some();
   }
@@ -113,11 +122,12 @@ impl CommitsModal {
     self.loading = true;
   }
 
-  /// Install the worker's payload and clear the loader. The scroll cursor
+  /// Install the worker's payload and clear the loader. `loaded` is the
+  /// commit count the read reported, not `lines.len()`. The scroll cursor
   /// is whatever [`Self::begin`] (top) or [`Self::begin_more`] (unchanged)
   /// left; the renderer re-clamps it against the new content.
-  pub fn load(&mut self, lines: Vec<Line<'static>>) {
-    self.loaded = lines.len();
+  pub fn load(&mut self, lines: Vec<Line<'static>>, loaded: usize) {
+    self.loaded = loaded;
     self.lines = lines;
     self.loading = false;
   }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -14,10 +14,12 @@
 //! - `github_fetch` — TTL cache + inflight dedupe for `gh` shell-outs (#128, this PR)
 //! - `async_task` — generic off-thread spine (coalescing + late-drop) for slow ops (#231)
 //! - `config_panel` — scroll + resolved-row snapshot for the Configuration overlay (#232)
+//! - `commits` — scroll + paged snapshot for the full-size commit listing (#593)
 
 pub mod async_task;
 pub mod clean_overlay;
 pub mod command_logs;
+pub mod commits;
 pub mod config_panel;
 pub mod confirm;
 pub mod create_form;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2201,23 +2201,45 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// behaviour: one commit per visual line, overflow cut at the right
 /// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize, theme: &Theme) -> Vec<Line<'static>> {
+  recent_commits_listing(w, limit, theme).0
+}
+
+/// As [`recent_commits_lines`], plus the number of commits the rows
+/// describe.
+///
+/// The two are not the same number and the difference is not cosmetic: an
+/// unborn HEAD, an empty history or a failed read all paint exactly ONE
+/// sentinel row, so a caller inferring the count from `lines.len()` reads
+/// them as a repository with one commit (Codex review, PR #614). The
+/// commit-listing overlay (issue #593) titles itself with this count and
+/// decides whether a page is full from it, so it needs the real one; the
+/// sidebar pane only paints rows and keeps the thinner entry point.
+pub fn recent_commits_listing(w: &WorktreeInfo, limit: usize, theme: &Theme) -> (Vec<Line<'static>>, usize) {
   match worktree::recent_commits_cached(w, limit) {
     Ok(rows) if !rows.is_empty() => {
+      let count = rows.len();
       let graphs = super::commit_graph::render_commits(&rows, theme);
-      rows
+      let lines = rows
         .into_iter()
         .zip(graphs)
         .map(|(row, graph_spans)| commit_row_line(row, graph_spans, theme))
-        .collect()
+        .collect();
+      (lines, count)
     }
-    Ok(_) => vec![Line::from(Span::styled(
-      "(no commits)".to_string(),
-      Style::default().fg(theme.muted),
-    ))],
-    Err(e) => vec![Line::from(Span::styled(
-      format!("! {}", e),
-      Style::default().fg(theme.prunable),
-    ))],
+    Ok(_) => (
+      vec![Line::from(Span::styled(
+        "(no commits)".to_string(),
+        Style::default().fg(theme.muted),
+      ))],
+      0,
+    ),
+    Err(e) => (
+      vec![Line::from(Span::styled(
+        format!("! {}", e),
+        Style::default().fg(theme.prunable),
+      ))],
+      0,
+    ),
   }
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3001,6 +3001,12 @@ impl HintContext {
         // overlay-only — the footer is a teaser, `?` is the manual.
         Hint::Key(TerminalFullscreen, "open"),
         Hint::Key(LazyGitFullscreen, "git"),
+        // #593: reading the log and the checks is the same register as
+        // launching lazygit, and both keys mean this in either pane — so
+        // the worktrees footer advertises the pair the status footer does,
+        // ahead of the verbs that are reached less often.
+        Hint::Key(Commits, "commits"),
+        Hint::Key(CiChecks, "ci checks"),
         Hint::Key(ExecOverlay, "exec"),
         Hint::Key(AgentSessions, "agents"),
         // #515: the note is written far more often than a review is

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4491,7 +4491,7 @@ fn draw_commits(f: &mut Frame, app: &mut App) {
   let accent = app.theme.accent;
   let muted = app.theme.muted;
 
-  let more = app.commits.can_load_more();
+  let more = app.commits_can_load_more();
   let loading = app.commits.loading;
   // The `+` tracks "a deeper page exists", which is true while one is being
   // read too: `can_load_more` is false then only because the read is out.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -172,6 +172,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     View::CommandPalette => draw_command_palette(f, app),
     View::CommandLogs => draw_command_logs(f, app),
     View::Config => draw_config_panel(f, app),
+    View::Commits => draw_commits(f, app),
     View::Pty => draw_pty_overlay(f, app),
     View::Note => draw_note_editor(f, app),
     // #325: exec profile picker renders as a small centred modal.
@@ -3385,6 +3386,37 @@ pub fn command_logs_footer_hints(modal: &ModalKeymap) -> Vec<(String, String)> {
   hints
 }
 
+/// Commit-listing overlay footer hints (issue #593). `load more` / `close`
+/// resolve from the `Commits*` modal bindings so a rebind of
+/// `[tui.keys.modal.commits]` shows through; the scroll / top-bottom
+/// movement pairs stay literal, as the Command Logs footer does.
+///
+/// `load more` is dropped when `more` is false — there is no deeper page,
+/// either because the revwalk ran out of history or because the paging cap
+/// was reached. Advertising a key that does nothing is how a working
+/// overlay reads as broken. While `loading`, the slot says so instead: the
+/// key is equally inert there, but for a reason that resolves on its own.
+pub fn commits_footer_hints(modal: &ModalKeymap, more: bool, loading: bool) -> Vec<(String, String)> {
+  let mut hints: Vec<(String, String)> = vec![
+    ("j/k".to_string(), "scroll".to_string()),
+    ("g/G".to_string(), "top/bottom".to_string()),
+  ];
+  if loading {
+    // `more` is false while a read is out, so without this the hint slot
+    // would simply go blank and a deeper page would look refused rather
+    // than under way.
+    hints.push(("…".to_string(), "loading".to_string()));
+  } else if more {
+    if let Some(k) = modal.primary_key(ModalAction::CommitsLoadMore) {
+      hints.push((k, "load more".to_string()));
+    }
+  }
+  if let Some(k) = modal.primary_key(ModalAction::CommitsClose) {
+    hints.push((k, "close".to_string()));
+  }
+  hints
+}
+
 pub fn modal_hint_for_context(ctx: HintContext, keymap: &Keymap, modal: &ModalKeymap, theme: &Theme) -> Line<'static> {
   modal_hint_for_context_with_fields(ctx, keymap, modal, theme, &CANONICAL_TRIPLE)
 }
@@ -3894,6 +3926,10 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
   rows.push(entry(Action::FocusStatus, "focus the status pane (opens it if hidden)"));
   rows.push(entry(Action::CommandLogs, "show the command logs overlay"));
   rows.push(entry(Action::ConfigPanel, "show the resolved configuration panel"));
+  rows.push(entry(
+    Action::Commits,
+    "show the commit listing full size, with load-more",
+  ));
   // #334 review: the exec / clean overlays are picker-gated (`run_action`
   // no-ops them in `gwm switch`), so only advertise them outside picker mode.
   if !picker_mode {
@@ -4202,6 +4238,15 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       ),
       modal_entry(ModalAction::CommandLogsClose, "close"),
       HelpRow::Blank,
+      HelpRow::Section("Commits".to_string()),
+      HelpRow::Blank,
+      modal_entry(ModalAction::CommitsScrollDown, "scroll down"),
+      modal_entry(ModalAction::CommitsScrollUp, "scroll up"),
+      modal_entry(ModalAction::CommitsScrollTop, "jump to the top"),
+      modal_entry(ModalAction::CommitsScrollBottom, "jump to the bottom"),
+      modal_entry(ModalAction::CommitsLoadMore, "read one page deeper"),
+      modal_entry(ModalAction::CommitsClose, "close"),
+      HelpRow::Blank,
       HelpRow::Section("Settings".to_string()),
       HelpRow::Blank,
       modal_entry(ModalAction::ConfigNextTab, "next tab"),
@@ -4426,6 +4471,70 @@ fn draw_help(f: &mut Frame, app: &mut App) {
 /// against the live viewport so `App`'s scroll cursor can never run past
 /// the content. Colours track `[theme]` roles (`clean` ok / `prunable`
 /// fail / `muted` output) so a theme override applies here too.
+/// Render the full-size commit listing (issue #593).
+///
+/// The same `~90% x 85%` canvas the Command Logs overlay uses, painting the
+/// snapshot `App::enter_commits` took — one row per commit, short hash /
+/// author initials / `o`-`@` graph / subject, exactly as the sidebar pane
+/// paints them.
+///
+/// No horizontal pan: `recent_commits_lines` deliberately leaves subjects
+/// untruncated and relies on ratatui's hard clip at the right edge, which is
+/// lazygit's behaviour. The whole point of the overlay is that the canvas is
+/// wide enough for that clip to stop mattering.
+///
+/// The title carries the row count so `load more` has visible feedback; a
+/// trailing `+` means a deeper page exists. It rides the top rule, which is
+/// clipped from the LEFT when centred, so the count sits last on purpose.
+fn draw_commits(f: &mut Frame, app: &mut App) {
+  let area = centered(90, 85, f.area());
+  let accent = app.theme.accent;
+  let muted = app.theme.muted;
+
+  let more = app.commits.can_load_more();
+  let loading = app.commits.loading;
+  // The `+` tracks "a deeper page exists", which is true while one is being
+  // read too: `can_load_more` is false then only because the read is out.
+  let deeper = more || (loading && app.commits.loaded >= app.commits.limit);
+  let title = format!("Commits ({}{})", app.commits.loaded, if deeper { "+" } else { "" });
+  let block = overlay_block_titled(&title, accent);
+  let inner = block.inner(area);
+  f.render_widget(Clear, area);
+  f.render_widget(block, area);
+
+  let [body_area, footer_area] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+  // A muted loader rather than an empty canvas while the first page is
+  // being walked: blank reads as "no commits", which is the one answer this
+  // overlay must not give by accident. A deeper page keeps the rows it
+  // already has on screen instead, and says `loading` in the footer.
+  let lines: Vec<Line<'static>> = if !app.commits.lines.is_empty() {
+    app.commits.lines.clone()
+  } else if loading {
+    vec![Line::from(Span::styled(
+      " loading…".to_string(),
+      Style::default().fg(muted),
+    ))]
+  } else {
+    vec![Line::from(Span::styled(
+      "No commits.".to_string(),
+      Style::default().fg(muted),
+    ))]
+  };
+
+  // Publish the scroll bound against the BODY viewport only (issue #279).
+  let body_viewport = body_area.height as usize;
+  app.commits.max_scroll = (lines.len().saturating_sub(body_viewport)) as u16;
+  app.commits.scroll = app.commits.scroll.min(app.commits.max_scroll);
+  let scroll = app.commits.scroll;
+  let text_area = scrollable_body_area(f, body_area, scroll, lines.len(), &app.theme);
+  f.render_widget(Paragraph::new(lines).scroll((scroll, 0)), text_area);
+
+  let footer_owned = commits_footer_hints(&app.modal_keymap, more, loading);
+  let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
+  f.render_widget(modal_hint_line(&footer_hints, &app.theme), footer_area);
+}
+
 fn draw_command_logs(f: &mut Frame, app: &mut App) {
   let area = centered(90, 85, f.area());
   let accent = app.theme.accent;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2,6 +2,7 @@ use super::app::{App, GitHubFetchState, LinkPromptStage, LinkTarget, View};
 use super::keymap::{Action, KeyStroke, Keymap};
 use super::modal_keymap::{KeyContext, ModalAction, ModalKeymap};
 use super::state::async_task::TaskKind;
+use super::state::commits::{CommitsSnapshot, MetaColumn};
 use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::{Field, Mode};
@@ -2201,45 +2202,120 @@ pub const COMMIT_HASH_DISPLAY_LEN: usize = 8;
 /// behaviour: one commit per visual line, overflow cut at the right
 /// edge without `…`.
 pub fn recent_commits_lines(w: &WorktreeInfo, limit: usize, theme: &Theme) -> Vec<Line<'static>> {
-  recent_commits_listing(w, limit, theme).0
+  // The sidebar pane paints rows only, so the metadata columns it never
+  // shows are built and dropped. Cheap next to the revwalk that precedes
+  // them, and one listing routine is one place for the row format to live.
+  recent_commits_listing(w, limit, worktree::unix_now(), theme).lines
 }
 
-/// As [`recent_commits_lines`], plus the number of commits the rows
-/// describe.
+/// Gap, in cells, between the commit subject and the metadata column.
+pub const COMMITS_META_GAP: usize = 2;
+
+/// Cells the subject must keep for the metadata column to be worth showing.
 ///
-/// The two are not the same number and the difference is not cosmetic: an
+/// The graph is variable-width (`build_pipe_sets` sizes it on the branch
+/// topology), so what the left side needs cannot be derived from a
+/// constant: the policy is stated as a floor on what survives instead. A
+/// merge-heavy history at 80 columns would otherwise leave a subject of ten
+/// cells to buy an author column, which is a worse listing than no column.
+pub const COMMITS_SUBJECT_FLOOR: usize = 30;
+
+/// Pick the widest metadata column that leaves the subject its floor.
+///
+/// `body_w` is the text area AFTER the scrollbar column is reserved.
+/// Returns the chosen column's width, or `None` when even the narrow one
+/// does not fit and the listing renders full-width as it did before.
+///
+/// A pure function on three widths so the policy is testable without a
+/// terminal: the render path only decides which `MetaColumn` this names.
+pub fn commits_meta_pick(body_w: usize, wide: usize, narrow: usize) -> Option<usize> {
+  [wide, narrow]
+    .into_iter()
+    .find(|&w| w > 0 && body_w >= w + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR)
+}
+
+/// Build the two right-hand metadata columns for a commit listing.
+///
+/// `wide` carries `author · age`, `narrow` the age alone — the initials are
+/// already on the left, so the full author is the second tier of
+/// information, not the first. The age is what the listing genuinely lacks
+/// today.
+///
+/// Ages are computed against `now` HERE, not stored on the row: the rows
+/// are memoised by `(repo, tip, limit)`, so an age baked into them would be
+/// frozen at the first read. They are still a snapshot in the sense that
+/// the overlay does not re-read itself while open, so a listing left up for
+/// an hour keeps saying `2m`.
+pub fn commit_meta_columns(rows: &[worktree::CommitRow], now: i64, theme: &Theme) -> (MetaColumn, MetaColumn) {
+  let mut wide = MetaColumn::default();
+  let mut narrow = MetaColumn::default();
+  for row in rows {
+    let age = worktree::format_relative_duration(worktree::commit_age(row.time, now));
+    let age_style = Style::default().fg(freshness_color(worktree::commit_age(row.time, now), theme));
+    let author = row.author.trim();
+
+    narrow.width = narrow.width.max(cells(&age));
+    narrow.lines.push(Line::from(Span::styled(age.clone(), age_style)));
+
+    let wide_line = if author.is_empty() {
+      Line::from(Span::styled(age.clone(), age_style))
+    } else {
+      Line::from(vec![
+        Span::styled(author.to_string(), Style::default().fg(theme.muted)),
+        Span::styled(" · ".to_string(), Style::default().fg(theme.muted)),
+        Span::styled(age.clone(), age_style),
+      ])
+    };
+    wide.width = wide.width.max(wide_line.width());
+    wide.lines.push(wide_line);
+  }
+  (wide, narrow)
+}
+
+/// The full result of one read of the log: the rows, the commit count, and
+/// the two right-hand metadata columns.
+///
+/// The count is not `lines.len()` and the difference is not cosmetic: an
 /// unborn HEAD, an empty history or a failed read all paint exactly ONE
-/// sentinel row, so a caller inferring the count from `lines.len()` reads
-/// them as a repository with one commit (Codex review, PR #614). The
+/// sentinel row, so a caller inferring the count from the rows reads them
+/// as a repository with one commit (Codex review, PR #614). The
 /// commit-listing overlay (issue #593) titles itself with this count and
-/// decides whether a page is full from it, so it needs the real one; the
-/// sidebar pane only paints rows and keeps the thinner entry point.
-pub fn recent_commits_listing(w: &WorktreeInfo, limit: usize, theme: &Theme) -> (Vec<Line<'static>>, usize) {
+/// decides whether a page is full from it.
+///
+/// `now` is passed in rather than read here so the ages are deterministic
+/// under test.
+pub fn recent_commits_listing(w: &WorktreeInfo, limit: usize, now: i64, theme: &Theme) -> CommitsSnapshot {
   match worktree::recent_commits_cached(w, limit) {
     Ok(rows) if !rows.is_empty() => {
-      let count = rows.len();
+      let loaded = rows.len();
+      let (wide, narrow) = commit_meta_columns(&rows, now, theme);
       let graphs = super::commit_graph::render_commits(&rows, theme);
       let lines = rows
         .into_iter()
         .zip(graphs)
         .map(|(row, graph_spans)| commit_row_line(row, graph_spans, theme))
         .collect();
-      (lines, count)
+      CommitsSnapshot {
+        lines,
+        loaded,
+        wide,
+        narrow,
+      }
     }
-    Ok(_) => (
-      vec![Line::from(Span::styled(
+    Ok(_) => CommitsSnapshot {
+      lines: vec![Line::from(Span::styled(
         "(no commits)".to_string(),
         Style::default().fg(theme.muted),
       ))],
-      0,
-    ),
-    Err(e) => (
-      vec![Line::from(Span::styled(
+      ..Default::default()
+    },
+    Err(e) => CommitsSnapshot {
+      lines: vec![Line::from(Span::styled(
         format!("! {}", e),
         Style::default().fg(theme.prunable),
       ))],
-      0,
-    ),
+      ..Default::default()
+    },
   }
 }
 
@@ -2947,8 +3023,10 @@ impl HintContext {
         Hint::Key(Down, "scroll"),
         Hint::Key(WtScrollDown, "wt scroll"),
         Hint::Key(FetchGithub, "fetch"),
-        // #436: `c` routes to the CI checks overlay in this context.
-        Hint::Key(EditWorktree, "ci checks"),
+        // #593: `c` / `C` mean the same thing in both panes — this one's
+        // own content at full size, and the linked PR's checks.
+        Hint::Key(Commits, "commits"),
+        Hint::Key(CiChecks, "ci checks"),
         // Sidebar mode / layout.
         Hint::Key(ToggleSidebarMode, "mode"),
         Hint::Key(CycleSidebarLayout, "layout"),
@@ -4550,7 +4628,41 @@ fn draw_commits(f: &mut Frame, app: &mut App) {
   app.commits.scroll = app.commits.scroll.min(app.commits.max_scroll);
   let scroll = app.commits.scroll;
   let text_area = scrollable_body_area(f, body_area, scroll, lines.len(), &app.theme);
-  f.render_widget(Paragraph::new(lines).scroll((scroll, 0)), text_area);
+
+  // The metadata rides its own rect on the right rather than being appended
+  // to each row: the subject is deliberately hard-clipped without an
+  // ellipsis (lazygit's gocui behaviour, documented on
+  // `recent_commits_lines` and shared with the sidebar pane), so narrowing
+  // the left rect IS that same rule applied at a nearer edge. Both
+  // paragraphs take the same scroll offset, so the columns stay aligned.
+  let meta = commits_meta_pick(
+    text_area.width as usize,
+    app.commits.wide.width,
+    app.commits.narrow.width,
+  );
+
+  match meta {
+    Some(meta_w) => {
+      let meta_w = meta_w as u16;
+      let column = if meta_w as usize == app.commits.wide.width {
+        &app.commits.wide
+      } else {
+        &app.commits.narrow
+      };
+      let [left, _gap, right] = Layout::horizontal([
+        Constraint::Min(1),
+        Constraint::Length(COMMITS_META_GAP as u16),
+        Constraint::Length(meta_w),
+      ])
+      .areas(text_area);
+      f.render_widget(Paragraph::new(lines).scroll((scroll, 0)), left);
+      f.render_widget(
+        Paragraph::new(column.lines.clone()).right_aligned().scroll((scroll, 0)),
+        right,
+      );
+    }
+    None => f.render_widget(Paragraph::new(lines).scroll((scroll, 0)), text_area),
+  }
 
   let footer_owned = commits_footer_hints(&app.modal_keymap, more, loading);
   let footer_hints: Vec<(&str, &str)> = footer_owned.iter().map(|(k, l)| (k.as_str(), l.as_str())).collect();
@@ -7637,22 +7749,14 @@ pub fn github_status_lines(app: &App, max_width: usize) -> Vec<Line<'static>> {
   if let Some(n) = link.pr {
     let spinner = app.spinner.glyph(DOT_FRAMES);
     // #436: advertise the key that opens the CI checks overlay right after
-    // the indicator, resolved live so a rebind shows through. The key is
-    // context-accurate (Codex review #455): the contextual `c`
-    // (EditWorktree's chord) only while the status pane holds the focus —
-    // in the worktrees context that key opens the rename modal, so the
-    // global `ci_checks` binding is advertised instead. An unbound
-    // EditWorktree falls back to the global binding (still live in that
-    // context); only when both are unbound does the suffix disappear. In
-    // picker mode (`gwm switch`) run_action drops Action::CiChecks —
-    // printable keys feed the filter — so no key is advertised at all.
+    // the indicator, resolved live so a rebind shows through. Since #593
+    // that key is `ci_checks` in every context — the pane-dependent form
+    // this used to take existed only because the status pane borrowed
+    // `c`, and `c` now means the commit listing in both panes. In picker
+    // mode (`gwm switch`) run_action drops Action::CiChecks — printable
+    // keys feed the filter — so no key is advertised at all.
     let ci_key = if app.picker_mode {
       None
-    } else if app.sidebar.open && app.sidebar.focused {
-      app
-        .keymap
-        .primary_chord(Action::EditWorktree)
-        .or_else(|| app.keymap.primary_chord(Action::CiChecks))
     } else {
       app.keymap.primary_chord(Action::CiChecks)
     };

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -6,6 +6,7 @@ use super::state::commits::{CommitsSnapshot, MetaColumn};
 use super::state::config_panel::{FieldKind, SettingField, SettingsTab};
 use super::state::confirm::ConfirmButton;
 use super::state::create_form::{Field, Mode};
+use std::collections::HashMap;
 
 /// The field set of the canonical `<type>/#<issue>-<desc>` triple, used as the
 /// default by the hint helpers that have no form in reach (issue #418). Every
@@ -2222,14 +2223,14 @@ pub const COMMITS_SUBJECT_FLOOR: usize = 30;
 
 /// Pick the widest metadata column that leaves the subject its floor.
 ///
-/// `body_w` is the text area AFTER the scrollbar column is reserved.
-/// Returns the chosen column's width, or `None` when even the narrow one
-/// does not fit and the listing renders full-width as it did before.
+/// `body_w` is the text area AFTER the scrollbar column is reserved. The
+/// tiers are tried widest first; `None` means even the narrowest does not
+/// fit and the listing renders full-width as it did before.
 ///
-/// A pure function on three widths so the policy is testable without a
-/// terminal: the render path only decides which `MetaColumn` this names.
-pub fn commits_meta_pick(body_w: usize, wide: usize, narrow: usize) -> Option<usize> {
-  [wide, narrow]
+/// A pure function on widths so the policy is testable without a terminal:
+/// the render path only decides which `MetaColumn` this names.
+pub fn commits_meta_pick(body_w: usize, tiers: [usize; 3]) -> Option<usize> {
+  tiers
     .into_iter()
     .find(|&w| w > 0 && body_w >= w + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR)
 }
@@ -2246,30 +2247,93 @@ pub fn commits_meta_pick(body_w: usize, wide: usize, narrow: usize) -> Option<us
 /// frozen at the first read. They are still a snapshot in the sense that
 /// the overlay does not re-read itself while open, so a listing left up for
 /// an hour keeps saying `2m`.
-pub fn commit_meta_columns(rows: &[worktree::CommitRow], now: i64, theme: &Theme) -> (MetaColumn, MetaColumn) {
+pub fn commit_meta_columns(
+  rows: &[worktree::CommitRow],
+  now: i64,
+  stats: &HashMap<git2::Oid, worktree::CommitStat>,
+  theme: &Theme,
+) -> [MetaColumn; 3] {
   let mut wide = MetaColumn::default();
+  let mut mid = MetaColumn::default();
   let mut narrow = MetaColumn::default();
+  let sep = || Span::styled(" · ".to_string(), Style::default().fg(theme.muted));
+
   for row in rows {
-    let age = worktree::format_relative_duration(worktree::commit_age(row.time, now));
-    let age_style = Style::default().fg(freshness_color(worktree::commit_age(row.time, now), theme));
+    let age_d = worktree::commit_age(row.time, now);
+    let age = worktree::format_relative_duration(age_d);
+    let age_style = Style::default().fg(freshness_color(age_d, theme));
+    let age_span = || Span::styled(age.clone(), age_style);
     let author = row.author.trim();
+    // Absent means "not read yet", which is not the same as a commit that
+    // changed nothing — the second read fills the map and the columns are
+    // rebuilt from it.
+    let stat = stats.get(&row.hash).copied();
 
-    narrow.width = narrow.width.max(cells(&age));
-    narrow.lines.push(Line::from(Span::styled(age.clone(), age_style)));
+    narrow.lines.push(Line::from(age_span()));
 
-    let wide_line = if author.is_empty() {
-      Line::from(Span::styled(age.clone(), age_style))
-    } else {
-      Line::from(vec![
-        Span::styled(author.to_string(), Style::default().fg(theme.muted)),
-        Span::styled(" · ".to_string(), Style::default().fg(theme.muted)),
-        Span::styled(age.clone(), age_style),
-      ])
-    };
-    wide.width = wide.width.max(wide_line.width());
-    wide.lines.push(wide_line);
+    let mut mid_spans: Vec<Span<'static>> = Vec::new();
+    if let Some(s) = stat {
+      mid_spans.extend(commit_stat_spans(s, theme));
+      mid_spans.push(sep());
+    }
+    mid_spans.push(age_span());
+    mid.lines.push(Line::from(mid_spans));
+
+    let mut wide_spans: Vec<Span<'static>> = Vec::new();
+    if !author.is_empty() {
+      wide_spans.push(Span::styled(author.to_string(), Style::default().fg(theme.muted)));
+      wide_spans.push(sep());
+    }
+    if let Some(s) = stat {
+      wide_spans.extend(commit_stat_spans(s, theme));
+      wide_spans.push(sep());
+    }
+    wide_spans.push(age_span());
+    wide.lines.push(Line::from(wide_spans));
   }
-  (wide, narrow)
+
+  for col in [&mut wide, &mut mid, &mut narrow] {
+    col.width = col.lines.iter().map(Line::width).max().unwrap_or(0);
+  }
+  [wide, mid, narrow]
+}
+
+/// One commit's diff counts as coloured spans: `3~ 1+ 1- +120 -34`.
+///
+/// The file counts reuse the working-tree pane's roles (#287) so a created
+/// file reads the same colour here as it does there, and the line counts
+/// reuse the diff pair. A category with nothing in it is omitted rather
+/// than printed as a zero: five zeroes on every quiet commit is noise, and
+/// the row is competing with the subject for width.
+pub fn commit_stat_spans(s: worktree::CommitStat, theme: &Theme) -> Vec<Span<'static>> {
+  let mut spans: Vec<Span<'static>> = Vec::new();
+  let mut push = |text: String, color: Color| {
+    if !spans.is_empty() {
+      spans.push(Span::raw(" "));
+    }
+    spans.push(Span::styled(text, Style::default().fg(color)));
+  };
+  if s.files_modified > 0 {
+    push(format!("{}~", s.files_modified), theme.dirty);
+  }
+  if s.files_added > 0 {
+    push(format!("{}+", s.files_added), theme.clean);
+  }
+  if s.files_deleted > 0 {
+    push(format!("{}-", s.files_deleted), theme.prunable);
+  }
+  if s.insertions > 0 {
+    push(format!("+{}", s.insertions), theme.clean);
+  }
+  if s.deletions > 0 {
+    push(format!("-{}", s.deletions), theme.prunable);
+  }
+  if spans.is_empty() {
+    // An empty commit, or a merge that brought nothing onto its first
+    // parent. Silence would read as "not loaded yet".
+    spans.push(Span::styled("0".to_string(), Style::default().fg(theme.muted)));
+  }
+  spans
 }
 
 /// The full result of one read of the log: the rows, the commit count, and
@@ -2288,18 +2352,19 @@ pub fn recent_commits_listing(w: &WorktreeInfo, limit: usize, now: i64, theme: &
   match worktree::recent_commits_cached(w, limit) {
     Ok(rows) if !rows.is_empty() => {
       let loaded = rows.len();
-      let (wide, narrow) = commit_meta_columns(&rows, now, theme);
+      let tiers = commit_meta_columns(&rows, now, &HashMap::new(), theme);
       let graphs = super::commit_graph::render_commits(&rows, theme);
       let lines = rows
-        .into_iter()
+        .iter()
+        .cloned()
         .zip(graphs)
         .map(|(row, graph_spans)| commit_row_line(row, graph_spans, theme))
         .collect();
       CommitsSnapshot {
         lines,
         loaded,
-        wide,
-        narrow,
+        rows,
+        tiers,
       }
     }
     Ok(_) => CommitsSnapshot {
@@ -4348,6 +4413,8 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
       HelpRow::Blank,
       modal_entry(ModalAction::CommitsScrollDown, "scroll down"),
       modal_entry(ModalAction::CommitsScrollUp, "scroll up"),
+      modal_entry(ModalAction::CommitsHalfDown, "scroll down half a screen"),
+      modal_entry(ModalAction::CommitsHalfUp, "scroll up half a screen"),
       modal_entry(ModalAction::CommitsScrollTop, "jump to the top"),
       modal_entry(ModalAction::CommitsScrollBottom, "jump to the bottom"),
       modal_entry(ModalAction::CommitsLoadMore, "read one page deeper"),
@@ -4630,6 +4697,7 @@ fn draw_commits(f: &mut Frame, app: &mut App) {
 
   // Publish the scroll bound against the BODY viewport only (issue #279).
   let body_viewport = body_area.height as usize;
+  app.commits.viewport = body_area.height;
   app.commits.max_scroll = (lines.len().saturating_sub(body_viewport)) as u16;
   app.commits.scroll = app.commits.scroll.min(app.commits.max_scroll);
   let scroll = app.commits.scroll;
@@ -4641,20 +4709,17 @@ fn draw_commits(f: &mut Frame, app: &mut App) {
   // `recent_commits_lines` and shared with the sidebar pane), so narrowing
   // the left rect IS that same rule applied at a nearer edge. Both
   // paragraphs take the same scroll offset, so the columns stay aligned.
-  let meta = commits_meta_pick(
-    text_area.width as usize,
-    app.commits.wide.width,
-    app.commits.narrow.width,
-  );
+  let widths = [
+    app.commits.tiers[0].width,
+    app.commits.tiers[1].width,
+    app.commits.tiers[2].width,
+  ];
+  let meta = commits_meta_pick(text_area.width as usize, widths);
 
   match meta {
     Some(meta_w) => {
+      let column = &app.commits.tiers[widths.iter().position(|&w| w == meta_w).unwrap_or(2)];
       let meta_w = meta_w as u16;
-      let column = if meta_w as usize == app.commits.wide.width {
-        &app.commits.wide
-      } else {
-        &app.commits.narrow
-      };
       let [left, _gap, right] = Layout::horizontal([
         Constraint::Min(1),
         Constraint::Length(COMMITS_META_GAP as u16),

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1143,6 +1143,145 @@ pub fn git_log_with_author(path: &Path, n: usize) -> Result<Vec<CommitRow>> {
   recent_commits_revwalk(&repo, tip, n)
 }
 
+/// What one commit did, in counts: how many files it added, changed and
+/// removed, and how many lines it inserted and deleted.
+///
+/// The listing overlay (#593) shows this per row. `files_*` come from the
+/// `--raw` status letters, the line counts from `--numstat`; a binary file
+/// contributes to `files_*` with no lines, since git reports `-` for both.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CommitStat {
+  pub files_added: usize,
+  pub files_modified: usize,
+  pub files_deleted: usize,
+  pub insertions: usize,
+  pub deletions: usize,
+}
+
+impl CommitStat {
+  /// Every file the commit touched, whatever it did to it.
+  pub fn files_touched(self) -> usize {
+    self.files_added + self.files_modified + self.files_deleted
+  }
+}
+
+/// Per-commit diff counts for exactly `oids`, read in one `git log`.
+///
+/// Shells out rather than walking with libgit2: a `diff_tree_to_tree` per
+/// commit costs 33s for 300 commits on this repo (measured, debug build),
+/// where git streams the same answer in about a second. This runs on a
+/// worker, never on the render path.
+///
+/// **`--diff-merges=first-parent` is load-bearing.** `git log` emits no
+/// diff at all for a merge by default, and this project merges rather than
+/// squashes, so a fifth of the rows here are merges: without it they would
+/// silently read as "changed nothing". It gives a merge its diff against
+/// parent 1 WITHOUT touching traversal, unlike `--first-parent`.
+///
+/// **`--no-walk` with an explicit oid list** is what keeps this set equal
+/// to the rows on screen. `-N` would not: the revwalk sorts
+/// `TIME | TOPOLOGICAL` and `git log` does not, so the two disagree on
+/// which commits the first N are. The oids go through argv (about 41 bytes
+/// each, so ~61 KB at the `COMMITS_MAX` page cap, well under `ARG_MAX`).
+///
+/// An oid git has nothing to say about is absent from the map rather than
+/// zero, so a caller can tell "no changes" from "not read".
+pub fn commit_stats(dir: &Path, oids: &[git2::Oid]) -> Result<HashMap<git2::Oid, CommitStat>> {
+  if oids.is_empty() {
+    return Ok(HashMap::new());
+  }
+  let hashes: Vec<String> = oids.iter().map(|o| o.to_string()).collect();
+  let mut args: Vec<&str> = vec![
+    "log",
+    "--no-walk",
+    "--diff-merges=first-parent",
+    "--raw",
+    "--numstat",
+    "-z",
+    "--format=%H",
+  ];
+  args.extend(hashes.iter().map(String::as_str));
+  Ok(parse_commit_stats(&run_git(dir, &args)?))
+}
+
+/// Parse `git log --raw --numstat -z --format=%H` into per-commit counts.
+///
+/// The `-z` stream is one flat run of NUL-terminated tokens, and the tokens
+/// are classified BY SHAPE rather than by counting positions:
+///
+/// - a bare 40-hex token starts a new commit (the `%H`, whose trailing
+///   newline the format leaves in front of the next token),
+/// - a token opening with `:` is a `--raw` entry, whose last field is the
+///   status letter (`R100` and `C50` carry a score, so only the letter is
+///   read),
+/// - `<n>\t<n>\t…` or `-\t-\t…` is a `--numstat` entry.
+///
+/// Anything else is a path, and paths are ignored. Counting positions is
+/// what a rename breaks: `R` and `C` emit TWO paths where every other
+/// status emits one, so a positional walk desynchronises for the rest of
+/// the commit. Shape classification cannot: it never has to know how many
+/// paths came before.
+///
+/// The one thing it cannot survive is a path that is itself shaped like a
+/// numstat entry — POSIX allows tabs in filenames — which would add its
+/// digits to the totals. That miscounts a row; it cannot desynchronise the
+/// commit boundaries, which only a 40-hex token moves.
+pub fn parse_commit_stats(raw: &str) -> HashMap<git2::Oid, CommitStat> {
+  let mut out: HashMap<git2::Oid, CommitStat> = HashMap::new();
+  let mut current: Option<git2::Oid> = None;
+
+  for token in raw.split('\0') {
+    let token = token.trim_start_matches(['\n', '\r']);
+    if token.is_empty() {
+      continue;
+    }
+
+    if token.len() == 40 && token.bytes().all(|b| b.is_ascii_hexdigit()) {
+      current = git2::Oid::from_str(token).ok();
+      if let Some(oid) = current {
+        out.entry(oid).or_default();
+      }
+      continue;
+    }
+
+    let Some(oid) = current else { continue };
+
+    if let Some(rest) = token.strip_prefix(':') {
+      // `:<mode> <mode> <sha> <sha> <status>` — the status is the last
+      // whitespace-separated field, and only its first letter matters.
+      let Some(status) = rest.split_whitespace().next_back().and_then(|f| f.chars().next()) else {
+        continue;
+      };
+      let e = out.entry(oid).or_default();
+      match status {
+        'A' | 'C' => e.files_added += 1,
+        'D' => e.files_deleted += 1,
+        // M, R (a rename is the file changed, under a new name), T, U and
+        // anything git grows later.
+        _ => e.files_modified += 1,
+      }
+      continue;
+    }
+
+    let mut fields = token.split('\t');
+    let (Some(ins), Some(del)) = (fields.next(), fields.next()) else {
+      continue;
+    };
+    // `-\t-` is git's way of saying "binary": the file counts, the lines
+    // do not exist.
+    if ins == "-" && del == "-" {
+      continue;
+    }
+    let (Ok(ins), Ok(del)) = (ins.parse::<usize>(), del.parse::<usize>()) else {
+      continue;
+    };
+    let e = out.entry(oid).or_default();
+    e.insertions += ins;
+    e.deletions += del;
+  }
+  out
+}
+
 /// Return recent commits for one worktree, memoised by branch-tip OID and
 /// limit. `WorktreeInfo.head` is populated by [`list`], so normal TUI sidebar
 /// refreshes can hit the cache without reopening the repo. Fixtures and older

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1119,6 +1119,17 @@ pub struct CommitRow {
   pub author: String,
   pub parents: Vec<git2::Oid>,
   pub subject: String,
+  /// Commit time, Unix seconds, as git recorded it.
+  ///
+  /// Kept raw rather than as a `Duration` since now: the rows are memoised
+  /// by `(repo, tip, limit)`, so a pre-computed age would be frozen at the
+  /// first read and every later cache hit would serve it. The age is
+  /// derived at render time from this instead.
+  ///
+  /// It can be AHEAD of the local clock — skew, a rewritten history, a
+  /// rebase preserving author dates — so any subtraction against `now`
+  /// saturates at zero rather than underflowing.
+  pub time: i64,
 }
 
 /// Return recent commits for the sidebar using libgit2. This is the uncached
@@ -1193,6 +1204,7 @@ fn recent_commits_revwalk(repo: &Repository, tip: git2::Oid, limit: usize) -> Re
       author: commit.author().name().unwrap_or("").to_string(),
       parents: commit.parent_ids().collect(),
       subject: commit.summary().ok().flatten().unwrap_or("").to_string(),
+      time: commit.time().seconds(),
     });
   }
   Ok(rows)
@@ -1224,6 +1236,7 @@ fn parse_git_log_with_author_output(raw: &str) -> Result<Vec<CommitRow>> {
       author,
       parents,
       subject,
+      time: 0,
     });
   }
   Ok(rows)
@@ -1642,6 +1655,26 @@ pub fn branch_age(repo: &Repository, branch: &str) -> Option<Duration> {
 /// from lazygit: single-character suffix, no plural, capital `M` to
 /// disambiguate from minutes. Bounded at 4 chars for two-digit values in
 /// each unit, which is enough for any realistic branch age.
+/// Age of a commit timestamp against `now`, both in Unix seconds.
+///
+/// Saturates at zero: a commit can be dated in the future (clock skew, a
+/// rewritten history, a rebase that preserved author dates), and the naive
+/// subtraction would underflow into "55 thousand years ago". Zero renders
+/// as `0s`, which reads as "just now" — the least wrong thing to say about
+/// a timestamp the local clock has not reached.
+pub fn commit_age(commit_time: i64, now: i64) -> Duration {
+  Duration::from_secs(now.saturating_sub(commit_time).max(0) as u64)
+}
+
+/// Unix seconds now, or 0 if the system clock predates the epoch. Never
+/// panics: this feeds a user-facing render path.
+pub fn unix_now() -> i64 {
+  std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_secs() as i64)
+    .unwrap_or(0)
+}
+
 pub fn format_relative_duration(d: Duration) -> String {
   const MINUTE: u64 = 60;
   const HOUR: u64 = 60 * MINUTE;

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15137,3 +15137,218 @@ fn emptying_the_buffer_with_dd_removes_the_note_too() {
 
   assert!(!path.exists(), "an emptied note is removed, not blanked");
 }
+
+// ---- full-size commit listing (issue #593) ---------------------------------
+
+/// Flatten a rendered modal line into its plain text.
+fn commits_line_text(l: &ratatui::text::Line<'_>) -> String {
+  l.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+/// Drain until the commit-listing worker lands, or fail loudly.
+fn settle_commits(app: &mut App) {
+  use std::time::{Duration, Instant};
+  let deadline = Instant::now() + Duration::from_secs(10);
+  while app.is_commits_loading() && Instant::now() < deadline {
+    app.drain_task_results();
+    std::thread::sleep(Duration::from_millis(5));
+  }
+  assert!(
+    !app.is_commits_loading(),
+    "the commit-listing worker never landed within 10s"
+  );
+}
+
+#[test]
+fn commits_modal_snapshots_the_log_on_open() {
+  // Issue #593: `6` opens the commit listing full size. The snapshot is
+  // taken AT OPEN, not read from the sidebar cache — the sidebar is a
+  // hidden pane here (`open = false`), the state in which that cache is
+  // never rebuilt, and the overlay must still show the log.
+  use gwm::tui::COMMITS_PAGE;
+  let (_dir, mut app) = make_app();
+  app.sidebar.open = false;
+
+  app.enter_commits();
+  assert_eq!(app.view, View::Commits);
+  assert!(
+    app.is_commits_loading(),
+    "the overlay opens on a loader; the revwalk is on a worker, not the keypress"
+  );
+  settle_commits(&mut app);
+
+  let text: Vec<String> = app.commits.lines.iter().map(commits_line_text).collect();
+  assert!(
+    text.iter().any(|l| l.contains("init")),
+    "the repo's only commit subject is listed — got {text:?}"
+  );
+  assert_eq!(app.commits.limit, COMMITS_PAGE, "the first page reads one page deep");
+  assert_eq!(app.commits.loaded, 1, "one row per commit — got {text:?}");
+  assert_eq!(app.commits.scroll, 0, "a fresh open starts at the top");
+}
+
+#[test]
+fn load_more_is_refused_once_history_runs_out() {
+  // The revwalk returned fewer rows than the limit asked for, so the whole
+  // history is already on screen: raising the limit would re-walk the same
+  // graph for the same rows. This is the common case — most worktrees have
+  // far fewer than a page of commits.
+  use gwm::tui::COMMITS_PAGE;
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+
+  assert!(
+    !app.commits.can_load_more(),
+    "1 row against a {COMMITS_PAGE}-row limit is an exhausted history"
+  );
+  app.load_more_commits();
+  assert_eq!(
+    app.commits.limit, COMMITS_PAGE,
+    "a refused page must not raise the limit"
+  );
+}
+
+#[test]
+fn load_more_raises_the_limit_by_one_page() {
+  // A full first page means there is probably more behind it. `loaded` is
+  // forced here rather than committing 300 times: the fixture repo cannot
+  // fill a page, and this pins the App-level wiring (limit -> worker ->
+  // payload), not the revwalk.
+  use gwm::tui::COMMITS_PAGE;
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+
+  assert!(app.commits.can_load_more(), "a full page can be paged past");
+  app.load_more_commits();
+  assert_eq!(app.commits.limit, COMMITS_PAGE * 2, "load-more reads one page deeper");
+  assert!(app.is_commits_loading(), "the deeper read is on a worker too");
+  assert!(
+    !app.commits.lines.is_empty(),
+    "the rows already read stay on screen while the deeper page loads"
+  );
+
+  settle_commits(&mut app);
+  assert_eq!(
+    app.commits.limit,
+    COMMITS_PAGE * 2,
+    "the payload lands on the deeper page"
+  );
+  assert!(
+    !app.commits.lines.is_empty(),
+    "the deeper page is installed, not left blank"
+  );
+}
+
+#[test]
+fn a_second_load_more_cannot_queue_while_the_first_is_out() {
+  // `loaded` still describes the previous page while the worker runs, so
+  // without the loading gate a held `m` would raise the limit again and
+  // queue a duplicate walk — and the slot would coalesce the second onto
+  // the first, whose payload the drain then drops on the limit check,
+  // leaving the loader up forever.
+  use gwm::tui::COMMITS_PAGE;
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+
+  app.load_more_commits();
+  app.load_more_commits();
+  assert_eq!(
+    app.commits.limit,
+    COMMITS_PAGE * 2,
+    "the second press while a read is out must not page again"
+  );
+  settle_commits(&mut app);
+}
+
+#[test]
+fn reopening_on_another_worktree_gets_its_own_read() {
+  // Coalescing is only sound for the same worktree at the same limit: the
+  // drain drops a payload whose path does not match, so without freeing the
+  // slot the reopen waits on a worker whose result it will never accept and
+  // the loader never clears.
+  //
+  // The in-flight read is staged by hand rather than raced against a real
+  // worker: on a one-commit fixture the thread finishes before the second
+  // open, so a raced version passes with the invalidate removed. Occupying
+  // the slot is what makes the guard the only thing standing between this
+  // test and a 10s timeout.
+  use gwm::tui::{TaskKind, COMMITS_PAGE};
+  let (dir, mut app) = make_app();
+  let other = dir.path().join("elsewhere");
+
+  app.commits.begin(Some(&other), COMMITS_PAGE);
+  app.tasks.request(TaskKind::Commits).expect("the slot starts free");
+
+  app.enter_commits();
+  settle_commits(&mut app);
+  assert!(!app.is_commits_loading(), "the reopen's own read cleared the loader");
+}
+
+#[test]
+fn reopening_after_a_deeper_page_gets_its_own_read() {
+  // Same hole, reached by the limit rather than the path: close the overlay
+  // while a 600-commit page is out, reopen, and the first page's request
+  // would coalesce onto a read whose payload the drain drops on the limit
+  // check.
+  use gwm::tui::{TaskKind, COMMITS_PAGE};
+  let (dir, mut app) = make_app();
+
+  app.commits.begin(Some(dir.path()), COMMITS_PAGE * 2);
+  app.tasks.request(TaskKind::Commits).expect("the slot starts free");
+
+  app.enter_commits();
+  settle_commits(&mut app);
+  assert_eq!(app.commits.limit, COMMITS_PAGE, "the reopen is back at the first page");
+}
+
+#[test]
+fn paging_stops_at_the_cap() {
+  // #593 notes the memo in `recent_commits_cached` is keyed on the limit
+  // and evicts an arbitrary entry when full, so unbounded paging would push
+  // other worktrees' sidebar entries out. The cap is what bounds it.
+  use gwm::tui::{CommitsModal, COMMITS_MAX, COMMITS_PAGE};
+  let mut m = CommitsModal::new();
+  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_MAX);
+  m.load(vec![ratatui::text::Line::from("x"); COMMITS_MAX]);
+
+  assert!(!m.can_load_more(), "the cap is a hard stop even on a full page");
+
+  m.limit = COMMITS_MAX - 1;
+  assert_eq!(m.next_limit(), COMMITS_MAX, "the last page clamps to the cap");
+
+  // And the cap leaves room for more than the first page, or load-more
+  // would be dead on arrival.
+  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_PAGE);
+  m.load(vec![ratatui::text::Line::from("x"); COMMITS_PAGE]);
+  assert!(m.can_load_more(), "a full first page is under the cap");
+}
+
+#[test]
+fn a_deeper_page_keeps_the_scroll_position() {
+  // The user pages from the bottom of the list. Rewinding to the top there
+  // would throw away the position they paged from — unlike a fresh open,
+  // which does rewind.
+  use gwm::tui::CommitsModal;
+  let path = std::path::Path::new("/tmp/x");
+  let mut m = CommitsModal::new();
+  m.begin(Some(path), 10);
+  m.load(vec![ratatui::text::Line::from("x"); 10]);
+  m.max_scroll = 8;
+  m.scroll_to_bottom();
+  assert_eq!(m.scroll, 8);
+
+  m.begin_more(20);
+  assert_eq!(m.scroll, 8, "arming a deeper page keeps the cursor and the rows");
+  assert_eq!(m.lines.len(), 10, "the rows already read stay up while it loads");
+  m.load(vec![ratatui::text::Line::from("x"); 20]);
+  assert_eq!(m.scroll, 8, "and the payload does not rewind either");
+
+  m.begin(Some(path), 20);
+  assert_eq!(m.scroll, 0, "a fresh open still rewinds");
+  assert!(m.lines.is_empty(), "and drops the previous listing");
+}

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15371,7 +15371,10 @@ fn the_count_is_commits_not_rendered_rows() {
   let snap = recent_commits_listing(&w, 10, 0, &Theme::default());
   assert_eq!(snap.loaded, 0, "an unborn HEAD has no commits");
   assert_eq!(snap.lines.len(), 1, "but it still paints one sentinel row");
-  assert!(snap.wide.lines.is_empty(), "and a sentinel carries no metadata column");
+  assert!(
+    snap.tiers.iter().all(|t| t.lines.is_empty()),
+    "and a sentinel carries no metadata column"
+  );
 }
 
 #[test]
@@ -15411,26 +15414,29 @@ fn the_metadata_column_only_takes_room_the_subject_can_spare() {
   // merge-heavy history at 80 columns would otherwise buy an author column
   // with a ten-cell subject, which is a worse listing than no column.
   use gwm::tui::{commits_meta_pick, COMMITS_META_GAP, COMMITS_SUBJECT_FLOOR};
-  let (wide, narrow) = (20usize, 4usize);
+  // author · stats · age / stats · age / age
+  let tiers = [30usize, 14, 4];
+  let room_for = |w: usize| w + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR;
 
-  let room_for_wide = wide + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR;
-  assert_eq!(commits_meta_pick(room_for_wide, wide, narrow), Some(wide));
+  assert_eq!(commits_meta_pick(room_for(tiers[0]), tiers), Some(tiers[0]));
   assert_eq!(
-    commits_meta_pick(room_for_wide - 1, wide, narrow),
-    Some(narrow),
-    "one cell short of the wide column falls back to the narrow one"
+    commits_meta_pick(room_for(tiers[0]) - 1, tiers),
+    Some(tiers[1]),
+    "one cell short of the widest tier drops the author, not the stats"
   );
-
-  let room_for_narrow = narrow + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR;
-  assert_eq!(commits_meta_pick(room_for_narrow, wide, narrow), Some(narrow));
   assert_eq!(
-    commits_meta_pick(room_for_narrow - 1, wide, narrow),
+    commits_meta_pick(room_for(tiers[1]) - 1, tiers),
+    Some(tiers[2]),
+    "one cell short of the middle tier keeps the age alone"
+  );
+  assert_eq!(
+    commits_meta_pick(room_for(tiers[2]) - 1, tiers),
     None,
     "below the floor the listing keeps the whole width"
   );
 
   assert_eq!(
-    commits_meta_pick(500, 0, 0),
+    commits_meta_pick(500, [0, 0, 0]),
     None,
     "a sentinel row carries no column, however wide the terminal"
   );
@@ -15451,10 +15457,16 @@ fn the_metadata_columns_carry_the_author_and_the_age() {
     subject: "whatever".into(),
     time: now - 3 * 86_400,
   };
-  let (wide, narrow) = commit_meta_columns(&[row], now, &Theme::default());
+  let none = std::collections::HashMap::new();
+  let [wide, mid, narrow] = commit_meta_columns(&[row], now, &none, &Theme::default());
 
   let text = |l: &ratatui::text::Line<'_>| -> String { l.spans.iter().map(|s| s.content.as_ref()).collect() };
   assert_eq!(text(&wide.lines[0]), "Kylian Bardini · 3d");
+  assert_eq!(
+    text(&mid.lines[0]),
+    "3d",
+    "with no stats reads the middle tier is the age"
+  );
   assert_eq!(text(&narrow.lines[0]), "3d");
   assert_eq!(wide.width, "Kylian Bardini · 3d".chars().count());
   assert_eq!(narrow.width, 2);
@@ -15474,7 +15486,8 @@ fn an_authorless_commit_keeps_the_age_alone() {
     subject: String::new(),
     time: now - 60,
   };
-  let (wide, _) = commit_meta_columns(&[row], now, &Theme::default());
+  let none = std::collections::HashMap::new();
+  let [wide, _, _] = commit_meta_columns(&[row], now, &none, &Theme::default());
   let text: String = wide.lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
   assert_eq!(text, "1m", "no author, no separator");
 }
@@ -15540,4 +15553,69 @@ fn a_deeper_page_keeps_the_scroll_position() {
   m.begin(Some(path), 20, None);
   assert_eq!(m.scroll, 0, "a fresh open still rewinds");
   assert!(m.lines.is_empty(), "and drops the previous listing");
+}
+
+#[test]
+fn the_stats_read_is_chained_after_the_rows_and_grows_the_column() {
+  // Issue #593: the rows come from a ~0.4s revwalk, the diff counts from a
+  // one-to-three second `git log`. Folding them into one read would hold
+  // the listing behind the slower half, so the second is chained from the
+  // drain and the column grows under rows already on screen.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+
+  let before = app.commits.tiers[1].width;
+  assert!(!app.commits.stats_loaded, "the rows land without the stats");
+
+  use std::time::{Duration, Instant};
+  let deadline = Instant::now() + Duration::from_secs(20);
+  while !app.commits.stats_loaded && Instant::now() < deadline {
+    app.drain_task_results();
+    std::thread::sleep(Duration::from_millis(10));
+  }
+  assert!(app.commits.stats_loaded, "the chained stats read never landed");
+  assert!(
+    app.commits.tiers[1].width > before,
+    "the middle tier grew by the diff counts: {} -> {}",
+    before,
+    app.commits.tiers[1].width
+  );
+}
+
+#[test]
+fn a_stats_payload_for_another_listing_is_dropped() {
+  // Same three-part identity the rows are matched on. Unlike the rows,
+  // dropping one strands nothing: the columns already carry author and
+  // age, and the next chained request covers the current listing.
+  use gwm::tui::{MetaColumn, TaskKind, TaskMsg, COMMITS_PAGE};
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+
+  let fat = MetaColumn {
+    lines: vec![ratatui::text::Line::from("XXXXXXXXXXXX")],
+    width: 12,
+  };
+  let tiers = [fat.clone(), fat.clone(), fat];
+  let path = app.commits.path.clone().unwrap();
+  let generation = app.tasks.request(TaskKind::CommitStats).unwrap_or(0);
+
+  // Right path, wrong limit — injected through the spine, the path a real
+  // worker takes.
+  app
+    .task_result_sender()
+    .send(TaskMsg::CommitStats(
+      generation,
+      path.clone(),
+      COMMITS_PAGE * 2,
+      app.commits.head.clone(),
+      tiers,
+    ))
+    .unwrap();
+  app.drain_task_results();
+  assert!(
+    !app.commits.stats_loaded,
+    "a payload read at another page depth is not this listing's"
+  );
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -3487,31 +3487,32 @@ fn pr_line_ci_hint_follows_the_focus_context() {
       .collect()
   };
 
-  app.focus_worktrees();
-  let unfocused = text_of(&app);
-  assert!(
-    unfocused.contains("10/10 [C]"),
-    "worktrees focus advertises the global ci_checks binding: {unfocused}"
-  );
+  // #593: `C` opens the checks in both panes, so the badge no longer
+  // changes under the focus. The pane-dependent form it used to take
+  // existed only because the status pane borrowed `c` for the checks.
+  for focus_status in [false, true] {
+    if focus_status {
+      app.focus_status();
+    } else {
+      app.focus_worktrees();
+    }
+    let text = text_of(&app);
+    assert!(
+      text.contains("10/10 [C]"),
+      "the ci_checks binding is advertised in both panes (status focus = {focus_status}): {text}"
+    );
+  }
 
-  app.focus_status();
-  let focused = text_of(&app);
-  assert!(
-    focused.contains("10/10 [c]"),
-    "status focus advertises the contextual c: {focused}"
-  );
-
-  // Codex review #455 (P2): with `edit_worktree` explicitly unbound the
-  // contextual key is gone, but the global `ci_checks` binding still opens
-  // the overlay — advertise it instead of dropping the hint entirely.
+  // With `ci_checks` explicitly unbound there is no key to advertise and
+  // the suffix disappears rather than naming a phantom one.
   app
     .keymap
-    .apply_override(gwm::tui::keymap::Action::EditWorktree, vec![])
+    .apply_override(gwm::tui::keymap::Action::CiChecks, vec![])
     .unwrap();
   let unbound = text_of(&app);
   assert!(
-    unbound.contains("10/10 [C]"),
-    "unbound edit_worktree falls back to the global ci_checks key: {unbound}"
+    unbound.contains("10/10") && !unbound.contains("10/10 ["),
+    "an unbound ci_checks drops the key suffix: {unbound}"
   );
 }
 
@@ -3640,7 +3641,7 @@ fn ci_filter_enter_on_a_urlless_check_leaves_the_filter_and_signals_it() {
 }
 
 #[test]
-fn edit_worktree_action_routes_to_ci_checks_when_status_focused() {
+fn the_ci_overlay_opens_from_the_status_pane() {
   // Issue #436: `c` is contextual, same dispatch mechanism that turns j/k
   // into sidebar scroll — worktrees context keeps the rename modal, status
   // context opens the CI checks overlay.
@@ -3669,31 +3670,9 @@ fn edit_worktree_action_routes_to_ci_checks_when_status_focused() {
     detail: Default::default(),
   }));
 
-  // Codex review on PR #455: the contextual routing lives on the KEY path
-  // only — a pure pre-resolution the event loop applies before run_action.
-  // The palette's `edit-worktree` entry must stay a rename everywhere, so
-  // accept_command_palette returns the action unresolved.
-  use gwm::tui::keymap::Action;
-  app.focus_status();
-  assert_eq!(
-    app.resolve_contextual_action(Action::EditWorktree),
-    Action::CiChecks,
-    "status focus routes the edit-worktree KEY to the CI overlay"
-  );
-  assert_eq!(
-    app.resolve_contextual_action(Action::Down),
-    Action::Down,
-    "other actions pass through untouched"
-  );
-
-  app.focus_worktrees();
-  assert_eq!(
-    app.resolve_contextual_action(Action::EditWorktree),
-    Action::EditWorktree,
-    "worktrees context keeps the rename on c"
-  );
-
-  // The resolved CiChecks action opens the overlay as before.
+  // #593 replaced the #436 contextual routing: `c` and `C` mean the same
+  // thing in both panes now, so there is nothing left to re-resolve under
+  // the focus, and `enter_ci_checks` is reached the same way from either.
   app.focus_status();
   app.enter_ci_checks();
   assert_eq!(app.view, View::DetailOverlay);
@@ -15389,21 +15368,115 @@ fn the_count_is_commits_not_rendered_rows() {
   git2::Repository::init(dir.path()).unwrap();
   let w = worktree_pointing_at_dir(dir.path());
 
-  let (lines, count) = recent_commits_listing(&w, 10, &Theme::default());
-  assert_eq!(count, 0, "an unborn HEAD has no commits");
-  assert_eq!(lines.len(), 1, "but it still paints one sentinel row");
+  let snap = recent_commits_listing(&w, 10, 0, &Theme::default());
+  assert_eq!(snap.loaded, 0, "an unborn HEAD has no commits");
+  assert_eq!(snap.lines.len(), 1, "but it still paints one sentinel row");
+  assert!(snap.wide.lines.is_empty(), "and a sentinel carries no metadata column");
 }
 
 #[test]
 fn a_sentinel_row_is_not_a_full_page() {
   // The consequence that matters: a sentinel counted as a row would make
   // `loaded >= limit` true at limit 1 and offer a page that does not exist.
-  use gwm::tui::CommitsModal;
+  use gwm::tui::{CommitsModal, CommitsSnapshot};
   let mut m = CommitsModal::new();
   m.begin(Some(std::path::Path::new("/tmp/x")), 1, None);
-  m.load(vec![ratatui::text::Line::from("! unborn HEAD")], 0);
+  m.load(CommitsSnapshot {
+    lines: vec![ratatui::text::Line::from("! unborn HEAD")],
+    loaded: 0,
+    ..Default::default()
+  });
   assert_eq!(m.loaded, 0, "the sentinel is a row, not a commit");
   assert!(!m.can_load_more(), "and an empty history has no deeper page");
+}
+
+#[test]
+fn a_commit_dated_in_the_future_reads_as_just_now() {
+  // A commit time can be AHEAD of the local clock: skew, a rewritten
+  // history, a rebase that preserved author dates. The naive subtraction
+  // underflows into "55 thousand years"; saturating at zero renders `0s`,
+  // which is the least wrong thing to say about a timestamp we have not
+  // reached. No panic either, and this is a render path.
+  use gwm::worktree::{commit_age, format_relative_duration};
+  let now = 1_000_000i64;
+  assert_eq!(commit_age(now + 3600, now).as_secs(), 0, "the future saturates");
+  assert_eq!(format_relative_duration(commit_age(now + 3600, now)), "0s");
+  assert_eq!(commit_age(now - 3600, now).as_secs(), 3600, "the past is unaffected");
+}
+
+#[test]
+fn the_metadata_column_only_takes_room_the_subject_can_spare() {
+  // The graph is variable-width, so what the left side needs cannot be a
+  // constant — the policy is a floor on what survives instead. A
+  // merge-heavy history at 80 columns would otherwise buy an author column
+  // with a ten-cell subject, which is a worse listing than no column.
+  use gwm::tui::{commits_meta_pick, COMMITS_META_GAP, COMMITS_SUBJECT_FLOOR};
+  let (wide, narrow) = (20usize, 4usize);
+
+  let room_for_wide = wide + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR;
+  assert_eq!(commits_meta_pick(room_for_wide, wide, narrow), Some(wide));
+  assert_eq!(
+    commits_meta_pick(room_for_wide - 1, wide, narrow),
+    Some(narrow),
+    "one cell short of the wide column falls back to the narrow one"
+  );
+
+  let room_for_narrow = narrow + COMMITS_META_GAP + COMMITS_SUBJECT_FLOOR;
+  assert_eq!(commits_meta_pick(room_for_narrow, wide, narrow), Some(narrow));
+  assert_eq!(
+    commits_meta_pick(room_for_narrow - 1, wide, narrow),
+    None,
+    "below the floor the listing keeps the whole width"
+  );
+
+  assert_eq!(
+    commits_meta_pick(500, 0, 0),
+    None,
+    "a sentinel row carries no column, however wide the terminal"
+  );
+}
+
+#[test]
+fn the_metadata_columns_carry_the_author_and_the_age() {
+  // `wide` is `author · age`, `narrow` the age alone: the initials are
+  // already on the left, so the full author is the second tier of
+  // information and the age is the first — it is what the listing lacks.
+  use gwm::tui::commit_meta_columns;
+  use gwm::worktree::CommitRow;
+  let now = 1_000_000i64;
+  let row = CommitRow {
+    hash: git2::Oid::ZERO_SHA1,
+    author: "Kylian Bardini".into(),
+    parents: vec![],
+    subject: "whatever".into(),
+    time: now - 3 * 86_400,
+  };
+  let (wide, narrow) = commit_meta_columns(&[row], now, &Theme::default());
+
+  let text = |l: &ratatui::text::Line<'_>| -> String { l.spans.iter().map(|s| s.content.as_ref()).collect() };
+  assert_eq!(text(&wide.lines[0]), "Kylian Bardini · 3d");
+  assert_eq!(text(&narrow.lines[0]), "3d");
+  assert_eq!(wide.width, "Kylian Bardini · 3d".chars().count());
+  assert_eq!(narrow.width, 2);
+}
+
+#[test]
+fn an_authorless_commit_keeps_the_age_alone() {
+  // The `git log` fallback parser can yield an empty author, and a
+  // dangling ` · ` separator with nothing before it reads as a bug.
+  use gwm::tui::commit_meta_columns;
+  use gwm::worktree::CommitRow;
+  let now = 1_000_000i64;
+  let row = CommitRow {
+    hash: git2::Oid::ZERO_SHA1,
+    author: "   ".into(),
+    parents: vec![],
+    subject: String::new(),
+    time: now - 60,
+  };
+  let (wide, _) = commit_meta_columns(&[row], now, &Theme::default());
+  let text: String = wide.lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+  assert_eq!(text, "1m", "no author, no separator");
 }
 
 #[test]
@@ -15411,10 +15484,14 @@ fn paging_stops_at_the_cap() {
   // #593 notes the memo in `recent_commits_cached` is keyed on the limit
   // and evicts an arbitrary entry when full, so unbounded paging would push
   // other worktrees' sidebar entries out. The cap is what bounds it.
-  use gwm::tui::{CommitsModal, COMMITS_MAX, COMMITS_PAGE};
+  use gwm::tui::{CommitsModal, CommitsSnapshot, COMMITS_MAX, COMMITS_PAGE};
   let mut m = CommitsModal::new();
   m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_MAX, None);
-  m.load(vec![ratatui::text::Line::from("x"); COMMITS_MAX], COMMITS_MAX);
+  m.load(CommitsSnapshot {
+    lines: vec![ratatui::text::Line::from("x"); COMMITS_MAX],
+    loaded: COMMITS_MAX,
+    ..Default::default()
+  });
 
   assert!(!m.can_load_more(), "the cap is a hard stop even on a full page");
 
@@ -15424,7 +15501,11 @@ fn paging_stops_at_the_cap() {
   // And the cap leaves room for more than the first page, or load-more
   // would be dead on arrival.
   m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_PAGE, None);
-  m.load(vec![ratatui::text::Line::from("x"); COMMITS_PAGE], COMMITS_PAGE);
+  m.load(CommitsSnapshot {
+    lines: vec![ratatui::text::Line::from("x"); COMMITS_PAGE],
+    loaded: COMMITS_PAGE,
+    ..Default::default()
+  });
   assert!(m.can_load_more(), "a full first page is under the cap");
 }
 
@@ -15433,11 +15514,15 @@ fn a_deeper_page_keeps_the_scroll_position() {
   // The user pages from the bottom of the list. Rewinding to the top there
   // would throw away the position they paged from — unlike a fresh open,
   // which does rewind.
-  use gwm::tui::CommitsModal;
+  use gwm::tui::{CommitsModal, CommitsSnapshot};
   let path = std::path::Path::new("/tmp/x");
   let mut m = CommitsModal::new();
   m.begin(Some(path), 10, None);
-  m.load(vec![ratatui::text::Line::from("x"); 10], 10);
+  m.load(CommitsSnapshot {
+    lines: vec![ratatui::text::Line::from("x"); 10],
+    loaded: 10,
+    ..Default::default()
+  });
   m.max_scroll = 8;
   m.scroll_to_bottom();
   assert_eq!(m.scroll, 8);
@@ -15445,7 +15530,11 @@ fn a_deeper_page_keeps_the_scroll_position() {
   m.begin_more(20);
   assert_eq!(m.scroll, 8, "arming a deeper page keeps the cursor and the rows");
   assert_eq!(m.lines.len(), 10, "the rows already read stay up while it loads");
-  m.load(vec![ratatui::text::Line::from("x"); 20], 20);
+  m.load(CommitsSnapshot {
+    lines: vec![ratatui::text::Line::from("x"); 20],
+    loaded: 20,
+    ..Default::default()
+  });
   assert_eq!(m.scroll, 8, "and the payload does not rewind either");
 
   m.begin(Some(path), 20, None);

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15307,6 +15307,30 @@ fn reopening_after_a_deeper_page_gets_its_own_read() {
 }
 
 #[test]
+fn load_more_pages_the_worktree_the_overlay_opened_on() {
+  // Codex review, PR #614: the auto-refresh can move the selection while
+  // the overlay is up. Paging from `selected()` would fire a read for the
+  // NEW worktree, which the drain then drops on the path check — after
+  // `complete` freed the slot — so nothing is ever left to clear the
+  // loader. The target captured at open is the only sound one.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+
+  // The selection drifts, the overlay does not.
+  app.worktrees.push(worktree_fixture("feat-0-elsewhere"));
+  app.list_state.select(Some(app.worktrees.len() - 1));
+
+  app.load_more_commits();
+  settle_commits(&mut app);
+  assert!(
+    !app.is_commits_loading(),
+    "the deeper page landed on the captured target"
+  );
+}
+
+#[test]
 fn paging_stops_at_the_cap() {
   // #593 notes the memo in `recent_commits_cached` is keyed on the limit
   // and evicts an arbitrary entry when full, so unbounded paging would push

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15331,6 +15331,31 @@ fn load_more_pages_the_worktree_the_overlay_opened_on() {
 }
 
 #[test]
+fn a_vanished_worktree_stops_advertising_load_more() {
+  // Codex review, PR #614: another process removes the worktree while the
+  // overlay is up and the auto-refresh drops it from the list. The modal's
+  // own arithmetic still says "a full page, under the cap", so the footer
+  // kept offering `m` for a read that can no longer resolve a target. The
+  // hint and the handler have to agree, or a live key reads as broken.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+  assert!(app.commits_can_load_more(), "a full page on a live worktree pages");
+
+  app.worktrees.clear();
+
+  assert!(
+    app.commits.can_load_more(),
+    "the modal's own arithmetic cannot see the list, and still says yes"
+  );
+  assert!(
+    !app.commits_can_load_more(),
+    "but the App knows the target is gone, so the key is not offered"
+  );
+}
+
+#[test]
 fn paging_stops_at_the_cap() {
   // #593 notes the memo in `recent_commits_cached` is keyed on the limit
   // and evicts an arbitrary entry when full, so unbounded paging would push

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15281,7 +15281,7 @@ fn reopening_on_another_worktree_gets_its_own_read() {
   let (dir, mut app) = make_app();
   let other = dir.path().join("elsewhere");
 
-  app.commits.begin(Some(&other), COMMITS_PAGE);
+  app.commits.begin(Some(&other), COMMITS_PAGE, None);
   app.tasks.request(TaskKind::Commits).expect("the slot starts free");
 
   app.enter_commits();
@@ -15298,7 +15298,7 @@ fn reopening_after_a_deeper_page_gets_its_own_read() {
   use gwm::tui::{TaskKind, COMMITS_PAGE};
   let (dir, mut app) = make_app();
 
-  app.commits.begin(Some(dir.path()), COMMITS_PAGE * 2);
+  app.commits.begin(Some(dir.path()), COMMITS_PAGE * 2, None);
   app.tasks.request(TaskKind::Commits).expect("the slot starts free");
 
   app.enter_commits();
@@ -15356,14 +15356,65 @@ fn a_vanished_worktree_stops_advertising_load_more() {
 }
 
 #[test]
+fn a_moved_tip_is_not_coalesced_onto_the_previous_read() {
+  // Codex review, PR #614: close the overlay mid-read, land a commit, and
+  // reopen on the same worktree. Path and limit both match, so the request
+  // coalesced onto the worker already out — which still holds the OLD
+  // `WorktreeInfo.head`, so its payload passes both drain checks and the
+  // reopen silently shows a log missing the new commits. The tip is part
+  // of what identifies a read.
+  //
+  // The in-flight read is staged rather than raced: the fixture's walk
+  // finishes long before a second open could reach the guard.
+  use gwm::tui::{TaskKind, COMMITS_PAGE};
+  let (_dir, mut app) = make_app();
+  let path = app.selected().expect("the fixture repo is listed").path.clone();
+
+  app.commits.begin(Some(&path), COMMITS_PAGE, Some("0".repeat(40)));
+  app.tasks.request(TaskKind::Commits).expect("the slot starts free");
+
+  app.enter_commits();
+  settle_commits(&mut app);
+  assert!(!app.is_commits_loading(), "the reopen at the new tip got its own read");
+}
+
+#[test]
+fn the_count_is_commits_not_rendered_rows() {
+  // Codex review, PR #614: `recent_commits_lines` paints ONE sentinel row
+  // for an unborn HEAD or a failed read, so counting rows called that
+  // "1 commit" and the title read `Commits (1)` over a repo with none.
+  // The count travels with the rows instead of being inferred from them.
+  use gwm::tui::recent_commits_listing;
+  let dir = tempfile::tempdir().unwrap();
+  git2::Repository::init(dir.path()).unwrap();
+  let w = worktree_pointing_at_dir(dir.path());
+
+  let (lines, count) = recent_commits_listing(&w, 10, &Theme::default());
+  assert_eq!(count, 0, "an unborn HEAD has no commits");
+  assert_eq!(lines.len(), 1, "but it still paints one sentinel row");
+}
+
+#[test]
+fn a_sentinel_row_is_not_a_full_page() {
+  // The consequence that matters: a sentinel counted as a row would make
+  // `loaded >= limit` true at limit 1 and offer a page that does not exist.
+  use gwm::tui::CommitsModal;
+  let mut m = CommitsModal::new();
+  m.begin(Some(std::path::Path::new("/tmp/x")), 1, None);
+  m.load(vec![ratatui::text::Line::from("! unborn HEAD")], 0);
+  assert_eq!(m.loaded, 0, "the sentinel is a row, not a commit");
+  assert!(!m.can_load_more(), "and an empty history has no deeper page");
+}
+
+#[test]
 fn paging_stops_at_the_cap() {
   // #593 notes the memo in `recent_commits_cached` is keyed on the limit
   // and evicts an arbitrary entry when full, so unbounded paging would push
   // other worktrees' sidebar entries out. The cap is what bounds it.
   use gwm::tui::{CommitsModal, COMMITS_MAX, COMMITS_PAGE};
   let mut m = CommitsModal::new();
-  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_MAX);
-  m.load(vec![ratatui::text::Line::from("x"); COMMITS_MAX]);
+  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_MAX, None);
+  m.load(vec![ratatui::text::Line::from("x"); COMMITS_MAX], COMMITS_MAX);
 
   assert!(!m.can_load_more(), "the cap is a hard stop even on a full page");
 
@@ -15372,8 +15423,8 @@ fn paging_stops_at_the_cap() {
 
   // And the cap leaves room for more than the first page, or load-more
   // would be dead on arrival.
-  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_PAGE);
-  m.load(vec![ratatui::text::Line::from("x"); COMMITS_PAGE]);
+  m.begin(Some(std::path::Path::new("/tmp/x")), COMMITS_PAGE, None);
+  m.load(vec![ratatui::text::Line::from("x"); COMMITS_PAGE], COMMITS_PAGE);
   assert!(m.can_load_more(), "a full first page is under the cap");
 }
 
@@ -15385,8 +15436,8 @@ fn a_deeper_page_keeps_the_scroll_position() {
   use gwm::tui::CommitsModal;
   let path = std::path::Path::new("/tmp/x");
   let mut m = CommitsModal::new();
-  m.begin(Some(path), 10);
-  m.load(vec![ratatui::text::Line::from("x"); 10]);
+  m.begin(Some(path), 10, None);
+  m.load(vec![ratatui::text::Line::from("x"); 10], 10);
   m.max_scroll = 8;
   m.scroll_to_bottom();
   assert_eq!(m.scroll, 8);
@@ -15394,10 +15445,10 @@ fn a_deeper_page_keeps_the_scroll_position() {
   m.begin_more(20);
   assert_eq!(m.scroll, 8, "arming a deeper page keeps the cursor and the rows");
   assert_eq!(m.lines.len(), 10, "the rows already read stay up while it loads");
-  m.load(vec![ratatui::text::Line::from("x"); 20]);
+  m.load(vec![ratatui::text::Line::from("x"); 20], 20);
   assert_eq!(m.scroll, 8, "and the payload does not rewind either");
 
-  m.begin(Some(path), 20);
+  m.begin(Some(path), 20, None);
   assert_eq!(m.scroll, 0, "a fresh open still rewinds");
   assert!(m.lines.is_empty(), "and drops the previous listing");
 }

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -15555,6 +15555,17 @@ fn a_deeper_page_keeps_the_scroll_position() {
   assert!(m.lines.is_empty(), "and drops the previous listing");
 }
 
+/// Drain until the chained diff-stat read lands, or fail loudly.
+fn settle_commit_stats(app: &mut App) {
+  use std::time::{Duration, Instant};
+  let deadline = Instant::now() + Duration::from_secs(20);
+  while !app.commits.stats_loaded && Instant::now() < deadline {
+    app.drain_task_results();
+    std::thread::sleep(Duration::from_millis(10));
+  }
+  assert!(app.commits.stats_loaded, "the chained stats read never landed");
+}
+
 #[test]
 fn the_stats_read_is_chained_after_the_rows_and_grows_the_column() {
   // Issue #593: the rows come from a ~0.4s revwalk, the diff counts from a
@@ -15568,13 +15579,7 @@ fn the_stats_read_is_chained_after_the_rows_and_grows_the_column() {
   let before = app.commits.tiers[1].width;
   assert!(!app.commits.stats_loaded, "the rows land without the stats");
 
-  use std::time::{Duration, Instant};
-  let deadline = Instant::now() + Duration::from_secs(20);
-  while !app.commits.stats_loaded && Instant::now() < deadline {
-    app.drain_task_results();
-    std::thread::sleep(Duration::from_millis(10));
-  }
-  assert!(app.commits.stats_loaded, "the chained stats read never landed");
+  settle_commit_stats(&mut app);
   assert!(
     app.commits.tiers[1].width > before,
     "the middle tier grew by the diff counts: {} -> {}",
@@ -15592,6 +15597,12 @@ fn a_stats_payload_for_another_listing_is_dropped() {
   let (_dir, mut app) = make_app();
   app.enter_commits();
   settle_commits(&mut app);
+  // Let the chained read this open fired land FIRST, then pretend it never
+  // did. Injecting while it is still in flight makes the assertion a race
+  // with a worker the test did not start: green locally, red on CI, which
+  // is exactly what happened.
+  settle_commit_stats(&mut app);
+  app.commits.stats_loaded = false;
 
   let fat = MetaColumn {
     lines: vec![ratatui::text::Line::from("XXXXXXXXXXXX")],
@@ -15599,7 +15610,10 @@ fn a_stats_payload_for_another_listing_is_dropped() {
   };
   let tiers = [fat.clone(), fat.clone(), fat];
   let path = app.commits.path.clone().unwrap();
-  let generation = app.tasks.request(TaskKind::CommitStats).unwrap_or(0);
+  let generation = app
+    .tasks
+    .request(TaskKind::CommitStats)
+    .expect("the chained read has landed, so the slot is free");
 
   // Right path, wrong limit — injected through the spine, the path a real
   // worker takes.

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -162,6 +162,15 @@ fn digit_keys_dispatch_pane_focus_actions() {
 }
 
 #[test]
+fn the_sixth_digit_opens_the_commit_listing() {
+  // Issue #593: `6` continues the "numbers open panels" family (`3` command
+  // logs, `4` settings). Pinned here because the chord is what the docs,
+  // the help overlay and the footer all advertise.
+  let (_dir, mut app) = make_app();
+  assert_eq!(app.dispatch_key(press('6')), Some(Action::Commits));
+}
+
+#[test]
 fn focus_actions_respect_user_keymap_override() {
   // `[tui.keys]` must be able to rebind the new focus verbs like any other
   // action — the override replaces the default `2`.
@@ -545,6 +554,7 @@ fn help_overlay_documents_every_modal_action_in_its_section() {
       KeyContext::Help => "Help Overlay",
       KeyContext::Detail => "Agent Sessions",
       KeyContext::CommandLogs => "Command Logs",
+      KeyContext::Commits => "Commits",
       KeyContext::Config | KeyContext::ConfigEdit => "Settings",
       KeyContext::Report => "Bootstrap Report",
       KeyContext::OpenMenu => "Browse Links",

--- a/tests/tui_chord_tests.rs
+++ b/tests/tui_chord_tests.rs
@@ -162,12 +162,40 @@ fn digit_keys_dispatch_pane_focus_actions() {
 }
 
 #[test]
-fn the_sixth_digit_opens_the_commit_listing() {
-  // Issue #593: `6` continues the "numbers open panels" family (`3` command
-  // logs, `4` settings). Pinned here because the chord is what the docs,
-  // the help overlay and the footer all advertise.
+fn the_commit_and_check_keys_mean_the_same_in_both_panes() {
+  // Issue #593: `c` opens the commit listing, `C` the CI checks, and
+  // neither changes meaning under the focus. That uniformity is the whole
+  // point of the rebind: it replaced the #436 contextual routing, which
+  // gave the status pane its own `c`. It displaced the rename onto `e`,
+  // the letter that names it, and `exit_to_worktree` onto `E`.
   let (_dir, mut app) = make_app();
-  assert_eq!(app.dispatch_key(press('6')), Some(Action::Commits));
+  for focus_status in [false, true] {
+    if focus_status {
+      app.focus_status();
+    } else {
+      app.focus_worktrees();
+    }
+    assert_eq!(
+      app.dispatch_key(press('c')),
+      Some(Action::Commits),
+      "c is the commit listing (status focus = {focus_status})"
+    );
+    assert_eq!(
+      app.dispatch_key(press_shift_upper('C')),
+      Some(Action::CiChecks),
+      "C is the CI checks (status focus = {focus_status})"
+    );
+    assert_eq!(
+      app.dispatch_key(press('e')),
+      Some(Action::EditWorktree),
+      "the rename took the letter that names it (status focus = {focus_status})"
+    );
+    assert_eq!(
+      app.dispatch_key(press_shift_upper('E')),
+      Some(Action::ExitToWorktree),
+      "and the exit took the shifted one (status focus = {focus_status})"
+    );
+  }
 }
 
 #[test]

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -359,10 +359,26 @@ fn worktrees_hints_are_grouped_lifecycle_then_act_then_navigate_then_global() {
   assert_eq!(
     labels,
     vec![
-      "new", "del", "mark", "boot", // lifecycle
-      "open", "git", "exec", "agents", "note", "review", "yank", // act on the selected worktree
-      "filter", "status", "logs", "settings", // find / navigate
-      "help", "quit", // global
+      "new",
+      "del",
+      "mark",
+      "boot", // lifecycle
+      // #593: `commits` / `ci checks` read the same in both footers.
+      "open",
+      "git",
+      "commits",
+      "ci checks",
+      "exec",
+      "agents",
+      "note",
+      "review",
+      "yank", // act on the selected worktree
+      "filter",
+      "status",
+      "logs",
+      "settings", // find / navigate
+      "help",
+      "quit", // global
     ],
     "worktrees footer hints must follow the grouped order (#453 re-audit: \
      exec and agent sessions joined the act family; clean / mux / macros \

--- a/tests/tui_footer_tests.rs
+++ b/tests/tui_footer_tests.rs
@@ -384,7 +384,10 @@ fn status_hints_are_grouped_read_then_sidebar_then_navigate_then_global() {
       "scroll",
       "wt scroll", // #437: Working Tree pane scroll
       "fetch",     // read the status pane
-      "ci checks", // #436: `c` routes to the CI checks overlay here
+      // #593: this pane's own content at full size, then the linked PR's
+      // checks. The pair reads the same in the worktrees footer.
+      "commits",
+      "ci checks",
       "mode",
       "layout", // sidebar mode / layout
       "worktrees",

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -369,6 +369,62 @@ fn command_logs_modal_renders_title_and_entry_argv() {
   assert_present(&buf, "copy", "command logs copy hint");
 }
 
+/// Drain until the commit-listing worker lands, or fail loudly.
+fn settle_commits(app: &mut gwm::tui::App) {
+  use std::time::{Duration, Instant};
+  let deadline = Instant::now() + Duration::from_secs(10);
+  while app.is_commits_loading() && Instant::now() < deadline {
+    app.drain_task_results();
+    std::thread::sleep(Duration::from_millis(5));
+  }
+  assert!(
+    !app.is_commits_loading(),
+    "the commit-listing worker never landed within 10s"
+  );
+}
+
+#[test]
+fn commits_modal_paints_a_loader_before_the_walk_lands() {
+  // The revwalk is on a worker, so the first frame has no rows. A blank
+  // canvas there reads as "no commits", which is the one answer this
+  // overlay must not give by accident.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  let buf = render(&mut app);
+  assert_present(&buf, "loading", "loader while the walk is out");
+  assert_absent(&buf, "No commits", "empty-state placeholder during a load");
+  settle_commits(&mut app);
+}
+
+#[test]
+fn commits_modal_renders_the_graph_and_counts_its_rows() {
+  // Issue #593: `6` paints the sidebar's commit graph on the full canvas.
+  // The count rides the title so `load more` has visible feedback; the
+  // fixture repo has one commit, so there is no deeper page and no `+`.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  let buf = render(&mut app);
+  assert_present(&buf, "Commits (1)", "commits title with its row count");
+  assert_present(&buf, "init", "the commit subject");
+  assert_absent(&buf, "load more", "load-more hint on an exhausted history");
+  assert_absent(&buf, "loading", "loader after the walk landed");
+}
+
+#[test]
+fn commits_modal_advertises_load_more_only_when_a_page_is_full() {
+  // The footer hint and `App::load_more_commits` read the same predicate,
+  // so a key that does nothing is never advertised. Forced rather than
+  // committed 300 times: this pins the footer, not the revwalk.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+  let buf = render(&mut app);
+  assert_present(&buf, "load more", "load-more hint on a full page");
+  assert_present(&buf, "+", "the title flags that a deeper page exists");
+}
+
 #[test]
 fn command_logs_modal_renders_empty_placeholder() {
   let (_dir, mut app) = make_app();
@@ -1532,6 +1588,17 @@ fn sizing_matrix() -> Vec<(&'static str, ModalSetup, u16, u16)> {
       Box::new(|| {
         let (d, mut a) = make_app();
         a.view = View::CommandLogs;
+        (d, a)
+      }),
+      72,
+      180,
+    ),
+    (
+      "commits",
+      Box::new(|| {
+        let (d, mut a) = make_app();
+        a.enter_commits();
+        settle_commits(&mut a);
         (d, a)
       }),
       72,

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -412,6 +412,19 @@ fn commits_modal_renders_the_graph_and_counts_its_rows() {
 }
 
 #[test]
+fn commits_modal_drops_load_more_when_the_worktree_is_gone() {
+  // The render-side half of the same rule: a full page whose worktree left
+  // the list must not paint the hint, nor the title's `+`.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  app.commits.loaded = app.commits.limit;
+  app.worktrees.clear();
+  let buf = render(&mut app);
+  assert_absent(&buf, "load more", "load-more hint for a vanished worktree");
+}
+
+#[test]
 fn commits_modal_advertises_load_more_only_when_a_page_is_full() {
   // The footer hint and `App::load_more_commits` read the same predicate,
   // so a key that does nothing is never advertised. Forced rather than

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -2394,3 +2394,177 @@ fn a_detached_head_is_recorded_as_such_and_deletes_no_branch() {
     "a detached removal deletes no branch, whatever --delete-branch says"
   );
 }
+
+// ---- per-commit diff stats (issue #593) ------------------------------------
+
+/// Build a `git log --raw --numstat -z --format=%H` stream by hand. The
+/// real one puts the `%H`'s trailing newline in front of the next token,
+/// which the parser has to strip, so the fixture reproduces it.
+fn z_stream(records: &[(&str, &[&str])]) -> String {
+  let mut out = String::new();
+  for (hash, tokens) in records {
+    out.push_str(hash);
+    out.push('\0');
+    out.push('\n');
+    for t in *tokens {
+      out.push_str(t);
+      out.push('\0');
+    }
+  }
+  out
+}
+
+const OID_A: &str = "1111111111111111111111111111111111111111";
+const OID_B: &str = "2222222222222222222222222222222222222222";
+
+#[test]
+fn commit_stats_count_adds_changes_and_removals() {
+  use gwm::worktree::parse_commit_stats;
+  let raw = z_stream(&[(
+    OID_A,
+    &[
+      ":100644 100644 aaa bbb M",
+      "src/one.rs",
+      ":000000 100644 000 ccc A",
+      "src/new.rs",
+      ":100644 000000 ddd 000 D",
+      "src/gone.rs",
+      "6\t2\tsrc/one.rs",
+      "40\t0\tsrc/new.rs",
+      "0\t17\tsrc/gone.rs",
+    ],
+  )]);
+
+  let stats = parse_commit_stats(&raw);
+  let s = stats[&git2::Oid::from_str(OID_A).unwrap()];
+  assert_eq!(s.files_added, 1);
+  assert_eq!(s.files_modified, 1);
+  assert_eq!(s.files_deleted, 1);
+  assert_eq!(s.files_touched(), 3);
+  assert_eq!(s.insertions, 46);
+  assert_eq!(s.deletions, 19);
+}
+
+#[test]
+fn a_rename_does_not_desynchronise_the_next_commit() {
+  // `R` emits TWO paths where every other status emits one. A parser that
+  // counted token positions would read the second path as the next record
+  // and charge the rest of this commit to the wrong oid — or to none.
+  use gwm::worktree::parse_commit_stats;
+  let raw = z_stream(&[
+    (
+      OID_A,
+      &[
+        ":100644 100644 aaa bbb R100",
+        "src/old.rs",
+        "src/new.rs",
+        ":100644 100644 ccc ddd M",
+        "src/after.rs",
+        "0\t0\tsrc/old.rs\tsrc/new.rs",
+        "3\t1\tsrc/after.rs",
+      ],
+    ),
+    (OID_B, &[":100644 100644 eee fff M", "src/b.rs", "9\t4\tsrc/b.rs"]),
+  ]);
+
+  let stats = parse_commit_stats(&raw);
+  let a = stats[&git2::Oid::from_str(OID_A).unwrap()];
+  assert_eq!(
+    a.files_modified, 2,
+    "the rename and the plain edit both count as changed"
+  );
+  assert_eq!(a.insertions, 3);
+  assert_eq!(a.deletions, 1);
+
+  let b = stats[&git2::Oid::from_str(OID_B).unwrap()];
+  assert_eq!(b.files_modified, 1, "the second commit is not polluted by the first");
+  assert_eq!(b.insertions, 9);
+  assert_eq!(b.deletions, 4);
+}
+
+#[test]
+fn a_binary_file_counts_as_touched_with_no_lines() {
+  // git reports `-` for both counts on a binary blob. It changed a file,
+  // so it belongs in `files_*`; it has no lines to add to the totals.
+  use gwm::worktree::parse_commit_stats;
+  let raw = z_stream(&[(OID_A, &[":100644 100644 aaa bbb M", "logo.png", "-\t-\tlogo.png"])]);
+
+  let s = parse_commit_stats(&raw)[&git2::Oid::from_str(OID_A).unwrap()];
+  assert_eq!(s.files_modified, 1);
+  assert_eq!(s.insertions, 0);
+  assert_eq!(s.deletions, 0);
+}
+
+#[test]
+fn a_commit_that_changed_nothing_is_present_and_zero() {
+  // An empty commit emits no diff entries at all. It must still appear in
+  // the map: an absent oid is "not read yet" to the caller, and a row that
+  // says nothing forever is worse than one that says zero.
+  use gwm::worktree::parse_commit_stats;
+  let stats = parse_commit_stats(&z_stream(&[(OID_A, &[])]));
+  let s = stats[&git2::Oid::from_str(OID_A).unwrap()];
+  assert_eq!(s.files_touched(), 0);
+  assert_eq!(s, Default::default());
+}
+
+#[test]
+fn commit_stats_gives_a_merge_its_first_parent_diff() {
+  // `git log` emits NO diff for a merge by default, and this project
+  // merges rather than squashes, so without `--diff-merges=first-parent` a
+  // large share of real rows would read as "changed nothing" — confidently
+  // wrong, and invisible on a linear fixture. Hence a fixture that merges.
+  use gwm::worktree::commit_stats;
+  let (dir, repo) = init_repo();
+  let sig = git2::Signature::now("gwm-test", "gwm@test").unwrap();
+  let base = repo.head().unwrap().peel_to_commit().unwrap();
+
+  // A side branch with one file, merged back into a main that moved on.
+  // The index is reset to `base` before each side: sharing it would let the
+  // second branch inherit the first one's file, and the merge would then
+  // introduce nothing and pass this test for the wrong reason.
+  let commit_on_base = |name: &str, file: &str, update_ref: Option<&str>| {
+    std::fs::write(dir.path().join(file), format!("fn {name}() {{}}\n")).unwrap();
+    let mut idx = repo.index().unwrap();
+    idx.read_tree(&base.tree().unwrap()).unwrap();
+    idx.add_path(std::path::Path::new(file)).unwrap();
+    let tree = repo.find_tree(idx.write_tree().unwrap()).unwrap();
+    let oid = repo.commit(update_ref, &sig, &sig, name, &tree, &[&base]).unwrap();
+    repo.find_commit(oid).unwrap()
+  };
+  let side = commit_on_base("side", "side.rs", None);
+  let main = commit_on_base("main", "main.rs", Some("HEAD"));
+  let merge = {
+    let mut idx = repo.merge_commits(&main, &side, None).unwrap();
+    let tree = repo.find_tree(idx.write_tree_to(&repo).unwrap()).unwrap();
+    repo
+      .commit(Some("HEAD"), &sig, &sig, "merge side", &tree, &[&main, &side])
+      .unwrap()
+  };
+
+  let stats = commit_stats(dir.path(), &[merge]).unwrap();
+  let s = stats.get(&merge).expect("the merge is in the map");
+  assert_eq!(
+    s.files_added, 1,
+    "the merge brought side.rs onto the first parent — got {s:?}"
+  );
+  assert!(s.insertions > 0, "and its lines with it — got {s:?}");
+}
+
+#[test]
+fn commit_stats_reads_the_oids_it_is_given() {
+  // The set must equal the rows on screen, which is why the oids are
+  // passed explicitly instead of trusting a `-N` that sorts differently
+  // from the revwalk.
+  use gwm::worktree::commit_stats;
+  let (dir, repo) = init_repo();
+  let seed = repo.head().unwrap().target().unwrap();
+
+  let stats = commit_stats(dir.path(), &[seed]).unwrap();
+  assert_eq!(stats.len(), 1, "one oid in, one entry out");
+  assert!(stats.contains_key(&seed));
+
+  assert!(
+    commit_stats(dir.path(), &[]).unwrap().is_empty(),
+    "no oids means no git call and no entries"
+  );
+}


### PR DESCRIPTION
## Description

The sidebar's Commits pane is a fraction of a sidebar shared with four other blocks, and it stops at `RECENT_COMMITS_LIMIT` (300): reading further meant leaving gwm for lazygit. `6` now paints the same graph renderer on a 90% canvas, and `m` re-reads one page deeper up to 1500, so history is paged rather than capped.

Closes #593

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `View::Commits` + `Action::Commits` (`commits`, default `6`) + `KeyContext::Commits` with `close` / `load_more` / `scroll_*` verbs under `[tui.keys.modal.commits]`, plus the palette entry and both help-overlay surfaces (list-view action and its own section).
- `CommitsModal` (`src/tui/state/commits.rs`): the snapshotted graph rows, the limit they were read at, the scroll cursor, the loader flag and the worktree path the payload must match. `COMMITS_PAGE` = the sidebar's own 300, `COMMITS_MAX` = 1500.
- The read runs on a `TaskKind::Commits` worker, never on the keypress. The revwalk sorts `TIME | TOPOLOGICAL`, so it traverses the whole reachable graph before yielding a row: **measured on this repo (2058 commits), asking for 300 costs the same as asking for all of them** (405ms vs 493ms, debug). The limit truncates the output, it bounds nothing about the latency. Paging is not cheap either, which is half the reason for the cap.
- The other half: `recent_commits_cached` is keyed on `(repo, tip, limit)`, holds 64 entries and evicts an arbitrary one when full, so unbounded paging would push other worktrees' sidebar entries out and force them to re-walk.
- `can_load_more` gates on the loader too: `loaded` still describes the previous page while a read is out, so a held `m` would raise the limit again and coalesce onto a read whose payload the drain then drops on the limit check, leaving the loader up forever. The drain checks both path and limit; a reopen differing in either frees the slot first.
- Title carries the row count and a trailing `+` while a deeper page exists; the footer drops `load more` when the key would do nothing and says `loading` while a read is out.
- Rows are snapshotted at open rather than read from `SidebarState::cache` (only rebuilt while the sidebar is open and in commits mode, so empty in the two states where the overlay is most useful). The first page reads at the sidebar's limit, so a warm tip makes the worker a hash lookup.

## Tests

- [x] `cargo test` passes locally (104 test binaries green, real exit code, `--no-fail-fast`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Seven pins in `tests/tui_app_tests.rs` plus three render tests and the `sizing_matrix` entry. Every guard was falsified to prove its red:

- the width pin was faked (72/180 to 71/179) and both width guards named `commits`;
- dropping the cap from `can_load_more` reddened `paging_stops_at_the_cap`;
- removing the help section reddened the `#453` completeness guard (and surfaced that `#334` wanted a list-view `entry(Action::Commits, …)` too, which `cargo test`'s fail-fast had been hiding);
- removing the slot invalidation turned both reopen tests into a 10s timeout.

The two reopen tests stage the in-flight read by occupying the task slot rather than racing a real worker: raced, they pass with the invalidate removed, because on a one-commit fixture the thread finishes before the second open. That version was written first and thrown away.

Also ran the CI-like minimal-PATH pass (`PATH="$(dirname "$(command -v cargo)"):/usr/bin:/bin"`, after a normal-PATH `--no-run` since the macOS linker needs the full PATH to find `iconv`): green.

## Screenshots / TUI captures

None yet. **Visual validation is pending your local GO** (this session is not interactive), which is the usual gate for a TUI change here.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a, no CLI surface change)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a, `[tui.keys.modal.<context>]` takes any exposed context; the four docs pages carry the new one)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #593
- Related PR: #612 (#592, the Working Tree modal)
- Docs: `docs/2.tui/1.keybindings.md`, `docs/4.configuration/1.gwm-toml.md` and both `docs/fr/` mirrors

## Notes for reviewers

**This takes `6`, not `5`.** #612 owns `5` for the Working Tree listing and is not merged yet, so `5` looks free on `dev` but is not. Branching this off `dev` rather than stacking on #612 was deliberate (#612 is currently `CONFLICTING` with uncommitted work in its worktree, so basing on it makes this unmergeable by construction). Whoever merges second resolves purely additive collisions: the `View` enum, `KeyContext::all()`, `palette_entries()`, `sizing_matrix()`, `help_rows`, the docs tables and the CHANGELOG. Until #612 lands, the numeric family reads `3`, `4`, `6` with a gap.

Two follow-ups deliberately left out of scope:

- The overlay does not share a shell with #592's. Two overlays is not an abstraction; if a third arrives, that is the moment to factor one.
- `Enter` on a row (copy the sha, open the commit on the forge) is in the issue as an explicit non-requirement for the first cut.