### PR TITLE
✅ test(ci): msrv, test and audit could go quiet without a guard moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three CI jobs could be switched off without a test going red**
+  ([#646](https://github.com/kbrdn1/gwm-cli/issues/646)). GitHub Actions
+  resolves `if:` and `continue-on-error:` at the job level as well as the
+  step level, and the job wins. Every guard covering `msrv`, `test` and
+  `audit` read `step[...]` and never the job containing it, so `if: false`
+  on the `test` job left all 19 tests in `release_workflow_tests` green
+  while `cargo build`, `cargo nextest run` and `cargo test --doc` had
+  stopped running. `audit` had no test naming it at all, which is the job
+  whose `continue-on-error` hid RUSTSEC-2025-0068 for nine months.
+
+  The triplet already written for `bench` is now one helper,
+  `assert_job_is_blocking`, shared by the two test binaries that parse
+  `ci.yml` and applied to all four jobs. It also refuses an absent job and
+  an empty `steps:`, because a deleted job parses to null and every
+  assertion walks past null. A step that needs a condition passes its exact
+  value rather than a waiver, so the one legitimate `if:` in the tree, the
+  doctest step narrowed to the ubuntu matrix row, is still pinned to that
+  condition. The `audit` guard adds `--deny warnings` and rejects a pipe on
+  the command, since a pipeline reports its last element's exit status.
+
+  Each guard was proved by mutating `ci.yml` and rerunning the two affected
+  binaries, `bench` included, so the refactor cannot have traded coverage
+  for a shared definition.
+
 - **The warm-cache sidebar bench runs again, and a CI job now runs the
   benches** ([#634](https://github.com/kbrdn1/gwm-cli/issues/634)).
   `benches/sidebar_cache_hit.rs` drew one frame and asserted the sidebar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   condition. The `audit` guard adds `--deny warnings` and rejects a pipe on
   the command, since a pipeline reports its last element's exit status.
 
+  A fifth way to switch a job off is covered as well, found while reviewing
+  the first four: GitHub skips a job whose dependency was skipped, so
+  `needs: doctor` on any of the four stops it on every event that does not
+  target `dev` while its own `if:` and `continue-on-error:` stay clean.
+  `doctor` sits one screen below `audit` in the same file and is narrowed
+  exactly that way. The whole `needs:` closure is walked, since a job two
+  hops from a conditional one is skipped the same way.
+
   Each guard was proved by mutating `ci.yml` and rerunning the two affected
   binaries, `bench` included, so the refactor cannot have traded coverage
   for a shared definition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assertion walks past null. A step that needs a condition passes its exact
   value rather than a waiver, so the one legitimate `if:` in the tree, the
   doctest step narrowed to the ubuntu matrix row, is still pinned to that
-  condition. The `audit` guard adds `--deny warnings` and rejects a pipe on
+  condition. That allowance also has to land on exactly one step: the label
+  it is keyed on comes from `name:`, so relabelling a second step to match
+  would otherwise hand it the same exemption, and renaming the step it was
+  written for would leave a waiver covering nothing. The `audit` guard adds `--deny warnings` and rejects a pipe on
   the command, since a pipeline reports its last element's exit status.
 
   A fifth way to switch a job off is covered as well, found while reviewing

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -113,8 +113,8 @@ pub fn git_only_bin() -> &'static Path {
 /// stopped running, and `continue-on-error` on the `audit` job is what hid
 /// RUSTSEC-2025-0068 for nine months.
 ///
-/// Four ways to neutralise a job, four assertions, plus the two that keep
-/// this from passing over nothing:
+/// Five ways to neutralise a job, plus the two assertions that keep this from
+/// passing over nothing:
 ///
 /// - the job must **exist**, and hold at least one step. An absent job parses
 ///   to `Value::Null`, and `null["if"]` is null, `null["steps"]` yields an
@@ -122,7 +122,17 @@ pub fn git_only_bin() -> &'static Path {
 ///   job outright would otherwise walk past every assertion below;
 /// - no `if:` on the job, and none on any step, except the exact conditions
 ///   passed in `steps_allowed_an_if`;
-/// - no `continue-on-error:` on the job, and none on any step.
+/// - no `continue-on-error:` on the job, and none on any step;
+/// - nothing in its `needs:` closure is narrowed with an `if:`. GitHub skips a
+///   job whose dependency was skipped, so `needs: doctor` on a guarded job
+///   stops it on every event that does not target `dev` while all of the above
+///   stay green. `ci.yml` ships exactly such a job one screen away, which is
+///   why this is checked rather than assumed. A `continue-on-error:` on a
+///   dependency is deliberately not an error: it makes the dependency report
+///   success, which lets the dependent run rather than skipping it.
+///
+/// The whole closure is walked, not just the direct dependencies: a job two
+/// hops away from a conditional one is skipped exactly the same way.
 ///
 /// `steps_allowed_an_if` carries the **value**, not a dispensation: a step
 /// listed here still has to match the condition it was allowed, so widening
@@ -134,7 +144,8 @@ pub fn git_only_bin() -> &'static Path {
 /// does for an absent key, and the canonical way to switch something off would
 /// take the "no `if:` at all" arm (the defect fixed at `6bb82758`).
 #[allow(dead_code)] // used by the two test binaries that parse ci.yml.
-pub fn assert_job_is_blocking(job: &serde_yaml_ng::Value, job_name: &str, steps_allowed_an_if: &[(&str, &str)]) {
+pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, steps_allowed_an_if: &[(&str, &str)]) {
+  let job = &workflow["jobs"][job_name];
   assert!(
     !job.is_null(),
     "ci.yml must define a `{job_name}` job: an absent job parses to null, and every \
@@ -161,6 +172,32 @@ pub fn assert_job_is_blocking(job: &serde_yaml_ng::Value, job_name: &str, steps_
      runs and reports success while doing nothing"
   );
 
+  // The `needs:` closure. A dependency that gets skipped skips everything
+  // below it, so a job whose own `if:` and `continue-on-error:` are clean can
+  // still be switched off through the job it waits on.
+  let mut pending: Vec<String> = job_needs(job);
+  let mut seen: Vec<String> = vec![job_name.to_string()];
+  while let Some(dep) = pending.pop() {
+    if seen.contains(&dep) {
+      continue;
+    }
+    let upstream = &workflow["jobs"][dep.as_str()];
+    assert!(
+      !upstream.is_null(),
+      "the `{job_name}` job waits on `{dep}`, which ci.yml does not define: the workflow \
+       would not start at all"
+    );
+    assert!(
+      upstream["if"].is_null(),
+      "the `{job_name}` job waits on `{dep}`, which is narrowed with `if: {:?}`. GitHub \
+       skips a job whose dependency was skipped, so this switches `{job_name}` off on every \
+       event the condition excludes while its own `if:` and `continue-on-error:` stay clean",
+      upstream["if"]
+    );
+    pending.extend(job_needs(upstream));
+    seen.push(dep);
+  }
+
   for step in &steps {
     let label = step["name"]
       .as_str()
@@ -184,5 +221,25 @@ pub fn assert_job_is_blocking(job: &serde_yaml_ng::Value, job_name: &str, steps_
       "step {label:?} of the `{job_name}` job may not be conditioned away: it carries \
        `if: {cond:?}` and the only condition allowed for it is {allowed:?}"
     );
+  }
+}
+
+/// The `needs:` of a job, as a list. The Actions schema allows both a bare
+/// string and a sequence, and a job with no dependency parses to null, so the
+/// three shapes are read here rather than at each call site.
+#[allow(dead_code)] // used by the two test binaries that parse ci.yml.
+fn job_needs(job: &serde_yaml_ng::Value) -> Vec<String> {
+  match &job["needs"] {
+    serde_yaml_ng::Value::String(one) => vec![one.clone()],
+    serde_yaml_ng::Value::Sequence(many) => many
+      .iter()
+      .map(|v| {
+        v.as_str()
+          .unwrap_or_else(|| panic!("a `needs:` entry must be a job name, got {v:?}"))
+          .to_string()
+      })
+      .collect(),
+    serde_yaml_ng::Value::Null => Vec::new(),
+    other => panic!("`needs:` must be a job name or a list of them, got {other:?}"),
   }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -198,12 +198,25 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
     seen.push(dep);
   }
 
+  // A waiver names one step, so it has to land on one step. The label comes
+  // from `name:`, which anyone can edit: renaming a second step to the label a
+  // waiver was written for hands that step the exemption too. That is not
+  // theoretical, it was found by mutation on this very helper: relabelling
+  // `cargo nextest run` as `cargo test --doc` and giving it the ubuntu `if:`
+  // narrows the whole suite to one runner with every test still green.
+  for (name, cond) in steps_allowed_an_if {
+    let hits = steps.iter().filter(|s| step_label(s) == *name).count();
+    assert_eq!(
+      hits, 1,
+      "the `{job_name}` job allows step {name:?} the condition {cond:?}, and exactly one step \
+       must answer to that label, found {hits}. Zero means the step was renamed and the waiver \
+       now covers nothing; more than one means a second step inherited an exemption written \
+       for its neighbour"
+    );
+  }
+
   for step in &steps {
-    let label = step["name"]
-      .as_str()
-      .or_else(|| step["uses"].as_str())
-      .or_else(|| step["run"].as_str())
-      .unwrap_or("<unnamed step>");
+    let label = step_label(step);
     assert!(
       step["continue-on-error"].is_null(),
       "no step of the `{job_name}` job may swallow its own failure: step {label:?} carries \
@@ -242,4 +255,17 @@ fn job_needs(job: &serde_yaml_ng::Value) -> Vec<String> {
     serde_yaml_ng::Value::Null => Vec::new(),
     other => panic!("`needs:` must be a job name or a list of them, got {other:?}"),
   }
+}
+
+/// How a step is named in an assertion message, and the key a waiver in
+/// `steps_allowed_an_if` is matched on. `name:` first because that is what the
+/// workflow author reads, then `uses:` for the action-only steps that carry no
+/// name, then the script itself.
+#[allow(dead_code)] // used by the two test binaries that parse ci.yml.
+fn step_label(step: &serde_yaml_ng::Value) -> &str {
+  step["name"]
+    .as_str()
+    .or_else(|| step["uses"].as_str())
+    .or_else(|| step["run"].as_str())
+    .unwrap_or("<unnamed step>")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -101,3 +101,88 @@ pub fn git_only_bin() -> &'static Path {
     })
     .as_path()
 }
+
+/// Asserts that a CI job is **blocking**: that it runs, and that it can turn
+/// the workflow red.
+///
+/// Issue #646. GitHub Actions applies `if:` and `continue-on-error:` at the
+/// job level as well as the step level, and the job wins. A guard that reads
+/// only `step[...]` therefore says nothing about the job containing it: `if:
+/// false` on the `test` job left all 19 tests in `release_workflow_tests`
+/// green while `cargo build`, `cargo nextest run` and `cargo test --doc` had
+/// stopped running, and `continue-on-error` on the `audit` job is what hid
+/// RUSTSEC-2025-0068 for nine months.
+///
+/// Four ways to neutralise a job, four assertions, plus the two that keep
+/// this from passing over nothing:
+///
+/// - the job must **exist**, and hold at least one step. An absent job parses
+///   to `Value::Null`, and `null["if"]` is null, `null["steps"]` yields an
+///   empty sequence, and `.all()` over an empty sequence is true. Deleting a
+///   job outright would otherwise walk past every assertion below;
+/// - no `if:` on the job, and none on any step, except the exact conditions
+///   passed in `steps_allowed_an_if`;
+/// - no `continue-on-error:` on the job, and none on any step.
+///
+/// `steps_allowed_an_if` carries the **value**, not a dispensation: a step
+/// listed here still has to match the condition it was allowed, so widening
+/// `matrix.os == 'ubuntu-latest'` into `false` is caught here and not left to
+/// whichever other test happens to pin that step today.
+///
+/// The `if:` comparisons go through the `Value`, never `as_str()`: `if: false`
+/// is a YAML boolean, so `as_str()` hands back `None` for it exactly as it
+/// does for an absent key, and the canonical way to switch something off would
+/// take the "no `if:` at all" arm (the defect fixed at `6bb82758`).
+#[allow(dead_code)] // used by the two test binaries that parse ci.yml.
+pub fn assert_job_is_blocking(job: &serde_yaml_ng::Value, job_name: &str, steps_allowed_an_if: &[(&str, &str)]) {
+  assert!(
+    !job.is_null(),
+    "ci.yml must define a `{job_name}` job: an absent job parses to null, and every \
+     assertion below passes over null, so deleting the job would go unseen"
+  );
+  assert!(
+    job["if"].is_null(),
+    "the `{job_name}` job must carry no `if:`: a job-level condition switches every step \
+     off at once while step-level guards stay green, got `if: {:?}`",
+    job["if"]
+  );
+  assert!(
+    job["continue-on-error"].is_null(),
+    "the `{job_name}` job must carry no `continue-on-error:` at all. The key has to be \
+     absent, not `false`, so that a later `true` is a diff against nothing rather than a \
+     one-word edit. Got `continue-on-error: {:?}`",
+    job["continue-on-error"]
+  );
+
+  let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
+  assert!(
+    !steps.is_empty(),
+    "the `{job_name}` job must hold at least one step: emptying `steps:` leaves a job that \
+     runs and reports success while doing nothing"
+  );
+
+  for step in &steps {
+    let label = step["name"]
+      .as_str()
+      .or_else(|| step["uses"].as_str())
+      .or_else(|| step["run"].as_str())
+      .unwrap_or("<unnamed step>");
+    assert!(
+      step["continue-on-error"].is_null(),
+      "no step of the `{job_name}` job may swallow its own failure: step {label:?} carries \
+       `continue-on-error: {:?}`",
+      step["continue-on-error"]
+    );
+
+    let cond = &step["if"];
+    let allowed = steps_allowed_an_if
+      .iter()
+      .find(|(name, _)| *name == label)
+      .map(|(_, cond)| *cond);
+    assert!(
+      cond.is_null() || (allowed.is_some() && cond.as_str() == allowed),
+      "step {label:?} of the `{job_name}` job may not be conditioned away: it carries \
+       `if: {cond:?}` and the only condition allowed for it is {allowed:?}"
+    );
+  }
+}

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -21,6 +21,9 @@
 use std::fs;
 use std::path::PathBuf;
 
+mod common;
+use common::assert_job_is_blocking;
+
 fn repo_file(rel: &str) -> PathBuf {
   PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
 }
@@ -195,4 +198,21 @@ fn ci_checks_the_msrv_locked_and_without_default_features() {
      `cmd_daemon` / `cmd_statusline`, and that build is documented as supported. \
      Got: {checks:?}"
   );
+}
+
+/// Issue #646. The four guards above read `strategy`, `steps`, `uses`, `with`
+/// and `run`, and none of them reads the job's own `if:` or
+/// `continue-on-error:`. `if: false` was mutated onto the `msrv` job and all
+/// four stayed green.
+///
+/// What that job holds off is the whole point of #491: it is the only thing
+/// that compiles at the declared floor, so a dependency raising its own
+/// `rust-version` reaches users as a broken `cargo install gwm-cli` and
+/// nothing else in the repo says a word. Reading the graph through `cargo
+/// metadata` does not settle it either, since metadata said `1.88` where a
+/// build said `1.95`, so a job that does not run leaves no second oracle
+/// behind.
+#[test]
+fn ci_msrv_job_cannot_be_switched_off_or_made_advisory() {
+  assert_job_is_blocking(&msrv_job(), "msrv", &[]);
 }

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -93,10 +93,12 @@ fn every_live_msrv_claim_matches_cargo_toml() {
 /// `toolchain: 1.95` while keeping that step would have kept the old guard
 /// green, reintroducing exactly the drift it exists to block. The value of the
 /// input is now compared to the step output it must reference.
+fn ci_workflow() -> serde_yaml_ng::Value {
+  serde_yaml_ng::from_str(&read(".github/workflows/ci.yml")).expect("ci.yml must be valid YAML")
+}
+
 fn msrv_job() -> serde_yaml_ng::Value {
-  let workflow: serde_yaml_ng::Value =
-    serde_yaml_ng::from_str(&read(".github/workflows/ci.yml")).expect("ci.yml must be valid YAML");
-  workflow["jobs"]["msrv"].clone()
+  ci_workflow()["jobs"]["msrv"].clone()
 }
 
 fn steps(job: &serde_yaml_ng::Value) -> Vec<serde_yaml_ng::Value> {
@@ -214,5 +216,5 @@ fn ci_checks_the_msrv_locked_and_without_default_features() {
 /// behind.
 #[test]
 fn ci_msrv_job_cannot_be_switched_off_or_made_advisory() {
-  assert_job_is_blocking(&msrv_job(), "msrv", &[]);
+  assert_job_is_blocking(&ci_workflow(), "msrv", &[]);
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -384,10 +384,12 @@ fn docs_sync_watches_every_root_the_site_reads() {
 /// `\n  hook-smoke:` markers, so inserting any job between the two silently
 /// emptied what the assertions ran against, the same failure mode the `msrv`
 /// tests already parse the YAML to avoid.
+fn ci_workflow() -> serde_yaml_ng::Value {
+  serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap()).expect("ci.yml must be valid YAML")
+}
+
 fn ci_job(name: &str) -> serde_yaml_ng::Value {
-  let workflow: serde_yaml_ng::Value =
-    serde_yaml_ng::from_str(&fs::read_to_string(".github/workflows/ci.yml").unwrap())
-      .expect("ci.yml must be valid YAML");
+  let workflow = ci_workflow();
   let job = workflow["jobs"][name].clone();
   assert!(!job.is_null(), "ci.yml must define a `{name}` job");
   job
@@ -506,7 +508,7 @@ fn ci_runs_the_benches_and_can_fail_on_one() {
   // and it has to run at all: the `doctor` job in this same file is narrowed
   // with an `if:`, and doing that here would keep every assertion above green
   // while the benches quietly stopped running on pull requests.
-  assert_job_is_blocking(&job, "bench", &[]);
+  assert_job_is_blocking(&ci_workflow(), "bench", &[]);
 }
 
 #[test]
@@ -771,7 +773,7 @@ fn ci_runs_doctests_since_nextest_cannot() {
 #[test]
 fn ci_test_job_cannot_be_switched_off_or_made_advisory() {
   assert_job_is_blocking(
-    &ci_job("test"),
+    &ci_workflow(),
     "test",
     &[("cargo test --doc", "matrix.os == 'ubuntu-latest'")],
   );
@@ -800,7 +802,7 @@ fn ci_test_job_cannot_be_switched_off_or_made_advisory() {
 #[test]
 fn ci_audits_dependencies_and_can_fail_on_an_advisory() {
   let job = ci_job("audit");
-  assert_job_is_blocking(&job, "audit", &[]);
+  assert_job_is_blocking(&ci_workflow(), "audit", &[]);
 
   let step = job["steps"]
     .as_sequence()

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -2,6 +2,9 @@ use std::fs;
 #[cfg(unix)]
 use std::{path::Path, process::Command};
 
+mod common;
+use common::assert_job_is_blocking;
+
 #[cfg(unix)]
 const CHECK_RC_DUPES: &str = ".github/scripts/check-rc-changelog-dupes.sh";
 
@@ -499,27 +502,11 @@ fn ci_runs_the_benches_and_can_fail_on_one() {
     "piping the bench command reports the pipe's exit code, not the bench runner's, \
      the panic this job exists to catch would be swallowed, got {bench_run:?}"
   );
-  assert!(
-    job["continue-on-error"].is_null(),
-    "the bench job must be able to fail the workflow: a dead bench is what #634 is about"
-  );
-  let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
-  assert!(
-    steps.iter().all(|s| s["continue-on-error"].is_null()),
-    "no step of the bench job may swallow its own failure"
-  );
-  // The `doctor` job in this same file is narrowed with an `if:`. Doing that
-  // here would keep all the assertions above green while the benches quietly
-  // stop running on pull requests, which is the state #634 exists to close.
-  assert!(
-    job["if"].is_null(),
-    "the bench job must not be narrowed with an `if:`: it has to run on every event this \
-     workflow runs on, or a dead bench goes unseen again"
-  );
-  assert!(
-    steps.iter().all(|s| s["if"].is_null()),
-    "no step of the bench job may be conditioned away"
-  );
+  // A dead bench is what #634 is about, so the job has to be able to go red,
+  // and it has to run at all: the `doctor` job in this same file is narrowed
+  // with an `if:`, and doing that here would keep every assertion above green
+  // while the benches quietly stopped running on pull requests.
+  assert_job_is_blocking(&job, "bench", &[]);
 }
 
 #[test]
@@ -768,5 +755,79 @@ fn ci_runs_doctests_since_nextest_cannot() {
   assert!(
     cond.is_null() || cond.as_str() == Some("matrix.os == 'ubuntu-latest'"),
     "the doctest step may only be narrowed to the ubuntu matrix row, got `if: {cond:?}`"
+  );
+}
+
+/// Issue #646. The `test` job is the one carrying `cargo build`, `cargo
+/// nextest run` and `cargo test --doc`, so switching it off takes the whole
+/// suite with it. `if: false` on this job was mutated into `ci.yml` and all 19
+/// tests in this binary stayed green, because every guard here reads
+/// `step[...]` and GitHub Actions resolves `if:` at the job level too.
+///
+/// The doctest step keeps its one legitimate `if:`, because doctests behave
+/// identically on the three runners and are paid for once on the row with the
+/// slack. The helper pins that condition by value rather than waiving the
+/// check for the step.
+#[test]
+fn ci_test_job_cannot_be_switched_off_or_made_advisory() {
+  assert_job_is_blocking(
+    &ci_job("test"),
+    "test",
+    &[("cargo test --doc", "matrix.os == 'ubuntu-latest'")],
+  );
+}
+
+/// Issue #646. `cargo audit` had no test naming it at all: `grep -rn '"audit"'
+/// tests/*.rs` returned nothing, while `tests/release_workflow_tests.rs` cited
+/// the job twice to justify guards placed elsewhere. Three simultaneous
+/// neutralisations, `continue-on-error: true` on the job and `cargo audit
+/// --deny warnings` rewritten to `cargo audit || true`, left 23 tests green
+/// across the two binaries that parse `ci.yml`.
+///
+/// Two properties on top of the job being blocking:
+///
+/// - `--deny warnings`, without which warning-class advisories (unmaintained /
+///   unsound / yanked) exit 0. That is half of how RUSTSEC-2025-0068
+///   (`serde_yml`, unsound + unmaintained) slipped past for nine months;
+/// - no pipe on the command. A shell pipeline reports the exit status of its
+///   last element, so `cargo audit --deny warnings || true` and `cargo audit |
+///   tee log` both report success over a failing audit. Testing for `|` covers
+///   `||` as well.
+///
+/// Accepted advisories belong in `audit.toml` (`[advisories] ignore = […]`)
+/// with a rationale, which is a conscious decision in a reviewed diff (#340),
+/// not a job that cannot fail.
+#[test]
+fn ci_audits_dependencies_and_can_fail_on_an_advisory() {
+  let job = ci_job("audit");
+  assert_job_is_blocking(&job, "audit", &[]);
+
+  let step = job["steps"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .into_iter()
+    .find(|s| s["name"].as_str() == Some("cargo audit"))
+    .expect("the audit job needs a step named `cargo audit` that runs the audit");
+  let run = step["run"]
+    .as_str()
+    .expect("the `cargo audit` step must carry a `run:` script")
+    .to_string();
+
+  assert!(
+    run.contains("cargo audit"),
+    "the `cargo audit` step must actually run cargo-audit, got {run:?}"
+  );
+  assert!(
+    run.contains("--deny warnings"),
+    "cargo audit must run with `--deny warnings`: plain `cargo audit` exits 0 on \
+     unmaintained, unsound and yanked advisories, which is how RUSTSEC-2025-0068 went \
+     unseen for nine months. Got {run:?}"
+  );
+  assert!(
+    !run.contains('|'),
+    "the audit command must carry no pipe and no `||`: a shell pipeline reports its last \
+     element's exit status, so `cargo audit --deny warnings || true` succeeds over a \
+     failing audit exactly as the `continue-on-error` this guard also forbids. Got {run:?}"
   );
 }


### PR DESCRIPTION
## Description

Three jobs in `.github/workflows/ci.yml` could be switched off, or made
non-blocking, without a single test going red. GitHub Actions resolves `if:`
and `continue-on-error:` at the job level as well as the step level, and the
job wins, so guards that read `step[...]` said nothing about the job holding
that step.

`bench` already had the right shape, inline. That triplet is now one helper,
`assert_job_is_blocking`, in `tests/common/mod.rs`, applied to `msrv`, `test`
and `audit`, with `bench` refactored onto it so there is one definition
rather than four copies.

Reviewing those four turned up a fifth way to switch a job off that none of
them saw: GitHub skips a job whose dependency was skipped, and `ci.yml` ships
a conditional `doctor` job one screen below `audit`. That is covered too.

Closes #646

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

- `tests/common/mod.rs`: `assert_job_is_blocking(job, name, steps_allowed_an_if)`
  asserts `job["if"].is_null()`, `job["continue-on-error"].is_null()`, and the
  same two across every step.
- Two assertions the inline version on `bench` did not have: the job must
  exist, and it must hold at least one step. An absent job parses to
  `Value::Null`, `null["if"]` is null, `null["steps"]` yields an empty
  sequence, and `.all()` over an empty sequence is true, so deleting a job
  outright would walk past everything else.
- A step allowed a condition passes its **exact value**, not a waiver:
  `&[("cargo test --doc", "matrix.os == 'ubuntu-latest'")]`. Narrowing that
  step further is caught here rather than resting on whichever other test
  happens to pin it today. Each waiver must also match **exactly one** step,
  since the label comes from `name:` and anyone can edit it.
- Applied to `msrv` (`tests/msrv_tests.rs`), `test` and `audit`
  (`tests/release_workflow_tests.rs`); `bench` refactored onto it.
- The `audit` guard also asserts the run line carries `--deny warnings` and
  contains no `|` (which covers `||`).
- All `if:` comparisons go through the `Value`, never `as_str()`: `if: false`
  is a YAML boolean, so `as_str()` returns `None` for it exactly as for an
  absent key. That is the defect closed at `6bb82758`.
- **`needs:`** (found in review): nothing in a guarded job's `needs:` closure
  may be narrowed with an `if:`. The whole closure is walked, not the direct
  dependencies alone, and both shapes the Actions schema allows for `needs:`
  are read. A `continue-on-error:` upstream is deliberately not an error: it
  makes the dependency report success, which lets the dependent run rather
  than skipping it. The helper takes the workflow rather than the job, since
  reading a dependency means reading a sibling.

## Tests

- [x] `cargo test` passes locally: **3536 passed, 0 failed** across 111 test
  binaries plus doctests, `EXIT=0`.
- [x] `cargo fmt --check` passes (`EXIT=0`)
- [x] `cargo clippy --all-targets -- -D warnings` passes (`EXIT=0`)
- [x] New tests added under `tests/`

### Demonstrated red

Twenty-one mutations, each applied to the real `.github/workflows/ci.yml`, both
affected binaries were run with `--no-fail-fast`, and the exit code was read
from `$?` rather than through a pipe. `ci.yml` was restored from a copy, not
with `git checkout --`, so the test edits in the same worktree survived.

**`msrv`, `if: false` on the job**

```
$ cargo test --no-fail-fast --test release_workflow_tests --test msrv_tests
EXIT=101
---- ci_msrv_job_cannot_be_switched_off_or_made_advisory stdout ----
the `msrv` job must carry no `if:`: a job-level condition switches every step
off at once while step-level guards stay green, got `if: Bool(false)`
test result: FAILED. 4 passed; 1 failed   (msrv_tests)
test result: ok. 21 passed; 0 failed      (release_workflow_tests)
```

**`msrv`, `continue-on-error: true` on the job**

```
EXIT=101
the `msrv` job must carry no `continue-on-error:` at all. The key has to be
absent, not `false`, so that a later `true` is a diff against nothing rather
than a one-word edit. Got `continue-on-error: Bool(true)`
test result: FAILED. 4 passed; 1 failed
```

**`msrv`, job deleted outright.** `msrv_job()` has no existence check of its
own, so this is the case the helper closes:

```
EXIT=101
---- ci_msrv_job_cannot_be_switched_off_or_made_advisory stdout ----
ci.yml must define a `msrv` job: an absent job parses to null, and every
assertion below passes over null, so deleting the job would go unseen
test result: FAILED. 1 passed; 4 failed
```

**`test`, `if: false` on the job.** This is the one from the issue: the job
carrying `cargo build`, `cargo nextest run` and `cargo test --doc`.

```
EXIT=101
---- ci_test_job_cannot_be_switched_off_or_made_advisory stdout ----
the `test` job must carry no `if:`: a job-level condition switches every step
off at once while step-level guards stay green, got `if: Bool(false)`
test result: FAILED. 20 passed; 1 failed
```

**`test`, `continue-on-error: true` on the job**

```
EXIT=101
the `test` job must carry no `continue-on-error:` at all. […]
Got `continue-on-error: Bool(true)`
test result: FAILED. 20 passed; 1 failed
```

**`test`, the doctest step's `if:` widened to `false`.** The value is pinned,
not waived, so two tests fire:

```
EXIT=101
---- ci_runs_doctests_since_nextest_cannot stdout ----
---- ci_test_job_cannot_be_switched_off_or_made_advisory stdout ----
step "cargo test --doc" of the `test` job may not be conditioned away: it
carries `if: Bool(false)` and the only condition allowed for it is
Some("matrix.os == 'ubuntu-latest'")
test result: FAILED. 19 passed; 2 failed
```

**`audit`, `continue-on-error: true` on the job**

```
EXIT=101
---- ci_audits_dependencies_and_can_fail_on_an_advisory stdout ----
the `audit` job must carry no `continue-on-error:` at all. […]
Got `continue-on-error: Bool(true)`
test result: FAILED. 20 passed; 1 failed
```

**`audit`, `cargo audit --deny warnings` rewritten to `cargo audit || true`**
(applied alone, so the assertion is not masked by the `continue-on-error` one).
Note that this mutation drops `--deny warnings` as well, so it is the flag
assertion that fires, not the pipe one. The pipe assertion gets its own
mutation below:

```
EXIT=101
cargo audit must run with `--deny warnings`: plain `cargo audit` exits 0 on
unmaintained, unsound and yanked advisories, which is how RUSTSEC-2025-0068
went unseen for nine months. Got "cargo audit || true"
test result: FAILED. 20 passed; 1 failed
```

**`audit`, a pipe added while `--deny warnings` is kept**
(`cargo audit --deny warnings | tee audit.log`). This is the mutation that
isolates the pipe assertion, since the one above never reaches it:

```
EXIT=101
---- ci_audits_dependencies_and_can_fail_on_an_advisory stdout ----
the audit command must carry no pipe and no `||`: a shell pipeline reports its
last element's exit status, so `cargo audit --deny warnings || true` succeeds
over a failing audit exactly as the `continue-on-error` this guard also
forbids. Got "cargo audit --deny warnings | tee audit.log"
test result: FAILED. 20 passed; 1 failed
```

**`audit`, `steps:` emptied to `[]`.** The job still exists, so this is the
half of the existence check that deleting the job does not reach:

```
EXIT=101
---- ci_audits_dependencies_and_can_fail_on_an_advisory stdout ----
the `audit` job must hold at least one step: emptying `steps:` leaves a job
that runs and reports success while doing nothing
test result: FAILED. 20 passed; 1 failed
```

**`audit`, job deleted outright.** Attribution matters here: this one panics
in `ci_job` (`release_workflow_tests.rs:394`), which already asserted a
non-null job before this PR, not in the helper's own existence check. It is
kept because deleting the job has to be shown to go red somewhere, but the
helper's check is the `msrv` deletion two entries above, where `msrv_job()`
had no such guard:

```
EXIT=101
thread 'ci_audits_dependencies_and_can_fail_on_an_advisory' panicked at
tests/release_workflow_tests.rs:394:3:
ci.yml must define a `audit` job
```

**`audit`, `needs: ghost`**, a dependency `ci.yml` does not define. Without
this the walk would step onto `Value::Null`, whose `if` is null, and validate
over nothing:

```
EXIT=101
thread 'ci_audits_dependencies_and_can_fail_on_an_advisory' panicked at
tests/common/mod.rs:185:5:
the `audit` job waits on `ghost`, which ci.yml does not define: the workflow
would not start at all
test result: FAILED. 20 passed; 1 failed
```

**`audit`, `needs: doctor`.** `doctor` is narrowed to `dev`, so this stops
`audit` on every other event while its own `if:` and `continue-on-error:` stay
absent:

```
EXIT=101
---- ci_audits_dependencies_and_can_fail_on_an_advisory stdout ----
the `audit` job waits on `doctor`, which is narrowed with `if:
String("(github.event_name == 'push' && github.ref == 'refs/heads/dev') ||\n
(github.event_name == 'pull_request' && github.base_ref == 'dev')\n")`. GitHub
skips a job whose dependency was skipped, so this switches `audit` off on every
event the condition excludes while its own `if:` and `continue-on-error:` stay
clean
test result: FAILED. 20 passed; 1 failed
```

**`msrv`, `needs: doctor`**

```
EXIT=101
---- ci_msrv_job_cannot_be_switched_off_or_made_advisory stdout ----
the `msrv` job waits on `doctor`, which is narrowed with `if: […]`
test result: FAILED. 4 passed; 1 failed   (msrv_tests)
test result: ok. 21 passed; 0 failed      (release_workflow_tests)
```

**`test`, `needs: [fmt, doctor]`**, the sequence shape of the schema rather
than the bare string:

```
EXIT=101
---- ci_test_job_cannot_be_switched_off_or_made_advisory stdout ----
the `test` job waits on `doctor`, which is narrowed with `if: […]`
test result: FAILED. 20 passed; 1 failed
```

**Two hops**, `audit` needs `bench`, `bench` needs `doctor`. The closure is
walked, so both jobs name `doctor` and not their direct dependency:

```
EXIT=101
---- ci_audits_dependencies_and_can_fail_on_an_advisory stdout ----
the `audit` job waits on `doctor`, which is narrowed with `if: […]`
---- ci_runs_the_benches_and_can_fail_on_one stdout ----
the `bench` job waits on `doctor`, which is narrowed with `if: […]`
test result: FAILED. 19 passed; 2 failed
```

**`continue-on-error: true` on a step**, the fourth assertion of the helper,
which none of the mutations above reached:

```
EXIT=101
thread 'ci_audits_dependencies_and_can_fail_on_an_advisory' panicked at
tests/common/mod.rs:220:5:
no step of the `audit` job may swallow its own failure: step "cargo audit"
carries `continue-on-error: Bool(true)`
```

**A second step relabelled to claim the doctest waiver.** `cargo nextest run`
renamed to `cargo test --doc` with `if: matrix.os == 'ubuntu-latest'` narrows
the whole suite to one runner; before this assertion, all 26 tests stayed
green:

```
EXIT=101
thread 'ci_test_job_cannot_be_switched_off_or_made_advisory' panicked at
tests/common/mod.rs:209:5:
assertion `left == right` failed: the `test` job allows step "cargo test --doc"
the condition "matrix.os == 'ubuntu-latest'", and exactly one step must answer
to that label, found 2. […]
  left: 2
 right: 1
```

**The waived step renamed instead**, so the waiver covers nothing and reads as
a guard that still holds:

```
EXIT=101
… exactly one step must answer to that label, found 0. […]
  left: 0
 right: 1
```

**`bench`, both mutations, after the refactor.** Not asked for by the issue,
but it is the only guard here that had a proof and was moved, so the refactor
has to be shown not to have weakened it:

```
$ # if: false on the bench job
EXIT=101
---- ci_runs_the_benches_and_can_fail_on_one stdout ----
the `bench` job must carry no `if:`: […] got `if: Bool(false)`
test result: FAILED. 20 passed; 1 failed

$ # continue-on-error: true on the bench job
EXIT=101
the `bench` job must carry no `continue-on-error:` at all. […]
test result: FAILED. 20 passed; 1 failed
```

In every run the unaffected binary stayed green, which is the other half of
the proof: a mutation on `test` must not redden `msrv_tests`.

## Screenshots / TUI captures

N/A, no TUI surface touched.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits (see CONTRIBUTING.md)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (N/A)
- [x] `examples/gwm.toml.example` updated if config schema changed (N/A)
- [x] No `unwrap()` on user-facing paths (return `GwmError` instead) (N/A, tests only)
- [x] No `println!` in TUI render code (status bar only) (N/A)

## Linked issues / docs

- Issue: #646
- Follow-ups filed from this review: #652 (a `run:` line can still be made
  unable to fail), #653 (neutralisation above the job: `matrix.exclude` and
  the workflow's `on:` block)
- Related: #634 (the perf guards, where the job-level pair was first written),
  #491 (msrv and `cargo install`), #340 (`audit.toml` and accepted advisories),
  RUSTSEC-2025-0068

## Notes for reviewers

Two design calls worth a look.

**The exemption carries a value, not a dispensation.** The first shape was
`steps_allowed_an_if: &[&str]`, which would have removed the `if` check for
the doctest step and left the hole closed only by
`ci_runs_doctests_since_nextest_cannot` pinning the exact condition. That is
an invisible coupling: it breaks silently if that test ever moves. The pair
form keeps the check inside the helper, and the redundancy with the other
test is deliberate.

**The existence check is not in the issue.** `ci_job()` in
`release_workflow_tests.rs` already asserts a non-null job, so the hole was
only open in `msrv_tests.rs`, whose `msrv_job()` does not. Putting it in the
helper closes it for every caller, present and future, for two lines.

**`needs:` started as a documented omission and is now covered.** The first
version of this PR argued that none of the four guarded jobs had a dependency
today, so there was nothing to close, and that `job["needs"].is_null()` would
forbid a legitimate dependency later. The second half of that was right and
the first half was not the question: the guard exists for the edit nobody has
made yet. The shape that resolves both is to allow `needs:` and require the
closure to be unconditional, which is what landed.

**The waiver was keyed on a mutable label.** Review mutated this helper
against itself: relabelling a second step to `cargo test --doc` handed it the
doctest exemption and narrowed the whole suite to one runner, with every test
green. Requiring each waiver to match exactly one step closes it in both
directions, including the waived step being renamed out from under its own
waiver.

**Two more ways to silence CI sit above the job, and are out of scope here.**
Review verified both by mutation: `strategy.matrix.exclude` deletes matrix
rows (so `test (windows-latest)` stops existing and
`ci_test_matrix_runs_on_windows_latest` passes over nothing), and narrowing
the workflow's own `on: branches:` to `[main]` stops all four jobs at once.
Neither violates what this helper claims, which is that the job runs and can
go red; both are a level above it, and the second also covers `fmt`, `clippy`
and `hook-smoke`, which this PR does not touch. Filed together as #653.

**One finding was raised in review and deliberately left out of this PR.** A
`run:` line can be neutralised without any of the five keys above:
`cargo nextest run || true` on the `test` job, or `set +e` around
`cargo audit`, leaves every assertion here green. It is real, and it is a
different guard: `!run.contains('|')` works for `audit` because that job runs
one self-contained command, but it is wrong as a general rule, since the
`read the declared MSRV` step legitimately pipes `grep` into `cut`. Telling a
plumbing pipe from one that swallows an exit status needs a design this issue
did not ask for, and the repo's own rule is that a follow-up issue beats scope
creep. Filed as #652, with the mutations that prove it and the four traps a
naive guard would fall into.

Sequencing, from the issue: this one introduces the helper, then #647, then
#649. All three touch `tests/release_workflow_tests.rs`.

https://claude.ai/code/session_01Sqahwoxj6v4hXgUCTVkrT4
