### PR TITLE
📝 docs(integrations): the five `:::` callouts are GFM alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tapes as living outside the script
   ([#631](https://github.com/kbrdn1/gwm-cli/issues/631)).
 
+- The five `:::` callouts under `docs/` are GFM alerts
+  ([#641](https://github.com/kbrdn1/gwm-cli/issues/641)). Container syntax is
+  markdown-it / Nuxt Content, and this tree is read by neither: GitHub emitted
+  the directive as literal text in a paragraph, and Starlight wants
+  `:::caution[title]` with the colons glued to one of four names it knows,
+  which `::: warning` is not. So the security callout on the GitLab page, the
+  one explaining that a bare `forge` key authorises nothing, was raw
+  punctuation in both places. The one that carried a title keeps it as a bold
+  first line inside the quote, since a GFM alert has no title slot.
+  `docs/fr/5.integrations/1.github-linking.md` gains the multi-forge callout
+  its English half already had. `tests/docs_callout_tests.rs` rejects the whole
+  `:::` prefix rather than the spaced form the tree happened to carry:
+  `:::note` is valid Starlight and would render on the site while staying
+  literal on GitHub, which is the same defect seen from the other side. Astro
+  does not implement GFM alerts natively, so the matching half, folding them
+  back into Starlight asides, lives in
+  [kbrdn1/kbrdn-docs#81](https://github.com/kbrdn1/kbrdn-docs/issues/81).
+
 
 ## Past releases
 

--- a/docs/5.integrations/1.github-linking.md
+++ b/docs/5.integrations/1.github-linking.md
@@ -9,9 +9,8 @@ Added by [#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://gith
 
 Every worktree can be linked to a GitHub issue and / or pull request. The link drives the live `Issue / PR` block in the [TUI sidebar](/tui/sidebar#issue--pr-block) and surfaces in `gwm status` for scripting.
 
-::: tip
-Since [#419](https://github.com/kbrdn1/gwm-cli/issues/419) this page describes the **GitHub** backend. The storage model, auto-detection and TUI surfaces below are forge-agnostic and apply unchanged to GitLab. See [GitLab (multi-forge)](/integrations/gitlab) for what differs.
-:::
+> [!TIP]
+> Since [#419](https://github.com/kbrdn1/gwm-cli/issues/419) this page describes the **GitHub** backend. The storage model, auto-detection and TUI surfaces below are forge-agnostic and apply unchanged to GitLab. See [GitLab (multi-forge)](/integrations/gitlab) for what differs.
 
 ![The Issue·PR pane with a gh-detected open PR and its live CI rollup](./_assets/github-linking.png)
 

--- a/docs/5.integrations/5.gitlab.md
+++ b/docs/5.integrations/5.gitlab.md
@@ -60,17 +60,17 @@ gwm trust add     # in the repo, once
 
 That is the same TOFU ledger `[[bootstrap.command]]` uses, and the same decision: `.gwm.toml` ships with the repo, so letting it name the host on its own would hand a hostile clone an authenticated call to its own server from a plain `gwm status`. Approving covers the file as it is now: editing it changes its hash and revokes the approval. `gwm trust list` shows what you have approved, `gwm trust revoke <origin>` takes it back, and `GWM_ALLOW_BOOTSTRAP=1` bypasses the check for CI runners with no one to answer.
 
-::: warning A bare `forge` key authorises nothing
-`forge = "gitlab"`, wherever you set it (repo or global), states which backend you use. It does not state which hosts may receive your token, and gwm does not read it as though it did. Otherwise the single most ordinary setup there is (one key, set once, at a GitLab shop) would authorise every host in existence, including one an attacker put in a clone's `origin`. That is not hypothetical: given `GITLAB_HOST`, `glab` sends the ambient `GITLAB_TOKEN` to whatever it names, as a `Private-Token` header, with no host scoping of its own.
-:::
+> [!WARNING]
+> **A bare `forge` key authorises nothing**
+>
+> `forge = "gitlab"`, wherever you set it (repo or global), states which backend you use. It does not state which hosts may receive your token, and gwm does not read it as though it did. Otherwise the single most ordinary setup there is (one key, set once, at a GitLab shop) would authorise every host in existence, including one an attacker put in a clone's `origin`. That is not hypothetical: given `GITLAB_HOST`, `glab` sends the ambient `GITLAB_TOKEN` to whatever it names, as a `Private-Token` header, with no host scoping of its own.
 
 ### on the vendors' own domains
 
 None of this applies on `github.com`, `ghe.com` or `gitlab.com`: the host already states which forge it runs, so no authorisation is needed. The `forge` key is free there and still wins in both directions: `forge = "github"` forces the GitHub backend even on a `gitlab.com` remote. The call reaches a vendor either way, so the worst case is gwm talking to GitLab with `gh`.
 
-::: tip
-`gwm doctor` probes for the forge CLI (`gh` / `glab`) **only when `forge` is set explicitly**: an explicit key is read as "I talk to this forge", which makes the warning actionable. Repos that never opt in get no new warning.
-:::
+> [!TIP]
+> `gwm doctor` probes for the forge CLI (`gh` / `glab`) **only when `forge` is set explicitly**: an explicit key is read as "I talk to this forge", which makes the warning actionable. Repos that never opt in get no new warning.
 
 ## nested groups
 

--- a/docs/fr/5.integrations/1.github-linking.md
+++ b/docs/fr/5.integrations/1.github-linking.md
@@ -9,6 +9,9 @@ Ajouté par [#67](https://github.com/kbrdn1/gwm-cli/issues/67) / [#68](https://g
 
 Chaque worktree peut être lié à une issue GitHub et / ou à une pull request. La liaison alimente le bloc `Issue / PR` en temps réel dans la [barre latérale du TUI](/fr/tui/sidebar#bloc-issue--pr) et apparaît dans `gwm status` pour le scripting.
 
+> [!TIP]
+> Depuis [#419](https://github.com/kbrdn1/gwm-cli/issues/419) cette page décrit le backend **GitHub**. Le modèle de stockage, l'auto-détection et les surfaces TUI ci-dessous sont neutres vis-à-vis de la forge et s'appliquent tels quels à GitLab. Voir [GitLab (multi-forge)](/fr/integrations/gitlab) pour ce qui diffère.
+
 ![Le panneau Issue·PR avec une PR ouverte détectée via gh et son état CI en direct](../../5.integrations/_assets/github-linking.png)
 
 ## modèle de stockage

--- a/docs/fr/5.integrations/5.gitlab.md
+++ b/docs/fr/5.integrations/5.gitlab.md
@@ -60,17 +60,17 @@ gwm trust add     # dans le dépôt, une fois
 
 C'est la même barrière TOFU que celle utilisée par `[[bootstrap.command]]`, et la même décision : `.gwm.toml` est livré avec le dépôt, donc le laisser nommer l'hôte tout seul offrirait à un clone hostile un appel authentifié vers son propre serveur depuis un simple `gwm status`. L'approbation couvre le fichier tel qu'il est à cet instant ; l'éditer change son empreinte et révoque l'approbation. `gwm trust list` montre ce que vous avez approuvé, `gwm trust revoke <origin>` le reprend, et `GWM_ALLOW_BOOTSTRAP=1` contourne la vérification pour les runners CI où personne ne peut répondre.
 
-::: warning Une clé `forge` seule n'autorise rien
-`forge = "gitlab"`, où que vous la posiez (dépôt ou global), énonce quel backend vous utilisez. Elle n'énonce pas quels hôtes peuvent recevoir votre jeton, et gwm ne la lit pas comme si c'était le cas. Sans quoi la configuration la plus ordinaire qui soit (une clé, posée une fois, dans une boutique GitLab) autoriserait tous les hôtes de la terre, y compris celui qu'un attaquant aurait placé dans l'`origin` d'un clone. Ce n'est pas hypothétique : avec `GITLAB_HOST` défini, `glab` envoie le `GITLAB_TOKEN` ambiant vers ce qu'il nomme, sous forme d'en-tête `Private-Token`, sans aucun cadrage d'hôte de son côté.
-:::
+> [!WARNING]
+> **Une clé `forge` seule n'autorise rien**
+>
+> `forge = "gitlab"`, où que vous la posiez (dépôt ou global), énonce quel backend vous utilisez. Elle n'énonce pas quels hôtes peuvent recevoir votre jeton, et gwm ne la lit pas comme si c'était le cas. Sans quoi la configuration la plus ordinaire qui soit (une clé, posée une fois, dans une boutique GitLab) autoriserait tous les hôtes de la terre, y compris celui qu'un attaquant aurait placé dans l'`origin` d'un clone. Ce n'est pas hypothétique : avec `GITLAB_HOST` défini, `glab` envoie le `GITLAB_TOKEN` ambiant vers ce qu'il nomme, sous forme d'en-tête `Private-Token`, sans aucun cadrage d'hôte de son côté.
 
 ### sur les domaines propres aux éditeurs
 
 Rien de tout cela ne s'applique sur `github.com`, `ghe.com` ou `gitlab.com` : l'hôte énonce déjà quelle forge il fait tourner, aucune autorisation n'est donc nécessaire. La clé `forge` y est libre et l'emporte toujours dans les deux sens : `forge = "github"` force le backend GitHub même sur un remote `gitlab.com`. L'appel atteint un éditeur dans tous les cas, donc le pire scénario est gwm parlant à GitLab avec `gh`.
 
-::: tip
-`gwm doctor` sonde la CLI de forge (`gh` / `glab`) **uniquement quand `forge` est définie explicitement** : une clé explicite se lit comme « je parle à cette forge », ce qui rend l'avertissement actionnable. Les dépôts qui n'y souscrivent jamais ne gagnent aucun nouvel avertissement.
-:::
+> [!TIP]
+> `gwm doctor` sonde la CLI de forge (`gh` / `glab`) **uniquement quand `forge` est définie explicitement** : une clé explicite se lit comme « je parle à cette forge », ce qui rend l'avertissement actionnable. Les dépôts qui n'y souscrivent jamais ne gagnent aucun nouvel avertissement.
 
 ## groupes imbriqués
 

--- a/tests/docs_callout_tests.rs
+++ b/tests/docs_callout_tests.rs
@@ -1,0 +1,102 @@
+//! Guard on the callout syntax used across `docs/**` (issue #641).
+//!
+//! A `:::` container is markdown-it / Nuxt Content syntax, and this tree is
+//! read by neither. It ships green and renders **nowhere**:
+//!
+//! - **GitHub** does GFM alerts, not containers. The blob page for
+//!   `docs/5.integrations/5.gitlab.md` output `<p>::: warning A bare
+//!   <code>forge</code> key authorises nothing …</p>` — raw punctuation where
+//!   a security callout was meant to be, on the page that travels with the
+//!   code.
+//! - **The docs site** (Starlight, via the `kbrdn-docs` sync) wants
+//!   `:::caution[title]`, colons glued to the name, and only knows `note`,
+//!   `tip`, `caution`, `danger`. `::: warning` matches neither half of that
+//!   and is not parsed at all.
+//!
+//! So the guard rejects the **whole** `:::` prefix, not just the spaced form
+//! the tree happened to carry: `:::note` is valid Starlight and would render
+//! on the site while staying raw text on GitHub, which is the same defect
+//! seen from the other side. After #641 the repo has one answer, GFM alerts
+//! (`> [!TIP]`, `> [!WARNING]`, …), and the site half of the mapping lives in
+//! the sync script (kbrdn1/kbrdn-docs#81) rather than in this tree.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn docs_root() -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs")
+}
+
+/// Every `.md` under `docs/`, repo-relative, sorted for stable failures.
+fn markdown_pages() -> Vec<PathBuf> {
+  let mut out = Vec::new();
+  collect_markdown(&docs_root(), &mut out);
+  out.sort();
+  out
+}
+
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
+  let entries = fs::read_dir(dir).unwrap_or_else(|err| panic!("{} must be readable: {err}", dir.display()));
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_dir() {
+      collect_markdown(&path, out);
+    } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+      out.push(path);
+    }
+  }
+}
+
+/// `1`-based line numbers holding a container directive, outside code fences.
+///
+/// Fenced blocks are skipped because a page is allowed to *show* the syntax it
+/// does not use. Line endings are normalised first: Windows runners check out
+/// with `core.autocrlf=true` and the fence tracking would otherwise see
+/// `` ```\r ``.
+fn container_lines(page: &Path) -> Vec<(usize, String)> {
+  let text = fs::read_to_string(page)
+    .unwrap_or_else(|err| panic!("{} must be readable: {err}", page.display()))
+    .replace("\r\n", "\n");
+  let mut out = Vec::new();
+  let mut in_fence = false;
+  for (index, line) in text.lines().enumerate() {
+    if line.trim_start().starts_with("```") {
+      in_fence = !in_fence;
+      continue;
+    }
+    if in_fence {
+      continue;
+    }
+    if line.trim_start().starts_with(":::") {
+      out.push((index + 1, line.trim().to_string()));
+    }
+  }
+  out
+}
+
+#[test]
+fn docs_carry_no_container_directives() {
+  let pages = markdown_pages();
+  assert!(
+    !pages.is_empty(),
+    "no markdown found under {} — the guard would pass on an empty tree",
+    docs_root().display()
+  );
+
+  let mut offenders = Vec::new();
+  for page in &pages {
+    let relative = page.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap_or(page);
+    for (line, text) in container_lines(page) {
+      offenders.push(format!("{}:{line}: {text}", relative.display()));
+    }
+  }
+
+  assert!(
+    offenders.is_empty(),
+    "{} container directive(s) found across {} pages; `:::` renders on neither \
+     GitHub nor the docs site — use a GFM alert (`> [!TIP]`, `> [!WARNING]`):\n{}",
+    offenders.len(),
+    pages.len(),
+    offenders.join("\n")
+  );
+}


### PR DESCRIPTION
## Description

Five callouts under `docs/` used markdown-it / Nuxt Content container syntax. This tree is read by neither renderer it reaches, so they rendered nowhere: GitHub emitted `<p>::: warning A bare <code>forge</code> key authorises nothing …</p>` on the blob page, and Starlight wants `:::caution[title]` with the colons glued to one of four names it knows, which `::: warning` is not. The callout that most needed to render, the security one on the GitLab page, was raw punctuation in both places.

Closes #641

## Type of change

- [x] 📝 Docs
- [x] ✅ Tests

## Changes

- `::: tip` → `> [!TIP]`, `::: warning` → `> [!WARNING]`, across `docs/5.integrations/1.github-linking.md` and `docs/{,fr/}5.integrations/5.gitlab.md`.
- The callout that carried a title keeps it as a bold first line inside the quote, since a GFM alert has no title slot.
- `docs/fr/5.integrations/1.github-linking.md` gains the multi-forge callout its English half already had, pointing at `/fr/integrations/gitlab` rather than the unprefixed path the English page uses.
- New `tests/docs_callout_tests.rs` rejects the **whole** `:::` prefix, not the spaced form the tree happened to carry: `:::note` is valid Starlight and would render on the site while staying literal on GitHub, the same defect seen from the other side. Fenced blocks are skipped so a page may still show the syntax it does not use, and an empty tree fails rather than passing vacuously.
- CHANGELOG entry under `[Unreleased] > Docs`.

## Tests

- [x] `cargo test` passes locally (111 test binaries, 0 failures)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] New test added under `tests/`

The guard was written first and run red on the unfixed tree: `10 container directive(s) found across 83 pages`, naming all ten lines. The page count is asserted non-empty so a mis-rooted walk fails instead of passing.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (n/a)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (test-only code)
- [x] No `println!` in TUI render code (n/a)

## Linked issues / docs

- Issue: #641
- Downstream half: [kbrdn1/kbrdn-docs#81](https://github.com/kbrdn1/kbrdn-docs/issues/81)

## Notes for reviewers

**No FR/EN callout-parity guard, deliberately.** `docs_assets_tests.rs` guards the French mirror for captures because a capture added on one side alone leaves the other page text-only forever. Callouts are not that: a locale may legitimately carry an aside the other does not (a translation note, a locale-specific caveat), so a count guard would be a rule the tree does not actually want. The parity gap on `github-linking.md` is fixed here by hand and named in the issue.

**The mapping's other half is not in this repo.** Astro does not implement GFM alerts natively, so the docs site needs a pass folding them back into Starlight asides. That is kbrdn-docs#81 and it is in flight; the contract it implements is the GitHub one, `[!TYPE]` alone on its first line and a bold-only first body line promoted to the aside title, which is exactly what this diff writes.

https://claude.ai/code/session_01Apu2AgnxMzXYYrbkQtwNHK