### PR TITLE
🐛 fix(tui): the selected worktree keeps the GitHub context fetched for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already done. Only a row with nothing linked still gets the link hint.
   Workspace mode gains the most: it skips the bulk prefetch by design, so
   before this the verbs there were fed by nothing at all.
+
+  Freshness is unchanged: a relist still expires every fetched status, so
+  `tui.auto_refresh_secs` (60 by default) still bounds how stale one can be.
+  That expiry moved ahead of the bulk prefetch's early returns, which is what
+  gives workspace mode the same bound rather than none.
 - **An overlay's toggle key closes it whatever it is bound to**
   ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). `3`, `4` and `W`
   each close the overlay they open, but the guard doing it asked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The selected worktree keeps the GitHub context that was fetched for it**
+  ([#597](https://github.com/kbrdn1/gwm-cli/issues/597)). Standing on any row
+  but the one the TUI opened on, `C` / `c` said "no CI checks to show: link a
+  PR and fetch (F) first" for a worktree whose PR was linked and whose checks
+  had already been fetched, and the rich Issue/PR view (`I`) refused for the
+  same reason. `f` did not help: it refreshes the worktree list, not the
+  GitHub layer, so only an `F` on that exact row filled the state back in.
+
+  gwm was throwing away its own prefetch. It fetches every linked issue and
+  PR at startup and on every relist, but the link re-read that runs on each
+  selection change flushed the whole result cache and dropped any in-flight
+  `gh` worker with it, so the prefetch died on the first `j`. That flush was
+  a leftover: the cache has been keyed by number since #138, so it cannot
+  serve one row's status for another, and a row that never fetched still
+  reads as unfetched. It is now dropped only when the origin actually moves
+  between two forge instances, which is the one case where a cached number
+  means something else.
+
+  The two verbs also stopped reading "nobody asked yet" as "nothing to show".
+  A linked PR that has never been fetched is now fetched on the spot, on the
+  same task spine, and reported as `fetching Pull request #61...`; one
+  already in flight says the same without starting a second call; one whose
+  probe failed shows what `gh` said instead of pointing at a fetch that had
+  already run; and a PR that is fetched with an empty rollup says its checks
+  have not been reported rather than naming a link and a fetch that are both
+  already done. Only a row with nothing linked still gets the link hint.
+  Workspace mode gains the most: it skips the bulk prefetch by design, so
+  before this the verbs there were fed by nothing at all.
 - **An overlay's toggle key closes it whatever it is bound to**
   ([#613](https://github.com/kbrdn1/gwm-cli/issues/613)). `3`, `4` and `W`
   each close the overlay they open, but the guard doing it asked

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7617,7 +7617,12 @@ impl App {
     // early return below, and it is what bounds staleness to
     // `tui.auto_refresh_secs`. Workspace mode needs it most, since it takes
     // the early return and refills per-selection instead.
-    self.invalidate_github();
+    //
+    // Settled entries only, and no spine generation-bump: a fetch in flight
+    // has no stale answer behind it to expire, so cancelling it would throw
+    // away work and expire nothing (Codex review on #618). The respawns
+    // below coalesce onto it through `TaskRunner::request`.
+    self.github.invalidate_settled();
 
     // Workspace mode (#36): this bulk prefetch resolves every merged row's
     // issue/PR against a single repo's slug (`self.github.link_slug`), which

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7181,22 +7181,31 @@ impl App {
 
   // ---- Issue/PR linking (issue #67) -------------------------------------
 
-  /// Re-read the link for the currently selected worktree's branch. Also
-  /// re-resolves the repo slug from the origin remote, and resets any
-  /// previously cached GitHub fetch state since it would refer to a
-  /// different (issue, pr) tuple now. Delegates to
-  /// [`GitHubFetch::refresh_link`] for the pure state mutation; the
-  /// branch resolution still lives here because it depends on
-  /// `App`'s `selected()` + `repo.head()` fallback.
+  /// Re-read the link for the currently selected worktree's branch, and
+  /// re-resolve the repo slug from the origin remote. Delegates to
+  /// [`GitHubFetch::reread_link`] for the pure state mutation; the branch
+  /// resolution still lives here because it depends on `App`'s
+  /// `selected()` + `repo.head()` fallback.
+  ///
+  /// **The fetched statuses survive this** (issue #597). The result cache
+  /// has been keyed by `(side, number)` since #138, so it cannot serve one
+  /// row's status for another: a row reads its own number, and a number it
+  /// never fetched reads `Idle`. Flushing it on every link re-read was a
+  /// leftover of the pre-#138 single slot (PR #68), and since this runs on
+  /// every navigation it threw away the prefetch `App::new` and every
+  /// relist start — which is why standing on any row but the one the TUI
+  /// opened on left `C` / `I` with nothing to show.
   pub fn refresh_link(&mut self) {
     let branch = self.selected_branch_name();
-    self.github.refresh_link(&self.repo, branch.as_deref(), &self.config);
-    // Navigation invariant (issue #255): the cache clear above must be paired
-    // with a spine generation-bump so any in-flight `gh` worker for the
-    // previous worktree's link is dropped instead of stamping the now-active
-    // worktree's cache. `refresh_link` no longer holds the old issue/PR
-    // numbers, so invalidate by predicate.
-    self.tasks.invalidate_matching(TaskKind::is_github);
+    // Only a change of forge *instance* makes a cached number mean
+    // something else, and `reread_link` reports exactly that by dropping
+    // the caches and returning `true`. Navigation invariant (issue #255):
+    // that flush must be paired with a spine generation-bump, so any
+    // in-flight `gh` worker started against the previous instance is
+    // dropped instead of stamping the new one's cache.
+    if self.github.reread_link(&self.repo, branch.as_deref(), &self.config) {
+      self.tasks.invalidate_matching(TaskKind::is_github);
+    }
     // Every link mutation funnels through here or through the
     // `refresh_github_status` re-probe — both revalidate the CI overlay's
     // pinned identity (Codex review #455): an auto-refresh relist can move

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3796,6 +3796,74 @@ impl App {
     self.view = View::DetailOverlay;
   }
 
+  /// Why a verb that needs the selected row's forge context cannot run
+  /// yet, and — when the answer is "nobody asked" — the fetch that fixes
+  /// it (issue #597).
+  ///
+  /// `Idle` on a LINKED side is not "nothing to show", it is "never
+  /// fetched". The bulk prefetch runs at startup and on every relist but
+  /// is skipped entirely in workspace mode, so a row can reach a verb with
+  /// a perfectly good link and a cold cache; reporting that as a missing
+  /// link sent the reader off to fix the one thing that was fine. An
+  /// `Error` is terminal in the cache, so it deserves the same distinction
+  /// for the opposite reason: the fetch the hint asked for has already run.
+  ///
+  /// Returns `None` when the side is `Loaded` (the caller renders it) or
+  /// unlinked — only the caller knows how to word which side it needed —
+  /// and otherwise the status line to show.
+  fn forge_fetch_gap(&mut self, side: LinkTarget) -> Option<String> {
+    /// The cache states without their payloads: the two sides carry
+    /// different ones and this decision reads neither.
+    enum Phase {
+      Fetched,
+      InFlight,
+      Failed(String),
+      Unfetched,
+    }
+    fn phase_of<T>(state: &GitHubFetchState<T>) -> Phase {
+      match state {
+        GitHubFetchState::Loaded(_) => Phase::Fetched,
+        GitHubFetchState::Loading => Phase::InFlight,
+        GitHubFetchState::Error(e) => Phase::Failed(e.clone()),
+        GitHubFetchState::Idle => Phase::Unfetched,
+      }
+    }
+
+    let number = match side {
+      LinkTarget::Issue => self.github.link.issue?,
+      LinkTarget::Pr => self.github.link.pr?,
+    };
+    let noun = match side {
+      LinkTarget::Issue => "Issue".to_string(),
+      LinkTarget::Pr => self.pr_noun_titlecase(),
+    };
+    let phase = match side {
+      LinkTarget::Issue => phase_of(self.github.issue_fetch_state(number)),
+      LinkTarget::Pr => phase_of(self.github.pr_fetch_state(number)),
+    };
+    match phase {
+      Phase::Fetched => None,
+      Phase::InFlight => Some(format!("fetching {noun} #{number}…")),
+      Phase::Failed(e) => Some(format!("{noun} #{number} could not be fetched: {e}")),
+      Phase::Unfetched => {
+        // Ask now, through the same spawn helpers and behind the same slug
+        // guard the bulk prefetch uses: without a resolved forge the spawn
+        // marks the cache `Loading` for a request that is never made, and
+        // the section would spin for good.
+        let slug = self.github.link_slug.clone()?;
+        let started = match side {
+          LinkTarget::Issue => self.spawn_github_issue(number, &slug),
+          LinkTarget::Pr => self.spawn_github_pr(number, &slug),
+        };
+        if !started {
+          return None;
+        }
+        self.spinner.reset();
+        Some(format!("fetching {noun} #{number}…"))
+      }
+    }
+  }
+
   /// Open the CI checks overlay (issue #436): one row per classified
   /// `statusCheckRollup` entry of the linked PR, in rollup order. With no
   /// linked PR or an empty rollup the overlay would be a bordered void —
@@ -3812,13 +3880,28 @@ impl App {
     }
     let checks = match self.pr_fetch_state() {
       GitHubFetchState::Loaded(pr) if !pr.checks.is_empty() => pr.checks.clone(),
+      // Fetched, and the rollup really is empty: a commit was just pushed
+      // and the workflows have not started. Naming the link and the fetch
+      // here named the two things that were already done (issue #597).
+      GitHubFetchState::Loaded(pr) => {
+        let number = pr.number;
+        self.status = format!("no CI checks reported by {} #{number}", self.pr_noun_titlecase());
+        return;
+      }
       _ => {
-        // Resolve the active fetch binding instead of hard-coding `F`
+        // A linked-but-unfetched PR is asked for rather than refused, and
+        // an in-flight or failed one is reported as what it is (#597).
+        // Only a row with no PR at all gets the link hint, and that hint
+        // resolves the active fetch binding instead of hard-coding `F`
         // (Codex review #455); an unbound action drops the parenthetical.
-        self.status = match self.keymap.primary_chord(Action::FetchGithub) {
-          Some(key) => format!("no CI checks to show: link a PR and fetch ({key}) first"),
-          None => "no CI checks to show: link a PR and fetch first".into(),
+        let msg = match self.forge_fetch_gap(LinkTarget::Pr) {
+          Some(msg) => msg,
+          None => match self.keymap.primary_chord(Action::FetchGithub) {
+            Some(key) => format!("no CI checks to show: link a PR and fetch ({key}) first"),
+            None => "no CI checks to show: link a PR and fetch first".into(),
+          },
         };
+        self.status = msg;
         return;
       }
     };
@@ -3896,12 +3979,22 @@ impl App {
       self.open_rich_overlay(source, title, width);
       return;
     }
+    // Neither side can be shown yet. A linked side that nobody has asked
+    // for is asked for here rather than reported as absent (issue #597) —
+    // the PR first, the side this view prefers. Both are probed, since
+    // either one landing is enough to fill the view.
+    let pr_gap = self.forge_fetch_gap(LinkTarget::Pr);
+    let issue_gap = self.forge_fetch_gap(LinkTarget::Issue);
     // Resolve the active binding rather than hard-coding `F`, the same way
     // `enter_ci_checks` does.
-    self.status = match self.keymap.primary_chord(Action::FetchGithub) {
-      Some(key) => format!("nothing to show: link an issue or PR and fetch ({key}) first"),
-      None => "nothing to show: link an issue or PR and fetch first".into(),
+    let msg = match pr_gap.or(issue_gap) {
+      Some(msg) => msg,
+      None => match self.keymap.primary_chord(Action::FetchGithub) {
+        Some(key) => format!("nothing to show: link an issue or PR and fetch ({key}) first"),
+        None => "nothing to show: link an issue or PR and fetch first".into(),
+      },
     };
+    self.status = msg;
   }
 
   /// Common tail of [`Self::enter_rich_view`]: build the rows, pin the

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7572,13 +7572,21 @@ impl App {
   }
 
   fn refresh_linked_github_statuses_for_worktrees(&mut self) -> u32 {
+    // A relist is the moment the fetched statuses stop being authoritative,
+    // and since #597 nothing else expires them: the link re-read on every
+    // navigation keeps them now. So the expiry runs FIRST, ahead of every
+    // early return below, and it is what bounds staleness to
+    // `tui.auto_refresh_secs`. Workspace mode needs it most, since it takes
+    // the early return and refills per-selection instead.
+    self.invalidate_github();
+
     // Workspace mode (#36): this bulk prefetch resolves every merged row's
     // issue/PR against a single repo's slug (`self.github.link_slug`), which
     // mis-attributes numbers across child repos with different remotes (Codex
     // review #303 P2). In workspace mode GitHub state is fetched per-selection
-    // instead — `sync_active_repo`/`on_navigation` call `refresh_link`, which
-    // re-resolves the slug from the selected row's own repo. So skip the bulk
-    // cross-repo prefetch here.
+    // instead — `sync_active_repo`/`on_navigation` call `refresh_link`, and
+    // the context verbs ask for what they need through `forge_fetch_gap`
+    // (#597). So skip the bulk cross-repo prefetch here.
     if self.is_workspace() {
       return 0;
     }
@@ -7603,7 +7611,6 @@ impl App {
       return 0;
     }
 
-    self.invalidate_github();
     let mut spawned = 0u32;
     for n in issues {
       if self.spawn_github_issue(n, &slug) {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1381,6 +1381,15 @@ impl App {
     // (the bulk prefetch is a no-op in workspace mode).
     self.sync_active_repo();
     self.refresh_link();
+    // The shared tail above expired every fetched status, and workspace mode
+    // has no bulk refill behind it: a fetch in flight when the auto-refresh
+    // timer fires would lose its generation and have its result dropped, with
+    // nothing to replace it — and with an `auto_refresh_secs` shorter than the
+    // forge's latency, every fetch a context verb starts could be cancelled
+    // that way (Codex review on #618). Refilled here rather than in that tail
+    // because only now has the repo swap resolved the link and the slug
+    // against the row actually selected.
+    self.spawn_selected_github();
   }
 
   /// Builder-style setter for `trust_mode`. The TUI entrypoint
@@ -7571,6 +7580,36 @@ impl App {
     }
   }
 
+  /// Request the SELECTED row's linked issue / PR, returning how many
+  /// workers actually started (issue #597, Codex review on #618).
+  ///
+  /// The narrow counterpart to
+  /// [`Self::refresh_linked_github_statuses_for_worktrees`]: the link and the
+  /// slug both belong to the active repo, so this is sound in workspace mode
+  /// where resolving *every* merged row against one slug is not (#303). Both
+  /// guards the bulk path uses still apply — no slug, no request; a terminal
+  /// cache hit or a coalesced spine slot does not spawn a second subprocess.
+  fn spawn_selected_github(&mut self) -> u32 {
+    let Some(slug) = self.github.link_slug.clone() else {
+      return 0;
+    };
+    let mut spawned = 0u32;
+    if let Some(n) = self.github.link.issue {
+      if self.spawn_github_issue(n, &slug) {
+        spawned += 1;
+      }
+    }
+    if let Some(n) = self.github.link.pr {
+      if self.spawn_github_pr(n, &slug) {
+        spawned += 1;
+      }
+    }
+    if spawned > 0 {
+      self.spinner.reset();
+    }
+    spawned
+  }
+
   fn refresh_linked_github_statuses_for_worktrees(&mut self) -> u32 {
     // A relist is the moment the fetched statuses stop being authoritative,
     // and since #597 nothing else expires them: the link re-read on every
@@ -7584,9 +7623,10 @@ impl App {
     // issue/PR against a single repo's slug (`self.github.link_slug`), which
     // mis-attributes numbers across child repos with different remotes (Codex
     // review #303 P2). In workspace mode GitHub state is fetched per-selection
-    // instead — `sync_active_repo`/`on_navigation` call `refresh_link`, and
-    // the context verbs ask for what they need through `forge_fetch_gap`
-    // (#597). So skip the bulk cross-repo prefetch here.
+    // instead — the relist refills the selected row through
+    // `spawn_selected_github`, and the context verbs ask for what they need
+    // through `forge_fetch_gap` (#597). So skip the bulk cross-repo prefetch
+    // here, having already expired what it would have replaced.
     if self.is_workspace() {
       return 0;
     }

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -248,6 +248,34 @@ impl GitHubFetch {
     self.pr_threads_cache.clear();
   }
 
+  /// Flush the cached *outcomes* and leave the fetches still in flight
+  /// alone (issue #597, Codex review on #618).
+  ///
+  /// What a relist expires is a result that has stopped being
+  /// authoritative. A `Loading` entry is not one: nothing has been read
+  /// yet, so there is no stale answer behind it, and dropping it only
+  /// throws away work in progress. Worse, the caller pairs a full
+  /// [`Self::invalidate`] with a spine generation-bump, so the worker's
+  /// result is discarded when it lands — and with a
+  /// `tui.auto_refresh_secs` shorter than the forge's latency, every tick
+  /// superseded the fetch before it could arrive, leaving the row unfilled
+  /// for good while the cancelled subprocesses kept running.
+  ///
+  /// Keeping an in-flight fetch is sound here because a relist does not
+  /// change what a number means: only a move between forge instances does,
+  /// and `App::refresh_link` still answers that with the full flush and the
+  /// generation-bump that must move with it.
+  pub fn invalidate_settled(&mut self) {
+    // A fn, not a closure: the three caches hold three different payload
+    // types and a closure cannot be generic over them.
+    fn in_flight<T>(state: &GitHubFetchState<T>) -> bool {
+      matches!(state, GitHubFetchState::Loading)
+    }
+    self.issue_cache.retain(|_, s| in_flight(s));
+    self.pr_cache.retain(|_, s| in_flight(s));
+    self.pr_threads_cache.retain(|_, s| in_flight(s));
+  }
+
   /// Stamp an auto-detected PR onto the resolved `link` when none is
   /// already linked (issue #181). Pure: the `App` orchestrator owns the
   /// `gh pr list --head <branch>` shell-out and feeds the detected number

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -121,7 +121,7 @@ pub struct GitHubFetch {
   pub link_slug: Option<String>,
   /// The resolved forge backend for the active repo (issue #419), or
   /// `None` when `origin` is missing / unparseable. Re-resolved on every
-  /// [`Self::refresh_link`] rather than cached on the `App`: in workspace
+  /// [`Self::reread_link`] rather than cached on the `App`: in workspace
   /// mode the active repo — and with it the `.gwm.toml` `forge` key — can
   /// change under the cursor.
   pub forge: Option<std::sync::Arc<dyn crate::forge::Forge>>,
@@ -147,7 +147,7 @@ impl Default for GitHubFetch {
 impl GitHubFetch {
   /// Construct an empty `GitHubFetch` with no link, no slug, and empty
   /// per-key caches. The `App` constructor calls this once and then
-  /// immediately runs [`Self::refresh_link`] against the repo so the
+  /// immediately runs [`Self::reread_link`] against the repo so the
   /// cold state lasts only as long as the constructor itself.
   pub fn new() -> Self {
     Self {
@@ -160,26 +160,18 @@ impl GitHubFetch {
     }
   }
 
-  /// Re-read the link for `branch` against `repo`, re-resolve the
-  /// repo slug from the `origin` remote, and reset every cached
-  /// fetch state. Called by `App::refresh_link` after the user
-  /// navigates to a different worktree — the cached state refers to a
-  /// different `(issue, pr)` tuple and would be misleading if reused.
-  /// (`App::refresh_link` separately drops any in-flight GitHub worker
-  /// on the spine — see [`Self::invalidate`] for the pairing.)
-  pub fn refresh_link(&mut self, repo: &Repository, branch: Option<&str>, config: &crate::config::Config) {
-    let _ = self.reread_link(repo, branch, config);
-    self.invalidate();
-  }
-
-  /// Re-read the link and forge **without** dropping fetched results.
+  /// Re-read the link and forge, keeping the fetched results.
   ///
-  /// [`Self::refresh_link`] clears the caches on purpose: a selection
-  /// change must not leave the previous row's status on screen (PR #68).
-  /// But the open menu calls it only to catch a link made in another
-  /// terminal, and clearing there wiped the server-reported `web_url` it
-  /// was about to read, so it always fell back to a locally built URL —
-  /// wrong exactly where it matters, on an origin whose web host or port
+  /// This used to have a wholesale-clearing sibling (`refresh_link`) that
+  /// every link re-read went through, on the PR #68 reasoning that a
+  /// selection change must not leave the previous row's status on screen.
+  /// Post-#138 the caches are keyed by number, so they cannot do that:
+  /// each row reads its own number and an unfetched one reads `Idle`. The
+  /// clear only threw away the prefetch, leaving the TUI's context verbs
+  /// with nothing on every row but the first (issue #597), and it was
+  /// wrong for the open menu too — it wiped the server-reported `web_url`
+  /// that menu was about to read, so the URL fell back to a locally built
+  /// one, wrong exactly where it matters: an origin whose web host or port
   /// gwm cannot infer (Codex review #458).
   ///
   /// Preserving is safe as long as the *instance* is unchanged: the
@@ -233,9 +225,12 @@ impl GitHubFetch {
 
   /// Flush every cached fetch state. Equivalent to "the cached
   /// `(issue, pr)` tuples are no longer authoritative". Called by
-  /// [`Self::refresh_link`]; exposed standalone for callers (e.g. an
-  /// explicit "force refresh" key like `F`) that want to wipe the cache
-  /// without re-reading the link.
+  /// [`Self::reread_link`] when the forge instance moves under the
+  /// selection; exposed standalone for callers (e.g. an explicit "force
+  /// refresh" key like `F`) that want to wipe the cache without
+  /// re-reading the link. Note that a plain selection change is NOT one
+  /// of them (issue #597) — the caches are per-number, so they stay
+  /// authoritative for whatever the new row links to.
   ///
   /// Post-#255 this clears only the result cache. Dropping any *in-
   /// flight* worker's late result is the spine's job: the `App` pairs

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -4297,6 +4297,145 @@ fn enter_ci_checks_error_resolves_the_fetch_key() {
   );
 }
 
+/// An App on `feat/#42-tui-search` with a GitHub origin and PR 61 linked,
+/// its fetch never started — the cold shape the #597 tests below act on.
+fn app_with_a_linked_unfetched_pr() -> (tempfile::TempDir, git2::Repository, App) {
+  let (dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  // The origin is what resolves the forge, and with it `link_slug` — the
+  // fetch refuses to start without one, exactly as the bulk prefetch does.
+  repo.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  gwm::github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  app.refresh_link();
+  (dir, repo, app)
+}
+
+#[test]
+fn enter_ci_checks_starts_the_fetch_nobody_asked_for() {
+  // Issue #597: `Idle` on a LINKED PR is "nobody asked yet", not "nothing
+  // to show". Workspace mode skips the bulk prefetch entirely, so before
+  // this the only filler was an explicit `F` on the right row — and the
+  // message sent the user to link a PR that was already linked.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Idle),
+    "the fixture must start unfetched, or the assertions below pass vacuously"
+  );
+
+  app.enter_ci_checks();
+
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
+    "the verb must ask for what it needs instead of refusing"
+  );
+  assert!(
+    app.status.contains("fetching") && app.status.contains("61"),
+    "and say which fetch it started: {}",
+    app.status
+  );
+  assert_ne!(app.view, View::DetailOverlay, "still nothing to render yet");
+}
+
+#[test]
+fn enter_ci_checks_while_the_pr_fetch_is_in_flight_says_so() {
+  // Issue #597: `Loading` is not a missing link either — a second spawn
+  // would be wrong and the link hint would be a lie.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+  let _generation = request_github_pr(&mut app, 61);
+
+  app.enter_ci_checks();
+
+  assert!(
+    app.status.contains("fetching") && app.status.contains("61"),
+    "an in-flight fetch is reported as one: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_ci_checks_after_a_failed_fetch_reports_the_failure() {
+  // Issue #597: `Error` is terminal in the cache, so the "fetch (F) first"
+  // hint pointed at a fetch that had already run and failed. The reason
+  // the user needs is the one `gh` gave.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+  app.apply_pr_fetch_result(Err("gh: HTTP 502".into()));
+
+  app.enter_ci_checks();
+
+  assert!(
+    app.status.contains("HTTP 502"),
+    "the probe failure is what the user has to act on: {}",
+    app.status
+  );
+  assert!(
+    !app.status.contains("link a PR"),
+    "a PR that is linked must not be reported as unlinked: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_ci_checks_on_a_fetched_pr_with_an_empty_rollup_says_that() {
+  // Issue #597: the fetched-but-empty case shared the unlinked message,
+  // which named the two things that were already done. The rollup is
+  // empty because the workflows have not started, and that is what to say.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+  app.apply_pr_fetch_result(Ok(PrStatus {
+    number: 61,
+    title: "no checks yet".into(),
+    state: PrState::Open,
+    url: "https://example.test/pull/61".into(),
+    updated_at: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    ci: CiState::None,
+    checks: vec![],
+    detail: Default::default(),
+  }));
+
+  app.enter_ci_checks();
+
+  assert_ne!(app.view, View::DetailOverlay, "an empty rollup opens nothing");
+  assert!(
+    app.status.contains("no CI checks") && !app.status.contains("link a PR"),
+    "a linked, fetched PR must not be reported as unlinked: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_rich_view_starts_the_fetch_nobody_asked_for() {
+  // Issue #597: the rich view reads the same cache and refused for the
+  // same reason. Same contract, same verb-level fix.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+
+  app.enter_rich_view();
+
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
+    "the view must ask for the PR it wants to show"
+  );
+  assert!(
+    app.status.contains("fetching") && app.status.contains("61"),
+    "and say so: {}",
+    app.status
+  );
+}
+
+#[test]
+fn enter_rich_view_after_a_failed_fetch_reports_the_failure() {
+  // Issue #597, PR side, same reasoning as the CI checks counterpart.
+  let (_dir, _repo, mut app) = app_with_a_linked_unfetched_pr();
+  app.apply_pr_fetch_result(Err("gh: HTTP 502".into()));
+
+  app.enter_rich_view();
+
+  assert!(
+    app.status.contains("HTTP 502"),
+    "the probe failure is what the user has to act on: {}",
+    app.status
+  );
+}
+
 #[test]
 fn loaded_explicit_pr_status_persists_title_for_no_fetch_startup() {
   let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
@@ -4714,14 +4853,83 @@ fn apply_fetch_error_stores_error_state() {
 }
 
 #[test]
-fn refresh_link_invalidates_fetch_state() {
-  // After the user changes selection or the branch link changes, any
-  // previously fetched status no longer applies. The state must reset.
+fn refresh_link_keeps_the_status_it_re_reads_the_link_for() {
+  // Issue #597. The result cache has been keyed by (side, number) since
+  // #138, so a link re-read cannot serve one row's status for another: a
+  // row reads its OWN number, and a number it never fetched reads `Idle`.
+  // Flushing the whole cache here was a leftover of the pre-#138 single
+  // slot (PR #68), and it threw away the prefetch that `App::new` and
+  // every relist run — the reason `C` / `I` had nothing to show.
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
-  app.apply_issue_fetch_result(Err("e".into()));
+  app.apply_issue_fetch_result(Ok(sample_issue(42)));
+  assert!(
+    matches!(app.issue_fetch_state(), GitHubFetchState::Loaded(_)),
+    "the fixture must start Loaded, or the assertion below passes vacuously"
+  );
+
   app.refresh_link();
-  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
-  assert!(matches!(app.pr_fetch_state(), GitHubFetchState::Idle));
+
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(i) => assert_eq!(i.number, 42),
+    other => panic!("re-reading the link must keep the fetched status: {other:?}"),
+  }
+}
+
+#[test]
+fn walking_the_list_and_back_finds_the_status_still_there() {
+  // Issue #597, the behaviour the acceptance test in the issue describes:
+  // open on a worktree with a fetched PR, move away, move back, and the
+  // context is still loaded. Pre-#597 `on_navigation` -> `refresh_link`
+  // flushed the cache and bumped the spine generation, so the prefetch
+  // died on the first `j` and every context-dependent verb reported
+  // "nothing to show" from then until an explicit `F`.
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  app.apply_issue_fetch_result(Ok(sample_issue(42)));
+  assert!(
+    matches!(app.issue_fetch_state(), GitHubFetchState::Loaded(_)),
+    "the fixture must start Loaded, or the assertions below pass vacuously"
+  );
+
+  app.next();
+  assert!(
+    matches!(app.issue_fetch_state(), GitHubFetchState::Idle),
+    "the other row reads its own number: #42's status must not leak onto it"
+  );
+
+  app.prev();
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(i) => assert_eq!(i.number, 42),
+    other => panic!("coming back must find #42's status still cached: {other:?}"),
+  }
+}
+
+#[test]
+fn navigation_keeps_an_in_flight_fetch_alive() {
+  // Issue #597, the half the cache alone does not cover: `refresh_link`
+  // also bumped the spine generation on every navigation, so a worker
+  // started by the prefetch had its result dropped by `drain` if the user
+  // pressed a key while it was in flight. Nothing then refilled the slot,
+  // which is how a row could sit on `Loading` forever.
+  use gwm::tui::TaskMsg;
+  let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  app.worktrees.push(worktree_fixture("alt"));
+  app.list_state.select(Some(0));
+  let generation = request_github_issue(&mut app, 42);
+
+  app.next();
+  app.prev();
+
+  app
+    .task_result_sender()
+    .send(TaskMsg::GithubIssue(generation, 42, Ok(sample_issue(42))))
+    .unwrap();
+  app.drain_task_results();
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(i) => assert_eq!(i.number, 42),
+    other => panic!("the in-flight worker must survive the navigation: {other:?}"),
+  }
 }
 
 #[test]
@@ -4750,10 +4958,15 @@ fn prev_resets_fetch_state_on_selection_change() {
 
 #[test]
 fn first_resets_fetch_state_on_selection_change() {
+  // The row `first()` lands on links #42, and it must not be handed the
+  // status of a number it does not link to. Seeded under the fixture row's
+  // own number rather than through `apply_issue_fetch_result` (which keys
+  // on the CURRENT link, so it would have stored #42's status and, since
+  // #597, that one legitimately survives).
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
   app.worktrees.push(worktree_fixture("alt"));
   app.list_state.select(Some(1));
-  app.apply_issue_fetch_result(Err("stale".into()));
+  app.github.complete_issue(0, Ok(sample_issue(0)));
   app.first();
   assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
 }
@@ -4769,20 +4982,43 @@ fn last_resets_fetch_state_on_selection_change() {
 }
 
 #[test]
-fn filter_clamping_resets_fetch_state_when_selection_moves() {
+fn filter_clamping_re_resolves_the_status_when_selection_moves() {
   // When typing into the filter narrows the visible set so much that the
-  // current selection no longer points at the same worktree, the link
-  // cache must invalidate too. Otherwise the right-panel block lies.
+  // current selection no longer points at the same worktree, the panel
+  // must follow — otherwise the right-panel block describes a row that is
+  // no longer selected. Since #597 that is a re-resolution, not a flush:
+  // both numbers stay cached and the selection decides which one is read.
+  //
+  // The full fixture name is typed rather than a single `z`: the repo row
+  // is a `tempfile` directory whose random name can contain one, which
+  // left two rows matching and the assertion at the mercy of the draw.
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
   app.worktrees.push(worktree_fixture("zzz-unique"));
-  app.list_state.select(Some(1));
-  app.apply_issue_fetch_result(Err("stale".into()));
+  app.list_state.select(Some(0));
+  app
+    .github
+    .complete_issue(42, Ok(sample_issue_titled(42, "the branch row")));
+  app
+    .github
+    .complete_issue(0, Ok(sample_issue_titled(0, "the fixture row")));
+  app.refresh_link();
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(i) => assert_eq!(i.title, "the branch row", "precondition"),
+    other => panic!("precondition: the branch row must read #42: {other:?}"),
+  }
+
   app.enter_filter();
-  app.filter_push_char('z'); // only the second fixture matches
-                             // The selection survives but the link cache should still reset because
-                             // the filter operation can drop selection back to index 0 on the
-                             // filtered subset. The contract: any selection-state mutation refreshes.
-  assert!(matches!(app.issue_fetch_state(), GitHubFetchState::Idle));
+  for c in "zzz-unique".chars() {
+    app.filter_push_char(c);
+  }
+
+  match app.issue_fetch_state() {
+    GitHubFetchState::Loaded(i) => assert_eq!(
+      i.title, "the fixture row",
+      "the narrowed selection must read its own number"
+    ),
+    other => panic!("expected the fixture row's own status: {other:?}"),
+  }
 }
 
 #[test]
@@ -13727,11 +13963,15 @@ fn a_failed_thread_fetch_is_shown_not_swallowed() {
 }
 
 #[test]
-fn a_link_refresh_drops_cached_threads_with_everything_else() {
-  // Threads live in their own cache, so the invalidation that clears the
-  // PR must clear them too — otherwise a refreshed PR renders next to the
-  // previous run's inline comments.
+fn cached_threads_move_with_the_pr_they_hang_from() {
+  // Threads live in their own cache, so whatever happens to the PR cache
+  // must happen to them — otherwise a refreshed PR renders next to the
+  // previous run's inline comments. Both halves of that, in order: a plain
+  // link re-read keeps them (they are keyed by PR number, so they are as
+  // authoritative as the PR itself — issue #597), and an origin moving
+  // between two instances that share a slug drops them (Codex review #458).
   let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  repo.remote("origin", "https://github.com/acme/widgets.git").unwrap();
   gwm::github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
   app.refresh_link();
   app.apply_pr_threads_fetch_result(61, Ok(one_thread()));
@@ -13741,10 +13981,18 @@ fn a_link_refresh_drops_cached_threads_with_everything_else() {
   );
 
   app.refresh_link();
+  assert!(
+    matches!(app.pr_threads_fetch_state(61), gwm::tui::GitHubFetchState::Loaded(_)),
+    "a link re-read on the same instance must keep #61's threads"
+  );
+
+  repo.remote_delete("origin").unwrap();
+  repo.remote("origin", "https://gitlab.com/acme/widgets.git").unwrap();
+  app.refresh_link();
 
   assert!(
     matches!(app.pr_threads_fetch_state(61), gwm::tui::GitHubFetchState::Idle),
-    "stale threads survived the invalidation"
+    "threads from the previous instance survived the identity change"
   );
 }
 

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -602,3 +602,44 @@ fn overlay_pin_markers_survive_an_active_repo_swap() {
       .collect::<Vec<_>>()
   );
 }
+
+// -- GitHub statuses stay bounded in workspace mode (issue #597) -----------
+
+fn sample_issue(n: u64) -> gwm::github::IssueStatus {
+  gwm::github::IssueStatus {
+    number: n,
+    title: "x".into(),
+    state: gwm::github::IssueState::Open,
+    url: String::new(),
+    labels: vec![],
+    updated_at: String::new(),
+    detail: Default::default(),
+  }
+}
+
+#[test]
+fn a_workspace_relist_expires_the_fetched_github_statuses() {
+  // Issue #597 made the fetch cache survive a selection change, which leaves
+  // the relist as the only thing bounding how stale it can get (60 s by
+  // default, `tui.auto_refresh_secs`). Single-repo mode gets that from the
+  // bulk prefetch, which invalidates before re-spawning; workspace mode
+  // skips that prefetch by design (one slug cannot resolve every child
+  // repo's numbers, Codex review #303), so the expiry has to run before that
+  // early return. Without it a workspace row would keep showing a CI state
+  // that went red hours ago, and only `F` would ever correct it.
+  use gwm::tui::GitHubFetchState;
+  let root = workspace_root();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  app.github.complete_issue(42, Ok(sample_issue(42)));
+  assert!(
+    matches!(app.github.issue_fetch_state(42), GitHubFetchState::Loaded(_)),
+    "precondition: the status must be cached, or the assertion below is vacuous"
+  );
+
+  app.refresh().unwrap();
+
+  assert!(
+    matches!(app.github.issue_fetch_state(42), GitHubFetchState::Idle),
+    "a relist must expire the statuses it can no longer vouch for"
+  );
+}

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -644,25 +644,77 @@ fn a_workspace_relist_expires_the_fetched_github_statuses() {
   );
 }
 
-#[test]
-fn a_workspace_relist_re_requests_the_selection_it_just_expired() {
-  // Codex review on PR #618. The relist expires every fetched status, and
-  // workspace mode has no bulk refill behind it: a fetch in flight when the
-  // auto-refresh timer fires had its generation bumped and its result dropped
-  // by `TaskRunner::complete`, with nothing to replace it. With an
-  // `auto_refresh_secs` shorter than the forge's latency, every fetch the
-  // context verbs start could be cancelled that way and the row would never
-  // fill in. The selected row's link resolves against the ACTIVE repo, so
-  // re-requesting it is the one refill that is sound across repos (#303).
-  use gwm::tui::GitHubFetchState;
+fn sample_pr(n: u64) -> gwm::github::PrStatus {
+  gwm::github::PrStatus {
+    number: n,
+    title: "x".into(),
+    state: gwm::github::PrState::Open,
+    url: String::new(),
+    updated_at: String::new(),
+    checks_passed: 0,
+    checks_total: 0,
+    ci: gwm::github::CiState::None,
+    checks: vec![],
+    detail: Default::default(),
+  }
+}
+
+/// A workspace whose anchor repo (alpha) has a GitHub origin and PR 61
+/// linked on `main`, with the anchor's own prefetch already landed: the
+/// spine slot is free and the cache holds a terminal result, which is the
+/// steady state a relist acts on.
+fn workspace_with_a_fetched_pr() -> (TempDir, App) {
+  use gwm::tui::TaskKind;
   let root = workspace_root();
   let alpha = Repository::open(root.path().join("alpha")).unwrap();
   alpha.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
   gwm::github::link_pr(&alpha, "main", 61).unwrap();
   let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
-  // A fetch in flight. The workspace constructor anchors on alpha through the
-  // single-repo one, whose prefetch starts one for the linked PR — the same
-  // state a context verb leaves behind through `forge_fetch_gap`.
+  // The anchor constructor's prefetch left a worker in flight; land it, so
+  // the state under test is "fetched", not "still fetching".
+  app.tasks.invalidate_matching(TaskKind::is_github);
+  app.github.complete_pr(61, Ok(sample_pr(61)));
+  (root, app)
+}
+
+#[test]
+fn a_workspace_relist_re_requests_the_selection_it_just_expired() {
+  // Codex review on PR #618. The relist expires every fetched status, and
+  // workspace mode has no bulk refill behind it (one slug cannot resolve
+  // every child repo's numbers, #303), so the selected row would drop to
+  // `Idle` on every auto-refresh tick and only fill back in if the user
+  // happened to press a context verb. Its link resolves against the ACTIVE
+  // repo, so re-requesting that one row is sound where the bulk pass is not.
+  use gwm::tui::GitHubFetchState;
+  let (_root, mut app) = workspace_with_a_fetched_pr();
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loaded(_)),
+    "precondition: the status must be fetched, or the assertion below is vacuous"
+  );
+
+  app.refresh().unwrap();
+
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
+    "the relist expired the selection and put nothing back"
+  );
+}
+
+#[test]
+fn a_relist_does_not_cancel_the_fetch_it_is_waiting_on() {
+  // Codex review on PR #618, round 2. Expiring a `Loading` entry throws away
+  // work in progress without expiring anything: there is no stale result
+  // behind it to be wrong. With `tui.auto_refresh_secs` shorter than the
+  // forge's latency the relist did that on every tick, so the worker was
+  // always superseded before it could land, the row sat unfilled for good,
+  // and the cancelled subprocesses kept running behind it.
+  use gwm::tui::{FetchKey, GitHubFetchState, TaskKind, TaskMsg};
+  let (_root, mut app) = workspace_with_a_fetched_pr();
+  let generation = app
+    .tasks
+    .request(TaskKind::GithubPr(61))
+    .expect("the landed prefetch freed the slot");
+  app.github.mark_loading(FetchKey::Pr(61));
   assert!(
     matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
     "precondition: the fetch must be in flight, or the assertion below is vacuous"
@@ -670,8 +722,13 @@ fn a_workspace_relist_re_requests_the_selection_it_just_expired() {
 
   app.refresh().unwrap();
 
+  app
+    .task_result_sender()
+    .send(TaskMsg::GithubPr(generation, 61, Ok(sample_pr(61))))
+    .unwrap();
+  app.drain_task_results();
   assert!(
-    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
-    "the relist dropped the in-flight fetch and put nothing behind it"
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loaded(_)),
+    "the relist cancelled the worker it was waiting on"
   );
 }

--- a/tests/tui_workspace_tests.rs
+++ b/tests/tui_workspace_tests.rs
@@ -643,3 +643,35 @@ fn a_workspace_relist_expires_the_fetched_github_statuses() {
     "a relist must expire the statuses it can no longer vouch for"
   );
 }
+
+#[test]
+fn a_workspace_relist_re_requests_the_selection_it_just_expired() {
+  // Codex review on PR #618. The relist expires every fetched status, and
+  // workspace mode has no bulk refill behind it: a fetch in flight when the
+  // auto-refresh timer fires had its generation bumped and its result dropped
+  // by `TaskRunner::complete`, with nothing to replace it. With an
+  // `auto_refresh_secs` shorter than the forge's latency, every fetch the
+  // context verbs start could be cancelled that way and the row would never
+  // fill in. The selected row's link resolves against the ACTIVE repo, so
+  // re-requesting it is the one refill that is sound across repos (#303).
+  use gwm::tui::GitHubFetchState;
+  let root = workspace_root();
+  let alpha = Repository::open(root.path().join("alpha")).unwrap();
+  alpha.remote("origin", "https://github.com/kbrdn1/gwm-cli.git").unwrap();
+  gwm::github::link_pr(&alpha, "main", 61).unwrap();
+  let mut app = App::new_workspace_at_layered(root.path(), None).unwrap();
+  // A fetch in flight. The workspace constructor anchors on alpha through the
+  // single-repo one, whose prefetch starts one for the linked PR — the same
+  // state a context verb leaves behind through `forge_fetch_gap`.
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
+    "precondition: the fetch must be in flight, or the assertion below is vacuous"
+  );
+
+  app.refresh().unwrap();
+
+  assert!(
+    matches!(app.pr_fetch_state(), GitHubFetchState::Loading),
+    "the relist dropped the in-flight fetch and put nothing behind it"
+  );
+}


### PR DESCRIPTION
## Description

Standing on any row but the one the TUI opened on, `C` / `c` reported `no CI
checks to show: link a PR and fetch (F) first` for a worktree whose PR was
linked and whose checks had already been fetched, and `I` refused for the same
reason. `f` did not help: it refreshes the worktree list, not the GitHub layer.

gwm was throwing away its own prefetch. It fetches every linked issue and PR at
startup and on every relist, but `refresh_link` (which runs on every selection
change) flushed the whole result cache and dropped every in-flight `gh` worker
with it, so the prefetch died on the first `j`. That flush was a leftover of the
pre-#138 single-slot cache: results are keyed by `(side, number)` now, so a row
reads its own number and a number it never fetched reads `Idle`. It cannot serve
one row's status for another, which is the only thing the flush was defending.

Closes #597

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `App::refresh_link` keeps the fetched statuses and the in-flight workers.
  `reread_link` already reports the one case where a cached number means
  something else (an origin moving between two forge instances), so the flush
  and the spine generation-bump it must move with fire there and nowhere else.
  `GitHubFetch::refresh_link`, the wholesale-clearing wrapper, had one caller
  and is removed.
- The relist keeps that flush, and it moves ahead of every early return in
  `refresh_linked_github_statuses_for_worktrees` so the *relist* expires the
  statuses rather than the prefetch that happens to refill them. Workspace mode
  takes that early return by design (one slug cannot resolve every child repo's
  numbers, #303), so without the move it would have had no expiry at all once
  navigation stopped providing one.
- `forge_fetch_gap` answers, for one side of the link, why a context verb cannot
  run: a linked side never fetched is fetched now (same spawn helpers, same slug
  guard the bulk prefetch uses) and reported as in flight; one already in flight
  says the same without a second call; one whose probe failed reports what `gh`
  said, since `Error` is terminal in the cache and the "fetch first" hint pointed
  at a fetch that had already run. Only a row with nothing linked keeps the link
  hint.
- `enter_ci_checks` and `enter_rich_view` route through it. The CI overlay also
  splits out the fetched-but-empty rollup, which shared the link hint and so
  named a link and a fetch that were both already done.

## Tests

- [x] `cargo test` passes locally (full suite, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Ten new tests, written red first. Each asserts its `Loaded` / unfetched
precondition **before** the action, so none can pass vacuously on a harness that
never had the state.

In `tests/tui_app_tests.rs`: three replace `refresh_link_invalidates_fetch_state`,
whose subject was the pre-#138 single-slot cache. A status survives a link
re-read, survives walking away and back (and does not leak onto the row in
between), and an in-flight worker survives the navigation that used to drop its
result. Six more cover the verbs: `C` and `I` starting the fetch nobody asked
for, reporting one in flight, reporting a failed probe, and the empty rollup.

In `tests/tui_workspace_tests.rs`: one pins the staleness bound on the path that
takes the prefetch's early return.

Two existing tests were re-aimed rather than deleted, because they were reading
the flush as if it were their subject: `a_link_refresh_drops_cached_threads_with_everything_else`
becomes `cached_threads_move_with_the_pr_they_hang_from` and now pins both halves
(kept on a re-read, dropped when the instance moves), and the filter test pins
re-resolution rather than invalidation. That one also stopped typing a single
`z`, which the tempdir's random name could match too, making it order-dependent.

## Screenshots / TUI captures

None: the change is in what the status bar says and what state survives a
keypress, both covered by the state tests above.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a: no CLI surface change)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #597
- Context: #138 (per-number cache), #255 (task spine), #303 (why the workspace prefetch is skipped), #458 (forge identity), #68 (the flush this removes)

## Notes for reviewers

Two things worth a second pair of eyes.

**Workspace ordering.** In workspace mode `on_navigation` runs `refresh_link`
*before* `sync_active_repo` swaps `self.repo` (`app.rs:1241`), so that first
re-read resolves the forge against the old repo. The swap then calls
`refresh_link` again, the identity moves, and the caches drop, so a preserved
cache cannot be served across repos. Both calls happen before the next draw
(`tui/mod.rs:314`), so the intermediate state never renders.

**Cost and freshness.** No new forge calls on navigation: nothing is fetched
that the bulk prefetch would not already have fetched, and the on-demand kick is
bounded by what the user actually opens. Staleness stays bounded by
`tui.auto_refresh_secs` (60 by default) in both modes, which is what the moved
flush buys. So no debounce and no TTL, which the issue floated for the
fetch-on-selection option this deliberately does not take.

Workspace mode gains the most: it skips the bulk prefetch by design, so before
this the context verbs there were fed by nothing at all.

Not validated by eye yet: this wants a local install and a walk through a list
with a linked PR before it merges.