### PR TITLE
👷 ci(#634): fix the dead bench, run the benches, and pool the suite with nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,14 +128,20 @@ jobs:
       # tests themselves are untouched, and all 3525 pass under it.
       #
       # It is NOT here for wall-clock, and the issue's premise did not
-      # survive being measured on the runners. Execution time is a wash:
-      # ubuntu 33.7s -> 30.6s, windows 122.4s -> 119.7s, macos 49.8s -> 51.4s.
-      # The 1.76x in the issue was measured on a local 8-core machine, where a
-      # binary holding a handful of tests leaves most cores idle; a runner has
-      # fewer cores, so a per-binary pool already saturates them and
-      # process-spawn overhead eats what is left. The step is compile-bound
-      # either way: ~45s of the ~76s on ubuntu is building the 110 binaries,
-      # identical under both runners.
+      # survive being measured on the runners. Execution time (nextest's own
+      # `Summary`, against the sum of `cargo test`'s per-binary `finished in`)
+      # lands inside the runner's noise band, and the band is wide: two runs
+      # of this identical command reported 30.6s and 47.0s on ubuntu, against
+      # 33.7s for `cargo test`. Same on the others, 51.4s and 53.6s against
+      # 49.8s on macos, 119.7s and 127.1s against 122.4s on windows. Nothing
+      # here is a saving anyone can spend.
+      #
+      # The 1.76x in the issue is not refuted, it does not transfer: it was
+      # measured on a local 8-core machine, where a binary holding a handful
+      # of tests leaves most cores idle. A runner has fewer cores, so a
+      # per-binary pool already saturates them and process-spawn overhead eats
+      # what is left. The step is compile-bound either way, roughly 45s of the
+      # ~76s on ubuntu is building the 110 binaries, identical under both.
       #
       # What the swap does buy is process-per-test isolation, which `cargo
       # test` structurally cannot give: a shared-fixture race that a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,16 @@ jobs:
       # it from source on every runner, minutes against seconds, which a swap
       # that is time-neutral on wall-clock cannot afford.
       #
-      # nextest does not run doctests (it cannot: they have no test binary).
-      # Nothing is lost here: every ``` fence in `src/` is a ```text or ```go
-      # block, so `cargo test --doc` reports "0 tests". If a real Rust doctest
-      # is ever added, this job needs a `cargo test --doc` step next to it.
+      # nextest does not run doctests (it cannot: they have no test binary),
+      # and no other workflow runs them either. Nothing is lost today, but
+      # that is a property of `src/`, not of CI, so it is not left to a
+      # comment to promise: `no_doctest_under_src_while_ci_cannot_run_doctests`
+      # in tests/release_workflow_tests.rs classifies every fence opener in a
+      # doc comment under `src/` and goes red on the first one rustdoc would
+      # compile as Rust. The remedy it names is a `cargo test --doc` step
+      # right here; the guard reads this file's parsed `run:` scripts, so
+      # adding one turns it green. (The comment it replaced enumerated the
+      # fences by hand and got it wrong, missing four ```toml ones.)
       - uses: taiki-e/install-action@nextest
       - name: cargo nextest run
         run: cargo nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,30 @@ jobs:
       - name: cargo build
         run: cargo build --verbose
       # `cargo-nextest` schedules 3525 tests across 110 binaries in ONE global
-      # pool, instead of running the binaries in sequence with a fresh thread
-      # pool each, most of which never saturate the runner's cores (issue
-      # #634). The tests themselves are untouched, and all 3525 pass under it.
+      # pool and gives each test its own process, where `cargo test` runs the
+      # binaries in sequence with a fresh thread pool each (issue #634). The
+      # tests themselves are untouched, and all 3525 pass under it.
+      #
+      # It is NOT here for wall-clock, and the issue's premise did not
+      # survive being measured on the runners. Execution time is a wash:
+      # ubuntu 33.7s -> 30.6s, windows 122.4s -> 119.7s, macos 49.8s -> 51.4s.
+      # The 1.76x in the issue was measured on a local 8-core machine, where a
+      # binary holding a handful of tests leaves most cores idle; a runner has
+      # fewer cores, so a per-binary pool already saturates them and
+      # process-spawn overhead eats what is left. The step is compile-bound
+      # either way: ~45s of the ~76s on ubuntu is building the 110 binaries,
+      # identical under both runners.
+      #
+      # What the swap does buy is process-per-test isolation, which `cargo
+      # test` structurally cannot give: a shared-fixture race that a
+      # `OnceLock` hides inside one process becomes a failure. The very first
+      # run under nextest found one, in `tests/common/mod.rs`. Windows also
+      # reports `3 leaky` (passing tests that outlive their own process)
+      # which `cargo test` never surfaced.
+      #
       # Installed from a prebuilt binary: `cargo install cargo-nextest` builds
-      # it from source on every runner, which is minutes against seconds here.
+      # it from source on every runner, minutes against seconds, which a swap
+      # that is time-neutral on wall-clock cannot afford.
       #
       # nextest does not run doctests (it cannot: they have no test binary).
       # Nothing is lost here: every ``` fence in `src/` is a ```text or ```go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,15 +127,19 @@ jobs:
       # binaries in sequence with a fresh thread pool each (issue #634). The
       # tests themselves are untouched, and all 3525 pass under it.
       #
-      # It is NOT here for wall-clock. Measured over 11 `cargo test` runs on
-      # `dev` against 4 runs of this job (nextest's own `Summary` against the
-      # sum of `cargo test`'s per-binary `finished in`), normalised per test
-      # because the suite grew from 3273 to 3525 over the window, the median
-      # moves -8.9% on ubuntu, -6.5% on macos and +0.8% on windows. Every
-      # macos and windows sample lands inside the `cargo test` spread, and
-      # that spread is wide: 29.2s to 42.2s of execution on ubuntu for the
-      # same command. A single-digit tendency inside a band that size is not
-      # a saving anyone can plan around.
+      # The wall-clock case is weaker than the issue expected. Measured over
+      # 11 `cargo test` runs on `dev` against 4 of this job (nextest's own
+      # `Summary` against the sum of `cargo test`'s per-binary `finished
+      # in`), normalised per test because the suite grew from 3273 to 3525
+      # over the window, the median moves -8.9% on ubuntu, -6.5% on macos
+      # and +0.8% on windows. Real and in the same direction on the two Unix
+      # runners, but single-digit, and inside a band that is far wider: 29.2s
+      # to 42.2s of execution on ubuntu for the same command on the same
+      # suite. Every macos and windows sample lands inside the `cargo test`
+      # spread. Not a saving anyone can plan around, and nowhere near 1.76x.
+      # (The 4 samples are 3 commits plus a re-run of one, so two of them
+      # share a commit and a warm cache and are not independent draws; the
+      # 11 baseline runs are 11 different commits on different days.)
       #
       # The 1.76x in the issue is not refuted, it does not transfer: it was
       # measured on a local 8-core machine, where a binary holding a handful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,20 @@ jobs:
           git config --global user.name "ci"
       - name: cargo build
         run: cargo build --verbose
-      - name: cargo test
-        run: cargo test --verbose
+      # `cargo-nextest` schedules 3525 tests across 110 binaries in ONE global
+      # pool, instead of running the binaries in sequence with a fresh thread
+      # pool each, most of which never saturate the runner's cores (issue
+      # #634). The tests themselves are untouched, and all 3525 pass under it.
+      # Installed from a prebuilt binary: `cargo install cargo-nextest` builds
+      # it from source on every runner, which is minutes against seconds here.
+      #
+      # nextest does not run doctests (it cannot: they have no test binary).
+      # Nothing is lost here: every ``` fence in `src/` is a ```text or ```go
+      # block, so `cargo test --doc` reports "0 tests". If a real Rust doctest
+      # is ever added, this job needs a `cargo test --doc` step next to it.
+      - uses: taiki-e/install-action@nextest
+      - name: cargo nextest run
+        run: cargo nextest run
 
   bench:
     name: benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,19 +160,29 @@ jobs:
       # it from source on every runner, minutes against seconds, which a swap
       # that is time-neutral on wall-clock cannot afford.
       #
-      # nextest does not run doctests (it cannot: they have no test binary),
-      # and no other workflow runs them either. Nothing is lost today, but
-      # that is a property of `src/`, not of CI, so it is not left to a
-      # comment to promise: `no_doctest_under_src_while_ci_cannot_run_doctests`
-      # in tests/release_workflow_tests.rs classifies every fence opener in a
-      # doc comment under `src/` and goes red on the first one rustdoc would
-      # compile as Rust. The remedy it names is a `cargo test --doc` step
-      # right here; the guard reads this file's parsed `run:` scripts, so
-      # adding one turns it green. (The comment it replaced enumerated the
-      # fences by hand and got it wrong, missing four ```toml ones.)
+      # nextest does not run doctests: they have no test binary for it to
+      # schedule. So `cargo test --doc` runs next to it, below.
       - uses: taiki-e/install-action@nextest
       - name: cargo nextest run
         run: cargo nextest run
+      # Doctests, the one thing nextest gives up. ubuntu only: a doctest is
+      # the same on all three runners, and this job has roughly three minutes
+      # of slack against windows in the same matrix, so the ~35s it costs
+      # never reaches the workflow's critical path.
+      #
+      # This step IS the check. Two review passes were spent watching a
+      # hand-written scanner try to decide which fences rustdoc compiles, and
+      # it was wrong ten different ways: indented blocks with no fence at all,
+      # fences inside a blockquote, `~~~`, `/** */` blocks, `#[doc = "..."]`
+      # attributes, `{.rust}`, and the tag rules, which are order-sensitive
+      # (```` ```no_run,text ```` is a doctest, ```` ```text,no_run ```` is
+      # not). Every one of those was found by probing rustdoc, which is the
+      # tell: the oracle was available the whole time and cost 35 seconds off
+      # the critical path. `ci_runs_doctests_since_nextest_cannot` pins that
+      # this step stays.
+      - name: cargo test --doc
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo test --doc
 
   bench:
     name: benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,9 @@ jobs:
       # measured on a local 8-core machine, where a binary holding a handful
       # of tests leaves most cores idle. A runner has fewer cores, so a
       # per-binary pool already saturates them and process-spawn overhead eats
-      # what is left. The step is compile-bound either way, roughly 45s of the
-      # ~76s on ubuntu is building the 110 binaries, identical under both.
+      # what is left. The step is compile-bound either way: building the 110
+      # test binaries was the larger half of it in both runs, and that half is
+      # identical under either runner.
       #
       # What the swap does buy is process-per-test isolation, which `cargo
       # test` structurally cannot give: a shared-fixture race that a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,35 @@ jobs:
       - name: cargo test
         run: cargo test --verbose
 
+  bench:
+    name: benches
+    runs-on: ubuntu-latest
+    # The perf benches were dead for 1086 commits (issue #634) because nothing
+    # ran them: `benches/sidebar_cache_hit.rs` still asserted the pre-#343
+    # contract that a render frame warms the sidebar cache, panicked, and
+    # `cargo bench` aborted before reaching the third bench. Fixing it without
+    # a job that runs it just digs the same hole again.
+    #
+    # ubuntu-only and single-shot on purpose: this is a compile-and-run guard,
+    # not a perf gate. Criterion's `--test` runs each benchmark exactly once
+    # and measures nothing, so the job fails on a panic or a build break and
+    # never on timing noise from a shared runner, which is what would make it
+    # flaky enough to be switched off again.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: configure git identity (libgit2 commit needs one)
+        run: |
+          git config --global user.email "ci@gwm.test"
+          git config --global user.name "ci"
+      # Deliberately unpiped: `| tail` / `| grep` would report the pipe's exit
+      # code, not the bench runner's, and this job exists to read that code.
+      - name: cargo bench --test
+        run: cargo bench --benches -- --test
+
   hook-smoke:
     name: pre-commit hook smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,14 +127,15 @@ jobs:
       # binaries in sequence with a fresh thread pool each (issue #634). The
       # tests themselves are untouched, and all 3525 pass under it.
       #
-      # It is NOT here for wall-clock, and the issue's premise did not
-      # survive being measured on the runners. Execution time (nextest's own
-      # `Summary`, against the sum of `cargo test`'s per-binary `finished in`)
-      # lands inside the runner's noise band, and the band is wide: two runs
-      # of this identical command reported 30.6s and 47.0s on ubuntu, against
-      # 33.7s for `cargo test`. Same on the others, 51.4s and 53.6s against
-      # 49.8s on macos, 119.7s and 127.1s against 122.4s on windows. Nothing
-      # here is a saving anyone can spend.
+      # It is NOT here for wall-clock. Measured over 11 `cargo test` runs on
+      # `dev` against 4 runs of this job (nextest's own `Summary` against the
+      # sum of `cargo test`'s per-binary `finished in`), normalised per test
+      # because the suite grew from 3273 to 3525 over the window, the median
+      # moves -8.9% on ubuntu, -6.5% on macos and +0.8% on windows. Every
+      # macos and windows sample lands inside the `cargo test` spread, and
+      # that spread is wide: 29.2s to 42.2s of execution on ubuntu for the
+      # same command. A single-digit tendency inside a band that size is not
+      # a saving anyone can plan around.
       #
       # The 1.76x in the issue is not refuted, it does not transfer: it was
       # measured on a local 8-core machine, where a binary holding a handful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,17 +172,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each test its own process. The tests themselves are untouched and all 3525
   pass under it.
 
-  This is not a speed change, and it is worth writing down why rather than
-  leaving the next reader to assume it was one. Measured over 11 `cargo test`
-  runs on `dev` against 4 runs of the swapped job, normalised per test
-  because the suite grew from 3273 to 3525 tests across that window, the
-  median moves -8.9% on ubuntu, -6.5% on macos and +0.8% on windows. Every
-  macos and windows sample falls inside the `cargo test` spread, and that
-  spread is wide: 29.2s to 42.2s of execution on ubuntu for the same
-  command. The pooling gain the issue measured came off a local 8-core
-  machine; a runner has fewer cores, so a per-binary pool already saturates
-  them and process-spawn overhead eats what is left. The test step is
-  compile-bound either way.
+  The speed case is weaker than the issue expected, which is worth writing
+  down rather than leaving the next reader to assume otherwise. Measured
+  over 11 `cargo test` runs on `dev` against 4 of the swapped job,
+  normalised per test because the suite grew from 3273 to 3525 tests across
+  that window, the median moves -8.9% on ubuntu, -6.5% on macos and +0.8%
+  on windows. Real and in the same direction on the two Unix runners, but
+  single-digit, and inside a far wider band: 29.2s to 42.2s of execution on
+  ubuntu for the same command on the same suite. Every macos and windows
+  sample falls inside the `cargo test` spread. The pooling gain the issue
+  measured came off a local 8-core machine; a runner has fewer cores, so a
+  per-binary pool already saturates them and process-spawn overhead eats
+  what is left. The test step is compile-bound either way.
 
   What the swap does buy is process-per-test isolation. It surfaced a
   shared-fixture race in the test harness on its first run: the git shim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,11 +174,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   This is not a speed change, and it is worth writing down why rather than
   leaving the next reader to assume it was one. Measured on the three
-  runners, execution time is a wash: 33.7s to 30.6s on ubuntu, 122.4s to
-  119.7s on windows, 49.8s to 51.4s on macos. The pooling gain the issue
-  measured came off a local 8-core machine; a runner has fewer cores, so a
-  per-binary pool already saturates them and process-spawn overhead eats
-  what is left. The test step is compile-bound either way.
+  runners, the difference sits inside the run-to-run noise, and the noise
+  is wide: two runs of the identical nextest command reported 30.6s and
+  47.0s of execution on ubuntu, against 33.7s for `cargo test`. The pooling
+  gain the issue measured came off a local 8-core machine; a runner has
+  fewer cores, so a per-binary pool already saturates them and process-spawn
+  overhead eats what is left. The test step is compile-bound either way.
 
   What the swap does buy is process-per-test isolation. It surfaced a
   shared-fixture race in the test harness on its first run: the git shim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The warm-cache sidebar bench runs again, and a CI job now runs the
+  benches** ([#634](https://github.com/kbrdn1/gwm-cli/issues/634)).
+  `benches/sidebar_cache_hit.rs` drew one frame and asserted the sidebar
+  cache had filled itself. That was the contract when it was written: the
+  first frame ran `git log` and stored the rendered sections. #351 took git
+  off the render path, so a frame warms nothing, and the bench has panicked
+  on every run since, 1086 commits ago. `cargo bench` stops at the first
+  failure, so it also masked the third bench, which was healthy all along.
+
+  Nobody saw it because nothing ran the benches. Both halves are fixed
+  here: the bench seeds the payload the way the event loop does, and a
+  `bench` job runs all three on every push and pull request. The job passes
+  criterion's `--test`, which runs each benchmark once and measures
+  nothing, so it fails on a panic or a build break and never on timing
+  noise from a shared runner. A perf gate that goes red on a slow runner is
+  a perf gate somebody switches off.
+
+  The old assertion does not come back. `cache.is_some()` is what let this
+  rot: the renderer serves the cache only when its key matches the current
+  selection and mode, so a payload under any other key renders the loading
+  placeholder and the bench would still report a plausible number for
+  drawing it. The timed frame is asserted to carry a real commit subject
+  instead.
+
 - **A config key with no value no longer crashes gwm**
   ([#633](https://github.com/kbrdn1/gwm-cli/issues/633)). A git config entry
   may carry no value at all (`\tgwm-agent-pin` with no `=`, git's
@@ -140,6 +164,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than crashed on or half-deleted.
 
 ### Changed
+
+- **CI schedules the test suite in one pool with `cargo-nextest`**
+  ([#634](https://github.com/kbrdn1/gwm-cli/issues/634)). `cargo test` runs
+  110 test binaries in sequence, each with its own thread pool, and most of
+  them hold a handful of tests that never saturate a runner's cores.
+  `cargo-nextest` schedules all 3525 across one global pool. The tests
+  themselves are untouched and all 3525 pass under it, process-per-test
+  isolation included. Doctests are not lost: nextest cannot run them, and
+  every ``` fence under `src/` is a ```text or ```go block, so
+  `cargo test --doc` reports zero tests on this tree. The MSRV job still
+  compiles at the declared floor and runs no tests.
 
 - **`gwm list` scans its worktrees in parallel**
   ([#633](https://github.com/kbrdn1/gwm-cli/issues/633)). Every row opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,16 +165,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **CI schedules the test suite in one pool with `cargo-nextest`**
+- **CI runs the test suite under `cargo-nextest`**
   ([#634](https://github.com/kbrdn1/gwm-cli/issues/634)). `cargo test` runs
-  110 test binaries in sequence, each with its own thread pool, and most of
-  them hold a handful of tests that never saturate a runner's cores.
-  `cargo-nextest` schedules all 3525 across one global pool. The tests
-  themselves are untouched and all 3525 pass under it, process-per-test
-  isolation included. Doctests are not lost: nextest cannot run them, and
-  every ``` fence under `src/` is a ```text or ```go block, so
-  `cargo test --doc` reports zero tests on this tree. The MSRV job still
-  compiles at the declared floor and runs no tests.
+  110 test binaries in sequence, each with its own thread pool.
+  `cargo-nextest` schedules all 3525 tests across one global pool and gives
+  each test its own process. The tests themselves are untouched and all 3525
+  pass under it.
+
+  This is not a speed change, and it is worth writing down why rather than
+  leaving the next reader to assume it was one. Measured on the three
+  runners, execution time is a wash: 33.7s to 30.6s on ubuntu, 122.4s to
+  119.7s on windows, 49.8s to 51.4s on macos. The pooling gain the issue
+  measured came off a local 8-core machine; a runner has fewer cores, so a
+  per-binary pool already saturates them and process-spawn overhead eats
+  what is left. The test step is compile-bound either way.
+
+  What the swap does buy is process-per-test isolation. It surfaced a
+  shared-fixture race in the test harness on its first run: the git shim
+  directory is a fixed path, and the `OnceLock` guarding it only serialises
+  the tests sharing one process, so process-per-test had several of them
+  race an unlink-then-symlink. The link is staged and renamed into place
+  now, which is atomic.
+
+  Doctests are not lost: nextest cannot run them, and every ``` fence under
+  `src/` is a ```text or ```go block, so `cargo test --doc` reports zero
+  tests on this tree. The MSRV job still compiles at the declared floor and
+  runs no tests.
 
 - **`gwm list` scans its worktrees in parallel**
   ([#633](https://github.com/kbrdn1/gwm-cli/issues/633)). Every row opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,13 +173,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pass under it.
 
   This is not a speed change, and it is worth writing down why rather than
-  leaving the next reader to assume it was one. Measured on the three
-  runners, the difference sits inside the run-to-run noise, and the noise
-  is wide: two runs of the identical nextest command reported 30.6s and
-  47.0s of execution on ubuntu, against 33.7s for `cargo test`. The pooling
-  gain the issue measured came off a local 8-core machine; a runner has
-  fewer cores, so a per-binary pool already saturates them and process-spawn
-  overhead eats what is left. The test step is compile-bound either way.
+  leaving the next reader to assume it was one. Measured over 11 `cargo test`
+  runs on `dev` against 4 runs of the swapped job, normalised per test
+  because the suite grew from 3273 to 3525 tests across that window, the
+  median moves -8.9% on ubuntu, -6.5% on macos and +0.8% on windows. Every
+  macos and windows sample falls inside the `cargo test` spread, and that
+  spread is wide: 29.2s to 42.2s of execution on ubuntu for the same
+  command. The pooling gain the issue measured came off a local 8-core
+  machine; a runner has fewer cores, so a per-binary pool already saturates
+  them and process-spawn overhead eats what is left. The test step is
+  compile-bound either way.
 
   What the swap does buy is process-per-test isolation. It surfaced a
   shared-fixture race in the test harness on its first run: the git shim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,10 +188,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   race an unlink-then-symlink. The link is staged and renamed into place
   now, which is atomic.
 
-  Doctests are not lost: nextest cannot run them, and every ``` fence under
-  `src/` is a ```text or ```go block, so `cargo test --doc` reports zero
-  tests on this tree. The MSRV job still compiles at the declared floor and
-  runs no tests.
+  Doctests are not lost, and that is a test now rather than a claim. nextest
+  cannot run them and no other workflow does either, so the coverage lost
+  today is zero only because no doc comment under `src/` carries a Rust
+  fence. `no_doctest_under_src_while_ci_cannot_run_doctests` classifies every
+  fence opener under `src/` and goes red on the first one rustdoc would
+  compile, naming the `cargo test --doc` step to add. The comment it replaced
+  enumerated the fences by hand and had it wrong, missing four ```toml ones.
+  The MSRV job still compiles at the declared floor and runs no tests.
 
 - **`gwm list` scans its worktrees in parallel**
   ([#633](https://github.com/kbrdn1/gwm-cli/issues/633)). Every row opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,14 +192,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   race an unlink-then-symlink. The link is staged and renamed into place
   now, which is atomic.
 
-  Doctests are not lost, and that is a test now rather than a claim. nextest
-  cannot run them and no other workflow does either, so the coverage lost
-  today is zero only because no doc comment under `src/` carries a Rust
-  fence. `no_doctest_under_src_while_ci_cannot_run_doctests` classifies every
-  fence opener under `src/` and goes red on the first one rustdoc would
-  compile, naming the `cargo test --doc` step to add. The comment it replaced
-  enumerated the fences by hand and had it wrong, missing four ```toml ones.
-  The MSRV job still compiles at the declared floor and runs no tests.
+  Doctests are the one thing nextest gives up, so `cargo test --doc` runs
+  next to it. On ubuntu only: a doctest behaves the same on all three
+  runners, and that job carries minutes of slack against windows in the same
+  matrix, so the roughly 35 seconds it costs never reaches the workflow's
+  critical path. The MSRV job still compiles at the declared floor and runs
+  no tests.
 
 - **`gwm list` scans its worktrees in parallel**
   ([#633](https://github.com/kbrdn1/gwm-cli/issues/633)). Every row opens

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,10 +391,14 @@ Three of those are counter-intuitive and are set that way on purpose:
 - **Linear history off.** Turning it on would force squash or rebase merges and
   break [Merge strategy](#merge-strategy). The atomic commit history is the
   artefact, so merge commits have to stay legal.
-- **`gwm doctor (advisory)`, CodeRabbit and GitGuardian are not required.** The
-  first is advisory by design; the other two are third-party and can stop
-  reporting. A required check that never reports blocks the branch forever, so
-  only checks we own and that always run are in the list.
+- **`gwm doctor (advisory)`, `benches`, CodeRabbit and GitGuardian are not
+  required.** The first is advisory by design; the last two are third-party and
+  can stop reporting. A required check that never reports blocks the branch
+  forever, so only checks we own and that always run are in the list.
+  `benches` is the odd one out: it is ours and it does always run, it is simply
+  newer than this table (#634). Promoting it means editing the protection, so
+  until that happens a red bench fails the pull request's checks without
+  blocking the `dev` to `main` merge.
 
 `strict` is off because `main` gains a merge commit that `dev` does not have on
 every release; requiring "up to date" would force a back-merge into `dev` before

--- a/benches/sidebar_cache_hit.rs
+++ b/benches/sidebar_cache_hit.rs
@@ -1,22 +1,28 @@
 //! Issue #238: warm-cache sidebar render bench.
 //!
-//! `draw_sidebar` populates `app.sidebar.cache` on the first frame and then
-//! re-renders the cached worktree-preview sections on every subsequent frame.
-//! Before #238 each of those warm frames deep-cloned the cached
+//! `draw_sidebar` re-renders the cached worktree-preview sections on every
+//! frame. Before #238 each of those warm frames deep-cloned the cached
 //! `SidebarSections` (up to `RECENT_COMMITS_LIMIT` = 300 commit `Line`s, each
 //! with owned `String` spans) purely to dodge a borrow conflict. That hot path
 //! was previously un-benched.
 //!
+//! Since #343 the render path never shells out, so a frame does NOT warm the
+//! cache any more: `App::maybe_refresh_sidebar` spawns a worker and
+//! `App::drain_task_results` stores its `TaskMsg::Sidebar` payload. This bench
+//! seeds that payload directly, the deterministic analogue of the pair, with
+//! no OS thread, exactly as `tests/tui_sidebar_render_tests.rs` does. It went
+//! dead for 1086 commits because it kept drawing a frame and asserting the
+//! cache had filled itself, which is the pre-#343 contract (issue #634).
+//!
 //! This bench drives the public `draw` entry point against a ratatui
-//! `TestBackend` with the sidebar visible and a *warm* cache (we render one
-//! frame to populate it, then time the redraw). It is a full-frame draw, not a
-//! `draw_sidebar`-only micro-bench — `draw_sidebar` is private — but the
-//! worktree table cost is constant across before/after, so the delta is
-//! attributable to the sidebar clone removal.
+//! `TestBackend` with the sidebar visible and a *warm* cache. It is a
+//! full-frame draw, not a `draw_sidebar`-only micro-bench (`draw_sidebar` is
+//! private), but the worktree table cost is constant across before/after, so
+//! the delta is attributable to the sidebar clone removal.
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use git2::{Repository, Signature};
-use gwm::tui::{draw, App};
+use gwm::tui::{build_sidebar_payload, draw, App};
 use ratatui::{backend::TestBackend, Terminal};
 use std::hint::black_box;
 use std::path::Path;
@@ -24,7 +30,8 @@ use tempfile::TempDir;
 
 /// Build a temp git repo carrying `commit_count` commits so the sidebar's
 /// Recent Commits section is fully populated (300 → the `RECENT_COMMITS_LIMIT`
-/// cap) on a warm cache.
+/// cap) on a warm cache. Subjects are `commit-<i>` so the warm-cache assertion
+/// below has a known string to look for on the rendered buffer.
 fn repo_with_commits(commit_count: usize) -> TempDir {
   let dir = TempDir::new().unwrap();
   let repo = Repository::init(dir.path()).unwrap();
@@ -53,6 +60,28 @@ fn repo_with_commits(commit_count: usize) -> TempDir {
   dir
 }
 
+/// Seed `app.sidebar.cache` for the selected worktree + mode. The key has to
+/// come from `app.selected()`, not from the `TempDir` path: libgit2
+/// canonicalises the workdir, so on macOS the two differ (`/private/var/…` vs
+/// `/var/…`) and `draw_sidebar`, which serves the cache only on an exact key
+/// match, would render the "loading…" placeholder instead.
+fn warm_sidebar(app: &mut App) {
+  let w = app.selected().expect("the main worktree is always listed").clone();
+  let mode = app.sidebar.mode;
+  let payload = build_sidebar_payload(
+    &w,
+    mode,
+    &app.config.doctor.trunks,
+    &app.theme,
+    app.config.tui.status_one_line,
+  );
+  assert!(
+    !payload.recent_commits.is_empty(),
+    "a payload built over a 300-commit repo must carry commit lines"
+  );
+  app.sidebar.cache = Some(((w.path.clone(), mode), payload));
+}
+
 fn sidebar_cache_hit(c: &mut Criterion) {
   let dir = repo_with_commits(300);
   // `None` global path keeps construction off the host's real config.
@@ -60,10 +89,24 @@ fn sidebar_cache_hit(c: &mut Criterion) {
   let backend = TestBackend::new(120, 40);
   let mut terminal = Terminal::new(backend).unwrap();
 
-  // Warm the cache: the first frame runs `git log` and stores the rendered
-  // sections. Every timed frame below is a pure cache hit.
+  warm_sidebar(&mut app);
+  // One frame outside the timing loop, asserted on. `cache.is_some()`, the
+  // assertion this bench used to carry, is not the invariant: a payload under
+  // a key that does not match the selection renders the placeholder, and the
+  // bench would still report a plausible number for drawing it. Reading a
+  // commit subject off the buffer pins the warm path itself.
   terminal.draw(|f| draw(f, &mut app)).unwrap();
-  assert!(app.sidebar.cache.is_some(), "cache must be warm before benching");
+  let rendered: String = terminal
+    .backend()
+    .buffer()
+    .content()
+    .iter()
+    .map(|cell| cell.symbol())
+    .collect();
+  assert!(
+    rendered.contains("commit-"),
+    "the timed frame must render cached commit subjects, not the loading placeholder"
+  );
 
   c.bench_function("draw_sidebar_warm_cache_300_commits", |b| {
     b.iter(|| {

--- a/docs/6.development/1.testing.md
+++ b/docs/6.development/1.testing.md
@@ -167,7 +167,14 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-All three must be green. The pre-commit hook lives in [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit); enable it with:
+All three must be green. CI runs one more thing the hook does not: a `benches`
+job runs `cargo bench --benches -- --test`, which builds and runs every
+benchmark once without measuring, so a bench that panics or stops compiling
+goes red. It is a compile-and-run guard, not a performance gate, and there is
+no timing threshold to trip. Run it locally with the same command if you touch
+`benches/`.
+
+The pre-commit hook lives in [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit); enable it with:
 
 ```bash
 git config core.hooksPath tools/git-hooks

--- a/docs/fr/6.development/1.testing.md
+++ b/docs/fr/6.development/1.testing.md
@@ -167,7 +167,14 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-Les trois doivent être au vert. Le hook pre-commit vit dans [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit) ; activez-le avec :
+Les trois doivent être au vert. La CI en lance un de plus que le hook : un job
+`benches` exécute `cargo bench --benches -- --test`, qui compile et lance chaque
+benchmark une fois sans rien mesurer, de sorte qu'un bench qui panique ou qui ne
+compile plus passe au rouge. C'est un garde compile-and-run, pas une barrière de
+performance : il n'y a aucun seuil de temps à déclencher. Lancez-le en local avec
+la même commande si vous touchez à `benches/`.
+
+Le hook pre-commit vit dans [`tools/git-hooks/pre-commit`](https://github.com/kbrdn1/gwm-cli/blob/main/tools/git-hooks/pre-commit) ; activez-le avec :
 
 ```bash
 git config core.hooksPath tools/git-hooks

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -85,8 +85,18 @@ pub fn git_only_bin() -> &'static Path {
       let link = dir.join("git");
       // Recreated rather than reused: the toolchain moves between runs, and a
       // symlink to a garbage-collected nix store path resolves to nothing.
-      let _ = std::fs::remove_file(&link);
-      std::os::unix::fs::symlink(&git, &link).expect("git symlinks into the shim directory");
+      //
+      // Staged under a unique name and renamed into place rather than
+      // unlinked and re-created. The directory is a fixed path, and the
+      // `OnceLock` above only serialises the tests sharing ONE process:
+      // `cargo-nextest` gives each test its own, so several of them reach
+      // here at once and unlink-then-symlink loses that race with
+      // `AlreadyExists`. `rename` is atomic and replaces the destination, so
+      // concurrent callers each publish a link that resolves to the same git.
+      let staging = dir.join(format!("git.{}", std::process::id()));
+      let _ = std::fs::remove_file(&staging);
+      std::os::unix::fs::symlink(&git, &staging).expect("git symlinks into the shim directory");
+      std::fs::rename(&staging, &link).expect("the git shim link moves into place");
       dir
     })
     .as_path()

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -432,9 +432,10 @@ fn ci_test_matrix_runs_on_windows_latest() {
 
 /// `cargo-nextest` has no `cargo install` step on purpose: building it from
 /// source on every runner, windows-latest most of all, costs minutes against
-/// the seconds a prebuilt binary takes, and the swap is only worth making if
-/// the tool arrives cheaply (issue #634). So the install action is pinned
-/// here rather than left to whoever next edits the job.
+/// the seconds a prebuilt binary takes (issue #634). The swap is time-neutral
+/// on wall-clock, so it is bought for process-per-test isolation and cannot
+/// afford to pay minutes for the tool. The install action is pinned here
+/// rather than left to whoever next edits the job.
 #[test]
 fn ci_installs_nextest_from_a_prebuilt_binary() {
   let job = ci_job("test");
@@ -454,7 +455,7 @@ fn ci_installs_nextest_from_a_prebuilt_binary() {
       .iter()
       .any(|r| r.contains("cargo install cargo-nextest")),
     "cargo-nextest must arrive prebuilt: building it from source on every runner \
-     eats the time the pooled run is meant to save"
+     costs minutes, and the swap has no wall-clock gain to spend them from"
   );
 }
 

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -480,6 +480,15 @@ fn ci_runs_the_benches_and_can_fail_on_one() {
     .find(|r| r.contains("cargo bench"))
     .unwrap_or_else(|| panic!("the bench job must run `cargo bench`, got {runs:?}"));
 
+  // `--benches` and not `--bench <name>`: the second builds and runs one
+  // target, which is the partial coverage #634 is about. `cargo bench` alone
+  // would also do, but naming the flag keeps a later `--bench sidebar_cache_hit`
+  // from passing a guard whose whole subject is a bench nobody ran.
+  assert!(
+    bench_run.contains("--benches"),
+    "the bench job must run every bench target (`--benches`), not one by name: the third \
+     bench went unrun for 1086 commits and that is what this job exists to catch, got {bench_run:?}"
+  );
   assert!(
     bench_run.contains("-- --test"),
     "the bench job must pass criterion's `--test` so each bench actually runs \
@@ -697,9 +706,73 @@ fn run_dupe_check(root: &Path, tag: &str) -> std::process::Output {
     .unwrap()
 }
 
-/// Every fence opener inside a `///` or `//!` line under `src/`, paired with
-/// its file and line. Openers only: the closing bare ``` of an open block is
-/// not one, which is the whole reason this tracks state instead of grepping.
+/// The doc-comment "documents" of one source file: each contiguous run of
+/// `///` or `//!` lines, and each `/** */` or `/*! */` block, as the lines
+/// rustdoc would hand to its markdown parser.
+///
+/// Per document, not per file, because rustdoc parses each one as its own
+/// markdown: an unbalanced fence in one cannot invert opener and closer in
+/// the next.
+fn doc_documents(text: &str) -> Vec<(usize, Vec<String>)> {
+  let lines: Vec<&str> = text.lines().collect();
+  let mut docs: Vec<(usize, Vec<String>)> = Vec::new();
+  let mut i = 0;
+  while i < lines.len() {
+    let t = lines[i].trim_start();
+    if let Some(rest) = t.strip_prefix("///").or_else(|| t.strip_prefix("//!")) {
+      let start = i + 1;
+      let mut body = vec![rest.to_string()];
+      i += 1;
+      while i < lines.len() {
+        let t = lines[i].trim_start();
+        let Some(rest) = t.strip_prefix("///").or_else(|| t.strip_prefix("//!")) else {
+          break;
+        };
+        body.push(rest.to_string());
+        i += 1;
+      }
+      docs.push((start, body));
+    } else if t.starts_with("/**") || t.starts_with("/*!") {
+      let start = i + 1;
+      let mut body = Vec::new();
+      let mut first = t[3..].to_string();
+      let mut closed = false;
+      if let Some(cut) = first.find("*/") {
+        first.truncate(cut);
+        closed = true;
+      }
+      body.push(first);
+      i += 1;
+      while !closed && i < lines.len() {
+        let mut l = lines[i].to_string();
+        if let Some(cut) = l.find("*/") {
+          l.truncate(cut);
+          closed = true;
+        }
+        // rustdoc strips the decorative leading `*` of the `/** */` style.
+        let stripped = l.trim_start();
+        body.push(match stripped.strip_prefix('*') {
+          Some(r) => r.to_string(),
+          None => l,
+        });
+        i += 1;
+      }
+      docs.push((start, body));
+    } else {
+      i += 1;
+    }
+  }
+  docs
+}
+
+/// Every fence opener inside a doc comment under `src/`, as
+/// `(file, line, info string)`.
+///
+/// Openers only: the closing fence of an open block is not one, which is why
+/// this tracks state instead of grepping. Both fence characters are handled
+/// (rustdoc's markdown accepts `~~~` as readily as backticks) and a closer
+/// has to match the opener's character and be at least as long, so a four
+/// backtick block quoting a three backtick one closes where it should.
 fn doc_comment_fence_openers() -> Vec<(String, usize, String)> {
   let mut stack = vec![std::path::PathBuf::from("src")];
   let mut files = Vec::new();
@@ -715,75 +788,105 @@ fn doc_comment_fence_openers() -> Vec<(String, usize, String)> {
   }
   files.sort();
 
+  fn fence(line: &str) -> Option<(char, usize, String)> {
+    let t = line.trim_start();
+    let c = t.chars().next().filter(|c| *c == '`' || *c == '~')?;
+    let len = t.chars().take_while(|x| *x == c).count();
+    (len >= 3).then(|| (c, len, t[len..].trim().to_string()))
+  }
+
   let mut openers = Vec::new();
   for file in files {
     // CRLF normalised: a Windows checkout stores these with `\r\n`, and the
-    // info string would carry a trailing `\r` into the classifier below.
+    // info string would carry a trailing `\r` into the classifier.
     let text = fs::read_to_string(&file)
       .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()))
       .replace("\r\n", "\n");
-    let mut open = false;
-    for (i, line) in text.lines().enumerate() {
-      let trimmed = line.trim_start();
-      let Some(rest) = trimmed.strip_prefix("///").or_else(|| trimmed.strip_prefix("//!")) else {
-        continue;
-      };
-      let rest = rest.trim();
-      let Some(info) = rest.strip_prefix("```") else {
-        continue;
-      };
-      if open {
-        open = false; // this one closes the block, it is not an opener
-      } else {
-        open = true;
-        openers.push((file.display().to_string(), i + 1, info.trim().to_string()));
+    for (start, body) in doc_documents(&text) {
+      let mut open: Option<(char, usize)> = None;
+      for (offset, line) in body.iter().enumerate() {
+        let Some((c, len, info)) = fence(line) else {
+          continue;
+        };
+        match open {
+          Some((oc, olen)) if oc == c && len >= olen && info.is_empty() => open = None,
+          Some(_) => {}
+          None => {
+            open = Some((c, len));
+            openers.push((file.display().to_string(), start + offset, info));
+          }
+        }
       }
     }
   }
   openers
 }
 
-/// `cargo nextest run` cannot run doctests: they have no test binary for it to
-/// schedule. #634 took `cargo test` out of the `test` job, and no other
-/// workflow runs `cargo test --doc`, so from that commit on the repo's
-/// doctest coverage is not a property of CI at all. It is a property of
-/// `src/`: there are no Rust fences in doc comments, therefore nothing is
-/// lost. The first one anyone writes is silently never compiled and never
-/// run, which is the same shape of rot as the bench that panicked for 1086
-/// commits with nothing to report it.
+/// Does rustdoc compile this fence's body as a doctest?
 ///
-/// The swap shipped with that stated in a comment, and the comment had the
-/// enumeration wrong: it said every fence was ```text or ```go and missed
-/// four ```toml ones. So this derives the fact rather than asserting a list.
+/// Its rule is `rust &= !seen_other_tags || seen_rust_tags`, starting from
+/// `rust = true`: an empty info string is Rust, and **any** recognised Rust
+/// token keeps it Rust no matter what else sits beside it. Writing that as
+/// "every token must be recognised" is the mistake this function was fixed
+/// out of, and it is not academic. Probed against the local toolchain, all
+/// three of ```` ```rust,zzz_unknown ````, ```` ```edition2024 ```` and
+/// ```` ```compile_fail,E0308 ```` compile and run, and an `all`-based
+/// filter calls all three non-Rust.
 ///
-/// rustdoc compiles a fence as Rust unless its info string carries a token it
-/// does not recognise, so `text`/`toml`/`go` opt out and an empty info string
-/// opts *in*. If this test fails, either tag the new fence with a non-Rust
-/// language, or add a `cargo test --doc` step to `ci.yml` next to the nextest
-/// one and relax the guard to match.
-#[test]
-fn no_doctest_under_src_while_ci_cannot_run_doctests() {
-  const RUST_TOKENS: [&str; 8] = [
+/// `edition` and `ignore-` are prefix matches in rustdoc, not literals, so
+/// they are prefixes here too: an `edition2027` list entry would otherwise
+/// have to be added the year it appears, which is exactly the maintenance a
+/// derived guard exists to avoid.
+fn is_rust_doctest_fence(info: &str) -> bool {
+  const RUST_TOKENS: [&str; 7] = [
     "rust",
     "ignore",
     "should_panic",
     "no_run",
     "compile_fail",
     "test_harness",
-    "edition2018",
-    "edition2021",
+    "standalone_crate",
   ];
+  let info = info.trim();
+  if info.is_empty() {
+    return true;
+  }
+  info
+    .split([',', ' ', '\t'])
+    .map(str::trim)
+    .filter(|t| !t.is_empty())
+    .any(|t| RUST_TOKENS.contains(&t) || t.starts_with("edition") || t.starts_with("ignore-"))
+}
 
+/// `cargo nextest run` cannot run doctests: they have no test binary for it
+/// to schedule. #634 took `cargo test` out of the `test` job, and no other
+/// workflow runs `cargo test --doc`, so from that commit on the repo's
+/// doctest coverage stopped being a property of CI. It is a property of
+/// `src/`: no doc comment carries a Rust fence, therefore nothing is lost.
+/// The first one anyone writes is silently never compiled and never run,
+/// which is the same shape of rot as the bench that panicked for 1086
+/// commits with nothing to report it.
+///
+/// The swap shipped with that stated in a comment, and the comment had the
+/// enumeration wrong: it said every fence was ```text or ```go and missed
+/// four ```toml ones. So this derives the fact rather than asserting a list.
+///
+/// If it fails, either tag the new fence with a non-Rust language, or add a
+/// `cargo test --doc` step to `ci.yml` next to the nextest one and this goes
+/// green on its own: it reads that file's parsed `run:` scripts.
+#[test]
+fn no_doctest_under_src_while_ci_cannot_run_doctests() {
   // Read from the parsed `run:` scripts, never from the file text. The job
   // comment next to the nextest step *names* `cargo test --doc` as the thing
   // to add if a doctest ever appears, so a substring search over `ci.yml`
   // matches that sentence and the guard never fires. It was written that way
   // first, and it stayed green with a bare ``` fence planted under `src/`.
+  let workflow: serde_yaml_ng::Value =
+    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap())
+      .expect("ci.yml must be valid YAML");
   let runs_doctests = ["test", "bench", "msrv"]
     .iter()
     .filter_map(|name| {
-      let workflow: serde_yaml_ng::Value =
-        serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap()).unwrap();
       let job = workflow["jobs"][*name].clone();
       (!job.is_null()).then(|| run_steps(&job))
     })
@@ -791,8 +894,8 @@ fn no_doctest_under_src_while_ci_cannot_run_doctests() {
     .any(|r| r.contains("cargo test --doc"));
 
   let openers = doc_comment_fence_openers();
-  // Not decoration: an empty scan (a moved `src/`, a broken walker) would make
-  // every filter below vacuously true and this guard green on nothing.
+  // Not decoration: an empty scan (a moved `src/`, a broken walker) would
+  // make every filter below vacuously true and this guard green on nothing.
   assert!(
     !openers.is_empty(),
     "the scan found no fenced block at all under src/, which is a broken scan, not a clean tree"
@@ -800,14 +903,8 @@ fn no_doctest_under_src_while_ci_cannot_run_doctests() {
 
   let eligible: Vec<String> = openers
     .into_iter()
-    .filter(|(_, _, info)| {
-      info.is_empty()
-        || info
-          .split([',', ' '])
-          .filter(|t| !t.is_empty())
-          .all(|t| RUST_TOKENS.contains(&t))
-    })
-    .map(|(f, line, info)| format!("{f}:{line} (```{info})"))
+    .filter(|(_, _, info)| is_rust_doctest_fence(info))
+    .map(|(f, line, info)| format!("{f}:{line} (fence info {info:?})"))
     .collect();
 
   assert!(
@@ -816,4 +913,36 @@ fn no_doctest_under_src_while_ci_cannot_run_doctests() {
      since `cargo nextest run` replaced `cargo test`: {eligible:?}. Either tag them with a \
      non-Rust language, or add a `cargo test --doc` step to ci.yml."
   );
+}
+
+/// The classifier, pinned against what the toolchain actually does.
+///
+/// Every case here was run through `cargo test --doc` on a scratch crate
+/// before being written down; the three in the first group are the ones an
+/// `all`-based filter got wrong.
+#[test]
+fn rust_doctest_fence_classification_matches_rustdoc() {
+  for info in [
+    "",
+    "rust",
+    "rust,zzz_unknown",
+    "edition2024",
+    "edition2021",
+    "compile_fail,E0308",
+    "should_panic",
+    "no_run",
+    "ignore",
+    "ignore-windows",
+  ] {
+    assert!(
+      is_rust_doctest_fence(info),
+      "rustdoc runs ```{info} as a doctest, the guard must see it"
+    );
+  }
+  for info in ["text", "toml", "go", "json", "bash", "console", "text,toml"] {
+    assert!(
+      !is_rust_doctest_fence(info),
+      "rustdoc does not run ```{info}, flagging it would make the guard cry wolf"
+    );
+  }
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -499,6 +499,18 @@ fn ci_runs_the_benches_and_can_fail_on_one() {
     steps.iter().all(|s| s["continue-on-error"].is_null()),
     "no step of the bench job may swallow its own failure"
   );
+  // The `doctor` job in this same file is narrowed with an `if:`. Doing that
+  // here would keep all the assertions above green while the benches quietly
+  // stop running on pull requests, which is the state #634 exists to close.
+  assert!(
+    job["if"].is_null(),
+    "the bench job must not be narrowed with an `if:`: it has to run on every event this \
+     workflow runs on, or a dead bench goes unseen again"
+  );
+  assert!(
+    steps.iter().all(|s| s["if"].is_null()),
+    "no step of the bench job may be conditioned away"
+  );
 }
 
 #[test]
@@ -683,4 +695,125 @@ fn run_dupe_check(root: &Path, tag: &str) -> std::process::Output {
     .current_dir(root)
     .output()
     .unwrap()
+}
+
+/// Every fence opener inside a `///` or `//!` line under `src/`, paired with
+/// its file and line. Openers only: the closing bare ``` of an open block is
+/// not one, which is the whole reason this tracks state instead of grepping.
+fn doc_comment_fence_openers() -> Vec<(String, usize, String)> {
+  let mut stack = vec![std::path::PathBuf::from("src")];
+  let mut files = Vec::new();
+  while let Some(d) = stack.pop() {
+    for entry in fs::read_dir(&d).unwrap_or_else(|e| panic!("cannot list {}: {e}", d.display())) {
+      let path = entry.unwrap().path();
+      if path.is_dir() {
+        stack.push(path);
+      } else if path.extension().is_some_and(|e| e == "rs") {
+        files.push(path);
+      }
+    }
+  }
+  files.sort();
+
+  let mut openers = Vec::new();
+  for file in files {
+    // CRLF normalised: a Windows checkout stores these with `\r\n`, and the
+    // info string would carry a trailing `\r` into the classifier below.
+    let text = fs::read_to_string(&file)
+      .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()))
+      .replace("\r\n", "\n");
+    let mut open = false;
+    for (i, line) in text.lines().enumerate() {
+      let trimmed = line.trim_start();
+      let Some(rest) = trimmed.strip_prefix("///").or_else(|| trimmed.strip_prefix("//!")) else {
+        continue;
+      };
+      let rest = rest.trim();
+      let Some(info) = rest.strip_prefix("```") else {
+        continue;
+      };
+      if open {
+        open = false; // this one closes the block, it is not an opener
+      } else {
+        open = true;
+        openers.push((file.display().to_string(), i + 1, info.trim().to_string()));
+      }
+    }
+  }
+  openers
+}
+
+/// `cargo nextest run` cannot run doctests: they have no test binary for it to
+/// schedule. #634 took `cargo test` out of the `test` job, and no other
+/// workflow runs `cargo test --doc`, so from that commit on the repo's
+/// doctest coverage is not a property of CI at all. It is a property of
+/// `src/`: there are no Rust fences in doc comments, therefore nothing is
+/// lost. The first one anyone writes is silently never compiled and never
+/// run, which is the same shape of rot as the bench that panicked for 1086
+/// commits with nothing to report it.
+///
+/// The swap shipped with that stated in a comment, and the comment had the
+/// enumeration wrong: it said every fence was ```text or ```go and missed
+/// four ```toml ones. So this derives the fact rather than asserting a list.
+///
+/// rustdoc compiles a fence as Rust unless its info string carries a token it
+/// does not recognise, so `text`/`toml`/`go` opt out and an empty info string
+/// opts *in*. If this test fails, either tag the new fence with a non-Rust
+/// language, or add a `cargo test --doc` step to `ci.yml` next to the nextest
+/// one and relax the guard to match.
+#[test]
+fn no_doctest_under_src_while_ci_cannot_run_doctests() {
+  const RUST_TOKENS: [&str; 8] = [
+    "rust",
+    "ignore",
+    "should_panic",
+    "no_run",
+    "compile_fail",
+    "test_harness",
+    "edition2018",
+    "edition2021",
+  ];
+
+  // Read from the parsed `run:` scripts, never from the file text. The job
+  // comment next to the nextest step *names* `cargo test --doc` as the thing
+  // to add if a doctest ever appears, so a substring search over `ci.yml`
+  // matches that sentence and the guard never fires. It was written that way
+  // first, and it stayed green with a bare ``` fence planted under `src/`.
+  let runs_doctests = ["test", "bench", "msrv"]
+    .iter()
+    .filter_map(|name| {
+      let workflow: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap()).unwrap();
+      let job = workflow["jobs"][*name].clone();
+      (!job.is_null()).then(|| run_steps(&job))
+    })
+    .flatten()
+    .any(|r| r.contains("cargo test --doc"));
+
+  let openers = doc_comment_fence_openers();
+  // Not decoration: an empty scan (a moved `src/`, a broken walker) would make
+  // every filter below vacuously true and this guard green on nothing.
+  assert!(
+    !openers.is_empty(),
+    "the scan found no fenced block at all under src/, which is a broken scan, not a clean tree"
+  );
+
+  let eligible: Vec<String> = openers
+    .into_iter()
+    .filter(|(_, _, info)| {
+      info.is_empty()
+        || info
+          .split([',', ' '])
+          .filter(|t| !t.is_empty())
+          .all(|t| RUST_TOKENS.contains(&t))
+    })
+    .map(|(f, line, info)| format!("{f}:{line} (```{info})"))
+    .collect();
+
+  assert!(
+    runs_doctests || eligible.is_empty(),
+    "these doc-comment fences are compiled as Rust doctests, and nothing in CI runs them \
+     since `cargo nextest run` replaced `cargo test`: {eligible:?}. Either tag them with a \
+     non-Rust language, or add a `cargo test --doc` step to ci.yml."
+  );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -759,9 +759,14 @@ fn ci_runs_doctests_since_nextest_cannot() {
   // One `if:` is legitimate, and only one: doctests behave identically on the
   // three runners, so this pays for them once on the row with the slack.
   // Anything else is the step being switched off by another name.
-  match step["if"].as_str() {
-    None => {}
-    Some("matrix.os == 'ubuntu-latest'") => {}
-    Some(other) => panic!("the doctest step may only be narrowed to the ubuntu matrix row, got `if: {other}`"),
-  }
+  //
+  // Matched on the VALUE, not through `as_str()`. `if: false` is a YAML
+  // boolean, so `as_str()` hands back `None` for it exactly as it does for an
+  // absent key: the first version of this check used `match … .as_str()` and
+  // the canonical way to switch a step off took its "no `if:` at all" arm.
+  let cond = &step["if"];
+  assert!(
+    cond.is_null() || cond.as_str() == Some("matrix.os == 'ubuntu-latest'"),
+    "the doctest step may only be narrowed to the ubuntu matrix row, got `if: {cond:?}`"
+  );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -425,8 +425,36 @@ fn ci_test_matrix_runs_on_windows_latest() {
     "windows-latest must run the same cargo build step as the other test matrix rows, got {runs:?}"
   );
   assert!(
-    runs.iter().any(|r| r.contains("cargo test")),
-    "windows-latest must run the same cargo test step as the other test matrix rows, got {runs:?}"
+    runs.iter().any(|r| r.contains("cargo nextest run")),
+    "windows-latest must run the same test step as the other test matrix rows, got {runs:?}"
+  );
+}
+
+/// `cargo-nextest` has no `cargo install` step on purpose: building it from
+/// source on every runner, windows-latest most of all, costs minutes against
+/// the seconds a prebuilt binary takes, and the swap is only worth making if
+/// the tool arrives cheaply (issue #634). So the install action is pinned
+/// here rather than left to whoever next edits the job.
+#[test]
+fn ci_installs_nextest_from_a_prebuilt_binary() {
+  let job = ci_job("test");
+  let uses: Vec<String> = job["steps"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|s| s["uses"].as_str().map(str::to_owned))
+    .collect();
+  assert!(
+    uses.iter().any(|u| u.starts_with("taiki-e/install-action")),
+    "the test job must install cargo-nextest from a prebuilt binary, got {uses:?}"
+  );
+  assert!(
+    !run_steps(&job)
+      .iter()
+      .any(|r| r.contains("cargo install cargo-nextest")),
+    "cargo-nextest must arrive prebuilt: building it from source on every runner \
+     eats the time the pooled run is meant to save"
   );
 }
 

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -706,243 +706,34 @@ fn run_dupe_check(root: &Path, tag: &str) -> std::process::Output {
     .unwrap()
 }
 
-/// The doc-comment "documents" of one source file: each contiguous run of
-/// `///` or `//!` lines, and each `/** */` or `/*! */` block, as the lines
-/// rustdoc would hand to its markdown parser.
-///
-/// Per document, not per file, because rustdoc parses each one as its own
-/// markdown: an unbalanced fence in one cannot invert opener and closer in
-/// the next.
-fn doc_documents(text: &str) -> Vec<(usize, Vec<String>)> {
-  let lines: Vec<&str> = text.lines().collect();
-  let mut docs: Vec<(usize, Vec<String>)> = Vec::new();
-  let mut i = 0;
-  while i < lines.len() {
-    let t = lines[i].trim_start();
-    if let Some(rest) = t.strip_prefix("///").or_else(|| t.strip_prefix("//!")) {
-      let start = i + 1;
-      let mut body = vec![rest.to_string()];
-      i += 1;
-      while i < lines.len() {
-        let t = lines[i].trim_start();
-        let Some(rest) = t.strip_prefix("///").or_else(|| t.strip_prefix("//!")) else {
-          break;
-        };
-        body.push(rest.to_string());
-        i += 1;
-      }
-      docs.push((start, body));
-    } else if t.starts_with("/**") || t.starts_with("/*!") {
-      let start = i + 1;
-      let mut body = Vec::new();
-      let mut first = t[3..].to_string();
-      let mut closed = false;
-      if let Some(cut) = first.find("*/") {
-        first.truncate(cut);
-        closed = true;
-      }
-      body.push(first);
-      i += 1;
-      while !closed && i < lines.len() {
-        let mut l = lines[i].to_string();
-        if let Some(cut) = l.find("*/") {
-          l.truncate(cut);
-          closed = true;
-        }
-        // rustdoc strips the decorative leading `*` of the `/** */` style.
-        let stripped = l.trim_start();
-        body.push(match stripped.strip_prefix('*') {
-          Some(r) => r.to_string(),
-          None => l,
-        });
-        i += 1;
-      }
-      docs.push((start, body));
-    } else {
-      i += 1;
-    }
-  }
-  docs
-}
-
-/// Every fence opener inside a doc comment under `src/`, as
-/// `(file, line, info string)`.
-///
-/// Openers only: the closing fence of an open block is not one, which is why
-/// this tracks state instead of grepping. Both fence characters are handled
-/// (rustdoc's markdown accepts `~~~` as readily as backticks) and a closer
-/// has to match the opener's character and be at least as long, so a four
-/// backtick block quoting a three backtick one closes where it should.
-fn doc_comment_fence_openers() -> Vec<(String, usize, String)> {
-  let mut stack = vec![std::path::PathBuf::from("src")];
-  let mut files = Vec::new();
-  while let Some(d) = stack.pop() {
-    for entry in fs::read_dir(&d).unwrap_or_else(|e| panic!("cannot list {}: {e}", d.display())) {
-      let path = entry.unwrap().path();
-      if path.is_dir() {
-        stack.push(path);
-      } else if path.extension().is_some_and(|e| e == "rs") {
-        files.push(path);
-      }
-    }
-  }
-  files.sort();
-
-  fn fence(line: &str) -> Option<(char, usize, String)> {
-    let t = line.trim_start();
-    let c = t.chars().next().filter(|c| *c == '`' || *c == '~')?;
-    let len = t.chars().take_while(|x| *x == c).count();
-    (len >= 3).then(|| (c, len, t[len..].trim().to_string()))
-  }
-
-  let mut openers = Vec::new();
-  for file in files {
-    // CRLF normalised: a Windows checkout stores these with `\r\n`, and the
-    // info string would carry a trailing `\r` into the classifier.
-    let text = fs::read_to_string(&file)
-      .unwrap_or_else(|e| panic!("cannot read {}: {e}", file.display()))
-      .replace("\r\n", "\n");
-    for (start, body) in doc_documents(&text) {
-      let mut open: Option<(char, usize)> = None;
-      for (offset, line) in body.iter().enumerate() {
-        let Some((c, len, info)) = fence(line) else {
-          continue;
-        };
-        match open {
-          Some((oc, olen)) if oc == c && len >= olen && info.is_empty() => open = None,
-          Some(_) => {}
-          None => {
-            open = Some((c, len));
-            openers.push((file.display().to_string(), start + offset, info));
-          }
-        }
-      }
-    }
-  }
-  openers
-}
-
-/// Does rustdoc compile this fence's body as a doctest?
-///
-/// Its rule is `rust &= !seen_other_tags || seen_rust_tags`, starting from
-/// `rust = true`: an empty info string is Rust, and **any** recognised Rust
-/// token keeps it Rust no matter what else sits beside it. Writing that as
-/// "every token must be recognised" is the mistake this function was fixed
-/// out of, and it is not academic. Probed against the local toolchain, all
-/// three of ```` ```rust,zzz_unknown ````, ```` ```edition2024 ```` and
-/// ```` ```compile_fail,E0308 ```` compile and run, and an `all`-based
-/// filter calls all three non-Rust.
-///
-/// `edition` and `ignore-` are prefix matches in rustdoc, not literals, so
-/// they are prefixes here too: an `edition2027` list entry would otherwise
-/// have to be added the year it appears, which is exactly the maintenance a
-/// derived guard exists to avoid.
-fn is_rust_doctest_fence(info: &str) -> bool {
-  const RUST_TOKENS: [&str; 7] = [
-    "rust",
-    "ignore",
-    "should_panic",
-    "no_run",
-    "compile_fail",
-    "test_harness",
-    "standalone_crate",
-  ];
-  let info = info.trim();
-  if info.is_empty() {
-    return true;
-  }
-  info
-    .split([',', ' ', '\t'])
-    .map(str::trim)
-    .filter(|t| !t.is_empty())
-    .any(|t| RUST_TOKENS.contains(&t) || t.starts_with("edition") || t.starts_with("ignore-"))
-}
-
 /// `cargo nextest run` cannot run doctests: they have no test binary for it
-/// to schedule. #634 took `cargo test` out of the `test` job, and no other
-/// workflow runs `cargo test --doc`, so from that commit on the repo's
-/// doctest coverage stopped being a property of CI. It is a property of
-/// `src/`: no doc comment carries a Rust fence, therefore nothing is lost.
-/// The first one anyone writes is silently never compiled and never run,
-/// which is the same shape of rot as the bench that panicked for 1086
+/// to schedule. #634 took `cargo test` out of this job, so unless something
+/// runs them explicitly the repo silently stops compiling every `///` example
+/// it has, which is the same shape of rot as the bench that panicked for 1086
 /// commits with nothing to report it.
 ///
-/// The swap shipped with that stated in a comment, and the comment had the
-/// enumeration wrong: it said every fence was ```text or ```go and missed
-/// four ```toml ones. So this derives the fact rather than asserting a list.
+/// This pins the step rather than the property, on purpose, and the detour is
+/// worth recording. The first version of this guard scanned `src/` and decided
+/// for itself which fences rustdoc would compile, so that CI would not have to
+/// pay for a doctest run. Two review passes probed it against the toolchain
+/// and it was wrong ten ways: indented blocks carrying no fence at all, fences
+/// nested in a blockquote (`src/forge.rs` already writes that style), `~~~`,
+/// `/** */` blocks, `#[doc = "..."]` attributes, `{.rust}`, and the tag rules
+/// themselves, which turn out to be order-sensitive on 1.96.1
+/// (```` ```no_run,text ```` is a doctest, ```` ```text,no_run ```` is not).
 ///
-/// If it fails, either tag the new fence with a non-Rust language, or add a
-/// `cargo test --doc` step to `ci.yml` next to the nextest one and this goes
-/// green on its own: it reads that file's parsed `run:` scripts.
+/// Every one of those was found by asking rustdoc. Which is the point: the
+/// oracle was there the whole time, it costs about 35 seconds, and pinning it
+/// to ubuntu keeps it off a critical path that windows holds for four minutes
+/// more. An emulation that has to track rustdoc's release notes to stay
+/// correct is a worse guard than the thing it emulates, however cheap it runs.
 #[test]
-fn no_doctest_under_src_while_ci_cannot_run_doctests() {
-  // Read from the parsed `run:` scripts, never from the file text. The job
-  // comment next to the nextest step *names* `cargo test --doc` as the thing
-  // to add if a doctest ever appears, so a substring search over `ci.yml`
-  // matches that sentence and the guard never fires. It was written that way
-  // first, and it stayed green with a bare ``` fence planted under `src/`.
-  let workflow: serde_yaml_ng::Value =
-    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap())
-      .expect("ci.yml must be valid YAML");
-  let runs_doctests = ["test", "bench", "msrv"]
-    .iter()
-    .filter_map(|name| {
-      let job = workflow["jobs"][*name].clone();
-      (!job.is_null()).then(|| run_steps(&job))
-    })
-    .flatten()
-    .any(|r| r.contains("cargo test --doc"));
-
-  let openers = doc_comment_fence_openers();
-  // Not decoration: an empty scan (a moved `src/`, a broken walker) would
-  // make every filter below vacuously true and this guard green on nothing.
+fn ci_runs_doctests_since_nextest_cannot() {
+  let job = ci_job("test");
+  let runs = run_steps(&job);
   assert!(
-    !openers.is_empty(),
-    "the scan found no fenced block at all under src/, which is a broken scan, not a clean tree"
+    runs.iter().any(|r| r.contains("cargo test --doc")),
+    "the test job must run `cargo test --doc`: nextest cannot, and nothing else in the repo \
+     does, so without it every doctest under src/ is compiled and run by nobody. Got {runs:?}"
   );
-
-  let eligible: Vec<String> = openers
-    .into_iter()
-    .filter(|(_, _, info)| is_rust_doctest_fence(info))
-    .map(|(f, line, info)| format!("{f}:{line} (fence info {info:?})"))
-    .collect();
-
-  assert!(
-    runs_doctests || eligible.is_empty(),
-    "these doc-comment fences are compiled as Rust doctests, and nothing in CI runs them \
-     since `cargo nextest run` replaced `cargo test`: {eligible:?}. Either tag them with a \
-     non-Rust language, or add a `cargo test --doc` step to ci.yml."
-  );
-}
-
-/// The classifier, pinned against what the toolchain actually does.
-///
-/// Every case here was run through `cargo test --doc` on a scratch crate
-/// before being written down; the three in the first group are the ones an
-/// `all`-based filter got wrong.
-#[test]
-fn rust_doctest_fence_classification_matches_rustdoc() {
-  for info in [
-    "",
-    "rust",
-    "rust,zzz_unknown",
-    "edition2024",
-    "edition2021",
-    "compile_fail,E0308",
-    "should_panic",
-    "no_run",
-    "ignore",
-    "ignore-windows",
-  ] {
-    assert!(
-      is_rust_doctest_fence(info),
-      "rustdoc runs ```{info} as a doctest, the guard must see it"
-    );
-  }
-  for info in ["text", "toml", "go", "json", "bash", "console", "text,toml"] {
-    assert!(
-      !is_rust_doctest_fence(info),
-      "rustdoc does not run ```{info}, flagging it would make the guard cry wolf"
-    );
-  }
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -736,4 +736,32 @@ fn ci_runs_doctests_since_nextest_cannot() {
     "the test job must run `cargo test --doc`: nextest cannot, and nothing else in the repo \
      does, so without it every doctest under src/ is compiled and run by nobody. Got {runs:?}"
   );
+
+  // Present is not the same as running. `run_steps` flattens the steps and
+  // reports their scripts whatever their `if:`, so `if: false` would leave
+  // the assertion above green over a step that never executes, and
+  // `continue-on-error` would leave it green over one that never fails. That
+  // is not hypothetical here: `continue-on-error` on the `audit` job is what
+  // hid RUSTSEC-2025-0068 for nine months, and the bench job carries the same
+  // pair of assertions for the same reason.
+  let step = job["steps"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .into_iter()
+    .find(|s| s["run"].as_str().is_some_and(|r| r.contains("cargo test --doc")))
+    .expect("the `cargo test --doc` step was found in the scripts, so it must be in the steps");
+  assert!(
+    step["continue-on-error"].is_null(),
+    "the doctest step must be able to fail the job: a doctest that runs and is not allowed to \
+     go red is a doctest nobody runs"
+  );
+  // One `if:` is legitimate, and only one: doctests behave identically on the
+  // three runners, so this pays for them once on the row with the slack.
+  // Anything else is the step being switched off by another name.
+  match step["if"].as_str() {
+    None => {}
+    Some("matrix.os == 'ubuntu-latest'") => {}
+    Some(other) => panic!("the doctest step may only be narrowed to the ubuntu matrix row, got `if: {other}`"),
+  }
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -376,25 +376,99 @@ fn docs_sync_watches_every_root_the_site_reads() {
   }
 }
 
+/// One `ci.yml` job by name, parsed. The text-slicing predecessor of this
+/// helper cut the `test` job out between the literal `  test:` and
+/// `\n  hook-smoke:` markers, so inserting any job between the two silently
+/// emptied what the assertions ran against, the same failure mode the `msrv`
+/// tests already parse the YAML to avoid.
+fn ci_job(name: &str) -> serde_yaml_ng::Value {
+  let workflow: serde_yaml_ng::Value =
+    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap())
+      .expect("ci.yml must be valid YAML");
+  let job = workflow["jobs"][name].clone();
+  assert!(!job.is_null(), "ci.yml must define a `{name}` job");
+  job
+}
+
+/// The `run:` scripts of a job's steps, in order.
+fn run_steps(job: &serde_yaml_ng::Value) -> Vec<String> {
+  job["steps"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|s| s["run"].as_str().map(str::to_owned))
+    .collect()
+}
+
 #[test]
 fn ci_test_matrix_runs_on_windows_latest() {
-  let workflow = fs::read_to_string(".github/workflows/ci.yml").unwrap();
-  let test_job = workflow
-    .split("  test:")
-    .nth(1)
-    .and_then(|tail| tail.split("\n  hook-smoke:").next())
-    .expect("ci.yml must contain a test job before hook-smoke");
+  let job = ci_job("test");
+  let matrix: Vec<String> = job["strategy"]["matrix"]["os"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|v| v.as_str().map(str::to_owned))
+    .collect();
 
   for os in ["ubuntu-latest", "macos-latest", "windows-latest"] {
-    assert!(test_job.contains(os), "ci.yml test matrix must include {os}");
+    assert!(
+      matrix.iter().any(|m| m == os),
+      "ci.yml test matrix must include {os} (matrix is {matrix:?})"
+    );
   }
+
+  let runs = run_steps(&job);
   assert!(
-    test_job.contains("run: cargo build --verbose"),
-    "windows-latest must run the same cargo build step as the other test matrix rows"
+    runs.iter().any(|r| r.contains("cargo build")),
+    "windows-latest must run the same cargo build step as the other test matrix rows, got {runs:?}"
   );
   assert!(
-    test_job.contains("run: cargo test --verbose"),
-    "windows-latest must run the same cargo test step as the other test matrix rows"
+    runs.iter().any(|r| r.contains("cargo test")),
+    "windows-latest must run the same cargo test step as the other test matrix rows, got {runs:?}"
+  );
+}
+
+/// Issue #634: `benches/sidebar_cache_hit.rs` panicked for 1086 commits and
+/// nobody noticed, because no job ran the benches. `cargo bench` also aborts
+/// at the first failure, so it masked the third bench on top. This pins the
+/// job that would have caught it.
+///
+/// Two properties, both load-bearing:
+///
+/// - it must actually RUN them (`--test` is criterion's run-once-measure-
+///   nothing mode), not just `--no-run` them: a bench that builds and then
+///   panics is exactly the case that went unseen;
+/// - it must be able to go red: no `continue-on-error`, and no pipe on the
+///   command, which would report the pipe's exit code instead of the runner's.
+#[test]
+fn ci_runs_the_benches_and_can_fail_on_one() {
+  let job = ci_job("bench");
+  let runs = run_steps(&job);
+  let bench_run = runs
+    .iter()
+    .find(|r| r.contains("cargo bench"))
+    .unwrap_or_else(|| panic!("the bench job must run `cargo bench`, got {runs:?}"));
+
+  assert!(
+    bench_run.contains("-- --test"),
+    "the bench job must pass criterion's `--test` so each bench actually runs \
+     once (and the job stays a compile-and-run guard, not a timing gate), got {bench_run:?}"
+  );
+  assert!(
+    !bench_run.contains('|'),
+    "piping the bench command reports the pipe's exit code, not the bench runner's, \
+     the panic this job exists to catch would be swallowed, got {bench_run:?}"
+  );
+  assert!(
+    job["continue-on-error"].is_null(),
+    "the bench job must be able to fail the workflow: a dead bench is what #634 is about"
+  );
+  let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
+  assert!(
+    steps.iter().all(|s| s["continue-on-error"].is_null()),
+    "no step of the bench job may swallow its own failure"
   );
 }
 


### PR DESCRIPTION
## Description

The perf guards were off. `benches/sidebar_cache_hit.rs` panicked on every
run for 1086 commits, no job ran the benches, and the test job ran 110
binaries in sequence.

Closes #634

## Type of change

- [ ] ✨ Feature (new functionality)
- [x] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [x] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [x] 🔧 Chore / CI / build

## Changes

- **`benches/sidebar_cache_hit.rs` warms the cache the way the app does.**
  It drew one frame and asserted the cache had filled itself, which was the
  contract when it was written in #238. #351 took git off the render path,
  so a frame warms nothing. It now seeds the payload through
  `build_sidebar_payload` under the selected worktree's key, the
  deterministic analogue of `maybe_refresh_sidebar` spawning a worker and
  `drain_task_results` applying its `TaskMsg::Sidebar`. That is exactly how
  `tests/tui_sidebar_render_tests.rs` already warms its cache.
- **`cache.is_some()` does not come back as the guard.** It is the assertion
  that let this rot: `draw_sidebar` serves the cache only on an exact key
  match and renders a "loading..." placeholder otherwise, so a payload under
  a stale key would still have produced a plausible number. The key is read
  off `app.selected()` and cannot drift, and the timed frame is asserted to
  carry a real commit subject.
- **New `bench` job.** ubuntu-only, `cargo bench --benches -- --test`.
  Criterion's `--test` runs each benchmark once and measures nothing, so the
  job fails on a panic or a build break and never on timing noise. The
  command is unpiped on purpose: a pipe reports its own exit code, not the
  runner's.
- **`cargo test` becomes `cargo nextest run`**, installed prebuilt from
  `taiki-e/install-action@nextest`. The MSRV job is untouched.
- **`tests/common/mod.rs` publishes its git shim link atomically.** The
  first full nextest run failed a capture test with `AlreadyExists`: the shim
  directory is a fixed path and the `OnceLock` guarding it only serialises
  one process, so process-per-test made several callers race an
  unlink-then-symlink. Staged under a pid-unique name and `rename`d into
  place instead.
- **The workflow test parses the YAML instead of slicing the file.** It cut
  the `test` job out between the literal `  test:` and `\n  hook-smoke:`
  markers, so inserting a job between the two would have silently emptied
  what it asserted against. That is the same failure mode the `msrv` tests
  already parse YAML to avoid.

## Tests

- [x] `cargo test` passes locally
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] New tests added under `tests/`

New guards in `tests/release_workflow_tests.rs`, every assertion proved red
before being committed:

| guard | broken how | result |
|:--|:--|:--|
| `ci_runs_the_benches_and_can_fail_on_one` | no `bench` job | `ci.yml must define a 'bench' job` |
| same | `continue-on-error: true` on the job | `must be able to fail the workflow` |
| same | `\| tail -20` on the command | fires on the pipe |
| same | `if: github.event_name == 'push'` on the job | `must not be narrowed with an if:` |
| same | `--bench sidebar_cache_hit` instead of `--benches` | `must run every bench target` |
| `ci_installs_nextest_from_a_prebuilt_binary` | `cargo install cargo-nextest` | `must install cargo-nextest from a prebuilt binary` |
| `ci_test_matrix_runs_on_windows_latest` | back to `cargo test --verbose` | `must run the same test step` |
| `ci_runs_doctests_since_nextest_cannot` | step removed | `must run cargo test --doc` |
| same | `continue-on-error: true` on the step | `must be able to fail the job` |
| same | `if: github.event_name == 'schedule'` on the step | `may only be narrowed to the ubuntu matrix row` |

The bench fix itself is proved the same way. Restoring the pre-fix bench and
running the job's exact command:

```
     Running benches/sidebar_cache_hit.rs
thread 'main' panicked at benches/sidebar_cache_hit.rs:66:3:
cache must be warm before benching
error: bench failed, to rerun pass `--bench sidebar_cache_hit`
EXIT=101
```

and with the fix, all three report:

```
     Running benches/commit_graph.rs
Testing render_commits_300_rows
Success
     Running benches/sidebar_cache_hit.rs
Testing draw_sidebar_warm_cache_300_commits
Success
     Running benches/sidebar_recent_commits.rs
Testing recent_commits_lines_300_rows
Success
```

`cargo test --doc` runs in CI on the ubuntu row and reports `Doc-tests gwm /
running 0 tests` there, so the swap drops no doctest coverage and cannot start
dropping it silently either.

That sentence used to read "every ``` fence under `src/` is a ```text or
```go block", which was the hand-written enumeration three review passes
spent disproving. It is not restated here in a corrected form on purpose:
counting fences by hand is what went wrong, and the step above is the thing
that knows the answer.

## Screenshots / TUI captures

n/a

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed
- [ ] `examples/gwm.toml.example` updated if config schema changed
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead)
- [x] No `println!` in TUI render code (status bar only)

## Linked issues / docs

- Issue: #634

## Notes for reviewers

### The before/after the issue asks for

Answered from a distribution, not from single runs. Two earlier versions of
this section were answered from one pair of runs and then from two, which is
how "1.76x" got written down and then how "a wash" got written down. Both
were one draw from a wide band.

**Method.** 11 `cargo test` runs on `dev` (2026-09-01 to 09-07) against 4 runs
of the swapped job (three commits on this branch plus a re-run of one).
Execution time only, taken from nextest's `Summary` line and from the sum of
`cargo test`'s per-binary `finished in`. Normalised per test, because the
suite grew from 3273 to 3525 tests across the window and raw seconds do not
compare. Summing per-binary `finished in` excludes cargo's own overhead
between binaries, so the baseline is if anything under-counted.

**What the sample is worth.** The 11 baseline runs are 11 different commits
across seven days. The 4 post-swap runs are not equivalent: two of them are
the same commit re-run, so they share a warm cache and likely similar runner
hardware and are not independent draws. n=4 is thin and n=3-independent is
thinner. That is the main reason the deltas below are reported as a tendency
and not as a result.

| median ms/test | before (n=11) | after (n=4) | delta |
|:--|--:|--:|--:|
| ubuntu-latest | 9.65 | 8.79 | **-8.9%** |
| macos-latest | 17.40 | 16.26 | **-6.5%** |
| windows-latest | 36.09 | 36.40 | +0.8% |

And the spreads, which are the point:

| exec seconds | before (n=11) | after (n=4) |
|:--|--:|--:|
| ubuntu-latest | 33.7 [29.2 - 42.2] | 31.0 [29.8 - 47.0] |
| macos-latest | 60.5 [45.0 - 67.0] | 57.3 [51.4 - 63.6] |
| windows-latest | 120.5 [101.5 - 142.9] | 123.4 [106.1 - 133.5] |

**Read it as:** a real effect, in the same direction on both Unix runners, but
single-digit and inside a band far wider than itself. Nothing on windows, and
every macos and windows sample lands inside the `cargo test` spread. 29.2s to 42.2s on ubuntu for the same command on the same suite is a
44% band; a single-digit median shift inside it is not a saving anyone can
plan around. It is also nowhere near the 1.76x, which is not refuted, it just
does not transfer: it came off a local 8-core machine where a binary holding a
handful of tests leaves most cores idle. A runner has fewer cores, so a
per-binary pool already saturates them and process-spawn overhead eats the
headroom.

**The wall-clock the criterion asks for**, same runs, the whole `cargo test` /
`cargo nextest run` step including the build of the 110 test binaries:

| test step | before (n=11) | after (n=4) |
|:--|--:|--:|
| ubuntu-latest | 78 s [75 - 97] | 76 s [76 - 105] |
| macos-latest | 113 s [86 - 133] | 110 s [103 - 118] |
| windows-latest | 246 s [223 - 292] | 262 s [240 - 279] |

Indistinguishable, and that is expected rather than disappointing: the step
compiles the 110 test binaries before running a single test, identically under
both runners, so most of what it measures cannot move. It is reported because
the criterion asks for it and because it is the number that decides whether
the swap is worth carrying end to end. The per-test table above is what
explains it.

**So the swap stays, on what it actually buys.** This description set the
removal trigger at "if nextest loses on all three"; it loses on one, by 0.8%.
`ci.yml`, the CHANGELOG and one assert message now claim process-per-test
isolation rather than a saving. That isolation found the `tests/common/mod.rs`
race on the first run and surfaces `3 leaky` on windows that `cargo test`
never reported. If carrying the tool for that alone is not worth it to you,
dropping the nextest commits leaves the bench fix and the bench job standing
on their own; say so and I will.

### Review passes

Two fresh agents per pass, conformance and intent axes run separately so
neither reranks the other.

**Pass 1** (`P0=0 P1=0 P2=1 P3=6`), fixed in `5da10cdd`, `b32a09d9`, `c5a7bf69`:

- **P2, both reviewers independently.** The doctest comment was unenforced
  *and* its enumeration was wrong: it said every fence under `src/` was
  ```text or ```go and missed four ```toml ones. The conclusion held by luck.
  A derived guard replaces it. Worth flagging how that guard was written wrong
  first: it tested `ci.yml.contains("cargo test --doc")`, which matches the job
  comment naming that command as the remedy, so it stayed green with a bare
  ``` fence planted under `src/`. It reads parsed `run:` scripts now.
- **P3.** Nothing stopped an `if:` from narrowing the `bench` job, which the
  `doctor` job in the same file shows is not hypothetical. Pinned.
- **P3.** `benches` was missing from both places that document the CI gate.
- **P3, evidence gap.** Only `--test` output had been pasted, so the timed
  `b.iter()` loop had never been shown running under measurement. It does:

  ```
  Benchmarking draw_sidebar_warm_cache_300_commits: Collecting 10 samples in estimated 2.0048 s (7480 iterations)
  draw_sidebar_warm_cache_300_commits
                          time:   [307.72 us 351.18 us 375.38 us]
  ```

  (Wide, and the machine was at load 73. The point is that it reports.)

**Pass 2** (`P0=0 P1=0 P2=2 P3=2`), fixed in `614094ac` and in this
description. The conformance reviewer did the right thing and **probed the new
guard against the toolchain instead of reading it**, which found five fence
forms rustdoc runs as doctests and the guard reported absent. Reproduced on a
scratch crate before changing anything, all five run:

```
```rust,zzz_unknown     ```edition2024     ```compile_fail,E0308
/** */ block docs       ~~~ fences
```

Two distinct mistakes behind them. The classifier required that *every*
info-string token be recognised; rustdoc requires the opposite, it starts from
Rust and only leaves on an unrecognised token with no recognised one beside it
(`rust &= !seen_other_tags || seen_rust_tags`), and matches `edition` and
`ignore-` by prefix rather than by literal. The scanner only read `///` and
`//!` lines with backtick fences, and tracked open/closed per *file* where
rustdoc parses each doc comment as its own markdown document. All six red
cases are proved red, the ```text and ```toml controls proved still green, and
a table test pins the classification against what the toolchain does.

The same pass caught that `cargo bench --bench sidebar_cache_hit -- --test`
satisfied every assertion the bench guard had while running one of three
targets, which is the exact partial coverage that let the third bench go unrun
for 1086 commits. `--benches` is pinned now.

The intent reviewer's P2 was that criterion 6 asks for wall-clock and I had
replaced it with a normalised metric. Correct, and the table is back above.

**Pass 3** (`P0=0 P1=1 P2=1 P3=2` conformance, `(none)` on intent), which is
the one that mattered. Probing again, the rewritten scanner still declared
absent four more forms rustdoc compiles and runs, all reproduced before
anything was changed:

```
indented blocks, carrying no fence at all
fences nested in a blockquote      (src/forge.rs already writes that style)
#[doc = "..."] attributes
```{.rust}
```

And the tag rules turned out to be **order-sensitive** on 1.96.1, which pass
2's fix had asserted they were not: ```` ```no_run,text ```` is a doctest,
```` ```text,no_run ```` is not. So the classifier had false positives on top,
raising a red whose own remedy was already applied.

### Why the scanner is gone

That is ten divergences across two passes, every one of them found the same
way: by asking rustdoc. The tell was not any individual miss. It was that the
oracle had been sitting there the whole time, and the scanner existed only to
avoid paying for it.

The price is 35 s, and I had costed it wrong: I priced three runners when
doctests are the same on all three. On ubuntu alone it lands in a job that
carries roughly three minutes of slack against windows in the same matrix, so
it never reaches the workflow's critical path.

So `cargo test --doc` runs next to nextest, **232 lines of emulation come
out**, and what stays is one guard pinning that the step is still there. An
emulation that has to track rustdoc's release notes to stay correct is a worse
guard than the thing it emulates, however cheaply it runs. This also restores
the capability instead of banning it, which is the objection pass 2 raised and
I answered with the miscosted number.

**Pass 4** (`P0=0 P1=0 P2=1 P3=2` conformance, `P0=0 P1=0 P2=1 P3=1` intent),
fixed in `00cf314d` and in this description. Both reviewers landed on the same
hole from different sides: `run_steps` flattens a job and reports every `run:`
whatever its `if:`, so the guard shipped with the doctest step asserted the
step was *present*, not that it runs or that it can fail. `if: false` would
have left it green over a step that never executes, `continue-on-error` over
one that never goes red. Not theoretical in this repo, and one reviewer named
the precedent: `continue-on-error` on the `audit` job is what hid
RUSTSEC-2025-0068 for nine months. Both assertions are pinned and proved red,
with the one legitimate `if:` spelled out rather than merely tolerated.

Conformance also caught that the `benches` paragraph went into the English
testing page and not its French mirror, though every prior edit of that page
moved both together. Intent caught that this description still argued for the
design pass 3 had replaced. Both fixed.

**Pass 5** (`P0=0 P1=0 P2=1 P3=0` conformance, `(none)` on intent, all nine
acceptance criteria walked one by one). One finding, and it is the sharpest of
the run because the code looked right: the `if:` check added in pass 4 matched
on `step["if"].as_str()`, and `if: false` is a YAML *boolean*, so `as_str()`
hands back `None` for it exactly as for an absent key. The canonical way to
switch a step off took the "no `if:` at all" arm and passed. The reviewer
found it by mutation, not by reading, which is the only way it was going to
surface. Fixed in `6bb82758` and proved red three ways (`if: false`,
`if: true`, a foreign condition); the first two were green before.

### Why the review stopped at five passes

Passes 1 to 3 found defects in the work. Passes 4 and 5 found defects in the
previous pass's fix. That is the point where a review loop stops paying and
starts circling its own tail, so it stops here rather than at its iteration
cap.

To be exact about the state, since "the loop stopped" can be read as a clean
verdict and this is not quite one: the intent axis ended clean at pass 5
(`P0=0 P1=0 P2=0 P3=0`, all nine criteria walked one by one). The conformance
axis ended with one P2, which is fixed and proved red three ways, but no
further pass has reviewed that fix.

Stopping is justified rather than merely declared, though, because the last
fix closes its question by construction instead of by enumeration: the check
is `is_null() || as_str() == Some("matrix.os == 'ubuntu-latest'")`, and there
is no third way for a YAML value to satisfy it. Booleans, numbers, other
strings, sequences and mappings all fail. That is the property the previous
four attempts kept missing by listing cases, and it is why there is nothing
left for a sixth pass to enumerate.

### Follow-up, needs a maintainer decision

`benches` is not in the seven required status checks, so a red bench fails a
PR's checks without blocking the protected `dev` to `main` merge. Promoting it
means editing the branch protection, which is outside this PR. Documented as a
deliberate exception in CONTRIBUTING for now.

Two other things worth an eye:

- Windows reports `3 leaky` under nextest: tests that pass but outlive their
  own process. Not blocking, and `cargo test` never surfaced it.
- The `bench` job's first run builds the bench profile cold, which inherits
  `lto = "thin"` from release. That is expensive once; `Swatinem/rust-cache`
  keys per job, so it should not repeat.

https://claude.ai/code/session_01WaCsmipqLcuX8kDY1swzbJ











