### PR TITLE
✅ test(ci): the guard walks the jobs instead of naming four of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,14 +179,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   property asserted either, because it is not true and never was: `doctor`'s
   checkout, toolchain install and `cargo build` all fail hard, and should.
 
-  Twenty-four mutations, each applied alone and each read back to confirm it
+  Both commands are pinned by value rather than screened flag by flag, for the
+  same reason `RUSTFLAGS` is. A `contains` reads a line whose last flag wins:
+  `cargo clippy --all-targets --all-features -- -D warnings --cap-lints=allow`
+  keeps every substring a screen would look for, is one bare invocation,
+  touches no `env:`, and exits 0 on every lint in the tree;
+  `--config=disable_all_formatting=true` does the same to `fmt`. Refusing the
+  neutralisation inside the variable while handing it over on the line beside
+  it is not a guard. The `doctor` exemption is pinned by value too, since
+  `if: always()` satisfies a presence check while losing the restriction the
+  message names.
+
+  Twenty-six mutations, each applied alone and each read back to confirm it
   fired the assertion it was aimed at and not an earlier one. Applying them
   together proves less than it looks, since the job-level `if:` is checked
   before `continue-on-error:` and both before the command, so a combined
   mutation panics on the first and never reaches the one it is meant to
-  demonstrate. Four of the eighteen mutate the test rather than the workflow,
+  demonstrate. Two of the twenty-six mutate the test rather than the workflow,
   since moving the step-level `if:` waivers out of a call argument and into a
-  lookup is plumbing that can break on its own.
+  lookup is plumbing that can break on its own. The set was replayed in full
+  against the final code rather than accumulated across passes: a table quoting
+  an assertion an earlier commit has since rewritten documents a guard nobody
+  ships.
 
 - **CI could still be silenced, below the job and above it**
   ([#652](https://github.com/kbrdn1/gwm-cli/issues/652),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The caller list is replaced by a sweep over `jobs:`, because a list is what
   produced this in the first place: #646 guarded what it had looked at, #652
   and #653 widened the helper without widening its callers, and a ninth job
-  would arrive unguarded the same way. `doctor` is the one exemption and it is
+  would arrive unguarded the same way. A sweep guards what it finds and says
+  nothing about what stopped existing, so the eight jobs are also named: that
+  enumeration is bounded, covering what `ci.yml` ships today while the sweep
+  covers what it does not, which is the inverse of the caller list it replaces.
+  A missing job is not always a blocked merge either, since only five of the
+  eight are required contexts on `main`. `doctor` is the one exemption and it is
   pinned rather than waived. It is advisory by design, `continue-on-error:
   true` on its step and an `if:` restricting it to `dev`, and should it lose
   either property the exemption goes red instead of quietly covering a job it
@@ -155,12 +160,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own `RUSTFLAGS: -D warnings` is not leant on for clippy: it is set once for
   all eight jobs, and `msrv` already overrides it to `""` at job level.
 
-  Fourteen mutations, each applied alone and each read back to confirm it
+  Eighteen mutations, each applied alone and each read back to confirm it
   fired the assertion it was aimed at and not an earlier one. Applying them
   together proves less than it looks, since the job-level `if:` is checked
   before `continue-on-error:` and both before the command, so a combined
   mutation panics on the first and never reaches the one it is meant to
-  demonstrate.
+  demonstrate. Four of the eighteen mutate the test rather than the workflow,
+  since moving the step-level `if:` waivers out of a call argument and into a
+  lookup is plumbing that can break on its own.
 
 - **CI could still be silenced, below the job and above it**
   ([#652](https://github.com/kbrdn1/gwm-cli/issues/652),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,11 +156,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   what separates enforcing from reporting here, the same class as `cargo
   bench --no-run` (#634) and a `cargo audit` without `--deny warnings` (#340).
   So `--check`, `--all`, `-D warnings` and `--all-targets` are asserted on the
-  commands themselves, where `CLAUDE.md` already states them. The workflow's
-  own `RUSTFLAGS: -D warnings` is not leant on for clippy: it is set once for
-  all eight jobs, and `msrv` already overrides it to `""` at job level.
+  commands themselves, where `CLAUDE.md` already states them.
 
-  Eighteen mutations, each applied alone and each read back to confirm it
+  For clippy the command is only half of it, and the other half wins. The lint
+  level is the command *and* `RUSTFLAGS`, so `env: RUSTFLAGS:
+  "--cap-lints=allow"` on the job exits it 0 on every lint in the tree with
+  the denial sitting there untouched, on a required check, and takes half the
+  MSRV guarantee (`clippy::incompatible_msrv`) with it. The flags reaching the
+  job are pinned by value at the three levels `env:` exists, rather than
+  screened for weakening spellings: `--cap-lints`, `-A warnings`,
+  `--force-warn` and a `-D warnings` cancelled by an earlier flag are not a
+  closed set, which is the denylist #652 already walked through.
+  `CARGO_ENCODED_RUSTFLAGS` is refused outright, since cargo reads it instead
+  of `RUSTFLAGS` and would leave the pin describing a variable nothing reads.
+
+  The `doctor` exemption is pinned to the step that carries it, never asserted
+  existentially over the job's steps. "Some step of `doctor` is
+  `continue-on-error`" is satisfied by any of them, so moving the marker onto
+  `cargo build` keeps such an assertion green while `gwm doctor` itself
+  becomes able to fail the job, which is the exact drift the exemption claims
+  to catch. "The job cannot turn the workflow red" is deliberately not the
+  property asserted either, because it is not true and never was: `doctor`'s
+  checkout, toolchain install and `cargo build` all fail hard, and should.
+
+  Twenty-four mutations, each applied alone and each read back to confirm it
   fired the assertion it was aimed at and not an earlier one. Applying them
   together proves less than it looks, since the job-level `if:` is checked
   before `continue-on-error:` and both before the command, so a combined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Four of the eight CI jobs were guarded, and two of the unguarded ones are
+  required checks on `main`**
+  ([#655](https://github.com/kbrdn1/gwm-cli/issues/655)).
+  `assert_job_is_blocking` had four callers for eight jobs, and the four were
+  the ones #646's own audit happened to name. `fmt`, `clippy` and `hook-smoke`
+  were not among them, and all three are contexts `main` requires: `if: false`,
+  `continue-on-error: true` and `|| true` on the command, applied to `clippy`
+  at once, left all 27 tests across the two binaries that parse `ci.yml` green.
+  Those are exactly the neutralisations #646, #652 and #653 exist to close,
+  pointed at jobs nobody had pointed the guard at.
+
+  The caller list is replaced by a sweep over `jobs:`, because a list is what
+  produced this in the first place: #646 guarded what it had looked at, #652
+  and #653 widened the helper without widening its callers, and a ninth job
+  would arrive unguarded the same way. `doctor` is the one exemption and it is
+  pinned rather than waived. It is advisory by design, `continue-on-error:
+  true` on its step and an `if:` restricting it to `dev`, and should it lose
+  either property the exemption goes red instead of quietly covering a job it
+  was not written for. `hook-smoke` had been written down as exempt too, on
+  the reasoning that its shell gates are legitimately multi-line with pipes;
+  running the guard against it before believing that said otherwise, since a
+  `run:` block invoking no cargo is outside the command invariant's scope to
+  begin with. It costs one iteration of the sweep and it is a required check,
+  so it is guarded.
+
+  Being blocking is not the whole property for these two. `cargo fmt --all`
+  without `--check` rewrites the tree and exits 0, and `cargo clippy` without
+  `-D warnings` exits 0 on every lint it finds. Both are one bare cargo
+  invocation on one line under a built-in shell, so they satisfy every
+  assertion the helper makes, and neither is `--no-run` or `--dry-run`, which
+  is the bounded list it already carries. A flag, not a shell operator, is
+  what separates enforcing from reporting here, the same class as `cargo
+  bench --no-run` (#634) and a `cargo audit` without `--deny warnings` (#340).
+  So `--check`, `--all`, `-D warnings` and `--all-targets` are asserted on the
+  commands themselves, where `CLAUDE.md` already states them. The workflow's
+  own `RUSTFLAGS: -D warnings` is not leant on for clippy: it is set once for
+  all eight jobs, and `msrv` already overrides it to `""` at job level.
+
+  Fourteen mutations, each applied alone and each read back to confirm it
+  fired the assertion it was aimed at and not an earlier one. Applying them
+  together proves less than it looks, since the job-level `if:` is checked
+  before `continue-on-error:` and both before the command, so a combined
+  mutation panics on the first and never reaches the one it is meant to
+  demonstrate.
+
 - **CI could still be silenced, below the job and above it**
   ([#652](https://github.com/kbrdn1/gwm-cli/issues/652),
   [#653](https://github.com/kbrdn1/gwm-cli/issues/653)). #646 pinned the job

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -462,7 +462,7 @@ fn job_needs(job: &serde_yaml_ng::Value) -> Vec<String> {
 /// workflow author reads, then `uses:` for the action-only steps that carry no
 /// name, then the script itself.
 #[allow(dead_code)] // used by the two test binaries that parse ci.yml.
-fn step_label(step: &serde_yaml_ng::Value) -> &str {
+pub fn step_label(step: &serde_yaml_ng::Value) -> &str {
   step["name"]
     .as_str()
     .or_else(|| step["uses"].as_str())

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -927,3 +927,163 @@ fn ci_fires_on_main_and_dev_with_nothing_filtered_out() {
      pushing a commit"
   );
 }
+
+/// Issue #655. `assert_job_is_blocking` had four callers for eight jobs, and
+/// the four were the ones #646's own audit happened to name. `fmt` and
+/// `clippy` are two of the seven contexts `main` requires and neither was
+/// among them: `grep -rn '"fmt"\|"clippy"' tests/` returned nothing for the
+/// jobs. `hook-smoke` is a required context too and was equally unnamed.
+///
+/// So the caller list is replaced by a sweep. A list is what produced this
+/// issue: #646 guarded what it had looked at, #652 and #653 widened the
+/// helper without widening its callers, and a ninth job added tomorrow would
+/// arrive unguarded exactly the same way. Walking `jobs:` instead means a new
+/// job is covered the moment it exists, and switching one off is a diff
+/// against this test rather than against nothing.
+///
+/// `doctor` is the one exemption, and it is pinned rather than waived. It is
+/// advisory by design: `continue-on-error: true` on the `gwm doctor` step and
+/// an `if:` restricting the job to `dev`, both deliberate (the report wants
+/// eyes, not a blocked merge, and `lazygit` is absent on the runner so a
+/// Warning is its floor). What is asserted here is that it is *still* that
+/// job. Should it ever lose either property it stops being advisory, the
+/// assertion below fails, and it has to move into the guarded set rather than
+/// sit in an exemption written for a job it no longer is.
+///
+/// The three per-job callers elsewhere in this file and in `msrv_tests` stay:
+/// each carries a rationale and properties this sweep cannot express (the
+/// `test` job's one legitimate doctest `if:`, `audit`'s `--deny warnings`).
+/// They overlap with the sweep on purpose. Redundant coverage costs a
+/// millisecond; a gap costs nine months, which is what RUSTSEC-2025-0068 did.
+#[test]
+fn ci_every_job_is_blocking_except_the_advisory_doctor() {
+  let workflow = ci_workflow();
+  let jobs: Vec<String> = workflow["jobs"]
+    .as_mapping()
+    .expect("ci.yml must define a `jobs:` mapping")
+    .keys()
+    .filter_map(|k| k.as_str().map(str::to_owned))
+    .collect();
+
+  // An empty `jobs:` parses to a mapping with no keys, and a loop over it
+  // asserts nothing at all. The count is deliberately a floor and not an
+  // equality: adding a job must not be a red test, only removing the guard
+  // from one.
+  assert!(
+    jobs.len() >= 8,
+    "ci.yml must still define its eight jobs: a `jobs:` block emptied down to one leaves \
+     this sweep iterating over nothing while reporting success. Got {jobs:?}"
+  );
+
+  for job_name in &jobs {
+    if job_name == "doctor" {
+      let job = &workflow["jobs"]["doctor"];
+      assert!(
+        !job["if"].is_null(),
+        "the `doctor` job is exempt from the blocking guard because it is advisory, and it \
+         has lost the `if:` that restricts it to `dev`. It is no longer the job this \
+         exemption was written for: guard it like the rest, or restore the condition"
+      );
+      let advisory = job["steps"]
+        .as_sequence()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .any(|s| s["continue-on-error"].as_bool() == Some(true));
+      assert!(
+        advisory,
+        "the `doctor` job is exempt from the blocking guard because it is advisory, and no \
+         step of it carries `continue-on-error: true` any more. A job that can turn the \
+         workflow red does not belong in an exemption for one that cannot"
+      );
+      continue;
+    }
+    assert_job_is_blocking(&workflow, job_name, steps_allowed_an_if(job_name));
+  }
+}
+
+/// The `if:` conditions the sweep above allows, by job. Everything not listed
+/// gets `&[]`, which is the helper refusing every step-level `if:`.
+///
+/// One entry today: doctests behave identically on the three runners and are
+/// paid for once, on the row with the slack against windows. The waiver
+/// carries the condition by value, so widening it to `false` is caught here
+/// and not left to whichever other test happens to pin that step.
+fn steps_allowed_an_if(job_name: &str) -> &'static [(&'static str, &'static str)] {
+  match job_name {
+    "test" => &[("cargo test --doc", "matrix.os == 'ubuntu-latest'")],
+    _ => &[],
+  }
+}
+
+/// Issue #655. Being blocking is not enough for `fmt`: `cargo fmt --all`
+/// without `--check` **rewrites the tree and exits 0**. It is one bare cargo
+/// invocation on one line under a built-in shell, so it satisfies every
+/// assertion in `assert_job_is_blocking` including the bare-command
+/// invariant, and it is not `--no-run` or `--dry-run` either. The job goes
+/// green forever while formatting drift lands, on a runner whose working tree
+/// is thrown away a minute later.
+///
+/// That is the same class as `cargo bench --no-run` (#634) and `cargo audit`
+/// without `--deny warnings` (#340): a flag, not a shell operator, is what
+/// separates a command that enforces from one that reports. The shape of the
+/// command cannot see it, so it is asserted here, where `CLAUDE.md` states
+/// it: "CI enforces `cargo fmt --check`".
+#[test]
+fn ci_fmt_job_checks_formatting_rather_than_rewriting_it() {
+  let runs = run_steps(&ci_job("fmt"));
+  let fmt = runs
+    .iter()
+    .find(|r| r.contains("cargo fmt"))
+    .unwrap_or_else(|| panic!("the fmt job must run `cargo fmt`, got {runs:?}"));
+
+  assert!(
+    fmt.contains("--check"),
+    "the fmt job must run `cargo fmt` with `--check`: without it cargo rewrites the tree in \
+     place and exits 0, so the job reports success over formatting it silently fixed on a \
+     runner and threw away. Got {fmt:?}"
+  );
+  assert!(
+    fmt.contains("--all"),
+    "the fmt job must check every crate in the workspace (`--all`): a single-package check \
+     leaves the rest unformatted while the job name still reads `rustfmt`. Got {fmt:?}"
+  );
+}
+
+/// Issue #655. The same hole one job over. `cargo clippy --all-targets` with
+/// `-D warnings` dropped exits 0 on every lint it finds, and `cargo clippy -D
+/// warnings` without `--all-targets` never lints `tests/`, `benches/` or
+/// `examples/` at all, which in this repo is 110 test binaries and three
+/// benches, the larger half of the code. Both are one bare cargo invocation
+/// and both pass `assert_job_is_blocking` unchanged.
+///
+/// Neither flag is incidental: `CLAUDE.md` states the command as `cargo
+/// clippy --all-targets -- -D warnings` and the house rule that an
+/// `#[allow(...)]` needs a comment only means anything while the lint would
+/// otherwise have failed the build.
+///
+/// The workflow-level `RUSTFLAGS: -D warnings` is not a second line of
+/// defence to lean on here. It is set once at the top of `ci.yml` for every
+/// job, so it is one edit away from being gone for all eight of them, and the
+/// `msrv` job already overrides it to `""` at job level, which is precedent
+/// that it does get overridden. The command has to carry its own denial.
+#[test]
+fn ci_clippy_job_denies_warnings_across_all_targets() {
+  let runs = run_steps(&ci_job("clippy"));
+  let clippy = runs
+    .iter()
+    .find(|r| r.contains("cargo clippy"))
+    .unwrap_or_else(|| panic!("the clippy job must run `cargo clippy`, got {runs:?}"));
+
+  assert!(
+    clippy.contains("-D warnings"),
+    "the clippy job must pass `-D warnings`: clippy exits 0 on a lint it only warns about, \
+     so dropping the denial leaves the job green over every lint in the tree. Got {clippy:?}"
+  );
+  assert!(
+    clippy.contains("--all-targets"),
+    "the clippy job must lint every target (`--all-targets`): the default leaves `tests/`, \
+     `benches/` and `examples/` unlinted, which here is 110 test binaries and three benches \
+     the job would report clean without having read. Got {clippy:?}"
+  );
+}

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::{path::Path, process::Command};
 
 mod common;
-use common::{assert_job_is_blocking, effective_matrix_os};
+use common::{assert_job_is_blocking, effective_matrix_os, step_label};
 
 #[cfg(unix)]
 const CHECK_RC_DUPES: &str = ".github/scripts/check-rc-changelog-dupes.sh";
@@ -999,29 +999,65 @@ fn ci_every_job_is_blocking_except_the_advisory_doctor() {
 
   for job_name in &jobs {
     if job_name == "doctor" {
-      let job = &workflow["jobs"]["doctor"];
-      assert!(
-        !job["if"].is_null(),
-        "the `doctor` job is exempt from the blocking guard because it is advisory, and it \
-         has lost the `if:` that restricts it to `dev`. It is no longer the job this \
-         exemption was written for: guard it like the rest, or restore the condition"
-      );
-      let advisory = job["steps"]
-        .as_sequence()
-        .cloned()
-        .unwrap_or_default()
-        .iter()
-        .any(|s| s["continue-on-error"].as_bool() == Some(true));
-      assert!(
-        advisory,
-        "the `doctor` job is exempt from the blocking guard because it is advisory, and no \
-         step of it carries `continue-on-error: true` any more. A job that can turn the \
-         workflow red does not belong in an exemption for one that cannot"
-      );
+      assert_doctor_is_still_the_advisory_job(&workflow["jobs"]["doctor"]);
       continue;
     }
     assert_job_is_blocking(&workflow, job_name, steps_allowed_an_if(job_name));
   }
+}
+
+/// What the sweep's one exemption is exempt *as*: the advisory job, its `if:`
+/// restricting it to `dev` and its report step marked `continue-on-error:
+/// true`. Both are deliberate, the report wants eyes rather than a blocked
+/// merge and `lazygit` is absent on the runner so a Warning is its floor. Lose
+/// either and it is no longer the job the exemption was written for, so it
+/// goes red here and has to join the guarded set instead.
+///
+/// The marker is pinned to the step that carries it, never asserted
+/// existentially over the job's steps. "some step of `doctor` is
+/// `continue-on-error`" is satisfied by any of them, so moving the marker off
+/// `gwm doctor` and onto `cargo build` leaves an existential assertion green
+/// while `gwm doctor` itself becomes able to fail the job, which is the exact
+/// drift the exemption claims to catch. `assert_job_is_blocking` already
+/// closes that shape for its `if:` waivers by requiring exactly one step to
+/// answer to the label; it is closed the same way here.
+///
+/// "The job cannot turn the workflow red" is deliberately *not* the property
+/// asserted, because it is not true and never was: `doctor`'s checkout, its
+/// toolchain install and its `cargo build` all fail hard, and should. Only the
+/// report is advisory.
+fn assert_doctor_is_still_the_advisory_job(job: &serde_yaml_ng::Value) {
+  assert!(
+    !job["if"].is_null(),
+    "the `doctor` job is exempt from the blocking guard because it is advisory, and it has \
+     lost the `if:` that restricts it to `dev`. It is no longer the job this exemption was \
+     written for: guard it like the rest, or restore the condition"
+  );
+
+  let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
+  let reports: Vec<&serde_yaml_ng::Value> = steps
+    .iter()
+    .filter(|s| s["name"].as_str() == Some("gwm doctor"))
+    .collect();
+  assert_eq!(
+    reports.len(),
+    1,
+    "the `doctor` job must hold exactly one step named `gwm doctor`, found {}. Zero means \
+     the step this exemption is written around was renamed or removed and the exemption now \
+     covers nothing; more than one means a second step answers to the label and inherits \
+     the advisory marker written for its neighbour",
+    reports.len()
+  );
+  assert_eq!(
+    reports[0]["continue-on-error"].as_bool(),
+    Some(true),
+    "the `gwm doctor` step must carry `continue-on-error: true`: that one step being \
+     advisory is the whole reason this job sits outside the blocking guard. Asserting it of \
+     the step rather than of the job as a whole is deliberate, since `some step is \
+     continue-on-error` stays green when the marker moves onto `cargo build` and `gwm \
+     doctor` quietly becomes able to fail the job. Got `continue-on-error: {:?}`",
+    reports[0]["continue-on-error"]
+  );
 }
 
 /// The `if:` conditions the sweep above allows, by job. Everything not listed
@@ -1089,9 +1125,30 @@ fn ci_fmt_job_checks_formatting_rather_than_rewriting_it() {
 /// job, so it is one edit away from being gone for all eight of them, and the
 /// `msrv` job already overrides it to `""` at job level, which is precedent
 /// that it does get overridden. The command has to carry its own denial.
+///
+/// It is also not inert, which is the other half of the same fact and the
+/// hole the paragraph above left open. The lint level clippy runs at is the
+/// command *and* `RUSTFLAGS`, and `RUSTFLAGS` wins: `env: RUSTFLAGS:
+/// "--cap-lints=allow"` on this job makes `cargo clippy --all-targets
+/// --all-features -- -D warnings` exit 0 on every lint in the tree, denial
+/// intact, one bare invocation, job green. So the flags that reach the job are
+/// pinned rather than left to the command alone, at the two levels `env:`
+/// exists above a step and on the steps themselves.
+///
+/// Pinned by value, not screened for weakening spellings. `--cap-lints=allow`,
+/// `-A warnings`, `--force-warn`, a `-D warnings` cancelled by an earlier
+/// `--cap-lints`: rustc's flags are not a fixed set and enumerating the ones
+/// that weaken is the denylist #652 already walked through. The exact value is
+/// the only statement that also closes the ones nobody has thought of.
+///
+/// `CARGO_ENCODED_RUSTFLAGS` is refused outright rather than pinned, because
+/// cargo reads it *instead of* `RUSTFLAGS` when it is set: a job carrying it
+/// would leave the pin above describing a variable nothing reads.
 #[test]
 fn ci_clippy_job_denies_warnings_across_all_targets() {
-  let runs = run_steps(&ci_job("clippy"));
+  let workflow = ci_workflow();
+  let job = ci_job("clippy");
+  let runs = run_steps(&job);
   let clippy = runs
     .iter()
     .find(|r| r.contains("cargo clippy"))
@@ -1107,5 +1164,48 @@ fn ci_clippy_job_denies_warnings_across_all_targets() {
     "the clippy job must lint every target (`--all-targets`): the default leaves `tests/`, \
      `benches/` and `examples/` unlinted, which here is 110 test binaries and three benches \
      the job would report clean without having read. Got {clippy:?}"
+  );
+
+  assert_eq!(
+    workflow["env"]["RUSTFLAGS"].as_str(),
+    Some("-D warnings"),
+    "the workflow-wide `RUSTFLAGS` must stay exactly `-D warnings`, because it is half of \
+     the lint level `cargo clippy` runs at and the half that wins: `--cap-lints=allow` here \
+     exits the job 0 on every lint in the tree while the `-D warnings` on the command sits \
+     there untouched. Changing what clippy is allowed to ignore is a conscious decision in \
+     a reviewed diff, not a one-word edit to a shared `env:` block. Got {:?}",
+    workflow["env"]["RUSTFLAGS"]
+  );
+
+  // Below the workflow, `env:` exists at exactly two levels, and either one
+  // shadows the value pinned above for this job alone. `msrv` overriding
+  // `RUSTFLAGS` to `""` two jobs away is the precedent that this does happen.
+  let mut envs: Vec<(&serde_yaml_ng::Value, String)> = vec![(&job["env"], "the `clippy` job".to_string())];
+  let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
+  for step in &steps {
+    envs.push((&step["env"], format!("step {:?} of the `clippy` job", step_label(step))));
+  }
+  for (env, where_) in &envs {
+    assert!(
+      env["RUSTFLAGS"].is_null(),
+      "`RUSTFLAGS` must not be set on {where_}: it shadows the workflow-wide `-D warnings` \
+       for this job alone, and it decides the lint level over the command's own denial. Got \
+       `RUSTFLAGS: {:?}`",
+      env["RUSTFLAGS"]
+    );
+    assert!(
+      env["CARGO_ENCODED_RUSTFLAGS"].is_null(),
+      "`CARGO_ENCODED_RUSTFLAGS` must not be set on {where_}: cargo reads it *instead of* \
+       `RUSTFLAGS`, so it silently replaces the value pinned above rather than adding to it. \
+       Got `CARGO_ENCODED_RUSTFLAGS: {:?}`",
+      env["CARGO_ENCODED_RUSTFLAGS"]
+    );
+  }
+  assert!(
+    workflow["env"]["CARGO_ENCODED_RUSTFLAGS"].is_null(),
+    "`CARGO_ENCODED_RUSTFLAGS` must not be set workflow-wide either, for the same reason: \
+     cargo reads it instead of `RUSTFLAGS`, so the pin above would describe a variable \
+     nothing reads. Got {:?}",
+    workflow["env"]["CARGO_ENCODED_RUSTFLAGS"]
   );
 }

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -950,11 +950,14 @@ fn ci_fires_on_main_and_dev_with_nothing_filtered_out() {
 /// assertion below fails, and it has to move into the guarded set rather than
 /// sit in an exemption written for a job it no longer is.
 ///
-/// The three per-job callers elsewhere in this file and in `msrv_tests` stay:
-/// each carries a rationale and properties this sweep cannot express (the
-/// `test` job's one legitimate doctest `if:`, `audit`'s `--deny warnings`).
-/// They overlap with the sweep on purpose. Redundant coverage costs a
-/// millisecond; a gap costs nine months, which is what RUSTSEC-2025-0068 did.
+/// The four per-job callers stay: `bench`, `test` and `audit` elsewhere in
+/// this file, `msrv` in `msrv_tests`. Each carries a rationale the sweep
+/// cannot hold, and two carry a property it cannot express either, `audit`'s
+/// `--deny warnings` and `bench`'s `--benches -- --test`. The `test` job's
+/// doctest `if:` is not one of them: that waiver moved into
+/// `steps_allowed_an_if` and the sweep enforces it by value now. They overlap
+/// with the sweep on purpose. Redundant coverage costs a millisecond; a gap
+/// costs nine months, which is what RUSTSEC-2025-0068 did.
 #[test]
 fn ci_every_job_is_blocking_except_the_advisory_doctor() {
   let workflow = ci_workflow();

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -965,15 +965,37 @@ fn ci_every_job_is_blocking_except_the_advisory_doctor() {
     .filter_map(|k| k.as_str().map(str::to_owned))
     .collect();
 
-  // An empty `jobs:` parses to a mapping with no keys, and a loop over it
-  // asserts nothing at all. The count is deliberately a floor and not an
-  // equality: adding a job must not be a red test, only removing the guard
-  // from one.
-  assert!(
-    jobs.len() >= 8,
-    "ci.yml must still define its eight jobs: a `jobs:` block emptied down to one leaves \
-     this sweep iterating over nothing while reporting success. Got {jobs:?}"
-  );
+  // A sweep guards the jobs it finds and says nothing about the ones that
+  // stopped existing. An emptied `jobs:` leaves it iterating over nothing
+  // while reporting success, and a count-based floor does not close that
+  // either: deleting one job while adding another satisfies any count. So the
+  // eight are named.
+  //
+  // This is an enumeration, and deliberately so, because it is a **bounded**
+  // one. It covers the jobs `ci.yml` ships today; the sweep below covers the
+  // ones it does not, which is the exact inverse of the caller list this test
+  // replaces, a list that could only ever cover what someone remembered to add
+  // to it. Membership is a floor and never an equality: a ninth job has to be
+  // a green test that the sweep then guards, not a red one.
+  for expected in [
+    "fmt",
+    "clippy",
+    "msrv",
+    "test",
+    "bench",
+    "hook-smoke",
+    "audit",
+    "doctor",
+  ] {
+    assert!(
+      jobs.iter().any(|j| j == expected),
+      "ci.yml must still define the `{expected}` job. Deleting or renaming it is invisible to \
+       the sweep below, which guards whatever jobs it finds, and a job going quiet is not \
+       always a blocked merge either: only five of the eight are required contexts on `main`, \
+       so `msrv`, `bench` and `doctor` can vanish with nothing on GitHub's side objecting. \
+       Got {jobs:?}"
+    );
+  }
 
   for job_name in &jobs {
     if job_name == "doctor" {

--- a/tests/release_workflow_tests.rs
+++ b/tests/release_workflow_tests.rs
@@ -1026,12 +1026,37 @@ fn ci_every_job_is_blocking_except_the_advisory_doctor() {
 /// asserted, because it is not true and never was: `doctor`'s checkout, its
 /// toolchain install and its `cargo build` all fail hard, and should. Only the
 /// report is advisory.
+///
+/// `DOCTOR_CONDITION` is the condition spelled on one line: `ci.yml` writes it
+/// as a block scalar across two.
+const DOCTOR_CONDITION: &str = "(github.event_name == 'push' && github.ref == 'refs/heads/dev') || \
+                                (github.event_name == 'pull_request' && github.base_ref == 'dev')";
+
 fn assert_doctor_is_still_the_advisory_job(job: &serde_yaml_ng::Value) {
-  assert!(
-    !job["if"].is_null(),
-    "the `doctor` job is exempt from the blocking guard because it is advisory, and it has \
-     lost the `if:` that restricts it to `dev`. It is no longer the job this exemption was \
-     written for: guard it like the rest, or restore the condition"
+  // By value, not by presence. `!job["if"].is_null()` is satisfied by any
+  // condition at all, `if: always()` included, while the message below claims
+  // the restriction to `dev` is what it checks. That is the same overstatement
+  // the `continue-on-error` assertion made before it was pinned to its step,
+  // and the same by-value standard `steps_allowed_an_if` already holds its
+  // waivers to.
+  //
+  // Whitespace is normalised first because the condition is a YAML block
+  // scalar: reflowing it across lines is a formatting change and must not be a
+  // red test, whereas changing what it admits must be.
+  let condition = job["if"]
+    .as_str()
+    .unwrap_or_default()
+    .split_whitespace()
+    .collect::<Vec<_>>()
+    .join(" ");
+  assert_eq!(
+    condition, DOCTOR_CONDITION,
+    "the `doctor` job is exempt from the blocking guard because it is advisory, and its \
+     `if:` no longer restricts it to `dev`. `main` is meant to be stable and the doctor \
+     exists to catch in-development regressions, so widening this runs an advisory job on \
+     every release path; narrowing it stops the only thing that exercises `gwm doctor` at \
+     all. Either way it is no longer the job this exemption was written for: guard it like \
+     the rest, or restore the condition"
   );
 
   let steps = job["steps"].as_sequence().cloned().unwrap_or_default();
@@ -1106,7 +1131,31 @@ fn ci_fmt_job_checks_formatting_rather_than_rewriting_it() {
     "the fmt job must check every crate in the workspace (`--all`): a single-package check \
      leaves the rest unformatted while the job name still reads `rustfmt`. Got {fmt:?}"
   );
+
+  // The two assertions above name the flags and why they matter, which is the
+  // diagnostic half. They do not close the command, because `contains` reads a
+  // line where a later flag overrides an earlier one: `cargo fmt --all --
+  // --check --config=disable_all_formatting=true` keeps both substrings, is
+  // one bare invocation, and exits 0 over a file rustfmt would otherwise
+  // reject. So the command is pinned by value, the same statement already made
+  // about the `RUSTFLAGS` that reaches `clippy`.
+  assert_eq!(
+    fmt, EXPECTED_FMT,
+    "the fmt job must run exactly `{EXPECTED_FMT}`. Appending to it is enough to undo it, \
+     since rustfmt takes `--config` on the command line and the last setting wins, so \
+     neither `--check` nor `--all` surviving in the line says the line still checks \
+     anything. Changing what CI formats is a conscious decision in a reviewed diff"
+  );
 }
+
+/// The formatting command, pinned. `CLAUDE.md`: "CI enforces `cargo fmt
+/// --check`".
+const EXPECTED_FMT: &str = "cargo fmt --all -- --check";
+
+/// The lint command, pinned. `CLAUDE.md`: "`cargo clippy --all-targets -- -D
+/// warnings` must pass". `--all-features` on top, because a lint behind a
+/// non-default feature is still a lint.
+const EXPECTED_CLIPPY: &str = "cargo clippy --all-targets --all-features -- -D warnings";
 
 /// Issue #655. The same hole one job over. `cargo clippy --all-targets` with
 /// `-D warnings` dropped exits 0 on every lint it finds, and `cargo clippy -D
@@ -1164,6 +1213,20 @@ fn ci_clippy_job_denies_warnings_across_all_targets() {
     "the clippy job must lint every target (`--all-targets`): the default leaves `tests/`, \
      `benches/` and `examples/` unlinted, which here is 110 test binaries and three benches \
      the job would report clean without having read. Got {clippy:?}"
+  );
+
+  // Same reason as the fmt job: `contains` reads a line whose last flag wins.
+  // `cargo clippy --all-targets --all-features -- -D warnings --cap-lints=allow`
+  // keeps both substrings, is one bare invocation, touches no `env:`, and exits
+  // 0 on every lint in the tree. Pinning `RUSTFLAGS` below while leaving the
+  // command open would refuse the neutralisation in the variable and hand it
+  // over on the line beside it.
+  assert_eq!(
+    clippy, EXPECTED_CLIPPY,
+    "the clippy job must run exactly `{EXPECTED_CLIPPY}`. `-D warnings` surviving in the \
+     line does not mean the line denies anything: `--cap-lints=allow` appended after it \
+     caps every lint in the tree and the job exits 0. Changing what CI lints is a conscious \
+     decision in a reviewed diff"
   );
 
   assert_eq!(


### PR DESCRIPTION
## Description

`assert_job_is_blocking` had four callers for eight jobs, and the four were the
ones #646's own audit happened to name. `fmt`, `clippy` and `hook-smoke` were
not among them, and all three are contexts `main` requires. The caller list is
replaced by a sweep over `jobs:`, so a ninth job is guarded the moment it
exists.

Closes #655

## Type of change

- [x] ✅ Tests

## Changes

- **`ci_every_job_is_blocking_except_the_advisory_doctor`** walks `jobs:` and
  calls `assert_job_is_blocking` on every job. A list is what produced this
  issue: #646 guarded what it had looked at, #652 and #653 widened the helper
  without widening its callers. The `if:` waivers move into a
  `steps_allowed_an_if(job_name)` lookup, one entry today (the doctest step's
  ubuntu row), still carried by value.
- **The eight jobs are also named, before the sweep walks them.** A sweep
  guards what it finds and says nothing about what stopped existing, and a
  count-based floor does not close that either: deleting one job while adding
  another satisfies any count. This enumeration is bounded on purpose, covering
  what `ci.yml` ships today while the sweep covers what it does not, which is
  the inverse of the caller list it replaces. GitHub is not a fallback here,
  since only five of the eight are required contexts on `main`.
- **`doctor` is pinned, not waived** — by value on both properties. Its `if:`
  is compared to the `dev` restriction rather than merely asserted present
  (`if: always()` satisfies presence while losing the restriction the message
  names), and `continue-on-error: true` is pinned to the one step named `gwm
  doctor` rather than asserted existentially over the job's steps (moving the
  marker onto `cargo build` keeps an existential green while `gwm doctor`
  becomes able to fail the job).
- **`ci_fmt_job_checks_formatting_rather_than_rewriting_it`** and
  **`ci_clippy_job_denies_warnings_across_all_targets`**. `cargo fmt --all`
  rewrites the tree and exits 0; `cargo clippy` without `-D warnings` exits 0
  on every lint. Both are one bare cargo invocation on one line and neither is
  `--no-run`/`--dry-run`, so the shape `assert_job_is_blocking` checks passes
  them unchanged. The flags are asserted by name as the diagnostic half, and
  then **the whole command is pinned by value**, because `contains` reads a
  line whose last flag wins: `… -- -D warnings --cap-lints=allow` keeps every
  substring and exits 0 on every lint, `… --check --config=disable_all_formatting=true`
  keeps `--check` and leaves formatting drift green.
- **The `RUSTFLAGS` reaching `clippy` is pinned too**, at the three levels
  `env:` exists, and `CARGO_ENCODED_RUSTFLAGS` refused outright since cargo
  reads it instead. The lint level is the command *and* the variable, and the
  variable wins.
- The four existing per-job callers stay (`bench`, `test`, `audit` here,
  `msrv` in `msrv_tests`). Each carries a rationale the sweep cannot hold, and
  two carry a property it cannot express either: `audit`'s `--deny warnings`
  and `bench`'s `--benches -- --test`. They overlap with the sweep on purpose.
- `step_label` in `tests/common/mod.rs` becomes `pub` and is reused rather than
  spelled a second time: two copies of the step-naming convention drift, and
  the assertion messages would then name the same step two ways.

## Tests

- [x] `cargo test` passes locally (3540 tests across 111 binaries, exit 0)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] New tests added under `tests/`

### Demonstrated red

Twenty-six mutations, **each applied alone**, and the whole set **replayed
against the final code** rather than accumulated across passes. Applying the
neutralisations together proves less than it looks, because the job-level `if:`
is asserted before `continue-on-error:` and both before the command, so a
combined mutation panics on the first and never reaches the one it is meant to
demonstrate. Each run was read back to confirm *which* assertion fired.

Twenty-four mutate `.github/workflows/ci.yml`:

| Mutation | Red test | Assertion that fired |
|---|---|---|
| `if: false` on the `fmt` job | sweep | the `fmt` job must carry no `if:`: a job-level condition switches every step off at once while step-level guards stay green, got `if: Bool(false)` |
| `continue-on-error: true` on the `fmt` job | sweep | the `fmt` job must carry no `continue-on-error:` at all. The key has to be absent, not `false`, so that a later `true` is a diff against nothing rather than a one-word edit. Got `continue-on-error: Bool(true)` |
| `cargo fmt --all -- --check || true` | sweep + fmt | step "cargo fmt --check" of the `fmt` job must run cargo as a bare command: one invocation, no shell operators. `if ! cargo audit …; then …; fi` and `cargo bench … &` both report success over a failure while… |
| drop `--check` from the fmt command | fmt | the fmt job must run `cargo fmt` with `--check`: without it cargo rewrites the tree in place and exits 0, so the job reports success over formatting it silently fixed on a runner and threw away. Got "cargo f… |
| append `--config=disable_all_formatting=true` | fmt | the fmt job must run exactly `cargo fmt --all -- --check`. Appending to it is enough to undo it, since rustfmt takes `--config` on the command line and the last setting wins, so neither `--check` nor `--all`… |
| `if: false` on the `clippy` job | sweep | the `clippy` job must carry no `if:`: a job-level condition switches every step off at once while step-level guards stay green, got `if: Bool(false)` |
| `continue-on-error: true` on the `clippy` job | sweep | the `clippy` job must carry no `continue-on-error:` at all. The key has to be absent, not `false`, so that a later `true` is a diff against nothing rather than a one-word edit. Got `continue-on-error: Bool(t… |
| `cargo clippy … || true` | clippy + sweep | the clippy job must run exactly `cargo clippy --all-targets --all-features -- -D warnings`. `-D warnings` surviving in the line does not mean the line denies anything: `--cap-lints=allow` appended after it c… |
| drop `-D warnings` | clippy | the clippy job must pass `-D warnings`: clippy exits 0 on a lint it only warns about, so dropping the denial leaves the job green over every lint in the tree. Got "cargo clippy --all-targets --all-features" |
| drop `--all-targets` | clippy | the clippy job must lint every target (`--all-targets`): the default leaves `tests/`, `benches/` and `examples/` unlinted, which here is 110 test binaries and three benches the job would report clean without… |
| append `--cap-lints=allow` to the clippy command | clippy | the clippy job must run exactly `cargo clippy --all-targets --all-features -- -D warnings`. `-D warnings` surviving in the line does not mean the line denies anything: `--cap-lints=allow` appended after it c… |
| `env: RUSTFLAGS: --cap-lints=allow` on the clippy job | clippy | `RUSTFLAGS` must not be set on the `clippy` job: it shadows the workflow-wide `-D warnings` for this job alone, and it decides the lint level over the command's own denial. Got `RUSTFLAGS: String("--cap-lint… |
| `env: RUSTFLAGS` on the `cargo clippy` step | clippy | `RUSTFLAGS` must not be set on step "cargo clippy" of the `clippy` job: it shadows the workflow-wide `-D warnings` for this job alone, and it decides the lint level over the command's own denial. Got `RUSTFL… |
| `env: CARGO_ENCODED_RUSTFLAGS` on the clippy job | clippy | `CARGO_ENCODED_RUSTFLAGS` must not be set on the `clippy` job: cargo reads it *instead of* `RUSTFLAGS`, so it silently replaces the value pinned above rather than adding to it. Got `CARGO_ENCODED_RUSTFLAGS:… |
| weaken the workflow-wide `RUSTFLAGS` | clippy | the workflow-wide `RUSTFLAGS` must stay exactly `-D warnings`, because it is half of the lint level `cargo clippy` runs at and the half that wins: `--cap-lints=allow` here exits the job 0 on every lint in th… |
| `if: false` on the `hook-smoke` job | sweep | the `hook-smoke` job must carry no `if:`: a job-level condition switches every step off at once while step-level guards stay green, got `if: Bool(false)` |
| `continue-on-error: true` on the `hook-smoke` job | sweep | the `hook-smoke` job must carry no `continue-on-error:` at all. The key has to be absent, not `false`, so that a later `true` is a diff against nothing rather than a one-word edit. Got `continue-on-error: Bo… |
| widen `doctor`'s `if:` to `always()` | sweep | the `doctor` job is exempt from the blocking guard because it is advisory, and its `if:` no longer restricts it to `dev`. `main` is meant to be stable and the doctor exists to catch in-development regression… |
| drop `doctor`'s `dev`-only `if:` | sweep | the `doctor` job is exempt from the blocking guard because it is advisory, and its `if:` no longer restricts it to `dev`. `main` is meant to be stable and the doctor exists to catch in-development regression… |
| move `continue-on-error` off `gwm doctor` onto `cargo build` | sweep | the `gwm doctor` step must carry `continue-on-error: true`: that one step being advisory is the whole reason this job sits outside the blocking guard. Asserting it of the step rather than of the job as a who… |
| rename the `gwm doctor` step | sweep | the `doctor` job must hold exactly one step named `gwm doctor`, found 0. Zero means the step this exemption is written around was renamed or removed and the exemption now covers nothing; more than one means… |
| rename the `hook-smoke` key, keeping its display name | sweep | ci.yml must still define the `hook-smoke` job. Deleting or renaming it is invisible to the sweep below, which guards whatever jobs it finds, and a job going quiet is not always a blocked merge either: only f… |
| delete the `bench` job | sweep + bench guard | ci.yml must still define the `bench` job. Deleting or renaming it is invisible to the sweep below, which guards whatever jobs it finds, and a job going quiet is not always a blocked merge either: only five o… |
| widen the doctest waiver to `if: false` | sweep + doctest guard + test guard | step "cargo test --doc" of the `test` job may not be conditioned away: it carries `if: Bool(false)` and the only condition allowed for it is Some("matrix.os == 'ubuntu-latest'") |

Two mutate the test instead, because moving the step-level `if:` waivers out of
a call argument and into a lookup is plumbing that can break on its own:

| Mutation | Red test | Assertion that fired |
|---|---|---|
| `steps_allowed_an_if` stops returning the doctest waiver | sweep | step "cargo test --doc" of the `test` job may not be conditioned away: it carries `if: String("matrix.os == 'ubuntu-latest'")` and the only condition allowed for it is None |
| `steps_allowed_an_if` keyed on a label no step answers to | sweep | the `test` job allows step "cargo test --doctest" the condition "matrix.os == 'ubuntu-latest'", and exactly one step must answer to that label, found 0. Zero means the step was renamed and the waiver now cov… |

## Checklist

- [x] Branch follows `<type>/#<issue>-<description>`
- [x] Commits follow Gitmoji + Conventional Commits
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [ ] README updated if CLI surface changed (n/a)
- [ ] `examples/gwm.toml.example` updated if config schema changed (n/a)
- [x] No `unwrap()` on user-facing paths
- [x] No `println!` in TUI render code

## Linked issues / docs

- Issue: #655
- Related: #646 (introduced the helper), #652 / #653 (widened it), PR #654

## Notes for reviewers

**The issue's own exemption reasoning was wrong, and measuring caught it.**
#655 listed `hook-smoke` as exempt because "its `run:` blocks are legitimately
multi-line with pipes, so the cargo-shaped invariant does not apply". Running
`assert_job_is_blocking` against it before writing that down says otherwise:
`assert_run_cannot_swallow_its_failure` returns early on a `run:` block with no
`cargo` token, so none of `hook-smoke`'s steps ever reach the invariant. It
passes the guard unchanged, it is a required check on `main`, and it is now
guarded. `doctor` is the only genuine exemption.

**The rename case is the one required contexts cannot see.** A deleted job
usually blocks the merge on its own, because its context never reports. A
*renamed key* with the display name untouched does not: the context still
reports, the sweep guards the renamed job, and nothing notices. That is why the
eight are named rather than counted.

**Why the `RUSTFLAGS` pin is here rather than in a follow-up.** #655 does not
mention `env:`, and the repo rule is that follow-up issues beat scope creep,
"unless the bug invalidates its contract". It does: the clippy guard this PR
adds asserts a denial that a job-level `RUSTFLAGS` cancels outright, so without
the pin the new assertion claims a property it does not have, on a required
check. The same argument covers the command pin. Both fix defects in code this
PR introduces, not adjacent ones it noticed.

**Deliberately out of scope, and named rather than left silent.** Three things
this PR does not close, each weighed and skipped for a stated reason:

- **A test cross-referencing the guarded set against `main`'s seven required
  contexts.** It would need the protection API at test time or a hardcoded list
  that drifts exactly the way the caller list just did. Worth a follow-up issue.
- **`$GITHUB_ENV`.** A step `run: echo "RUSTFLAGS=--cap-lints=allow" >>
  "$GITHUB_ENV"` sets the variable for the next step without touching any
  `env:` key, so the pin does not see it (verified, suite stays green). Skipped
  because it takes writing a step whose only purpose is to neutralise the next
  one, which is intent rather than the drift these guards exist against, and
  the one-line closure available (`runs.len() == 1` on the job) would go red on
  a legitimate second step.
- **`rustfmt.toml`.** `disable_all_formatting = true` in the repo's own config
  makes `cargo fmt --all -- --check` exit 0 on a badly formatted file with
  `ci.yml` untouched (verified on rustfmt 1.9.0: exit 1 becomes exit 0). It is
  the "the command is only half of it" argument one file over, but there is no
  clean closure: pinning a file with legitimate edits by value is heavy, and
  enumerating the disabling options is the denylist #652 already rejected.

https://claude.ai/code/session_01RjyKzWYMAmqbudZCi5CzWv
