### PR TITLE
✨ feat(tui): pin the worktree context above the Commits and Working Tree listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock.bak
 
 # Local working notes (analysis, strategy, open questions)
 .notes/
+
+# Codebase graph output (graphify): regenerated on demand, never reviewed
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,6 +375,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   command and a URL's `?`, `&` and `#` cannot become shell syntax. Only
   absolute `http`/`https` URLs are passed on.
 
+- **The Commits and Working Tree overlays say which worktree they are showing**
+  ([#629](https://github.com/kbrdn1/gwm-cli/issues/629)). Both full-size
+  listings painted their snapshot and nothing else: a commit graph that could
+  be any branch's, a file tree that could be any worktree's. The modal title
+  could not carry it either, being centred and therefore clipped from the
+  left, and the commit overlay already spends its title on the row count.
+
+  Each now carries a fixed row above its body: the branch for the commit
+  listing, the worktree name and its path for the working tree. It is its own
+  rect above the scroll region, not the first line of the listing, so it stays
+  put while the body scrolls, and the Working Tree overlay renders it in its
+  loading arm too, so the listing lands exactly where the loader was instead
+  of jumping a line when the worker returns.
+
+  The row resolves from the path the overlay pinned when it opened, not from
+  the live selection: the auto-refresh moves the selection while an overlay is
+  up, so the cursor can point at a different worktree than the rows on screen.
+  It is an in-memory lookup, so the render path still shells out to nothing.
+
 ### Changed
 
 - **Modals follow `[tui] layout` instead of always being bordered**

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4838,6 +4838,81 @@ fn draw_help(f: &mut Frame, app: &mut App) {
   );
 }
 
+/// The worktree a full-size overlay's snapshot was taken on, resolved from
+/// the path the modal state pinned when it opened (issue #629).
+///
+/// Deliberately not [`App::selected`]: the auto-refresh moves the selection
+/// while an overlay is up (the lesson `commits_target` carries), so the live
+/// cursor can point at a different worktree than the rows on screen. An
+/// in-memory scan, so the context row costs the render path no I/O (#343).
+///
+/// `None` once another process removes the worktree and the refresh drops it
+/// from the list. The row degrades rather than lying.
+fn overlay_worktree<'a>(app: &'a App, path: Option<&std::path::Path>) -> Option<&'a WorktreeInfo> {
+  let path = path?;
+  app.worktrees.iter().find(|w| w.path == path)
+}
+
+/// The fixed context row above the Commits listing (issue #629): the branch
+/// the log was walked on.
+///
+/// Both full-size overlays paint a snapshot with no statement of what it is a
+/// snapshot *of* — a commit graph could be any branch's. The modal title
+/// cannot carry it: it is centred, so it is clipped from the LEFT, and this
+/// one already spends itself on the row count.
+///
+/// The branch wears the same worst-state colour it wears in the table and the
+/// identity card (PR #73), so the overlay reads as the same block at a
+/// different size. `-` on a detached HEAD, and on a worktree the refresh
+/// dropped from the list.
+fn commits_context_line(w: Option<&WorktreeInfo>, theme: &Theme) -> Line<'static> {
+  let muted = Style::default().fg(theme.muted);
+  let mut value = Span::styled("-".to_string(), muted);
+  if let Some(w) = w {
+    if let Some(b) = w.branch.as_deref() {
+      value = Span::styled(
+        crate::naming::sanitise_for_terminal(b),
+        Style::default().fg(branch_name_color(&w.status, theme)),
+      );
+    }
+  }
+  Line::from(vec![Span::styled("Branch  ".to_string(), muted), value])
+}
+
+/// The fixed context row above the Working Tree listing (issue #629): the
+/// worktree the files were read from, and where it lives on disk.
+///
+/// One leading space, as the listing pads its own rows, so the caption lines
+/// up with the tree under it.
+///
+/// **Order is the width policy**, the rule [`folded_status_line`] states: the
+/// row is hard-clipped on the right with no ellipsis, so the name leads (it is
+/// what the user scans for) and the path trails (it is the reference, and the
+/// half the row can most afford to lose).
+///
+/// With the row gone from the list, the pinned path is still the truthful
+/// half and is rendered alone rather than dropping the row and moving the
+/// listing up a line.
+fn working_tree_context_line(w: Option<&WorktreeInfo>, path: Option<&std::path::Path>, theme: &Theme) -> Line<'static> {
+  let muted = Style::default().fg(theme.muted);
+  let mut spans = vec![Span::styled(" Worktree  ".to_string(), muted)];
+  match (w, path) {
+    (Some(w), _) => {
+      spans.push(Span::styled(
+        crate::naming::sanitise_for_terminal(&w.name),
+        worktree_name_style(theme),
+      ));
+      spans.push(Span::styled("  ·  ".to_string(), muted));
+      // The same sink the identity card's `Path` row and the table's `PATH`
+      // cell owe the terminal (issue #568): tilde-compressed, sanitised.
+      spans.push(Span::styled(display_path(&w.path.display().to_string()), muted));
+    }
+    (None, Some(p)) => spans.push(Span::styled(display_path(&p.display().to_string()), muted)),
+    (None, None) => spans.push(Span::styled("-".to_string(), muted)),
+  }
+  Line::from(spans)
+}
+
 /// Full-size Working Tree listing (issue #592) — the sidebar pane's tree
 /// given the whole modal area.
 ///
@@ -4861,10 +4936,27 @@ fn draw_working_tree(f: &mut Frame, app: &mut App) {
     working_tree_counts_footer(&app.working_tree.counts, &theme),
   );
 
+  // The context row is its own rect ABOVE the scroll region (issue #629) —
+  // as the first line of the body it would scroll away, which is the whole
+  // thing it exists not to do. Built before the mutable borrows below.
+  let context = working_tree_context_line(
+    overlay_worktree(app, app.working_tree.path.as_deref()),
+    app.working_tree.path.as_deref(),
+    &theme,
+  );
+
   // A blank row between the listing and the hints, the gap every other
   // modal already leaves: content never sits flush against the footer.
-  let [body_area, _gap, footer_area] =
-    Layout::vertical([Constraint::Min(1), Constraint::Length(1), Constraint::Length(1)]).areas(inner);
+  let [context_area, body_area, _gap, footer_area] = Layout::vertical([
+    Constraint::Length(1),
+    Constraint::Min(1),
+    Constraint::Length(1),
+    Constraint::Length(1),
+  ])
+  .areas(inner);
+  // Rendered before the loading arm returns: a row present in only one of
+  // the two arms makes the listing jump a line when the worker lands.
+  f.render_widget(Paragraph::new(context), context_area);
 
   // While the worker is out, a muted loader rather than an empty canvas:
   // blank reads as "nothing changed", which is the one answer this overlay
@@ -4973,10 +5065,20 @@ fn draw_commits(f: &mut Frame, app: &mut App) {
   let frame = ModalFrame::resolve(app.config.tui.layout.is_compact(), accent, &app.theme);
   let inner = frame.render(f, area, &title, None);
 
+  // The branch this log was walked on, pinned above the scroll region
+  // (issue #629). Built before the mutable borrows below.
+  let context = commits_context_line(overlay_worktree(app, app.commits.path.as_deref()), &app.theme);
+
   // A blank row between the listing and the hints, the gap every other
   // modal already leaves: content never sits flush against the footer.
-  let [body_area, _gap, footer_area] =
-    Layout::vertical([Constraint::Min(1), Constraint::Length(1), Constraint::Length(1)]).areas(inner);
+  let [context_area, body_area, _gap, footer_area] = Layout::vertical([
+    Constraint::Length(1),
+    Constraint::Min(1),
+    Constraint::Length(1),
+    Constraint::Length(1),
+  ])
+  .areas(inner);
+  f.render_widget(Paragraph::new(context), context_area);
 
   // A muted loader rather than an empty canvas while the first page is
   // being walked: blank reads as "no commits", which is the one answer this

--- a/tests/tui_modal_render_tests.rs
+++ b/tests/tui_modal_render_tests.rs
@@ -514,6 +514,58 @@ fn commits_modal_advertises_load_more_only_when_a_page_is_full() {
 }
 
 #[test]
+fn commits_modal_pins_its_branch_above_the_scrolling_body() {
+  use ratatui::text::Line;
+
+  // Issue #629: the listing said nothing about the worktree it was walked
+  // on, and the title cannot carry it — a centred overlay title is clipped
+  // from the LEFT, so a branch name is exactly the wrong payload for it,
+  // and it already spends itself on the row count. A fixed row above the
+  // body carries it instead.
+  //
+  // Asserted by POSITION, not by presence: a `buffer_contains` scan over
+  // the whole buffer passes just as well when the branch is the first line
+  // of the *body* and scrolls away with it, which is the bug this pins.
+  let (_dir, mut app) = make_app();
+  app.enter_commits();
+  settle_commits(&mut app);
+  let branch = app.worktrees[0]
+    .branch
+    .clone()
+    .expect("the fixture worktree is on a branch");
+  // Enough rows that the body overflows a short terminal. Injected rather
+  // than committed 40 times: this pins the header, not the revwalk.
+  app.commits.lines = (0..40).map(|i| Line::from(format!("commit row {i}"))).collect();
+
+  let top = modal_rows(&render_at(&mut app, 100, 18));
+  let row = top
+    .iter()
+    .position(|r| r.contains(&branch))
+    .unwrap_or_else(|| panic!("no branch row — modal rows:\n{}", top.join("\n")));
+  assert!(
+    top[row + 1].contains("commit row 0"),
+    "the listing starts on the row right below it — got {:?}",
+    top[row + 1]
+  );
+
+  // Drive the cursor past the end; the renderer clamps it to the body's
+  // max-scroll, i.e. "scrolled to the bottom".
+  app.commits.scroll = u16::MAX;
+  let bottom = modal_rows(&render_at(&mut app, 100, 18));
+  assert!(
+    bottom[row].contains(&branch),
+    "the branch row is FIXED: same line at max scroll — got {:?}, modal rows:\n{}",
+    bottom[row],
+    bottom.join("\n")
+  );
+  assert!(
+    !bottom[row + 1].contains("commit row 0"),
+    "and it is the body that moved under it — got {:?}",
+    bottom[row + 1]
+  );
+}
+
+#[test]
 fn command_logs_modal_renders_empty_placeholder() {
   let (_dir, mut app) = make_app();
   app.command_logs.entries.clear();
@@ -2839,6 +2891,98 @@ fn working_tree_modal_renders_a_loader_while_the_worker_is_out() {
   assert_present(&buf, "loading", "the loader, not a blank canvas");
   // The exit is still advertised while it waits.
   assert_present(&buf, "close", "the modal footer advertises the exit");
+}
+
+#[test]
+fn working_tree_modal_pins_its_worktree_and_path_above_the_scrolling_body() {
+  use ratatui::text::Line;
+
+  // Issue #629, the other half: the listing is a set of file names with no
+  // statement of which worktree they were read from, and the auto-refresh
+  // can move the list selection while the overlay is up. The row resolves
+  // from the path pinned in `WorkingTreeModal` rather than from the live
+  // selection, so it describes the same worktree the rows describe.
+  //
+  // Asserted by POSITION for the same reason the commits case is: presence
+  // alone passes on a row that scrolls away.
+  let (_dir, mut app) = make_app();
+  let wt = deletable_worktree("payment-webhooks");
+  app.worktrees = vec![wt.clone()];
+  app.working_tree.begin(Some(&wt.path));
+  app.working_tree.loading = false;
+  app.working_tree.lines = (0..40).map(|i| Line::from(format!("file-{i}.rs"))).collect();
+  app.view = View::WorkingTree;
+
+  let top = modal_rows(&render_at(&mut app, 100, 18));
+  let row = top
+    .iter()
+    .position(|r| r.contains("/tmp/gwm-test/payment-webhooks"))
+    .unwrap_or_else(|| panic!("no context row — modal rows:\n{}", top.join("\n")));
+  assert!(
+    top[row].contains("payment-webhooks"),
+    "the row carries the worktree name beside its path — got {:?}",
+    top[row]
+  );
+  assert!(
+    top[row + 1].contains("file-0.rs"),
+    "the listing starts on the row right below it — got {:?}",
+    top[row + 1]
+  );
+
+  app.working_tree.scroll = u16::MAX;
+  let bottom = modal_rows(&render_at(&mut app, 100, 18));
+  assert!(
+    bottom[row].contains("/tmp/gwm-test/payment-webhooks"),
+    "the context row is FIXED: same line at max scroll — got {:?}, modal rows:\n{}",
+    bottom[row],
+    bottom.join("\n")
+  );
+  assert!(
+    !bottom[row + 1].contains("file-0.rs"),
+    "and it is the body that moved under it — got {:?}",
+    bottom[row + 1]
+  );
+}
+
+#[test]
+fn working_tree_modal_keeps_its_context_row_while_the_worker_is_out() {
+  use ratatui::text::Line;
+
+  // The loader arm returns early (PR #612), so it is a second renderer with
+  // its own layout. Without the row there, the loader and the first loaded
+  // row land on different lines and the content visibly jumps when the
+  // worker returns.
+  let (_dir, mut app) = make_app();
+  let wt = deletable_worktree("payment-webhooks");
+  app.worktrees = vec![wt.clone()];
+  app.working_tree.begin(Some(&wt.path));
+  app.view = View::WorkingTree;
+  assert!(app.is_working_tree_loading(), "the overlay opens on its loader");
+
+  let waiting = modal_rows(&render(&mut app));
+  let row = waiting
+    .iter()
+    .position(|r| r.contains("/tmp/gwm-test/payment-webhooks"))
+    .unwrap_or_else(|| panic!("no context row while loading — modal rows:\n{}", waiting.join("\n")));
+  assert!(
+    waiting[row + 1].contains("loading"),
+    "the loader sits under it — got {:?}",
+    waiting[row + 1]
+  );
+
+  // The same line in the loaded arm: the two renderers are separate, so a
+  // row present in only one of them makes the content jump when the worker
+  // lands.
+  app.working_tree.loading = false;
+  app.working_tree.lines = vec![Line::from("src/tui/ui.rs")];
+  let loaded = modal_rows(&render(&mut app));
+  assert!(
+    loaded[row].contains("/tmp/gwm-test/payment-webhooks") && loaded[row + 1].contains("src/tui/ui.rs"),
+    "the listing lands exactly where the loader was — rows {:?} / {:?}, modal rows:\n{}",
+    loaded[row],
+    loaded[row + 1],
+    loaded.join("\n")
+  );
 }
 
 #[test]


### PR DESCRIPTION
## Description

The two full-size overlays painted their snapshot and nothing else: a commit graph that could be any branch's, a file tree that could be any worktree's. Neither said which worktree the rows belong to, and the auto-refresh can move the list selection while the overlay is up, so there was no reliable on-screen answer. The title cannot carry it either, being centred and therefore clipped from the left, and the commits title already spends itself on the row count.

Each overlay now carries a fixed context row above its body: the branch for `Commits`, the worktree name and its path for `Working Tree`.

Closes #629

## Type of change

- [x] ✨ Feature (new functionality)

## Changes

- `commits_context_line` / `working_tree_context_line` in `src/tui/ui.rs`, built from `overlay_worktree`, which resolves the `WorktreeInfo` from the path the modal state pinned when it opened rather than from the live selection. An in-memory scan, so the render path still shells out to nothing (#343).
- Both `draw_commits` and `draw_working_tree` split their inner rect four ways instead of three, so the row is its own rect above the scroll region and survives a scroll. The scroll bound and `viewport` are published against the narrowed `body_area`, so the half-page verbs follow.
- `draw_working_tree` renders the row before its loading arm returns, so the listing lands on the exact line the loader occupied instead of jumping when the worker lands.
- The branch keeps its worst-state colour (PR #73), the path goes through the same `display_path` sink as the identity card and the table cell (#568), and both the name and the branch are sanitised for the terminal.
- Degrades rather than lying: `-` when nothing is selected or the HEAD is detached, and the pinned path alone when another process removed the worktree and the refresh dropped it from the list.

## Tests

- [x] `cargo test` passes locally (40 test binaries, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New tests added under `tests/`

Three cases in `tests/tui_modal_render_tests.rs`, written red first. They assert by POSITION, not by presence: a `buffer_contains` scan over the whole buffer goes green just as well when the row is the first line of the body and scrolls away with it, which is exactly the defect. Each locates the row in the first frame, drives the scroll to its clamped maximum, and asserts the same line still carries the context while the line under it no longer carries the first row. The loading case asserts the listing lands on the exact line the loader occupied.

## Screenshots / TUI captures

Compact layout, 110x24, rendered through `gwm::tui::draw`:

```
       Commits (1)
       Branch  main
       e783305b  gw  ○  init                                              gwm-test · 0s
```

```
       Working Tree
        Worktree  .tmpEx6bwk  ·  /private/var/folders/q1/.../T/.tmpEx6bwk/
        ✓ clean
```

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (no CLI surface change)
- [x] `examples/gwm.toml.example` updated if config schema changed (no schema change)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #629
- Related PR: #612 (Working Tree overlay), #614 (Commits overlay), #616 (modal layout)

## Notes for reviewers

The row is deliberately resolved from `CommitsModal::path` / `WorkingTreeModal::path` rather than `App::selected()`, for the reason `commits_target`'s doc comment already states. Reading the selection would let the row name a different worktree than the rows below it after an auto-refresh.

The name is repeated in the path, which is redundant on purpose: the request was for both, and the name is what gets scanned while the path is the reference. Order is the width policy, since the row is hard-clipped on the right with no ellipsis.

Measured degradation, disclosed rather than fixed: the row is a fourth `Length(1)` in a split that had three, so the height at which the bordered frame starves its footer moved up one row. Baseline on `dev` keeps the `Esc close` hint down to a 9-line terminal; with this change it needs 10. No panic at any height down to 6, and the compact layout is unaffected at every height tested. The Keybindings overlay has carried the same four-way split since #279 and degrades identically, so this is the house shape rather than a new one, and a 9-line terminal is well under any usable size. Say the word if you want the row dropped below a threshold instead.
