### PR TITLE
🐛 fix(tui): a relist keeps the threads the rich view is showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The rich Issue/PR view keeps its inline comments through a relist**
+  ([#619](https://github.com/kbrdn1/gwm-cli/issues/619)). With the rich PR
+  view open on a PR whose review threads had landed, a worktree relist (the
+  periodic `tui.auto_refresh_secs` one, or an explicit `f`) emptied the
+  thread cache, and the next PR result to land rebuilt the open view against
+  an empty one. The inline comments disappeared from under the reader, and
+  only closing and reopening the view, or refreshing it with `f`, brought
+  them back.
+
+  The view survives that same expiry for the PR itself because it renders
+  its own snapshot of it; the threads were the one thing it read live from
+  the cache. A relist now keeps the threads of the PR it is showing, which
+  are as authoritative as the PR they hang from, and expires everyone
+  else's as before. Re-requesting them on each tick instead would be fresher
+  and worse: the section collapses to a loading line for the round trip,
+  once per refresh interval, taking the reader's place in the comments with
+  it. Refreshing the view with `f` still asks for them again.
+
 - **The selected worktree keeps the GitHub context that was fetched for it**
   ([#597](https://github.com/kbrdn1/gwm-cli/issues/597)). Standing on any row
   but the one the TUI opened on, `C` / `c` said "no CI checks to show: link a

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -7610,6 +7610,26 @@ impl App {
     spawned
   }
 
+  /// The PR whose inline review threads the rich view is currently
+  /// rendering, if that is what is on screen (issue #619).
+  ///
+  /// Gated on the VIEW rather than on `rich_overlay_source` alone: the
+  /// source outlives the overlay until [`Self::close_detail_overlay`]
+  /// clears it, and a keep that outlives the reader would pin one PR's
+  /// threads in the cache for the rest of the session. `DetailOverlay`
+  /// covers the child modals that are overlays themselves (the CI checks
+  /// list, the agents list) — they come back to this view, so what they
+  /// come back to must still have its comments.
+  fn rich_view_pr_number(&self) -> Option<u64> {
+    if self.view != View::DetailOverlay {
+      return None;
+    }
+    match self.rich_overlay_source.as_ref()? {
+      RichSource::Pr(pr) => Some(pr.number),
+      RichSource::Issue(_) => None,
+    }
+  }
+
   fn refresh_linked_github_statuses_for_worktrees(&mut self) -> u32 {
     // A relist is the moment the fetched statuses stop being authoritative,
     // and since #597 nothing else expires them: the link re-read on every
@@ -7622,7 +7642,12 @@ impl App {
     // has no stale answer behind it to expire, so cancelling it would throw
     // away work and expire nothing (Codex review on #618). The respawns
     // below coalesce onto it through `TaskRunner::request`.
-    self.github.invalidate_settled();
+    //
+    // Except the inline review threads of a PR a rich view has on screen
+    // (#619): that view reads them live from the cache, so expiring them
+    // blanked the section under the reader on the next PR landing.
+    let on_screen = self.rich_view_pr_number();
+    self.github.invalidate_settled(on_screen);
 
     // Workspace mode (#36): this bulk prefetch resolves every merged row's
     // issue/PR against a single repo's slug (`self.github.link_slug`), which

--- a/src/tui/state/github_fetch.rs
+++ b/src/tui/state/github_fetch.rs
@@ -265,7 +265,18 @@ impl GitHubFetch {
   /// change what a number means: only a move between forge instances does,
   /// and `App::refresh_link` still answers that with the full flush and the
   /// generation-bump that must move with it.
-  pub fn invalidate_settled(&mut self) {
+  ///
+  /// `keep_pr_threads` names the one PR whose inline review threads a rich
+  /// view has on screen (issue #619). That view renders the PR from its own
+  /// snapshot, so expiring the PR cache never blanks it — but it reads the
+  /// threads live from here, so expiring them emptied the section under the
+  /// reader the moment the PR landed and rebuilt the rows. Re-requesting
+  /// them instead would be fresher and worse: the section collapses to
+  /// `loading…` for the round trip, once per `tui.auto_refresh_secs`,
+  /// taking the reader's scroll position with it. So the threads on screen
+  /// are held until the view is closed or refreshed (`f`), which flushes
+  /// them through [`Self::invalidate`] and asks again.
+  pub fn invalidate_settled(&mut self, keep_pr_threads: Option<u64>) {
     // A fn, not a closure: the three caches hold three different payload
     // types and a closure cannot be generic over them.
     fn in_flight<T>(state: &GitHubFetchState<T>) -> bool {
@@ -273,7 +284,9 @@ impl GitHubFetch {
     }
     self.issue_cache.retain(|_, s| in_flight(s));
     self.pr_cache.retain(|_, s| in_flight(s));
-    self.pr_threads_cache.retain(|_, s| in_flight(s));
+    self
+      .pr_threads_cache
+      .retain(|n, s| in_flight(s) || Some(*n) == keep_pr_threads);
   }
 
   /// Stamp an auto-detected PR onto the resolved `link` when none is

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -13997,6 +13997,62 @@ fn cached_threads_move_with_the_pr_they_hang_from() {
 }
 
 #[test]
+fn a_relist_keeps_the_threads_the_open_rich_view_is_showing() {
+  // Issue #619. The relist expires the fetched statuses, and the rich view
+  // survives that for the PR itself because it renders its OWN snapshot
+  // (`rich_overlay_source`) — but it reads the threads live from the cache.
+  // So the PR landing that follows rebuilt the open view against an `Idle`
+  // threads cache and the inline comments vanished from under the reader.
+  let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  gwm::github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  app.refresh_link();
+  app.apply_pr_fetch_result(Ok(rich_pr_fixture(61)));
+  app.enter_rich_view();
+  app.apply_pr_threads_fetch_result(61, Ok(one_thread()));
+  assert!(
+    overlay_text(&app).contains("This drops the guard."),
+    "precondition: the comments must be on screen before the relist"
+  );
+
+  app.refresh().unwrap();
+  // The landing is what rebuilds the open view — asserting on the cache
+  // alone would never touch the path that blanks the section.
+  app.apply_pr_fetch_result(Ok(rich_pr_fixture(61)));
+
+  assert!(
+    overlay_text(&app).contains("This drops the guard."),
+    "the relist blanked the inline comments of the view on screen:\n{}",
+    overlay_text(&app)
+  );
+}
+
+#[test]
+fn a_relist_still_expires_the_threads_of_a_pr_nobody_is_looking_at() {
+  // The keep is scoped to what is on screen, not a blanket exemption:
+  // #62's threads have no reader to disturb, so they expire with every
+  // other settled result and the next open re-requests them.
+  let (_dir, repo, mut app) = make_app_on_branch("feat/#42-tui-search");
+  gwm::github::link_pr(&repo, "feat/#42-tui-search", 61).unwrap();
+  app.refresh_link();
+  app.apply_pr_fetch_result(Ok(rich_pr_fixture(61)));
+  app.enter_rich_view();
+  app.apply_pr_threads_fetch_result(61, Ok(one_thread()));
+  app.apply_pr_threads_fetch_result(62, Ok(one_thread()));
+
+  app.refresh().unwrap();
+
+  assert!(
+    matches!(app.pr_threads_fetch_state(61), gwm::tui::GitHubFetchState::Loaded(_)),
+    "the open view's threads must survive"
+  );
+  assert!(
+    matches!(app.pr_threads_fetch_state(62), gwm::tui::GitHubFetchState::Idle),
+    "an unwatched PR's threads must still expire: {:?}",
+    app.pr_threads_fetch_state(62)
+  );
+}
+
+#[test]
 fn the_issue_view_never_grows_a_threads_section() {
   let (_dir, _repo, mut app) = make_app_on_branch("feat/#42-tui-search");
   app.apply_issue_fetch_result(Ok(rich_issue_fixture(42)));


### PR DESCRIPTION
## Description

With the rich PR view open on a PR whose inline review threads had landed, a
worktree relist (the periodic `tui.auto_refresh_secs` one, or an explicit `f`)
emptied the threads cache and nothing put them back. The next PR result to land
rebuilt the open view through `sync_rich_overlay`, read `pr_threads_state(n)` as
`Idle`, and the comments vanished from a view the reader was still looking at.

The view survives that same expiry for the PR itself because it renders its own
snapshot (`rich_overlay_source`); the threads were the one thing it read live
from the cache. `invalidate_settled` now takes the PR number the view has on
screen and keeps its threads, which are as authoritative as the PR they hang
from. Everyone else's still expire, so the relist stays the staleness bound it
became in #618.

Closes #619

## Type of change

- [x] 🐛 Fix (bug fix)

## Changes

- `GitHubFetch::invalidate_settled` takes `keep_pr_threads: Option<u64>` and
  retains that PR's threads alongside the in-flight entries.
- `App::rich_view_pr_number()` names it: the rich view's PR when a detail
  overlay is what is on screen. Gated on the view, not on `rich_overlay_source`
  alone, which outlives the overlay until `close_detail_overlay` clears it (a
  keep that outlived the reader would pin one PR's threads for the session).
- Two tests in `tests/tui_app_tests.rs`.

## Tests

- [x] `cargo test` passes locally (104 `test result: ok`, exit 0)
- [x] `cargo fmt --check` passes (`cargo fmt --all`, no diff outside the change)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

`a_relist_keeps_the_threads_the_open_rich_view_is_showing` runs the whole path,
not the cache: it opens the view, lands the threads, relists, then lands the PR
(what rebuilds the rows) and asserts the comment body is still in the rendered
rows. Red before the fix on that assertion.
`a_relist_still_expires_the_threads_of_a_pr_nobody_is_looking_at` pins the other
half, so the keep cannot degrade into a blanket exemption.

## Screenshots / TUI captures

None: the change is what does *not* happen after 60 s with the view open, which
a still frame cannot show.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a, no CLI surface)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #619
- Related PR: #618 (the relist expiry this sits on), #528 (the threads cache)

## Notes for reviewers

The trade-off is deliberate and worth challenging: the kept threads are frozen
while the view stays open, so the PR body around them keeps refreshing every
`auto_refresh_secs` and the comments do not. Re-requesting them instead is the
other option the issue lists, and it is worse on two counts: `threads_section`
collapses to a heading plus `loading…` for the round trip, so the section would
shrink once per interval and take the reader's scroll position with it, and a
failed re-fetch would replace good comments with an error row. `f` inside the
view still flushes and re-asks, which is the intentional way to get fresh ones.

Not covered: a relist landing while a *non-overlay* child modal is up over the
rich view (the merge confirmation, which leaves through `View::Confirm`). Same
class, far narrower window, and covering it means trusting `rich_return` not to
leak; say the word and it is three lines.