### PR TITLE
✨ feat(tui): Ctrl+n derives a worktree from an issue that already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than waiting for a message that would never arrive, since the fetch
   coalesces on a cache hit.
 
+  `Ctrl+t` is inert in this mode and the hint row does not offer it. The
+  toggle swaps between the structured triple and the free-form name, which
+  are two ways of typing the same worktree; this one is a two-step mode, left
+  by answering it or by cancelling, so a third stop on the cycle would only
+  make the key unpredictable.
+
 - **`gwm create --issue <N>` opens a worktree for an issue that already
   exists** ([#617](https://github.com/kbrdn1/gwm-cli/issues/617)). `gwm new`
   covered the issue that does not exist yet: it renders the issue from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Ctrl+n` opens the create form on an issue that already exists**
+  ([#625](https://github.com/kbrdn1/gwm-cli/issues/625)). `gwm create --issue`
+  (#617) derives the whole `<type> <issue> <desc>` triple from an issue on the
+  forge, and it was CLI-only. The TUI is where a worktree usually gets created,
+  so the one place already showing a worktree list and its linked issues was
+  the one place that still asked for the title to be retyped as a slug and the
+  branch type to be read off the labels by hand.
+
+  `Ctrl+n` (and `create-from-issue` in the command palette) opens the form on a
+  single field, the issue number. Enter looks the issue up rather than creating
+  anything; when the answer lands the form becomes the ordinary structured form
+  with the type, the number and the derived slug in it, and a second Enter
+  creates the worktree. Prefilling rather than creating is the point: the slug
+  is a guess about a title, and this is the surface that can show the guess
+  before committing to it. The derivation runs through the very functions the
+  CLI uses, so the two cannot produce different slugs for the same title.
+
+  Where the CLI has to refuse, the form asks. A non-interactive command has
+  nowhere to ask when the labels name no branch type or name two, which is what
+  `--type` is for; the form lands the cursor on the type selector with
+  everything else filled. A closed issue prefills with a warning rather than
+  refusing, since nothing is written until you confirm. A number that already
+  has a worktree closes the form and names it, matching the CLI's exit-0
+  behaviour, and reads the same link `gwm list` shows, so a worktree attached
+  by hand with `gwm link` counts too.
+
+  The lookup runs on the async task spine, never the render path, and a result
+  is applied only when the form asked for that exact number: the form is a
+  second consumer of a message that also fires for the sidebar prefetch and for
+  an explicit refresh. An issue already in the cache prefills straight away
+  rather than waiting for a message that would never arrive, since the fetch
+  coalesces on a cache hit.
+
 - **`gwm create --issue <N>` opens a worktree for an issue that already
   exists** ([#617](https://github.com/kbrdn1/gwm-cli/issues/617)). `gwm new`
   covered the issue that does not exist yet: it renders the issue from

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -44,6 +44,7 @@ The full key map for `gwm`'s ratatui interface. Press `?` at any time for the sa
 | `gg`        | jump to the first worktree (`top`)                                                                |
 | `G` / `End` | jump to the last worktree (`bottom`)                                                              |
 | `n`         | new worktree (`create`; form: type → issue → description) · gated by the [TOFU trust ledger](/configuration/trust-ledger), refuses with a status-bar hint on untrusted `.gwm.toml` |
+| `Ctrl+n`    | new worktree from an issue that already exists (`create_from_issue`), see [from an existing issue](#from-an-existing-issue-ctrln) |
 | `e`         | rename the selected worktree (`edit_worktree`; form pre-filled from the current branch), renames the local branch, the remote branch if it exists, and moves the worktree directory, all off-thread |
 | `N`         | edit the selected worktree's note in a modal (`edit_note`), see [notes](#notes-n)                 |
 | `Space`     | mark / unmark the highlighted worktree (`toggle_select`), see [bulk delete](#bulk-delete-space--d)  |
@@ -703,3 +704,15 @@ Three keys moved when [#75 (configurable launchers)](https://github.com/kbrdn1/g
 | _(none)_ | `R`   | launch the configured `[review]` command (lumen / claude / codex / aider / gh / custom)   |
 
 If you wired any of these into a custom script (unlikely, they're TUI-only), nothing breaks; this is purely about the in-app overlay.
+
+## From an existing issue (`Ctrl+n`)
+
+`n` opens the form on an empty triple. `Ctrl+n` opens it on a single field, the number of an issue that already exists on the forge, and derives the rest from it. The TUI half of [`gwm create --issue`](/cli/reference#from-an-existing-issue---issue), added by [#625](https://github.com/kbrdn1/gwm-cli/issues/625); it is also the `create-from-issue` entry in the [command palette](/tui/keymap-and-palette).
+
+Enter looks the issue up rather than creating anything. When the answer lands, the form becomes the ordinary structured form with the type, the number and the derived slug already in it, and a second Enter creates the worktree. Prefilling rather than creating is the point: the slug is a guess about a title, and this is the surface that can show the guess before committing to it.
+
+`<desc>` comes from the title with the branch type's `title_prefix` taken back off, through the same normaliser a hand-typed description goes through. `<type>` comes from the labels, via `[issue_template.by_type.*].labels` read backwards.
+
+Where the CLI has to refuse, the form asks. Labels that name no branch type, or two, leave everything else filled and put the cursor on the type selector, which is what `--type` is for on the command line. A closed issue prefills with a warning in the status bar, since nothing is written until you confirm. A number that already has a worktree closes the form and names it, matching the CLI's exit-0 behaviour, and it reads the same link `gwm list` shows, so a worktree attached by hand with `gwm link` counts too.
+
+`Ctrl+t` leaves the mode for the structured triple, like it does from free-form.

--- a/docs/2.tui/1.keybindings.md
+++ b/docs/2.tui/1.keybindings.md
@@ -715,4 +715,4 @@ Enter looks the issue up rather than creating anything. When the answer lands, t
 
 Where the CLI has to refuse, the form asks. Labels that name no branch type, or two, leave everything else filled and put the cursor on the type selector, which is what `--type` is for on the command line. A closed issue prefills with a warning in the status bar, since nothing is written until you confirm. A number that already has a worktree closes the form and names it, matching the CLI's exit-0 behaviour, and it reads the same link `gwm list` shows, so a worktree attached by hand with `gwm link` counts too.
 
-`Ctrl+t` leaves the mode for the structured triple, like it does from free-form.
+`Ctrl+t` does nothing here, and the hint row does not offer it. The toggle swaps between the structured triple and the free-form name, which are two ways of typing the same worktree; this is a two-step mode instead, left by answering it or by cancelling.

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -745,4 +745,4 @@ Entrée interroge l'issue, elle ne crée rien. Quand la réponse arrive, le form
 
 Là où le CLI doit refuser, le formulaire demande. Des labels qui ne désignent aucun type de branche, ou deux, laissent tout le reste rempli et placent le curseur sur le sélecteur de type — c'est le rôle de `--type` en ligne de commande. Une issue fermée préremplit avec un avertissement dans la barre de statut, puisque rien n'est écrit tant que vous ne confirmez pas. Un numéro qui a déjà un worktree ferme le formulaire et le nomme, comme la sortie en 0 du CLI, et il lit le même lien que `gwm list` affiche : un worktree rattaché à la main avec `gwm link` compte aussi.
 
-`Ctrl+t` quitte le mode pour le triplet structuré, comme depuis le mode libre.
+`Ctrl+t` ne fait rien ici, et la ligne d'indications ne le propose pas. Le toggle bascule entre le triplet structuré et le nom libre, qui sont deux façons de taper le même worktree ; celui-ci est un mode en deux temps, que l'on quitte en y répondant ou en annulant.

--- a/docs/fr/2.tui/1.keybindings.md
+++ b/docs/fr/2.tui/1.keybindings.md
@@ -48,6 +48,7 @@ La table complète des touches pour l'interface ratatui de `gwm`. Appuyez sur `?
 | `gg`        | sauter au premier worktree (`top`)                                                                |
 | `G` / `End` | sauter au dernier worktree (`bottom`)                                                             |
 | `n`         | nouveau worktree (`create` ; formulaire : type → issue → description) · protégé par le [registre de confiance TOFU](/fr/configuration/trust-ledger), refuse avec une indication dans la barre de statut sur un `.gwm.toml` non approuvé |
+| `Ctrl+n`    | nouveau worktree depuis une issue qui existe déjà (`create_from_issue`), voir [depuis une issue existante](#depuis-une-issue-existante-ctrln) |
 | `e`         | renommer le worktree sélectionné (`edit_worktree` ; formulaire pré-rempli depuis la branche courante), renomme la branche locale, la branche distante si elle existe, et déplace le répertoire du worktree, le tout hors thread |
 | `N`         | éditer la note du worktree sélectionné dans une modale (`edit_note`), voir [notes](#notes-n)     |
 | `Space`     | marquer / démarquer le worktree survolé (`toggle_select`), voir [suppression en lot](#suppression-en-lot-space--d) |
@@ -733,3 +734,15 @@ Trois touches ont changé lorsque [#75 (lanceurs configurables)](https://github.
 | _(aucune)_ | `R`   | lance la commande `[review]` configurée (lumen / claude / codex / aider / gh / personnalisée) |
 
 Si vous aviez câblé l'une de ces touches dans un script personnalisé (peu probable, elles sont uniquement liées à la TUI), rien ne casse ; il s'agit purement de la surcouche dans l'application.
+
+## Depuis une issue existante (`Ctrl+n`)
+
+`n` ouvre le formulaire sur un triplet vide. `Ctrl+n` l'ouvre sur un seul champ, le numéro d'une issue qui existe déjà sur la forge, et en dérive le reste. C'est la moitié TUI de [`gwm create --issue`](/fr/cli/reference#depuis-une-issue-existante---issue), ajoutée par [#625](https://github.com/kbrdn1/gwm-cli/issues/625) ; c'est aussi l'entrée `create-from-issue` de la [palette de commandes](/fr/tui/keymap-and-palette).
+
+Entrée interroge l'issue, elle ne crée rien. Quand la réponse arrive, le formulaire devient le formulaire structuré habituel avec le type, le numéro et le slug dérivé déjà dedans, et une seconde Entrée crée le worktree. Préremplir plutôt que créer est le fond de l'affaire : le slug est une supposition sur un titre, et c'est la surface qui peut montrer la supposition avant de s'y engager.
+
+`<desc>` vient du titre, dont le `title_prefix` du type de branche est retiré, par le même normaliseur qu'une description tapée à la main. `<type>` vient des labels, via `[issue_template.by_type.*].labels` lue à l'envers.
+
+Là où le CLI doit refuser, le formulaire demande. Des labels qui ne désignent aucun type de branche, ou deux, laissent tout le reste rempli et placent le curseur sur le sélecteur de type — c'est le rôle de `--type` en ligne de commande. Une issue fermée préremplit avec un avertissement dans la barre de statut, puisque rien n'est écrit tant que vous ne confirmez pas. Un numéro qui a déjà un worktree ferme le formulaire et le nomme, comme la sortie en 0 du CLI, et il lit le même lien que `gwm list` affiche : un worktree rattaché à la main avec `gwm link` compte aussi.
+
+`Ctrl+t` quitte le mode pour le triplet structuré, comme depuis le mode libre.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6568,13 +6568,11 @@ impl App {
           // The submit field is named from the patterns, not hardcoded to
           // `desc` (#418): a pattern without one told the user to press enter
           // on a field the form does not present.
-          // #625: the mode is left by answering it, so the toggle is
-          // advertised as the way back rather than as a mode cycle.
-          Mode::FromIssue if back.is_empty() => "issue number, then enter: derive the branch from it".into(),
-          Mode::FromIssue => format!(
-            "issue number, then enter: derive the branch from it{back}{}",
-            self.structured_mode_label()
-          ),
+          // #625: unreachable through this arm — the toggle is a no-op in
+          // this mode — but the match is over the mode, so it is written out
+          // rather than folded into a catch-all that would hide a future
+          // path in.
+          Mode::FromIssue => "issue number, then enter: derive the branch from it".into(),
           Mode::Structured if back.is_empty() => self.structured_form_instruction(),
           Mode::Structured => format!("{}{back}free-form", self.structured_form_instruction()),
         };
@@ -6720,8 +6718,10 @@ impl App {
       .unwrap_or_default();
     let desc = crate::issue_templates::desc_from_title(&status.title, &prefix).unwrap_or_default();
 
-    self.create_form.mode = Mode::FromIssue;
-    self.create_form.toggle_mode(); // back to Structured, focus on the entry field
+    // Set, not toggled: `toggle_mode` is a no-op in this mode, and the prefill
+    // is not the user asking to switch — it is this mode finishing.
+    self.create_form.mode = Mode::Structured;
+    self.create_form.field = self.create_form.entry_field();
     self.create_form.issue = status.number.to_string();
     self.create_form.desc = desc;
     self.create_form.awaiting_issue = None;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -28,7 +28,7 @@ use crate::error::{GwmError, Result};
 use crate::github::{self, BranchLink, IssueState, IssueStatus, PrStatus};
 use crate::launcher::{self, ExpandedCommand, LauncherContext};
 use crate::lifecycle::{self, HookPhase, HookSkips};
-use crate::naming::{BranchSpec, WorktreeName};
+use crate::naming::{sanitise_for_terminal, BranchSpec, WorktreeName};
 use crate::worktree::{self, WorktreeInfo};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::Repository;
@@ -2054,6 +2054,10 @@ impl App {
             self.persist_loaded_issue_title(status);
             self.sync_rich_overlay(RichSource::Issue(status.clone()));
           }
+          // #625: the create form is a second consumer of this message when
+          // it is waiting on this very number. Before `complete_issue` so the
+          // status line it sets is not overwritten by the refresh report.
+          self.apply_awaited_issue(number, &result);
           self.github.complete_issue(number, result);
           applied = true;
           github_applied = true;
@@ -2940,6 +2944,7 @@ impl App {
     use super::ui::HintContext;
     match self.create_form.mode {
       Mode::Freeform => HintContext::CreateFreeform,
+      Mode::FromIssue => HintContext::CreateFromIssue,
       Mode::Structured => HintContext::Create,
     }
   }
@@ -2954,7 +2959,11 @@ impl App {
     use super::ui::HintContext;
     match self.create_form.mode {
       Mode::Freeform => HintContext::RenameFreeform,
-      Mode::Structured => HintContext::Rename,
+      // The rename modal never opens in `FromIssue`: nothing routes there,
+      // and deriving a name for a worktree that already exists is what
+      // `gwm link` is for. It shares the structured row rather than growing
+      // a context no surface can reach.
+      Mode::FromIssue | Mode::Structured => HintContext::Rename,
     }
   }
 
@@ -5955,6 +5964,11 @@ impl App {
   fn worktree_name_from_form(&self) -> std::result::Result<WorktreeName, String> {
     match self.create_form.mode {
       Mode::Freeform => WorktreeName::freeform(&self.create_form.name).map_err(|e| e.to_string()),
+      // `FromIssue` has no name to compose yet — that is the point of the
+      // round trip. `submit_create` branches before reaching here; the live
+      // preview reaches here and gets a reason rather than a half-built
+      // branch built from an empty type.
+      Mode::FromIssue => Err("waiting for the issue".into()),
       Mode::Structured => {
         let type_ = self
           .branch_types
@@ -6436,6 +6450,22 @@ impl App {
     self.status = format!("{} · esc: cancel", self.structured_form_instruction());
   }
 
+  /// Open the create form on an issue number, to derive the triple from an
+  /// issue that already exists (issue #625).
+  ///
+  /// The counterpart of `gwm create --issue <N>`, and deliberately not its
+  /// mirror image: the CLI has to *refuse* labels that select no branch type
+  /// or two, because a non-interactive command has nowhere to ask and
+  /// `--type` is the escape hatch. A form does have somewhere to ask, so
+  /// those cases land the user on the type selector with everything else
+  /// filled in.
+  pub fn enter_create_from_issue(&mut self) {
+    self.view = View::Create;
+    self.create_form.enter_from_issue();
+    self.create_failure = None;
+    self.status = "issue number, then enter: derive the branch from it · esc: cancel".into();
+  }
+
   pub fn create_next_field(&mut self) {
     self.create_form.next_field();
   }
@@ -6538,6 +6568,13 @@ impl App {
           // The submit field is named from the patterns, not hardcoded to
           // `desc` (#418): a pattern without one told the user to press enter
           // on a field the form does not present.
+          // #625: the mode is left by answering it, so the toggle is
+          // advertised as the way back rather than as a mode cycle.
+          Mode::FromIssue if back.is_empty() => "issue number, then enter: derive the branch from it".into(),
+          Mode::FromIssue => format!(
+            "issue number, then enter: derive the branch from it{back}{}",
+            self.structured_mode_label()
+          ),
           Mode::Structured if back.is_empty() => self.structured_form_instruction(),
           Mode::Structured => format!("{}{back}free-form", self.structured_form_instruction()),
         };
@@ -6550,6 +6587,10 @@ impl App {
         // all, since Enter then only ever rotated.
         let submit_field = match self.create_form.mode {
           Mode::Freeform => Field::Name,
+          // `FromIssue` presents `Issue` alone whatever the patterns carry,
+          // so `last_field()` (which reads the patterns) would name an input
+          // this mode does not draw and Enter would only ever rotate.
+          Mode::FromIssue => Field::Issue,
           Mode::Structured => self.create_form.last_field(),
         };
         if self.create_form.field == submit_field {
@@ -6571,6 +6612,142 @@ impl App {
     CreateKey::Handled
   }
 
+  /// Resolve the number typed in [`Mode::FromIssue`] into a prefilled
+  /// structured form (issue #625).
+  ///
+  /// Two entry points into one prefill. A number the TUI has already fetched
+  /// (a linked row, the sidebar prefetch, a second attempt after `Esc`) is
+  /// read straight out of the cache, because `spawn_github_issue` coalesces
+  /// on a cache hit and no `TaskMsg::GithubIssue` would ever arrive — the
+  /// form would sit on a loader forever. Anything else marks the number as
+  /// awaited and spawns the worker, and
+  /// [`Self::apply_awaited_issue`] finishes the job when the result lands.
+  fn derive_from_issue(&mut self) -> Result<()> {
+    let typed = self.create_form.issue.trim();
+    let Some(number) = typed.parse::<u64>().ok().filter(|n| *n > 0) else {
+      self.status = "type the number of an issue that already exists, then enter".into();
+      return Ok(());
+    };
+
+    // Same refusal as `gwm create --issue`, and for the same reason: this is
+    // usually a wrong number. Checked before anything is fetched, and it
+    // reads the link `gwm list` renders, so a worktree attached by hand with
+    // `gwm link` counts too.
+    if let Some(existing) = self.worktrees.iter().find(|w| w.link.issue == Some(number)) {
+      self.status = format!("#{} already has a worktree: {}", number, existing.name);
+      self.view = View::List;
+      self.create_form.reset();
+      return Ok(());
+    }
+
+    if let GitHubFetchState::Loaded(status) = self.github.issue_fetch_state(number) {
+      let status = status.clone();
+      self.prefill_from_issue(&status);
+      return Ok(());
+    }
+
+    let Some(slug) = self.github.link_slug.clone() else {
+      self.status = "no forge remote: cannot look the issue up".into();
+      return Ok(());
+    };
+    self.create_form.awaiting_issue = Some(number);
+    if !self.spawn_github_issue(number, &slug) {
+      // Not a cache hit (that branch returned above), so the spine
+      // coalesced onto a worker already in flight for this number. Its
+      // result reaches `apply_awaited_issue` like any other.
+      self.status = format!("looking up #{} …", number);
+      return Ok(());
+    }
+    self.spinner.reset();
+    self.status = format!("looking up #{} …", number);
+    Ok(())
+  }
+
+  /// Apply a `TaskMsg::GithubIssue` result to a form that asked for it
+  /// (issue #625).
+  ///
+  /// Returns `true` when the message was this form's answer, so the caller
+  /// knows the status line has been claimed.
+  ///
+  /// The number comparison is the whole guard. This is a *second* consumer of
+  /// a message that also fires for the sidebar prefetch and for an explicit
+  /// refresh, and the spine's generation check is consumed before the form
+  /// sees it, so a result for any other issue must leave the form alone.
+  /// `pub` for `tests/tui_app_tests.rs`: the staleness guard is the whole
+  /// point of this function and it is not reachable through the event loop
+  /// from an integration test.
+  pub fn apply_awaited_issue(&mut self, number: u64, result: &std::result::Result<IssueStatus, String>) -> bool {
+    if self.create_form.awaiting_issue != Some(number) || self.view != View::Create {
+      return false;
+    }
+    self.create_form.awaiting_issue = None;
+    match result {
+      Ok(status) => {
+        let status = status.clone();
+        self.prefill_from_issue(&status);
+      }
+      Err(e) => {
+        // Stay in `FromIssue` with the number still typed: the forge said no
+        // (wrong number, no network), and retrying is one keystroke.
+        self.status = format!("#{}: {}", number, sanitise_for_terminal(e));
+      }
+    }
+    true
+  }
+
+  /// Fill the structured form from a fetched issue and hand it back to the
+  /// user (issue #625).
+  ///
+  /// Derived through the very functions `gwm create --issue` uses, so the two
+  /// surfaces cannot produce different slugs for the same title.
+  ///
+  /// It prefills rather than creating. The derivation is a guess about a
+  /// title, and this is the one surface that can show the guess before
+  /// committing to it: the user sees the branch the form will write, adjusts
+  /// the type or the slug, and confirms with a second Enter through the
+  /// ordinary, already-tested submit path.
+  fn prefill_from_issue(&mut self, status: &IssueStatus) {
+    let derived_type = crate::issue_templates::type_from_labels(&self.config.issue_template, &status.labels).ok();
+    if let Some(index) = derived_type
+      .as_deref()
+      .and_then(|name| self.branch_types.iter().position(|t| t.name == name))
+    {
+      self.create_form.type_index = index;
+    }
+    let prefix = derived_type
+      .as_deref()
+      .map(|name| crate::issue_templates::title_prefix_for(&self.repo, &self.config, name))
+      .unwrap_or_default();
+    let desc = crate::issue_templates::desc_from_title(&status.title, &prefix).unwrap_or_default();
+
+    self.create_form.mode = Mode::FromIssue;
+    self.create_form.toggle_mode(); // back to Structured, focus on the entry field
+    self.create_form.issue = status.number.to_string();
+    self.create_form.desc = desc;
+    self.create_form.awaiting_issue = None;
+
+    // Where the CLI refuses, the form asks: land focus on the type selector
+    // so the one thing the labels could not settle is the one thing under
+    // the cursor.
+    let mut notes: Vec<String> = Vec::new();
+    match derived_type {
+      Some(name) => notes.push(format!("type: {}", sanitise_for_terminal(&name))),
+      None => {
+        self.create_form.field = Field::Type;
+        notes.push("labels do not name one type: pick it".into());
+      }
+    }
+    if status.state == IssueState::Closed {
+      notes.push("issue is closed".into());
+    }
+    self.status = format!(
+      "#{} {} · {} · enter: create",
+      status.number,
+      sanitise_for_terminal(&status.title),
+      notes.join(" · ")
+    );
+  }
+
   pub fn submit_create(&mut self) -> Result<()> {
     // Issue #416: free-form validation lands here rather than per keystroke,
     // so the user can type through an intermediate state. A rejected name
@@ -6584,6 +6761,13 @@ impl App {
     // other still demanding a value it would discard — two composers of one
     // value drift, and this is the second time on this form (the previews did
     // it in #476).
+    // Issue #625: this mode has no branch to compose yet. Enter asks the
+    // forge, and the answer prefills the structured form; the create itself
+    // is the second Enter, through this same function.
+    if self.create_form.mode == Mode::FromIssue {
+      return self.derive_from_issue();
+    }
+
     let wt_name = match self.worktree_name_from_form() {
       Ok(n) => n,
       Err(e) => {

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -121,6 +121,9 @@ define_actions! {
   Refresh           => "refresh",
   Sync              => "sync",
   Create            => "create",
+  // #625: the create form opened on an issue number, to derive the triple
+  // from an issue that already exists on the forge.
+  CreateFromIssue   => "create_from_issue",
   DeleteConfirm     => "delete",
   Bootstrap         => "bootstrap",
   ToggleDeleteBranch => "delete_branch",
@@ -194,6 +197,11 @@ impl Action {
     matches!(
       self,
       Action::Create
+        // #625: same repo context as `Create` — it composes the branch from
+        // the active repo's patterns and queries the active repo's forge, so
+        // a stale workspace selection would target the previous repo twice
+        // over.
+        | Action::CreateFromIssue
         | Action::DeleteConfirm
         | Action::Bootstrap
         | Action::Sync
@@ -554,6 +562,10 @@ impl Keymap {
       // #290: `s` (lowercase) is now Sync — replaces ToggleSidebarMode.
       def(Action::Sync, &["s"]),
       def(Action::Create, &["n"]),
+      // #625: `Ctrl+n` reads as the sibling of `n`, and the single-letter
+      // space is full — `n` being a single key confiscates its own prefix,
+      // so `n i` is not available either (#484).
+      def(Action::CreateFromIssue, &["Ctrl+n"]),
       def(Action::DeleteConfirm, &["d"]),
       def(Action::Bootstrap, &["b"]),
       // #290: `D` (uppercase) is now ToggleDeleteBranch — `p` repurposed as Pull.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1096,6 +1096,7 @@ fn run_action(terminal: &mut Terminal<CrosstermBackend<io::Stderr>>, app: &mut A
       }
     }
     Action::Create if !app.picker_mode => app.enter_create(),
+    Action::CreateFromIssue if !app.picker_mode => app.enter_create_from_issue(),
     Action::DeleteConfirm if !app.picker_mode => app.enter_confirm_delete(),
     // #484: `Space` marks the cursor row. Picker-gated — `gwm switch` picks
     // exactly one path, so a mark set has nothing to act on there.

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -47,6 +47,11 @@ pub const fn palette_entries() -> &'static [PaletteEntry] {
       description: "new worktree (form opens)",
     },
     PaletteEntry {
+      action: Action::CreateFromIssue,
+      name: "create-from-issue",
+      description: "new worktree from an issue that already exists (derives type + slug)",
+    },
+    PaletteEntry {
       action: Action::DeleteConfirm,
       name: "delete",
       description: "delete the selected worktree(s) (with confirm)",

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -224,13 +224,19 @@ impl CreateForm {
         self.mode = Mode::Freeform;
         self.field = Field::Name;
       }
-      // `FromIssue` toggles back to the structured triple like free-form
-      // does: one key out of a mode the user opened by name, rather than a
-      // three-way cycle that makes `Ctrl+t` unpredictable.
-      Mode::Freeform | Mode::FromIssue => {
+      Mode::Freeform => {
         self.mode = Mode::Structured;
         self.field = self.entry_field();
       }
+      // `FromIssue` has no toggle. It is a two-step mode — ask, then confirm
+      // the prefilled structured form — so the way out is answering it or
+      // cancelling, and the toggle is left as the one verb that swaps between
+      // the two modes that are alternative ways of typing the same worktree.
+      // Guarded here rather than at the key handler: every path in flips the
+      // mode through this function, and the handler's arm has to keep
+      // matching so the key is swallowed rather than falling through to the
+      // literal-input fallback, which would type `t` into the number.
+      Mode::FromIssue => {}
     }
   }
 

--- a/src/tui/state/create_form.rs
+++ b/src/tui/state/create_form.rs
@@ -37,6 +37,15 @@ pub enum Mode {
   #[default]
   Structured,
   Freeform,
+  /// Collecting the number of an issue that already exists on the forge
+  /// (issue #625), to derive the triple from it the way `gwm create --issue`
+  /// does. One field, [`Field::Issue`], and no type selector: the type is
+  /// what is being derived.
+  ///
+  /// Transient by design. The fetch's result switches the form to
+  /// [`Mode::Structured`] with the derived values in place, so what the user
+  /// confirms is the ordinary create form showing the branch it will write.
+  FromIssue,
 }
 
 /// Which input is currently focused inside the create overlay. Selected
@@ -100,6 +109,17 @@ pub struct CreateForm {
   pub issue: String,
   pub desc: String,
   pub name: String,
+  /// The issue number a [`Mode::FromIssue`] submit is waiting a forge answer
+  /// for (issue #625).
+  ///
+  /// The orchestrator is a *second* consumer of `TaskMsg::GithubIssue`, which
+  /// also fires for issues nothing asked this form about (the sidebar
+  /// prefetch, a selection change, an explicit refresh), and the spine's
+  /// generation guard is consumed before the form sees the message. So the
+  /// number is stored and compared: a result for anything else is not this
+  /// form's answer, and prefilling from it would fill the form from an issue
+  /// the user never named.
+  pub awaiting_issue: Option<u64>,
   /// The structured fields the repo's patterns ask for, in pattern order
   /// (issue #418). Private, because the form's invariant is that [`Self::field`]
   /// is always one of these (or `Name` in free-form mode) — a focused field the
@@ -116,6 +136,7 @@ impl Default for CreateForm {
       issue: String::new(),
       desc: String::new(),
       name: String::new(),
+      awaiting_issue: None,
       fields: DEFAULT_FIELDS.to_vec(),
     }
   }
@@ -176,6 +197,21 @@ impl CreateForm {
     self.issue.clear();
     self.desc.clear();
     self.name.clear();
+    self.awaiting_issue = None;
+  }
+
+  /// Open on the issue number, to derive the triple from an issue that
+  /// already exists (issue #625).
+  ///
+  /// Focus is `Field::Issue` whatever the repo's patterns carry, and
+  /// deliberately so: this mode presents that one input regardless, because
+  /// the number is what gets *fetched* rather than what gets written. A
+  /// `{type}/{desc}` repo discards it from the branch name and still has an
+  /// issue to read the title and labels off.
+  pub fn enter_from_issue(&mut self) {
+    self.reset();
+    self.mode = Mode::FromIssue;
+    self.field = Field::Issue;
   }
 
   /// Flip between the structured triple and a free-form name (issue #416),
@@ -188,7 +224,10 @@ impl CreateForm {
         self.mode = Mode::Freeform;
         self.field = Field::Name;
       }
-      Mode::Freeform => {
+      // `FromIssue` toggles back to the structured triple like free-form
+      // does: one key out of a mode the user opened by name, rather than a
+      // three-way cycle that makes `Ctrl+t` unpredictable.
+      Mode::Freeform | Mode::FromIssue => {
         self.mode = Mode::Structured;
         self.field = self.entry_field();
       }
@@ -213,7 +252,9 @@ impl CreateForm {
   /// point of #418: a pattern that writes no issue number must not be able to
   /// put focus on an Issue field the renderer never draws.
   fn rotate(&mut self, step: isize) {
-    if self.mode == Mode::Freeform || self.fields.is_empty() {
+    // Both single-field modes stay put rather than walking focus onto inputs
+    // they do not present.
+    if matches!(self.mode, Mode::Freeform | Mode::FromIssue) || self.fields.is_empty() {
       return;
     }
     let at = self.fields.iter().position(|f| *f == self.field).unwrap_or(0) as isize;
@@ -272,6 +313,9 @@ impl CreateForm {
   fn accepts_input(&self) -> bool {
     match self.mode {
       Mode::Freeform => self.field == Field::Name,
+      // The number is what gets fetched, not what gets written, so this mode
+      // accepts it whether or not the repo's patterns carry `{issue}`.
+      Mode::FromIssue => self.field == Field::Issue,
       Mode::Structured => self.fields.contains(&self.field),
     }
   }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3299,12 +3299,13 @@ impl HintContext {
         Hint::Modal(ModalAction::CreateSubmit, "submit"),
         Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
-      // #625: one field and no type selector, so `field` / `type` are out.
-      // `submit` reads as "look it up" here because that is what Enter does
-      // in this mode; the create is the Enter after the prefill.
+      // #625: one field and no type selector, so `field` / `type` are out,
+      // and `toggle_mode` with them — it is a no-op here, and the rule this
+      // row already follows is to never advertise a key that does nothing.
+      // `submit` reads as "look it up" because that is what Enter does in
+      // this mode; the create is the Enter after the prefill.
       HintContext::CreateFromIssue => &[
         Hint::Modal(ModalAction::CreateSubmit, "look up"),
-        Hint::Modal(ModalAction::CreateToggleMode, "structured"),
         Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
       HintContext::Confirm => &[

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3095,6 +3095,10 @@ pub enum HintContext {
   /// one field and no type selector, so the `field` / `type` hints would
   /// name verbs that do nothing there.
   CreateFreeform,
+  /// Create-worktree form modal, deriving from an existing issue (issue
+  /// #625). One field, the issue number, and no type selector, so the
+  /// `field` / `type` hints would name verbs that do nothing here.
+  CreateFromIssue,
   /// Confirm-delete modal.
   Confirm,
   /// The confirmation modal when it is holding a merge (issue #551).
@@ -3163,7 +3167,7 @@ impl HintContext {
       HintContext::Worktrees => "worktrees",
       HintContext::Status => "status",
       HintContext::Picker => "switch",
-      HintContext::Create | HintContext::CreateFreeform => "create",
+      HintContext::Create | HintContext::CreateFreeform | HintContext::CreateFromIssue => "create",
       HintContext::Confirm => "confirm",
       HintContext::ConfirmMerge => "merge",
       HintContext::OpenMenu => "open",
@@ -3293,6 +3297,14 @@ impl HintContext {
       HintContext::CreateFreeform => &[
         Hint::Modal(ModalAction::CreateToggleMode, "structured"),
         Hint::Modal(ModalAction::CreateSubmit, "submit"),
+        Hint::Modal(ModalAction::CreateCancel, "cancel"),
+      ],
+      // #625: one field and no type selector, so `field` / `type` are out.
+      // `submit` reads as "look it up" here because that is what Enter does
+      // in this mode; the create is the Enter after the prefill.
+      HintContext::CreateFromIssue => &[
+        Hint::Modal(ModalAction::CreateSubmit, "look up"),
+        Hint::Modal(ModalAction::CreateToggleMode, "structured"),
         Hint::Modal(ModalAction::CreateCancel, "cancel"),
       ],
       HintContext::Confirm => &[
@@ -3522,9 +3534,11 @@ impl HintContext {
   /// hint key shadowed by a modal binding in the same context.
   fn modal_context(self) -> Option<KeyContext> {
     Some(match self {
-      HintContext::Create | HintContext::CreateFreeform | HintContext::Rename | HintContext::RenameFreeform => {
-        KeyContext::Create
-      }
+      HintContext::Create
+      | HintContext::CreateFreeform
+      | HintContext::CreateFromIssue
+      | HintContext::Rename
+      | HintContext::RenameFreeform => KeyContext::Create,
       // Both render the confirmation modal, so both resolve through its
       // key context; only the verbs they advertise differ (#551).
       HintContext::Confirm | HintContext::ConfirmMerge => KeyContext::Confirm,
@@ -4222,6 +4236,10 @@ pub fn help_rows(km: &super::keymap::Keymap, modal: &ModalKeymap, ctx: HintConte
     rows.push(fixed("enter", "select highlighted worktree (prints path on exit)"));
   } else {
     rows.push(entry(Action::Create, "new worktree"));
+    rows.push(entry(
+      Action::CreateFromIssue,
+      "new worktree from an existing issue (derives type + slug)",
+    ));
     // #484: the mark set is what `d` acts on when it is non-empty.
     rows.push(entry(
       Action::ToggleSelect,
@@ -5658,10 +5676,10 @@ fn draw_create(f: &mut Frame, app: &App) {
     .map(|t| (t.name.as_str(), t.description.as_str()))
     .unwrap_or(("", "(no branch types configured)"));
 
-  let title = if app.create_form.mode == Mode::Freeform {
-    "New Worktree (free-form)"
-  } else {
-    "New Worktree"
+  let title = match app.create_form.mode {
+    Mode::Freeform => "New Worktree (free-form)",
+    Mode::FromIssue => "New Worktree (from issue)",
+    Mode::Structured => "New Worktree",
   };
   let frame = ModalFrame::resolve(app.config.tui.layout.is_compact(), clean, &app.theme);
   let term = f.area();
@@ -5676,6 +5694,10 @@ fn draw_create(f: &mut Frame, app: &App) {
 
   let label = |s: &str| format!("{:<label_w$}", s);
   let freeform = app.create_form.mode == Mode::Freeform;
+  // Issue #625: nothing to preview yet. The triple is empty until the forge
+  // answers, and expanding the patterns over it renders the literal `/#-`,
+  // which reads as a branch this form is about to write.
+  let from_issue = app.create_form.mode == Mode::FromIssue;
   // Issue #416: a free-form name IS the branch, and the directory is that
   // name with `/` flattened — mirroring `WorktreeName::worktree_dirname`.
   let (branch_raw, dir_raw) = if freeform {
@@ -5691,19 +5713,42 @@ fn draw_create(f: &mut Frame, app: &App) {
   // the inputs so the resulting names stay in view while typing (issue #217
   // follow-up). Which inputs those are comes from the patterns (#418), so a
   // repo whose convention writes no issue number is not shown a field for one.
-  lines.push(Line::from(vec![
-    Span::raw("  Branch : "),
-    Span::styled(branch, Style::default().fg(app.theme.branch)),
-  ]));
-  lines.push(Line::from(vec![
-    Span::raw("  Dir    : "),
-    Span::styled(dirname, Style::default().fg(app.theme.dirty)),
-  ]));
+  if from_issue {
+    lines.push(Line::from(vec![
+      Span::raw("  "),
+      Span::styled(
+        "the type and the slug are read off the issue",
+        Style::default().fg(muted),
+      ),
+    ]));
+  } else {
+    lines.push(Line::from(vec![
+      Span::raw("  Branch : "),
+      Span::styled(branch, Style::default().fg(app.theme.branch)),
+    ]));
+    lines.push(Line::from(vec![
+      Span::raw("  Dir    : "),
+      Span::styled(dirname, Style::default().fg(app.theme.dirty)),
+    ]));
+  }
   lines.push(Line::from(String::new()));
   // Which row carries the focused input, so a form taller than the terminal
   // can scroll it into view rather than lose it off the bottom (issue #553).
   let focused_row;
-  if freeform {
+  if from_issue {
+    // One input, whatever the patterns carry: the number is fetched, not
+    // written, so a `{type}/{desc}` repo still has an issue to read.
+    focused_row = Some(lines.len());
+    lines.push(field_input_line(
+      &label("Issue"),
+      &app.create_form.issue,
+      app.create_form.field == Field::Issue,
+      value_w,
+      accent,
+      muted,
+      surface,
+    ));
+  } else if freeform {
     focused_row = Some(lines.len());
     lines.push(field_input_line(
       &label("Name"),

--- a/tests/tui_app_tests.rs
+++ b/tests/tui_app_tests.rs
@@ -2981,6 +2981,7 @@ fn filled_cells_floors_partial_progress() {
 // ---- Issue / PR linking (issue #67) -------------------------------------
 
 use gwm::github::{CiState, IssueState, IssueStatus, LinkSource, PrState, PrStatus};
+use gwm::tui::state::create_form::Mode;
 use gwm::tui::{GitHubFetchState, LinkPromptStage, LinkTarget};
 
 fn make_app_on_branch(name: &str) -> (tempfile::TempDir, git2::Repository, App) {
@@ -17516,4 +17517,151 @@ fn a_wrapper_named_by_its_full_path_still_reveals_the_browser_behind_it() {
     matches!(plan, gwm::tui::BrowserPlan::MuxPane { .. }),
     "a qualified wrapper with its browser present must open a pane"
   );
+}
+
+// ---- create-from-issue (issue #625) --------------------------------------
+
+fn issue_fixture(number: u64, title: &str, labels: &[&str], state: IssueState) -> IssueStatus {
+  IssueStatus {
+    number,
+    title: title.into(),
+    state,
+    url: format!("https://example.test/issues/{number}"),
+    labels: labels.iter().map(|l| (*l).to_string()).collect(),
+    updated_at: "2026-08-29T00:00:00Z".into(),
+    detail: Default::default(),
+  }
+}
+
+#[test]
+fn a_result_for_another_issue_leaves_the_create_form_alone() {
+  // The form is a *second* consumer of `TaskMsg::GithubIssue`, which also
+  // fires for the sidebar prefetch and for an explicit refresh, and the
+  // spine's generation guard is consumed before the form sees the message.
+  // Without the number comparison, the form would fill from an issue the
+  // user never named.
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.issue.push_str("594");
+  app.create_form.awaiting_issue = Some(594);
+
+  let claimed = app.apply_awaited_issue(597, &Ok(issue_fixture(597, "other", &["bug"], IssueState::Open)));
+
+  assert!(!claimed, "a result for another issue is not this form's answer");
+  assert_eq!(app.create_form.mode, Mode::FromIssue, "the mode must not flip");
+  assert_eq!(app.create_form.issue, "594", "the typed number must survive");
+  assert!(app.create_form.desc.is_empty(), "nothing may be derived from it");
+  assert_eq!(app.create_form.awaiting_issue, Some(594), "the form is still waiting");
+}
+
+#[test]
+fn a_result_that_lands_after_the_form_closed_is_ignored() {
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.awaiting_issue = Some(594);
+  app.view = View::List;
+
+  let claimed = app.apply_awaited_issue(594, &Ok(issue_fixture(594, "late", &["feature"], IssueState::Open)));
+
+  assert!(!claimed, "the form is gone; the message is nobody's answer");
+  assert!(app.create_form.desc.is_empty());
+}
+
+#[test]
+fn the_awaited_result_prefills_the_structured_form_rather_than_creating() {
+  // Prefill, not create: the derivation is a guess about a title, and this
+  // is the one surface that can show the guess before committing to it.
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.issue.push_str("594");
+  app.create_form.awaiting_issue = Some(594);
+
+  let claimed = app.apply_awaited_issue(
+    594,
+    &Ok(issue_fixture(
+      594,
+      "modals should follow layout",
+      &["feature"],
+      IssueState::Open,
+    )),
+  );
+
+  assert!(claimed);
+  assert_eq!(
+    app.create_form.mode,
+    Mode::Structured,
+    "the user confirms the ordinary form"
+  );
+  assert_eq!(app.create_form.issue, "594");
+  assert_eq!(app.create_form.desc, "modals-should-follow-layout");
+  assert_eq!(app.create_form.awaiting_issue, None);
+  assert_eq!(app.view, View::Create, "nothing is created yet");
+}
+
+#[test]
+fn labels_that_name_no_type_land_focus_on_the_type_selector() {
+  // Where `gwm create --issue` has to refuse (a non-interactive command has
+  // nowhere to ask, hence `--type`), the form asks: everything else is
+  // filled and the one unsettled thing is under the cursor.
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.awaiting_issue = Some(594);
+
+  app.apply_awaited_issue(
+    594,
+    &Ok(issue_fixture(594, "modal layout", &["question"], IssueState::Open)),
+  );
+
+  assert_eq!(app.create_form.field, Field::Type, "the unsettled field takes focus");
+  assert_eq!(app.create_form.desc, "modal-layout", "the rest is still derived");
+}
+
+#[test]
+fn a_failed_lookup_keeps_the_number_so_a_retry_is_one_keystroke() {
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.issue.push_str("594");
+  app.create_form.awaiting_issue = Some(594);
+
+  let claimed = app.apply_awaited_issue(594, &Err("could not resolve host".into()));
+
+  assert!(claimed, "the form asked for it, so the answer is its own");
+  assert_eq!(app.create_form.mode, Mode::FromIssue, "stay where the retry happens");
+  assert_eq!(app.create_form.issue, "594");
+  assert_eq!(app.create_form.awaiting_issue, None, "no longer waiting");
+  assert!(
+    app.status.contains("594"),
+    "the failure names the number: {}",
+    app.status
+  );
+}
+
+#[test]
+fn a_cached_issue_prefills_without_waiting_for_a_message() {
+  // `spawn_github_issue` coalesces on a cache hit and no `TaskMsg::GithubIssue`
+  // ever arrives, so a submit that only marked the form as waiting would sit
+  // on a loader forever for any issue the TUI had already fetched.
+  //
+  // `submit_create` can read the environment (the TOFU trust gate consults
+  // `GWM_ALLOW_BOOTSTRAP` / `GWM_TRUST_LEDGER`), so the binary's env lock is
+  // held across it — `env_guard_invariant_tests` enforces that for every
+  // caller, not only the ones that actually reach the gate.
+  let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+  let (_dir, mut app) = make_app();
+  app.github.complete_issue(
+    594,
+    Ok(issue_fixture(594, "modal layout", &["feature"], IssueState::Open)),
+  );
+
+  app.enter_create_from_issue();
+  app.create_form.issue.push_str("594");
+  app.submit_create().unwrap();
+
+  assert_eq!(
+    app.create_form.mode,
+    Mode::Structured,
+    "the cache hit prefills straight away"
+  );
+  assert_eq!(app.create_form.desc, "modal-layout");
+  assert_eq!(app.create_form.awaiting_issue, None, "nothing is being waited for");
 }

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -235,6 +235,11 @@ fn create_from_issue_modal_shows_one_field_and_no_empty_preview() {
   assert_present(&buf, "from issue", "the title says which mode this is");
   assert_present(&buf, "Issue", "the one field it collects");
   assert_present(&buf, "read off the issue", "what the missing preview is replaced by");
+  assert_absent(
+    &buf,
+    "structured",
+    "the toggle is inert here, so the hint row does not offer it",
+  );
   assert_absent(&buf, "Branch :", "no preview of a triple that does not exist yet");
   assert_absent(&buf, "Dir    :", "same for the directory row");
   assert_absent(&buf, "Desc", "the slug is derived, not typed here");

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -218,6 +218,59 @@ fn create_modal_renders_title_fields_and_buttons() {
 }
 
 #[test]
+fn create_from_issue_modal_shows_one_field_and_no_empty_preview() {
+  // #625: the triple is empty until the forge answers, so expanding the
+  // patterns over it renders the literal `/#-` — a branch this form is not
+  // about to write. The preview is replaced rather than shown empty, and the
+  // type selector and slug field are not drawn at all: this mode has one
+  // input.
+  //
+  // Asserted against the rendered buffer, not against the mode: a guard that
+  // matched by name would pass while the modal drew the structured form.
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  assert_eq!(app.view, View::Create);
+  let buf = render(&mut app);
+
+  assert_present(&buf, "from issue", "the title says which mode this is");
+  assert_present(&buf, "Issue", "the one field it collects");
+  assert_present(&buf, "read off the issue", "what the missing preview is replaced by");
+  assert_absent(&buf, "Branch :", "no preview of a triple that does not exist yet");
+  assert_absent(&buf, "Dir    :", "same for the directory row");
+  assert_absent(&buf, "Desc", "the slug is derived, not typed here");
+}
+
+#[test]
+fn create_from_issue_modal_becomes_the_structured_form_once_the_issue_lands() {
+  // The prefill is the point: what the user confirms is the ordinary create
+  // form, showing the branch it will write.
+  let (_dir, mut app) = make_app();
+  app.enter_create_from_issue();
+  app.create_form.awaiting_issue = Some(594);
+  app.apply_awaited_issue(
+    594,
+    &Ok(gwm::github::IssueStatus {
+      number: 594,
+      title: "modals should follow layout".into(),
+      state: gwm::github::IssueState::Open,
+      url: "https://example.test/issues/594".into(),
+      labels: vec!["feature".into()],
+      updated_at: "2026-08-29T00:00:00Z".into(),
+      detail: Default::default(),
+    }),
+  );
+
+  let buf = render(&mut app);
+  assert_present(&buf, "Branch", "the preview is back");
+  assert_present(&buf, "Desc", "and so is the slug field");
+  assert_present(
+    &buf,
+    "modals-should-follow-layout",
+    "the derived slug is in the form, visible before it is committed to",
+  );
+}
+
+#[test]
 fn create_modal_renders_loader_while_create_is_in_flight() {
   let (_dir, mut app) = make_app();
   app.enter_create();

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -540,16 +540,31 @@ fn from_issue_has_one_field_so_rotation_stays_put() {
 }
 
 #[test]
-fn from_issue_toggles_back_to_the_structured_triple() {
-  // One key out of a mode the user opened by name, rather than a three-way
-  // cycle that would make the toggle unpredictable.
+fn from_issue_has_no_toggle() {
+  // The toggle swaps between the two modes that are alternative ways of
+  // typing the same worktree. This one is a two-step mode — ask, then confirm
+  // the prefilled structured form — so it is left by answering it, and the
+  // key is inert rather than a third stop on a cycle.
   let mut form = CreateForm::new();
+  form.issue.push_str("594");
   form.enter_from_issue();
 
   form.toggle_mode();
 
+  assert_eq!(form.mode, Mode::FromIssue);
+  assert_eq!(form.field, Field::Issue);
+}
+
+#[test]
+fn the_toggle_still_swaps_the_other_two_modes() {
+  // Disabling it in one mode must not disable it: `Ctrl+t` is how free-form
+  // is reached at all.
+  let mut form = CreateForm::new();
+
+  form.toggle_mode();
+  assert_eq!(form.mode, Mode::Freeform);
+  form.toggle_mode();
   assert_eq!(form.mode, Mode::Structured);
-  assert_eq!(form.field, form.entry_field());
 }
 
 #[test]

--- a/tests/tui_state_create_form_tests.rs
+++ b/tests/tui_state_create_form_tests.rs
@@ -492,3 +492,76 @@ fn reset_clears_the_buffers_but_keeps_the_configured_field_set() {
   assert_eq!(form.fields(), expected.as_slice());
   assert!(form.desc.is_empty());
 }
+
+// ---- Mode::FromIssue (issue #625) ---------------------------------------
+
+#[test]
+fn enter_from_issue_opens_on_the_number_and_clears_what_was_typed() {
+  let mut form = CreateForm::new();
+  form.desc.push_str("stale");
+  form.name.push_str("stale");
+  form.type_index = 2;
+
+  form.enter_from_issue();
+
+  assert_eq!(form.mode, Mode::FromIssue);
+  assert_eq!(form.field, Field::Issue);
+  assert!(form.issue.is_empty());
+  assert!(form.desc.is_empty(), "a stale slug would survive the derivation");
+  assert_eq!(form.awaiting_issue, None);
+}
+
+#[test]
+fn from_issue_accepts_the_number_even_when_the_patterns_write_none() {
+  // A `{type}/{desc}` repo discards the number from the branch, so `Issue`
+  // is not in its field list — and this mode still has to collect it, since
+  // the number is what gets fetched rather than what gets written. Reading
+  // the pattern's field list here would make the form untypeable.
+  let mut form = CreateForm::new();
+  form.set_fields(vec![Field::Type, Field::Desc]);
+  form.enter_from_issue();
+
+  form.push_char('5');
+  form.push_char('9');
+  form.push_char('4');
+
+  assert_eq!(form.issue, "594");
+}
+
+#[test]
+fn from_issue_has_one_field_so_rotation_stays_put() {
+  let mut form = CreateForm::new();
+  form.enter_from_issue();
+
+  form.next_field();
+  assert_eq!(form.field, Field::Issue);
+  form.prev_field();
+  assert_eq!(form.field, Field::Issue);
+}
+
+#[test]
+fn from_issue_toggles_back_to_the_structured_triple() {
+  // One key out of a mode the user opened by name, rather than a three-way
+  // cycle that would make the toggle unpredictable.
+  let mut form = CreateForm::new();
+  form.enter_from_issue();
+
+  form.toggle_mode();
+
+  assert_eq!(form.mode, Mode::Structured);
+  assert_eq!(form.field, form.entry_field());
+}
+
+#[test]
+fn reset_clears_the_awaited_issue() {
+  // A form reopened while a fetch is still in flight must not adopt that
+  // fetch's answer: `reset` is what `enter_create` calls.
+  let mut form = CreateForm::new();
+  form.enter_from_issue();
+  form.awaiting_issue = Some(594);
+
+  form.reset();
+
+  assert_eq!(form.awaiting_issue, None);
+  assert_eq!(form.mode, Mode::Structured);
+}


### PR DESCRIPTION
## Description

`gwm create --issue <N>` ([#617](https://github.com/kbrdn1/gwm-cli/issues/617), PR #621) derives the whole `<type> <issue> <desc>` triple from an issue on the forge. It was CLI-only.

The TUI is where a worktree usually gets created, so the one place already showing a worktree list and its linked issues was the one place that still asked for the title to be retyped as a slug and the branch type to be read off the labels by hand.

`Ctrl+n`, and `create-from-issue` in the command palette, opens the create form on a single field: the issue number. Enter looks it up; the answer prefills the structured form; a second Enter creates the worktree.

Closes #625

## Type of change

- [x] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- **It prefills, it does not create.** The derivation is a guess about a title, and this is the one surface that can show the guess before committing to it: what the user confirms is the ordinary structured form showing the branch it will write, through the already-tested submit path. Auto-submitting on the fetch result would be fewer keystrokes and would discard the review step that makes a derived slug trustworthy.
- **Where the CLI refuses, the form asks.** A non-interactive command has nowhere to ask when the labels name no branch type or name two, which is exactly what `--type` exists for. Here the cursor lands on the type selector with everything else filled. A closed issue prefills with a warning rather than refusing, since nothing is written until Enter. A number that already has a worktree closes the form and names it, matching the CLI's exit-0 behaviour, and reads the same link `gwm list` renders, so a worktree attached by hand with `gwm link` counts too.
- **Two entry points, one prefill.** A number already in the cache is read straight out of it. `spawn_github_issue` coalesces on a cache hit and no `TaskMsg::GithubIssue` ever arrives, so a submit that only marked the form as waiting would sit on a loader forever for any issue the TUI had already fetched (a linked row, the sidebar prefetch, a second attempt after `Esc`).
- **The result is applied only to the form that asked for it.** `awaiting_issue` holds the number and the handler compares it. The form is a *second* consumer of a message that also fires for the sidebar prefetch and for an explicit refresh, and the spine's generation guard is consumed before the form sees it, so without the comparison the form would fill from an issue the user never named.
- **One derivation for both surfaces.** `issue_templates::{type_from_labels, title_prefix_for, desc_from_title}` are reused as-is, so the TUI and the CLI cannot produce different slugs for the same title.
- **`Mode::FromIssue` accepts the number whatever the patterns carry.** `{issue}` is not in a `{type}/{desc}` repo's field list, and reading that list here would make the form untypeable there: the number is fetched, not written.
- The modal draws one field and replaces the branch preview. Expanding the patterns over an empty triple renders the literal `/#-`, which reads as a branch the form is about to write.
- `is_repo_mutating` includes the new action: it composes from the active repo's patterns and queries the active repo's forge, so a stale workspace selection would target the previous repo twice over.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/` (TDD: a PR adding behaviour without tests is sent back)

`cargo test` exits 0, 106 targets green.

- `tests/tui_state_create_form_tests.rs` (5): the mode opens on the number and clears a stale slug, it accepts the number on a repo whose patterns write none, rotation stays put on a single field, the toggle leads back to the structured triple, and `reset` clears the awaited number.
- `tests/tui_app_tests.rs` (6): a result for another issue leaves the form alone, a result landing after the form closed is ignored, the awaited result prefills rather than creating, labels that name no type land focus on the type selector, a failed lookup keeps the number so a retry is one keystroke, and a cached issue prefills without waiting for a message.
- `tests/tui_modal_render_tests.rs` (2): asserted against the **rendered buffer**, not the mode — one field present, no `Branch :` / `Dir    :` preview rows, no `Desc` field; and after the prefill the ordinary structured form is back with the derived slug visible in it.

Every guard was **proved red** before being made green:

| Guard removed | Test that went red |
|:--|:--|
| the `accepts_input` / rotation arms | `from_issue_accepts_the_number_even_when_the_patterns_write_none`, `from_issue_has_one_field_so_rotation_stays_put` |
| the `awaiting_issue` comparison | `a_result_for_another_issue_leaves_the_create_form_alone` |
| the cache-hit branch | `a_cached_issue_prefills_without_waiting_for_a_message` |
| the `from_issue` render branch | `create_from_issue_modal_shows_one_field_and_no_empty_preview` |

The repo's own completeness guards were fed rather than worked around: `registry_covers_every_action_variant` (palette), `help_overlay_documents_every_action` (#334), the slug round-trip, and `env_guard_invariant_tests`, which correctly flagged that a test calling `submit_create` must hold the binary's env lock because the trust gate reads the environment.

## Screenshots / TUI captures

Not captured. The two render tests assert the buffer directly, which is the check a capture would be eyeballed for; the modal is worth a look during validation.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no CLI surface change; the CLI half shipped in #621)
- [x] `examples/gwm.toml.example` updated if config schema changed (no schema change; `create_from_issue` is bindable under `[tui.keys]` like any action)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #625
- Follows: #617 (PR #621, merged into `dev`) — the derivation this reuses
- Related: #416 (the free-form mode this one is shaped after), #484 (why `n` cannot host a chord), #334 (help-overlay completeness)

## Notes for reviewers

- **`Ctrl+n` was forced, and the issue body did not anticipate it.** #625 said the action would have no default binding and be palette-only. `tui_chord_tests.rs` requires a default chord for every `Action` and then requires the help overlay to document it with those exact keys, so palette-only is not a shape this codebase allows. The single-letter space is full, and `n` being a single key confiscates its own prefix (#484), so `n i` was out too. `Ctrl+n` reads as the sibling of `n`; happy to take a different one.
- **`apply_awaited_issue` is `pub`** so the staleness guard is reachable from an integration test. It is not reachable through the event loop from outside, and the guard is the whole point of the function. Same internal-seam caveat as the rest of the lib.
- **The rename modal shares `HintContext::Rename` for this mode.** Nothing routes the rename form into `FromIssue` — deriving a name for a worktree that already exists is what `gwm link` is for — so it shares the structured row rather than growing a context no surface can reach.
- **Not done, deliberately, and deferred in the issue:** prefilling the number from the selected row's linked issue. The point is creating a worktree for an issue that does not have one yet, so the number is rarely already on screen. Worth a second entry point later now that the mode exists.