### PR TITLE
✅ test(ci): CI could still be silenced, below the job and above it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,9 +124,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow and each leaving the whole suite green.
 
   **Below.** A command can be made unable to fail without touching any of the
-  keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, or an
-  `exit 0` after the command. All four are now rejected on any line that
-  invokes cargo, in every guarded job. Scoped to cargo lines rather than every
+  keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, an `exit 0`
+  anywhere in the block, or a custom `shell:` line that drops the `-e` GitHub
+  normally passes. All five are now rejected on any step that invokes cargo,
+  in every guarded job. Scoped to cargo lines rather than every
   line on purpose, since the property is not "no pipe": the `read the declared
   MSRV` step legitimately pipes `grep` into `cut`, and `exit 1` stays allowed
   because that same step uses it to fail loudly. Matched on `contains` rather
@@ -138,10 +139,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `strategy.matrix.os` and never the `exclude` beside it, so
   `test (windows-latest)` could stop existing while
   `ci_test_matrix_runs_on_windows_latest` kept passing. Both now read the
-  effective matrix. The workflow's own `on:` block takes all eight jobs at
-  once, so the events and branches it fires on are pinned, and `paths:` /
-  `paths-ignore:` are asserted absent: a path filter would skip CI entirely on
-  a change it does not match.
+  effective matrix, and `runs-on:` is pinned to it: a literal runner keeps
+  `test (windows-latest)` in the checks list, satisfying the required contexts
+  on `main`, while nothing ever compiles the
+  `[target."cfg(windows)".dependencies]` block. The workflow's own `on:` block
+  takes all eight jobs at once, so the events and branches it fires on are
+  pinned, and `paths:`, `paths-ignore:` and `types:` are asserted absent: a
+  path filter skips CI on a change it does not match, and `types:` has
+  defaults, so replacing them runs no CI on an ordinary pull request.
 
 - **Three CI jobs could be switched off without a test going red**
   ([#646](https://github.com/kbrdn1/gwm-cli/issues/646)). GitHub Actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI could still be silenced, below the job and above it**
+  ([#652](https://github.com/kbrdn1/gwm-cli/issues/652),
+  [#653](https://github.com/kbrdn1/gwm-cli/issues/653)). #646 pinned the job
+  level. Three ways around it were left, each found by mutating the real
+  workflow and each leaving the whole suite green.
+
+  **Below.** A command can be made unable to fail without touching any of the
+  keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, or an
+  `exit 0` after the command. All four are now rejected on any line that
+  invokes cargo, in every guarded job. Scoped to cargo lines rather than every
+  line on purpose, since the property is not "no pipe": the `read the declared
+  MSRV` step legitimately pipes `grep` into `cut`, and `exit 1` stays allowed
+  because that same step uses it to fail loudly. Matched on `contains` rather
+  than a prefix, so `env VAR=x cargo nextest run || true` is caught too, and
+  line continuations are joined first.
+
+  **Above.** `strategy.matrix.exclude` deletes matrix rows, which defeated the
+  two guards whose entire subject is the matrix: they read
+  `strategy.matrix.os` and never the `exclude` beside it, so
+  `test (windows-latest)` could stop existing while
+  `ci_test_matrix_runs_on_windows_latest` kept passing. Both now read the
+  effective matrix. The workflow's own `on:` block takes all eight jobs at
+  once, so the events and branches it fires on are pinned, and `paths:` /
+  `paths-ignore:` are asserted absent: a path filter would skip CI entirely on
+  a change it does not match.
+
 - **Three CI jobs could be switched off without a test going red**
   ([#646](https://github.com/kbrdn1/gwm-cli/issues/646)). GitHub Actions
   resolves `if:` and `continue-on-error:` at the job level as well as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead: a `run:` block that invokes cargo is exactly one bare cargo
   invocation, one line, no shell operators. Every spelling above fails that,
   including the ones nobody has thought of yet, and all eight cargo commands
-  in `ci.yml` pass it unchanged. Scoped to cargo lines rather than every
+  in `ci.yml` pass it unchanged. Two things the shape alone does not reach are
+  named separately: the `shell:` that runs the command, since `shell:` takes a
+  whole command line and `true {0}` never runs the script at all (read at step
+  level and in `defaults.run` at job and workflow level), and the cargo flags
+  that compile without executing, since `cargo bench --no-run --benches --
+  --test` satisfies the shape while being issue #634 verbatim. Scoped to cargo lines rather than every
   line on purpose, since the property is not "no pipe": the `read the declared
   MSRV` step legitimately pipes `grep` into `cut`, and `exit 1` stays allowed
   because that same step uses it to fail loudly. Matched on `contains` rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,24 +125,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **Below.** A command can be made unable to fail without touching any of the
   keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, `exit 0`,
-  `if ! cargo audit …; then …; fi`, a trailing `&`, a custom `shell:` line with
-  the `-e` dropped, or that same line moved to `defaults.run.shell`. Listing
-  those spellings does not converge, because the shell is a programming
-  language and the list is its grammar, so the guard states the property
-  instead: a `run:` block that invokes cargo is exactly one bare cargo
-  invocation, one line, no shell operators. Every spelling above fails that,
+  `if ! cargo audit …; then …; fi`, a trailing `&`. Listing those spellings
+  does not converge, because the shell is a programming language and the list
+  is its grammar, so the guard states the property instead: a `run:` block
+  that invokes cargo is exactly one bare cargo invocation, one line, made only
+  of characters that carry no shell meaning. Every spelling above fails that,
   including the ones nobody has thought of yet, and all eight cargo commands
-  in `ci.yml` pass it unchanged. Two things the shape alone does not reach are
-  named separately: the `shell:` that runs the command, since `shell:` takes a
-  whole command line and `true {0}` never runs the script at all (read at step
-  level and in `defaults.run` at job and workflow level), and the cargo flags
-  that compile without executing, since `cargo bench --no-run --benches --
-  --test` satisfies the shape while being issue #634 verbatim. Scoped to cargo lines rather than every
-  line on purpose, since the property is not "no pipe": the `read the declared
-  MSRV` step legitimately pipes `grep` into `cut`, and `exit 1` stays allowed
-  because that same step uses it to fail loudly. Matched on `contains` rather
-  than a prefix, so `env VAR=x cargo nextest run || true` is caught too, and
-  line continuations are joined first.
+  in `ci.yml` pass it unchanged.
+
+  Two things the shape alone does not reach are named separately. The `shell:`
+  that runs the command, because `shell:` takes a whole command line rather
+  than a keyword, so `true {0}` never runs the script and `bash -n {0}` only
+  parses it: the built-ins that do run it are whitelisted, at step level and in
+  `defaults.run` at job and workflow level. And the cargo flags that compile
+  without executing, because `cargo bench --no-run --benches -- --test`
+  satisfies the shape while being issue #634 verbatim.
+
+  Steps that do not invoke cargo stay free-form, which is what keeps the `read
+  the declared MSRV` step legal: it pipes `grep` into `cut` and uses `exit 1`
+  to fail loudly, both correct. A step is recognised by a whitespace-delimited
+  `cargo` token, so neither `Cargo.toml` nor a prefixed `env VAR=x cargo …`
+  fools it.
 
   **Above.** `strategy.matrix.exclude` deletes matrix rows, which defeated the
   two guards whose entire subject is the matrix: they read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,10 +124,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow and each leaving the whole suite green.
 
   **Below.** A command can be made unable to fail without touching any of the
-  keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, an `exit 0`
-  anywhere in the block, or a custom `shell:` line that drops the `-e` GitHub
-  normally passes. All five are now rejected on any step that invokes cargo,
-  in every guarded job. Scoped to cargo lines rather than every
+  keys #646 reads: `cargo nextest run || true`, a pipe, `set +e`, `exit 0`,
+  `if ! cargo audit …; then …; fi`, a trailing `&`, a custom `shell:` line with
+  the `-e` dropped, or that same line moved to `defaults.run.shell`. Listing
+  those spellings does not converge, because the shell is a programming
+  language and the list is its grammar, so the guard states the property
+  instead: a `run:` block that invokes cargo is exactly one bare cargo
+  invocation, one line, no shell operators. Every spelling above fails that,
+  including the ones nobody has thought of yet, and all eight cargo commands
+  in `ci.yml` pass it unchanged. Scoped to cargo lines rather than every
   line on purpose, since the property is not "no pipe": the `read the declared
   MSRV` step legitimately pipes `grep` into `cut`, and `exit 1` stays allowed
   because that same step uses it to fail loudly. Matched on `contains` rather
@@ -146,7 +151,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   takes all eight jobs at once, so the events and branches it fires on are
   pinned, and `paths:`, `paths-ignore:` and `types:` are asserted absent: a
   path filter skips CI on a change it does not match, and `types:` has
-  defaults, so replacing them runs no CI on an ordinary pull request.
+  defaults, so replacing them runs no CI on an ordinary pull request. Branch
+  membership alone was not enough either, since GitHub reads those entries as
+  patterns and a later `!dev` cancels an earlier `dev`.
 
 - **Three CI jobs could be switched off without a test going red**
   ([#646](https://github.com/kbrdn1/gwm-cli/issues/646)). GitHub Actions

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -241,52 +241,96 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
        `if: {cond:?}` and the only condition allowed for it is {allowed:?}"
     );
 
-    assert_run_cannot_swallow_its_failure(step, job_name, label);
+    assert_run_cannot_swallow_its_failure(workflow, job, step, job_name, label);
   }
 }
 
 /// A `run:` block that invokes cargo must be **exactly one bare cargo
-/// invocation** (issue #652).
+/// invocation**, run by a shell that actually runs it (issue #652).
 ///
-/// This started as a denylist, `||`, a pipe, `set +e`, `exit 0`, and two
-/// review passes walked straight through it: `if ! cargo audit --deny
-/// warnings; then echo 'advisories found'; fi` leaves the `audit` job green on
-/// a red audit, which is literally the RUSTSEC-2025-0068 scenario, and `cargo
-/// bench --benches -- --test &` leaves `bench` green without waiting for the
-/// bench at all. Neither carries any of the four. A `shell:` line with `-e`
-/// dropped, and the same line moved to `defaults.run.shell`, walked through it
-/// too.
+/// This started as a denylist, `||`, a pipe, `set +e`, `exit 0`, and review
+/// walked straight through it: `if ! cargo audit --deny warnings; then echo
+/// 'advisories found'; fi` leaves the `audit` job green on a red audit, which
+/// is the RUSTSEC-2025-0068 scenario itself, and `cargo bench --benches --
+/// --test &` leaves `bench` green without waiting. Neither carries any of the
+/// four. Enumerating the ways a shell can discard an exit status does not
+/// converge, because the shell is a programming language and the list is its
+/// grammar.
 ///
-/// Enumerating the ways a shell can discard an exit status does not converge,
-/// because the shell is a programming language and the list is its grammar.
-/// So the property is stated positively instead: one line, starting with
-/// `cargo `, made only of characters that carry no shell meaning. Everything
-/// above fails that, including the spellings nobody has thought of yet, and
-/// all eight cargo commands in `ci.yml` pass it unchanged.
+/// So the shape of the command is stated positively: one line, starting with
+/// `cargo `, made only of characters that carry no shell meaning. That closes
+/// the spellings nobody has thought of yet, and all eight cargo commands in
+/// `ci.yml` pass it unchanged.
 ///
-/// **Why there is no `shell:` assertion here.** A single command's exit status
-/// becomes the step's under every shell GitHub offers: `bash -e` and `sh -e`
-/// stop on it, and for `pwsh` GitHub appends `exit $LASTEXITCODE`. The
-/// denylist needed to know the shell because it allowed multi-command blocks,
-/// where errexit decides whether line 2 is reached. This does not allow them,
-/// so `shell:`, `defaults.run.shell` at job or workflow level, and pwsh's
-/// `$PSNativeCommandUseErrorActionPreference` all stop mattering. Removing
-/// that assertion is what the invariant buys, not something it overlooked.
+/// Two things the shape alone does not cover, both found by mutating this
+/// helper against itself:
+///
+/// - **the shell that runs it.** An earlier revision dropped the `shell:`
+///   assertion, reasoning that a single command's exit status becomes the
+///   step's "under every shell GitHub offers". That reasoning was an
+///   enumeration in disguise, and `shell:` also takes an arbitrary command
+///   line: `shell: 'true {0}'` never runs the script at all, and `shell: bash
+///   -n {0}` parses it without executing. Both are green against the shape.
+///   So the built-in keywords that do run the script are allowed and nothing
+///   else, at step level and in `defaults.run` at job and workflow level,
+///   which are the only two places `defaults` exists;
+/// - **flags that compile without running.** `cargo bench --no-run --benches
+///   -- --test` is one bare invocation and satisfies the shape, while being
+///   issue #634 verbatim: the benches build and never run. Unlike shell
+///   grammar, the set of cargo flags meaning "do not execute" is finite and
+///   documented by cargo, so naming them is a bounded list rather than an
+///   open-ended one, and it backs an invariant instead of standing alone.
 ///
 /// Steps that do not invoke cargo are out of scope and stay free-form: the
 /// `read the declared MSRV` step pipes `grep -m1 '^rust-version = ' Cargo.toml`
-/// into `cut -d'"' -f2` and uses `exit 1` to fail loudly, both of which are
-/// correct. It is detected by `contains("cargo ")` rather than a prefix,
-/// because a prefix test is defeated by `env VAR=x cargo …`, and `Cargo.toml`
-/// does not match it (capital C, no trailing space).
+/// into `cut -d'"' -f2` and uses `exit 1` to fail loudly, both correct. The
+/// step is detected by a whitespace-delimited `cargo` **token**, not by
+/// `contains("cargo ")`: that spelling hangs the whole check on one literal
+/// space, so `cargo\tcheck --locked || true` opted out of it entirely. A
+/// prefix test is no good either, since `env VAR=x cargo …` defeats it.
+/// `Cargo.toml` is not a `cargo` token, so the reader step stays out.
 #[allow(dead_code)] // used by the two test binaries that parse ci.yml.
-fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: &str, label: &str) {
+fn assert_run_cannot_swallow_its_failure(
+  workflow: &serde_yaml_ng::Value,
+  job: &serde_yaml_ng::Value,
+  step: &serde_yaml_ng::Value,
+  job_name: &str,
+  label: &str,
+) {
   let Some(script) = step["run"].as_str() else {
     return;
   };
   let lines: Vec<&str> = script.lines().collect();
-  if !lines.iter().any(|l| l.contains("cargo ")) {
+  let invokes_cargo = |l: &&str| l.split_whitespace().any(|tok| tok == "cargo");
+  if !lines.iter().any(invokes_cargo) {
     return;
+  }
+
+  // Whitelist, not a denylist: `shell:` accepts an arbitrary command line
+  // (`shell: command [...options] {0} [...more_options]`), so anything that is
+  // not a built-in keyword known to execute the script has to be refused
+  // rather than inspected. `defaults.run.shell` sets the same thing for a
+  // whole job or the whole workflow, and those are the only two levels it
+  // exists at.
+  for (shell, where_) in [
+    (&step["shell"], "on this step".to_string()),
+    (
+      &job["defaults"]["run"]["shell"],
+      format!("in `defaults.run` on the `{job_name}` job"),
+    ),
+    (
+      &workflow["defaults"]["run"]["shell"],
+      "in the workflow's `defaults.run`".to_string(),
+    ),
+  ] {
+    assert!(
+      shell.is_null() || matches!(shell.as_str(), Some("bash" | "sh" | "pwsh")),
+      "step {label:?} of the `{job_name}` job runs cargo under `shell: {shell:?}` set \
+       {where_}. Only the built-in `bash`, `sh` and `pwsh` keywords are allowed, because \
+       `shell:` otherwise takes a whole command line: `true {{0}}` never runs the script and \
+       `bash -n {{0}}` only parses it, both leaving a green step over a command that never \
+       executed"
+    );
   }
 
   assert_eq!(
@@ -300,8 +344,9 @@ fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: 
 
   // Bare invocation: the characters allowed are the ones that appear in a
   // cargo command line and carry no meaning to the shell. Everything else,
-  // `|`, `&`, `;`, `>`, backtick, `$`, `(`, `!`, `#`, quotes, is either a way
-  // to discard the status or a way to run something that is not this command.
+  // `|`, `&`, `;`, `>`, backtick, `$`, `(`, `!`, `#`, quotes and even a tab,
+  // is either a way to discard the status or a way to run something that is
+  // not this command.
   let line = lines[0];
   let bare = line.starts_with("cargo ")
     && line
@@ -315,6 +360,16 @@ fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: 
      `exit 0`, which is why this is stated as an invariant and not as a list of forbidden \
      spellings. Got {line:?}"
   );
+
+  for flag in ["--no-run", "--dry-run"] {
+    assert!(
+      !line.split_whitespace().any(|tok| tok == flag),
+      "step {label:?} of the `{job_name}` job must not pass `{flag}`: it compiles the \
+       target and never executes it, so the step reports success over work that never ran. \
+       `cargo bench --no-run --benches -- --test` is issue #634 verbatim, a bench that \
+       builds and is never run. Got {line:?}"
+    );
+  }
 }
 
 /// The matrix rows a job actually runs, after `exclude` is applied (issue

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -113,7 +113,7 @@ pub fn git_only_bin() -> &'static Path {
 /// stopped running, and `continue-on-error` on the `audit` job is what hid
 /// RUSTSEC-2025-0068 for nine months.
 ///
-/// Five ways to neutralise a job, plus the two assertions that keep this from
+/// Six ways to neutralise a job, plus the two assertions that keep this from
 /// passing over nothing:
 ///
 /// - the job must **exist**, and hold at least one step. An absent job parses
@@ -130,6 +130,13 @@ pub fn git_only_bin() -> &'static Path {
 ///   why this is checked rather than assumed. A `continue-on-error:` on a
 ///   dependency is deliberately not an error: it makes the dependency report
 ///   success, which lets the dependent run rather than skipping it.
+///
+/// - no command the job exists to run may swallow its own failure (issue
+///   #652). `cargo nextest run || true` needs none of the five keys above and
+///   produces the same dead job: the step reports success over a failing
+///   suite. Four shapes are rejected on any line that invokes cargo, `||`, a
+///   pipe, `set +e` anywhere in the same block, and `exit 0` anywhere after
+///   it.
 ///
 /// The whole closure is walked, not just the direct dependencies: a job two
 /// hops away from a conditional one is skipped exactly the same way.
@@ -234,7 +241,120 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
       "step {label:?} of the `{job_name}` job may not be conditioned away: it carries \
        `if: {cond:?}` and the only condition allowed for it is {allowed:?}"
     );
+
+    assert_run_cannot_swallow_its_failure(step, job_name, label);
   }
+}
+
+/// A `run:` block must let the command the job exists to run decide the step's
+/// exit status (issue #652).
+///
+/// The property is not "no pipe", which is why this is scoped rather than
+/// applied to every line: the `read the declared MSRV` step legitimately pipes
+/// `grep -m1 '^rust-version = ' Cargo.toml` into `cut -d'"' -f2`, and a guard
+/// that breaks it is the wrong guard. What matters is the command the job
+/// exists for, so only lines invoking cargo are read, and `exit 1` stays
+/// allowed, since that same step uses it to fail loudly.
+///
+/// The four shapes, each verified against the real workflow:
+///
+/// - `||`, which is how `cargo nextest run || true` reports success over a
+///   failing suite. `!line.contains('|')` covers the pipe case too;
+/// - a pipe, since a shell pipeline reports its last element's exit status;
+/// - `set +e` anywhere in the block, which disarms the `bash -e` GitHub runs
+///   `run:` under and leaves every following failure unreported;
+/// - `exit 0` anywhere after the command, which overrides whatever it returned.
+///   Not "at the end of the block": one on any later line does the same thing.
+///
+/// Matched with `contains("cargo ")` rather than `starts_with`, on purpose.
+/// `starts_with` tests a position, and a line prefixes: `env CARGO_TERM_COLOR=always
+/// cargo nextest run || true` and `timeout 600 cargo test --doc || true` are
+/// exactly the case this exists to catch and neither starts with `cargo `.
+/// `Cargo.toml` does not match it, capital C and no trailing space, which is
+/// checked against the real reader step rather than assumed.
+#[allow(dead_code)] // used by the two test binaries that parse ci.yml.
+fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: &str, label: &str) {
+  let Some(script) = step["run"].as_str() else {
+    return;
+  };
+  // Line continuations first: `cargo test \` then `|| true` on the next line is
+  // one command to the shell, and would read as two clean lines here.
+  let joined = script.replace("\\\n", " ");
+  let lines: Vec<&str> = joined.lines().collect();
+
+  let Some(at) = lines.iter().position(|l| l.contains("cargo ")) else {
+    return;
+  };
+
+  for line in lines.iter().filter(|l| l.contains("cargo ")) {
+    assert!(
+      !line.contains('|'),
+      "step {label:?} of the `{job_name}` job must let cargo decide the step's exit status: \
+       `||` reports success over a failure and a pipeline reports its last element's status, \
+       so the job goes green over a red command. Got {line:?}"
+    );
+  }
+  assert!(
+    !joined.contains("set +e"),
+    "step {label:?} of the `{job_name}` job must not `set +e`: GitHub runs `run:` under \
+     `bash -e`, and disarming it lets every later failure go unreported while the step \
+     still reports success. Got {script:?}"
+  );
+  for line in &lines[at + 1..] {
+    assert!(
+      !line.contains("exit 0"),
+      "step {label:?} of the `{job_name}` job must not `exit 0` after running cargo: it \
+       overrides whatever cargo returned. `exit 1` stays allowed, the MSRV reader uses it to \
+       fail loudly. Got {line:?}"
+    );
+  }
+}
+
+/// The matrix rows a job actually runs, after `exclude` is applied (issue
+/// #653).
+///
+/// Reading `strategy.matrix.os` alone is what `ci_test_matrix_runs_on_windows_latest`
+/// did, and an `exclude:` beside it deletes rows without touching that list:
+/// `test (windows-latest)` stops existing while the guard whose entire subject
+/// is the matrix keeps passing.
+///
+/// Anything this cannot reason about panics rather than answering vaguely. A
+/// second matrix dimension makes `exclude` a filter over combinations and not
+/// over names, and `include:` can add a row back after `exclude` removed it,
+/// so either one silently changes what the returned list means.
+#[allow(dead_code)] // used by the two test binaries that parse ci.yml.
+pub fn effective_matrix_os(job: &serde_yaml_ng::Value, job_name: &str) -> Vec<String> {
+  let matrix = &job["strategy"]["matrix"];
+  let keys: Vec<String> = matrix
+    .as_mapping()
+    .map(|m| m.keys().filter_map(|k| k.as_str().map(str::to_owned)).collect())
+    .unwrap_or_default();
+  for key in &keys {
+    assert!(
+      key == "os" || key == "exclude",
+      "the `{job_name}` matrix grew a `{key}` key, and this helper only knows how to apply \
+       `exclude` over a single `os` dimension. A second dimension makes `exclude` a filter \
+       over combinations, and `include:` adds rows back after `exclude` removed them, so \
+       the list returned here would no longer mean what its callers read it as"
+    );
+  }
+
+  let declared: Vec<String> = matrix["os"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|v| v.as_str().map(str::to_owned))
+    .collect();
+  let excluded: Vec<String> = matrix["exclude"]
+    .as_sequence()
+    .cloned()
+    .unwrap_or_default()
+    .iter()
+    .filter_map(|e| e["os"].as_str().map(str::to_owned))
+    .collect();
+
+  declared.into_iter().filter(|os| !excluded.contains(os)).collect()
 }
 
 /// The `needs:` of a job, as a list. The Actions schema allows both a bare

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -113,8 +113,8 @@ pub fn git_only_bin() -> &'static Path {
 /// stopped running, and `continue-on-error` on the `audit` job is what hid
 /// RUSTSEC-2025-0068 for nine months.
 ///
-/// Six ways to neutralise a job, plus the two assertions that keep this from
-/// passing over nothing:
+/// Five ways to neutralise a job, one invariant on the commands it runs, and
+/// the two assertions that keep this from passing over nothing:
 ///
 /// - the job must **exist**, and hold at least one step. An absent job parses
 ///   to `Value::Null`, and `null["if"]` is null, `null["steps"]` yields an
@@ -132,11 +132,10 @@ pub fn git_only_bin() -> &'static Path {
 ///   success, which lets the dependent run rather than skipping it.
 ///
 /// - no command the job exists to run may swallow its own failure (issue
-///   #652). `cargo nextest run || true` needs none of the five keys above and
-///   produces the same dead job: the step reports success over a failing
-///   suite. Four shapes are rejected on any line that invokes cargo, `||`, a
-///   pipe, `set +e` anywhere in the same block, and `exit 0` anywhere after
-///   it.
+///   #652). A `run:` block that invokes cargo must be **exactly one bare
+///   cargo invocation**, which is an invariant rather than a list of forbidden
+///   spellings. See `assert_run_cannot_swallow_its_failure` for why that
+///   distinction is the whole point.
 ///
 /// The whole closure is walked, not just the direct dependencies: a job two
 /// hops away from a conditional one is skipped exactly the same way.
@@ -246,89 +245,75 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
   }
 }
 
-/// A `run:` block must let the command the job exists to run decide the step's
-/// exit status (issue #652).
+/// A `run:` block that invokes cargo must be **exactly one bare cargo
+/// invocation** (issue #652).
 ///
-/// The property is not "no pipe", which is why this is scoped rather than
-/// applied to every line: the `read the declared MSRV` step legitimately pipes
-/// `grep -m1 '^rust-version = ' Cargo.toml` into `cut -d'"' -f2`, and a guard
-/// that breaks it is the wrong guard. What matters is the command the job
-/// exists for, so only lines invoking cargo are read, and `exit 1` stays
-/// allowed, since that same step uses it to fail loudly.
+/// This started as a denylist, `||`, a pipe, `set +e`, `exit 0`, and two
+/// review passes walked straight through it: `if ! cargo audit --deny
+/// warnings; then echo 'advisories found'; fi` leaves the `audit` job green on
+/// a red audit, which is literally the RUSTSEC-2025-0068 scenario, and `cargo
+/// bench --benches -- --test &` leaves `bench` green without waiting for the
+/// bench at all. Neither carries any of the four. A `shell:` line with `-e`
+/// dropped, and the same line moved to `defaults.run.shell`, walked through it
+/// too.
 ///
-/// The four shapes, each verified against the real workflow:
+/// Enumerating the ways a shell can discard an exit status does not converge,
+/// because the shell is a programming language and the list is its grammar.
+/// So the property is stated positively instead: one line, starting with
+/// `cargo `, made only of characters that carry no shell meaning. Everything
+/// above fails that, including the spellings nobody has thought of yet, and
+/// all eight cargo commands in `ci.yml` pass it unchanged.
 ///
-/// - `||`, which is how `cargo nextest run || true` reports success over a
-///   failing suite. `!line.contains('|')` covers the pipe case too;
-/// - a pipe, since a shell pipeline reports its last element's exit status;
-/// - `set +e` anywhere in the block, which disarms the `bash -e` GitHub runs
-///   `run:` under and leaves every following failure unreported;
-/// - a `shell:` whose command line drops `-e`, which disarms the same thing
-///   from outside the script. GitHub's own line for `shell: bash` is `bash
-///   --noprofile --norc -eo pipefail {0}`; writing that minus `-e` as a custom
-///   `shell:` is a one-word edit the `set +e` check cannot see, so only the
-///   built-in keywords that keep errexit are allowed;
-/// - `exit 0` anywhere in the block, before the command as well as on or after
-///   it. Before means cargo never runs, on or after means its status is
-///   discarded, and `cargo nextest run; exit 0` is the shortest spelling of
-///   the second.
+/// **Why there is no `shell:` assertion here.** A single command's exit status
+/// becomes the step's under every shell GitHub offers: `bash -e` and `sh -e`
+/// stop on it, and for `pwsh` GitHub appends `exit $LASTEXITCODE`. The
+/// denylist needed to know the shell because it allowed multi-command blocks,
+/// where errexit decides whether line 2 is reached. This does not allow them,
+/// so `shell:`, `defaults.run.shell` at job or workflow level, and pwsh's
+/// `$PSNativeCommandUseErrorActionPreference` all stop mattering. Removing
+/// that assertion is what the invariant buys, not something it overlooked.
 ///
-/// Matched with `contains("cargo ")` rather than `starts_with`, on purpose.
-/// `starts_with` tests a position, and a line prefixes: `env CARGO_TERM_COLOR=always
-/// cargo nextest run || true` and `timeout 600 cargo test --doc || true` are
-/// exactly the case this exists to catch and neither starts with `cargo `.
-/// `Cargo.toml` does not match it, capital C and no trailing space, which is
-/// checked against the real reader step rather than assumed.
+/// Steps that do not invoke cargo are out of scope and stay free-form: the
+/// `read the declared MSRV` step pipes `grep -m1 '^rust-version = ' Cargo.toml`
+/// into `cut -d'"' -f2` and uses `exit 1` to fail loudly, both of which are
+/// correct. It is detected by `contains("cargo ")` rather than a prefix,
+/// because a prefix test is defeated by `env VAR=x cargo …`, and `Cargo.toml`
+/// does not match it (capital C, no trailing space).
 #[allow(dead_code)] // used by the two test binaries that parse ci.yml.
 fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: &str, label: &str) {
   let Some(script) = step["run"].as_str() else {
     return;
   };
-  // Line continuations first: `cargo test \` then `|| true` on the next line is
-  // one command to the shell, and would read as two clean lines here.
-  let joined = script.replace("\\\n", " ");
-  let lines: Vec<&str> = joined.lines().collect();
-
+  let lines: Vec<&str> = script.lines().collect();
   if !lines.iter().any(|l| l.contains("cargo ")) {
     return;
   }
 
-  // Built-in keywords only. GitHub expands each into a command line that keeps
-  // errexit on (`bash --noprofile --norc -eo pipefail {0}`, `sh -e {0}`, and
-  // pwsh's `$ErrorActionPreference = 'stop'`), where a custom line is free to
-  // drop it. That is `set +e` written one level out, where the check below
-  // cannot reach.
-  let shell = &step["shell"];
-  assert!(
-    shell.is_null() || matches!(shell.as_str(), Some("bash" | "sh" | "pwsh")),
-    "step {label:?} of the `{job_name}` job runs cargo under `shell: {shell:?}`. Only the \
-     built-in `bash`, `sh` and `pwsh` keywords are allowed: a custom shell line is free to \
-     drop the `-e` that makes the step fail when cargo does, which is `set +e` moved out of \
-     the script where this guard cannot see it"
+  assert_eq!(
+    lines.len(),
+    1,
+    "step {label:?} of the `{job_name}` job invokes cargo, so its `run:` must be that one \
+     command and nothing else. A second line is where the exit status gets discarded, by an \
+     `exit 0`, by an `echo` that reports its own status, or by a `set +e` that stops errexit \
+     from ever reaching it. Got {script:?}"
   );
 
-  for line in lines.iter().filter(|l| l.contains("cargo ")) {
-    assert!(
-      !line.contains('|'),
-      "step {label:?} of the `{job_name}` job must let cargo decide the step's exit status: \
-       `||` reports success over a failure and a pipeline reports its last element's status, \
-       so the job goes green over a red command. Got {line:?}"
-    );
-  }
+  // Bare invocation: the characters allowed are the ones that appear in a
+  // cargo command line and carry no meaning to the shell. Everything else,
+  // `|`, `&`, `;`, `>`, backtick, `$`, `(`, `!`, `#`, quotes, is either a way
+  // to discard the status or a way to run something that is not this command.
+  let line = lines[0];
+  let bare = line.starts_with("cargo ")
+    && line
+      .chars()
+      .all(|c| c.is_ascii_alphanumeric() || " ._:/@=+-".contains(c));
   assert!(
-    !joined.contains("set +e"),
-    "step {label:?} of the `{job_name}` job must not `set +e`: GitHub runs `run:` under \
-     `bash -e`, and disarming it lets every later failure go unreported while the step \
-     still reports success. Got {script:?}"
-  );
-  // The whole block, not the lines after the command. `exit 0` before it means
-  // cargo never runs, on the same line (`cargo nextest run; exit 0`) means its
-  // status is discarded, and a window opened at `at + 1` sees neither.
-  assert!(
-    !joined.contains("exit 0"),
-    "step {label:?} of the `{job_name}` job must not carry `exit 0`: before the cargo line it \
-     stops cargo from running at all, on or after it the status cargo returned is discarded. \
-     `exit 1` stays allowed, the MSRV reader uses it to fail loudly. Got {script:?}"
+    bare,
+    "step {label:?} of the `{job_name}` job must run cargo as a bare command: one \
+     invocation, no shell operators. `if ! cargo audit …; then …; fi` and `cargo bench … &` \
+     both report success over a failure while carrying no `||`, no pipe, no `set +e` and no \
+     `exit 0`, which is why this is stated as an invariant and not as a list of forbidden \
+     spellings. Got {line:?}"
   );
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -358,7 +358,10 @@ fn assert_run_cannot_swallow_its_failure(
      invocation, no shell operators. `if ! cargo audit …; then …; fi` and `cargo bench … &` \
      both report success over a failure while carrying no `||`, no pipe, no `set +e` and no \
      `exit 0`, which is why this is stated as an invariant and not as a list of forbidden \
-     spellings. Got {line:?}"
+     spellings. A `${{{{ … }}}}` expression is refused too, deliberately: the runner splices it \
+     into the line before any shell sees it, so an attacker-controlled value becomes shell \
+     source. Pass it through `env:` and read it as `$VAR`, which is GitHub's own advice, in a \
+     step this guard leaves free-form. Got {line:?}"
   );
 
   for flag in ["--no-run", "--dry-run"] {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -263,8 +263,15 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
 /// - a pipe, since a shell pipeline reports its last element's exit status;
 /// - `set +e` anywhere in the block, which disarms the `bash -e` GitHub runs
 ///   `run:` under and leaves every following failure unreported;
-/// - `exit 0` anywhere after the command, which overrides whatever it returned.
-///   Not "at the end of the block": one on any later line does the same thing.
+/// - a `shell:` whose command line drops `-e`, which disarms the same thing
+///   from outside the script. GitHub's own line for `shell: bash` is `bash
+///   --noprofile --norc -eo pipefail {0}`; writing that minus `-e` as a custom
+///   `shell:` is a one-word edit the `set +e` check cannot see, so only the
+///   built-in keywords that keep errexit are allowed;
+/// - `exit 0` anywhere in the block, before the command as well as on or after
+///   it. Before means cargo never runs, on or after means its status is
+///   discarded, and `cargo nextest run; exit 0` is the shortest spelling of
+///   the second.
 ///
 /// Matched with `contains("cargo ")` rather than `starts_with`, on purpose.
 /// `starts_with` tests a position, and a line prefixes: `env CARGO_TERM_COLOR=always
@@ -282,9 +289,23 @@ fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: 
   let joined = script.replace("\\\n", " ");
   let lines: Vec<&str> = joined.lines().collect();
 
-  let Some(at) = lines.iter().position(|l| l.contains("cargo ")) else {
+  if !lines.iter().any(|l| l.contains("cargo ")) {
     return;
-  };
+  }
+
+  // Built-in keywords only. GitHub expands each into a command line that keeps
+  // errexit on (`bash --noprofile --norc -eo pipefail {0}`, `sh -e {0}`, and
+  // pwsh's `$ErrorActionPreference = 'stop'`), where a custom line is free to
+  // drop it. That is `set +e` written one level out, where the check below
+  // cannot reach.
+  let shell = &step["shell"];
+  assert!(
+    shell.is_null() || matches!(shell.as_str(), Some("bash" | "sh" | "pwsh")),
+    "step {label:?} of the `{job_name}` job runs cargo under `shell: {shell:?}`. Only the \
+     built-in `bash`, `sh` and `pwsh` keywords are allowed: a custom shell line is free to \
+     drop the `-e` that makes the step fail when cargo does, which is `set +e` moved out of \
+     the script where this guard cannot see it"
+  );
 
   for line in lines.iter().filter(|l| l.contains("cargo ")) {
     assert!(
@@ -300,14 +321,15 @@ fn assert_run_cannot_swallow_its_failure(step: &serde_yaml_ng::Value, job_name: 
      `bash -e`, and disarming it lets every later failure go unreported while the step \
      still reports success. Got {script:?}"
   );
-  for line in &lines[at + 1..] {
-    assert!(
-      !line.contains("exit 0"),
-      "step {label:?} of the `{job_name}` job must not `exit 0` after running cargo: it \
-       overrides whatever cargo returned. `exit 1` stays allowed, the MSRV reader uses it to \
-       fail loudly. Got {line:?}"
-    );
-  }
+  // The whole block, not the lines after the command. `exit 0` before it means
+  // cargo never runs, on the same line (`cargo nextest run; exit 0`) means its
+  // status is discarded, and a window opened at `at + 1` sees neither.
+  assert!(
+    !joined.contains("exit 0"),
+    "step {label:?} of the `{job_name}` job must not carry `exit 0`: before the cargo line it \
+     stops cargo from running at all, on or after it the status cargo returned is discarded. \
+     `exit 1` stays allowed, the MSRV reader uses it to fail loudly. Got {script:?}"
+  );
 }
 
 /// The matrix rows a job actually runs, after `exclude` is applied (issue
@@ -353,6 +375,21 @@ pub fn effective_matrix_os(job: &serde_yaml_ng::Value, job_name: &str) -> Vec<St
     .iter()
     .filter_map(|e| e["os"].as_str().map(str::to_owned))
     .collect();
+
+  // `runs-on:` is what actually decides where a row executes, and it sits one
+  // line above the matrix this function reads. Pinning it to the matrix is what
+  // makes the returned list mean anything: a literal `runs-on: ubuntu-latest`
+  // leaves `test (windows-latest)` in the checks list, satisfying the required
+  // contexts on `main`, while nothing ever compiles the
+  // `[target."cfg(windows)".dependencies]` block. Worse than the `exclude:`
+  // this function exists to catch, which at least deletes the row.
+  let runs_on = job["runs-on"].as_str().unwrap_or_default();
+  assert_eq!(
+    runs_on, "${{ matrix.os }}",
+    "the `{job_name}` job has a matrix, so its `runs-on:` must derive from it. A literal \
+     runner makes every row execute on the same machine while the rows keep their per-OS \
+     names, so the checks list still advertises the platform nobody tested on"
+  );
 
   declared.into_iter().filter(|os| !excluded.contains(os)).collect()
 }

--- a/tests/msrv_tests.rs
+++ b/tests/msrv_tests.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::path::PathBuf;
 
 mod common;
-use common::assert_job_is_blocking;
+use common::{assert_job_is_blocking, effective_matrix_os};
 
 fn repo_file(rel: &str) -> PathBuf {
   PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
@@ -107,14 +107,11 @@ fn steps(job: &serde_yaml_ng::Value) -> Vec<serde_yaml_ng::Value> {
 
 #[test]
 fn ci_runs_the_msrv_check_on_every_supported_platform() {
+  // Through `effective_matrix_os` and not `strategy.matrix.os` (issue #653):
+  // an `exclude:` deletes rows without touching that list, so this guard would
+  // keep passing over a matrix that no longer holds the rows it names.
   let job = msrv_job();
-  let matrix = job["strategy"]["matrix"]["os"]
-    .as_sequence()
-    .cloned()
-    .unwrap_or_default()
-    .iter()
-    .filter_map(|v| v.as_str().map(str::to_owned))
-    .collect::<Vec<_>>();
+  let matrix = effective_matrix_os(&job, "msrv");
   for os in ["ubuntu-latest", "macos-latest", "windows-latest"] {
     assert!(
       matrix.iter().any(|m| m == os),

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::{path::Path, process::Command};
 
 mod common;
-use common::assert_job_is_blocking;
+use common::{assert_job_is_blocking, effective_matrix_os};
 
 #[cfg(unix)]
 const CHECK_RC_DUPES: &str = ".github/scripts/check-rc-changelog-dupes.sh";
@@ -406,16 +406,14 @@ fn run_steps(job: &serde_yaml_ng::Value) -> Vec<String> {
     .collect()
 }
 
+/// Read through `effective_matrix_os` and not `strategy.matrix.os` directly
+/// (issue #653): an `exclude:` beside that list deletes rows without touching
+/// it, so `test (windows-latest)` stops existing while this guard, whose whole
+/// subject is the matrix, keeps passing.
 #[test]
 fn ci_test_matrix_runs_on_windows_latest() {
   let job = ci_job("test");
-  let matrix: Vec<String> = job["strategy"]["matrix"]["os"]
-    .as_sequence()
-    .cloned()
-    .unwrap_or_default()
-    .iter()
-    .filter_map(|v| v.as_str().map(str::to_owned))
-    .collect();
+  let matrix = effective_matrix_os(&job, "test");
 
   for os in ["ubuntu-latest", "macos-latest", "windows-latest"] {
     assert!(
@@ -831,5 +829,65 @@ fn ci_audits_dependencies_and_can_fail_on_an_advisory() {
     "the audit command must carry no pipe and no `||`: a shell pipeline reports its last \
      element's exit status, so `cargo audit --deny warnings || true` succeeds over a \
      failing audit exactly as the `continue-on-error` this guard also forbids. Got {run:?}"
+  );
+}
+
+/// Issue #653. Every guard in this file and in `msrv_tests.rs` reasons about
+/// jobs, and the workflow's own `on:` block switches all eight off at once,
+/// one level above every one of them. Narrowing `branches:` to `[main]` stops
+/// the whole of CI on a pull request targeting `dev`, which is where every
+/// feature branch lands, and leaves all 26 tests green.
+///
+/// `paths:` is the same hole in a subtler shape, and the reason it is asserted
+/// absent rather than merely checked: `paths: ['src/**']` would skip CI on a
+/// pull request touching only `tests/`, which is exactly the shape of this
+/// very change. It is `needs:` one level up.
+///
+/// The key is read as the string `"on"`. YAML 1.1 would resolve a bare `on`
+/// to the boolean `true`, which is the classic trap for anything parsing
+/// Actions workflows, but serde_yaml_ng implements YAML 1.2, where it stays a
+/// string. Checked against this file rather than assumed, and stated here so
+/// nobody "fixes" it into `workflow[true]`.
+#[test]
+fn ci_fires_on_main_and_dev_with_nothing_filtered_out() {
+  let on = &ci_workflow()["on"];
+  assert!(
+    !on.is_null(),
+    "ci.yml must declare an `on:` block: without one the workflow never runs and every \
+     job-level guard in this file passes over a workflow nobody triggers"
+  );
+
+  for event in ["push", "pull_request"] {
+    let branches: Vec<String> = on[event]["branches"]
+      .as_sequence()
+      .cloned()
+      .unwrap_or_default()
+      .iter()
+      .filter_map(|v| v.as_str().map(str::to_owned))
+      .collect();
+    for branch in ["main", "dev"] {
+      assert!(
+        branches.iter().any(|b| b == branch),
+        "ci.yml must fire on `{event}` for `{branch}` (branches are {branches:?}). `dev` is \
+         where every feature branch lands and `main` is what releases are cut from, so \
+         dropping either stops all eight jobs on that path while every job-level guard \
+         stays green"
+      );
+    }
+    for filter in ["paths", "paths-ignore"] {
+      assert!(
+        on[event][filter].is_null(),
+        "ci.yml must not filter `{event}` by `{filter}`: a path filter skips the whole \
+         workflow on a change it does not match, so a pull request touching only `tests/` \
+         would run no CI at all. Got `{filter}: {:?}`",
+        on[event][filter]
+      );
+    }
+  }
+
+  assert!(
+    on.as_mapping().is_some_and(|m| m.contains_key("workflow_dispatch")),
+    "ci.yml must keep `workflow_dispatch:`: it is the only way to re-run the suite without \
+     pushing a commit"
   );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -874,12 +874,35 @@ fn ci_fires_on_main_and_dev_with_nothing_filtered_out() {
          stays green"
       );
     }
-    for filter in ["paths", "paths-ignore"] {
+    // `types:` belongs beside the path filters and is the sharpest of the
+    // three, because it has defaults (`opened`, `synchronize`, `reopened`):
+    // `types: [labeled]` stops CI on every ordinary pull request while the
+    // event and its branches still read exactly as they do now.
+    //
+    // Each carries its own reason. A shared message would describe a path
+    // filter while firing on `types:`, which is an assertion lying about what
+    // it checks.
+    for (filter, why) in [
+      (
+        "paths",
+        "a path filter skips the whole workflow on a change it does not match, so a pull \
+         request touching only `tests/` would run no CI at all",
+      ),
+      (
+        "paths-ignore",
+        "an ignore filter skips the whole workflow on a change it does match, which is the \
+         same hole written the other way round",
+      ),
+      (
+        "types",
+        "restricting the activity types replaces the defaults (`opened`, `synchronize`, \
+         `reopened`), so something like `types: [labeled]` runs no CI on an ordinary pull \
+         request while the branches above still read as they do now",
+      ),
+    ] {
       assert!(
         on[event][filter].is_null(),
-        "ci.yml must not filter `{event}` by `{filter}`: a path filter skips the whole \
-         workflow on a change it does not match, so a pull request touching only `tests/` \
-         would run no CI at all. Got `{filter}: {:?}`",
+        "ci.yml must not filter `{event}` by `{filter}`: {why}. Got `{filter}: {:?}`",
         on[event][filter]
       );
     }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -865,6 +865,19 @@ fn ci_fires_on_main_and_dev_with_nothing_filtered_out() {
       .iter()
       .filter_map(|v| v.as_str().map(str::to_owned))
       .collect();
+    // Membership is not enough: GitHub reads these as patterns, and a later
+    // `!dev` excludes what an earlier `dev` included. `[main, dev, '!dev']`
+    // passes every membership test above while no pull request to `dev` runs
+    // any CI at all.
+    for pattern in &branches {
+      assert!(
+        !pattern.starts_with('!'),
+        "ci.yml must not carry a negative branch pattern on `{event}`: `{pattern}` excludes \
+         what an earlier entry includes, so the list still reads as if it covered that \
+         branch while nothing fires on it. Got {branches:?}"
+      );
+    }
+
     for branch in ["main", "dev"] {
       assert!(
         branches.iter().any(|b| b == branch),


### PR DESCRIPTION
## Description

#646 pinned the job level: a guarded job cannot be switched off through its own
`if:` or `continue-on-error:`, either of those on a step, or a `needs:` closure
narrowed with an `if:`. Reviewing it turned up three ways around that, one
below the job and two above. Each was found by mutating the real workflow, and
each left the whole suite green.

Both issues land in one PR because they touch the same three files and the same
helper, and the repo's rule is to keep at most a small number of PRs open on a
shared surface rather than stack them.

Closes #652
Closes #653

## Type of change

- [ ] ✨ Feature (new functionality)
- [ ] 🐛 Fix (bug fix)
- [ ] 🚑️ Hotfix (critical production fix)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] ⚡ Perf
- [ ] 🔧 Chore / CI / build

## Changes

**#652, below the job.** `assert_job_is_blocking` gains a sixth neutralisation:
a `run:` line that swallows its own failure.

This landed twice. The first version was a denylist, `||`, a pipe, `set +e`,
`exit 0`, and two review passes walked straight through it:

- `if ! cargo audit --deny warnings; then echo 'advisories found'; fi` leaves
  the `audit` job green on a red audit. That is the RUSTSEC-2025-0068 scenario
  itself, and it carries none of the four;
- `cargo bench --benches -- --test &` leaves `bench` green without waiting for
  the bench at all;
- `shell: bash --noprofile --norc {0}` (GitHub's own line minus `-e`) disarms
  errexit from outside the script, and moving it to `defaults.run.shell` puts
  it out of reach of a step-level check entirely.

Six vectors over two passes with no convergence, because the shell is a
programming language and a denylist is an attempt to write its grammar. So the
property is stated positively instead: **a `run:` block that invokes cargo is
exactly one line, starting with `cargo `, made only of characters that carry no
shell meaning.** Every vector above fails that, including the spellings nobody
has thought of yet, and all eight cargo commands in `ci.yml` pass it unchanged.

The character class was checked against those eight and against sixteen attack
spellings before being written, rather than after.

Two things the shape alone does not reach are named separately, both found by
mutating the invariant against itself:

- **the shell that runs it.** An intermediate revision dropped the `shell:`
  assertion, reasoning that a single command's exit status becomes the step's
  "under every shell GitHub offers". That reasoning was an enumeration in
  disguise, the very thing this PR spent two passes learning not to write:
  `shell:` takes an arbitrary command line, not a keyword, so `shell: 'true
  {0}'` never runs the script and `shell: bash -n {0}` only parses it. Both are
  green against the shape. The assertion is back as a whitelist of the
  built-ins that do run the script, read at step level and in `defaults.run` at
  job and workflow level, the only two places `defaults` exists;
- **flags that compile without running.** `cargo bench --no-run --benches --
  --test` is one bare invocation, satisfies the shape, and is issue #634
  verbatim: the benches build and never run. The bench test's own docstring
  names `--no-run` as what it must prevent and never asserted it. Unlike shell
  grammar, the set of cargo flags meaning "do not execute" is finite and
  documented by cargo, so naming them is a bounded list backing an invariant
  rather than standing in for one.

Steps that do not invoke cargo stay free-form, which is what keeps the `read
the declared MSRV` step legal: it pipes `grep` into `cut` and uses `exit 1` to
fail loudly, both correct. Detection is a whitespace-delimited `cargo`
**token**: a prefix test is defeated by `env VAR=x cargo …`, and
`contains("cargo ")` hung the whole check on one literal space, so
`cargo\tcheck --locked || true` opted out of it entirely. `Cargo.toml` is not a
`cargo` token, so the reader step stays out.


**#653, above the job.**

- `runs-on:` must derive from the matrix. A literal `runs-on: ubuntu-latest`
  keeps `test (windows-latest)` in the checks list, so the required contexts on
  `main` stay satisfied, while nothing ever compiles the
  `[target."cfg(windows)".dependencies]` block. Worse than the `exclude:` below,
  which at least deletes the row;
- `effective_matrix_os` applies `strategy.matrix.exclude`, and
  `ci_test_matrix_runs_on_windows_latest` /
  `ci_runs_the_msrv_check_on_every_supported_platform` now read it. They read
  `strategy.matrix.os` and never the `exclude` beside it, so
  `test (windows-latest)` could stop existing while the guard whose entire
  subject is the matrix kept passing. It panics rather than answering vaguely
  on a second matrix dimension or on an `include:`, either of which changes
  what the returned list means;
- `ci_fires_on_main_and_dev_with_nothing_filtered_out` pins the workflow's own
  trigger: `push` and `pull_request` on both `main` and `dev`,
  `workflow_dispatch` kept, and `paths:`, `paths-ignore:` and `types:` asserted
  **absent**, each with its own reason rather than a shared message that would
  describe a path filter while firing on `types:`. Branch membership alone was
  not enough: GitHub reads those entries as patterns, so
  `branches: [main, dev, '!dev']` passed every membership assertion while no
  pull request to `dev` fired anything. Negative patterns are rejected.
  A path filter is `needs:` one level up: `paths: ['src/**']` would skip CI
  entirely on a pull request touching only `tests/`, which is the shape of this
  very change.

The `on` key is read as the string `"on"`. YAML 1.1 resolves a bare `on` to the
boolean `true`, the classic trap for anything parsing Actions workflows;
serde_yaml_ng implements YAML 1.2, where it stays a string. Verified against
this file and stated in the test so nobody "fixes" it into `workflow[true]`.

## Tests

- [x] `cargo test` passes locally: **3537 passed, 0 failed** across 111 test
  binaries plus doctests, `EXIT=0`
- [x] `cargo fmt --check` passes (`EXIT=0`)
- [x] `cargo clippy --all-targets -- -D warnings` passes (`EXIT=0`)
- [x] New tests added under `tests/`

### Demonstrated red

Mutations against the real `.github/workflows/ci.yml`, both affected
binaries run with `--no-fail-fast`, exit code read from `$?` rather than through
a pipe, `ci.yml` restored from a copy rather than with `git checkout --`.

Every one below was checked for **which** assertion fired, not just that
something did. That distinction is what #651's review caught twice, and it
changed one of the entries here.

**#652, the four shapes**

| mutation | fires |
|---|---|
| `cargo nextest run \|\| true` | `must let cargo decide the step's exit status` |
| `cargo nextest run \| tee out.log` | same |
| `env CARGO_TERM_COLOR=always cargo nextest run \|\| true` | same, the prefix case |
| `timeout 600 cargo test --doc \|\| true` | same |
| `cargo check --all-targets --locked \|\| true` (msrv) | same |
| `cargo build --verbose \` + `\|\| true` (continuation) | same |
| `set +e` before `cargo audit` | `must not set +e` |
| `exit 0` after `cargo audit`, mid-block | `must not exit 0 after running cargo` |

```
$ # env prefix, the case `starts_with` would have missed
EXIT=101
step "cargo nextest run" of the `test` job must let cargo decide the step's exit
status: `||` reports success over a failure and a pipeline reports its last
element's status, so the job goes green over a red command.
Got "env CARGO_TERM_COLOR=always cargo nextest run || true"
```

```
$ # set +e, which `!run.contains('|')` would not have seen
EXIT=101
tests/common/mod.rs:297:3:
step "cargo audit" of the `audit` job must not `set +e`: GitHub runs `run:`
under `bash -e`, and disarming it lets every later failure go unreported while
the step still reports success. Got "set +e\ncargo audit --deny warnings\n"
```

```
$ # exit 0 on a line after the command, not at the end of the block
EXIT=101
tests/common/mod.rs:304:5:
step "cargo audit" of the `audit` job must not `exit 0` after running cargo: it
overrides whatever cargo returned. `exit 1` stays allowed, the MSRV reader uses
it to fail loudly. Got "exit 0"
```

**One attribution worth stating.** `cargo bench --benches -- --test || true`
does go red, but in `release_workflow_tests.rs:500`, on the
`!bench_run.contains('|')` assertion that predates this PR, never in the new
guard. So the new guard was isolated on `bench` with a mutation the old
assertion cannot see:

```
$ # set +e on the bench job
EXIT=101
tests/common/mod.rs:297:3:
step "cargo bench --test" of the `bench` job must not `set +e`: […]
```

That older assertion is now redundant with the new one for the pipe case. It is
left in place: it carries its own rationale about #634 and removing it is not
what this PR is for.

**#653, the matrix**

```
$ # exclude: [macos-latest, windows-latest] on the test job
EXIT=101
tests/release_workflow_tests.rs:419:5:
ci.yml test matrix must include macos-latest (matrix is ["ubuntu-latest"])
```

```
$ # same on msrv
EXIT=101
tests/msrv_tests.rs:116:5:
the msrv job must run on macos-latest, like the `test` job (matrix is
["ubuntu-latest"]). A single-platform run compiles neither the
`[target."cfg(windows)".dependencies]` block nor the `#[cfg(windows)]` code […]
```

```
$ # include: added, which the helper refuses to reason about
EXIT=101
tests/common/mod.rs:333:5:
the `msrv` matrix grew a `include` key, and this helper only knows how to apply
`exclude` over a single `os` dimension. […]
```

**#653, the trigger**

```
$ # branches: [main] instead of [main, dev]
EXIT=101
ci.yml must fire on `push` for `dev` (branches are ["main"]). `dev` is where
every feature branch lands and `main` is what releases are cut from, so
dropping either stops all eight jobs on that path while every job-level guard
stays green
```

```
$ # paths: ['src/**'] on pull_request
EXIT=101
ci.yml must not filter `pull_request` by `paths`: a path filter skips the whole
workflow on a change it does not match, so a pull request touching only
`tests/` would run no CI at all. Got `paths: Sequence [String("src/**")]`
```

```
$ # workflow_dispatch removed
EXIT=101
ci.yml must keep `workflow_dispatch:`: it is the only way to re-run the suite
without pushing a commit
```

### What review found

Four passes. Thirteen blocking findings, none cosmetic, none inside the
assertions themselves: every one was a hole **beside** them, each proved by a
mutation that left the whole suite green.

**Pass 1** (`e0f58750`). `exit 0` was scanned over `lines[at + 1..]`, a window
half-open the wrong way at both ends, so `cargo nextest run; exit 0` and an
`exit 0` placed *before* the command both passed. `shell:` was unread, though
it is the premise the `set +e` assertion rests on. `runs-on:` was unread, one
line above the matrix `effective_matrix_os` reads: a literal
`runs-on: ubuntu-latest` keeps `test (windows-latest)` in the checks list, so
the required contexts on `main` stay satisfied while nothing ever compiles the
`cfg(windows)` blocks. `types:` was missing from a test named
`with_nothing_filtered_out`.

**Pass 2** (`400e8767`). Four more ways past the denylist, including the two
that forced the rewrite, plus the negative branch pattern.

**Pass 3** (`7756f247`). The rewrite had overshot: dropping the `shell:`
assertion rested on an enumeration of shells, and `shell: 'true {0}'` is not in
it. `--no-run` satisfies the shape while being #634 verbatim. The detection
predicate hung on a literal space, so a tab opted a step out.

**A defect introduced while fixing.** Folding `types:` into the existing
`paths` loop made it fire with the path-filter message, an assertion lying
about what it checks, which is the exact defect class this PR is about. Each
filter now carries its own reason.


### Demonstrated red

Twenty-one mutations, both binaries, `--no-fail-fast`, exit code from `$?`,
`ci.yml` restored from a copy. Each was checked for **which** assertion fired.

| mutation | fires |
|---|---|
| `cargo nextest run \|\| true` | bare command |
| `cargo nextest run \| tee out.log` | bare command |
| `env CARGO_TERM_COLOR=always cargo nextest run \|\| true` | bare command |
| `cargo nextest run; exit 0` | bare command |
| `if ! cargo audit --deny warnings; then echo …; fi` | bare command |
| `cargo bench --benches -- --test &` | bare command |
| `cargo audit --deny warnings > /dev/null` | bare command |
| `cargo audit --deny warnings $(true)` | bare command |
| `set +e` then `cargo audit` | one command |
| `exit 0` then `cargo audit` | one command |
| `cargo nextest run` then `echo done` | one command |
| `shell: bash --noprofile --norc {0}` + second line | one command |
| `defaults.run.shell` custom + second line | one command |
| `branches: [main, dev, '!dev']` | negative pattern |
| `shell: 'true {0}'` on a cargo step | shell whitelist |
| `shell: bash -n {0}` | shell whitelist |
| `defaults.run.shell` custom, job level | shell whitelist |
| `defaults.run.shell` custom, workflow level | shell whitelist |
| `cargo bench --no-run --benches -- --test` | `must not pass --no-run` |
| `cargo nextest run --no-run` | same |
| `cargo\tcheck --all-targets --locked \|\| true` | bare command |

```
$ # the RUSTSEC scenario, which carried none of the four denylisted spellings
EXIT=101
step "cargo audit" of the `audit` job must run cargo as a bare command: one
invocation, no shell operators. `if ! cargo audit …; then …; fi` and
`cargo bench … &` both report success over a failure while carrying no `||`,
no pipe, no `set +e` and no `exit 0`, which is why this is stated as an
invariant and not as a list of forbidden spellings.
Got "if ! cargo audit --deny warnings; then echo 'advisories found'; fi"
```

```
$ # a shell that never runs the script it is handed
EXIT=101
step "cargo nextest run" of the `test` job runs cargo under
`shell: String("true {0}")` set on this step. Only the built-in `bash`, `sh`
and `pwsh` keywords are allowed, because `shell:` otherwise takes a whole
command line: `true {0}` never runs the script and `bash -n {0}` only parses
it, both leaving a green step over a command that never executed
```

```
$ # issue #634 verbatim, one bare invocation that builds and never runs
EXIT=101
step "cargo bench --test" of the `bench` job must not pass `--no-run`: it
compiles the target and never executes it, so the step reports success over
work that never ran.
Got "cargo bench --no-run --benches -- --test"
```

The earlier mutations for `#653` (matrix `exclude` on both jobs, `include`,
`runs-on` literal on both jobs, `branches: [main]`, `paths`, `types`,
`workflow_dispatch` removed) all still fire, each at its own assertion.


## Screenshots / TUI captures

N/A, no TUI surface touched.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] README updated if CLI surface changed (N/A)
- [x] `examples/gwm.toml.example` updated if config schema changed (N/A)
- [x] No `unwrap()` on user-facing paths (N/A, tests only)
- [x] No `println!` in TUI render code (N/A)

## Linked issues / docs

- Issues: #652, #653
- Both filed from the review of #651 (#646), which pinned the job level

## Where this stopped, and why it is not a clean counter

Review ran four passes and this PR **stops on stagnation, not on zero**. That
distinction is the reviewer's to weigh, so here it is plainly.

| pass | blocking | what they were |
|---|---|---|
| 1 | 5 | holes beside the new assertions |
| 2 | 5 | same family, which forced the rewrite |
| 3 | 3 | the shell, the flags, the detection predicate |
| 4 | 7 | three **new surfaces**, plus two already-fixed items and a stale CHANGELOG |

Pass 4 did not repeat pass 3. It opened `cargo test --doc zzz_no_such_doctest`
(a filter matching nothing), `CARGO_TARGET_<TRIPLE>_RUNNER: "true"` in the
workflow's `env:` block, and the same override written into
`.cargo/config.toml` by a non-cargo step. Different surfaces, not variants.

The reason is structural. This guard reads YAML; the property it reaches for is
"the command fails the job when the code is broken". Between the two sit cargo,
the shell, the process environment and `.cargo/config.toml`. A static reader
does not cross that gap. It can make each crossing **visible in a diff**, which
is what the bare-command invariant does, and that is its ceiling. A fifth pass
would open a sixth surface, not close the fifth.

So the remainder is filed rather than chased:

- **#655** is bounded and actionable: `fmt` and `clippy` are two of the seven
  required checks on `main` and no guard points at them. Pre-existing, not a
  regression from this PR, and the fix is two `assert_job_is_blocking` calls.
  Left out on the repo's own rule about widening a PR mid-review, after this
  one had already absorbed four rounds.
- **#656** records the ceiling itself, with the three surfaces and the two ways
  out (accept and document, or move to an observational check that breaks a
  test on a scratch branch and asserts the checks go red). One vector in it,
  criterion's exit code on a bench filter matching nothing, is flagged as
  **not measured**: the mutation was green against the guard, the exit code was
  never confirmed.

What this PR does close is real and proved: 21 mutations red, each checked for
which assertion fired.

## Notes for reviewers

**Where the scope line was drawn.** `assert_job_is_blocking` absorbs #652
because a command that swallows its failure makes the job non-blocking, which
is that helper's whole subject. #653 stays outside it: the matrix and the
trigger are not properties of one job, and folding them in would have given
that function a second subject.

**The narrowing is the design, and it is the part to attack.** Scoping to cargo
lines means a non-cargo command that the job depends on can still swallow its
failure. That is deliberate here, since `git config --global user.email` failing
is a different question, but it is a real limit rather than an oversight, and a
counter-example would be worth raising.

**Sequencing.** #646 set the order #646 → #647 → #649, all on
`tests/release_workflow_tests.rs`. #652 and #653 were taken first at the
maintainer's request, so #647 and #649 will rebase onto a moved file. #648 is
disjoint and unaffected.

https://claude.ai/code/session_01Sqahwoxj6v4hXgUCTVkrT4
