### PR TITLE
📝 docs(tests): name the three surfaces the cargo guard does not reach

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -333,7 +333,7 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
 ///   it before the cargo step runs.
 ///
 /// One vector named in the issue is deliberately not in that list. Both the
-/// empty filter and the runner override leave `cargo test --doc` at
+/// non-matching filter and the runner override leave `cargo test --doc` at
 /// `0 passed`, exit 0, and so does a plain `cargo test --doc` on this tree:
 /// the crate has no Rust doctests, every fenced block in its doc comments
 /// being `text`, `toml` or `go`. Nothing is being silenced there, the step

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -296,9 +296,11 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
 /// is broken". Between this file and that property sit cargo's own argument
 /// parsing, the process environment and `.cargo/config.toml`, and a reader of
 /// the workflow does not cross that gap. It can only make a crossing visible
-/// in a diff, which is what the shape above does. Three surfaces measured
-/// while reviewing #654 sit on the far side, and #656 records the decision to
-/// name them here rather than chase them: each review pass opened a surface
+/// in a diff, which is what the shape above does. Three surfaces sit on the
+/// far side. Reviewing #654 found them; they are listed below as this branch
+/// re-measured them against the commands the workflow actually runs, which
+/// moved two of them away from where #656 put them. #656 records the decision
+/// to name them here rather than chase them: each review pass opened a surface
 /// the previous fix did not touch instead of a variant of it, which is a
 /// domain with no last entry.
 ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -302,27 +302,43 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
 /// the previous fix did not touch instead of a variant of it, which is a
 /// domain with no last entry.
 ///
-/// - **a filter that matches nothing.** Every guarded runner has one, all
-///   measured locally at exit 0. `cargo test --doc zzz_no_such_doctest`
-///   reports `0 passed`; `cargo nextest run --no-tests pass zzz_no_such_test`
-///   reports `0 tests run`, and bare nextest 0.9.143 exits 4 on no tests, so
-///   it is `--no-tests pass` that silences it; `cargo bench --benches --
-///   --test zzz_no_such_bench` runs the three bench binaries, prints nothing
-///   and exits 0. Each one is a single bare line of allowed characters.
-///   Telling a filter from the value of a flag means re-implementing cargo's
-///   argument parsing on both sides of `--`, which is the mistake #634 already
-///   paid for, a model written in place of the oracle;
-/// - **the environment.** `CARGO_TARGET_<TRIPLE>_RUNNER: "true"` has every
-///   test binary executed by `true`:
-///   `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=true cargo test --test
-///   msrv_tests` never launches the binary and exits 0. Walking the `env:`
-///   mappings would not close it either, because a step can write the same
-///   variable into `$GITHUB_ENV`, which GitHub documents as inherited by every
-///   later step of the job;
-/// - **configuration on disk.** The same override lives in
-///   `.cargo/config.toml`, which a step can write before the cargo step runs.
+/// - **a filter that matches nothing.** `cargo nextest run --no-tests pass
+///   zzz_no_such_test` reports `0 tests run` and exits 0, and `cargo bench
+///   --benches -- --test zzz_no_such_bench` exits 0 having measured nothing:
+///   `--benches` picks up the lib and bin harnesses alongside the three
+///   criterion benches, the harnesses answer `0 tests` and the benches print
+///   nothing at all. Each is a single bare line of allowed characters. A bare
+///   filter is not enough against nextest 0.9.143, which exits 4 on a run of
+///   zero tests, so it is `--no-tests pass` that does the silencing. Telling a
+///   filter from the value of a flag means re-implementing cargo's argument
+///   parsing on both sides of `--`, which is the mistake #634 already paid
+///   for, a model written in place of the oracle;
+/// - **the environment.** `CARGO_TARGET_<TRIPLE>_RUNNER: "true"` has cargo put
+///   each test or bench binary through `true` instead of executing it, and
+///   `env:` sits three lines from the `RUSTFLAGS` the `msrv` job already
+///   overrides. Measured against the commands this workflow runs, it reaches
+///   `bench` and stops there:
+///   `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=true cargo bench --benches --
+///   --test` reports all five of those binaries as run and exits 0 without
+///   executing one, the harness lines gone with them. `cargo nextest run`
+///   exits 4 under the same override, since nextest lists tests by running
+///   each binary and `true` lists none, so the `test` job goes red rather than
+///   quiet. Walking the `env:` mappings would not close the bench case either,
+///   because a step can write the same variable into `$GITHUB_ENV`, which
+///   GitHub documents as inherited by every later step of the job;
+/// - **configuration on disk.** `target.<triple>.runner` in
+///   `.cargo/config.toml` is that override in file form, and a step can write
+///   it before the cargo step runs.
 ///
-/// The last two are one shape: a step this guard leaves free-form
+/// One vector named in the issue is deliberately not in that list. Both the
+/// empty filter and the runner override leave `cargo test --doc` at
+/// `0 passed`, exit 0, and so does a plain `cargo test --doc` on this tree:
+/// the crate has no Rust doctests, every fenced block in its doc comments
+/// being `text`, `toml` or `go`. Nothing is being silenced there, the step
+/// has nothing to run, which is a defect of its own and not a limit of this
+/// guard, filed as #659.
+///
+/// The last two surfaces are one shape: a step this guard leaves free-form
 /// reconfigures what cargo reads, and the cargo line it does guard is
 /// untouched. Closing them means constraining every step of a job rather than
 /// its cargo steps, which is a different guard with a different cost.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -289,6 +289,49 @@ pub fn assert_job_is_blocking(workflow: &serde_yaml_ng::Value, job_name: &str, s
 /// space, so `cargo\tcheck --locked || true` opted out of it entirely. A
 /// prefix test is no good either, since `env VAR=x cargo …` defeats it.
 /// `Cargo.toml` is not a `cargo` token, so the reader step stays out.
+///
+/// ## Where this stops (issue #656)
+///
+/// The property being reached for is "the command fails the job when the code
+/// is broken". Between this file and that property sit cargo's own argument
+/// parsing, the process environment and `.cargo/config.toml`, and a reader of
+/// the workflow does not cross that gap. It can only make a crossing visible
+/// in a diff, which is what the shape above does. Three surfaces measured
+/// while reviewing #654 sit on the far side, and #656 records the decision to
+/// name them here rather than chase them: each review pass opened a surface
+/// the previous fix did not touch instead of a variant of it, which is a
+/// domain with no last entry.
+///
+/// - **a filter that matches nothing.** Every guarded runner has one, all
+///   measured locally at exit 0. `cargo test --doc zzz_no_such_doctest`
+///   reports `0 passed`; `cargo nextest run --no-tests pass zzz_no_such_test`
+///   reports `0 tests run`, and bare nextest 0.9.143 exits 4 on no tests, so
+///   it is `--no-tests pass` that silences it; `cargo bench --benches --
+///   --test zzz_no_such_bench` runs the three bench binaries, prints nothing
+///   and exits 0. Each one is a single bare line of allowed characters.
+///   Telling a filter from the value of a flag means re-implementing cargo's
+///   argument parsing on both sides of `--`, which is the mistake #634 already
+///   paid for, a model written in place of the oracle;
+/// - **the environment.** `CARGO_TARGET_<TRIPLE>_RUNNER: "true"` has every
+///   test binary executed by `true`:
+///   `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=true cargo test --test
+///   msrv_tests` never launches the binary and exits 0. Walking the `env:`
+///   mappings would not close it either, because a step can write the same
+///   variable into `$GITHUB_ENV`, which GitHub documents as inherited by every
+///   later step of the job;
+/// - **configuration on disk.** The same override lives in
+///   `.cargo/config.toml`, which a step can write before the cargo step runs.
+///
+/// The last two are one shape: a step this guard leaves free-form
+/// reconfigures what cargo reads, and the cargo line it does guard is
+/// untouched. Closing them means constraining every step of a job rather than
+/// its cargo steps, which is a different guard with a different cost.
+///
+/// So a green run here says the workflow carries no visible off switch on the
+/// cargo commands it guards. It does not say CI is honest. The instrument that
+/// would say that is observational, a canary that breaks a test on a scratch
+/// branch and watches the checks turn red, and it costs a CI run every time it
+/// runs. #656 holds that trade-off.
 #[allow(dead_code)] // used by the two test binaries that parse ci.yml.
 fn assert_run_cannot_swallow_its_failure(
   workflow: &serde_yaml_ng::Value,


### PR DESCRIPTION
## Description

#656 asked for a decision, not for code: the static CI guards built by #646,
#652 and #653 read `.github/workflows/ci.yml` and reach for "the command fails
the job when the code is broken", and reviewing #654 crossed the gap between
those two three times, each on a surface the previous fix did not touch.

The decision is to **accept the ceiling and name it** in
`assert_run_cannot_swallow_its_failure`, so a green suite is not read as a
proof that CI is honest. The alternative, an observational canary that breaks
a test on a scratch branch and watches the checks turn red, measures the
property itself and costs a full CI run every time it runs; it is recorded as
the other option rather than built.

Closes #656

## Type of change

- [x] 📝 Docs

## Changes

- `assert_run_cannot_swallow_its_failure` gains a `## Where this stops` section
  naming the surfaces out of reach, each with the measurement behind it.
- No guard changes. The point of the issue is that a sixth pass adding
  `CARGO_TARGET_*` and empty filters to a list is what should not happen.

**Every vector was re-measured against the commands `ci.yml` actually runs,
and two of the issue's own claims did not survive that.**

| vector | job | measured |
| --- | --- | --- |
| `cargo bench --benches -- --test zzz_no_such_bench` | `bench` | exit **0**, nothing measured. This is the one #656 flagged as never confirmed. |
| `cargo nextest run --no-tests pass zzz_no_such_test` | `test` | exit **0**, `0 tests run` |
| `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=true cargo bench --benches -- --test` | `bench` | exit **0**, five binaries reported as run, none executed |
| `CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=true cargo nextest run` | `test` | exit **4**. nextest lists tests by running each binary, `true` lists none, and it refuses a run of zero tests, so the job goes **red** |

So the runner override does **not** silence the `test` job, contrary to what
#656 states. The issue measured it on `cargo test --test msrv_tests` and on
`cargo test --doc`, neither of which this workflow runs.

And `cargo test --doc` is worse than inconclusive: it answers `0 passed` under
both vectors **and** with no vector at all. The crate has no Rust doctests,
every fenced block in its doc comments being `text`, `toml` or `go`, so that
measurement was never isolating. The CI step cannot fail today, which is a
defect of its own and is filed as **#659**.

## Tests

- [x] `cargo test` passes locally (3537 tests, 111 binaries, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] New tests added under `tests/`: none. This is a doc comment on an
      existing helper, which is the "comments-only" exception in CLAUDE.md. The
      only test shaped like this change would assert that the docstring
      contains its own text, which passes by construction and is the
      grep-your-own-prompt defect this repo has already fixed three times.

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [ ] CHANGELOG.md updated under `## [Unreleased]`: deliberately not. Nothing
      here changes what gwm does, and the `[Unreleased]` entry for #652/#653
      already scopes its claims to the shape of the command.
- [x] README updated if CLI surface changed (n/a)
- [x] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths (n/a)
- [x] No `println!` in TUI render code (n/a)

## Linked issues / docs

- Issue: #656
- Filed from this work: #659 (`cargo test --doc` runs zero doctests)
- Related PRs: #651 (the job level), #654 (the command and above the job)
- Still open and **bounded**, unlike this one: #655 (`fmt` and `clippy` are two
  of the seven required checks on `main` and no guard points at them)

## Notes for reviewers

Two things worth knowing before proposing a fix:

1. **An `env:` whitelist would not close the environment surface.** A step can
   write `CARGO_TARGET_<TRIPLE>_RUNNER=true` into `$GITHUB_ENV`, which GitHub
   documents as inherited by every later step of the job, so walking the `env:`
   mappings would ship a guard that claims the surface is handled while half of
   it stays open. The environment and `.cargo/config.toml` are one shape: a
   free-form step reconfigures what cargo reads, and the cargo line the guard
   does read is untouched.
2. **Findings that propose closing these surfaces are out of scope by
   decision**, not by oversight. The issue exists because that list has no last
   entry. A finding is in scope if it shows the note is wrong, a measurement is
   misreported, or a surface exists that the note does not name. The first
   review pass produced exactly that twice, and both were taken.

Considered and left out: asserting the repo ships no `.cargo/config.toml`
declaring a target runner. It closes the committed half of that surface, leaves
the write-at-CI-time half open, and would need the note to explain which half
it covers. Not worth the words.

https://claude.ai/code/session_01Sqahwoxj6v4hXgUCTVkrT4
